### PR TITLE
resgroup: provide an API to get resgroup id of my proc.

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -932,6 +932,27 @@ ResGroupIsAssigned(void)
 	return selfIsAssigned();
 }
 
+/*
+ * Get resource group id of my proc.
+ *
+ * Returns InvalidOid in any of below cases:
+ * - resource group is not enabled;
+ * - resource group is not activated (initialized);
+ * - my proc is not running inside a transaction;
+ * - my proc is not assigned a resource group yet;
+ *
+ * Otherwise a valid resource group id is returned.
+ *
+ * This function is not dead code although there is no consumer in the gpdb
+ * code tree.  Some extensions require this to get the internal resource group
+ * information.
+ */
+Oid
+GetMyResGroupId(void)
+{
+	return self->groupId;
+}
+
 int32
 ResGroupGetVmemLimitChunks(void)
 {

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -168,6 +168,15 @@ extern void ResGroupCreateOnAbort(const ResourceGroupCallbackContext *callbackCt
 extern void ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx);
 extern void ResGroupCheckForDrop(Oid groupId, char *name);
 
+/*
+ * Get resource group id of my proc.
+ *
+ * This function is not dead code although there is no consumer in the gpdb
+ * code tree.  Some extensions require this to get the internal resource group
+ * information.
+ */
+extern Oid GetMyResGroupId(void);
+
 extern int32 ResGroupGetVmemLimitChunks(void);
 extern int32 ResGroupGetVmemChunkSizeInBits(void);
 extern int32 ResGroupGetMaxChunksPerQuery(void);


### PR DESCRIPTION
Resource group id of my proc is stored in a local variable accessible
only in resgroup.c, but this information can also be interested in other
contexts, so an API `GetMyResGroupId()` is provided to get this
information.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
