### PR TITLE
docs - updates for online expand

### DIFF
--- a/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
@@ -2,15 +2,17 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="expand-initialize" xml:lang="en">
-
   <title id="no160120">Initializing New Segments</title>
-  <shortdesc>Use the <codeph>gpexpand</codeph> utility to initialize the new segments, create the
-    expansion schema, and set a system-wide random distribution policy for the database. </shortdesc>
+  <shortdesc>Use the <codeph>gpexpand</codeph> utility to create and initialize the new segment
+    instances and create the expansion schema. </shortdesc>
   <body>
-    <p>The first time you run <codeph>gpexpand</codeph> with a valid input file it creates the
-      expansion schema and sets the distribution policy for all tables to <codeph>DISTRIBUTED
-        RANDOMLY</codeph>. After these steps are completed, running <codeph>gpexpand</codeph>
-      detects if the expansion schema has been created and, if so, performs table redistribution. </p>
+    <draft-comment author="msk">GPDB 6 -online expand <p>remove change of distribution
+      policy</p></draft-comment>
+    <p>The first time you run <codeph><xref href="../../utility_guide/admin_utilities/gpexpand.xml"
+          >gpexand</xref></codeph> with a valid input file it creates and initializes segment
+      instances and creates the expansion schema. After these steps are completed, running
+        <codeph>gpexpand</codeph> detects if the expansion schema has been created and, if so,
+      performs table redistribution. </p>
     <ul id="ul_od1_h1v_mr">
       <li>
         <xref href="#topic23" format="dita"/>
@@ -113,8 +115,8 @@
     <topic id="topic25" xml:lang="en">
       <title id="no165820">Expansion Input File Format</title>
       <body>
-        <p>Use the interactive interview process to create your own input file
-          unless your expansion scenario has atypical needs. </p>
+        <p>Use the interactive interview process to create your own input file unless your expansion
+          scenario has atypical needs. </p>
         <p>The format for expansion input files is:</p>
         <codeblock>hostname:address:port:datadir:dbid:content:preferred_role</codeblock>
         <p>For example:</p>
@@ -151,8 +153,8 @@ sdw5:sdw5-1:60012:/gpdata/mirror/gp10:14:10:m</codeblock>
               <row>
                 <entry colname="col1">datadir</entry>
                 <entry colname="col2">Directory name</entry>
-                <entry colname="col3">The data directory location for a segment as per
-                  the gp_segment_configuration system catalog.</entry>
+                <entry colname="col3">The data directory location for a segment as per the
+                  gp_segment_configuration system catalog.</entry>
               </row>
               <row>
                 <entry colname="col1">dbid</entry>
@@ -160,9 +162,9 @@ sdw5:sdw5-1:60012:/gpdata/mirror/gp10:14:10:m</codeblock>
                   values.</entry>
                 <entry colname="col3">Database ID for the segment. The values you enter should be
                   incremented sequentially from existing <i>dbid</i> values shown in the system
-                  catalog <codeph>gp_segment_configuration</codeph>. For example, to add four nodes
-                  to an existing ten-segment array with <i>dbid </i> values of 1-10, list new
-                    <i>dbid</i> values of 11, 12, 13 and 14.</entry>
+                  catalog <codeph>gp_segment_configuration</codeph>. For example, to add four
+                  segment instances to an existing ten-segment array with <i>dbid </i> values of
+                  1-10, list new <i>dbid</i> values of 11, 12, 13 and 14.</entry>
               </row>
               <row>
                 <entry colname="col1">content</entry>
@@ -191,8 +193,7 @@ sdw5:sdw5-1:60012:/gpdata/mirror/gp10:14:10:m</codeblock>
     <title id="no164605">Running gpexpand to Initialize New Segments</title>
     <body>
       <p>After you have created an input file, run <codeph>gpexpand</codeph> to initialize new
-        segments. The utility automatically stops Greenplum Database segment initialization and
-        restarts the system when the process finishes.</p>
+        segment instances. </p>
       <section id="no160378">
         <title>To run gpexpand with an input file</title>
         <ol>
@@ -219,7 +220,9 @@ sdw5:sdw5-1:60012:/gpdata/mirror/gp10:14:10:m</codeblock>
   <topic id="topic27" xml:lang="en">
     <title>Rolling Back a Failed Expansion Setup</title>
     <body>
-      <p>You can roll back an expansion setup operation only if the operation fails. </p>
+      <draft-comment author="msk">Is rollback true for online expand?</draft-comment>
+      <p>You can roll back an expansion setup operation (adding segment instances and segment hosts)
+        only if the operation fails. </p>
       <p>If the expansion fails during the initialization step, while the database is down, you must
         first restart the database in master-only mode by running the <codeph>gpstart -m</codeph>
         command. </p>

--- a/gpdb-doc/dita/admin_guide/expand/expand-main.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-main.xml
@@ -4,7 +4,7 @@
 <topic id="topic1" xml:lang="en">
   <title>Expanding a Greenplum System</title>
   <shortdesc>To scale up performance and storage capacity, expand your Greenplum system by adding
-    hosts to the array.</shortdesc>
+    hosts to the system.</shortdesc>
   <body>
     <p>Data warehouses typically grow over time as additional data is gathered and the retention
       periods increase for existing data. At times, it is necessary to increase database capacity to

--- a/gpdb-doc/dita/admin_guide/expand/expand-nodes.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-nodes.xml
@@ -2,22 +2,27 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic1" xml:lang="en">
-  <title>Preparing and Adding Nodes</title>
-  <shortdesc>Verify your new nodes are ready for integration into the existing Greenplum system. </shortdesc>
+  <title>Preparing and Adding Hosts</title>
+  <shortdesc>Verify your new host systems are ready for integration into the existing Greenplum
+    system. </shortdesc>
   <body>
-    <p>To prepare new system nodes for expansion, install the Greenplum Database software binaries,
+    <draft-comment author="msk">GPDB 6 updates for online expand</draft-comment>
+    <p>To prepare new host systems for expansion, install the Greenplum Database software binaries,
       exchange the required SSH keys, and run performance tests. </p>
-    <p>Run performance tests first on the new nodes and then all nodes. Run
-      the tests on all nodes with the system offline so user activity does not distort results.</p>
-    <p>Generally, you should run performance tests when an administrator modifies node
-      networking or other special conditions in the system. For example, if you will run the
-      expanded system on two network clusters, run tests on each cluster.</p>
+    <p>Run performance tests first on the new hosts and then all hosts. Run the tests on all hosts
+      with the system offline so user activity does not distort results.</p>
+    <p>Generally, you should run performance tests when an administrator modifies host networking or
+      other special conditions in the system. For example, if you will run the expanded system on
+      two network clusters, run tests on each cluster.</p>
   </body>
   <topic id="topic18" xml:lang="en">
-    <title id="no159311">Adding New Nodes to the Trusted Host Environment</title>
+    <title id="no159311">Adding New Hosts to the Trusted Host Environment</title>
     <body>
-      <p>New nodes must exchange SSH keys with the existing nodes to enable Greenplum administrative
-        utilities to connect to all segments without a password prompt. Perform the key exchange process twice.</p>
+      <p>New hosts must exchange SSH keys with the existing hosts to enable Greenplum administrative
+        utilities to connect to all segments without a password prompt. Perform the key exchange
+        process twice with the <codeph><xref
+            href="../../utility_guide/admin_utilities/gpssh-exkeys.xml">gpssh-exkeys</xref></codeph>
+        utility.</p>
       <p>First perform the process as <codeph>root</codeph>, for administration convenience, and
         then as the user <codeph>gpadmin</codeph>, for management utilities. Perform the following
         tasks in order:</p>
@@ -79,9 +84,10 @@ sdw3-4</codeblock></li>
       <section id="no160595">
         <title>To create the <codeph>gpadmin</codeph> user</title>
         <ol id="ol_amb_xjr_g4">
-          <li id="no160603">Use <codeph>gpssh</codeph> to create the <codeph>gpadmin</codeph> user
-            on all the new segment hosts (if it does not exist already). Use the list of new hosts
-            you created for the key exchange. For
+          <li id="no160603">Use <codeph><xref href="../../utility_guide/admin_utilities/gpssh.xml"
+                >gpssh</xref></codeph> to create the <codeph>gpadmin</codeph> user on all the new
+            segment hosts (if it does not exist already). Use the list of new hosts you created for
+            the key exchange. For
             example:<codeblock># gpssh -f <i>new_hosts_file</i> '/usr/sbin/useradd <i>gpadmin</i> -d 
 /home/<i>gpadmin</i> -s /bin/bash'</codeblock></li>
           <li id="no160614">Set a password for the new <codeph>gpadmin</codeph> user. On Linux, you
@@ -111,8 +117,9 @@ gpadmin --stdin'</codeblock></li>
   <topic id="topic19" xml:lang="en">
     <title id="no159124">Verifying OS Settings</title>
     <body>
