### PR TITLE
Remove GPDB_94_STABLE_MERGE_FIXME

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10184,14 +10184,6 @@ xlog_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribut
 		 * users of the nextOid counter are required to avoid assignment of
 		 * duplicates, so that a somewhat out-of-date value should be safe.
 		 */
-		/*
-		 * GPDB_94_MERGE_FIXME: PG 94 STABLE removed similar code for nextOid.
-		 * Do we need to do that for gpdb specific nextRelfilenode also?
-		 */
-		LWLockAcquire(OidGenLock, LW_EXCLUSIVE);
-		ShmemVariableCache->nextRelfilenode = checkPoint.nextRelfilenode;
-		ShmemVariableCache->relfilenodeCount = 0;
-		LWLockRelease(OidGenLock);
 
 		/* Handle multixact */
 		MultiXactAdvanceNextMXact(checkPoint.nextMulti,


### PR DESCRIPTION
When we ignore the nextOid counter in an ONLINE checkpoint, can also
remove nextRelfilenode, even if there is a collision about same
relfilenode, the logic in calling GpCheckRelFileCollision, would
choose another different relfilenode, should be no harm

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
