### PR TITLE
Assign plan_node_id for ModifyTable, MergeAppend

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1937,90 +1937,24 @@ shareinput_walker(SHAREINPUT_MUTATOR f, Node *node, PlannerInfo *root)
 
 typedef struct
 {
+	plan_tree_base_prefix base; /* Required prefix for
+								 * plan_tree_walker/mutator */
 	int			nextPlanId;
-} assign_plannode_id_walker_context;
+} assign_plannode_id_context;
 
-static void
-assign_plannode_id_walker(Node *node, assign_plannode_id_walker_context *ctxt)
+static bool
+assign_plannode_id_walker(Node *node, assign_plannode_id_context *ctxt)
 {
-	Plan	   *plan;
-
 	if (node == NULL)
-		return;
+		return false;
 
-	if (IsA(node, List))
-	{
-		List	   *l = (List *) node;
-		ListCell   *lc;
+	if (is_plan_node(node))
+		((Plan *) node)->plan_node_id = ++ctxt->nextPlanId;
 
-		foreach(lc, l)
-		{
-			Node	   *n = lfirst(lc);
+	if (IsA(node, SubPlan))
+		return false;
 
-			assign_plannode_id_walker(n, ctxt);
-		}
-		return;
-	}
-
-	if (!is_plan_node(node))
-		return;
-
-	plan = (Plan *) node;
-
-	plan->plan_node_id = ++ctxt->nextPlanId;
-
-	if (IsA(node, Append))
-	{
-		ListCell   *cell;
-		Append	   *app = (Append *) node;
-
-		foreach(cell, app->appendplans)
-			assign_plannode_id_walker((Node *) lfirst(cell), ctxt);
-	}
-	else if (IsA(node, MergeAppend))
-	{
-		ListCell *cell;
-		MergeAppend *mapp = (Append *) node;
-
-		foreach(cell, mapp->mergeplans)
-			assign_plannode_id_walker((Node *)lfirst(cell), ctxt);
-	}
-	else if (IsA(node, ModifyTable))
-	{
-		ListCell *cell;
-		ModifyTable *mt = (Sequence *) node;
-
-		foreach(cell, mt->plans)
-			assign_plannode_id_walker((Node *)lfirst(cell), ctxt);
-	}
-	else if (IsA(node, BitmapAnd))
-	{
-		ListCell   *cell;
-		BitmapAnd  *ba = (BitmapAnd *) node;
-
-		foreach(cell, ba->bitmapplans)
-			assign_plannode_id_walker((Node *) lfirst(cell), ctxt);
-	}
-	else if (IsA(node, BitmapOr))
-	{
-		ListCell   *cell;
-		BitmapOr   *bo = (BitmapOr *) node;
-
-		foreach(cell, bo->bitmapplans)
-			assign_plannode_id_walker((Node *) lfirst(cell), ctxt);
-	}
-	else if (IsA(node, SubqueryScan))
-	{
-		SubqueryScan *subqscan = (SubqueryScan *) node;
-
-		assign_plannode_id_walker((Node *) subqscan->subplan, ctxt);
-	}
-	else
-	{
-		assign_plannode_id_walker((Node *) plan->lefttree, ctxt);
-		assign_plannode_id_walker((Node *) plan->righttree, ctxt);
-		assign_plannode_id_walker((Node *) plan->initPlan, ctxt);
-	}
+	return plan_tree_walker(node, assign_plannode_id_walker, ctxt);
 }
 
 /*
@@ -2719,14 +2653,16 @@ apply_shareinput_xslice(Plan *plan, PlannerInfo *root)
 }
 
 /*
- * assign_plannode_id - Assign an id for each plan node.  Used by gpmon.
+ * assign_plannode_id - Assign an id for each plan node.
+ * Used by gpmon and instrument.
  */
 void
 assign_plannode_id(PlannedStmt *stmt)
 {
-	assign_plannode_id_walker_context ctxt;
+	assign_plannode_id_context ctxt;
 	ListCell   *lc;
 
+	ctxt.base.node = (Node *) stmt->planTree;
 	ctxt.nextPlanId = 0;
 
 	assign_plannode_id_walker((Node *) stmt->planTree, &ctxt);

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1977,6 +1977,22 @@ assign_plannode_id_walker(Node *node, assign_plannode_id_walker_context *ctxt)
 		foreach(cell, app->appendplans)
 			assign_plannode_id_walker((Node *) lfirst(cell), ctxt);
 	}
