### PR TITLE
Create replication slot on mirror promotion via FTS

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -16823,7 +16823,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         <indexterm>
          <primary>pg_create_physical_replication_slot</primary>
         </indexterm>
-        <literal><function>pg_create_physical_replication_slot(<parameter>slot_name</parameter> <type>name</type>)</function></literal>
+        <literal><function>pg_create_physical_replication_slot(<parameter>slot_name</parameter> <type>name</type><optional>, <parameter>immediately_reserve</> <type>boolean</> </optional>)</function></literal>
        </entry>
        <entry>
         (<parameter>slot_name</parameter> <type>name</type>, <parameter>xlog_position</parameter> <type>pg_lsn</type>)
@@ -16833,7 +16833,11 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         <parameter>slot_name</parameter>. Streaming changes from a physical slot
         is only possible with the streaming-replication protocol - see <xref
         linkend="protocol-replication">. Corresponds to the replication protocol
-        command <literal>CREATE_REPLICATION_SLOT ... PHYSICAL</literal>.
+        command <literal>CREATE_REPLICATION_SLOT ... PHYSICAL</literal>. The optional
+        second parameter,  when <literal>true</>, specifies that the <acronym>LSN</>
+        for this replication slot be reserved immediately; the <acronym<LSN</>
+        is otherwise reserved on first connection from a streaming replication
+        client.
        </entry>
       </row>
       <row>

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -426,7 +426,7 @@ class SegmentRewind(Command):
         # Build the pg_rewind command. Do not run pg_rewind if recovery.conf
         # file exists in target data directory because the target instance can
         # be started up normally as a mirror for WAL replication catch up.
-        rewind_cmd = '[ -f %s/recovery.conf ] || PGOPTIONS="-c gp_session_role=utility" $GPHOME/bin/pg_rewind --write-recovery-conf --source-server="%s" --target-pgdata=%s' % (target_datadir, source_server, target_datadir)
+        rewind_cmd = '[ -f %s/recovery.conf ] || PGOPTIONS="-c gp_session_role=utility" $GPHOME/bin/pg_rewind --write-recovery-conf --slot="internal_wal_replication_slot" --source-server="%s" --target-pgdata=%s' % (target_datadir, source_server, target_datadir)
 
         if verbose:
             rewind_cmd = rewind_cmd + ' --progress'

--- a/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
+++ b/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
@@ -1,6 +1,13 @@
 Feature: Replication Slots
 
-  Scenario: A new cluster setup
+  Scenario: Lifecycle of cluster's replication slots
     Given I have a machine with no cluster
     When I create a cluster
     Then the primaries and mirrors should be replicating using replication slots
+
+    Given a preferred primary has failed
+    When primary and mirror switch to non-preferred roles
+    Then the primaries and mirrors should be replicating using replication slots
+
+    When the user runs "gprecoverseg -ra"
+    Then gprecoverseg should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
@@ -5,8 +5,12 @@ from behave import given, when, then
 from test.behave_utils.utils import (
     stop_database,
     run_command,
+    stop_primary,
+    trigger_fts_probe,
+    run_gprecoverseg,
     execute_sql
 )
