### PR TITLE
Generate the correct numsegments for pg_upgrade

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1517,6 +1517,20 @@ getgpsegmentCount(void)
 		numsegments = cdbcomponent_getCdbComponents(true)->total_segments;
 	else if (Gp_role == GP_ROLE_EXECUTE)
 		numsegments = numsegmentsFromQD;
+	/*
+	 * If we are in 'Utility & Binary Upgrade' mode, it must be launched
+	 * by the pg_upgrade, so we give it an correct numsegments to make
+	 * sure the pg_upgrade can run normally.
+	 * Only Utility QD process have the entire information in the
+	 * gp_segment_configuration, so we count the segments count in this
+	 * process.
+	 */
+	else if (Gp_role == GP_ROLE_UTILITY &&
+			 IsBinaryUpgrade &&
+			 GpIdentity.segindex == -1)
+	{
+		numsegments = cdbcomponent_getCdbComponents(true)->total_segments;
+	}
 
 	return numsegments;
 }

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1527,7 +1527,7 @@ getgpsegmentCount(void)
 	 */
 	else if (Gp_role == GP_ROLE_UTILITY &&
 			 IsBinaryUpgrade &&
-			 GpIdentity.segindex == -1)
+			 IS_QUERY_DISPATCHER())
 	{
 		numsegments = cdbcomponent_getCdbComponents(true)->total_segments;
 	}

--- a/src/test/isolation2/expected/upgrade_numsegments.out
+++ b/src/test/isolation2/expected/upgrade_numsegments.out
@@ -1,0 +1,24 @@
+-- This test case is used to test if we can get the correct
+-- numsegments when the connection is in utility mode.
+-- With introducing the numsegments in gp_distribution_policy
+-- pg_upgrade can not run correctly because it is run in
+-- utility mode and the numsegments can not get correctly in
+-- utility mode, now we support to get the numsegments in
+-- utility mode when the connection is running for pg_upgrade.
+-- We can sure that CREATE TABLE command will try to get
+-- numsegments in utility mode, so we use it to test the
+-- function.
+-1U: create temp table t1(c1 int, c2 int);
+CREATE
+0U: create temp table t1(c1 int, c2 int);
+CREATE
+1U: create temp table t1(c1 int, c2 int);
+CREATE
+2U: create temp table t1(c1 int, c2 int);
+CREATE
+-- start_ignore
+-1Uq: ... <quitting>
+0Uq: ... <quitting>
+1Uq: ... <quitting>
+2Uq: ... <quitting>
+-- end_ignore

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -171,3 +171,6 @@ test: reindex/vacuum_while_reindex_ao_bitmap reindex/vacuum_while_reindex_heap_b
 test: cancel_plpython
 
 test: concurrent_update
+
+# Tests for getting numsegments in utility mode
+test: upgrade_numsegments

--- a/src/test/isolation2/sql/upgrade_numsegments.sql
+++ b/src/test/isolation2/sql/upgrade_numsegments.sql
@@ -1,0 +1,20 @@
+-- This test case is used to test if we can get the correct
+-- numsegments when the connection is in utility mode.
+-- With introducing the numsegments in gp_distribution_policy
+-- pg_upgrade can not run correctly because it is run in
+-- utility mode and the numsegments can not get correctly in
+-- utility mode, now we support to get the numsegments in
+-- utility mode when the connection is running for pg_upgrade.
+-- We can sure that CREATE TABLE command will try to get
+-- numsegments in utility mode, so we use it to test the
+-- function.
+-1U: create temp table t1(c1 int, c2 int);
+0U: create temp table t1(c1 int, c2 int);
+1U: create temp table t1(c1 int, c2 int);
+2U: create temp table t1(c1 int, c2 int);
+-- start_ignore
+-1Uq:
+0Uq:
+1Uq:
+2Uq:
+-- end_ignore


### PR DESCRIPTION
pg_upgrade upgrade the database in utility mode, but we can
not get the correct `numsegments` in the utility mode, now
we calculate the segments count by the gp_segment_configuration
when it is a utility QD process, then pg_upgrade can use it.

## Here are some reminders before you submit the pull request
- [  ] Add tests for the change
- [  ] Document changes
- [  ] Communicate in the mailing list if needed
- [  ] Pass `make installcheck`
