### PR TITLE
Set client_encoding to SQL_ASCII in QD->QE connections.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -23,6 +23,7 @@
 #include "utils/memutils.h"
 #include "libpq/libpq.h"
 #include "libpq/libpq-be.h"
+#include "libpq/pqformat.h"
 
 #include "cdb/cdbconn.h"		/* me */
 #include "cdb/cdbutil.h"		/* CdbComponentDatabaseInfo */
@@ -33,6 +34,8 @@ int			gp_segment_connect_timeout = 180;
 
 static uint32 cdbconn_get_motion_listener_port(PGconn *conn);
 static void cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc);
+
+static void MPPnoticeReceiver(void *arg, const PGresult *res);
 
 static const char *
 transStatusToString(PGTransactionStatusType status)
@@ -60,180 +63,6 @@ transStatusToString(PGTransactionStatusType status)
 			Assert(false);
 	}
 	return ret;
-}
-
-static void
-MPPnoticeReceiver(void *arg, const PGresult *res)
-{
-	PQExpBufferData msgbuf;
-	PGMessageField *pfield;
-	int			elevel = INFO;
-	char	   *sqlstate = "00000";
-	char	   *severity = "WARNING";
-	char	   *file = "";
-	char	   *line = NULL;
-	char	   *func = "";
-	char		message[1024];
-	char	   *detail = NULL;
-	char	   *hint = NULL;
-	char	   *context = NULL;
-
-	SegmentDatabaseDescriptor *segdbDesc = (SegmentDatabaseDescriptor *) arg;
-
-	if (!res)
-		return;
-
-	strcpy(message, "missing error text");
-
-	for (pfield = res->errFields; pfield != NULL; pfield = pfield->next)
-	{
-		switch (pfield->code)
-		{
-			case PG_DIAG_SEVERITY:
-				severity = pfield->contents;
-				if (strcmp(pfield->contents, "WARNING") == 0)
-					elevel = WARNING;
-				else if (strcmp(pfield->contents, "NOTICE") == 0)
-					elevel = NOTICE;
-				else if (strcmp(pfield->contents, "DEBUG1") == 0 ||
-						 strcmp(pfield->contents, "DEBUG") == 0)
-					elevel = DEBUG1;
-				else if (strcmp(pfield->contents, "DEBUG2") == 0)
-					elevel = DEBUG2;
-				else if (strcmp(pfield->contents, "DEBUG3") == 0)
-					elevel = DEBUG3;
-				else if (strcmp(pfield->contents, "DEBUG4") == 0)
-					elevel = DEBUG4;
-				else if (strcmp(pfield->contents, "DEBUG5") == 0)
-					elevel = DEBUG5;
-				else
-					elevel = INFO;
-				break;
-			case PG_DIAG_SQLSTATE:
-				sqlstate = pfield->contents;
-				break;
-			case PG_DIAG_MESSAGE_PRIMARY:
-				strncpy(message, pfield->contents, 800);
-				message[800] = '\0';
-				if (segdbDesc && segdbDesc->whoami && strlen(segdbDesc->whoami) < 200)
-				{
-					strcat(message, "  (");
-					strcat(message, segdbDesc->whoami);
-					strcat(message, ")");
-				}
-				break;
-			case PG_DIAG_MESSAGE_DETAIL:
-				detail = pfield->contents;
-				break;
-			case PG_DIAG_MESSAGE_HINT:
-				hint = pfield->contents;
-				break;
-			case PG_DIAG_STATEMENT_POSITION:
-			case PG_DIAG_INTERNAL_POSITION:
-			case PG_DIAG_INTERNAL_QUERY:
-				break;
-			case PG_DIAG_CONTEXT:
-				context = pfield->contents;
-				break;
-			case PG_DIAG_SOURCE_FILE:
-				file = pfield->contents;
-				break;
-			case PG_DIAG_SOURCE_LINE:
-				line = pfield->contents;
-				break;
-			case PG_DIAG_SOURCE_FUNCTION:
-				func = pfield->contents;
-				break;
-			case PG_DIAG_GP_PROCESS_TAG:
-				break;
-			default:
-				break;
-
-		}
-	}
-
-	if (elevel < client_min_messages && elevel != INFO)
-		return;
-
-	/*
-	 * We use PQExpBufferData instead of StringInfoData because the former
-	 * uses malloc, the latter palloc. We are in a thread, and we CANNOT use
-	 * palloc since it's not thread safe.  We cannot call elog or ereport
-	 * either for the same reason.
-	 */
-	initPQExpBuffer(&msgbuf);
-
-
-	if (PG_PROTOCOL_MAJOR(FrontendProtocol) >= 3)
-	{
-		/* New style with separate fields */
-
-		appendPQExpBufferChar(&msgbuf, PG_DIAG_SEVERITY);
-		appendBinaryPQExpBuffer(&msgbuf, severity, strlen(severity) + 1);
-
-		appendPQExpBufferChar(&msgbuf, PG_DIAG_SQLSTATE);
-		appendBinaryPQExpBuffer(&msgbuf, sqlstate, strlen(sqlstate) + 1);
-
-		/* M field is required per protocol, so always send something */
-		appendPQExpBufferChar(&msgbuf, PG_DIAG_MESSAGE_PRIMARY);
-		appendBinaryPQExpBuffer(&msgbuf, message, strlen(message) + 1);
-
-		if (detail)
-		{
-			appendPQExpBufferChar(&msgbuf, PG_DIAG_MESSAGE_DETAIL);
-			appendBinaryPQExpBuffer(&msgbuf, detail, strlen(detail) + 1);
-		}
-
-		if (hint)
-		{
-			appendPQExpBufferChar(&msgbuf, PG_DIAG_MESSAGE_HINT);
-			appendBinaryPQExpBuffer(&msgbuf, hint, strlen(hint) + 1);
-		}
-
-		if (context)
-		{
-			appendPQExpBufferChar(&msgbuf, PG_DIAG_CONTEXT);
-			appendBinaryPQExpBuffer(&msgbuf, context, strlen(context) + 1);
-		}
-
-		if (file)
-		{
-			appendPQExpBufferChar(&msgbuf, PG_DIAG_SOURCE_FILE);
-			appendBinaryPQExpBuffer(&msgbuf, file, strlen(file) + 1);
-		}
-
-		if (line)
-		{
-			appendPQExpBufferChar(&msgbuf, PG_DIAG_SOURCE_LINE);
-			appendBinaryPQExpBuffer(&msgbuf, line, strlen(line) + 1);
-		}
-
-		if (func)
-		{
-			appendPQExpBufferChar(&msgbuf, PG_DIAG_SOURCE_FUNCTION);
-			appendBinaryPQExpBuffer(&msgbuf, func, strlen(func) + 1);
-		}
-
-	}
-	else
-	{
-
-		appendPQExpBuffer(&msgbuf, "%s:  ", severity);
-
-		appendBinaryPQExpBuffer(&msgbuf, message, strlen(message));
-
-		appendPQExpBufferChar(&msgbuf, '\n');
-		appendPQExpBufferChar(&msgbuf, '\0');
-
-	}
-
-	appendPQExpBufferChar(&msgbuf, '\0');	/* terminator */
-
-	pq_putmessage('N', msgbuf.data, msgbuf.len);
-
-	termPQExpBuffer(&msgbuf);
-
-	pq_flush();
 }
 
 /* Initialize a QE connection descriptor in CdbComponentsContext */
