### PR TITLE
docs - REPEATABLE READ xact mode is supported. 

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -75,9 +75,9 @@
     DISTRIBUTED BY (a);</codeblock>
         </p>
         <p><codeph>UPDATE</codeph> and <codeph>DELETE</codeph> are not allowed on append-optimized
-          tables in a serializable transaction and will cause the transaction to abort.
-            <codeph>CLUSTER</codeph>, <codeph>DECLARE...FOR UPDATE</codeph>, and triggers are not
-          supported with append-optimized tables.</p>
+          tables in a repeatable read  or serizalizable transaction and will cause the transaction
+          to abort. <codeph>CLUSTER</codeph>, <codeph>DECLARE...FOR UPDATE</codeph>, and triggers
+          are not supported with append-optimized tables.</p>
       </section>
     </body>
   </topic>

--- a/gpdb-doc/dita/admin_guide/dml.xml
+++ b/gpdb-doc/dita/admin_guide/dml.xml
@@ -240,9 +240,9 @@
         <li id="ix155584"><codeph>SAVEPOINT</codeph> marks a place in a transaction and enables
           partial rollback. You can roll back commands executed after a savepoint while maintaining
           commands executed before the savepoint.</li>
-        <li id="ix155585"><codeph>ROLLBACK TO SAVEPOINT </codeph>rolls back a transaction to a
+        <li id="ix155585"><codeph>ROLLBACK TO SAVEPOINT</codeph> rolls back a transaction to a
           savepoint. </li>
-        <li id="ix155589"><codeph>RELEASE SAVEPOINT </codeph>destroys a savepoint within a
+        <li id="ix155589"><codeph>RELEASE SAVEPOINT</codeph> destroys a savepoint within a
           transaction.</li>
       </ul>
     </body>
@@ -251,72 +251,76 @@
       <body>
         <p>Greenplum Database accepts the standard SQL transaction levels as follows:</p>
         <ul>
-          <li id="ix153961"><i>read uncommitted</i> and <i>read committed </i> behave like the
-            standard <i>read committed</i></li>
-          <li><i>repeatable read</i> is disallowed. If the behavior of <i>repeatable read</i> is
-            required, use <i>serializable</i>.</li>
-          <li id="ix153971"><i>serializable</i> behaves in a manner similar to SQL standard
-              <i>serializable</i></li>
+          <li id="ix153961"><codeph>READ UNCOMMITTED</codeph> and <codeph>READ COMMITTED</codeph>
+            behave like the standard <codeph>READ COMMITTED</codeph>.</li>
+          <li><codeph>REPEATABLE READ</codeph> and <codeph>SERIALIZABLE</codeph> behave like
+              <codeph>REPEATABLE READ</codeph>.</li>
         </ul>
