### PR TITLE
pg_isready: handle PQPING_MIRROR_READY and reassign exported constant

### DIFF
--- a/src/bin/scripts/pg_isready.c
+++ b/src/bin/scripts/pg_isready.c
@@ -207,6 +207,9 @@ main(int argc, char **argv)
 			case PQPING_NO_ATTEMPT:
 				printf(_("no attempt\n"));
 				break;
+			case PQPING_MIRROR_READY:
+				printf(_("mirror ready\n"));
+				break;
 			default:
 				printf(_("unknown\n"));
 		}

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -122,7 +122,15 @@ typedef enum
 	PQPING_REJECT,				/* server is alive but rejecting connections */
 	PQPING_NO_RESPONSE,			/* could not establish connection */
 	PQPING_NO_ATTEMPT,			/* connection not attempted (bad params) */
-	PQPING_MIRROR_READY         /* mirror completed startup sequence */
+
+	/*
+	 * GPDB-specific additions, starting at 64 to avoid collisions with
+	 * upstream. (This is only somewhat arbitrary; values above 255 would
+	 * increase the size of the PGPing type, but values above 125 would also
+	 * conflict with Bash-specific signal codes. We take roughly half of what's
+	 * left.)
+	 */
+	PQPING_MIRROR_READY = 64,	/* mirror completed startup sequence */
 } PGPing;
 
 /* PGconn encapsulates a connection to the backend.


### PR DESCRIPTION
The GPDB-specific constant `PQPING_MIRROR_READY`, which indicates that a mirror is ready for replication, was not handled in pg_isready.

Additionally, the value we selected for `PQPING_MIRROR_READY` might at one point in the future conflict with upstream libpq, which would be a pain to untangle. Try to avoid that situation by increasing the value.

## Checkboxes
- [ ] ~Add tests for the change~
Unfortunately, pg_isready tests will need some serious janitorial work on the prove framework before we can get them working. This is true of most of the binaries in `src/bin/scripts`.
- [x] Pass `make installcheck`
