### PR TITLE
Declare cursor for update should handle replicated table too

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -3081,7 +3081,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			{
 				RelOptInfo *brel = root->simple_rel_array[rc->rti];
 
-				if (GpPolicyIsPartitioned(brel->cdbpolicy))
+				if (GpPolicyIsPartitioned(brel->cdbpolicy) ||
+					GpPolicyIsReplicated(brel->cdbpolicy))
 				{
 					if (rc->markType == ROW_MARK_EXCLUSIVE)
 						rc->markType = ROW_MARK_TABLE_EXCLUSIVE;

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -656,6 +656,18 @@ DETAIL:  view v_qux depends on table qux column ctid
 HINT:  system columns of replicated table will be exposed to users after altering, resolve dependencies first
 drop view v_qux;
 alter table qux set distributed replicated;
+-- Test cursor for update also works for replicated table
+create table cursor_update (c1 int, c2 int) distributed replicated;
+insert into cursor_update select i, i from generate_series(1, 10) i;
+begin;
+declare c1 cursor for select * from cursor_update order by c2 for update;
+fetch next from c1;
+ c1 | c2 
+----+----
+  1 |  1
+(1 row)
+
+end;
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 4 other objects

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -327,6 +327,14 @@ alter table qux set distributed replicated;
 drop view v_qux;
 alter table qux set distributed replicated;
 
+-- Test cursor for update also works for replicated table
+create table cursor_update (c1 int, c2 int) distributed replicated;
+insert into cursor_update select i, i from generate_series(1, 10) i;
+begin;
+declare c1 cursor for select * from cursor_update order by c2 for update;
+fetch next from c1;
+end;
+
 -- start_ignore
 drop schema rpt cascade;
 -- end_ignore


### PR DESCRIPTION
In 9.0 merge, we add bellow rule for FOR UPDATE:

> select for update will lock the whole table, we do it at addRangeTableEntry.
> The reason is that gpdb is an MPP database, the result tuples may not be on
> the same segment. And for cursor statement, reader gang cannot get Xid to lock
> the tuples, so we didn't add a LockRows node for distributed table to avoid
> it

this rule should also apply to replicated table.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