-        <p>The following information describes the behavior of the Greenplum transaction levels:</p>
-        <ul>
-          <li id="ix153954"><b>read committed/read uncommitted</b> — Provides fast, simple, partial
-            transaction isolation. With read committed and read uncommitted transaction isolation,
-              <codeph>SELECT</codeph>, <codeph>UPDATE</codeph>, and <codeph>DELETE</codeph>
-            transactions operate on a snapshot of the database taken when the query started.</li>
-        </ul>
-        <p> A <codeph>SELECT</codeph> query:</p>
-        <ul>
-          <li id="ix154052">Sees data committed before the query starts.</li>
-          <li id="ix154063">Sees updates executed within the transaction.</li>
-          <li id="ix154073">Does not see uncommitted data outside the transaction.</li>
-          <li id="ix154080">Can possibly see changes that concurrent transactions made if the
-            concurrent transaction is committed after the initial read in its own transaction.</li>
-        </ul>
-        <p>Successive <codeph>SELECT</codeph> queries in the same transaction can see different data
-          if other concurrent transactions commit changes before the queries start.
-            <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> commands find only rows committed
-          before the commands started. </p>
-        <p>Read committed or read uncommitted transaction isolation allows concurrent transactions
-          to modify or lock a row before <codeph>UPDATE</codeph> or <codeph>DELETE</codeph> finds
-          the row. Read committed or read uncommitted transaction isolation may be inadequate for
-          applications that perform complex queries and updates and require a consistent view of the
-          database.</p>
-        <ul>
-          <li id="ix141722"><b>serializable</b> — Provides strict transaction isolation in which
-            transactions execute as if they run one after another rather than concurrently.
-            Applications on the serializable level must be designed to retry transactions in case of
-            serialization failures. In Greenplum Database, <codeph>SERIALIZABLE</codeph> prevents
-            dirty reads, non-repeatable reads, and phantom reads without expensive locking, but
-            there are other interactions that can occur between some <codeph>SERIALIZABLE</codeph>
-            transactions in Greenplum Database that prevent them from being truly serializable.
-            Transactions that run concurrently should be examined to identify interactions that are
-            not prevented by disallowing concurrent updates of the same data. Problems identified
-            can be prevented by using explicit table locks or by requiring the conflicting
-            transactions to update a dummy row introduced to represent the conflict. </li>
-        </ul>
-        <p>A <codeph>SELECT</codeph> query:</p>
-        <ul>
-          <li id="ix154139">Sees a snapshot of the data as of the start of the transaction (not as
-            of the start of the current query within the transaction).</li>
-          <li id="ix155116">Sees only data committed before the query starts.</li>
-          <li id="ix154149">Sees updates executed within the transaction.</li>
-          <li id="ix154156">Does not see uncommitted data outside the transaction.</li>
-          <li id="ix154163">Does not see changes that concurrent transactions made.<p>Successive
-                <codeph>SELECT</codeph> commands within a single transaction always see the same
-              data.</p><p><codeph>UPDATE</codeph>, <codeph>DELETE, SELECT FOR UPDATE,</codeph> and
-                <codeph>SELECT FOR SHARE</codeph> commands find only rows committed before the
-              command started. If a concurrent transaction has already updated, deleted, or locked a
-              target row when the row is found, the serializable or repeatable read transaction
-              waits for the concurrent transaction to update the row, delete the row, or roll
-              back.</p><p>If the concurrent transaction updates or deletes the row, the serializable
-              or repeatable read transaction rolls back. If the concurrent transaction rolls back,
-              then the serializable or repeatable read transaction updates or deletes the
-            row.</p></li>
-        </ul>
-        <p id="ix141505">The default transaction isolation level in Greenplum Database is <i>read
-            committed</i>. To change the isolation level for a transaction, declare the isolation
-          level when you <codeph>BEGIN</codeph> the transaction or use the <codeph>SET
+        <p>The following information describes the behavior of the Greenplum transaction levels.</p>
+        <section>
+          <title>Read Uncommitted and Read Committed</title>
+          <p>Greenplum Database does not allow any command to see an uncommitted update in another
+            concurrent transaction, so <codeph>READ UNCOMMITTED</codeph> behaves the same as
+              <codeph>READ COMMITTED</codeph>. <codeph>READ COMMITTED</codeph> provides fast,
+            simple, partial transaction isolation. <codeph>SELECT</codeph>, <codeph>UPDATE</codeph>,
+            and <codeph>DELETE</codeph> commands operate on a snapshot of the database taken when
+            the query started.</p>
+          <p> A <codeph>SELECT</codeph> query:</p>
+          <ul id="ul_vgl_55p_lgb">
+            <li id="ix154052">Sees data committed before the query starts.</li>
+            <li id="ix154063">Sees updates executed within the transaction.</li>
+            <li id="ix154073">Does not see uncommitted data outside the transaction.</li>
+            <li id="ix154080">Can possibly see changes that concurrent transactions made if the
+              concurrent transaction is committed after the initial read in its own
+              transaction.</li>
+          </ul>
+          <p>Successive <codeph>SELECT</codeph> queries in the same transaction can see different
+            data if other concurrent transactions commit changes between the successive queries.
+              <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> commands find only rows committed
+            before the commands started.</p>
+          <p><codeph>READ COMMITTED</codeph> transaction isolation allows concurrent transactions to
+            modify or lock a row before <codeph>UPDATE</codeph> or <codeph>DELETE</codeph> find the
+            row. <codeph>READ COMMITTED</codeph> transaction isolation may be inadequate for
+            applications that perform complex queries and updates and require a consistent view of
+            the database.</p>
+        </section>
+        <section>
+          <title>Repeatable Read and Serializable</title>
+          <p><codeph>SERIALIZABLE</codeph> transaction isolation, as defined by the SQL standard,
+            ensures that transactions that run concurrently produce the same results as if they were
+            run one after another.  If you specify <codeph>SERIALIZABLE</codeph> Greenplum Database
+            falls back to <codeph>REPEATABLE READ</codeph>. <codeph>REPEATABLE READ</codeph>
+            transactions prevent dirty reads, non-repeatable reads, and phantom reads without
+            expensive locking, but Greenplum Database does not detect all serializability
+            interactions that can occur during concurrent transaction execution. Concurrent
+            transactions should be examined to identify interactions that are not prevented by
+            disallowing concurrent updates of the same data. You can prevent these interactions by
+            using explicit table locks or by requiring the conflicting transactions to update a
+            dummy row introduced to represent the conflict.</p>
+          <p>With <codeph>REPEATABLE READ</codeph> transactions, a <codeph>SELECT</codeph>
+            query:</p>
+          <ul id="ul_mpy_55p_lgb">
+            <li id="ix154139">Sees a snapshot of the data as of the start of the transaction (not as
+              of the start of the current query within the transaction).</li>
+            <li id="ix155116">Sees only data committed before the query starts.</li>
+            <li id="ix154149">Sees updates executed within the transaction.</li>
+            <li id="ix154156">Does not see uncommitted data outside the transaction.</li>
+            <li id="ix154163">Does not see changes that concurrent transactions make.</li>
+            <li>Successive <codeph>SELECT</codeph> commands within a single transaction always see
+              the same data.</li>
+            <li><codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, <codeph>SELECT FOR
+              UPDATE</codeph>, and <codeph>SELECT FOR SHARE</codeph> commands find only rows
+              committed before the command started. If a concurrent transaction has updated,
+              deleted, or locked a target row, the <codeph>REPEATABLE READ</codeph> transaction
+              waits for the concurrent transaction to commit or roll back the change. If the
+              concurrent transaction commits the change, the <codeph>REPEATABLE READ</codeph>
+              transaction rolls back. If the concurrent transaction rolls back its change,
+                the<codeph>REPEATABLE READ</codeph> transaction can commit its changes. </li>
+          </ul>
+        </section>
+        <p id="ix141505">The default transaction isolation level in Greenplum Database is
+            <codeph>READ COMITTED</codeph>. To change the isolation level for a transaction, declare
+          the isolation level when you <codeph>BEGIN</codeph> the transaction or use the <codeph>SET
             TRANSACTION</codeph> command after the transaction starts.</p>
       </body>
     </topic>

--- a/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
@@ -115,7 +115,7 @@
         support, with the phenomena that are allowed when transactions execute concurrently for each
         level. </p>
       <table frame="all" id="table_gxb_qsz_nt">
-        <title>Transaction Isolation Modes</title>
+        <title>SQL Transaction Isolation Modes</title>
         <tgroup cols="4">
           <colspec colname="c1" colnum="1" colwidth="1*"/>
           <colspec colname="c2" colnum="2" colwidth="1*"/>