-      <p>Use the <codeph>gpcheck</codeph> utility to verify all new hosts in your array have the
-        correct OS settings to run Greenplum Database software. </p>
+      <p>Use the <codeph><xref href="../../utility_guide/admin_utilities/gpcheck.xml"
+          >gpcheck</xref></codeph> utility to verify all new hosts in your array have the correct OS
+        settings to run Greenplum Database software. </p>
       <section id="no159174">
         <title>To run gpcheck</title>
         <ol>
@@ -128,7 +135,8 @@ gpadmin --stdin'</codeblock></li>
   <topic id="topic20" xml:lang="en">
     <title id="no159219">Validating Disk I/O and Memory Bandwidth</title>
     <body>
-      <p>Use the <codeph>gpcheckperf</codeph> utility to test disk I/O and memory bandwidth. </p>
+      <p>Use the <codeph><xref href="../../utility_guide/admin_utilities/gpcheckperf.xml"
+            >gpcheckperf</xref></codeph> utility to test disk I/O and memory bandwidth. </p>
       <section id="no159247">
         <title>To run gpcheckperf</title>
         <ol>
@@ -150,7 +158,7 @@ gpadmin --stdin'</codeblock></li>
     <body>
       <p>Before initializing the system with the new segments, shut down the system with
           <codeph>gpstop</codeph> to prevent user activity from skewing performance test results.
-        Then, repeat the performance tests using host files that include <i>all</i> nodes, existing
+        Then, repeat the performance tests using host files that include <i>all</i> hosts, existing
         and new:</p>
       <ul>
         <li id="no158731">

--- a/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
@@ -6,8 +6,6 @@
   <shortdesc>You can perform a Greenplum Database expansion to add segment instances and segment
     hosts with minimal downtime.</shortdesc>
   <body>
-    <draft-comment author="msk">GPDB 6 - does not require downtime to add segment
-      instances</draft-comment>
     <p>Data warehouses typically grow over time, often at a continuous pace, as additional data is
       gathered and the retention period increases for existing data. At times, it is necessary to
       increase database capacity to consolidate disparate data warehouses into a single database.
@@ -50,9 +48,7 @@
       /> for steps to prepare the new hosts for Greenplum Database.</p>
     <p>Once the new servers are installed and tested, the software phase of the Greenplum Database
       expansion process begins. The software phase is designed to be minimally disruptive,
-      transactionally consistent, reliable, and flexible. <draft-comment author="msk">Remove system
-        restart information. Remove change in distribution policy</draft-comment><ul
-        id="ul_zwt_png_tt">
+      transactionally consistent, reliable, and flexible. <ul id="ul_zwt_png_tt">
         <li>The first step of the software phase of expansion process is preparing the Greenplum
           Database system: adding new segment hosts and initializing new segment instances. This
           phase can be scheduled to occur during a period of low activity to avoid disrupting
@@ -61,15 +57,15 @@
             <li>Greenplum Database software is installed. </li>
             <li>Databases and database objects are created in the new segment instances on the new
               segment hosts. </li>
-            <li>The <i>gpexpand</i> schema is created in the master database. You use the tables in
-              the schema to control the expansion process.</li>
+            <li>The <i>gpexpand</i> schema is created in the master database. You can use the tables
+              in the schema to monitor and control the expansion process.</li>
           </ul><p>After the system has been updated, the new segment instances on the new segment
             hosts are available.</p><ul id="ul_dy3_xxn_kgb">
             <li>New segments are immediately available and participate in new queries and data
               loads. The existing data, however, is skewed. It is concentrated on the original
               segments and must be redistributed across the new total number of primary segments. </li>
             <li>Because some the table data is skewed, some queries might be less efficient because
-              more data motion operators might be needed. </li>
+              more data motion operations might be needed. </li>
           </ul></li>
         <li>The last step of the software phase is redistributing table data. Using the expansion
           control tables in the <i>gpexpand</i> schema as a guide, tables are redistributed. For

--- a/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
@@ -3,7 +3,11 @@
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic3" xml:lang="en">
   <title>System Expansion Overview</title>
+  <shortdesc>You can perform a Greenplum Database expansion to add segment instances and segment
+    hosts with minimal downtime.</shortdesc>
   <body>
+    <draft-comment author="msk">GPDB 6 - does not require downtime to add segment
+      instances</draft-comment>
     <p>Data warehouses typically grow over time, often at a continuous pace, as additional data is
       gathered and the retention period increases for existing data. At times, it is necessary to
       increase database capacity to consolidate disparate data warehouses into a single database.
@@ -18,9 +22,7 @@
           capacity and performance are the same as if the system had been originally implemented
           with the added resources. </li>
         <li>Uninterrupted service during expansion. Regular workloads, both scheduled and ad-hoc,
-          are not interrupted. A short, scheduled downtime period is required to initialize the new
-          servers, similar to downtime required to restart the system. The length of downtime is
-          unrelated to the size of the system before or after expansion. </li>
+          are not interrupted.</li>
         <li>Transactional consistency. </li>
         <li>Fault tolerance. During the expansion, standard fault-tolerance mechanisms—such as
           segment mirroring—remain active, consistent, and effective. </li>
@@ -48,43 +50,43 @@
       /> for steps to prepare the new hosts for Greenplum Database.</p>
     <p>Once the new servers are installed and tested, the software phase of the Greenplum Database
       expansion process begins. The software phase is designed to be minimally disruptive,
-      transactionally consistent, reliable, and flexible. <ul id="ul_zwt_png_tt">
-        <li>There is a brief period of downtime while the new segment hosts are initialized and the
-          system is prepared for the expansion process. This downtime can be scheduled to occur
-          during a period of low activity to avoid disrupting ongoing business operations. During
-          the initialization process, the following tasks are performed:<ul id="ul_s3v_vfh_mr">
+      transactionally consistent, reliable, and flexible. <draft-comment author="msk">Remove system
+        restart information. Remove change in distribution policy</draft-comment><ul
+        id="ul_zwt_png_tt">
+        <li>The first step of the software phase of expansion process is preparing the Greenplum
+          Database system: adding new segment hosts and initializing new segment instances. This
+          phase can be scheduled to occur during a period of low activity to avoid disrupting
+          ongoing business operations. During the initialization process, the following tasks are
+            performed:<ul id="ul_s3v_vfh_mr">
             <li>Greenplum Database software is installed. </li>
-            <li>Databases and database objects are created on the new segment hosts. </li>
-            <li>An expansion schema is created in the master database to control the expansion
-              process.</li>
-            <li>The distribution policy for each table is changed to <codeph>DISTRIBUTED
-                RANDOMLY</codeph>.</li>
-          </ul></li>
-        <li>The system is restarted and applications resume. <ul id="ul_tmw_b3h_mr">
+            <li>Databases and database objects are created in the new segment instances on the new
+              segment hosts. </li>
+            <li>The <i>gpexpand</i> schema is created in the master database. You use the tables in
+              the schema to control the expansion process.</li>
+          </ul><p>After the system has been updated, the new segment instances on the new segment
+            hosts are available.</p><ul id="ul_dy3_xxn_kgb">
             <li>New segments are immediately available and participate in new queries and data
               loads. The existing data, however, is skewed. It is concentrated on the original
               segments and must be redistributed across the new total number of primary segments. </li>
-            <li>Because tables now have a random distribution policy, the optimizer creates query
-              plans that are not dependent on distribution keys. Some queries will be less efficient
-              because more data motion operators are needed. </li>
+            <li>Because some the table data is skewed, some queries might be less efficient because
+              more data motion operators might be needed. </li>
           </ul></li>
-        <li>Using the expansion control tables as a guide, tables and partitions are redistributed.
-          For each table:<ul id="ul_uxt_png_tt">
-            <li> An <codeph>ALTER TABLE</codeph> statement is issued to change the distribution
-              policy back to the original policy. This causes an automatic data redistribution
-              operation, which spreads data across all of the servers, old and new, according to the
-              original distribution policy.</li>
+        <li>The last step of the software phase is redistributing table data. Using the expansion
+          control tables in the <i>gpexpand</i> schema as a guide, tables are redistributed. For
+          each table:<ul id="ul_uxt_png_tt">
+            <li>The <codeph><xref href="../../utility_guide/admin_utilities/gpexpand.xml"
+                  >gpexand</xref></codeph> utility redistributes the table data, across all of the
+              servers, old and new, according to the distribution policy.</li>
             <li>The table's status is updated in the expansion control tables.</li>
-            <li>The query optimizer creates more efficient execution plans by including the
-              distribution key in the planning.</li>
-          </ul></li>
-        <li>When all tables have been redistributed, the expansion is complete.</li>
+            <li>After data redistribution, the query optimizer creates more efficient execution
+              plans when data is not skewed.</li>
+          </ul><p>When all tables have been redistributed, the expansion is complete.</p></li>
       </ul></p>
-    <p>Redistributing data is a long-running process that creates a large volume of network and disk
-      activity. It can take days to redistribute some very large databases. To minimize the effects
-      of the increased activity on business operations, system administrators can pause and resume
-      expansion activity on an ad hoc basis, or according to a predetermined schedule. Datasets can
-      be prioritized so that critical applications benefit first from the expansion. </p>
+    <p>Redistributing table data is a long-running process that creates a large volume of network
+      and disk activity. It can take days to redistribute some very large databases. To minimize the
+      effects of the increased activity on business operations, system administrators can pause and
+      resume expansion activity on an ad hoc basis, or according to a predetermined schedule.
+      Datasets can be prioritized so that critical applications benefit first from the expansion. </p>
     <p>In a typical operation, you run the <codeph>gpexpand</codeph> utility four times with
       different options during the complete expansion process. </p>
     <ol id="ol_jjf_pmg_tt">
