### PR TITLE
Remove GPDB_93_MERGE_FIXME

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -81,13 +81,6 @@
 
 extern uint32 bootstrap_data_checksum_version;
 
-/* File path names (all relative to $PGDATA) */
-#define RECOVERY_COMMAND_FILE	"recovery.conf"
-#define RECOVERY_COMMAND_DONE	"recovery.done"
-#define PROMOTE_SIGNAL_FILE		"promote"
-#define FALLBACK_PROMOTE_SIGNAL_FILE "fallback_promote"
-
-
 /* User-settable parameters */
 int			CheckPointSegments = 3;
 int			wal_keep_segments = 0;

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -274,19 +274,6 @@ HandleFtsWalRepProbe(void)
 			/* Syncrep is enabled now, so respond accordingly. */
 			response.IsSyncRepEnabled = true;
 		}
-
-		/*
-		 * Precautionary action: Unlink PROMOTE_SIGNAL_FILE if incase it
-		 * exists. This is to avoid driving to any incorrect conclusions when
-		 * this segment starts acting as mirror or gets copied over using
-		 * pg_basebackup.
-		 */
-		// GPDB_93_MERGE_FIXME: should we check for FALLBACK_PROMOTE_SIGNAL_FILE, too?
-		if (CheckPromoteSignal())
-		{
-			unlink(PROMOTE_SIGNAL_FILE);
-			elog(LOG, "found and hence deleted '%s' file", PROMOTE_SIGNAL_FILE);
-		}
 	}
 
 	/*

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -80,7 +80,6 @@ test_HandleFtsWalRepProbePrimary(void **state)
 	will_be_called(GetMirrorStatus);
 
 	will_be_called(SetSyncStandbysDefined);
-	will_be_called(CheckPromoteSignal);
 
 	/* SyncRep should be enabled as soon as we found mirror is up. */
 	mockresponse.IsSyncRepEnabled = true;

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -304,6 +304,7 @@ extern CheckpointStatsData CheckpointStats;
 #define RECOVERY_COMMAND_FILE	"recovery.conf"
 #define RECOVERY_COMMAND_DONE	"recovery.done"
 #define PROMOTE_SIGNAL_FILE "promote"
+#define FALLBACK_PROMOTE_SIGNAL_FILE "fallback_promote"
 
 extern XLogRecPtr XLogInsert(RmgrId rmid, uint8 info, XLogRecData *rdata);
 extern XLogRecPtr XLogInsert_OverrideXid(RmgrId rmid, uint8 info, XLogRecData *rdata, TransactionId overrideXid);


### PR DESCRIPTION
Unlink PROMOTE_SIGNAL_FILE and FALLBACK_PROMOTE_SIGNAL_FILE both,
to avoid driving to any incorrect conclusions when this segment
starts acting as mirror or gets copied over using pg_basebackup.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