@@ -157,9 +157,11 @@
           </tbody>
         </tgroup>
       </table>
-      <p>Greenplum Database treats <codeph>READ UNCOMMITTED</codeph> the same as <codeph>READ
-          COMMITTED</codeph> and treats <codeph>SERIALIZABLE</codeph> the same as <codeph>REPEATABLE
-          READ</codeph>.</p>
+      <p>Greenplum Database <codeph>READ UNCOMMITTED</codeph> and <codeph>READ COMMITTED</codeph>
+        isolation modes behave like the SQL standard <codeph>READ COMMITTED</codeph> mode. Greenplum
+        Database <codeph>SERIALIZABLE</codeph> and <codeph>REPEATABLE READ</codeph> isolation modes
+        behave like the SQL standard <codeph>READ COMMITTED</codeph> mode, except that Greenplum
+        Database also prevents phantom reads.</p>
       <p>The difference between <codeph>READ COMMITTED</codeph> and <codeph>REPEATABLE READ</codeph>
         is that with <codeph>READ COMMITTED</codeph>, each statement in a transaction sees only rows
         committed before the <i>statement</i> started, while in <codeph>READ COMMITTED</codeph>
@@ -194,7 +196,7 @@
         anomalies. When potential serialization problems are found, one transaction is allowed to
         commit and others are rolled back and must be retried. </note>
       <p>Greenplum Database transactions that run concurrently should be examined to identify
-        interactions that are not prevented by disallowing concurrent updates of the same data.
+        interactions that may update the same data concurrently.
         Problems identified can be prevented by using explicit table locks or by requiring the
         conflicting transactions to update a dummy row introduced to represent the conflict. </p>
       <p>The SQL <codeph>SET TRANSACTION ISOLATION LEVEL</codeph> statement sets the isolation mode

--- a/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
@@ -111,8 +111,9 @@
           <li><i>Phantom read</i> – a query executed twice in the same transaction can return two
             different sets of rows because another concurrent transaction added rows.</li>
         </ul></p>
-      <p>The SQL standard defines four transaction isolation modes that database systems must
-        support: </p>
+      <p>The SQL standard defines four transaction isolation levels that database systems can
+        support, with the phenomena that are allowed when transactions execute concurrently for each
+        level. </p>
       <table frame="all" id="table_gxb_qsz_nt">
         <title>Transaction Isolation Modes</title>
         <tgroup cols="4">
@@ -156,39 +157,36 @@
           </tbody>
         </tgroup>
       </table>
-      <p>The Greenplum Database SQL commands allow you to request <codeph>READ UNCOMMITTED</codeph>,
-          <codeph>READ COMMITTED</codeph>, or <codeph>SERIALIZABLE</codeph>. Greenplum Database
-        treats <codeph>READ UNCOMMITTED</codeph> the same as <codeph>READ COMMITTED</codeph>.
-        Requesting <codeph>REPEATABLE READ</codeph> produces an error; use
-          <codeph>SERIALIZABLE</codeph> instead. The default isolation mode is <codeph>READ
-          COMMITTED</codeph>. </p>
-      <p>The difference between <codeph>READ COMMITTED</codeph> and <codeph>SERIALIZABLE</codeph> is
-        that in <codeph>READ COMMITTED</codeph> mode, each statement in a transaction sees only rows
-        committed before the <i>statement</i> started, while in <codeph>SERIALIZABLE</codeph> mode,
-        all statements in a transaction see only rows committed before the <i>transaction</i>
-        started. </p>
-      <p>The <codeph>READ COMMITTED</codeph> isolation mode permits greater concurrency and better
-        performance than the <codeph>SERIALIZABLE</codeph> mode. It allows <i>non-repeatable
-          reads</i>, where the values in a row retrieved twice in a transaction can differ because
-        another concurrent transaction has committed changes since the transaction began.
-          <codeph>READ COMMITTED</codeph> mode also permits <i>phantom reads</i>, where a query
-        executed twice in the same transaction can return two different sets of rows.</p>
-      <p>The <codeph>SERIALIZABLE</codeph> isolation mode prevents both non-repeatable reads and
-        phantom reads, but at the cost of concurrency and performance. Each concurrent transaction
-        has a consistent view of the database taken at the beginning of execution. A concurrent
-        transaction that attempts to modify data modified by another transaction is rolled back.
-        Applications that execute transactions in <codeph>SERIALIZABLE</codeph> mode must be
-        prepared to handle transactions that fail due to serialization errors. If
-          <codeph>SERIALIZABLE</codeph> isolation mode is not required by the application, it is
-        better to use <codeph>READ COMMITTED</codeph> mode. </p>
-      <p>The SQL standard specifies that concurrent serializable transactions produce the same
-        database state they would produce if executed sequentially. The MVCC snapshot isolation
-        model prevents dirty reads, non-repeatable reads, and phantom reads without expensive
-        locking, but there are other interactions that can occur between some
+      <p>Greenplum Database treats <codeph>READ UNCOMMITTED</codeph> the same as <codeph>READ
+          COMMITTED</codeph> and <codeph>SERIALIZABLE</codeph> the same as <codeph>REPEATABLE
+          READ</codeph>.</p>
+      <p>The difference between <codeph>READ COMMITTED</codeph> and <codeph>REPEATABLE READ</codeph>
+        is that with <codeph>READ COMMITTED</codeph>, each statement in a transaction sees only rows
+        committed before the <i>statement</i> started, while in <codeph>READ COMMITTED</codeph>
+        mode, statements in a transaction see only rows committed before the <i>transaction</i>
+        started.</p>
+      <p>With <codeph>READ COMMITTED</codeph> isolation mode the values in a row retrieved twice in
+        a transaction can differ if another concurrent transaction has committed changes since the
+        transaction began. <codeph>READ COMMITTED</codeph> mode also permits <i>phantom reads</i>,
+        where a query executed twice in the same transaction can return two different sets of
+        rows.</p>
+      <p>The <codeph>REPEATABLE READ</codeph> isolation mode prevents non-repeatable reads and
+        phantom reads, although the latter is not required by the standard. A transaction that
+        attempts to modify data modified by another concurrent transaction is rolled back.
+        Applications that execute transactions in <codeph>REPEATABLE READ</codeph> mode must be
+        prepared to handle transactions that fail due to serialization errors. If <codeph>REPEATABLE
+          READ</codeph> isolation mode is not required by the application, it is better to use
+          <codeph>READ COMMITTED</codeph> mode. </p>
+      <p><codeph>SERIALIZABLE</codeph> mode, which Greenplum Database does not fully support,
+        guarantees that a set of transactions executed concurrently produces the same result as if
+        the transactions executed sequentially one after the other. If <codeph>SERIALIZABLE</codeph>
+        is specified, Greenplum Database falls back to <codeph>REPEATABLE READ</codeph>. The MVCC
+        snapshot isolation model prevents dirty reads, non-repeatable reads, and phantom reads
+        without expensive locking, but there are other interactions that can occur between some
           <codeph>SERIALIZABLE</codeph> transactions in Greenplum Database that prevent them from
         being truly serializable. These anomalies can often be attributed to the fact that Greenplum
         Database does not perform <i>predicate locking</i>, which means that a write in one