@@ -346,7 +175,7 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 	keywords[nkeywords] = "dbname";
 	if(MyProcPort && MyProcPort->database_name)
 	{
-		values[nkeywords] = MyProcPort->database_name;	
+		values[nkeywords] = MyProcPort->database_name;
 	}
 	else
 	{
@@ -357,6 +186,22 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 		Assert(MyDatabaseId != InvalidOid);
 		values[nkeywords] = get_database_name(MyDatabaseId);
 	}
+	nkeywords++;
+
+	/*
+	 * Set the client encoding to match database encoding in QD->QE
+	 * connections.  All the strings dispatched from QD to be in the database
+	 * encoding, and all strings sent back to the QD will also be in the
+	 * database encoding.
+	 *
+	 * Most things don't pay attention to client_encoding in QE processes:
+	 * query results are normally sent back via the interconnect, and the 'M'
+	 * type QD->QE messages, used to dispatch queries, don't perform encoding
+	 * conversion.  But some things, like error messages, and internal
+	 * commands dispatched directly with CdbDispatchCommand, do care.
+	 */
+	keywords[nkeywords] = "client_encoding";
+	values[nkeywords] = GetDatabaseEncodingName();
 	nkeywords++;
 
 	keywords[nkeywords] = "user";
@@ -599,4 +444,365 @@ cdbconn_get_motion_listener_port(PGconn *conn)
 		return 0;
 
 	return result;
