### PR TITLE
Adjust cdb_restore_agent to use bash as default shell

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_restore_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_restore_agent.c
@@ -803,10 +803,10 @@ main(int argc, char **argv)
 			 */
 			setpgid(newpid, newpid);
 
-			execl("/bin/sh", "sh", "-c", pszCmdLine->data, NULL);
+			execl("/bin/bash", "bash", "-c", pszCmdLine->data, NULL);
 
 			mpp_err_msg(logInfo, progname, "Error in gp_restore_agent - execl of %s with Command Line %s failed",
-						"/bin/sh", pszCmdLine->data);
+						"/bin/bash", pszCmdLine->data);
 
 			_exit(127);
 		}


### PR DESCRIPTION
This change should not affect the rhel/centos/sles platforms because
/bin/sh is already symlinked to /bin/bash. This change will affect the
Ubuntu platform. On Ubuntu, /bin/bash is symlinked to /bin/dash (a shell
that in this case, we do not want to use).

Co-authored-by: Jason Vigil <jvigil@pivotal.io>
Co-authored-by: Fei Yang <fyang@pivotal.io>