### PR TITLE
Re-enable test with database name containing quotes.

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -36,12 +36,8 @@ reset client_min_messages;
 CREATE DATABASE "funny""db'with\\quotes";
 ALTER DATABASE "funny""db'with\\quotes" SET search_path="funny""schema'with\\quotes";
 
--- GPDB_91_MERGE_FIXME: It would be good to leave the database in place, to
--- also test gpcheckcat and pg_upgrade after all the regression tests have
--- completed. As of this writing pg_upgrade does not in fact handle that well.
--- Remove this DROP DATABASE once it's fixed. That should happen when we
--- reach commit a2385cac13, which was backported to PostgreSQL 9.1.
-DROP DATABASE "funny""db'with\\quotes";
+-- Leave the database in place, to also test gpcheckcat and pg_upgrade after
+-- all the regression tests have completed.
 
 -- There used to be a bug in the quoting when the search_path setting was sent
 -- to the segment. It was not easily visible when search_path was set with a

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -58,12 +58,8 @@ DROP DATABASE IF EXISTS "funny""db'with\\quotes";
 reset client_min_messages;
 CREATE DATABASE "funny""db'with\\quotes";
 ALTER DATABASE "funny""db'with\\quotes" SET search_path="funny""schema'with\\quotes";
--- GPDB_91_MERGE_FIXME: It would be good to leave the database in place, to
--- also test gpcheckcat and pg_upgrade after all the regression tests have
--- completed. As of this writing pg_upgrade does not in fact handle that well.
--- Remove this DROP DATABASE once it's fixed. That should happen when we
--- reach commit a2385cac13, which was backported to PostgreSQL 9.1.
-DROP DATABASE "funny""db'with\\quotes";
+-- Leave the database in place, to also test gpcheckcat and pg_upgrade after
+-- all the regression tests have completed.
 -- There used to be a bug in the quoting when the search_path setting was sent
 -- to the segment. It was not easily visible when search_path was set with a
 -- SET command, only when the setting was sent as part of the startup packet.


### PR DESCRIPTION
Since the PostgreSQL 9.4.20 merge, commit 928bca1a30, pg_upgrade can
handle database names that contain quotes correctly. Re-enable test for
it.

Fixes https://github.com/greenplum-db/gpdb/issues/3857
