### PR TITLE
gpcheckcat: add check for orphaned TOAST tables

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -269,7 +269,8 @@ check: $(MOCK_BIN)
 
 unitdevel:
 	@echo "Running pure unit tests..."
-	python -m unittest discover --verbose -s $(SRC)/gppylib -p "test_unit*.py"
+	PYTHONPATH=$(SERVER_SRC):$(SERVER_SBIN):$(PYTHONPATH):$(PYTHONSRC_INSTALL_PYTHON_PATH):$(SRC)/ext:$(SBIN_DIR):$(LIB_DIR):$(PYLIB_DIR)/mock-1.0.1 \
+	    python -m unittest discover --verbose -s $(SRC)/gppylib -p "test_unit*.py"
 
 solarisTest:
 	@if [ `uname -s` = 'SunOS' ]; then \

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3987,7 +3987,7 @@ class RelationObject(GPObject):
         self.paroid = None
 
     def reportAllIssues(self):
-        oid = 'N/A' if self.oid is None else self.oid
+        oid = 'N/A' if self.oid is None else str(self.oid)
         nspname = 'N/A' if self.nspname is None else self.nspname
         relname = 'N/A' if self.relname is None else self.relname
 
@@ -3996,14 +3996,14 @@ class RelationObject(GPObject):
             myprint('----------------------------------------------------')
 
             objname = 'Type' if self.relkind == 'c' else 'Relation'
-            myprint('%s oid: %d' % (objname, oid))
+            myprint('%s oid: %s' % (objname, oid))
             myprint('%s schema: %s' % (objname, nspname))
             myprint('%s name: %s' % (objname, relname))
 
         else:
             myprint('    Sub-object: ')
             myprint('    ----------------------------------------------------')
-            myprint('    Relation oid: %d' % oid)
+            myprint('    Relation oid: %s' % oid)
             myprint('    Relation schema: %s' % nspname)
             myprint('    Relation name: %s' % relname)
         myprint('')

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -17,12 +17,12 @@ Usage: gpcheckcat [<option>] [dbname]
     -C catname : run cross consistency, FK and ACL tests for this catalog table
 
 '''
+import datetime
 import getopt
 import logging
 import re
 import sys
 import time
-from datetime import datetime
 
 try:
     from gppylib import gplog
@@ -95,6 +95,8 @@ def setError(level):
 ###############################
 class Global():
     def __init__(self):
+        self.timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+
         self.retcode = SUCCESS
         self.opt = {}
         self.opt['-h'] = None
@@ -105,7 +107,7 @@ class Global():
         self.opt['-V'] = False
         self.opt['-t'] = False
 
-        self.opt['-g'] = 'gpcheckcat.repair.' + Repair.TIMESTAMP
+        self.opt['-g'] = 'gpcheckcat.repair.' + self.timestamp
         self.opt['-B'] = parallelism
         self.opt['-T'] = None
 
@@ -3177,7 +3179,7 @@ def print_repair_issues(repair_dir_path):
 def checkReindexRepair():
     if len(GV.Reindex) > 0:
         # dbname.type.timestamp.sql
-        filename = '%s.%s.%s.sql' % (GV.dbname, "reindex", Repair.TIMESTAMP)
+        filename = '%s.%s.%s.sql' % (GV.dbname, "reindex", GV.timestamp)
         fullpath = '%s/%s' % (GV.opt['-g'], filename)
         try:
             file = open(fullpath, 'w')
@@ -3209,7 +3211,7 @@ def checkPoliciesRepair():
 def checkSegmentRepair(maybeRemove, catmod_guc, seg):
     # dbid.host.port.dbname.timestamp.sql
     c = GV.cfg[seg]
-    filename = '%i.%s.%i.%s.%s.sql' % (seg, c['hostname'], c['port'], GV.dbname, Repair.TIMESTAMP)
+    filename = '%i.%s.%i.%s.%s.sql' % (seg, c['hostname'], c['port'], GV.dbname, GV.timestamp)
     filename = filename.replace(' ', '_')
     fullpath = '%s/%s' % (GV.opt['-g'], filename)
     try:
@@ -4171,7 +4173,7 @@ def checkcatReport():
     myprint('SUMMARY REPORT')
     myprint('===================================================================')
     elapsed = datetime.timedelta(seconds=int(GV.elapsedTime))
-    endTime = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    endTime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     myprint('Completed %d test(s) on database \'%s\' at %s with elapsed time %s' \
             % (GV.totalCheckRun, GV.dbname, endTime, elapsed))
 
@@ -4266,7 +4268,7 @@ def generateVerifyFile(catname, fields, results, checkname):
           ) alltyprelids
           GROUP BY relname, oid ORDER BY count(*) desc
     '''.format(in_clause=in_clause)