+	else if (IsA(node, MergeAppend))
+	{
+		ListCell *cell;
+		MergeAppend *mapp = (Append *) node;
+
+		foreach(cell, mapp->mergeplans)
+			assign_plannode_id_walker((Node *)lfirst(cell), ctxt);
+	}
+	else if (IsA(node, ModifyTable))
+	{
+		ListCell *cell;
+		ModifyTable *mt = (Sequence *) node;
+
+		foreach(cell, mt->plans)
+			assign_plannode_id_walker((Node *)lfirst(cell), ctxt);
+	}
 	else if (IsA(node, BitmapAnd))
 	{
 		ListCell   *cell;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -488,9 +488,9 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		/*
-		 * Generate a plan node id for each node. Used by gpmon. Note that
-		 * this needs to be the last step of the planning when the structure
-		 * of the plan is final.
+		 * Generate a plan node id for each node. Used by gpmon and instrument.
+		 * Note that this needs to be the last step of the planning when the
+		 * structure of the plan is final.
 		 */
 		assign_plannode_id(result);
 	}

--- a/src/test/isolation2/expected/instr_in_shmem_terminate.out
+++ b/src/test/isolation2/expected/instr_in_shmem_terminate.out
@@ -28,12 +28,10 @@ GRANT
 
 CREATE VIEW gp_instrument_shmem_detail AS WITH all_entries AS ( SELECT C.* FROM __gp_localid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 ) UNION ALL SELECT C.* FROM __gp_masterid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 )) SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples FROM all_entries ORDER BY segid;
 CREATE
-GRANT SELECT ON gp_instrument_shmem_details TO public;
-ERROR:  relation "gp_instrument_shmem_details" does not exist
 
-CREATE TABLE a (id int) DISTRIBUTED BY (id);
+CREATE TABLE a (id int, c char) DISTRIBUTED BY (id);
 CREATE
-INSERT INTO a SELECT * FROM generate_series(1, 50);
+INSERT INTO a SELECT *, 'a' FROM generate_series(1, 50);
 INSERT 50
 SET OPTIMIZER=OFF;
 SET
@@ -41,6 +39,7 @@ ANALYZE a;
 ANALYZE
 -- end_ignore
 
+-- test 1: pg_terminate_backend
 -- only this query in instrument slots, expected 1
 SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
  count 
@@ -75,6 +74,7 @@ SELECT count(*) FROM foo, pg_sleep(2);
  10    
 (1 row)
 
+-- test 2: pg_cancel_backend
 -- Expected result is 1 row, means only current query in instrument slots,
 -- If more than one row returned, means previous test has leaked slots.
 SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
@@ -95,6 +95,91 @@ SELECT pg_cancel_backend(pid, 'test pg_cancel_backend') FROM pg_stat_activity WH
 2<:  <... completed>
 ERROR:  canceling statement due to user request: "test pg_cancel_backend"
 2q: ... <quitting>
