### PR TITLE
Use the right rel for largest_child_relation().

### DIFF
--- a/src/test/regress/expected/partition_subquery.out
+++ b/src/test/regress/expected/partition_subquery.out
@@ -1,0 +1,22 @@
+CREATE SCHEMA partition_subquery;
+SET SEARCH_PATH=partition_subquery;
+-- Given a partition table
+CREATE TABLE pt1(id int) DISTRIBUTED BY (id) PARTITION BY RANGE (id) (DEFAULT PARTITION p1);
+NOTICE:  CREATE TABLE will create partition "pt1_1_prt_p1" for table "pt1"
+-- When I run a query, outermost query, and it is selecting FROM a subquery
+-- And that subquery, subquery 1, contains another subquery, subquery 2
+-- And the outermost query aggregates over a column from an inherited table
+-- And the subquery 1 is prevented from being pulled up into a join
+SELECT id FROM (
+	SELECT id, sum(id) OVER() as sum_id FROM (
+		SELECT id FROM pt1
+	) as sq1
+) as sq2 GROUP BY id;
+ id 
+----
+(0 rows)
+
+-- Then, the query executes successfully
+--start_ignore
+DROP TABLE IF EXISTS pt1;
+--end_ignore

--- a/src/test/regress/expected/partition_subquery_optimizer.out
+++ b/src/test/regress/expected/partition_subquery_optimizer.out
@@ -1,0 +1,22 @@
+CREATE SCHEMA partition_subquery;
+SET SEARCH_PATH=partition_subquery;
+-- Given a partition table
+CREATE TABLE pt1(id int) DISTRIBUTED BY (id) PARTITION BY RANGE (id) (DEFAULT PARTITION p1);
+NOTICE:  CREATE TABLE will create partition "pt1_1_prt_p1" for table "pt1"
+-- When I run a query, outermost query, and it is selecting FROM a subquery
+-- And that subquery, subquery 1, contains another subquery, subquery 2
+-- And the outermost query aggregates over a column from an inherited table
+-- And the subquery 1 is prevented from being pulled up into a join
+SELECT id FROM (
+	SELECT id, sum(id) OVER() as sum_id FROM (
+		SELECT id FROM pt1
+	) as sq1
+) as sq2 GROUP BY id;
+ id 
+----
+(0 rows)
+
+-- Then, the query executes successfully
+--start_ignore
+DROP TABLE IF EXISTS pt1;
+--end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -78,7 +78,7 @@ test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_grou
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.
-test: partition partition1 partition_indexing parruleord partition_storage partition_ddl partition_with_user_defined_function partition_unlogged
+test: partition partition1 partition_indexing parruleord partition_storage partition_ddl partition_with_user_defined_function partition_unlogged partition_subquery
 # 'partition_locking' gets confused if other backends run concurrently and
 # hold locks.
 test: partition_locking

--- a/src/test/regress/sql/partition_subquery.sql
+++ b/src/test/regress/sql/partition_subquery.sql
@@ -1,0 +1,20 @@
+CREATE SCHEMA partition_subquery;
+SET SEARCH_PATH=partition_subquery;
+
+-- Given a partition table
+CREATE TABLE pt1(id int) DISTRIBUTED BY (id) PARTITION BY RANGE (id) (DEFAULT PARTITION p1);
+
+-- When I run a query, outermost query, and it is selecting FROM a subquery
+-- And that subquery, subquery 1, contains another subquery, subquery 2
+-- And the outermost query aggregates over a column from an inherited table
+-- And the subquery 1 is prevented from being pulled up into a join
+SELECT id FROM (
+	SELECT id, sum(id) OVER() as sum_id FROM (
+		SELECT id FROM pt1
+	) as sq1
+) as sq2 GROUP BY id;
+-- Then, the query executes successfully
+
+--start_ignore
+DROP TABLE IF EXISTS pt1;
+--end_ignore


### PR DESCRIPTION
Function largest_child_relation() is used to find the largest child
relation for an inherited/partitioned relation, recursively. Previously
we passed a wrong rel as its param.

This patch finds in root->simple_rel_array the right rel for
largest_child_relation(). Also it replaces several rt_fetch with a
search in root->simple_rte_array.

This patch fixes #6599.

Co-authored-by-by: Melanie Plageman <mplageman@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