-    filename = 'gpcheckcat.verify.%s.%s.%s.%s.sql' % (GV.dbname, catname, checkname, Repair.TIMESTAMP)
+    filename = 'gpcheckcat.verify.%s.%s.%s.%s.sql' % (GV.dbname, catname, checkname, GV.timestamp)
     try:
         with open(filename, 'w') as fp:
             fp.write(verify_sql + '\n')

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -18,14 +18,15 @@ Usage: gpcheckcat [<option>] [dbname]
 
 '''
 import getopt
+import logging
 import re
 import sys
 import time
 from datetime import datetime
 
 try:
+    from gppylib import gplog
     from gppylib.db import dbconn
-    from gppylib.gplog import *
     from gppylib.gpcatalog import *
     from gppylib.commands.unix import *
     from gppylib.system.info import *
@@ -45,9 +46,9 @@ oidmap = {}
 
 # -------------------------------------------------------------------------------
 EXECNAME = os.path.split(__file__)[-1]
-setup_tool_logging(EXECNAME, getLocalHostname(), getUserName())
-very_quiet_stdout_logging()
-logger = get_default_logger()
+gplog.setup_tool_logging(EXECNAME, getLocalHostname(), getUserName())
+gplog.very_quiet_stdout_logging()
+logger = gplog.get_default_logger()
 
 sysinfo = SystemInfo(logger)
 
@@ -242,7 +243,7 @@ def parseCommandLine():
     if GV.opt['-l']: return
 
     if GV.opt['-v']:
-        enable_verbose_logging()
+        gplog.enable_verbose_logging()
 
     setdef('-P', 'PGPASSWORD')
     setdef('-U', 'PGUSER')
@@ -2395,9 +2396,9 @@ def checkTableACL(cat):
             logger.error('  %s acl check has %d issue(s)' % (catname, nrows))
 
             fields = curs.listfields()
-            log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
+            gplog.log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
             for row in curs.getresult():
-                log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
+                gplog.log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
             processACLResult(catname, fields, curs.getresult())
 
     except Exception, e:
@@ -2528,10 +2529,10 @@ def checkTableMissingEntry(cat):
                         ('WARNING' if log_level == logging.WARNING else 'FAIL'))
             logger_with_level('  %s has %d issue(s)' % (catname, nrows))
             fields = curs.listfields()
-            log_literal(logger, log_level, "    " + " | ".join(fields))
+            gplog.log_literal(logger, log_level, "    " + " | ".join(fields))
             results = curs.getresult()
             for row in results:
-                log_literal(logger, log_level, "    " + " | ".join(map(str, row)))
+                gplog.log_literal(logger, log_level, "    " + " | ".join(map(str, row)))
             processMissingDuplicateEntryResult(catname, fields, results, "missing")
             if catname == 'pg_type':
                 generateVerifyFile(catname, fields, results, 'missing_extraneous')
@@ -2682,9 +2683,9 @@ def checkTableInconsistentEntry(cat):
             logger.error('  %s has %d issue(s)' % (catname, nrows))
 
             fields = curs.listfields()
-            log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
+            gplog.log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
             for row in curs.getresult():
-                log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
+                gplog.log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
             results = curs.getresult()
             processInconsistentEntryResult(catname, pkey, fields, results)
             if catname == 'pg_type':
@@ -2821,10 +2822,10 @@ def checkTableDuplicateEntry(cat):
             logger.error('  %s has %d issue(s)' % (catname, nrows))
 
             fields = curs.listfields()
-            log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
+            gplog.log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
             results = curs.getresult()
             for row in results:
-                log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
+                gplog.log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
             processMissingDuplicateEntryResult(catname, fields, results, "duplicate")
             if catname == 'pg_type':
                 generateVerifyFile(catname, fields, results, 'duplicate')
@@ -4170,7 +4171,7 @@ def checkcatReport():
     myprint('SUMMARY REPORT')
     myprint('===================================================================')
     elapsed = datetime.timedelta(seconds=int(GV.elapsedTime))
-    endTime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    endTime = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     myprint('Completed %d test(s) on database \'%s\' at %s with elapsed time %s' \
             % (GV.totalCheckRun, GV.dbname, endTime, elapsed))
 
@@ -4185,7 +4186,7 @@ def checkcatReport():
         if total == 0:
             myprint('Found no catalog issue\n')
             if par.catname in ['pg_constraint']:
-                myprint('Warnings were generated, see %s for detail\n' % get_logfile())
+                myprint('Warnings were generated, see %s for detail\n' % gplog.get_logfile())
         else:
             myprint('Found a total of %d issue(s)' % total)
 
@@ -4245,11 +4246,11 @@ def checkcatReport():
     notReported = set(GV.failedChecks).difference(reportedCheck)
     if len(notReported) > 0:
         myprint('Failed test(s) that are not reported here: %s' % (', '.join(notReported)))
-        myprint('See %s for detail\n' % get_logfile())
+        myprint('See %s for detail\n' % gplog.get_logfile())
 
 
 def _myprint(str, level=logging.CRITICAL):
-    log_literal(logger, level, str)
+    gplog.log_literal(logger, level, str)
 
 
 myprint = _myprint

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -36,6 +36,7 @@ try:
     from gpcheckcat_modules.leaked_schema_dropper import LeakedSchemaDropper
     from gpcheckcat_modules.repair import Repair
     from gpcheckcat_modules.foreign_key_check import ForeignKeyCheck
+    from gpcheckcat_modules.orphaned_toast_tables_check import OrphanedToastTablesCheck, OrphanToastTableIssue, OrphanedTable
 
 
 except ImportError, e:
@@ -2908,6 +2909,59 @@ def log_unique_index_violations(violations):
     logger.error('\n'.join(log_output))
 
 
+# -------------------------------------------------------------------------------
+def checkOrphanedToastTables():
+    logger.info('-----------------------------------')
+    logger.info('Performing check: checking for orphaned TOAST tables')
+
+    db_connection = connect2(GV.cfg[1], utilityMode=False)
+    checker = OrphanedToastTablesCheck()
+    check_passed = checker.runCheck(db_connection)
+
+    checkname = 'orphaned toast table(s)'
+    if check_passed:
+        logger.info('[OK]  %s' % checkname)
+    else:
+        logger.info('[FAIL]  %s' % checkname)
+        GV.checkStatus = False
+        setError(ERROR_REMOVE)
+
+        # log raw orphan toast table query results only to the log file
+        log_output = ['Orphan toast tables detected for the following scenarios:']
+        for issue_type in checker.issue_types():
+            log_output.append('\n' + issue_type.header)
+            log_output.append('content_id | toast_table_oid | toast_table_name | expected_table_oid | expected_table_name | dependent_table_oid | dependent_table_name')
+            log_output.append('-----------+-----------------+------------------+--------------------+---------------------+---------------------+---------------------')
+            for row in checker.rows_of_type(issue_type):
+                log_output.append('{} | {} | {} | {} | {} | {} | {}'.format(
+                    row['content_id'],
+                    row['toast_table_oid'],
+                    row['toast_table_name'],
+                    row['expected_table_oid'],
+                    row['expected_table_name'],
+                    row['dependent_table_oid'],
+                    row['dependent_table_name']))
+        log_output = '\n'.join(log_output)
+        log_output = log_output + '\n'
+        logger.error(log_output)
+
+        # log fix instructions for the orphaned toast tables to stdout and log file
+        gplog.log_literal(logger, logging.CRITICAL, checker.get_fix_text())
+
+        # log per-orphan table issue and cause to stdout and log file
+        for issue, segments in checker.iterate_issues():
+            cat_issue_obj = CatOrphanToastTableIssue(issue.table.oid,
+                                                     issue.table.catname,
+                                                     issue,
+                                                     segments)
+            error_object = getGPObject(issue.table.oid, issue.table.catname)
+            error_object.addOrphanToastTableIssue(cat_issue_obj)
+
+        do_repair_for_segments(segments_to_repair_statements=checker.add_repair_statements(GV.cfg),
+                               issue_type="orphaned_toast_tables",
+                               description='Repairing orphaned TOAST tables')
+
+
 ############################################################################
 # Help populating repair part for all checked types
 # All functions dependent on results stored in global variable GV
@@ -3032,6 +3086,14 @@ all_checks = {
             "order": 13,
             "online": True
         },
+    "orphaned_toast_tables":
+        {
+            "description": "Check pg_class and pg_depend for orphaned TOAST tables",
+            "fn": checkOrphanedToastTables,
+            "version": 'main',
+            "order": 14,
+            "online": True
+        },
 }
 
 
@@ -3142,6 +3204,7 @@ def runAllChecks():
 
 
 def do_repair(sql_repair_contents, issue_type, description):
+    logger.info("Starting repair of %s with %d issues" % (description, len(sql_repair_contents)))
     if len(sql_repair_contents) == 0:
         return
 
@@ -3149,6 +3212,18 @@ def do_repair(sql_repair_contents, issue_type, description):
     try:
         repair_obj = Repair(context=GV, issue_type=issue_type, desc=description)
         repair_dir_path = repair_obj.create_repair(sql_repair_contents=sql_repair_contents)
+    except Exception, ex:
+        logger.fatal(str(ex))
+
+    print_repair_issues(repair_dir_path)
+
+def do_repair_for_segments(segments_to_repair_statements, issue_type, description):
+    logger.info("Starting repair of %s" % description)
+
+    repair_dir_path = ""
+    try:
+        repair_obj = Repair(context=GV, issue_type=issue_type, desc=description)
+        repair_dir_path = repair_obj.create_segment_repair_scripts(segments_to_repair_statements)
     except Exception, ex:
         logger.fatal(str(ex))
 
@@ -3163,7 +3238,8 @@ def do_repair_for_extra(catalog_issues):
             repair_obj = Repair(context=GV, issue_type="extra", desc="Removing extra entries")
             repair_dir_path = repair_obj.create_repair_for_extra_missing(catalog_table_obj=catalog_table_obj,
                                                                          issues=issues,
-                                                                         pk_name=pk_name)
+                                                                         pk_name=pk_name,
+                                                                         segments=GV.cfg)
         except Exception, ex:
             logger.fatal(str(ex))
 
@@ -3804,6 +3880,18 @@ class CatDependencyIssue:
         )
 
 # -------------------------------------------------------------------------------
+class CatOrphanToastTableIssue:
+    def __init__(self, oid, catname, issue, segments):
+        self.oid = oid
+        self.catname = catname
+        self.issue = issue
+        self.segments = segments
+
+    def report(self):
+        myprint('%s' % self.issue.description)
+        myprint('''On segment(s) %s table '%s' (oid: %s) %s''' % (', '.join(map(str, sorted(self.segments))), self.catname, self.oid, self.issue.cause))
+
+# -------------------------------------------------------------------------------
 class GPObject:
     def __init__(self, oid, catname):
         self.oid = oid
@@ -3814,6 +3902,7 @@ class GPObject:
         self.aclIssues = {}  # key=issue.catname, value=list of catACLIssue
         self.foreignkeyIssues = {}  # key=issue.catname, value=list of catForeignKeyIssue
         self.dependencyIssues = {} # key=issue.catname, value=list of catDependencyIssue
+        self.orphanToastTableIssues = {} # key=issue.catname, value=list of orphanToastTableIssues
 
     def addDependencyIssue(self, issue):
         if issue.catname in self.dependencyIssues:
@@ -3850,6 +3939,12 @@ class GPObject:
             self.foreignkeyIssues[issue.catname].append(issue)
         else:
             self.foreignkeyIssues[issue.catname] = [issue]
+
+    def addOrphanToastTableIssue(self, issue):
+        if issue.catname in self.orphanToastTableIssues:
+            self.orphanToastTableIssues[issue.catname].append(issue)
+        else:
+            self.orphanToastTableIssues[issue.catname] = [issue]
 
     def isTopLevel(self):
         return True
@@ -3939,6 +4034,13 @@ class GPObject:
         if len(self.aclIssues):
             for catname, issues in self.aclIssues.iteritems():
                 myprint('    Name of test which found this issue: acl_%s' % catname)
+                for each in issues:
+                    each.report()
+            myprint('')
+
+        # Report Orphan Toast Table issues
+        if len(self.orphanToastTableIssues):
+            for catname, issues in self.orphanToastTableIssues.iteritems():
                 for each in issues:
                     each.report()
             myprint('')
@@ -4168,7 +4270,7 @@ def checkcatReport():
             reportAllIssuesRecursive(child, graph)
 
     buildGraph()
-    reportedCheck = ['duplicate','missing_extraneous','inconsistent','foreign_key','acl']
+    reportedCheck = ['duplicate','missing_extraneous','inconsistent','foreign_key','acl', 'orphaned_toast_tables']
     myprint('')
     myprint('SUMMARY REPORT')
     myprint('===================================================================')

--- a/gpMgmt/bin/gpcheckcat_modules/orphan_toast_table_issues.py
+++ b/gpMgmt/bin/gpcheckcat_modules/orphan_toast_table_issues.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+
+class OrphanToastTableIssue(object):
+    def __init__(self, cause, row, table):
+        self.cause = cause
+        self.row = row
+        self.table = table
+
+    def __eq__(self, other):
+        if isinstance(other, OrphanToastTableIssue):
+            return self.cause == other.cause and self.row == self.row
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return "OrphanToastTableIssue(%s,%s)" % (self.cause, self.row)
+
+    def __hash__(self):
+        return hash(self.__repr__())
+
+    fix_text = []
+    header = ''
+    description = ''
+
+    @property
+    def repair_script(self):
+        return ''
+
+
+class DoubleOrphanToastTableIssue(OrphanToastTableIssue):
+    def __init__(self, row, table):
+        cause = ""
+        if row['double_orphan_parent_reltoastrelid'] is None:
+            cause = '''The parent table does not exist. Therefore, the toast table '%(toast_table_name)s' (oid: %(toast_table_oid)s) can likely be dropped.\n'''
+            cause = cause % dict(toast_table_oid=row['toast_table_oid'],
+                                 toast_table_name=row['toast_table_name'])
+        elif row['double_orphan_parent_oid'] and row['double_orphan_parent_toast_oid']:
+            cause = '''with parent table '%(double_orphan_parent_name)s' (oid: %(double_orphan_parent_oid)s). '''
+            cause += '''The parent table already references a valid toast table '%(double_orphan_parent_toast_name)s' (oid: %(double_orphan_parent_toast_oid)s). '''
+            cause += '''\nTo fix, either:\n  1) drop the orphan toast table '%(toast_table_name)s' (oid: %(toast_table_oid)s)\nor:'''
+            cause += '''\n  2a) drop the pg_depend entry for '%(double_orphan_parent_toast_name)s' (oid: %(double_orphan_parent_toast_oid)s)'''
+            cause += '''\n  2b) drop the toast table '%(double_orphan_parent_toast_name)s' (oid: %(double_orphan_parent_toast_oid)s),'''
+            cause += '''\n  2c) add pg_depend entry where objid is '%(toast_table_name)s' (oid: %(toast_table_oid)s) and refobjid is '%(double_orphan_parent_name)s' (oid: %(double_orphan_parent_oid)s) with deptype 'i'.'''
+            cause += '''\n  2d) update the pg_class entry for '%(double_orphan_parent_name)s' (oid: %(double_orphan_parent_oid)s), and set reltoastrelid to '%(toast_table_name)s' (oid: %(toast_table_oid)s).\n'''
+            cause = cause % dict(toast_table_oid=row['toast_table_oid'],
+                                 toast_table_name=row['toast_table_name'],
+                                 double_orphan_parent_oid=row['double_orphan_parent_oid'],
+                                 double_orphan_parent_name=row['double_orphan_parent_name'],
+                                 double_orphan_parent_toast_oid=row['double_orphan_parent_toast_oid'],
+                                 double_orphan_parent_toast_name=row['double_orphan_parent_toast_name'])
+        elif row['double_orphan_parent_oid'] and row['double_orphan_parent_toast_oid'] is None:
+            cause = '''with parent table '%(double_orphan_parent_name)s' (oid: %(double_orphan_parent_oid)s) has no valid toast table. '''
+            cause += '''Verify that the parent table requires a toast table. To fix:'''
+            cause += '''\n  1) update the pg_class entry for '%(double_orphan_parent_name)s' (oid: %(double_orphan_parent_oid)s) and set reltoastrelid to '%(toast_table_name)s' (oid: %(toast_table_oid)s).'''
+            cause += '''\n  2) add pg_depend entry where objid is '%(toast_table_name)s' (oid: %(toast_table_oid)s) and refobjid is '%(double_orphan_parent_name)s' (oid: %(double_orphan_parent_oid)s) with deptype 'i'.\n'''
+            cause = cause % dict(toast_table_oid=row['toast_table_oid'],
+                                 toast_table_name=row['toast_table_name'],
+                                 double_orphan_parent_oid=row['double_orphan_parent_oid'],
+                                 double_orphan_parent_name=row['double_orphan_parent_name'])
+
+        OrphanToastTableIssue.__init__(self, cause, row, table)
+
+    header = 'Double Orphan TOAST tables due to a missing reltoastrelid in pg_class and a missing pg_depend entry.'
+    fix_text = [
+        header, 
+        '''  A manual catalog change is needed to fix. Attempt to determine the original dependent table's OID from the name of the TOAST table.\n''',
+        '''  If the dependent table has a valid OID and exists, the update its pg_class entry with the correct reltoastrelid and adds a pg_depend entry.\n''',
+        '''  If the dependent table doesn't exist, delete the associated TOAST table.\n''',
+        '''  If the dependent table is invalid, the associated TOAST table has been renamed. A manual catalog change is needed.\n'''
+    ]
+    description = 'Found a "double orphan" orphaned TOAST table caused by missing reltoastrelid and missing pg_depend entry.'
+
+    @property
+    def repair_script(self):
+        # There are multiple ways a double orphan toast table can occur and thus be fixed.
+        # We need DBA input to determine how it is broken in order to safely fix it.
+        # Since, at this time, we cannot get user input, we chose not to generate a repair script
+        # in order to be conservative.
+        return ''
+
+class ReferenceOrphanToastTableIssue(OrphanToastTableIssue):
+    def __init__(self, row, table):
+        cause = '''has an orphaned TOAST table '%s' (OID: %s).''' % (row['toast_table_name'], row['toast_table_oid'])
+        OrphanToastTableIssue.__init__(self, cause, row, table)
+
+    header = 'Bad Reference Orphaned TOAST tables due to a missing reltoastrelid in pg_class'
+    description = 'Found a "bad reference" orphaned TOAST table caused by missing a reltoastrelid in pg_class.'
+    fix_text = [
+        header,
+        '''  To fix, run the generated repair script which updates a pg_class entry using the correct dependent table OID for reltoastrelid.\n'''
+    ]
+
+    @property
+    def repair_script(self):
+        return '''UPDATE "pg_class" SET reltoastrelid = %d WHERE oid = %s;''' % (
+            self.row["toast_table_oid"], self.row["dependent_table_oid"])
+
+
+class DependencyOrphanToastTableIssue(OrphanToastTableIssue):
+    def __init__(self, row, table):
+        cause = '''has an orphaned TOAST table '%s' (OID: %s).'''% (row['toast_table_name'], row['toast_table_oid'])
+        OrphanToastTableIssue.__init__(self, cause, row, table)
+
+    header = 'Bad Dependency Orphaned TOAST tables due to a missing pg_depend entry'
+    description = 'Found a "bad dependency" orphaned TOAST table caused by missing a pg_depend entry.'
+    fix_text = [
+        header,
+        '''  To fix, run the generated repair script which inserts a pg_depend entry using the correct dependent table OID for refobjid.\n'''
+    ]
+
+    @property
+    def repair_script(self):
+        # 1259 is the reserved oid for pg_class and 'i' means internal dependency; these are safe to hard-code
+        return '''INSERT INTO pg_depend VALUES (1259, %d, 0, 1259, %d, 0, 'i');''' % (
+            self.row["toast_table_oid"], self.row["expected_table_oid"])
+
+
+class MismatchOrphanToastTableIssue(OrphanToastTableIssue):
+    def __init__(self, row, table):
+        cause = '''has an orphaned TOAST table '%s' (OID: %s). Expected dependent table to be '%s' (OID: %s).''' % (
+            row['toast_table_name'], row['toast_table_oid'], row['expected_table_name'], row['expected_table_oid'])
+        OrphanToastTableIssue.__init__(self, cause, row, table)
+
+    header = 'Mismatch Orphaned TOAST tables due to reltoastrelid in pg_class pointing to an incorrect TOAST table'
+    description = 'Found a "mismatched" orphaned TOAST table caused by a reltoastrelid in pg_class pointing to an incorrect TOAST table. A manual catalog change is needed.'
+    fix_text = [
+        header,
+        '''  A manual catalog change is needed to fix by updating the pg_depend TOAST table entry and setting the refobjid field to the correct dependent table.\n'''
+    ]
+
+    @property
+    def repair_script(self):
+        # There can be a cyclic reference in reltoastrelid in pg_class which
+        # is difficult to determine the valid toast table (if any).
+        # Therefore, no repair script can safely be generated and
+        # not loose customer data.
+        return ''

