### PR TITLE
Explicitly pass 0 as number of dead tuples to pgstat when vacuuming A…

### DIFF
--- a/src/backend/commands/vacuumlazy.c
+++ b/src/backend/commands/vacuumlazy.c
@@ -532,11 +532,17 @@ lazy_vacuum_aorel(Relation onerel, VacuumStmt *vacstmt)
 							false,
 							true /* isvacuum */);
 
-		/* report results to the stats collector, too */
+		/*
+		 * Report results to the stats collector.
+		 * Explicitly pass 0 as num_dead_tuples. AO tables use hidden
+		 * tuples in a conceptually similar way that regular tables
+		 * use dead tuples. However with regards to pgstat these are
+		 * semantically distinct thus exposing them will be ambiguous.
+		 */
 		pgstat_report_vacuum(RelationGetRelid(onerel),
 							 onerel->rd_rel->relisshared,
 							 vacrelstats->new_rel_tuples,
-							 0); // GPDB_94_MERGE_FIXME: is 0 dead tuples appropriate for AO tables?
+							 0 /* num_dead_tuples */);
 	}
 }
 


### PR DESCRIPTION
…O tables.

An argument can be made that hidden tuples in AO tables are similar to dead tuples
for regular tables. However, the use of this information with regards to pgstats
seems to be semantically distinct and consequently should not be exposed. As example
after a VACUUM (FULL, ANALYZE) of an AO table, hidden tuples will remain if AO
compaction thresholds are not met.

It seems preferable to explicitly pass 0 instead of the already zero'd LVRelStats
member for clarity.

Addresses GPDB_94_MERGE_FIXME 