+}
+
+
+/*-------------------------------------------------------------------------
+ * QE Notice receiver support
+ *
+ * When a QE process emits a NOTICE (or WARNING, INFO, etc.) message, it
+ * needs to be delivered to the user. To do that, we install a libpq Notice
+ * receiver callback to every QD->QE connection.
+ *
+ * The callback is very limited in what it can do, so it cannot directly
+ * forward the Notice to the user->QD connection. Instead, it queues the
+ * Notices as a list of QENotice structs. Later, when we are out of of the
+ * callback, forwardQENotices() sends the queued Notices to the client.
+ *-------------------------------------------------------------------------
+ */
+
+typedef struct QENotice QENotice;
+struct QENotice
+{
+	QENotice   *next;
+
+	int			elevel;
+	char		sqlstate[6];
+	char		severity[10];
+	char	   *file;
+	char		line[10];
+	char	   *func;
+	char	   *message;
+	char	   *detail;
+	char	   *hint;
+	char	   *context;
+
+	char		buf[];
+};
+
+static QENotice *qeNotices_head = NULL;
+static QENotice *qeNotices_tail = NULL;
+
+/*
+ * libpq Notice receiver callback.
+ *
+ * NB: This is a callback, so we are very limited in what we can do. In
+ * particular, we must not call ereport() or elog(), which might longjmp()
+ * out of the callback. Libpq might get confused by that. That also means
+ * that we cannot call palloc()!
+ *
+ * A QENotice struct is created for each incoming Notice, and put in a
+ * queue for later processing. The QENotices are allocatd with good old
+ * malloc()!
+ */
+static void
+MPPnoticeReceiver(void *arg, const PGresult *res)
+{
+	PGMessageField *pfield;
+	int			elevel = INFO;
+	char	   *sqlstate = "00000";
+	char	   *severity = "WARNING";
+	char	   *file = "";
+	char	   *line = NULL;
+	char	   *func = "";
+	char		message[1024];
+	char	   *detail = NULL;
+	char	   *hint = NULL;
+	char	   *context = NULL;
+
+	SegmentDatabaseDescriptor *segdbDesc = (SegmentDatabaseDescriptor *) arg;
+
+	if (!res)
+		return;
+
+	strcpy(message, "missing error text");
+
+	for (pfield = res->errFields; pfield != NULL; pfield = pfield->next)
+	{
+		switch (pfield->code)
+		{
+			case PG_DIAG_SEVERITY:
+				severity = pfield->contents;
+				if (strcmp(pfield->contents, "WARNING") == 0)
+					elevel = WARNING;
+				else if (strcmp(pfield->contents, "NOTICE") == 0)
+					elevel = NOTICE;
+				else if (strcmp(pfield->contents, "DEBUG1") == 0 ||
+						 strcmp(pfield->contents, "DEBUG") == 0)
+					elevel = DEBUG1;
+				else if (strcmp(pfield->contents, "DEBUG2") == 0)
+					elevel = DEBUG2;
+				else if (strcmp(pfield->contents, "DEBUG3") == 0)
+					elevel = DEBUG3;
+				else if (strcmp(pfield->contents, "DEBUG4") == 0)
+					elevel = DEBUG4;
+				else if (strcmp(pfield->contents, "DEBUG5") == 0)
+					elevel = DEBUG5;
+				else
+					elevel = INFO;
+				break;
+			case PG_DIAG_SQLSTATE:
+				sqlstate = pfield->contents;
+				break;
+			case PG_DIAG_MESSAGE_PRIMARY:
+				strncpy(message, pfield->contents, 800);
+				message[800] = '\0';
+				if (segdbDesc && segdbDesc->whoami && strlen(segdbDesc->whoami) < 200)
+				{
+					strcat(message, "  (");
+					strcat(message, segdbDesc->whoami);
+					strcat(message, ")");
+				}
+				break;
+			case PG_DIAG_MESSAGE_DETAIL:
+				detail = pfield->contents;
+				break;
+			case PG_DIAG_MESSAGE_HINT:
+				hint = pfield->contents;
+				break;
+			case PG_DIAG_STATEMENT_POSITION:
+			case PG_DIAG_INTERNAL_POSITION:
+			case PG_DIAG_INTERNAL_QUERY:
+				break;
+			case PG_DIAG_CONTEXT:
+				context = pfield->contents;
+				break;
+			case PG_DIAG_SOURCE_FILE:
+				file = pfield->contents;
+				break;
+			case PG_DIAG_SOURCE_LINE:
+				line = pfield->contents;
+				break;
+			case PG_DIAG_SOURCE_FUNCTION:
+				func = pfield->contents;
+				break;
+			case PG_DIAG_GP_PROCESS_TAG:
+				break;
+			default:
+				break;
+
+		}
+	}
+
+	/*
+	 * If this message is filtered out by client_min_messages, we have nothing
+	 * to do. (The QE shouldn't have sent it to us in the first place...)
+	 */
+	if (elevel >= client_min_messages || elevel == INFO)
+	{
+		QENotice   *notice;
+		uint64		size;
+		char	   *bufptr;
+		int			file_len;
+		int			func_len;
+		int			message_len;
+		int			detail_len;
+		int			hint_len;
+		int			context_len;
+
+		/*
+		 * We use malloc(), because we are in a libpq callback, and we CANNOT
+		 * use palloc(). We allocate space for the QENotice and the strings in
+		 * a single malloc() call.
+		 */
+
+		/*
+		 * First, compute the required size of the allocation.
+		 */
+
+/* helper macro for computing the total allocation size */
+#define SIZE_VARLEN_FIELD(fldname) \
+		if (fldname) \
+		{ \
+			fldname##_len = strlen(fldname) + 1; \
+			size += fldname##_len; \
+		} \
+		else \
+			fldname##_len = 0
+
+		size = offsetof(QENotice, buf);
+		SIZE_VARLEN_FIELD(file);
+		SIZE_VARLEN_FIELD(func);
+		SIZE_VARLEN_FIELD(message);
+		SIZE_VARLEN_FIELD(detail);
+		SIZE_VARLEN_FIELD(hint);
+		SIZE_VARLEN_FIELD(context);
+
+		/*
+		 * Perform the allocation.  Put a limit on the max size, as a sanity
+		 * check.  (The libpq protocol itself limits the size the message can
+		 * be, but better safe than sorry.)
+		 *
+		 * We can't ereport() if this fails, so we just drop the notice to
+		 * the floor. Hope it wasn't important...
+		 */
+		if (size >= MaxAllocSize)
+			return;
+
+		notice = malloc(size);
+		if (!notice)
+			return;
+
+		/*
+		 * Allocation succeeded.  Now fill in the struct.
+		 */
+		bufptr = notice->buf;
+
+#define COPY_VARLEN_FIELD(fldname) \
+		if (fldname) \
+		{ \
+			notice->fldname = bufptr; \
+			memcpy(bufptr, fldname, fldname##_len); \
+			bufptr += fldname##_len; \
+		} \
+		else \
+			notice->fldname = NULL
+
+		notice->elevel = elevel;
+		strlcpy(notice->sqlstate, sqlstate, sizeof(notice->sqlstate));
+		strlcpy(notice->severity, severity, sizeof(notice->severity));
+		COPY_VARLEN_FIELD(file);
+		strlcpy(notice->line, line, sizeof(notice->line));
+		COPY_VARLEN_FIELD(func);
+		COPY_VARLEN_FIELD(message);
+		COPY_VARLEN_FIELD(detail);
+		COPY_VARLEN_FIELD(hint);
+		COPY_VARLEN_FIELD(context);
+
+		Assert(bufptr - (char *) notice == size);
+
+		/* Link it to the queue */
+		notice->next = NULL;
+		if (qeNotices_tail)
+		{
+			qeNotices_tail->next = notice;
+			qeNotices_tail = notice;
+		}
+		else
+			qeNotices_tail = qeNotices_head = notice;
+	}
+}
+
+/*
+ * Send all Notices to the client, that we have accumulated from QEs since last
+ * call.
+ *
+ * This should be called after every libpq call that might read from the QD->QE
+ * connection, so that the notices are sent to the user in a timely fashion.
+ */
+void
+forwardQENotices(void)
+{
+	while (qeNotices_head)
+	{
+		QENotice *notice;;
+		StringInfoData msgbuf;
+
+		notice = qeNotices_head;
+
+		/*
+		 * Unlink it first, so that if something goes wrong in sending it to
+		 * the client, we don't get stuck in a loop trying to send the same
+		 * message again and again.
+		 */
+		qeNotices_head = notice->next;
+		if (qeNotices_head == NULL)
+			qeNotices_tail = NULL;
+
+		/*
+		 * Use PG_TRY() - PG_CATCH() to make sure we free the struct, no
+		 * matter what.
+		 */
+		PG_TRY();
+		{
+			/* 'N' (Notice) is for nonfatal conditions, 'E' is for errors */
+			pq_beginmessage(&msgbuf, 'N');
+
+			if (PG_PROTOCOL_MAJOR(FrontendProtocol) >= 3)
+			{
+				/* New style with separate fields */
+				pq_sendbyte(&msgbuf, PG_DIAG_SEVERITY);
+				pq_sendstring(&msgbuf, notice->severity);
+
+				pq_sendbyte(&msgbuf, PG_DIAG_SQLSTATE);
+				pq_sendstring(&msgbuf, notice->sqlstate);
+
+				/* M field is required per protocol, so always send something */
+				pq_sendbyte(&msgbuf, PG_DIAG_MESSAGE_PRIMARY);
+				pq_sendstring(&msgbuf, notice->message);
+
+				if (notice->detail)
+				{
+					pq_sendbyte(&msgbuf, PG_DIAG_MESSAGE_DETAIL);
+					pq_sendstring(&msgbuf, notice->detail);
+				}
+
+				if (notice->hint)
+				{
+					pq_sendbyte(&msgbuf, PG_DIAG_MESSAGE_HINT);
+					pq_sendstring(&msgbuf, notice->hint);
+				}
+
+				if (notice->context)
+				{
+					pq_sendbyte(&msgbuf, PG_DIAG_CONTEXT);
+					pq_sendstring(&msgbuf, notice->context);
+				}
+
+				if (notice->file)
+				{
+					pq_sendbyte(&msgbuf, PG_DIAG_SOURCE_FILE);
+					pq_sendstring(&msgbuf, notice->file);
+				}
+
+				if (notice->line)
+				{
+					pq_sendbyte(&msgbuf,PG_DIAG_SOURCE_LINE);
+					pq_sendstring(&msgbuf, notice->line);
+				}
+
+				if (notice->func)
+				{
+					pq_sendbyte(&msgbuf, PG_DIAG_SOURCE_FUNCTION);
+					pq_sendstring(&msgbuf, notice->func);
+				}
+
+				pq_sendbyte(&msgbuf, '\0');		/* terminator */
+			}
+			else
+			{
+				/* Old style --- gin up a backwards-compatible message */
+				StringInfoData buf;
+
+				initStringInfo(&buf);
+
+				appendStringInfo(&buf, "%s:  ", notice->severity);
+
+				if (notice->func)
+					appendStringInfo(&buf, "%s: ", notice->func);
+
+				if (notice->message)
+					appendStringInfoString(&buf, notice->message);
+				else
+					appendStringInfoString(&buf, _("missing error text"));
+
+				appendStringInfoChar(&buf, '\n');
+
+				pq_sendstring(&msgbuf, buf.data);
+
+				pfree(buf.data);
+			}
+
+			pq_endmessage(&msgbuf);
+			free(notice);
+		}
+		PG_CATCH();
+		{
+			free(notice);
+			PG_RE_THROW();
+		}
+		PG_END_TRY();
+	}
+
+	pq_flush();
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -579,6 +579,8 @@ dispatchCommand(CdbDispatchResult *dispatchResult,
 						dispatchResult->segdbDesc->whoami, msg ? msg : "unknown error")));
 	}
 
