### PR TITLE
Bring queryCommandId back to PGPROC for better monitorability

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -721,6 +721,7 @@ gpvars_check_statement_mem(int *newval, void **extra, GucSource source)
 /*
  * increment_command_count
  *	  Increment gp_command_count. If the new command count is 0 or a negative number, reset it to 1.
+ *	  And keep MyProc->queryCommandId synced with gp_command_count.
  */
 void
 increment_command_count()

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -728,9 +728,12 @@ increment_command_count()
 {
 	gp_command_count++;
 	if (gp_command_count <= 0)
-	{
 		gp_command_count = 1;
-	}
+
+	/*
+	 * No need to maintenance MyProc->queryCommandId elsewhere, we guarantee
+	 * they are always synced here.
+	 */
 	MyProc->queryCommandId = gp_command_count;
 }
 

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -731,7 +731,7 @@ increment_command_count()
 		gp_command_count = 1;
 
 	/*
-	 * No need to maintenance MyProc->queryCommandId elsewhere, we guarantee
+	 * No need to maintain MyProc->queryCommandId elsewhere, we guarantee
 	 * they are always synced here.
 	 */
 	MyProc->queryCommandId = gp_command_count;

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -730,6 +730,7 @@ increment_command_count()
 	{
 		gp_command_count = 1;
 	}
+	MyProc->queryCommandId = gp_command_count;
 }
 
 Datum mpp_execution_segment(PG_FUNCTION_ARGS);

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -501,6 +501,8 @@ InitProcess(void)
 	/* Set wait portal (do not check if resource scheduling is enabled) */
 	MyProc->waitPortalId = INVALID_PORTALID;
 
+	MyProc->queryCommandId = -1;
+
 	/* Init gxact */
 	initGxact(MyTmGxact);
 
@@ -667,6 +669,8 @@ InitAuxiliaryProcess(void)
 	 * necessary anymore, but seems like a good idea for cleanliness.)
 	 */
 	PGSemaphoreReset(&MyProc->sem);
+
+	MyProc->queryCommandId = -1;
 
 	/*
 	 * Arrange to clean up at process exit.

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -168,6 +168,12 @@ struct PGPROC
 	 */
 	uint32		combocid_map_count; /* how many entries in the map ? */
 
+	/*
+	 * Current command_id for the running query
+	 * Required by Command Center for monitoring purpose
+	 */
+	int			queryCommandId;
+
 	bool serializableIsoLevel; /* true if proc has serializable isolation level set */
 
 	/*

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -170,7 +170,12 @@ struct PGPROC
 
 	/*
 	 * Current command_id for the running query
-	 * Required by Command Center for monitoring purpose
+	 * This counter is not dead code although there is no consumer in the gpdb
+	 * code tree, it is required by external monitoring infrastructure.
+	 * As a monitoring approach, each query execution is assigned with a unique
+	 * ID. The queryCommandId is part of the ID. Monitoring extension with
+	 * shared memory access can use queryCommandId to map query execution with
+	 * a backend entity to access related metrics information.
 	 */
 	int			queryCommandId;
 


### PR DESCRIPTION
Per discussion in https://github.com/greenplum-db/gpdb/issues/6569, we want to bring back `queryCommandId` to ProcArray.

Although we have a backend private variable `gp_command_count` already, as command center digging into complex monitoring scenarios, we need the aid from ProcArray to help maintain consistency of metrics being collected.

This PR bring `queryCommandId` back, making it always up to date with `gp_command_count `.
Currently, I haven't write any test for this change because the code is pretty straight forward.