### PR TITLE
Check cluster expansion status by numsegments

### DIFF
--- a/contrib/pg_upgrade/check_gp.c
+++ b/contrib/pg_upgrade/check_gp.c
@@ -20,6 +20,7 @@ static void check_external_partition(void);
 static void check_covering_aoindex(void);
 static void check_partition_indexes(void);
 static void check_orphaned_toastrels(void);
+static void check_online_expansion(void);
 
 /*
  *	check_greenplum
@@ -32,10 +33,79 @@ static void check_orphaned_toastrels(void);
 void
 check_greenplum(void)
 {
+	check_online_expansion();
 	check_external_partition();
 	check_covering_aoindex();
 	check_partition_indexes();
 	check_orphaned_toastrels();
+}
+
+/*
+ *	check_online_expansion
+ *
+ *	Check for online expansion status and refuse the upgrade if online
+ *	expansion is in progress.
+ */
+static void
+check_online_expansion(void)
+{
+	bool		expansion = false;
+	int			dbnum;
+
+	/*
+	* Only need to check cluster expansion status in gpdb6 or later.
+	*/
+	if (GET_MAJOR_VERSION(old_cluster.major_version) < 804)
+		return;
+
+	/*
+	* We only need to check the cluster expansion status on master.
+	* In the other hand the status can not be detected correctly on segments.
+	*/
+	if (user_opts.segment_mode == SEGMENT)
+		return;
+
+	prep_status("Checking for online expansion status");
+
+	/* Check if the cluster is in expansion status */
+	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		int			ntups;
+		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	   *conn;
+
+		conn = connectToServer(&old_cluster, active_db->db_name);
+		res = executeQueryOrDie(conn,
+								"SELECT true AS expansion "
+								"FROM gp_distribution_policy d "
+								"JOIN (SELECT count(*) segcount "
+								"      FROM gp_segment_configuration "
+								"      WHERE content >= 0 and role = 'p') s "
+								"ON d.numsegments <> s.segcount "
+								"LIMIT 1;");
+
+		ntups = PQntuples(res);
+
+		if (ntups > 0)
+			expansion = true;
+
+		PQclear(res);
+		PQfinish(conn);
+
+		if (expansion)
+			break;
+	}
+
+	if (expansion)
+	{
+		pg_log(PG_REPORT, "fatal\n");
+		pg_log(PG_FATAL,
+			   "| Your installation is in progress of online expansion,\n"
+			   "| must complete that job before the upgrade.\n\n");
+	}
+	else
+		check_ok();
 }
 
 /*

--- a/contrib/pg_upgrade/check_gp.c
+++ b/contrib/pg_upgrade/check_gp.c
@@ -53,15 +53,15 @@ check_online_expansion(void)
 	int			dbnum;
 
 	/*
-	* Only need to check cluster expansion status in gpdb6 or later.
-	*/
+	 * Only need to check cluster expansion status in gpdb6 or later.
+	 */
 	if (GET_MAJOR_VERSION(old_cluster.major_version) < 804)
 		return;
 
 	/*
-	* We only need to check the cluster expansion status on master.
-	* In the other hand the status can not be detected correctly on segments.
-	*/
+	 * We only need to check the cluster expansion status on master.
+	 * On the other hand the status can not be detected correctly on segments.
+	 */
 	if (user_opts.segment_mode == SEGMENT)
 		return;
 

--- a/contrib/pg_upgrade/check_gp.c
+++ b/contrib/pg_upgrade/check_gp.c
@@ -78,9 +78,9 @@ check_online_expansion(void)
 		conn = connectToServer(&old_cluster, active_db->db_name);
 		res = executeQueryOrDie(conn,
 								"SELECT true AS expansion "
-								"FROM gp_distribution_policy d "
+								"FROM pg_catalog.gp_distribution_policy d "
 								"JOIN (SELECT count(*) segcount "
-								"      FROM gp_segment_configuration "
+								"      FROM pg_catalog.gp_segment_configuration "
 								"      WHERE content >= 0 and role = 'p') s "
 								"ON d.numsegments <> s.segcount "
 								"LIMIT 1;");

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -586,6 +586,9 @@ rollback;
 insert into r1 (c4) values (pg_relation_size('r2'));
 
 -- start_ignore
+-- We need to do a cluster expansion which will check if there are partial
+-- tables, we need to drop the partial tables to keep the cluster expansion
+-- run correctly.
 reset search_path;
 drop schema test_partial_table cascade;
 -- end_ignore

--- a/src/test/regress/sql/partial_table.sql
+++ b/src/test/regress/sql/partial_table.sql
@@ -584,3 +584,8 @@ rollback;
 -- to perform distributed commit on the other segments.
 --
 insert into r1 (c4) values (pg_relation_size('r2'));
+
+-- start_ignore
+reset search_path;
+drop schema test_partial_table cascade;
+-- end_ignore


### PR DESCRIPTION
If the cluster is in expansion mode, then there must be some partial
tables which are not equal between numsegments and cluster size.
Now we check the expansion status by table's numsegments when we run
gpexpand, gpexpand will raise an error if there are partial tables.

## Here are some reminders before you submit the pull request
- [  ] Add tests for the change
- [  ] Document changes
- [  ] Communicate in the mailing list if needed
- [  ] Pass `make installcheck`
