### PR TITLE
pg_rewind: Update tests to create separate datadirs for each test

### DIFF
--- a/src/bin/pg_rewind/Makefile
+++ b/src/bin/pg_rewind/Makefile
@@ -52,7 +52,7 @@ uninstall:
 
 clean distclean maintainer-clean:
 	rm -f pg_rewind$(X) $(OBJS) xlogreader.c
-	rm -rf tmp_check
+	rm -rf tmp_check_local tmp_check_remote
 
 # GPDB_95_MERGE_FIXME: 9.4 version of tests were used instead of 9.5 since 9.5
 # once have dependency on common TAP framework functions which are not yet

--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -39,8 +39,8 @@ export PATH
 
 # Adjust these paths for your environment
 TESTROOT=$PWD/tmp_check_$TEST_SUITE
-TEST_MASTER=$TESTROOT/data_master
-TEST_STANDBY=$TESTROOT/data_standby
+TEST_MASTER=$TESTROOT/$TESTNAME/data_master
+TEST_STANDBY=$TESTROOT/$TESTNAME/data_standby
 
 # Create the root folder for test data
 mkdir -p $TESTROOT

--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -42,6 +42,17 @@ TESTROOT=$PWD/tmp_check_$TEST_SUITE
 TEST_MASTER=$TESTROOT/$TESTNAME/data_master
 TEST_STANDBY=$TESTROOT/$TESTNAME/data_standby
 
+# Remove data dirs from previous passing tests. Only retain the ones that
+# failed. We parse regression.out to determine which previous tests directories
+# can be deleted. Unfortunately this has the effect of leaving the last test
+# untouched. We could check the last test inside the Makefile if we wish to.
+if [ -f regression.out ]; then
+	PASSED_TEST=`tail -2 regression.out | grep -w "ok" | cut -d " " -f2`
+	if [ ! -z $PASSED_TEST ]; then
+		rm -rf $TESTROOT/$PASSED_TEST
+	fi
+fi
+
 # Create the root folder for test data
 mkdir -p $TESTROOT
 

--- a/src/bin/pg_rewind/sql/pg_xlog_symlink.sql
+++ b/src/bin/pg_rewind/sql/pg_xlog_symlink.sql
@@ -13,7 +13,7 @@ TESTNAME=pg_xlog_symlink
 # Change location of pg_xlog and symlink to new location
 function before_master
 {
-	TEST_XLOG=$TESTROOT/pg_xlog
+	TEST_XLOG=$TESTROOT/$TESTNAME/pg_xlog
 	rm -rf $TEST_XLOG
 	mkdir $TEST_XLOG
 	cp -r $TEST_MASTER/pg_xlog/* $TEST_XLOG/


### PR DESCRIPTION
This is a quick patch to keep around datadirs of failing pg_rewind tests.  Prior to this, the test deleted and recreated the tmp_check_* directory for each running test. This would lead to loosing the datadir for the failing test if it wasn't the last one. This commit, creates a unique directory specific to each test.