+
 
 def create_cluster(context):
     cmd = """
@@ -28,24 +32,52 @@ def create_cluster(context):
         raise Exception('%s' % context.error_message)
 
 
+def ensure_primary_mirror_switched_roles():
+    results = execute_sql(
+        "postgres",
+        "select * from gp_segment_configuration where preferred_role <> role"
+    )
+
+    if results.rowcount != 2:
+        raise Exception("expected 2 segments to not be in preferred roles")
+
+
 @given(u'I have a machine with no cluster')
 def step_impl(context):
     stop_database(context)
+
 
 @when(u'I create a cluster')
 def step_impl(context):
     create_cluster(context)
 
+
 @then(u'the primaries and mirrors should be replicating using replication slots')
 def step_impl(context):
-    results = execute_sql(
+    result_cursor = execute_sql(
         "postgres",
-        "select pg_get_replication_slots() from gp_dist_random('gp_id')"
+        "select pg_get_replication_slots() from gp_dist_random('gp_id') order by gp_segment_id"
     )
 
-    if results.rowcount != 3:
+    if result_cursor.rowcount != 3:
         raise Exception("expected all three primaries to have replication slots")
 
-    for result in results.fetchall():
+    for content_id, result in enumerate(result_cursor.fetchall()):
         if not result[0].startswith('(internal_wal_replication_slot,,physical,,t,'):
-            raise Exception("expected replication slot to be active")
+            raise Exception(
+                "expected replication slot to be active for content id %d, got %s" %
+                (content_id, result[0])
+            )
+
+
+@given(u'a preferred primary has failed')
+def step_impl(context):
+    stop_primary(context, 0)
+
+
+@when('primary and mirror switch to non-preferred roles')
+def step_impl(context):
+    trigger_fts_probe()
+    run_gprecoverseg()
+
+    ensure_primary_mirror_switched_roles()

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -189,6 +189,24 @@ def stop_database(context):
     if context.exception:
         raise context.exception
 
+def stop_primary(context, content_id):
+    get_psegment_sql = 'select datadir, hostname from gp_segment_configuration where content=%i and role=\'p\';' % content_id
+    with dbconn.connect(dbconn.DbURL(dbname='template1')) as conn:
+        cur = dbconn.execSQL(conn, get_psegment_sql)
+        rows = cur.fetchall()
+        seg_data_dir = rows[0][0]
+        seg_host = rows[0][1]
+    pid = get_pid_for_segment(seg_data_dir, seg_host)
+    kill_process(pid)
+
+
+def trigger_fts_probe():
+    run_cmd('psql -c "select gp_request_fts_probe_scan()" postgres')
+
+
+def run_gprecoverseg():
+    run_cmd('gprecoverseg -a -v')
+
 
 def getRows(dbname, exec_sql):
     with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -1357,6 +1357,13 @@ LANGUAGE INTERNAL
 VOLATILE ROWS 1000 COST 1000
 AS 'pg_logical_slot_peek_binary_changes';
 
+CREATE OR REPLACE FUNCTION pg_create_physical_replication_slot(
+    IN slot_name name, IN immediately_reserve boolean DEFAULT false,
+    OUT slot_name name, OUT xlog_position pg_lsn)
+RETURNS RECORD
+LANGUAGE INTERNAL
+AS 'pg_create_physical_replication_slot';
+
 CREATE OR REPLACE FUNCTION
   make_interval(years int4 DEFAULT 0, months int4 DEFAULT 0, weeks int4 DEFAULT 0,
                 days int4 DEFAULT 0, hours int4 DEFAULT 0, mins int4 DEFAULT 0,

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -14,7 +14,8 @@ ftsmessagehandler.t: \
     $(MOCK_DIR)/backend/libpq/pqcomm_mock.o \
     $(MOCK_DIR)/backend/tcop/dest_mock.o \
     $(MOCK_DIR)/backend/postmaster/postmaster_mock.o \
-    $(MOCK_DIR)/backend/access/transam/xlog_mock.o
+    $(MOCK_DIR)/backend/access/transam/xlog_mock.o \
+    $(MOCK_DIR)/backend/replication/slot_mock.o
 
 ftsprobe.t: \
     $(MOCK_DIR)/backend/fts/fts_mock.o \

--- a/src/backend/replication/logical/logical.c
+++ b/src/backend/replication/logical/logical.c
@@ -258,52 +258,7 @@ CreateInitDecodingContext(char *plugin,
 	NameStr(slot->data.plugin)[NAMEDATALEN - 1] = '\0';
 	SpinLockRelease(&slot->mutex);
 
-	/*
-	 * The replication slot mechanism is used to prevent removal of required
-	 * WAL. As there is no interlock between this and checkpoints required WAL
-	 * could be removed before ReplicationSlotsComputeRequiredLSN() has been
-	 * called to prevent that. In the very unlikely case that this happens
-	 * we'll just retry.
-	 */
-	while (true)
-	{
-		XLogSegNo	segno;
-
-		/*
-		 * Let's start with enough information if we can, so log a standby
-		 * snapshot and start decoding at exactly that position.
-		 */
-		if (!RecoveryInProgress())
-		{
-			XLogRecPtr	flushptr;
-
-			/* start at current insert position */
-			slot->data.restart_lsn = GetXLogInsertRecPtr();
-
-			/* make sure we have enough information to start */
-			flushptr = LogStandbySnapshot();
-
-			/* and make sure it's fsynced to disk */
-			XLogFlush(flushptr);
-		}
-		else
-			slot->data.restart_lsn = GetRedoRecPtr();
-
-		/* prevent WAL removal as fast as possible */
-		ReplicationSlotsComputeRequiredLSN();
-
-		/*
-		 * If all required WAL is still there, great, otherwise retry. The
-		 * slot should prevent further removal of WAL, unless there's a
-		 * concurrent ReplicationSlotsComputeRequiredLSN() after we've written
-		 * the new restart_lsn above, so normally we should never need to loop
-		 * more than twice.
-		 */
-		XLByteToSeg(slot->data.restart_lsn, segno);
-		if (XLogGetLastRemovedSegno() < segno)
-			break;
-	}
-
+	ReplicationSlotReserveWal();
 
 	/* ----
 	 * This is a bit tricky: We need to determine a safe xmin horizon to start

--- a/src/backend/replication/slot.c
+++ b/src/backend/replication/slot.c
@@ -40,6 +40,7 @@
 #include <sys/stat.h>
 
 #include "access/transam.h"
+#include "access/xlog_internal.h"
 #include "common/string.h"
 #include "miscadmin.h"
 #include "replication/slot.h"
@@ -809,6 +810,76 @@ CheckSlotRequirements(void)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("replication slots can only be used if wal_level >= archive")));
+}
+
+/*
+ * Reserve WAL for the currently active slot.
+ *
+ * Compute and set restart_lsn in a manner that's appropriate for the type of
+ * the slot and concurrency safe.
+ */
+void
+ReplicationSlotReserveWal(void)
+{
+	ReplicationSlot *slot = MyReplicationSlot;
+
+	Assert(slot != NULL);
+	Assert(slot->data.restart_lsn == InvalidXLogRecPtr);
+
+	/*
+	 * The replication slot mechanism is used to prevent removal of required
+	 * WAL. As there is no interlock between this routine and checkpoints, WAL
+	 * segments could concurrently be removed when a now stale return value of
+	 * ReplicationSlotsComputeRequiredLSN() is used. In the unlikely case that
+	 * this happens we'll just retry.
+	 */
+	while (true)
+	{
+		XLogSegNo	segno;
+
+		/*
+		 * For logical slots log a standby snapshot and start logical decoding
+		 * at exactly that position. That allows the slot to start up more
+		 * quickly.
+		 *
+		 * That's not needed (or indeed helpful) for physical slots as they'll
+		 * start replay at the last logged checkpoint anyway. Instead return
+		 * the location of the last redo LSN. While that slightly increases
+		 * the chance that we have to retry, it's where a base backup has to
+		 * start replay at.
+		 */
+		if (!RecoveryInProgress() && SlotIsLogical(slot))
+		{
+			XLogRecPtr	flushptr;
+
+			/* start at current insert position */
+			slot->data.restart_lsn = GetXLogInsertRecPtr();
+
+			/* make sure we have enough information to start */
+			flushptr = LogStandbySnapshot();
+
+			/* and make sure it's fsynced to disk */
+			XLogFlush(flushptr);
+		}
+		else
+		{
+			slot->data.restart_lsn = GetRedoRecPtr();
+		}
+
+		/* prevent WAL removal as fast as possible */
+		ReplicationSlotsComputeRequiredLSN();
+
+		/*
+		 * If all required WAL is still there, great, otherwise retry. The
+		 * slot should prevent further removal of WAL, unless there's a
+		 * concurrent ReplicationSlotsComputeRequiredLSN() after we've written
+		 * the new restart_lsn above, so normally we should never need to loop
+		 * more than twice.
+		 */
+		XLByteToSeg(slot->data.restart_lsn, segno);
+		if (XLogGetLastRemovedSegno() < segno)
+			break;
+	}
 }
 
 /*

--- a/src/bin/pg_rewind/fetch.h
+++ b/src/bin/pg_rewind/fetch.h
@@ -43,7 +43,7 @@ extern void copy_executeFileMap(filemap_t *map);
 typedef void (*process_file_callback_t) (const char *path, file_type_t type, size_t size, const char *link_target);
 extern void traverse_datadir(const char *datadir, process_file_callback_t callback);
 
-extern void GenerateRecoveryConf(void);
+extern void GenerateRecoveryConf(char *replication_slot_name);
 extern void WriteRecoveryConf(void);
 
 #endif   /* FETCH_H */

--- a/src/bin/pg_rewind/libpq_fetch.c
+++ b/src/bin/pg_rewind/libpq_fetch.c
@@ -661,7 +661,7 @@ escape_quotes(const char *src)
  * Create a recovery.conf file in memory using a PQExpBuffer
  */
 void
-GenerateRecoveryConf(void)
+GenerateRecoveryConf(char *replication_slot)
 {
 	PQconninfoOption *connOptions;
 	PQconninfoOption *option;
@@ -724,6 +724,13 @@ GenerateRecoveryConf(void)
 	escaped = escape_quotes(conninfo_buf.data);
 	appendPQExpBuffer(recoveryconfcontents, "primary_conninfo = '%s'\n", escaped);
 	free(escaped);
+
+	if (replication_slot)
+	{
+		escaped = escape_quotes(replication_slot);
+		appendPQExpBuffer(recoveryconfcontents, "primary_slot_name = '%s'\n", replication_slot);
+		free(escaped);
+	}
 
 	if (PQExpBufferBroken(recoveryconfcontents) ||
 		PQExpBufferDataBroken(conninfo_buf))

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301812111
+#define CATALOG_VERSION_NO	301901101
 
 #endif

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5100,7 +5100,7 @@ DATA(insert OID = 3473 (  spg_range_quad_leaf_consistent	PGNSP PGUID 12 1 0 0 0 
 DESCR("SP-GiST support for quad tree over range");
 
 /* replication slots */
-DATA(insert OID = 3779 (  pg_create_physical_replication_slot PGNSP PGUID 12 1 0 0 0 f f f f t f v 1 0 2249 "19" "{19,19,3220}" "{i,o,o}" "{slot_name,slot_name,xlog_position}" _null_ pg_create_physical_replication_slot _null_ _null_ _null_ ));
+DATA(insert OID = 3779 (  pg_create_physical_replication_slot PGNSP PGUID 12 1 0 0 0 f f f f f f v 2 0 2249 "19 16" "{19,16,19,3220}" "{i,i,o,o}" "{slot_name,immediately_reserve,slot_name,xlog_position}" _null_ pg_create_physical_replication_slot _null_ _null_ _null_ ));
 DESCR("create a physical replication slot");
 DATA(insert OID = 3780 (  pg_drop_replication_slot PGNSP PGUID 12 1 0 0 0 f f f f t f v 1 0 2278 "19" _null_ _null_ _null_ _null_ pg_drop_replication_slot _null_ _null_ _null_ ));
 DESCR("drop a replication slot");

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -95,6 +95,8 @@ enum probe_transition_e
 /* buffer size for SQL command */
 #define SQL_CMD_BUF_SIZE     1024
 
+#define INTERNAL_WAL_REPLICATION_SLOT_NAME	"internal_wal_replication_slot"
+
 /*
  * STRUCTURES
  */

--- a/src/include/replication/slot.h
+++ b/src/include/replication/slot.h
@@ -125,6 +125,9 @@ typedef struct ReplicationSlot
 	XLogRecPtr	candidate_restart_lsn;
 } ReplicationSlot;
 
+#define SlotIsPhysical(slot) (slot->data.database == InvalidOid)
+#define SlotIsLogical(slot) (slot->data.database != InvalidOid)
+
 /*
  * Shared memory control area for all of replication slots.
  */
@@ -159,6 +162,7 @@ extern void ReplicationSlotMarkDirty(void);
 
 /* misc stuff */
 extern bool ReplicationSlotValidateName(const char *name, int elevel);
+extern void ReplicationSlotReserveWal(void);
 extern void ReplicationSlotsComputeRequiredXmin(bool already_locked);
 extern void ReplicationSlotsComputeRequiredLSN(void);
 extern XLogRecPtr ReplicationSlotsComputeLogicalRestartLSN(void);


### PR DESCRIPTION
- Cherry pick upstream commit "Allow pg_create_physical_replication_slot() to reserve WAL". We need this functionality when creating replication slot on mirror promotion.

- Add --slot option in pg_rewind to add slot to recovery.conf created by pg_rewind

- Create replication slot on mirror promotion via FTS. To "incrementally" recover old primary as a mirror at a later time via pg_rewind, all xlog must be preserved from point of divergence.  Hence, replication slot must be created at promote time. Add logic on FTS promote message to create physical replication slot and also sets the restart_lsn of the slot to start preserving the xlog right away.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