--- a/gpMgmt/bin/gpcheckcat_modules/orphaned_toast_tables_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/orphaned_toast_tables_check.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+
+import itertools
+
+from collections import defaultdict, namedtuple
+from gppylib.db import dbconn
+from gpcheckcat_modules.orphan_toast_table_issues import OrphanToastTableIssue, DoubleOrphanToastTableIssue, ReferenceOrphanToastTableIssue, DependencyOrphanToastTableIssue, MismatchOrphanToastTableIssue
+
+
+OrphanedTable = namedtuple('OrphanedTable', 'oid catname')
+
+
+class OrphanedToastTablesCheck:
+    def __init__(self):
+        self._issues = []
+
+        # Normally, there's a "loop" between a table and its TOAST table:
+        # - The table's reltoastrelid field in pg_class points to its TOAST table
+        # - The TOAST table has an entry in pg_depend pointing to its table
+        # This can break and orphan a TOAST table in one of three ways:
+        # - The reltoastrelid entry is set to 0
+        # - The reltoastrelid entry is set to a different oid value
+        # - The pg_depend entry is missing
+        # - The reltoastrelid entry is wrong *and* the pg_depend entry is missing
+        # The following query attempts to "follow" the loop from pg_class to
+        # pg_depend back to pg_class, and if the table oids don't match and/or
+        # one is missing, the TOAST table is considered to be an orphan.
+        self.orphaned_toast_tables_query = """
+SELECT
+    gp_segment_id AS content_id,
+    toast_table_oid,
+    toast_table_name,
+    expected_table_oid,
+    expected_table_name,
+    dependent_table_oid,
+    dependent_table_name,
+    double_orphan_parent_oid,
+    double_orphan_parent_name,
+    double_orphan_parent_reltoastrelid,
+    double_orphan_parent_toast_oid,
+    double_orphan_parent_toast_name
+FROM (
+    SELECT
+        tst.gp_segment_id,
+        tst.oid AS toast_table_oid,
+        tst.relname AS toast_table_name,
+        tbl.oid AS expected_table_oid,
+        tbl.relname AS expected_table_name,
+        dep.refobjid AS dependent_table_oid,
+        dep.refobjid::regclass::text AS dependent_table_name,
+        dbl.oid AS double_orphan_parent_oid,
+        dbl.relname AS double_orphan_parent_name,
+        dbl.reltoastrelid AS double_orphan_parent_reltoastrelid,
+        dbl_tst.oid AS double_orphan_parent_toast_oid,
+        dbl_tst.relname AS double_orphan_parent_toast_name
+    FROM
+        pg_class tst
+        LEFT JOIN pg_depend dep ON tst.oid = dep.objid
+        LEFT JOIN pg_class tbl ON tst.oid = tbl.reltoastrelid
+        LEFT JOIN pg_class dbl
+            ON trim('pg_toast.pg_toast_' FROM tst.oid::regclass::text)::int::regclass::oid = dbl.oid
+        LEFT JOIN pg_class dbl_tst ON dbl.reltoastrelid = dbl_tst.oid
+    WHERE tst.relkind='t'
+        AND	(
+            tbl.oid IS NULL
+            OR refobjid IS NULL
+            OR tbl.oid != dep.refobjid
+        )
+        AND (
+            tbl.relnamespace IS NULL
+            OR tbl.relnamespace != (SELECT oid FROM pg_namespace WHERE nspname = 'pg_catalog')
+        )
+    UNION ALL
+    SELECT
+        tst.gp_segment_id,
+        tst.oid AS toast_table_oid,
+        tst.relname AS toast_table_name,
+        tbl.oid AS expected_table_oid,
+        tbl.relname AS expected_table_name,
+        dep.refobjid AS dependent_table_oid,
+        dep.refobjid::regclass::text AS dependent_table_name,
+        dbl.oid AS double_orphan_parent_oid,
+        dbl.relname AS double_orphan_parent_name,
+        dbl.reltoastrelid AS double_orphan_parent_reltoastrelid,
+        dbl.reltoastrelid AS double_orphan_parent_toast_oid,
+        dbl_tst.relname AS double_orphan_parent_toast_name
+    FROM gp_dist_random('pg_class') tst
+        LEFT JOIN gp_dist_random('pg_depend') dep ON tst.oid = dep.objid AND tst.gp_segment_id = dep.gp_segment_id
+        LEFT JOIN gp_dist_random('pg_class') tbl ON tst.oid = tbl.reltoastrelid AND tst.gp_segment_id = tbl.gp_segment_id
+        LEFT JOIN gp_dist_random('pg_class') dbl
+            ON trim('pg_toast.pg_toast_' FROM tst.oid::regclass::text)::int::regclass::oid = dbl.oid 
+            AND tst.gp_segment_id = dbl.gp_segment_id
+        LEFT JOIN pg_class dbl_tst ON dbl.reltoastrelid = dbl_tst.oid AND tst.gp_segment_id = dbl_tst.gp_segment_id
+    WHERE tst.relkind='t'
+        AND (
+            tbl.oid IS NULL
+            OR refobjid IS NULL
+            OR tbl.oid != dep.refobjid
+        )
+        AND (
+            tbl.relnamespace IS NULL
+            OR tbl.relnamespace != (SELECT oid FROM pg_namespace WHERE nspname = 'pg_catalog')
+        )
+    ORDER BY toast_table_oid, expected_table_oid, dependent_table_oid, gp_segment_id
+) AS subquery
+GROUP BY gp_segment_id, toast_table_oid, toast_table_name, expected_table_oid, expected_table_name, dependent_table_oid, dependent_table_name,
+    double_orphan_parent_oid,
+    double_orphan_parent_name,
+    double_orphan_parent_reltoastrelid,
+    double_orphan_parent_toast_oid,
+    double_orphan_parent_toast_name;
+"""
+
+    def runCheck(self, db_connection):
+        orphaned_toast_tables = db_connection.query(self.orphaned_toast_tables_query).dictresult()
+        if len(orphaned_toast_tables) == 0:
+            return True
+
+        for row in orphaned_toast_tables:
+            if row['expected_table_oid'] is None and row['dependent_table_oid'] is None:
+                table = OrphanedTable(row['toast_table_oid'], row['toast_table_name'])
+                issue_type = DoubleOrphanToastTableIssue
+
+            elif row['expected_table_oid'] is None:
+                table = OrphanedTable(row['dependent_table_oid'], row['dependent_table_name'])
+                issue_type = ReferenceOrphanToastTableIssue
+
+            elif row['dependent_table_oid'] is None:
+                table = OrphanedTable(row['expected_table_oid'], row['expected_table_name'])
+                issue_type = DependencyOrphanToastTableIssue
+
+            else:
+                table = OrphanedTable(row['dependent_table_oid'], row['dependent_table_name'])
+                issue_type = MismatchOrphanToastTableIssue
+
+            issue = issue_type(row, table)
+            self._issues.append(issue)
+
+        return False
+
+    def iterate_issues(self):
+        """
+        Yields an OrphanToastTableIssue instance, and the set of segment IDs
+        that exhibit that issue, for every issue found by the checker. For
+        instance, if table 'my_table' has a double-orphan issue on segments 1
+        and 2, and a dependency-orphan issue on segment -1, iterate_issues()
+        will generate two tuples:
+
+            ( DoubleOrphanToastTableIssue('my_table', ...),     { 1, 2 } )
+            ( DependencyOrphanToastTableIssue('my_table', ...), { -1 }   )
+
+        The OrphanToastTableIssue instance internally corresponds to a segment
+        that exhibits the issue, but in cases where there is more than one
+        segment with the problem, *which* segment it corresponds to is not
+        defined. (For instance, in the above example, the
+        DoubleOrphanToastTableIssue's row['content_id'] could be either 1 or 2.)
+
+        It's assumed that this is not a problem (and if it becomes a problem,
+        this implementation will need a rework).
+        """
+        # The hard part here is that our "model" has one issue per segment,
+        # whereas we want to present one issue per (table, issue type) pair as
+        # our "view".
+        #
+        # We use itertools.groupby() as the core. This requires us to sort our
+        # list by (table, issue type) before performing the grouping, for the
+        # same reason that you need to perform `sort` in a `sort | uniq`
+        # pipeline.
+        def issue_key(issue):
+            return (issue.table.oid, type(issue))
+
+        def key_sort(this, that):
+            return cmp(hash(issue_key(this)), hash(issue_key(that)))
+
+        sorted_issues = sorted(self._issues, key_sort)
+
+        for _, group in itertools.groupby(sorted_issues, issue_key):
+            issues = list(group)
+            yield issues[0], { i.row['content_id'] for i in issues }
+
+    def rows_of_type(self, issue_cls):
+        return [ issue.row for issue in self._issues if isinstance(issue, issue_cls) ]
+
+    def issue_types(self):
+        return { type(issue) for issue in self._issues }
+
+    def get_fix_text(self):
+        log_output = ['\nORPHAN TOAST TABLE FIXES:',
+                      '===================================================================']
+        for issue_type in self.issue_types():
+            log_output += issue_type.fix_text
+        return '\n'.join(log_output)
+
+    def add_repair_statements(self, segments):
+        content_id_to_segment_map = self._get_content_id_to_segment_map(segments)
+
+        for issue in self._issues:
+            if issue.repair_script:
+                content_id_to_segment_map[issue.row['content_id']]['repair_statements'].append(issue.repair_script)
+
+        segments_with_repair_statements = filter(lambda segment: len(segment['repair_statements']) > 0, content_id_to_segment_map.values())
+        for segment in segments_with_repair_statements:
+            segment['repair_statements'] = ["SET allow_system_table_mods=true;"] + segment['repair_statements']
+
+        return segments_with_repair_statements
+
+    @staticmethod
+    def _get_content_id_to_segment_map(segments):
+        content_id_to_segment = {}
+        for segment in segments.values():
+            segment['repair_statements'] = []
+            content_id_to_segment[segment['content']] = segment
+
+        return content_id_to_segment

