### PR TITLE
Stabilize the pg_rewind regress tests

### DIFF
--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -84,7 +84,7 @@ STANDBY_PG_CTL_OPTIONS="-p ${PORT_STANDBY} $PG_CTL_COMMON_OPTIONS"
 MASTER_PG_CTL_STOP_MODE="fast"
 
 function wait_for_promotion {
-   retry=50
+   retry=150
    until [ $retry -le 0 ]
    do
       PGOPTIONS=${PGOPTIONS_UTILITY} ${1} -c "select 1;" && break


### PR DESCRIPTION
Increase timeout for promotion from 10 seconds to 30 seconds. We noticed
that in failing tests that promotion took longer than 10 seconds.

Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>

There is a separate PR #6689 to create separate datadirs for each test to improve debugging.