@@ -97,32 +99,28 @@
           segments, and captures metadata for each table in an expansion schema for status tracking.
           After this process completes, the expansion operation is committed and
         irrevocable.</p></li>
-      <li id="no176239"><xref href="expand-redistribute.xml#topic28">To redistribute
-          tables</xref>:<codeblock>gpexpand -d <i>duration</i></codeblock><p>At initialization,
-            <codeph>gpexpand</codeph> nullifies hash distribution policies on tables in all existing
-          databases, except for parent tables of a partitioned table, and sets the distribution
-          policy for all tables to random distribution.</p><p>To complete system expansion, you must
-          run <codeph>gpexpand</codeph> to redistribute data tables across the newly added segments.
-          Depending on the size and scale of your system, redistribution can be accomplished in a
-          single session during low-use hours, or you can divide the process into batches over an
-          extended period. Each table or partition is unavailable for read or write operations
-          during redistribution. As each table is redistributed across the new segments, database
-          performance should incrementally improve until it exceeds pre-expansion performance
-          levels.</p><p>You may need to run <codeph>gpexpand</codeph> several times to complete the
-          expansion in large-scale systems that require multiple redistribution sessions.
-            <codeph>gpexpand</codeph> can benefit from explicit table redistribution ranking; see
-            <xref href="expand-planning.xml#topic10" type="topic" format="dita"/>.</p><p>Users can
-          access Greenplum Database after initialization completes and the system is back online,
-          but they may experience performance degradation on systems that rely heavily on hash
-          distribution of tables. Normal operations such as ETL jobs, user queries, and reporting
-          can continue, though users might experience slower response times.</p><p>When a table has
-          a random distribution policy, Greenplum Database cannot enforce unique constraints (such
-          as <codeph>PRIMARY KEY</codeph>). This can affect your ETL and loading processes until
-          table redistribution completes because duplicate rows do not issue a constraint violation
-          error. </p></li>
+      <li id="no176239"><xref href="expand-redistribute.xml#topic28">To redistribute table
+          data</xref>:<codeblock>gpexpand -d <i>duration</i></codeblock><p>During initialization,
+            <codeph>gpexpand</codeph> adds and initializes new segment instances. To complete system
+          expansion, you must run <codeph>gpexpand</codeph> to redistribute data tables across the
+          newly added segment instances. Depending on the size and scale of your system,
+          redistribution can be accomplished in a single session during low-use hours, or you can
+          divide the process into batches over an extended period. Each table or partition is
+          unavailable for read or write operations during redistribution. As each table is
+          redistributed across the new segments, database performance should incrementally improve
+          until it exceeds pre-expansion performance levels.</p><p>You may need to run
+            <codeph>gpexpand</codeph> several times to complete the expansion in large-scale systems
+          that require multiple redistribution sessions. <codeph>gpexpand</codeph> can benefit from
+          explicit table redistribution ranking; see <xref href="expand-planning.xml#topic10"
+            type="topic" format="dita"/>.</p><p>Users can access Greenplum Database during
+          initialization, but they may experience performance degradation on systems that rely
+          heavily on hash distribution of tables. Normal operations such as ETL jobs, user queries,
+          and reporting can continue, though users might experience slower response times.</p></li>
       <li id="no165990">To remove the expansion schema:<codeblock>gpexpand -c</codeblock></li>
     </ol>
-    <p>For information about the <codeph>gpexpand</codeph> utility and the other utilities that are
-      used for system expansion, see the <i>Greenplum Database Utility Guide</i>. </p>
+    <p>For information about the <codeph><xref
+          href="../../utility_guide/admin_utilities/gpexpand.xml">gpexand</xref></codeph> utility
+      and the other utilities that are used for system expansion, see the <i>Greenplum Database
+        Utility Guide</i>. </p>
   </body>
 </topic>

--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -2,11 +2,12 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="expand-planning" xml:lang="en">
-
   <title id="no159872">Planning Greenplum System Expansion</title>
   <shortdesc>Careful planning will help to ensure a successful Greenplum expansion
     project.</shortdesc>
   <body>
+    <draft-comment author="msk">Remove downtime when adding segment instances.<p>Add link to block
+        mirror?</p></draft-comment>
     <p>The topics in this section help to ensure that you are prepared to execute a system
       expansion.</p>
     <ul id="ul_gdc_hp5_mr">
@@ -87,7 +88,7 @@
                     id="image_qkb_t1m_2r"/>
                 </entry>
                 <entry>Validate disk I/O and memory bandwidth of the new hardware or cloud resources
-                  (<codeph>gpcheckperf</codeph>).</entry>
+                    (<codeph>gpcheckperf</codeph>).</entry>
               </row>
               <row>
                 <entry>
@@ -99,25 +100,18 @@
                   <ph>directories</ph>.</entry>
               </row>
               <row>
+                <entry namest="c1" nameend="c2"><p><b>Offline Pre-Expansion Tasks</b></p>
+                  <ph otherprops="red">* The system is unavailable to all user activity during this
+                    process.</ph>
+                </entry>
+              </row>
+              <row>
                 <entry>
                   <image href="../graphics/green-checkbox.jpg" width="29px" height="28px"
                     id="image_wch_t1m_2r"/>
                 </entry>
                 <entry>Validate that there are no catalog issues
                   (<codeph>gpcheckcat</codeph>).</entry>
-              </row>
-              <row>
-                <entry>
-                  <image href="../graphics/green-checkbox.jpg" width="29px" height="28px"
-                    id="image_ct3_t1m_2r"/>
-                </entry>
-                <entry>Prepare an expansion input file (<codeph>gpexpand</codeph>). </entry>
-              </row>
-              <row>
-                <entry namest="c1" nameend="c2"><p><b>Offline Expansion Tasks</b></p>
-                  <ph otherprops="red">* The system is locked and unavailable to all user activity
-                    during this process.</ph>
-                </entry>
               </row>
               <row>
                 <entry>
@@ -134,6 +128,18 @@
                 </entry>
                 <entry>Validate disk I/O and memory bandwidth of the combined existing and new
                   hardware or cloud resources (<codeph>gpcheckperf</codeph>). </entry>
+              </row>
+              <row>
+                <entry namest="c1" nameend="c2"><p><b>Online Segment Instance
+                    Initialization</b></p><ph>* System is up and available</ph>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <image href="../graphics/green-checkbox.jpg" width="29px" height="28px"
+                    id="image_ct3_t1m_2r"/>
+                </entry>
+                <entry>Prepare an expansion input file (<codeph>gpexpand</codeph>). </entry>
               </row>
               <row>
                 <entry>
@@ -192,9 +198,11 @@
     <body>
       <p>A deliberate, thorough approach to deploying compatible hardware greatly minimizes risk to
         the expansion process.</p>
+      <draft-comment author="msk">Change reference from Platform Engineering to Pivotal
+        Support</draft-comment>
       <p>Hardware resources and configurations for new segment hosts should match those of the
-        existing hosts. Work with <i>Greenplum Platform Engineering</i> before making a hardware
-        purchase to expand Greenplum Database.</p>
+        existing hosts.<ph otherprops="pivotal"> Work with <i>Pivotal Support</i> before making a
+          hardware purchase to expand Greenplum Database.</ph></p>
       <p>The steps to plan and set up new hardware platforms vary for each deployment. Some
         considerations include how to:</p>
       <ul id="ul_alt_tl5_mr">
@@ -217,33 +225,51 @@
   <topic id="topic6" xml:lang="en">
     <title>Planning New Segment Initialization</title>
     <body>
-      <p>Expanding Greenplum Database requires a limited period of system downtime. During this
-        period, run <codeph>gpexpand</codeph> to initialize new segments into the array and create
+      <p>Expanding Greenplum Database can be performed when the system is up and available. Run
+          <codeph>gpexpand</codeph> to initialize new segments instances into the array and create
         an expansion schema.</p>
       <p>The time required depends on the number of schema objects in the Greenplum system and other
         factors related to hardware performance. In most environments, the initialization of new
         segments requires less than thirty minutes offline.</p>
-      <note type="note">After you begin initializing new segments, you can no longer restore the
-        system using backup files created for the pre-expansion system. When initialization
+      <p>These utilities cannot be run while <codeph>gpexpand</codeph> is performing segment
+          initialization.<ul id="ul_c3w_wdp_lgb">
+          <li><codeph>gppkg</codeph></li>
+          <li><codeph>gpconfig</codeph></li>
+          <li><codeph>gpcheck</codeph></li>
+          <li><codeph>gpcheckat</codeph></li>
+        </ul></p>
+      <note type="important">After you begin initializing new segments, you can no longer restore
+        the system using backup files created for the pre-expansion system. When initialization
         successfully completes, the expansion is committed and cannot be rolled back. </note>
     </body>
     <topic id="topic7" xml:lang="en">
       <title id="no164776">Planning Mirror Segments</title>
       <body>
