### PR TITLE
docs - replicated tables don't support updatable cursors

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/DECLARE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DECLARE.xml
@@ -147,7 +147,8 @@
         with the <codeph>CLOSE</codeph> command.</p>
       <p>Scrollable cursors are not currently supported in Greenplum Database. You can only use
           <codeph>FETCH</codeph> to move the cursor position forward, not backwards.</p>
-      <p><codeph>DECLARE...FOR UPDATE</codeph> is not supported with append-optimized tables.</p>
+      <p><codeph>DECLARE...FOR UPDATE</codeph> is not supported with append-optimized tables or
+        replicated tables.</p>
       <p>You can see all available cursors by querying the <codeph>pg_cursors</codeph> system view.
       </p>
     </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
@@ -26,6 +26,8 @@
                 the specific circumstances. </p>
             <p>If the <codeph>WHERE CURRENT OF</codeph> clause is specified, the row that is deleted
                 is the one most recently fetched from the specified cursor. </p>
+            <p>The <codeph>WHERE CURRENT OF</codeph> clause is not supported with replicated
+                tables.</p>
             <p>The optional <codeph>RETURNING</codeph> clause causes <codeph>DELETE</codeph> to
                 compute and return value(s) based on each row actually deleted. Any expression using
                 the table's columns, and/or columns of other tables mentioned in

--- a/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
@@ -27,6 +27,7 @@
         clause. Which technique is more appropriate depends on the specific circumstances. </p>
       <p>If the <codeph>WHERE CURRENT OF</codeph> clause is specified, the row that is updated is
         the one most recently fetched from the specified cursor. </p>
+      <p>The <codeph>WHERE CURRENT OF</codeph> clause is not supported with replicated tables.</p>
       <p>You must have the <codeph>UPDATE</codeph> privilege on the table, or at least on the column(s) that are listed to be updated. You must also have
         the <codeph>SELECT</codeph> privilege on any column whose values are read in the <varname>expression</varname>s
         or <varname>condition</varname>.</p>


### PR DESCRIPTION
Adds a simple disclaimer to the DECLARE, UPDATE, and DELETE reference pages. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