-        transaction can affect the result of a previous read in another concurrent transaction. </p>
+        transaction can affect the result of a previous read in another concurrent transaction.</p>
       <p>Transactions that run concurrently should be examined to identify interactions that are not
         prevented by disallowing concurrent updates of the same data. Problems identified can be
         prevented by using explicit table locks or by requiring the conflicting transactions to
@@ -198,12 +196,12 @@
           <codeph>INSERT</codeph>, <codeph>DELETE</codeph>, <codeph>UPDATE</codeph>, or
           <codeph>COPY</codeph>
         statements:<codeblock>BEGIN;
-SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ...
 COMMIT;
 </codeblock></p>
       <p>The isolation mode can also be specified as part of the <codeph>BEGIN</codeph>
-        statement:<codeblock>BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;</codeblock></p>
+        statement:<codeblock>BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;</codeblock></p>
       <p>The default transaction isolation mode can be changed for a session by setting the
           <varname>default_transaction_isolation</varname> configuration property.</p>
     </section>

--- a/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_mvcc.xml
@@ -158,7 +158,7 @@
         </tgroup>
       </table>
       <p>Greenplum Database treats <codeph>READ UNCOMMITTED</codeph> the same as <codeph>READ
-          COMMITTED</codeph> and <codeph>SERIALIZABLE</codeph> the same as <codeph>REPEATABLE
+          COMMITTED</codeph> and treats <codeph>SERIALIZABLE</codeph> the same as <codeph>REPEATABLE
           READ</codeph>.</p>
       <p>The difference between <codeph>READ COMMITTED</codeph> and <codeph>REPEATABLE READ</codeph>
         is that with <codeph>READ COMMITTED</codeph>, each statement in a transaction sees only rows
@@ -181,16 +181,22 @@
         guarantees that a set of transactions executed concurrently produces the same result as if
         the transactions executed sequentially one after the other. If <codeph>SERIALIZABLE</codeph>
         is specified, Greenplum Database falls back to <codeph>REPEATABLE READ</codeph>. The MVCC
-        snapshot isolation model prevents dirty reads, non-repeatable reads, and phantom reads
+        Snapshot Isolation (SI) model prevents dirty reads, non-repeatable reads, and phantom reads
         without expensive locking, but there are other interactions that can occur between some
           <codeph>SERIALIZABLE</codeph> transactions in Greenplum Database that prevent them from
         being truly serializable. These anomalies can often be attributed to the fact that Greenplum
         Database does not perform <i>predicate locking</i>, which means that a write in one
         transaction can affect the result of a previous read in another concurrent transaction.</p>
-      <p>Transactions that run concurrently should be examined to identify interactions that are not
-        prevented by disallowing concurrent updates of the same data. Problems identified can be
-        prevented by using explicit table locks or by requiring the conflicting transactions to
-        update a dummy row introduced to represent the conflict. </p>
+      <note>The PostgreSQL 9.1 <codeph>SERIALIZABLE</codeph> isolation level introduces a new
+        Serializable Snapshot Isolation (SSI) model, which is fully compliant with the SQL standard
+        definition of serializable transactions. This model is not available in Greenplum Database.
+        SSI monitors concurrent transactions for conditions that could cause serialization
+        anomalies. When potential serialization problems are found, one transaction is allowed to
+        commit and others are rolled back and must be retried. </note>
+      <p>Greenplum Database transactions that run concurrently should be examined to identify
+        interactions that are not prevented by disallowing concurrent updates of the same data.
+        Problems identified can be prevented by using explicit table locks or by requiring the
+        conflicting transactions to update a dummy row introduced to represent the conflict. </p>
       <p>The SQL <codeph>SET TRANSACTION ISOLATION LEVEL</codeph> statement sets the isolation mode
         for the current transaction. The mode must be set before any <codeph>SELECT</codeph>,
           <codeph>INSERT</codeph>, <codeph>DELETE</codeph>, <codeph>UPDATE</codeph>, or

