### PR TITLE
Updates readme to include library used by default configuration.

### DIFF
--- a/README.ubuntu.bash
+++ b/README.ubuntu.bash
@@ -25,6 +25,7 @@ apt-get install -y \
   libxerces-c-dev \
   libxml2-dev \
   libyaml-dev \
+  libzstd-dev \
   locales \
   net-tools \
   ninja-build \


### PR DESCRIPTION
Z standard is now enabled by default, unless explicitly disabled during configure.