+-- end_ignore
+
+-- query backend to ensure no PANIC on postmaster and wait cleanup done
+SELECT count(*) FROM foo, pg_sleep(2);
+ count 
+-------
+ 10    
+(1 row)
+
+-- test 3: DML should expose plan_node_id for whole plan tree
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+ count 
+-------
+ 1     
+(1 row)
+
+-- this query will be cancelled by 'test pg_cancel_backend'
+3&:SET OPTIMIZER TO off;EXPLAIN ANALYZE INSERT INTO QUERY_METRICS.a SELECT *, pg_sleep(1) FROM generate_series(1,10);  <waiting ...>
+
+-- validate plan nodes exist in instrument solts
+SELECT ro, CASE WHEN max(nid) > 2 THEN 'ok' ELSE 'wrong' END isok FROM ( SELECT CASE WHEN segid >= 0 THEN 's' ELSE 'm' END ro, nid FROM gp_instrument_shmem_detail WHERE ssid <> (SELECT setting FROM pg_settings WHERE name = 'gp_session_id')::int AND nid > 0 ) dt GROUP BY (ro) ORDER BY ro;
+ ro | isok 
+----+------
+ m  | ok   
+ s  | ok   
+(2 rows)
+-- cancel the query
+SELECT pg_cancel_backend(pid, 'test DML') FROM pg_stat_activity WHERE query LIKE 'SET OPTIMIZER TO off;EXPLAIN ANALYZE INSERT INTO QUERY_METRICS.a SELECT%' ORDER BY pid LIMIT 1;
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+
+-- start_ignore
+3<:  <... completed>
+ERROR:  canceling statement due to user request: "test DML"
+3q: ... <quitting>
+-- end_ignore
+
+-- query backend to ensure no PANIC on postmaster and wait cleanup done
+SELECT count(*) FROM foo, pg_sleep(2);
+ count 
+-------
+ 10    
+(1 row)
+
+-- test 4: Merge Append should expose plan_node_id for whole plan tree
+CREATE TABLE QUERY_METRICS.mergeappend_test (a int, b int, x int) DISTRIBUTED BY (a,b);
+CREATE
+INSERT INTO QUERY_METRICS.mergeappend_test SELECT g/100, g/100, g FROM generate_series(1, 500) g;
+INSERT 500
+ANALYZE QUERY_METRICS.mergeappend_test;
+ANALYZE
+
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+ count 
+-------
+ 1     
+(1 row)
+
+-- this query will be cancelled by 'test pg_cancel_backend'
+4&:SET OPTIMIZER TO off;SELECT a, b, array_dims(array_agg(x)) FROM QUERY_METRICS.mergeappend_test r GROUP BY a, b UNION ALL SELECT NULL, NULL, array_dims(array_agg(x)) FROM QUERY_METRICS.mergeappend_test r, pg_sleep(10) ORDER BY 1,2;  <waiting ...>
+
+-- validate plan nodes exist in instrument solts
+SELECT ro, CASE WHEN max(nid) > 5 THEN 'ok' ELSE 'wrong' END isok FROM ( SELECT CASE WHEN segid >= 0 THEN 's' ELSE 'm' END ro, nid FROM gp_instrument_shmem_detail WHERE ssid <> (SELECT setting FROM pg_settings WHERE name = 'gp_session_id')::int AND nid > 0 ) dt GROUP BY (ro) ORDER BY ro;
+ ro | isok 
+----+------
+ m  | ok   
+ s  | ok   
+(2 rows)
+-- cancel the query
+SELECT pg_cancel_backend(pid, 'test MergeAppend') FROM pg_stat_activity WHERE query LIKE 'SET OPTIMIZER TO off;SELECT a, b, array_dims(array_agg(x)) FROM QUERY_METRICS.mergeappend_test%' ORDER BY pid LIMIT 1;
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+
+-- start_ignore
+4<:  <... completed>
+ERROR:  canceling statement due to user request: "test MergeAppend"
+4q: ... <quitting>
 -- end_ignore
 
 -- query backend to ensure no PANIC on postmaster and wait cleanup done


### PR DESCRIPTION
Before this fix, plan.plan_node_id is not populated for ModifyTable and MergeAppend.
As a result, these plan nodes and children do not have a correct instrumentation record for external monitoring agent.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