--- a/gpdb-doc/dita/ref_guide/SQL2008_support.xml
+++ b/gpdb-doc/dita/ref_guide/SQL2008_support.xml
@@ -847,8 +847,9 @@
           <row>
             <entry colname="col1">E152-01</entry>
             <entry colname="col2"><codeph>ISOLATION LEVEL SERIALIZABLE</codeph> clause</entry>
-            <entry colname="col3">YES</entry>
-            <entry colname="col4"/>
+            <entry colname="col3">NO</entry>
+            <entry colname="col4">Can be declared but is treated as a synonym for <codeph>REPEATABLE
+                READ</codeph></entry>
           </row>
           <row>
             <entry colname="col1">E152-02</entry>
@@ -1179,9 +1180,8 @@
           <row>
             <entry colname="col1">F111-03</entry>
             <entry colname="col2"><codeph>REPEATABLE READ</codeph> isolation level</entry>
-            <entry colname="col3">NO</entry>
-            <entry colname="col4">Use <codeph>SERIALIZABLE</codeph>
-            </entry>
+            <entry colname="col3">YES</entry>
+            <entry colname="col4"> </entry>
           </row>
           <row>
             <entry colname="col1">F121</entry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -1681,7 +1681,8 @@
           </thead>
           <tbody>
             <row>
-              <entry colname="col1">read committed<p>read uncommitted</p><p>serializable</p></entry>
+              <entry colname="col1">read committed<p>read uncommitted</p><p>repeatable
+                  read</p><p>serializable</p></entry>
               <entry colname="col2">read committed</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -1666,7 +1666,9 @@
   <topic id="default_transaction_isolation">
     <title>default_transaction_isolation</title>
     <body>
-      <p>Controls the default isolation level of each new transaction.</p>
+      <p>Controls the default isolation level of each new transaction. Greenplum Database treats
+          <codeph>read uncommitted</codeph> the same as <codeph>read committed</codeph>, and treats
+          <codeph>serializable</codeph> the same as <codeph>repeatable read</codeph>. </p>
       <table id="default_transaction_isolation_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/BEGIN.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/BEGIN.xml
@@ -9,8 +9,8 @@
             <title>Synopsis</title>
             <codeblock id="sql_command_synopsis">BEGIN [WORK | TRANSACTION] [<varname>transaction_mode</varname>]
       [READ ONLY | READ WRITE]</codeblock>
-            <p>where <varname>transaction_mode</varname> is one of:</p>
-            <codeblock>ISOLATION LEVEL | {SERIALIZABLE | READ COMMITTED | READ UNCOMMITTED}</codeblock>
+            <p>where <varname>transaction_mode</varname> is:</p>
+            <codeblock>ISOLATION LEVEL {READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SERIALIZABLE}</codeblock>
         </section>
         <section id="section3">
             <title>Description</title>
@@ -42,33 +42,30 @@
                     <pt>SERIALIZABLE</pt>
                     <pt>READ COMMITTED</pt>
                     <pt>READ UNCOMMITTED</pt>
-                    <pd id="be137522">The SQL standard defines four transaction isolation levels:
-                            <codeph>READ COMMITTED</codeph>, <codeph>READ UNCOMMITTED</codeph>,
-                            <codeph>SERIALIZABLE</codeph>, and <codeph>REPEATABLE READ</codeph>. The
-                        default behavior is that a statement can only see rows committed before it
-                        began (<codeph>READ COMMITTED</codeph>). In Greenplum Database <codeph>READ
-                            UNCOMMITTED</codeph> is treated the same as <codeph>READ
-                            COMMITTED</codeph>. <codeph>REPEATABLE READ</codeph> is not supported;
-                        use <codeph>SERIALIZABLE</codeph> if this behavior is required.
-                            <codeph>SERIALIZABLE</codeph> is the strictest transaction isolation.
-                        This level emulates serial transaction execution, as if transactions had
-                        been executed one after another, serially, rather than concurrently.
-                        Applications using this level must be prepared to retry transactions due to
-                        serialization failures.</pd>
-                </plentry>
-                <plentry>
-                    <pt>READ WRITE</pt>
-                    <pt>READ ONLY</pt>
-                    <pd>Determines whether the transaction is read/write or read-only. Read/write is
-                        the default. When a transaction is read-only, the following SQL commands are
-                        disallowed: <codeph>INSERT</codeph>, <codeph>UPDATE</codeph>,
-                            <codeph>DELETE</codeph>, and <codeph>COPY FROM</codeph> if the table
-                        they would write to is not a temporary table; all <codeph>CREATE</codeph>,
-                            <codeph>ALTER</codeph>, and <codeph>DROP</codeph> commands;
-                            <codeph>GRANT</codeph>, <codeph>REVOKE</codeph>,
-                            <codeph>TRUNCATE</codeph>; and <codeph>EXPLAIN ANALYZE</codeph> and
-                            <codeph>EXECUTE</codeph> if the command they would execute is among
-                        those listed.</pd>
+                    <pd>The SQL standard defines four transaction isolation levels: <codeph>READ
+                            UNCOMMITTED</codeph>, <codeph>READ COMMITTED</codeph>,
+                            <codeph>REPEATABLE READ</codeph>, and
+                        <codeph>SERIALIZABLE</codeph>.</pd>
+                    <pd><codeph>READ UNCOMMITTED</codeph> allows transactions to see changes made by
+                        uncomitted concurrent transactions. This is not possible in Greenplum
+                        Database, so <codeph>READ UNCOMMITTED</codeph> is treated the same as
+                            <codeph>READ COMMITTED</codeph>.</pd>
+                    <pd><codeph>READ COMMITTED</codeph>, the default isolation level in Greenplum
+                        Database, guarantees that a statement can only see rows committed before it
+                        began. The same statement executed twice in a transaction can produce
+                        different results if another concurrent transaction commits after the
+                        statement is executed the first time. </pd>
+                    <pd>The <codeph>REPEATABLE READ</codeph> isolation level guarantees that a
+                        transaction can only see rows committed before it began. <codeph>REPEATABLE
+                            READ</codeph> is the strictest transaction isolation level Greenplum
+                        Database supports. Applications that use the <codeph>REPEATABLE
+                            READ</codeph> isolation level must be prepared to retry transactions due
+                        to serialization failures.</pd>
+                    <pd>The <codeph>SERIALIZABLE</codeph> transaction isolation level guarantees
+                        that executing multiple concurrent transactions produces the same effects as
+                        running the same transactions one at a time. If you specify
+                            <codeph>SERIALIZABLE</codeph>, Greenplum Database falls back to
+                            <codeph>REPEATABLE READ</codeph>.</pd>
                 </plentry>
             </parml>
         </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -641,9 +641,9 @@
             constraints, indexes and table privileges are <i>not</i> inherited in the current
             implementation.</p></li>
         <li>For append-optimized tables, <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> are not