+	forwardQENotices();
+
 	if (DEBUG1 >= log_min_messages)
 	{
 		TimestampDifference(beforeSend, GetCurrentTimestamp(), &secs, &usecs);
@@ -639,6 +641,7 @@ handlePollError(CdbDispatchCmdAsync *pParms)
 			dispatchResult->stillRunning = false;
 		}
 	}
+	forwardQENotices();
 
 	return;
 }
@@ -852,6 +855,7 @@ processResults(CdbDispatchResult *dispatchResult)
 									   segdbDesc->whoami, msg ? msg : "unknown error");
 		return true;
 	}
+	forwardQENotices();
 
 	/*
 	 * If we have received one or more complete messages, process them.
@@ -862,6 +866,8 @@ processResults(CdbDispatchResult *dispatchResult)
 		PGresult   *pRes;
 		ExecStatusType resultStatus;
 		int			resultIndex;
+
+		forwardQENotices();
 
 		/*
 		 * PQisBusy() does some error handling, which can cause the connection
@@ -979,6 +985,8 @@ processResults(CdbDispatchResult *dispatchResult)
 		}
 	}
 
+	forwardQENotices();
+
 	/*
 	 * If there was nextval request then respond back on this libpq connection
 	 * with the next value. Check and process nextval message only if QD has not
@@ -1022,6 +1030,8 @@ processResults(CdbDispatchResult *dispatchResult)
 	}
 	if (nextval)
 		PQfreemem(nextval);
+
+	forwardQENotices();
 
 	return false;				/* we must keep on monitoring this socket */
 }

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -56,6 +56,7 @@
 #include "access/fileam.h"
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbaocsam.h"
+#include "cdb/cdbconn.h"
 #include "cdb/cdbcopy.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