-        <p>If your existing array has mirror segments, the new segments must have mirroring
+        <draft-comment author="msk">Add link to block mirroring in Best Practices?</draft-comment>
+        <p>If your existing system has mirror segments, the new segments must have mirroring
           configured. If there are no mirrors configured for existing segments, you cannot add
-          mirrors to new hosts with the <codeph>gpexpand</codeph> utility. </p>
+          mirrors to new hosts with the <codeph>gpexpand</codeph> utility. For more information
+          about segment mirroring, see <xref href="../intro/about_ha.xml#about_ha/segment_mirroring"
+          />.</p>
         <p>For Greenplum Database arrays with mirror segments, ensure you add enough new host
           machines to accommodate new mirror segments. The number of new hosts required depends on
           your mirroring strategy:</p>
         <ul id="ul_dnt_tl5_mr">
           <li id="no165384"><b>Spread Mirroring</b> — Add at least one more host to the array than
             the number of segments per host. The number of separate hosts must be greater than the
-            number of segment instances per host to ensure even spreading.</li>
+            number of segment instances per host to ensure even spreading. You can specify this type
+            of mirroring during system initialization or when you enable segment mirroring for an
+            existing system.</li>
           <li id="no165386"><b>Grouped Mirroring</b> — Add at least two new hosts so the mirrors for
             the first host can reside on the second host, and the mirrors for the second host can
-            reside on the first. For more information, see <xref
-              href="../intro/about_ha.xml#about_ha/segment_mirroring"/>.</li>
+            reside on the first. This is the default type of mirroring if you enable segment
+            mirroring during system initialization if you enable segment mirroring for an existing
+            system.</li>
+          <li><b>Block Mirroring</b> — Adding one or more blocks of host systems. For example add a
+            block of four or eight hosts. Block mirroring is a custom mirroring configuration. For
+            more information about block mirroring, see <xref
+              href="../../best_practices/ha.xml#topic_cnm_vxc_54"/><ph otherprops="op-print"> in the
+                <cite>Greenplum Database Best Practices Guide</cite></ph>.</li>
         </ul>
       </body>
     </topic>
@@ -258,7 +284,7 @@
         <p>The interactive process for creating an expansion input file prompts for this option; you
           can also specify new segment directories manually in the input configuration file. For
           more information, see <xref href="expand-initialize.xml#topic23" type="topic"
-            format="dita" />.</p>
+            format="dita"/>.</p>
       </body>
     </topic>
     <topic id="topic9" xml:lang="en">
@@ -300,9 +326,11 @@
       <note type="important">To perform table redistribution, your segment hosts must have enough
         disk space to temporarily hold a copy of your largest table. All tables are unavailable for
         read and write operations during redistribution. </note>
+      <draft-comment author="msk">true for default of gp_expand_method GUC. recommendation for
+          <codeph>move</codeph> setting </draft-comment>
       <p>The performance impact of table redistribution depends on the size, storage type, and
         partitioning design of a table. For any given table, redistributing it with
-        <codeph>gpexpand</codeph> takes as much time as a <codeph>CREATE TABLE AS SELECT</codeph>
+          <codeph>gpexpand</codeph> takes as much time as a <codeph>CREATE TABLE AS SELECT</codeph>
         operation would. When redistributing a terabyte-scale fact table, the expansion utility can
         use much of the available system resources, which could affect query performance or other
         database workloads.</p>
@@ -310,14 +338,36 @@
     <topic id="topic11" xml:lang="en">
       <title id="no167000">Managing Redistribution in Large-Scale Greenplum Systems</title>
       <body>
+        <draft-comment author="msk">mention gp_expand_method GUC. Recommendations? </draft-comment>
         <p>You can manage the order in which tables are redistributed by adjusting their ranking.
           See <xref href="expand-redistribute.xml#topic29" type="topic" format="dita"/>.
           Manipulating the redistribution order can help adjust for limited disk space and restore
           optimal query performance for high-priority queries sooner. </p>