-          allowed in a serializable transaction and will cause the transaction to abort.
-            <codeph>CLUSTER</codeph>, <codeph>DECLARE...FOR UPDATE</codeph>, and triggers are not
-          supported with append-optimized tables.</li>
+          allowed in a repeatable read or serializable transaction and will cause the transaction to
+          abort. <codeph>CLUSTER</codeph>, <codeph>DECLARE...FOR UPDATE</codeph>, and triggers are
+          not supported with append-optimized tables.</li>
         <li>To insert data into a partitioned table, you specify the root partitioned table, the
           table created with the <codeph>CREATE TABLE</codeph> command. You also can specify a leaf
           child table of the partitioned table in an <codeph>INSERT</codeph> command. An error is

--- a/gpdb-doc/dita/ref_guide/sql_commands/SET_TRANSACTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SET_TRANSACTION.xml
@@ -112,7 +112,7 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <varname>transaction_mode</varname>
       <title>Examples</title>
       <p>Set the transaction isolation level for the current transaction:</p>
       <codeblock>BEGIN;
-SET TRANSACTION ISOLATION LEVEL REPEATLE READ;</codeblock>
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;</codeblock>
     </section>
     <section id="section7">
       <title>Compatibility</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/SET_TRANSACTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SET_TRANSACTION.xml
@@ -31,9 +31,8 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <varname>transaction_mode</varname>
       </ul>
       <p>The SQL standard defines two additional levels, <codeph>READ UNCOMMITTED</codeph> and
           <codeph>SERIALIZABLE</codeph>. In Greenplum Database <codeph>READ UNCOMMITTED</codeph> is