@@ -2648,7 +2649,8 @@ CopyToDispatch(CopyState cstate)
 
 		cdbCopyStart(cdbCopy, stmt,
 					 RelationBuildPartitionDesc(cstate->rel, false),
-					 NIL);
+					 NIL,
+					 cstate->file_encoding);
 
 		if (cstate->binary)
 		{
@@ -3741,7 +3743,7 @@ CopyFrom(CopyState cstate)
 		elog(DEBUG5, "COPY command sent to segdbs");
 
 		cdbCopyStart(cdbCopy, glob_copystmt,
-					 estate->es_result_partitions, cstate->ao_segnos);
+					 estate->es_result_partitions, cstate->ao_segnos, cstate->file_encoding);
 
 		/*
 		 * Skip header processing if dummy file get from master for COPY FROM ON

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7392,6 +7392,13 @@ DispatchSetPGVariable(const char *name, List *args, bool is_local)
 	if (Gp_role != GP_ROLE_DISPATCH || IsBootstrapProcessingMode())
 		return;
 
+	/*
+	 * client_encoding is always kept at SQL_ASCII in QE processes. (See also
+	 * cdbconn_doConnectStart().)
+	 */
+	if (strcmp(name, "client_encoding") == 0)
+		return;
+
 	initStringInfo( &buffer );
 
 	if (args == NIL)

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -100,4 +100,7 @@ void cdbconn_setQEIdentifier(SegmentDatabaseDescriptor *segdbDesc, int sliceInde
  * (not necessarily received by the target process).
  */
 bool cdbconn_signalQE(SegmentDatabaseDescriptor *segdbDesc, char *errbuf, bool isCancel);
+
+extern void forwardQENotices(void);
+
 #endif   /* CDBCONN_H */

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -44,7 +44,7 @@ typedef struct CdbCopy
 /* global function declarations */
 extern CdbCopy *makeCdbCopy(bool copy_in);
 extern void cdbCopyStart(CdbCopy *cdbCopy, CopyStmt *stmt,
-			 PartitionNode *partitions, List *ao_segnos);
+			 PartitionNode *partitions, List *ao_segnos, int file_encoding);
 extern void cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes);
 extern void cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer, int nbytes);
 extern bool cdbCopyGetData(CdbCopy *c, bool cancel, uint64 *rows_processed);