--- a/gpMgmt/bin/gpcheckcat_modules/repair.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair.py
@@ -13,19 +13,14 @@ Creates repair for the following gpcheckcat checks
 
 import os
 import stat
-from datetime import datetime
 from gpcheckcat_modules.repair_missing_extraneous import RepairMissingExtraneous
 
 
 class Repair:
-
-    TIMESTAMP = datetime.now().strftime("%Y%m%d%H%M%S")
-
     def __init__(self, context=None, issue_type=None, desc=None):
         self._context = context
         self._issue_type = issue_type
         self._desc = desc
-        self._repair_script = 'runsql_%s.sh' % self.TIMESTAMP
 
     def create_repair(self, sql_repair_contents):
         repair_dir = self.create_repair_dir()
@@ -88,20 +83,20 @@ class Repair:
         self.append_content_to_bash_script(repair_dir, bash_script_content, catalog_name)
 
     def __get_sql_filename(self):
-        return '%s_%s_%s.sql' % (self._context.dbname, self._issue_type, self.TIMESTAMP)
+        return '%s_%s_%s.sql' % (self._context.dbname, self._issue_type, self._context.timestamp)
 
     def __get_bash_filepath(self, repair_dir, catalog_name):
-        bash_file_name = self._repair_script
+        bash_file_name = 'runsql_%s.sh' % self._context.timestamp
 
         if self._issue_type and catalog_name:
             bash_file_name = 'run_{0}_{1}_{2}_{3}.sh'.format(self._context.dbname, self._issue_type,
-                                                             catalog_name, self.TIMESTAMP)
+                                                             catalog_name, self._context.timestamp)
 
         return os.path.join(repair_dir, bash_file_name)
 
     def __get_bash_script_content(self, filename, segment_id):
         c = self._context.report_cfg[segment_id]