-        treated as <codeph>READ COMMITTED</codeph>. <codeph>SERIALIZABLE</codeph> is not supported;
-        if you specify <codeph>SERIALIZABLE</codeph>, Greenplum Database falls back to
-          <codeph>REPEATABLE READ</codeph>.</p>
+        treated as <codeph>READ COMMITTED</codeph>. If you specify <codeph>SERIALIZABLE</codeph>,
+        Greenplum Database falls back to <codeph>REPEATABLE READ</codeph>.</p>
       <p>The transaction isolation level cannot be changed after the first query or
         data-modification statement (<codeph>SELECT</codeph>, <codeph>INSERT</codeph>,
           <codeph>DELETE</codeph>, <codeph>UPDATE</codeph>, <codeph>FETCH</codeph>, or
@@ -79,8 +78,11 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <varname>transaction_mode</varname>
             transactions due to serialization failures.</pd>
           <pd>The <codeph>SERIALIZABLE</codeph> transaction isolation level guarantees that
             executing multiple concurrent transactions produces the same effects as running the same
-            transactions one at a time. If you specify <codeph>SERIALIZABLE</codeph>, Greenplum
-            Database falls back to <codeph>REPEATABLE READ</codeph>.</pd>
+            transactions one at a time. Greenplum Database does not fully support
+              <codeph>SERIALIZABLE</codeph> as defined by the standard, so if you specify
+              <codeph>SERIALIZABLE</codeph>, Greenplum Database falls back to <codeph>REPEATABLE
+              READ</codeph>. See <xref href="#topic1/section7" format="dita"/> for more information
+            about transaction serializability in Greenplum Database.</pd>
         </plentry>
         <plentry>
           <pt>READ WRITE</pt>
@@ -101,7 +103,7 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <varname>transaction_mode</varname>
       <p>If <codeph>SET TRANSACTION</codeph> is executed without a prior <codeph>START
           TRANSACTION</codeph> or <codeph>BEGIN</codeph>, it will appear to have no effect. </p>
       <p>It is possible to dispense with <codeph>SET TRANSACTION</codeph> by instead specifying the
-        desired transaction_modes in <codeph>BEGIN</codeph> or <codeph>START TRANSACTION</codeph>. </p>
+        desired transaction modes in <codeph>BEGIN</codeph> or <codeph>START TRANSACTION</codeph>. </p>
       <p>The session default transaction modes can also be set by setting the configuration
         parameters <varname>default_transaction_isolation</varname> and
           <varname>default_transaction_read_only</varname>.</p>
@@ -110,17 +112,22 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <varname>transaction_mode</varname>
       <title>Examples</title>
       <p>Set the transaction isolation level for the current transaction:</p>
       <codeblock>BEGIN;
-SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;</codeblock>
+SET TRANSACTION ISOLATION LEVEL REPEATLE READ;</codeblock>
     </section>
     <section id="section7">
       <title>Compatibility</title>
       <p>Both commands are defined in the SQL standard. <codeph>SERIALIZABLE</codeph> is the default
         transaction isolation level in the standard. In Greenplum Database the default is
-          <codeph>READ COMMITTED</codeph>. Because of lack of predicate locking, the
-          <codeph>SERIALIZABLE</codeph> level is not truly serializable. Essentially, a
-        predicate-locking system prevents phantom reads by restricting what is written, whereas a
-        multi-version concurrency control model (MVCC) as used in Greenplum Database prevents them
-        by restricting what is read. </p>
+          <codeph>READ COMMITTED</codeph>. Due to lack of predicate locking, Greenplum Database does
+        not fully support the <codeph>SERIALIZABLE</codeph> level, so it falls back to the
+          <codeph>REPEATABLE READ</codeph> level when <codeph>SERIAL</codeph> is specified.
+        Essentially, a predicate-locking system prevents phantom reads by restricting what is
+        written, whereas a multi-version concurrency control model (MVCC) as used in Greenplum
+        Database prevents them by restricting what is read. </p>
+      <p>PostgreSQL provides a true serializable isolation level, called serializable snapshot
+        isolation (SSI), which monitors concurrent transactions and rolls back transactions that
+        could introduce serialization anomalies. Greenplum Database does not implement this
+        isolation mode. </p>
       <p>In the SQL standard, there is one other transaction characteristic that can be set with
         these commands: the size of the diagnostics area. This concept is specific to embedded SQL,
         and therefore is not implemented in the Greenplum Database server. </p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/SET_TRANSACTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SET_TRANSACTION.xml
@@ -12,7 +12,7 @@
 SET SESSION CHARACTERISTICS AS TRANSACTION <varname>transaction_mode</varname> 
      [READ ONLY | READ WRITE]</codeblock>
       <p>where <varname>transaction_mode</varname> is one of:</p>
-      <codeblock>   ISOLATION LEVEL {SERIALIZABLE | READ COMMITTED | READ UNCOMMITTED}</codeblock>
+      <codeblock>   ISOLATION LEVEL {SERIALIZABLE | REPEATABLE READ | READ COMMITTED | READ UNCOMMITTED}</codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -25,15 +25,15 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <varname>transaction_mode</varname>
       <ul>
         <li id="em137940"><b>READ COMMITTED</b> — A statement can only see rows committed before it
           began. This is the default. </li>
-        <li id="em137943"><b>SERIALIZABLE</b> — All statements of the current transaction can only
-          see rows committed before the first query or data-modification statement was executed in
-          this transaction.</li>
+        <li id="em137943"><b>REPEATABLE READ</b> — All statements in the current transaction can
+          only see rows committed before the first query or data-modification statement executed in
+          the transaction.</li>
       </ul>
       <p>The SQL standard defines two additional levels, <codeph>READ UNCOMMITTED</codeph> and
-          <codeph>REPEATABLE READ</codeph>. In Greenplum Database <codeph>READ UNCOMMITTED</codeph>
-        is treated as <codeph>READ COMMITTED</codeph>. <codeph>REPEATABLE READ</codeph> is not
-        supported; use <codeph>SERIALIZABLE</codeph> if <codeph>REPEATABLE READ</codeph> behavior is
-        required. </p>
+          <codeph>SERIALIZABLE</codeph>. In Greenplum Database <codeph>READ UNCOMMITTED</codeph> is
+        treated as <codeph>READ COMMITTED</codeph>. <codeph>SERIALIZABLE</codeph> is not supported;
+        if you specify <codeph>SERIALIZABLE</codeph>, Greenplum Database falls back to
+          <codeph>REPEATABLE READ</codeph>.</p>
       <p>The transaction isolation level cannot be changed after the first query or
         data-modification statement (<codeph>SELECT</codeph>, <codeph>INSERT</codeph>,
           <codeph>DELETE</codeph>, <codeph>UPDATE</codeph>, <codeph>FETCH</codeph>, or
@@ -57,20 +57,30 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <varname>transaction_mode</varname>
             session.</pd>
         </plentry>
         <plentry>
-          <pt>SERIALIZABLE</pt>
-          <pt>READ COMMITTED</pt>
           <pt>READ UNCOMMITTED</pt>
+          <pt>READ COMMITTED</pt>
+          <pt>REPEATABLE READ</pt>
+          <pt>SERIALIZABLE</pt>
           <pd>The SQL standard defines four transaction isolation levels: <codeph>READ
-              COMMITTED</codeph>, <codeph>READ UNCOMMITTED</codeph>, <codeph>SERIALIZABLE</codeph>,
-            and <codeph>REPEATABLE READ</codeph>. The default behavior is that a statement can only
-            see rows committed before it began (<codeph>READ COMMITTED</codeph>). In Greenplum
-            Database <codeph>READ UNCOMMITTED</codeph> is treated the same as <codeph>READ
-              COMMITTED</codeph>.  <codeph>REPEATABLE READ</codeph> is not supported; use
-              <codeph>SERIALIZABLE</codeph> instead. <codeph>SERIALIZABLE</codeph> is the strictest
-            transaction isolation. This level emulates serial transaction execution, as if
-            transactions had been executed one after another, serially, rather than concurrently.
-            Applications using this level must be prepared to retry transactions due to
-            serialization failures.</pd>
+              UNCOMMITTED</codeph>, <codeph>READ COMMITTED</codeph>, <codeph>REPEATABLE
+              READ</codeph>, and <codeph>SERIALIZABLE</codeph>.</pd>
+          <pd><codeph>READ UNCOMMITTED</codeph> allows transactions to see changes made by
+            uncomitted concurrent transactions. This is not possible in Greenplum Database, so
+              <codeph>READ UNCOMMITTED</codeph> is treated the same as <codeph>READ
+              COMMITTED</codeph>.</pd>
+          <pd><codeph>READ COMMITTED</codeph>, the default isolation level in Greenplum Database,
+            guarantees that a statement can only see rows committed before it began. The same
+            statement executed twice in a transaction can produce different results if another
+            concurrent transaction commits after the statement is executed the first time. </pd>
+          <pd>The <codeph>REPEATABLE READ</codeph> isolation level guarantees that a transaction can
+            only see rows committed before it began. <codeph>REPEATABLE READ</codeph> is the
+            strictest transaction isolation level Greenplum Database supports. Applications that use
+            the <codeph>REPEATABLE READ</codeph> isolation level must be prepared to retry
+            transactions due to serialization failures.</pd>
+          <pd>The <codeph>SERIALIZABLE</codeph> transaction isolation level guarantees that
+            executing multiple concurrent transactions produces the same effects as running the same
+            transactions one at a time. If you specify <codeph>SERIALIZABLE</codeph>, Greenplum
+            Database falls back to <codeph>REPEATABLE READ</codeph>.</pd>
         </plentry>
         <plentry>
           <pt>READ WRITE</pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/START_TRANSACTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/START_TRANSACTION.xml
@@ -23,24 +23,34 @@
             <title>Parameters</title>
             <parml>
                 <plentry>
-                    <pt>SERIALIZABLE</pt>
-                    <pt>READ COMMITTED</pt>
                     <pt>READ UNCOMMITTED</pt>
+                    <pt>READ COMMITTED</pt>
+                    <pt>REPEATABLE READ</pt>
+                    <pt>SERIALIZABLE</pt>
                     <pd>The SQL standard defines four transaction isolation levels: <codeph>READ
-                            COMMITTED</codeph>, <codeph>READ UNCOMMITTED</codeph>,
-                            <codeph>SERIALIZABLE</codeph>, and <codeph>REPEATABLE READ</codeph>. The
-                        default behavior is that a statement can only see rows committed before it
-                        began (<codeph>READ COMMITTED</codeph>). In Greenplum Database <codeph>READ
-                            UNCOMMITTED</codeph> is treated the same as <codeph>READ
-                            COMMITTED</codeph>.  <codeph>REPEATABLE READ</codeph> is not supported;
-                        use <codeph>SERIALIZABLE</codeph> if this behavior is required.
-                            <codeph>SERIALIZABLE</codeph>, wherein all statements of the current
-                        transaction can only see rows committed before the first statement was
-                        executed in the transaction, is the strictest transaction isolation. This
-                        level emulates serial transaction execution, as if transactions had been
-                        executed one after another, serially, rather than concurrently. Applications
-                        using this level must be prepared to retry transactions due to serialization
-                        failures.</pd>
+                            UNCOMMITTED</codeph>, <codeph>READ COMMITTED</codeph>,
+                            <codeph>REPEATABLE READ</codeph>, and
+                        <codeph>SERIALIZABLE</codeph>.</pd>
+                    <pd><codeph>READ UNCOMMITTED</codeph> allows transactions to see changes made by
+                        uncomitted concurrent transactions. This is not possible in Greenplum
+                        Database, so <codeph>READ UNCOMMITTED</codeph> is treated the same as
+                            <codeph>READ COMMITTED</codeph>.</pd>
+                    <pd><codeph>READ COMMITTED</codeph>, the default isolation level in Greenplum
+                        Database, guarantees that a statement can only see rows committed before it
+                        began. The same statement executed twice in a transaction can produce
+                        different results if another concurrent transaction commits after the
+                        statement is executed the first time. </pd>
+                    <pd>The <codeph>REPEATABLE READ</codeph> isolation level guarantees that a
+                        transaction can only see rows committed before it began. <codeph>REPEATABLE
+                            READ</codeph> is the strictest transaction isolation level Greenplum
+                        Database supports. Applications that use the <codeph>REPEATABLE
+                            READ</codeph> isolation level must be prepared to retry transactions due
+                        to serialization failures.</pd>
+                    <pd>The <codeph>SERIALIZABLE</codeph> transaction isolation level guarantees
+                        that executing multiple concurrent transactions produces the same effects as
+                        running the same transactions one at a time. If you specify
+                            <codeph>SERIALIZABLE</codeph>, Greenplum Database falls back to
+                            <codeph>REPEATABLE READ</codeph>.</pd>
                 </plentry>
                 <plentry>
                     <pt>READ WRITE</pt>
@@ -73,7 +83,7 @@
                 relational database systems may offer an autocommit feature as a convenience. </p>
             <p>The SQL standard requires commas between successive
                     <varname>transaction_modes</varname>, but for historical reasons Greenplum
-                Database allows the commas to be omitted. </p>
+                Database allows the commas to be omitted.</p>
             <p>See also the compatibility section of <codeph><xref href="SET_TRANSACTION.xml#topic1"
                         type="topic" format="dita"/></codeph>.</p>
         </section>


### PR DESCRIPTION
SERIALIZABLE falls back to REPEATABLE READ.

URLs (larger changes) for review:

- http://docs-litzell-gpdb6.cfapps.io/600/admin_guide/dml.html#topic7
- http://docs-litzell-gpdb6.cfapps.io/600/admin_guide/intro/about_mvcc.html#topic_kl4_pl2_2s__section_f4m_n5n_fs
- http://docs-litzell-gpdb6.cfapps.io/600/ref_guide/sql_commands/BEGIN.html
- http://docs-litzell-gpdb6.cfapps.io/600/ref_guide/sql_commands/SET_TRANSACTION.html
- http://docs-litzell-gpdb6.cfapps.io/600/ref_guide/sql_commands/START_TRANSACTION.html