-        <p>When planning the redistribution phase, consider the impact of the exclusive lock taken
-          on each table during redistribution. User activity on a table can delay its
-          redistribution, but also tables are unavailable for user activity during redistribution.
-        </p>
+        <section>
+          <title>Table Redstribution Methods</title>
+          <draft-comment author="msk">add GUC - NEEDS EDIT</draft-comment>
+          <p>There are two methods of redistributing data when performing a Greenplum Database
+            expansion. <ul id="ul_hkz_jdv_kgb">
+              <li>rebuild - Create a new table, copy all the data from the old to the new table, and
+                replace the old table. This is the default. The rebuild method is similar creating a
+                new table with a <codeph>CREATE TABLE AS SELECT</codeph> command.</li>
+              <li>move - Scan all the data and perform an <codeph>UPDATE</codeph> operation to move
+                rows as needed to different segment instances. In general, this method requires less
+                disk space, however, it creates obsolete table rows and might require a
+                  <codeph>VACUUM</codeph> operation on the table. Also, this method updates indexes
+                one row at a time, which can be much slower than rebuilding the index with the
+                  <codeph>CREATE INDEX</codeph> command.</li>
+            </ul></p>
+          <p>The server configuration parameter <codeph><xref
+                href="../../ref_guide/config_params/guc-list.xml#gp_expand_method"
+                >gp_expand_method</xref></codeph> controls the redistribution method.</p>
+          <draft-comment author="msk">leave out until gp_use_legacy_hashops and upgrade are
+            available.</draft-comment>
+          <p>When planning the redistribution phase, consider the impact of the exclusive lock taken
+            on each table during redistribution. User activity on a table can delay its
+            redistribution, but also tables are unavailable for user activity during redistribution.
+          </p>
+        </section>
         <section>
           <title>Systems with Abundant Free Disk Space</title>
           <p>In systems with abundant free disk space (required to store a copy of the largest
@@ -349,6 +399,7 @@
     <topic id="topic13" xml:lang="en">
       <title>Redistributing Append-Optimized and Compressed Tables</title>
       <body>
+        <draft-comment author="msk">removed mention of zlib option.</draft-comment>
         <p><codeph>gpexpand</codeph> redistributes append-optimized and compressed append-optimized
           tables at different rates than heap tables. The CPU capacity required to compress and
           decompress data tends to increase the impact on system performance. For similar-sized
@@ -356,14 +407,14 @@
             following:<ul id="ul_ocf_3fr_g4">
             <li id="no163863">Uncompressed append-optimized tables expand 10% faster than heap
               tables.</li>
-            <li id="no170207"><codeph>zlib</codeph>-compressed append-optimized tables expand at a
-              significantly slower rate than uncompressed append-optimized tables, potentially up to
-              80% slower.</li>
+            <li id="no170207">Append-optimized tables are defined to use data compression expand at
+              a significantly slower rate than uncompressed append-optimized tables, potentially up
+              to 80% slower.</li>
             <li id="no170253">Systems with data compression such as ZFS/LZJB take longer to
               redistribute.</li>
           </ul></p>
-        <note type="important">If your system nodes use data compression, use identical compression
-          on new nodes to avoid disk space shortage. </note>
+        <note type="important">If your system hosts use data compression, use identical compression
+          setting on the new hosts to avoid disk space shortage. </note>
       </body>
     </topic>
     <topic id="topic14" xml:lang="en">

--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -6,8 +6,6 @@
   <shortdesc>Careful planning will help to ensure a successful Greenplum expansion
     project.</shortdesc>
   <body>
-    <draft-comment author="msk">Remove downtime when adding segment instances.<p>Add link to block
-        mirror?</p></draft-comment>
     <p>The topics in this section help to ensure that you are prepared to execute a system
       expansion.</p>
     <ul id="ul_gdc_hp5_mr">
@@ -198,8 +196,6 @@
     <body>
       <p>A deliberate, thorough approach to deploying compatible hardware greatly minimizes risk to
         the expansion process.</p>
-      <draft-comment author="msk">Change reference from Platform Engineering to Pivotal
-        Support</draft-comment>
       <p>Hardware resources and configurations for new segment hosts should match those of the
         existing hosts.<ph otherprops="pivotal"> Work with <i>Pivotal Support</i> before making a
           hardware purchase to expand Greenplum Database.</ph></p>
@@ -245,7 +241,6 @@
     <topic id="topic7" xml:lang="en">
       <title id="no164776">Planning Mirror Segments</title>
       <body>
-        <draft-comment author="msk">Add link to block mirroring in Best Practices?</draft-comment>
         <p>If your existing system has mirror segments, the new segments must have mirroring
           configured. If there are no mirrors configured for existing segments, you cannot add
           mirrors to new hosts with the <codeph>gpexpand</codeph> utility. For more information
@@ -326,8 +321,6 @@
       <note type="important">To perform table redistribution, your segment hosts must have enough
         disk space to temporarily hold a copy of your largest table. All tables are unavailable for
         read and write operations during redistribution. </note>
-      <draft-comment author="msk">true for default of gp_expand_method GUC. recommendation for
-          <codeph>move</codeph> setting </draft-comment>
       <p>The performance impact of table redistribution depends on the size, storage type, and
         partitioning design of a table. For any given table, redistributing it with
           <codeph>gpexpand</codeph> takes as much time as a <codeph>CREATE TABLE AS SELECT</codeph>
@@ -338,35 +331,35 @@
     <topic id="topic11" xml:lang="en">
       <title id="no167000">Managing Redistribution in Large-Scale Greenplum Systems</title>
       <body>
-        <draft-comment author="msk">mention gp_expand_method GUC. Recommendations? </draft-comment>
+        <p>When planning the redistribution phase, consider the impact of the <codeph>ACCESS
+            EXCLUSIVE</codeph> lock taken on each table, and the table data redistribution method.
+          User activity on a table can delay its redistribution, but also tables are unavailable for
+          user activity during redistribution. </p>
         <p>You can manage the order in which tables are redistributed by adjusting their ranking.
           See <xref href="expand-redistribute.xml#topic29" type="topic" format="dita"/>.
           Manipulating the redistribution order can help adjust for limited disk space and restore
           optimal query performance for high-priority queries sooner. </p>
         <section>
           <title>Table Redstribution Methods</title>
-          <draft-comment author="msk">add GUC - NEEDS EDIT</draft-comment>
           <p>There are two methods of redistributing data when performing a Greenplum Database
             expansion. <ul id="ul_hkz_jdv_kgb">
-              <li>rebuild - Create a new table, copy all the data from the old to the new table, and
-                replace the old table. This is the default. The rebuild method is similar creating a
-                new table with a <codeph>CREATE TABLE AS SELECT</codeph> command.</li>
-              <li>move - Scan all the data and perform an <codeph>UPDATE</codeph> operation to move
-                rows as needed to different segment instances. In general, this method requires less
-                disk space, however, it creates obsolete table rows and might require a
-                  <codeph>VACUUM</codeph> operation on the table. Also, this method updates indexes
-                one row at a time, which can be much slower than rebuilding the index with the
-                  <codeph>CREATE INDEX</codeph> command.</li>
+              <li><codeph>rebuild</codeph> - Create a new table, copy all the data from the old to
+                the new table, and replace the old table. This is the default. The rebuild method is
+                similar to creating a new table with a <codeph>CREATE TABLE AS SELECT</codeph>
+                command. During data redistribution, an <codeph>ACCESS EXCLUSIVE</codeph> lock is
+                acquired on the table.</li>
+              <li><codeph>move</codeph> - Scan all the data and perform an <codeph>UPDATE</codeph>
+                operation to move rows as needed to different segment instances. During data
+                redistribution, an <codeph>ACCESS EXCLUSIVE</codeph> lock is acquired on the table.
+                In general, this method requires less disk space, however, it creates obsolete table
+                rows and might require a <codeph>VACUUM</codeph> operation on the table after the
+                data redistribution. Also, this method updates indexes one row at a time, which can
+                be much slower than rebuilding the index with the <codeph>CREATE INDEX</codeph>
+                command.</li>
             </ul></p>
           <p>The server configuration parameter <codeph><xref
                 href="../../ref_guide/config_params/guc-list.xml#gp_expand_method"
                 >gp_expand_method</xref></codeph> controls the redistribution method.</p>
-          <draft-comment author="msk">leave out until gp_use_legacy_hashops and upgrade are
-            available.</draft-comment>
-          <p>When planning the redistribution phase, consider the impact of the exclusive lock taken
-            on each table during redistribution. User activity on a table can delay its
-            redistribution, but also tables are unavailable for user activity during redistribution.
-          </p>
         </section>
         <section>
           <title>Systems with Abundant Free Disk Space</title>
@@ -399,7 +392,6 @@
     <topic id="topic13" xml:lang="en">
       <title>Redistributing Append-Optimized and Compressed Tables</title>
       <body>
-        <draft-comment author="msk">removed mention of zlib option.</draft-comment>
         <p><codeph>gpexpand</codeph> redistributes append-optimized and compressed append-optimized
           tables at different rates than heap tables. The CPU capacity required to compress and
           decompress data tends to increase the impact on system performance. For similar-sized

--- a/gpdb-doc/dita/admin_guide/expand/expand-redistribute.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-redistribute.xml
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-
 <topic id="topic28" xml:lang="en">
   <title id="expand-redistribute">Redistributing Tables</title>
   <shortdesc>Redistribute tables to balance existing data over the newly expanded cluster. </shortdesc>
   <body>
-    <p>After creating an expansion schema, you can bring Greenplum Database back online and
-      redistribute tables across the entire array with <codeph>gpexpand</codeph>. Aim to run this
-      during low-use hours when the utility's CPU usage and table locks have minimal impact on
-      operations. Rank tables to redistribute the largest or most critical tables first.</p>
+    <draft-comment author="msk">GPDB 6 - online expand</draft-comment>
+    <p>After creating an expansion schema, you can redistribute tables across the entire system with
+          <codeph><xref href="../../utility_guide/admin_utilities/gpexpand.xml"
+        >gpexand</xref></codeph>. Aim to run this during low-use hours when the utility's CPU usage
+      and table locks have minimal impact on operations. Rank tables to redistribute the largest or
+      most critical tables first.</p>
     <note>When redistributing data, Greenplum Database must be running in production mode. Greenplum
-      Database cannot be restricted mode or in master mode. The <codeph>gpstart</codeph> options
+      Database cannot be restricted mode or in master mode. The <codeph><xref
+          href="../../utility_guide/admin_utilities/gpstart.xml">gpstart</xref></codeph> options
         <codeph>-R</codeph> or <codeph>-m</codeph> cannot be specified to start Greenplum
       Database.</note>
+    <draft-comment author="msk">Mention two redistribute methods see GUC
+      gp_expand_method</draft-comment>
     <p>While table redistribution is underway, any new tables or partitions created are distributed
       across all segments exactly as they would be under normal operating conditions. Queries can
       access all segments, even before the relevant data is redistributed to tables on the new
@@ -34,13 +38,15 @@
   <topic id="topic29" xml:lang="en">
     <title id="no161370">Ranking Tables for Redistribution</title>
     <body>
-      <p>For large systems, you can control the table redistribution order. Adjust
-        tables' <codeph>rank</codeph> values in the expansion schema to prioritize heavily-used
-        tables and minimize performance impact. Available free disk space can affect table ranking;
-        see <xref href="expand-planning.xml#topic11" type="topic" format="dita"/>.</p>
-      <p>To rank tables for redistribution by updating <codeph>rank</codeph> values in
-          <i>gpexpand.status_detail</i>, connect to Greenplum Database using <codeph>psql</codeph>
-        or another supported client. Update <i>gpexpand.status_detail</i> with commands such as:</p>
+      <p>For large systems, you can control the table redistribution order. Adjust tables'
+          <codeph>rank</codeph> values in the expansion schema to prioritize heavily-used tables and
+        minimize performance impact. Available free disk space can affect table ranking; see <xref
+          href="expand-planning.xml#topic11" type="topic" format="dita"/>.</p>
+      <p>To rank tables for redistribution by updating <codeph>rank</codeph> values in <i><xref
+            href="../../ref_guide/system_catalogs/gp_expansion_tables.xml"
+            >gpexpand.status_detail</xref></i>, connect to Greenplum Database using
+          <codeph>psql</codeph> or another supported client. Update <i>gpexpand.status_detail</i>
+        with commands such as:</p>
       <codeblock>=&gt; UPDATE gpexpand.status_detail SET rank=10;
 
 =&gt; UPDATE gpexpand.status_detail SET rank=1 WHERE fq_name = 'public.lineitem';
@@ -56,19 +62,21 @@
   <topic id="topic30" xml:lang="en">
     <title>Redistributing Tables Using gpexpand</title>
     <body>
+      <draft-comment author="msk">There are two redistribute methods see GUC
+        gp_expand_method</draft-comment>
       <section id="no162282">
         <title>To redistribute tables with gpexpand</title>
         <ol>
           <li id="no162285">Log in on the master host as the user who will run your Greenplum
             Database system, for example, <codeph>gpadmin</codeph>.</li>
-
           <li id="no162763">Run the <codeph>gpexpand</codeph> utility. You can use the
               <codeph>-d</codeph> or <codeph>-e</codeph> option to define the expansion session time
             period. For example, to run the utility for up to 60 consecutive
               hours:<codeblock>$ gpexpand -d 60:00:00</codeblock><p>The utility redistributes tables
               until the last table in the schema completes or it reaches the specified duration or
-              end time. <codeph>gpexpand</codeph> updates the status and time in
-                <i>gpexpand.status</i> when a session starts and finishes.</p></li>
+              end time. <codeph>gpexpand</codeph> updates the status and time in <i><xref
+                  href="../../ref_guide/system_catalogs/gp_expansion_status.xml"
+                  >gpexpand.status</xref></i> when a session starts and finishes.</p></li>
         </ol>
       </section>
     </body>
@@ -77,9 +85,11 @@
     <title>Monitoring Table Redistribution</title>
     <body>
       <p>You can query the expansion schema during the table redistribution process. The view
-          <i>gpexpand.expansion_progress</i> provides a current progress summary, including the
-        estimated rate of table redistribution and estimated time to completion. You can query the
-        table <i>gpexpand.status_detail</i> for per-table status information.</p>
+            <i><xref href="../../ref_guide/system_catalogs/gpexpand_expansion_progress.xml"
+            >gpexpand.expansion_progress</xref></i> provides a current progress summary, including
+        the estimated rate of table redistribution and estimated time to completion. You can query
+        the table <i><xref href="../../ref_guide/system_catalogs/gp_expansion_tables.xml"
+            >gpexpand.status_detail</xref></i> for per-table status information.</p>
     </body>
     <topic id="topic32" xml:lang="en">
       <title>Viewing Expansion Status</title>
@@ -87,7 +97,7 @@
         <p>After the first table completes redistribution, <i>gpexpand.expansion_progress</i>
           calculates its estimates and refreshes them based on all tables' redistribution rates.
           Calculations restart each time you start a table redistribution session with
-            <codeph>gpexpand</codeph>. To monitor progress, connect to Greenplum Database using
+            <codeph>gpexpand</codeph>. To monitor progress, connect to Greenplum Data\base using
             <codeph>psql</codeph> or another supported client; query
             <i>gpexpand.expansion_progress</i> with a command like the following:</p>
         <p>

--- a/gpdb-doc/dita/admin_guide/expand/expand-redistribute.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-redistribute.xml
@@ -5,7 +5,6 @@
   <title id="expand-redistribute">Redistributing Tables</title>
   <shortdesc>Redistribute tables to balance existing data over the newly expanded cluster. </shortdesc>
   <body>
-    <draft-comment author="msk">GPDB 6 - online expand</draft-comment>
     <p>After creating an expansion schema, you can redistribute tables across the entire system with
           <codeph><xref href="../../utility_guide/admin_utilities/gpexpand.xml"
         >gpexand</xref></codeph>. Aim to run this during low-use hours when the utility's CPU usage
@@ -16,8 +15,6 @@
           href="../../utility_guide/admin_utilities/gpstart.xml">gpstart</xref></codeph> options
         <codeph>-R</codeph> or <codeph>-m</codeph> cannot be specified to start Greenplum
       Database.</note>
-    <draft-comment author="msk">Mention two redistribute methods see GUC
-      gp_expand_method</draft-comment>
     <p>While table redistribution is underway, any new tables or partitions created are distributed
       across all segments exactly as they would be under normal operating conditions. Queries can
       access all segments, even before the relevant data is redistributed to tables on the new

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -3354,24 +3354,21 @@
   <topic id="gp_expand_method">
     <title>gp_expand_method</title>
     <body>
-      <draft-comment author="msk">DRAFT <xref
-          href="https://www.pivotaltracker.com/story/show/162535111" format="html" scope="external"
-          >162535111</xref>
-        <xref href="https://github.com/greenplum-db/gpdb/pull/6630" format="html" scope="external"
-          >gpdb-feature/pull/66300</xref> merged to feature<p><b>[Q:]</b> Will both expand methods
-          work with both hashmethods?</p></draft-comment>
-      <p>This parameter controls how<codeph>gpexpand</codeph> redistributes table data during the
+      <p>This parameter controls how <codeph>gpexpand</codeph> redistributes table data during the
         table data redistribution phase of a system expansion. There are two ways
           <codeph>gpexpand</codeph> can perform table data redistribution.<ul id="ol_xdd_1py_jgb">
-          <li>rebuild - Create a new table, copy all the data from the old to the new table, and
-            replace the old table. This is the default. The rebuild method is similar creating a new
-            table with a <codeph>CREATE TABLE AS SELECT</codeph> command.</li>
-          <li>move - Scan the table data and perform an <codeph>UPDATE</codeph> operation to move
-            rows as needed to different segment instances. In general, this method requires less
-            disk space, however, it creates obsolete table rows and might require a
-              <codeph>VACUUM</codeph> operation on the table. Also, this method updates indexes one
-            row at a time, which can be much slower than rebuilding the index with the
-              <codeph>CREATE INDEX</codeph> command.</li>
+          <li><codeph>rebuild</codeph> - Create a new table, copy all the data from the old to the
+            new table, and replace the old table. This is the default. The rebuild method is similar
+            to creating a new table with a <codeph>CREATE TABLE AS SELECT</codeph> command. During
+            data redistribution an <codeph>ACCESS EXCLUSIVE</codeph> lock is acquired on the
+            table.</li>
+          <li><codeph>move</codeph> - Scan the table data and perform an <codeph>UPDATE</codeph>
+            operation to move rows as needed to different segment instances. During data
+            redistribution an <codeph>ACCESS EXCLUSIVE</codeph> lock is acquired on the table. In
+            general, this method requires less disk space, however, it creates obsolete table rows
+            and might require a <codeph>VACUUM</codeph> operation on the table. Also, this method
+            updates indexes one row at a time, which can be much slower than rebuilding the index
+            with the <codeph>CREATE INDEX</codeph> command.</li>
         </ul></p>
       <table id="table_utp_zny_jgb">
         <tgroup cols="3">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -245,6 +245,8 @@
             <li>
               <xref href="#gp_enable_sort_limit"/>
             </li>
+            <li><xref href="#gp_expand_method"/>
+            </li>
           </ul>
         </stentry>
         <stentry>
@@ -407,6 +409,8 @@
             </li>
             <li>
               <xref href="#gp_statistics_use_fkeys"/>
+            </li>
+            <li><xref href="#gp_use_legacy_hashops"/>
             </li>
             <li>
               <xref href="#gp_vmem_idle_resource_timeout"/>
@@ -3347,6 +3351,51 @@
       </table>
     </body>
   </topic>
+  <topic id="gp_expand_method">
+    <title>gp_expand_method</title>
+    <body>
+      <draft-comment author="msk">DRAFT <xref
+          href="https://www.pivotaltracker.com/story/show/162535111" format="html" scope="external"
+          >162535111</xref>
+        <xref href="https://github.com/greenplum-db/gpdb/pull/6630" format="html" scope="external"
+          >gpdb-feature/pull/66300</xref> merged to feature<p><b>[Q:]</b> Will both expand methods
+          work with both hashmethods?</p></draft-comment>
+      <p>This parameter controls how<codeph>gpexpand</codeph> redistributes table data during the
+        table data redistribution phase of a system expansion. There are two ways
+          <codeph>gpexpand</codeph> can perform table data redistribution.<ul id="ol_xdd_1py_jgb">
+          <li>rebuild - Create a new table, copy all the data from the old to the new table, and
+            replace the old table. This is the default. The rebuild method is similar creating a new
+            table with a <codeph>CREATE TABLE AS SELECT</codeph> command.</li>
+          <li>move - Scan the table data and perform an <codeph>UPDATE</codeph> operation to move
+            rows as needed to different segment instances. In general, this method requires less
+            disk space, however, it creates obsolete table rows and might require a
+              <codeph>VACUUM</codeph> operation on the table. Also, this method updates indexes one
+            row at a time, which can be much slower than rebuilding the index with the
+              <codeph>CREATE INDEX</codeph> command.</li>
+        </ul></p>
+      <table id="table_utp_zny_jgb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">rebuild<p>move</p></entry>
+              <entry colname="col2">rebuild</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="gp_external_enable_exec">
     <title>gp_external_enable_exec</title>
     <body>
@@ -5072,6 +5121,43 @@
             <row>
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">off</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_use_legacy_hashops">
+    <title>gp_use_legacy_hashops</title>
+    <body>
+      <draft-comment author="msk">DRAFT <xref
+          href="https://github.com/greenplum-db/gpdb/pull/6327/commits/e6ce8e2a" format="html"
+          scope="external">gpdb/pull/6327/commits/e6ce8e2a</xref><p><b>[Q:]</b> expand changes
+          hashmethod from 0 (modulo) to 1 (jump consistent) - What happens if GUC is
+        true?</p></draft-comment>
+      <p>For a table that is defined with a <codeph>DISTRIBUTED BY
+          <varname>key_column</varname></codeph> clause, this parameter controls the hash algorithm
+        that is used to distribute table data among segment instances. The default value is
+          <codeph>false</codeph>, use the jump constant hash algorithm. </p>
+      <p>Setting the value to <codeph>true</codeph> uses the modulo hash algorithm that is
+        compatible with Greenplum Database 5.x and earlier releases.</p>
+      <table id="gp_interconnect_fc_method_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">false</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1071,7 +1071,8 @@
               <xref href="guc-list.xml#deadlock_timeout" type="section">deadlock_timeout</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#gp_global_deadlock_detector_period" type="section">gp_global_deadlock_detector_period</xref>
+              <xref href="guc-list.xml#gp_global_deadlock_detector_period" type="section"
+                >gp_global_deadlock_detector_period</xref>
             </p>
           </stentry>
           <stentry>
@@ -1263,6 +1264,10 @@
             </p>
             <p><xref href="guc-list.xml#gp_enable_segment_copy_checking"
                 >gp_enable_segment_copy_checking</xref></p>
+            <p><xref href="guc-list.xml#gp_expand_method">gp_expand_method</xref></p>
+            <p>
+              <xref href="guc-list.xml#gp_use_legacy_hashops" type="section"
+                >gp_use_legacy_hashops</xref></p>
           </stentry>
         </strow>
       </simpletable>
@@ -1320,8 +1325,7 @@
               </p>
             </stentry>
             <stentry>
-              <p>
-                <xref href="guc-list.xml#regex_flavor" type="section">regex_flavor</xref>
+              <p><xref href="guc-list.xml#regex_flavor" type="section">regex_flavor</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#standard_conforming_strings" type="section"

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -105,6 +105,7 @@
             <topicref href="guc-list.xml#gp_enable_segment_copy_checking"/>
             <topicref href="guc-list.xml#gp_enable_sort_distinct"/>
             <topicref href="guc-list.xml#gp_enable_sort_limit"/>
+            <topicref href="guc-list.xml#gp_expand_method"/>
             <topicref href="guc-list.xml#gp_external_enable_exec"/>
             <topicref href="guc-list.xml#gp_external_max_segs"/>
             <topicref href="guc-list.xml#gp_external_enable_filter_pushdown"/>
@@ -161,6 +162,7 @@
             <topicref href="guc-list.xml#gp_set_read_only"/>
             <topicref href="guc-list.xml#gp_statistics_pullup_from_child_partition"/>
             <topicref href="guc-list.xml#gp_statistics_use_fkeys"/>
+            <topicref href="guc-list.xml#gp_use_legacy_hashops"/>
             <topicref href="guc-list.xml#gp_vmem_idle_resource_timeout"/>
             <topicref href="guc-list.xml#gp_vmem_protect_limit"/>
             <topicref href="guc-list.xml#gp_vmem_protect_segworker_cache_limit"/>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_distribution_policy.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_distribution_policy.xml
@@ -4,9 +4,11 @@
 <topic id="topic1" xml:lang="en">
   <title id="ey142834">gp_distribution_policy</title>
   <body>
-    <p>The <codeph>gp_distribution_policy</codeph> table contains information about Greenplum Database tables and their policy for distributing table data across the
-      segments. This table is populated only on the master. This table is not globally shared,
-      meaning each database has its own copy of this table.</p>
+    <draft-comment author="msk">GPDB 6 - added numsegments</draft-comment>
+    <p>The <codeph>gp_distribution_policy</codeph> table contains information about Greenplum
+      Database tables and their policy for distributing table data across the segments. This table
+      is populated only on the master. This table is not globally shared, meaning each database has
+      its own copy of this table.</p>
     <table id="ey142842">
       <title>pg_catalog.gp_distribution_policy</title>
       <tgroup cols="4">
@@ -25,7 +27,7 @@
         <tbody>
           <row>
             <entry colname="col1">
-              <codeph id="ey142864">localoid</codeph>
+              <codeph>localoid</codeph>
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_class.oid</entry>
@@ -33,7 +35,7 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph id="ey142874">attrnums</codeph>
+              <codeph>attrnums</codeph>
             </entry>
             <entry colname="col2">smallint[]</entry>
             <entry colname="col3">pg_attribute.attnum</entry>
@@ -41,15 +43,21 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph id="ey142874">policytype</codeph>
+              <codeph>policytype</codeph>
             </entry>
             <entry colname="col2">char</entry>
-            <entry colname="col3"></entry>
+            <entry colname="col3"/>
             <entry colname="col4">The table distribution policy:<ul>
-              <li><codeph>p</codeph> - The table has a partitioned
-                distribution policy.</li>
-              <li><codeph>r</codeph> - The table has a replicated distribution
-                policy.</li></ul></entry>
+                <li><codeph>p</codeph> - The table has a partitioned distribution policy.</li>
+                <li><codeph>r</codeph> - The table has a replicated distribution policy.</li>
+              </ul></entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>numsegments</codeph></entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The number of segment instances the table data is distributed
+              on.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_distribution_policy.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_distribution_policy.xml
@@ -4,7 +4,6 @@
 <topic id="topic1" xml:lang="en">
   <title id="ey142834">gp_distribution_policy</title>
   <body>
-    <draft-comment author="msk">GPDB 6 - added numsegments</draft-comment>
     <p>The <codeph>gp_distribution_policy</codeph> table contains information about Greenplum
       Database tables and their policy for distributing table data across the segments. This table
       is populated only on the master. This table is not globally shared, meaning each database has
@@ -47,17 +46,19 @@
             </entry>
             <entry colname="col2">char</entry>
             <entry colname="col3"/>
-            <entry colname="col4">The table distribution policy:<ul>
-                <li><codeph>p</codeph> - The table has a partitioned distribution policy.</li>
-                <li><codeph>r</codeph> - The table has a replicated distribution policy.</li>
+            <entry colname="col4">The table distribution policy:<ul id="ul_a52_yj2_4gb">
+                <li><codeph>p</codeph> - Partitioned policy. Table data is distributed among segment
+                  instances. </li>
+                <li><codeph>r</codeph> - Replicated policy. Table data is replicated on each segment
+                  instance. </li>
               </ul></entry>
           </row>
           <row>
             <entry colname="col1"><codeph>numsegments</codeph></entry>
             <entry colname="col2">integer</entry>
             <entry colname="col3"/>
-            <entry colname="col4">The number of segment instances the table data is distributed
-              on.</entry>
+            <entry colname="col4">The number of segment instances on which the table data is
+              distributed.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
@@ -4,16 +4,14 @@
 <topic id="topic1" xml:lang="en">
   <title id="fb138336">gpexpand.status_detail</title>
   <body>
-    <draft-comment author="msk">updates for GPDB 6<p>distribution_policy_type,
-        root_partition_name</p></draft-comment>
     <p>The <codeph>gpexpand.status_detail</codeph> table contains information about the status of
       tables involved in a system expansion operation. You can query this table to determine the
       status of tables being expanded, or to view the start and end time for completed tables. </p>
     <p>This table also stores related information about the table such as the oid, disk size, and
       normal distribution policy and key. Overall status information for the expansion is stored in
         <xref href="gp_expansion_status.xml#topic1" type="topic" format="dita"/>.</p>
-    <p>In a normal expansion operation it is not necessary to modify the data stored in this table.
-      .</p>
+    <p>In a normal expansion operation it is not necessary to modify the data stored in this
+      table.</p>
     <table id="fb138428">
       <title>gpexpand.status_detail</title>
       <tgroup cols="4">
@@ -85,7 +83,8 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Column IDs for the distribution keys of the table.</entry>
+            <entry colname="col4">Column IDs for the distribution keys of the table. Value is
+                <codeph>None</codeph> if the table does not have a distribution key column.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -93,7 +92,9 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
-            <entry colname="col4">???</entry>
+            <entry colname="col4">Table data distribution. Valid values are: <codeph>p</codeph> -
+              table data is distributed among segment instances, <codeph>r</codeph> - table data is
+              replicated on each segment instance.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -101,7 +102,8 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
-            <entry colname="col4">???</entry>
+            <entry colname="col4">For a partitioned table, the name of the root partition.
+              Otherwise, <codeph>None</codeph>.</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
@@ -4,6 +4,8 @@
 <topic id="topic1" xml:lang="en">
   <title id="fb138336">gpexpand.status_detail</title>
   <body>
+    <draft-comment author="msk">updates for GPDB 6<p>distribution_policy_type,
+        root_partition_name</p></draft-comment>
     <p>The <codeph>gpexpand.status_detail</codeph> table contains information about the status of
       tables involved in a system expansion operation. You can query this table to determine the
       status of tables being expanded, or to view the start and end time for completed tables. </p>
@@ -84,6 +86,22 @@
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
             <entry colname="col4">Column IDs for the distribution keys of the table.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>distribution_policy _type</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">???</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>root_partition_name</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">???</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_tablespace.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_tablespace.xml
@@ -1,11 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1" xml:lang="en"><title id="hx156255">pg_tablespace</title><body><p>The <codeph>pg_tablespace</codeph> system catalog table stores information about the available
-      tablespaces. Tables can be placed in particular tablespaces to aid administration of disk
-      layout. Unlike most system catalogs, <codeph>pg_tablespace</codeph> is shared across all
-      databases of a Greenplum system: there is only one copy of
-        <codeph>pg_tablespace</codeph> per system, not one per database.</p><table id="hx156260"><title>pg_catalog.pg_tablespace</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>spcname</codeph></entry><entry colname="col2">name</entry><entry colname="col3"/><entry colname="col4">Tablespace name.</entry></row><row><entry colname="col1"><codeph>spcowner</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_authid.oid</entry><entry colname="col4">Owner of the tablespace, usually the user who
-created it.</entry></row><row><entry colname="col1"><codeph>spclocation</codeph></entry><entry colname="col2">text[]</entry><entry colname="col3"/><entry colname="col4">Unused.</entry></row><row><entry colname="col1"><codeph>spcacl </codeph></entry><entry colname="col2">aclitem[] </entry><entry colname="col3"/><entry colname="col4">Tablespace access privileges.</entry></row><row><entry colname="col1"><codeph>spcfsoid</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_filespace.oid</entry><entry colname="col4">The object id of the filespace used by this
-tablespace. A filespace defines directory locations on the primary, mirror
-and master segments.</entry></row></tbody></tgroup></table></body></topic>
+<topic id="topic1" xml:lang="en">
+  <title id="hx156255">pg_tablespace</title>
+  <body>
+    <draft-comment author="msk">6.0 remove spclocation, spcfsoid add spcoptions</draft-comment>
+    <p>The <codeph>pg_tablespace</codeph> system catalog table stores information about the
+      available tablespaces. Tables can be placed in particular tablespaces to aid administration of
+      disk layout. Unlike most system catalogs, <codeph>pg_tablespace</codeph> is shared across all
+      databases of a Greenplum system: there is only one copy of <codeph>pg_tablespace</codeph> per
+      system, not one per database.</p>
+    <table id="hx156260">
+      <title>pg_catalog.pg_tablespace</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>spcname</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Tablespace name.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>spcowner</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_authid.oid</entry>
+            <entry colname="col4">Owner of the tablespace, usually the user who created it.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>spcacl </codeph></entry>
+            <entry colname="col2">aclitem[] </entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Tablespace access privileges.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>spcoptions</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Tablespace contentID locations.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
@@ -4,7 +4,8 @@
 <topic id="topic1">
   <title id="kt20941">gpexpand</title>
   <body>
-    <p>Expands an existing Greenplum Database across new hosts in the array.</p>
+    <draft-comment author="msk">GPDB 6 - online expand</draft-comment>
+    <p>Expands an existing Greenplum Database across new hosts in the system.</p>
     <section id="section2">
       <title>Synopsis</title>
       <codeblock><b>gpexpand</b> [{<b>-f</b>|<b>--hosts-file</b>} <varname>hosts_file</varname>]
@@ -41,34 +42,39 @@
             <codeph>gpstart</codeph> options <codeph>-R</codeph> or <codeph>-m</codeph> cannot be
           specified to start Greenplum Database. </li>
       </ul>
+      <p>For information about preparing a system for expansion, see <xref
+          href="../../admin_guide/expand/expand-main.xml" scope="peer">Expanding a Greenplum
+          System</xref><ph otherprops="op-print"> in the <cite>Greenplum Database Administrator
+            Guide</cite></ph>.</p>
     </section>
     <section id="section4">
       <title>Description</title>
       <p>The <codeph>gpexpand</codeph> utility performs system expansion in two phases: segment
-        initialization and then table redistribution. </p>
+        instance initialization and then table data redistribution. </p>
       <p>In the initialization phase, <codeph>gpexpand</codeph> runs with an input file that
         specifies data directories, <varname>dbid</varname> values, and other characteristics of the
-        new segments. You can create the input file manually, or by following the prompts in an
-        interactive interview.</p>
+        new segment instances. You can create the input file manually, or by following the prompts
+        in an interactive interview.</p>
       <p>If you choose to create the input file using the interactive interview, you can optionally
-        specify a file containing a list of expansion hosts. If your platform or command shell
-        limits the length of the list of hostnames that you can type when prompted in the interview,
-        specifying the hosts with <codeph>-f</codeph> may be mandatory. </p>
-      <p>In addition to initializing the segments, the initialization phase performs these
+        specify a file containing a list of expansion system hosts. If your platform or command
+        shell limits the length of the list of hostnames that you can type when prompted in the
+        interview, specifying the hosts with <codeph>-f</codeph> may be mandatory. </p>
+      <p>In addition to initializing the segment instances, the initialization phase performs these
         actions:</p>
       <ul>
         <li id="kt138259">Creates an expansion schema to store the status of the expansion
           operation, including detailed status for tables.</li>
-        <li id="kt138260">Changes the distribution policy for all tables to <codeph>DISTRIBUTED
-            RANDOMLY</codeph>. The original distribution policies are later restored in the
-          redistribution phase.</li>
       </ul>
+      <p>In the table data redistribution phase, <codeph>gpexapand</codeph> redistributes table data
+        to rebalance the data across the old and new segment instances.</p>
       <note>Data redistribution should be performed during low-use hours. Redistribution can divided
         into batches over an extended period.</note>
+      <draft-comment author="msk">Reference to time is for default expand method. mention
+        gp_expand_method GUC. Recommendations? </draft-comment>
       <p>To begin the redistribution phase, run <codeph>gpexpand</codeph> with either the
           <codeph>-d</codeph> (duration) or <codeph>-e</codeph> (end time) options, or with no
         options. If you specify an end time or duration, then the utility redistributes tables in
-        the expansion schema until the specified end time or duration is reached.  If you specify no
+        the expansion schema until the specified end time or duration is reached. If you specify no
         options, then the utility redistribution phase continues until all tables in the expansion
         schema are reorganized. Each table is reorganized using <codeph>ALTER TABLE</codeph>
         commands to rebalance the tables across new segments, and to set tables to their original
@@ -128,14 +134,14 @@
             Each line of the file must contain a single host name. </pd>
           <pd>This file can contain hostnames with or without network interfaces specified. The
               <codeph>gpexpand</codeph> utility handles either case, adding interface numbers to end
-            of the hostname if the original nodes are configured with multiple network
-              interfaces.<note>The Greenplum Database segment host naming convention is
-                <codeph>sdwN</codeph> where <codeph>sdw</codeph> is a prefix and <codeph>N</codeph>
-              is an integer. For example, <codeph>sdw1</codeph>, <codeph>sdw2</codeph> and so on.
-              For hosts with multiple interfaces, the convention is to append a dash
-                (<codeph>-</codeph>) and number to the host name. For example,
-                <codeph>sdw1-1</codeph> and <codeph>sdw1-2</codeph> are the two interface names for
-              host <codeph>sdw1</codeph>. </note></pd>
+            of the hostname if the original nodes are configured with multiple network interfaces.
+            <note>The Greenplum Database segment host naming convention is <codeph>sdwN</codeph>
+              where <codeph>sdw</codeph> is a prefix and <codeph>N</codeph> is an integer. For
+              example, <codeph>sdw1</codeph>, <codeph>sdw2</codeph> and so on. For hosts with
+              multiple interfaces, the convention is to append a dash (<codeph>-</codeph>) and
+              number to the host name. For example, <codeph>sdw1-1</codeph> and
+                <codeph>sdw1-2</codeph> are the two interface names for host <codeph>sdw1</codeph>.
+            </note></pd>
         </plentry>
         <plentry>
           <pt>-i | --input <varname>input_file</varname></pt>
@@ -208,7 +214,8 @@
       <title>See Also</title>
       <p>
         <codeph><xref href="gpssh-exkeys.xml#topic1"/></codeph>, <xref
-          href="../../admin_guide/expand/expand-main.xml" scope="peer">Expanding a Greenplum System</xref>
+          href="../../admin_guide/expand/expand-main.xml" scope="peer">Expanding a Greenplum
+          System</xref>
         <ph otherprops="op-print">in the <cite>Greenplum Database Administrator
         Guide</cite></ph></p>
     </section>


### PR DESCRIPTION
These are changes for the HA "how to" (procedural) topics in the Admin Guide for current online expand.
--Removed mention of system being offline during new segment initialization
--Add information about table redistribution using rebuild and move
--Other misc. updates.

Changes to reference information
--Add GUCs gp_expand_method and gp_use_legacy_hashops
--Changes to catalog tables.
--updates to gpexpand utility

TO DO
--need to test w/ working utilities when available.
--update docs when gpexpand online feature branch is merged.

Link to HTML format of updated docs on a GPDB review site.
Admin Guide topics
https://docs-msk-gpdb6-dev.cfapps.io/600/admin_guide/expand/expand-initialize.html
https://docs-msk-gpdb6-dev.cfapps.io/600/admin_guide/expand/expand-main.html
https://docs-msk-gpdb6-dev.cfapps.io/600/admin_guide/expand/expand-nodes.html
https://docs-msk-gpdb6-dev.cfapps.io/600/admin_guide/expand/expand-overview.html
https://docs-msk-gpdb6-dev.cfapps.io/600/admin_guide/expand/expand-planning.html
https://docs-msk-gpdb6-dev.cfapps.io/600/admin_guide/expand/expand-redistribute.html

Util Guide topic
https://docs-msk-gpdb6-dev.cfapps.io/600/utility_guide/admin_utilities/gpexpand.html

New GUCs gp_expand_method, gp_use_legacy_hashops
https://docs-msk-gpdb6-dev.cfapps.io/600/ref_guide/config_params/guc-list.html#gp_expand_method
https://docs-msk-gpdb6-dev.cfapps.io/600/ref_guide/config_params/guc-list.html#gp_use_legacy_hashops

Changes to catalog tables
https://docs-msk-gpdb6-dev.cfapps.io/600/ref_guide/system_catalogs/gp_distribution_policy.html
https://docs-msk-gpdb6-dev.cfapps.io/600/ref_guide/system_catalogs/gp_expansion_tables.html
https://docs-msk-gpdb6-dev.cfapps.io/600/ref_guide/system_catalogs/pg_tablespace.html