-        out_filename = "{0}_{1}_{2}".format(self._context.dbname, self._issue_type, self.TIMESTAMP)
+        out_filename = "{0}_{1}_{2}".format(self._context.dbname, self._issue_type, self._context.timestamp)
         bash_script_content = '\necho "{0}"\n'.format(self._desc)
         bash_script_content += self.__get_psql_command(segment_id).format(hostname=c['hostname'],
                                                                           port=c['port'], sql=filename,

--- a/gpMgmt/bin/gpcheckcat_modules/repair.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair.py
@@ -27,8 +27,8 @@ class Repair:
 
         master_segment = next(segment for segment in self._context.cfg.values() if segment['content'] == -1)
 
-        sql_filename = self.__create_sql_file_in_repair_dir(repair_dir, sql_repair_contents, master_segment)
-        self.__create_bash_script_in_repair_dir(repair_dir, sql_filename, master_segment)
+        sql_filename = self._create_sql_file_in_repair_dir(repair_dir, sql_repair_contents, master_segment)
+        self._create_bash_script_in_repair_dir(repair_dir, sql_filename, master_segment)
 
         return repair_dir
 
@@ -44,8 +44,8 @@ class Repair:
             segment = next(segment for segment in self._context.cfg.values() if segment['content'] == segment_id)
 
             sql_content = extra_missing_repair_obj.get_delete_sql(oids)
-            self.__create_bash_script_in_repair_dir(repair_dir, sql_content,
-                                                    segment=segment, catalog_name=catalog_name)
+            self._create_bash_script_in_repair_dir(repair_dir, sql_content,
+                                                   segment=segment, catalog_name=catalog_name)
 
         return repair_dir
 
@@ -53,8 +53,8 @@ class Repair:
         repair_dir = self.create_repair_dir()
 
         for segment in segments:
-            sql_filename = self.__create_sql_file_in_repair_dir(repair_dir, segment['repair_statements'], segment)
-            self.__create_bash_script_in_repair_dir(repair_dir, sql_filename, segment)
+            sql_filename = self._create_sql_file_in_repair_dir(repair_dir, segment['repair_statements'], segment)
+            self._create_bash_script_in_repair_dir(repair_dir, sql_filename, segment)
 
         return repair_dir
 
@@ -66,7 +66,7 @@ class Repair:
         return repair_dir
 
     def append_content_to_bash_script(self, repair_dir_path, script, catalog_name=None):
-        bash_file_path = self.__get_bash_filepath(repair_dir_path, catalog_name)
+        bash_file_path = self._get_bash_filepath(repair_dir_path, catalog_name)
         if not os.path.isfile(bash_file_path):
             script = '#!/bin/bash\ncd $(dirname $0)\n' + script
 
@@ -75,8 +75,8 @@ class Repair:
 
         os.chmod(bash_file_path, stat.S_IXUSR | stat.S_IRUSR | stat.S_IWUSR)
 
-    def __create_sql_file_in_repair_dir(self, repair_dir, sql_repair_contents, segment):
-        sql_filename = self.__get_sql_filename(segment) + ".sql"
+    def _create_sql_file_in_repair_dir(self, repair_dir, sql_repair_contents, segment):
+        sql_filename = self._get_sql_filename(segment) + ".sql"
         sql_file_path = os.path.join(repair_dir, sql_filename)
 
         with open(sql_file_path, 'w') as sql_file:
@@ -85,24 +85,24 @@ class Repair:
 
         return sql_filename
 
-    def __create_bash_script_in_repair_dir(self, repair_dir, sql, segment, catalog_name=None):
+    def _create_bash_script_in_repair_dir(self, repair_dir, sql, segment, catalog_name=None):
         if not sql:
             return
 
-        bash_script_content = self.__get_bash_script_content(sql, segment)
+        bash_script_content = self._get_bash_script_content(sql, segment)
         self.append_content_to_bash_script(repair_dir, bash_script_content, catalog_name)
 
-    def __get_bash_or_out_filename(self):
+    def _get_bash_or_out_filename(self):
         return '%s_%s_%s' % (self._context.dbname, self._issue_type, self._context.timestamp)
 
-    def __get_sql_filename(self, segment):
+    def _get_sql_filename(self, segment):
         if segment['content'] == -1:
-            return self.__get_bash_or_out_filename()
+            return self._get_bash_or_out_filename()
         else:
             filename = '%i.%s.%i.%s.%s' % (segment['dbid'], segment['hostname'], segment['port'], self._context.dbname, self._context.timestamp)
             return filename.replace(' ', '_')
 
-    def __get_bash_filepath(self, repair_dir, catalog_name=None):
+    def _get_bash_filepath(self, repair_dir, catalog_name=None):
         bash_filename = 'runsql_%s.sh' % self._context.timestamp
 
         if self._issue_type and catalog_name:
@@ -110,14 +110,14 @@ class Repair:
 
         return os.path.join(repair_dir, bash_filename)
 
-    def __get_bash_script_content(self, sql, segment):
-        out_filename = self.__get_bash_or_out_filename() + ".out"
+    def _get_bash_script_content(self, sql, segment):
+        out_filename = self._get_bash_or_out_filename() + ".out"
 
         bash_script_content = '\necho "{0}"\n'.format(self._desc)
-        bash_script_content += self.__get_psql_command(segment, sql, out_filename)
+        bash_script_content += self._get_psql_command(segment, sql, out_filename)
         return bash_script_content
 
-    def __get_psql_command(self, segment, sql, out_filename):
+    def _get_psql_command(self, segment, sql, out_filename):
         """
         cases to consider
         self._issue_type : extra/missing vs everything else(policies, owner, constraint)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -294,6 +294,17 @@ class GpCheckCatTestCase(GpTestCase):
         report_cfg = self.subject.getReportConfiguration()
         self.assertEqual("content -1", report_cfg[-1]['segname'])
 
+    def test_RelationObject_reportAllIssues_handles_None_fields(self):
+        uut = self.subject.RelationObject(None, 'pg_class')
+        uut.setRelInfo(relname=None, nspname=None, relkind='t', paroid=0)
+
+        uut.reportAllIssues()
+        log_messages = [args[0][1].strip() for args in self.subject.logger.log.call_args_list]
+
+        self.assertIn('Relation oid: N/A', log_messages)
+        self.assertIn('Relation schema: N/A', log_messages)
+        self.assertIn('Relation name: N/A', log_messages)
+
     ####################### PRIVATE METHODS #######################
 
     def _run_batch_size_experiment(self, num_primaries):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -135,7 +135,7 @@ class GpCheckCatTestCase(GpTestCase):
 
     @patch('gpcheckcat.GPCatalog', return_value=Mock())
     @patch('sys.exit')
-    @patch('gpcheckcat.log_literal')
+    @patch('gppylib.gplog.log_literal')
     def test_truncate_batch_size(self, mock_log, mock_gpcheckcat, mock_sys_exit):
         self.subject.GV.opt['-B'] = 300  # override the setting from available memory
         # setup conditions for 50 primaries and plenty of RAM such that max threads > 50

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
@@ -38,8 +38,8 @@ class RepairTestCase(GpTestCase):
                          'psql -X -a -h somehost -p 15432 -f "somedb_issuetype_timestamp.sql" '
                          '"somedb" >> somedb_issuetype_timestamp.out 2>&1\n']
 
-        self.verify_repair_dir_contents(os.path.join(repair_dir, "somedb_issuetype_timestamp.sql"), sql_contents)
-        self.verify_repair_dir_contents(os.path.join(repair_dir, "runsql_timestamp.sh"), bash_contents)
+        self.verify_repair_dir_contents("somedb_issuetype_timestamp.sql", sql_contents)
+        self.verify_repair_dir_contents("runsql_timestamp.sh", bash_contents)
 
     @patch('gpcheckcat_modules.repair.RepairMissingExtraneous', autospec=True)
     def test_create_repair_extra__normal(self, mock_repair):
@@ -74,7 +74,8 @@ class RepairTestCase(GpTestCase):
                     "echo \"some desc\"\n",
                     "psql -X -a -h somehost -p 15432 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n"]
 
-        self.verify_repair_dir_contents(os.path.join(repair_dir, "run_somedb_extra_{0}_timestamp.sh".format(catalog_table_name)), bash_contents)
+        self.verify_repair_dir_contents("run_somedb_extra_{}_timestamp.sh".format(catalog_table_name),
+                                        bash_contents)
 
     def test_create_segment_repair_scripts(self):
         self.subject = Repair(self.context, "orphan_toast_tables", "some desc")
@@ -100,7 +101,7 @@ class RepairTestCase(GpTestCase):
             "echo \"some desc\"\n",
             "PGOPTIONS='-c gp_session_role=utility' psql -X -a -h somehost -p 25434 -f \"2.somehost.25434.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n"]
 
-        self.verify_repair_dir_contents(os.path.join(repair_dir, "runsql_timestamp.sh"), bash_contents)
+        self.verify_repair_dir_contents("runsql_timestamp.sh", bash_contents)
 
 
     def test_append_content_to_bash_script__with_catalog_table(self):
@@ -112,7 +113,7 @@ class RepairTestCase(GpTestCase):
             "cd $(dirname $0)\n",
             "some script here"]
 
-        self.verify_repair_dir_contents(os.path.join(self.repair_dir_path, "run_somedb_issuetype_catalog_timestamp.sh".format(catalog_table_name)),
+        self.verify_repair_dir_contents("run_somedb_issuetype_{}_timestamp.sh".format(catalog_table_name),
                                         bash_contents)
 
     def test_append_content_to_bash_script__without_catalog_table(self):
@@ -123,9 +124,10 @@ class RepairTestCase(GpTestCase):
             "cd $(dirname $0)\n",
             "some script here"]
 
-        self.verify_repair_dir_contents(os.path.join(self.repair_dir_path, "runsql_timestamp.sh"), bash_contents)
+        self.verify_repair_dir_contents("runsql_timestamp.sh", bash_contents)
 
-    def verify_repair_dir_contents(self, file_path, contents):
+    def verify_repair_dir_contents(self, repair_script, contents):
+        file_path = os.path.join(self.repair_dir_path, repair_script)
         with open(file_path) as f:
             file_contents = f.readlines()
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
@@ -10,6 +10,7 @@ class RepairTestCase(GpTestCase):
         self.repair_dir_path = tempfile.mkdtemp()
 
         self.context = Mock()
+        self.context.timestamp = 'timestamp'
         self.context.opt = dict()
         self.context.opt["-g"] = self.repair_dir_path
         self.context.report_cfg = {0: {'segname': 'seg1', 'hostname': 'somehost', 'port': 25432},
@@ -19,8 +20,6 @@ class RepairTestCase(GpTestCase):
         self.context.dbname = "somedb"
 
         self.subject = Repair(self.context, "issuetype", "some desc")
-        self.subject.TIMESTAMP = "timestamp"
-        self.subject._repair_script = "runsql_timestamp.sh"
         self.repair_sql_contents = ["some sql1", "some sql2"]
         extra_missing_repair_obj = Mock(spec=['get_segment_to_oid_mapping', 'get_delete_sql'])
         extra_missing_repair_obj.get_segment_to_oid_mapping.return_value = {
@@ -52,7 +51,6 @@ class RepairTestCase(GpTestCase):
 
     def test_create_repair_extra__normal(self):
         self.subject = Repair(self.context, "extra", "some desc")
-        self.subject.TIMESTAMP = "timestamp"
         catalog_table_obj = Mock()
         catalog_table_name = "catalog"
         catalog_table_obj.getTableName.return_value = catalog_table_name

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
@@ -8,7 +8,6 @@ import shutil
 class RepairTestCase(GpTestCase):
     def setUp(self):
         self.repair_dir_path = tempfile.mkdtemp()
-
         self.context = Mock()
         self.context.timestamp = 'timestamp'
         self.context.opt = dict()
@@ -17,6 +16,10 @@ class RepairTestCase(GpTestCase):
                                    1: {'segname': 'seg2', 'hostname': 'somehost', 'port': 25433},
                                    2: {'segname': 'seg3', 'hostname': 'somehost', 'port': 25434},
                                    -1: {'segname': 'master', 'hostname': 'somehost', 'port': 15432}}
+        self.context.cfg = {0: {'content': 0, 'dbid': 0, 'segname': 'seg1', 'hostname': 'somehost', 'port': 25432},
+                            1: {'content': 1, 'dbid': 1, 'segname': 'seg2', 'hostname': 'somehost', 'port': 25433},
+                            2: {'content': 2, 'dbid': 2, 'segname': 'seg3', 'hostname': 'somehost', 'port': 25434},
+                            3: {'content': -1, 'dbid': 3, 'segname': 'master', 'hostname': 'somehost', 'port': 15432}}
         self.context.dbname = "somedb"
 
         self.subject = Repair(self.context, "issuetype", "some desc")
@@ -54,7 +57,7 @@ class RepairTestCase(GpTestCase):
         catalog_table_obj = Mock()
         catalog_table_name = "catalog"
         catalog_table_obj.getTableName.return_value = catalog_table_name
-        repair_dir = self.subject.create_repair_for_extra_missing(catalog_table_obj, issues=None, pk_name=None)
+        repair_dir = self.subject.create_repair_for_extra_missing(catalog_table_obj, issues=None, pk_name=None, segments=self.context.cfg)
         self.assertEqual(repair_dir, self.repair_dir_path)
         bash_contents =[
                     "#!/bin/bash\n",
@@ -69,8 +72,34 @@ class RepairTestCase(GpTestCase):
                     "echo \"some desc\"\n",
                     "psql -X -a -h somehost -p 15432 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n"]
 
-        self.verify_repair_dir_contents(os.path.join(repair_dir, "run_somedb_extra_{0}_timestamp.sh".
-                                                         format(catalog_table_name)), bash_contents)
+        self.verify_repair_dir_contents(os.path.join(repair_dir, "run_somedb_extra_{0}_timestamp.sh".format(catalog_table_name)), bash_contents)
+
+    def test_create_segment_repair_scripts(self):
+        self.subject = Repair(self.context, "orphan_toast_tables", "some desc")
+
+        segments_with_repair_statements = []
+        for segment in self.context.cfg.values():
+            if segment['content'] != -1:
+                segment['repair_statements'] = ['UPDATE pg_class']
+                segments_with_repair_statements.append(segment)
+
+        repair_dir = self.subject.create_segment_repair_scripts(segments=segments_with_repair_statements)
+        self.assertEqual(repair_dir, self.repair_dir_path)
+        bash_contents =[
+            "#!/bin/bash\n",
+            "cd $(dirname $0)\n",
+            "\n",
+            "echo \"some desc\"\n",
+            "PGOPTIONS='-c gp_session_role=utility' psql -X -a -h somehost -p 25432 -f \"0.somehost.25432.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n",
+            "\n",
+            "echo \"some desc\"\n",
+            "PGOPTIONS='-c gp_session_role=utility' psql -X -a -h somehost -p 25433 -f \"1.somehost.25433.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n",
+            "\n",
+            "echo \"some desc\"\n",
+            "PGOPTIONS='-c gp_session_role=utility' psql -X -a -h somehost -p 25434 -f \"2.somehost.25434.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n"]
+
+        self.verify_repair_dir_contents(os.path.join(repair_dir, "runsql_timestamp.sh"), bash_contents)
+
 
     def test_append_content_to_bash_script__with_catalog_table(self):
         catalog_table_name = "catalog"
@@ -81,8 +110,8 @@ class RepairTestCase(GpTestCase):
             "cd $(dirname $0)\n",
             "some script here"]
 
-        self.verify_repair_dir_contents(os.path.join(self.repair_dir_path, "run_somedb_issuetype_catalog_timestamp.sh".
-                                                     format(catalog_table_name)), bash_contents)
+        self.verify_repair_dir_contents(os.path.join(self.repair_dir_path, "run_somedb_issuetype_catalog_timestamp.sh".format(catalog_table_name)),
+                                        bash_contents)
 
     def test_append_content_to_bash_script__without_catalog_table(self):
         script = "some script here"

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -425,3 +425,137 @@ Feature: gpcheckcat tests
         Then gpcheckcat should print "Name of test which found this issue: dependency_pg_type" to stdout
         Then gpcheckcat should print "Table pg_type has a dependency issue on oid .* at content 0" to stdout
         And the user runs "dropdb gpcheckcat_dependency"
+
+    @orphaned_toast
+    Scenario: gpcheckcat should repair "bad reference" orphaned toast tables (caused by missing reltoastrelid)
+        Given the database "gpcheckcat_orphans" is broken with "bad reference" orphaned toast tables
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And gpcheckcat should print "To fix, run the generated repair script which updates a pg_class entry using the correct dependent table OID for reltoastrelid" to stdout
+        And run all the repair scripts in the dir "repair_dir"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "dropdb gpcheckcat_orphans"
+        And the path "repair_dir" is removed from current working directory
+
+    @orphaned_toast
+    Scenario: gpcheckcat should repair "bad dependency" orphaned toast tables (caused by missing pg_depend entry)
+        Given the database "gpcheckcat_orphans" is broken with "bad dependency" orphaned toast tables
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And gpcheckcat should print "To fix, run the generated repair script which inserts a pg_depend entry using the correct dependent table OID for refobjid" to stdout
+        And run all the repair scripts in the dir "repair_dir"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "dropdb gpcheckcat_orphans"
+        And the path "repair_dir" is removed from current working directory
+
+    @orphaned_toast
+    Scenario: gpcheckcat should log and not attempt to repair "double orphan - no parent" orphaned toast tables (caused by both missing reltoastrelid and missing pg_depend entry)
+        Given the database "gpcheckcat_orphans" is broken with "double orphan - no parent" orphaned toast tables
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And gpcheckcat should print "The parent table does not exist. Therefore, the toast table" to stdout
+        And run all the repair scripts in the dir "repair_dir"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And the user runs "dropdb gpcheckcat_orphans"
+        And the path "repair_dir" is removed from current working directory
+
+    @orphaned_toast
+    Scenario: gpcheckcat should log and not attempt to repair "double orphan - valid parent" orphaned toast tables (caused by both missing reltoastrelid and missing pg_depend entry)
+        Given the database "gpcheckcat_orphans" is broken with "double orphan - valid parent" orphaned toast tables
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And gpcheckcat should print "The parent table already references a valid toast table" to stdout
+        And run all the repair scripts in the dir "repair_dir"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And the user runs "dropdb gpcheckcat_orphans"
+        And the path "repair_dir" is removed from current working directory
+
+    @orphaned_toast
+    Scenario: gpcheckcat should log and not attempt to repair "double orphan - invalid parent" orphaned toast tables (caused by both missing reltoastrelid and missing pg_depend entry)
+        Given the database "gpcheckcat_orphans" is broken with "double orphan - invalid parent" orphaned toast tables
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And gpcheckcat should print "Verify that the parent table requires a toast table." to stdout
+        And run all the repair scripts in the dir "repair_dir"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And the user runs "dropdb gpcheckcat_orphans"
+        And the path "repair_dir" is removed from current working directory
+
+    @orphaned_toast
+    Scenario: gpcheckcat should log and not repair "mismatched non-cyclic" orphaned toast tables (caused by non-matching reltoastrelid)
+        Given the database "gpcheckcat_orphans" is broken with "mismatched non-cyclic" orphaned toast tables
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And gpcheckcat should print "A manual catalog change is needed to fix by updating the pg_depend TOAST table entry and setting the refobjid field to the correct dependent table" to stdout
+        And run all the repair scripts in the dir "repair_dir"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And gpcheckcat should print "A manual catalog change is needed" to stdout
+        And the user runs "dropdb gpcheckcat_orphans"
+        And the path "repair_dir" is removed from current working directory
+
+    @orphaned_toast
+    Scenario: gpcheckcat should log and not attempt to repair "mismatched cyclic" orphaned toast tables
+        Given the database "gpcheckcat_orphans" is broken with "mismatched cyclic" orphaned toast tables
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And gpcheckcat should print "A manual catalog change is needed to fix by updating the pg_depend TOAST table entry and setting the refobjid field to the correct dependent table" to stdout
+        And run all the repair scripts in the dir "repair_dir"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And gpcheckcat should print "A manual catalog change is needed" to stdout
+        And the user runs "dropdb gpcheckcat_orphans"
+        And the path "repair_dir" is removed from current working directory
+
+    @orphaned_toast
+    Scenario: gpcheckcat should repair orphaned toast tables that are only orphaned on some segments
+        Given the database "gpcheckcat_orphans" is broken with "bad reference" orphaned toast tables only on segments with content IDs "0, 1"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print "On segment\(s\) 0, 1 table" to stdout
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And run all the repair scripts in the dir "repair_dir"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "dropdb gpcheckcat_orphans"
+        And the path "repair_dir" is removed from current working directory
+
+    @orphaned_toast
+    Scenario: gpcheckcat should repair orphaned toast tables that are only orphaned on the master
+		# TODO: should we just combine this into the test above?
+        Given the database "gpcheckcat_orphans" is broken with "bad reference" orphaned toast tables only on segments with content IDs "-1"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print "On segment\(s\) -1 table" to stdout
+        And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+        And run all the repair scripts in the dir "repair_dir"
+        When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+        And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "dropdb gpcheckcat_orphans"
+        And the path "repair_dir" is removed from current working directory
+
+    @orphaned_toast
+    Scenario: gpcheckcat should repair tables that are orphaned in different ways per segment
+        Given the database "gpcheckcat_orphans" has a table that is orphaned in multiple ways
+         When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+         Then gpcheckcat should return a return code of 1
+          And gpcheckcat should print "Found a \"bad reference\" orphaned TOAST table caused by missing a reltoastrelid in pg_class." to stdout
+          And gpcheckcat should print "Found a \"bad dependency\" orphaned TOAST table caused by missing a pg_depend entry." to stdout
+          And gpcheckcat should print "catalog issue\(s\) found , repair script\(s\) generated" to stdout
+          And run all the repair scripts in the dir "repair_dir"
+         When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"
+         Then gpcheckcat should print "Found no catalog issue" to stdout
+          And the user runs "dropdb gpcheckcat_orphans"
+          And the path "repair_dir" is removed from current working directory

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1609,12 +1609,10 @@ def impl(context, path, num):
 
 @then('run all the repair scripts in the dir "{dir}"')
 def impl(context, dir):
-    bash_files = glob.glob("%s/*.sh" % dir)
-    for file in bash_files:
-        run_command(context, "bash %s" % file)
-
-        if context.ret_code != 0:
-            raise Exception("Error running repair script %s: %s" % (file, context.stdout_message))
+    command = "find {0} -name *.sh -exec bash {{}} \;".format(dir)
+    run_command(context, command)
+    if context.ret_code != 0:
+        raise Exception("Error running repair script %s: %s" % (file, context.stdout_message))
 
 @when(
     'the entry for the table "{user_table}" is removed from "{catalog_table}" with key "{primary_key}" in the database "{db_name}"')


### PR DESCRIPTION
During the course of this PR, several refactors were made for code hygiene and to help implement the feature.

There are four main types of orphan TOAST tables:
- Double Orphan TOAST tables due to a missing reltoastrelid in pg_class and a missing pg_depend entry.
- Bad Reference Orphaned TOAST tables due to a missing reltoastrelid in pg_class.
- Bad Dependency Orphaned TOAST tables due to a missing entry in pg_depend.
- Mismatch Orphaned TOAST tables due to reltoastrelid in pg_class pointing to an incorrect TOAST table.

Repair scripts are done on a per-segment basis since catalog changes are required.

Note: A repair script cannot be generated for mismatch orphan TOAST tables 
because the current repair implementation does not work with two or more tables, 
so let the user repair manually for safety. A manual catalogue change is needed 
to fix by updating the pg_depend TOAST table entry and setting the refobjid 
field to the correct dependent table.