--- a/src/test/mb/expected/sjis.out
+++ b/src/test/mb/expected/sjis.out
@@ -91,3 +91,7 @@ copy 計算機用語 to stdout;
 コンピュータディスプレイ	機A01上	\N
 コンピュータグラフィックス	分B10中	\N
 コンピュータプログラマー	人Z01下	\N
+-- start_ignore
+-- The end. (This comment is needed, so that gpdiff.pl recognizes the end of
+-- COPY output).
+-- end_ignore

--- a/src/test/mb/mbregress.sh
+++ b/src/test/mb/mbregress.sh
@@ -49,9 +49,9 @@ do
 		EXPECTED="expected/${i}.out"
 	fi
 
-	if [ `gpdiff.pl ${EXPECTED} results/${i}.out | wc -l` -ne 0 ]
+	if [ `gpdiff.pl -I GP_IGNORE: ${EXPECTED} results/${i}.out | wc -l` -ne 0 ]
 	then
-		( diff -C3 ${EXPECTED} results/${i}.out; \
+		( gpdiff.pl -I GP_IGNORE: -C3 ${EXPECTED} results/${i}.out; \
 		echo "";  \
 		echo "----------------------"; \
 		echo "" ) >> regression.diffs

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -1362,7 +1362,7 @@ sub atmsort_bigloop
             #  copy test1 to stdout
             #  \copy test1 to stdout
             my $matches_copy_to_stdout = 0;
-            if ($ini =~ m/^(?:\\)?copy\s+(?:(?:\(select.*\))|\w+)\s+to stdout.*$/i)
+            if ($ini =~ m/^(?:\\)?copy\s+(?:(?:\(select.*\))|\S+)\s+to stdout.*$/i)
             {
                 $matches_copy_to_stdout = 1;
             }

--- a/src/test/regress/expected/dispatch_encoding.out
+++ b/src/test/regress/expected/dispatch_encoding.out
@@ -1,0 +1,42 @@
+-- More tests related to dispatching and QD->QE communication.
+--
+-- Test that error messages come out correctly, with non-default
+-- client_encoding. (This test assumes that the regression database does
+-- *not* use latin1, otherwise this doesn't test anything interesting.)
+--
+set client_encoding='utf8';
+create function raise_notice(t text) returns void as $$
+begin
+  raise notice 'raise_notice called on "%"', t;
+end;
+$$ language plpgsql;
+create function raise_error(t text) returns void as $$
+begin
+  raise 'raise_error called on "%"', t;
+end;
+$$ language plpgsql;
+create table enctest(t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Unicode code point 196 is "Latin Capital Letter a with Diaeresis".
+insert into enctest values ('funny char ' || chr(196));
+select raise_notice(t) from enctest;
+NOTICE:  raise_notice called on "funny char Ã„"  (seg2 slice1 127.0.0.1:40002 pid=30772)
+ raise_notice 
+--------------
+ 
+(1 row)
+
+select raise_error(t) from enctest;
+ERROR:  raise_error called on "funny char Ã„"  (seg2 slice1 127.0.0.1:40002 pid=30772)
+-- now do it again with latin1
+set client_encoding='latin1';
+select raise_notice(t) from enctest;
+NOTICE:  raise_notice called on "funny char Ä"  (seg2 slice1 127.0.0.1:40002 pid=30772)
+ raise_notice 
+--------------
+ 
+(1 row)
+
+select raise_error(t) from enctest;
+ERROR:  raise_error called on "funny char Ä"  (seg2 slice1 127.0.0.1:40002 pid=30772)

--- a/src/test/regress/expected/gpcopy_encoding.out
+++ b/src/test/regress/expected/gpcopy_encoding.out
@@ -1,0 +1,67 @@
+--
+-- Test different combinations of client and server encodings with COPY.
+--
+CREATE DATABASE utf8db ENCODING 'utf8' TEMPLATE=template0 LC_COLLATE='C' LC_CTYPE='C';
+CREATE DATABASE latin1db ENCODING 'latin1' TEMPLATE=template0 LC_COLLATE='C' LC_CTYPE='C';
+-- First, connect to the UTF-8 database, and use COPY TO with non-ASCII data.
+-- Use both explicit ENCODING, and client_encoding, to specify the output
+-- encoding.
+\c utf8db
+set client_encoding='utf8';
+CREATE TABLE enctest (t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into enctest values (chr(196)); -- Latin Capital Letter a with Diaeresis
+-- with UTF-8 as the server encoding, it should be stored as two bytes.
+select octet_length(t) from enctest;
+ octet_length 
+--------------
+            2
+(1 row)
+
+copy enctest to '/tmp/enctest_utf_to_latin1-1' encoding 'latin1';
+set client_encoding='latin1';
+copy enctest to stdout;
+�
+copy enctest to '/tmp/enctest_utf_to_latin1-2';
+-- Connect to 'latin1' database, and load back the files we just created.
+-- This is to check that they were created correctly, and that the ENCODING
+-- option works correctly also in COPY FROM.
+\c latin1db
+CREATE TABLE enctest (t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set client_encoding='latin1';
+copy enctest from '/tmp/enctest_utf_to_latin1-1';
+copy enctest from '/tmp/enctest_utf_to_latin1-2';
+set client_encoding='utf8';
+copy enctest from '/tmp/enctest_utf_to_latin1-1' encoding 'latin1';
+copy enctest from '/tmp/enctest_utf_to_latin1-2' encoding 'latin1';
+-- with latin1 as the server encoding, the character we used in the tests should be
+-- stored as one byte.
+select octet_length(t) from enctest;
+ octet_length 
+--------------
+            1
+            1
+            1
+            1
+(4 rows)
+
+select * from enctest;
+ t 
+---
+ Ä
+ Ä
+ Ä
+ Ä
+(4 rows)
+
+copy enctest to stdout;
+Ä
+Ä
+Ä
+Ä
+\c regression
+drop database utf8db;
+drop database latin1db;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -23,7 +23,7 @@ test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parame
 test: spi_processed64bit
 test: python_processed64bit
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table gp_create_view window_views namespace_gp
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp
 
 # GPDB_94_MERGE_FIXME: explain_format test was dropped for below group. It's
 # failing without asserts but passing with asserts. Need investigation for the
@@ -33,7 +33,7 @@ test: filter gpctas gpdist matrix toast sublink table_functions olap_setup compl
 # bitmap_index triggers recovery, run it seperately
 test: bitmap_index
 test: gp_dump_query_oids analyze gp_owner_permission incremental_analyze
-test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules
+test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules dispatch_encoding
 # dispatch should always run seperately from other cases.
 test: dispatch
 

--- a/src/test/regress/sql/dispatch_encoding.sql
+++ b/src/test/regress/sql/dispatch_encoding.sql
@@ -1,0 +1,33 @@
+-- More tests related to dispatching and QD->QE communication.
+
+--
+-- Test that error messages come out correctly, with non-default
+-- client_encoding. (This test assumes that the regression database does
+-- *not* use latin1, otherwise this doesn't test anything interesting.)
+--
+set client_encoding='utf8';
+
+create function raise_notice(t text) returns void as $$
+begin
+  raise notice 'raise_notice called on "%"', t;
+end;
+$$ language plpgsql;
+
+create function raise_error(t text) returns void as $$
+begin
+  raise 'raise_error called on "%"', t;
+end;
+$$ language plpgsql;
+
+create table enctest(t text);
+-- Unicode code point 196 is "Latin Capital Letter a with Diaeresis".
+insert into enctest values ('funny char ' || chr(196));
+
+select raise_notice(t) from enctest;
+select raise_error(t) from enctest;
+
+-- now do it again with latin1
+set client_encoding='latin1';
+
+select raise_notice(t) from enctest;
+select raise_error(t) from enctest;

--- a/src/test/regress/sql/gpcopy_encoding.sql
+++ b/src/test/regress/sql/gpcopy_encoding.sql
@@ -1,0 +1,48 @@
+--
+-- Test different combinations of client and server encodings with COPY.
+--
+CREATE DATABASE utf8db ENCODING 'utf8' TEMPLATE=template0 LC_COLLATE='C' LC_CTYPE='C';
+CREATE DATABASE latin1db ENCODING 'latin1' TEMPLATE=template0 LC_COLLATE='C' LC_CTYPE='C';
+
+-- First, connect to the UTF-8 database, and use COPY TO with non-ASCII data.
+-- Use both explicit ENCODING, and client_encoding, to specify the output
+-- encoding.
+\c utf8db
+set client_encoding='utf8';
+CREATE TABLE enctest (t text);
+insert into enctest values (chr(196)); -- Latin Capital Letter a with Diaeresis
+
+-- with UTF-8 as the server encoding, it should be stored as two bytes.
+select octet_length(t) from enctest;
+
+copy enctest to '/tmp/enctest_utf_to_latin1-1' encoding 'latin1';
+
+set client_encoding='latin1';
+copy enctest to stdout;
+copy enctest to '/tmp/enctest_utf_to_latin1-2';
+
+-- Connect to 'latin1' database, and load back the files we just created.
+-- This is to check that they were created correctly, and that the ENCODING
+-- option works correctly also in COPY FROM.
+\c latin1db
+CREATE TABLE enctest (t text);
+
+set client_encoding='latin1';
+copy enctest from '/tmp/enctest_utf_to_latin1-1';
+copy enctest from '/tmp/enctest_utf_to_latin1-2';
+
+set client_encoding='utf8';
+
+copy enctest from '/tmp/enctest_utf_to_latin1-1' encoding 'latin1';
+copy enctest from '/tmp/enctest_utf_to_latin1-2' encoding 'latin1';
+
+-- with latin1 as the server encoding, the character we used in the tests should be
+-- stored as one byte.
+select octet_length(t) from enctest;
+
+select * from enctest;
+copy enctest to stdout;
+
+\c regression
+drop database utf8db;
+drop database latin1db;


### PR DESCRIPTION
QE processes largely don't care about client_encoding, because query
results are sent through the interconnect, except for a few internal
commands, and the query text is presumed to already be in the database
encoding, in QD->QE messages.

But there were a couple of cases where it mattered. Error messages
generated in QEs were being converted to client_encoding, but QD assumed
that they were in server encoding.

Now that the QEs don't know the user's client_encoding, COPY TO needs
changes. In COPY TO, the QEs are responsible for forming the rows in the
final cilent_encoding, so the QD now needs to explicitly use the COPY's
ENCODING option, when it dispatches the COPY to QEs.

The COPY TO handling wasn't quite right, even before this patch. It showed
up as regression failure in the src/test/mb/mbregress.sh 'sjis' test. When
client_encoding was set with the PGCLIENTENCODING, however, it wasn't set
correctly in the QEs, which showed up as incorrectly encoded COPY output.
Now that we always set it to SQL_ASCII in QEs, that's moot.

While we're at it, change the mbregress test so that it's not sensitive to
row orderings. And make atmsort.pm more lenient, to recognize "COPY
<tablename> TO STDOUT", even when the tablename contains non-ascii
characters. These changes were needed to make the src/test/mb/ tests passcleanly.

Fixes https://github.com/greenplum-db/gpdb/issues/5241.

Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/WPmHXuU9T94/gvpNOE73FwAJ
