### PR TITLE
Save git root, submodule and changelog information.

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -88,7 +88,7 @@ function git_info() {
 
   "${CWDIR}/git_info.bash" | tee ${GREENPLUM_INSTALL_DIR}/etc/git-info.json
 
-  PREV_TAG=$(git describe --tags --abbrev=0 @^)
+  PREV_TAG=$(git describe --tags --abbrev=0 HEAD^)
 
   cat > ${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt <<-EOF
 	======================================================================
@@ -97,7 +97,7 @@ function git_info() {
 
 	EOF
 
-  git log --abbrev-commit --date=relative "${PREV_TAG}..@" | tee -a ${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt
+  git log --abbrev-commit --date=relative "${PREV_TAG}..HEAD" | tee -a ${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt
 
   popd
 }

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -83,6 +83,25 @@ function build_gppkg() {
   popd
 }
 
+function git_info() {
+  pushd ${GPDB_SRC_PATH}
+
+  "${CWDIR}/git_info.bash" | tee ${GREENPLUM_INSTALL_DIR}/etc/git-info.json
+
+  PREV_TAG=$(git describe --tags --abbrev=0 @^)
+
+  cat > ${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt <<-EOF
+	======================================================================
+	Git log since previous release tag (${PREV_TAG})
+	----------------------------------------------------------------------
+
+	EOF
+
+  git log --abbrev-commit --date=relative "${PREV_TAG}..@" | tee -a ${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt
+
+  popd
+}
+
 function unittest_check_gpdb() {
   pushd ${GPDB_SRC_PATH}
     source ${GREENPLUM_INSTALL_DIR}/greenplum_path.sh
@@ -182,6 +201,7 @@ function _main() {
       # Do not build quicklz support for windows
       build_quicklz
   fi
+  git_info
   build_gppkg
   if [ "${TARGET_OS}" != "win32" ] ; then
       # Don't unit test when cross compiling. Tests don't build because they

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -97,7 +97,7 @@ function git_info() {
 
 	EOF
 
-  git log --abbrev-commit --date=relative "${PREV_TAG}..HEAD" | tee -a ${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt
+  git log --abbrev-commit --date=relative "${PREV_TAG}..HEAD" >> ${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt
 
   popd
 }

--- a/concourse/scripts/git_info.bash
+++ b/concourse/scripts/git_info.bash
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -uo pipefail
+
+# ----------------------------------------------------------------------
+# Check for prerequisite utilities
+# ----------------------------------------------------------------------
+
+PREREQ_COMMANDS="git"
+
+for COMMAND in ${PREREQ_COMMANDS}; do
+    type "${COMMAND}" >/dev/null 2>&1 || { echo >&2 "Required command line utility \"${COMMAND}\" is not available.  Aborting."; exit 1; }
+done
+
+# ----------------------------------------------------------------------
+# Retrieve root URI and commit SHA1
+# ----------------------------------------------------------------------
+
+URI=$( git remote -v | grep "fetch" | grep "origin" | awk '{print $2}' )
+SHA1=$( git rev-parse HEAD )
+
+# ----------------------------------------------------------------------
+# Generate root JSON record
+# ----------------------------------------------------------------------
+
+echo -n "
+{\"root\": {
+  \"uri\": \"${URI}\",
+  \"sha1\": \"${SHA1}\"},
+  \"submodules\": ["
+
+# ----------------------------------------------------------------------
+# Generate submodule records
+# ----------------------------------------------------------------------
+
+submodules=$( git submodule status )
+submodule_count=$( git submodule status | wc -l | tr -d ' ' )
+
+COUNTER=0
+IFS=$'\n'
+
+for line in $submodules; do
+    SOURCE_PATH=$( echo "${line}" | cut -d " " -f3 )
+    SHA1=$( echo "${line}" | cut -d " " -f2 )
+    TAG=$( echo "${line}" | cut -d " " -f4 )
+    COUNTER=$((COUNTER+1))
+
+echo -n "
+     {\"source_path\": \"${SOURCE_PATH}\",
+      \"sha1\": \"${SHA1}\",
+      \"tag\": \"${TAG//[)(]/}\"}"
+
+    if [ "${COUNTER}" != "${submodule_count}" ]; then
+        echo -n ","
+    fi
+done
+
+echo "]}"


### PR DESCRIPTION
This is a cherry pick from 5X_STABLE. The `git-info.json` is useful information during integration testing.

The following information will be saved in
${GREENPLUM_INSTALL_DIR}/etc/git-info.json:

* Root repo (uri, sha1)
* Submodules (submodule source path, sha1, tag)

Save git commits since last release tag into
${GREENPLUM_INSTALL_DIR}/etc/git-current-changelog.txt

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
