### PR TITLE
Revert "Add hook functions for diskquota extension."

### DIFF
--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -23,11 +23,6 @@
 #include "cdb/cdbbufferedappend.h"
 #include "utils/guc.h"
 
-/*
- * Hook function in BufferedAppendWrite, used by plugins to call
- * when the size of AO table is increased.
- */
-BufferedAppendWrite_hook_type BufferedAppendWrite_hook = NULL;
 static void BufferedAppendWrite(
 					BufferedAppend *bufferedAppend,
 					bool needsWAL);
@@ -201,8 +196,6 @@ BufferedAppendWrite(BufferedAppend *bufferedAppend, bool needsWAL)
 		   bufferedAppend->filePathName,
 		   bufferedAppend->largeWritePosition,
 		   bytestotal);
-	if (BufferedAppendWrite_hook)
-		(*BufferedAppendWrite_hook)(bufferedAppend);
 
 	/*
 	 * Log each varblock to the XLog. Write to the file first, before

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -48,8 +48,6 @@
  */
 #define DISPATCH_WAIT_CANCEL_TIMEOUT_MSEC 100
 
-DispatcherCheckPerms_hook_type DispatcherCheckPerms_hook = NULL;
-
 typedef struct CdbDispatchCmdAsync
 {
 
@@ -539,12 +537,6 @@ checkDispatchResult(CdbDispatcherState *ds,
 			{
 				ftsVersion = getFtsVersion();
 				checkSegmentAlive(pParms);
-			}
-
-			/* Hook to check permissions when dispatcher timeout */
-			if (DispatcherCheckPerms_hook && pParms->waitMode == DISPATCH_WAIT_NONE)
-			{
-				(*DispatcherCheckPerms_hook)();
 			}
 
 			if (!wait)

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -33,16 +33,6 @@
 #include "utils/inval.h"
 
 /*
- * Hook for plugins to extend smgr functions.
- * for example, collect statistics from smgr functions
- * via recording the active relfilenode information.
- */
-smgrcreate_hook_type smgrcreate_hook = NULL;
-smgrextend_hook_type smgrextend_hook = NULL;
-smgrtruncate_hook_type smgrtruncate_hook = NULL;
-smgrdounlinkall_hook_type smgrdounlinkall_hook = NULL;
-
-/*
  * Each backend has a hashtable that stores all extant SMgrRelation objects.
  * In addition, "unowned" SMgrRelation objects are chained together in a list.
  */
@@ -339,11 +329,6 @@ smgrcreate(SMgrRelation reln, ForkNumber forknum, bool isRedo)
 	if (isRedo && reln->md_fd[forknum] != NULL)
 		return;
 
-	if (smgrcreate_hook)
-	{
-		(*smgrcreate_hook)(reln, forknum, isRedo);
-	}
-
 	/*
 	 * We may be using the target table space for the first time in this
 	 * database, so create a per-database subdirectory if needed.
@@ -460,11 +445,6 @@ smgrdounlinkall(SMgrRelation *rels, int nrels, bool isRedo, char *relstorages)
 	if (nrels == 0)
 		return;
 
-	if (smgrdounlinkall_hook)
-	{
-		(*smgrdounlinkall_hook)(rels, nrels, isRedo, relstorages);
-	}
-
 	/*
 	 * create an array which contains all relations to be dropped, and close
 	 * each relation's forks at the smgr level while at it
@@ -539,11 +519,6 @@ void
 smgrextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 		   char *buffer, bool skipFsync)
 {
-	if (smgrextend_hook)
-	{
-		(*smgrextend_hook)(reln, forknum, blocknum, buffer, skipFsync);
-	}
-
 	mdextend(reln, forknum, blocknum, buffer, skipFsync);
 }
 
@@ -612,11 +587,6 @@ smgrnblocks(SMgrRelation reln, ForkNumber forknum)
 void
 smgrtruncate(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks)
 {
-	if (smgrtruncate_hook)
-	{
-		(*smgrtruncate_hook)(reln, forknum, nblocks);
-	}
-
 	/*
 	 * Get rid of any buffers for the about-to-be-deleted blocks. bufmgr will
 	 * just drop them without bothering to write the contents.

--- a/src/include/cdb/cdbbufferedappend.h
+++ b/src/include/cdb/cdbbufferedappend.h
@@ -182,8 +182,4 @@ extern void BufferedAppendCompleteFile(
 extern void BufferedAppendFinish(
     BufferedAppend *bufferedAppend);
 
-/* Hook type and declaration in BufferedAppendWrite */
-typedef void (*BufferedAppendWrite_hook_type)(BufferedAppend *bufferedAppend);
-extern PGDLLIMPORT BufferedAppendWrite_hook_type BufferedAppendWrite_hook;
-
 #endif   /* CDBBUFFEREDAPPEND_H */

--- a/src/include/cdb/cdbdisp_async.h
+++ b/src/include/cdb/cdbdisp_async.h
@@ -18,12 +18,4 @@
 
 extern DispatcherInternalFuncs DispatcherAsyncFuncs;
 
-/*
- * Hook for plugins to check permissions in dispatcher
- * One example is to check whether disk quota limit is 
- * exceeded for the table which is loading data.
- */
-typedef bool (*DispatcherCheckPerms_hook_type) (void);
-extern PGDLLIMPORT DispatcherCheckPerms_hook_type DispatcherCheckPerms_hook;
-
 #endif

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -146,32 +146,4 @@ extern Datum smgrin(PG_FUNCTION_ARGS);
 extern Datum smgreq(PG_FUNCTION_ARGS);
 extern Datum smgrne(PG_FUNCTION_ARGS);
 
-/*
- * Hook for plugins to extend smgr functions.
- * for example, collect statistics from smgr functions
- * via recording the active relfilenode information.
- */
-typedef void (*smgrcreate_hook_type)(SMgrRelation reln,
-									 ForkNumber forknum,
-									 bool isRedo);
-extern PGDLLIMPORT smgrcreate_hook_type smgrcreate_hook;
-
-typedef void (*smgrextend_hook_type)(SMgrRelation reln,
-									 ForkNumber forknum,
-									 BlockNumber blocknum,
-									 char *buffer,
-									 bool skipFsync);
-extern PGDLLIMPORT smgrextend_hook_type smgrextend_hook;
-
-typedef void (*smgrtruncate_hook_type)(SMgrRelation reln,
-									   ForkNumber forknum,
-									   BlockNumber nblocks);
-extern PGDLLIMPORT smgrtruncate_hook_type smgrtruncate_hook;
-
-typedef void (*smgrdounlinkall_hook_type)(SMgrRelation *rels,
-										  int nrels,
-										  bool isRedo,
-										  char *relstorages);
-extern PGDLLIMPORT smgrdounlinkall_hook_type smgrdounlinkall_hook;
-
 #endif   /* SMGR_H */


### PR DESCRIPTION
Reverts greenplum-db/gpdb#6624
Based on Heikki's comments, we still need more discussion on the hook position.
For heap table part, continue to work on pgsql-hackers, to define the appropriate set of hooks for PostgreSQL, which we can then adopt in GPDB.
For AO/CO part, continue to talk on original PR and gpdb-dev list.