### PR TITLE
Fix COPY FROM to mixed partitioned table with mixed heap/AO partitions.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4022,17 +4022,9 @@ CopyFrom(CopyState cstate)
 			if (resultRelInfo->ri_RelationDesc->rd_att->constr)
 				ExecConstraints(resultRelInfo, slot, estate);
 
-			if (useHeapMultiInsert)
-			{
-				char relstorage = RelinfoGetStorage(resultRelInfo);
-				if (relstorage == RELSTORAGE_AOROWS ||
-					relstorage == RELSTORAGE_AOCOLS ||
-					relstorage == RELSTORAGE_EXTERNAL)
-					useHeapMultiInsert = false;
-			}
-
 			/* OK, store the tuple and create index entries for it */
-			if (useHeapMultiInsert) {
+			if (useHeapMultiInsert && relstorage == RELSTORAGE_HEAP)
+			{
 				HeapTuple	tuple;
 				if (resultRelInfo->nBufferedTuples == 0)
 					firstBufferedLineNo = cstate->cur_lineno;
@@ -4072,7 +4064,9 @@ CopyFrom(CopyState cstate)
 					nTotalBufferedTuples = 0;
 					totalBufferedTuplesSize = 0;
 				}
-			} else {
+			}
+			else
+			{
 				List	   *recheckIndexes = NIL;
 
 				if (relstorage == RELSTORAGE_AOROWS)

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -1330,6 +1330,34 @@ select * from foo_p_1_prt_p2;
 (1 row)
 
 drop table foo_p;
+-- Same as above, but the input is ordered so that the inserts to the heap
+-- partition happen first. Had a bug related flushing the multi-insert
+-- buffers in that scenario at one point.
+-- (https://github.com/greenplum-db/gpdb/issues/6678
+create table mixed_ao_part(distkey int, partkey int)
+with (appendonly=true) distributed by(distkey)
+partition by range(partkey) (
+  partition p1 start(0) end(100) with (appendonly = false),
+   partition p2 start(100) end(199)
+);
+copy mixed_ao_part from stdin;
+select * from mixed_ao_part;
+ distkey | partkey 
+---------+---------
+       1 |      95
+       1 |     100
+       2 |      96
+       2 |     101
+       3 |      97
+       3 |     102
+       4 |      98
+       4 |     103
+       5 |      99
+       5 |     104
+(10 rows)
+
+-- Don't drop the table, so that we leave behind a mixed table in the
+-- regression database for pg_dump/restore testing.
 -- MPP-3283
 CREATE TABLE PARTSUPP (
 PS_PARTKEY INTEGER,

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -1334,6 +1334,34 @@ select * from foo_p_1_prt_p2;
 (1 row)
 
 drop table foo_p;
+-- Same as above, but the input is ordered so that the inserts to the heap
+-- partition happen first. Had a bug related flushing the multi-insert
+-- buffers in that scenario at one point.
+-- (https://github.com/greenplum-db/gpdb/issues/6678
+create table mixed_ao_part(distkey int, partkey int)
+with (appendonly=true) distributed by(distkey)
+partition by range(partkey) (
+  partition p1 start(0) end(100) with (appendonly = false),
+   partition p2 start(100) end(199)
+);
+copy mixed_ao_part from stdin;
+select * from mixed_ao_part;
+ distkey | partkey 
+---------+---------
+       1 |      95
+       1 |     100
+       2 |      96
+       2 |     101
+       3 |      97
+       3 |     102
+       4 |      98
+       4 |     103
+       5 |      99
+       5 |     104
+(10 rows)
+
+-- Don't drop the table, so that we leave behind a mixed table in the
+-- regression database for pg_dump/restore testing.
 -- MPP-3283
 CREATE TABLE PARTSUPP (
 PS_PARTKEY INTEGER,


### PR DESCRIPTION
We cleared the local 'useHeapMultiInsert' variable, as soon as we saw
at least one AO partition, even if we had already buffered tuples for
a heap partition earlier. As a result, we didn't flush the multi-insert
buffer at the end of the COPY.

Fixes https://github.com/greenplum-db/gpdb/issues/6678
