### PR TITLE
Fix gpexpand bug

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -525,7 +525,8 @@ class GpExpandStatus():
     def set_status(self, status, status_info=None, force=False):
         """Sets the current status.  gpexpand status must be set in
            proper order.  Any out of order status result in an
-           InvalidStatusError exception"""
+           InvalidStatusError exception. But if force is True, setting
+           status out of order is allowded"""
         self.logger.debug("Transitioning from %s to %s" % (self._status[-1], status))
 
         if not self._fp:
@@ -629,6 +630,18 @@ class GpExpandStatus():
         if int(self._status_values[status]) >= int(self._status_values['UPDATE_CATALOG_DONE']):
             return False
         return True
+
+    def rewind(self, status, status_info=None):
+        """
+        Rewind to a particular status.
+        """
+        self.logger.debug("Rewind the status to %s" % status)
+
+        if not self._fp:
+            self._fp = open(self._status_filename, 'a+')
+        if self._master_mirror and not self._fp_standby:
+            self._fp_standby = open(self._status_standby_filename, 'a+')
+        self.set_status(status, status_info, True)
 
 
 # -------------------------------------------------------------------------
@@ -2644,7 +2657,7 @@ def main(options, args, parser):
             Reset status to UPDATA_CATALOG_DONE
             So following work can continue
             """
-            _gp_expand.statusLogger.set_status('UPDATE_CATALOG_DONE', 'Reset status forcedly to retry the following work', True)
+            _gp_expand.statusLogger.rewind('UPDATE_CATALOG_DONE', 'Reset status forcedly to retry the following work')
 
             """Redo the following work"""
             _gp_expand.setup_schema()

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -337,7 +337,7 @@ Feature: expand the cluster by adding more segments
         # Temporarily comment the verifys until redistribute is fixed. This allows us to commit a resource to get a dump of the ICW dump for other tests to use
         # Then distribution information from table "public.redistribute" with data in "gptest" is verified against saved data
 
-    @gpexpand_no_mirrors
+    @gpexpand_mirrors
     @gpexpand_rollback
     Scenario: inject a fail and test if rollback is ok
         Given a working directory of the test as '/data/gpdata/gpexpand'
@@ -345,22 +345,20 @@ Feature: expand the cluster by adding more segments
         And the user runs command "rm -rf /data/gpdata/gpexpand/*"
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the database is not running
-        And a cluster is created with no mirrors on "mdw" and "sdw1"
+        And a cluster is created with mirrors on "mdw" and "sdw1"
+        And the user runs gpinitstandby with options " "
         And database "gptest" exists
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "mdw,sdw1"
         And the gp_segment_configuration have been saved
-        And the number of segments have been saved
         And set fault inject "gpexpand rollback test fault injection"
-        And the user runs gpexpand interview to add 1 new segment and 0 new host "ignored.host"
-        When the user runs gpexpand with the latest gpexpand_inputfile without ret code check
+        When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors without ret code check
         Then gpexpand should return a return code of 3
-        And verify that the cluster has 1 new segments
         And run rollback with database "gptest"
         And verify the gp_segment_configuration has been restored
         And unset fault inject
 
-    @gpexpand_no_mirrors
+    @gpexpand_mirrors
     @gpexpand_retry_failing_work_in_phase1_after_releasing_catalog_lock
     Scenario: inject a fail and test if retry is ok
         Given a working directory of the test as '/data/gpdata/gpexpand'
@@ -368,17 +366,15 @@ Feature: expand the cluster by adding more segments
         And the user runs command "rm -rf /data/gpdata/gpexpand/*"
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the database is not running
-        And a cluster is created with no mirrors on "mdw" and "sdw1"
+        And a cluster is created with mirrors on "mdw" and "sdw1"
+        And the user runs gpinitstandby with options " "
         And database "gptest" exists
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "mdw,sdw1"
         And the gp_segment_configuration have been saved
-        And the number of segments have been saved
-        And the user runs gpexpand interview to add 1 new segment and 0 new host "ignored.host"
         And set fault inject "gpexpand retry after releaseing catalog lock fault injection"
-        When the user runs gpexpand with the latest gpexpand_inputfile without ret code check
+        When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors without ret code check
         Then gpexpand should return a return code of 3
         And unset fault inject
-        And verify that the cluster has 1 new segments
-        When the user runs gpexpand with the latest gpexpand_inputfile without ret code check
+        When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors without ret code check
         Then gpexpand should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2163,6 +2163,18 @@ sdw1:sdw1:21503:/tmp/gpexpand_behave/data/mirror/gpseg3:9:3:m"""
     if ret_code != 0:
         raise Exception("gpexpand exited with return code: %d.\nstderr=%s\nstdout=%s" % (ret_code, std_err, std_out))
 
+@when('the user runs gpexpand with a static inputfile for a single-node cluster with mirrors without ret code check')
+def impl(context):
+    inputfile_contents = """sdw1:sdw1:20502:/data/gpdata/gpexpand/data/primary/gpseg2:7:2:p
+sdw1:sdw1:21502:/data/gpdata/gpexpand/data/mirror/gpseg2:8:2:m"""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    inputfile_name = "%s/gpexpand_inputfile_%s" % (context.working_directory, timestamp)
+    with open(inputfile_name, 'w') as fd:
+        fd.write(inputfile_contents)
+
+    gpexpand = Gpexpand(context, working_directory=context.working_directory, database='gptest')
+    gpexpand.initialize_segments()
+
 @given('the master pid has been saved')
 def impl(context):
     data_dir = os.path.join(context.working_directory,


### PR DESCRIPTION
The current progress of gpexpand segment preparation is
1. create template base on master
2. lock catalog
3. build and start new segments
4. update gp_segment_configuration (then new transaction will see new nodes)
5. unlock catalog
6. create schema and table for phase2(data redistribution)

If it fails before step 5, it can be rolled back to original state by running gpexpand with -r.
But if it fails after step5, it can not be rolled back. Because new database/table/schema may be created after unlocking the catalog. And new data may be inserted into new segments.

If it fails in step 6 now, DBA can do nothing. They can not roll back and also can not conitnue to retry the failing work in step 6 without complex manual intervention. So we change the behaviour here, if gpexpand finds that the last expansion didn't complete successfully and can not roll back, it will cleanup the schemas and tables built in step 6 last time and retry the step 6.
