### PR TITLE
resgroup: add new flatten views on the status. (v2)

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1816,6 +1816,98 @@ CREATE VIEW gp_toolkit.gp_resgroup_status AS
 GRANT SELECT ON gp_toolkit.gp_resgroup_status TO public;
 
 --------------------------------------------------------------------------------
+-- @view:
+--              gp_toolkit.gp_resgroup_status_per_host
+--
+-- @doc:
+--              Resource group runtime status information grouped by host
+--
+--------------------------------------------------------------------------------
+
+CREATE VIEW gp_toolkit.gp_resgroup_status_per_host AS
+    WITH s AS (
+        SELECT
+            rsgname
+          , groupid
+          , (json_each(cpu_usage)).key::smallint AS segment_id
+          , (json_each(cpu_usage)).value AS cpu
+          , (json_each(memory_usage)).value AS memory
+        FROM gp_toolkit.gp_resgroup_status
+    )
+    SELECT
+        s.rsgname
+      , s.groupid
+      , c.hostname
+      , sum((s.cpu                       )::text::numeric) AS cpu
+      , sum((s.memory->'used'            )::text::integer) AS memory_used
+      , sum((s.memory->'available'       )::text::integer) AS memory_available
+      , sum((s.memory->'quota_used'      )::text::integer) AS memory_quota_used
+      , sum((s.memory->'quota_available' )::text::integer) AS memory_quota_available
+      , sum((s.memory->'quota_proposed'  )::text::integer) AS memory_quota_proposed
+      , sum((s.memory->'shared_used'     )::text::integer) AS memory_shared_used
+      , sum((s.memory->'shared_available')::text::integer) AS memory_shared_available
+      , sum((s.memory->'shared_granted'  )::text::integer) AS memory_shared_granted
+      , sum((s.memory->'shared_proposed' )::text::integer) AS memory_shared_proposed
+    FROM s
+    INNER JOIN pg_catalog.gp_segment_configuration AS c
+        ON s.segment_id = c.content
+        AND c.role = 'p'
+    GROUP BY
+        s.rsgname
+      , s.groupid
+      , c.hostname
+    ;
+
+GRANT SELECT ON gp_toolkit.gp_resgroup_status_per_host TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--              gp_toolkit.gp_resgroup_status_per_segment
+--
+-- @doc:
+--              Resource group runtime status information grouped by segment
+--
+--------------------------------------------------------------------------------
+
+CREATE VIEW gp_toolkit.gp_resgroup_status_per_segment AS
+    WITH s AS (
+        SELECT
+            rsgname
+          , groupid
+          , (json_each(cpu_usage)).key::smallint AS segment_id
+          , (json_each(cpu_usage)).value AS cpu
+          , (json_each(memory_usage)).value AS memory
+        FROM gp_toolkit.gp_resgroup_status
+    )
+    SELECT
+        s.rsgname
+      , s.groupid
+      , c.hostname
+      , s.segment_id
+      , sum((s.cpu                       )::text::numeric) AS cpu
+      , sum((s.memory->'used'            )::text::integer) AS memory_used
+      , sum((s.memory->'available'       )::text::integer) AS memory_available
+      , sum((s.memory->'quota_used'      )::text::integer) AS memory_quota_used
+      , sum((s.memory->'quota_available' )::text::integer) AS memory_quota_available
+      , sum((s.memory->'quota_proposed'  )::text::integer) AS memory_quota_proposed
+      , sum((s.memory->'shared_used'     )::text::integer) AS memory_shared_used
+      , sum((s.memory->'shared_available')::text::integer) AS memory_shared_available
+      , sum((s.memory->'shared_granted'  )::text::integer) AS memory_shared_granted
+      , sum((s.memory->'shared_proposed' )::text::integer) AS memory_shared_proposed
+    FROM s
+    INNER JOIN pg_catalog.gp_segment_configuration AS c
+        ON s.segment_id = c.content
+        AND c.role = 'p'
+    GROUP BY
+        s.rsgname
+      , s.groupid
+      , c.hostname
+      , s.segment_id
+    ;
+
+GRANT SELECT ON gp_toolkit.gp_resgroup_status_per_segment TO public;
+
+--------------------------------------------------------------------------------
 -- AO/CO diagnostics functions
 --------------------------------------------------------------------------------
 

--- a/src/test/isolation2/expected/resgroup/resgroup_views.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views.out
@@ -1,0 +1,33 @@
+select * from gp_toolkit.gp_resgroup_config where groupname='default_group';
+ groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
+ 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+(1 row)
+
+select rsgname , groupid , num_running , num_queueing , num_queued , num_executed , cpu_usage->'-1' as qd_cpu_usage , memory_usage->'-1'->'used' as qd_memory_used , memory_usage->'-1'->'shared_used' as qd_memory_shared_used from gp_toolkit.gp_resgroup_status where rsgname='default_group';
+ rsgname       | groupid | num_running | num_queueing | num_queued | num_executed | qd_cpu_usage | qd_memory_used | qd_memory_shared_used 
+---------------+---------+-------------+--------------+------------+--------------+--------------+----------------+-----------------------
+ default_group | 6437    | 0           | 0            | 0          | 0            | 0.00         | 0              | 0                     
+(1 row)
+
+select rsgname , groupid , cpu , memory_used , memory_shared_used from gp_toolkit.gp_resgroup_status_per_host s join gp_segment_configuration c on s.hostname=c.hostname and c.content=-1 where rsgname='default_group';
+ rsgname       | groupid | cpu  | memory_used | memory_shared_used 
+---------------+---------+------+-------------+--------------------
+ default_group | 6437    | 0.00 | 0           | 0                  
+(1 row)
+
+select rsgname , groupid , segment_id , cpu , memory_used , memory_shared_used from gp_toolkit.gp_resgroup_status_per_segment where rsgname='default_group' and segment_id=-1;
+ rsgname       | groupid | segment_id | cpu  | memory_used | memory_shared_used 
+---------------+---------+------------+------+-------------+--------------------
+ default_group | 6437    | -1         | 0.00 | 0           | 0                  
+(1 row)
+
+-- also log the raw output of the views, if any of above tests failed it is
+-- easier to find out the causes with these logs.
+
+-- start_ignore
+select * from gp_toolkit.gp_resgroup_config;
+select * from gp_toolkit.gp_resgroup_status;
+select * from gp_toolkit.gp_resgroup_status_per_host;
+select * from gp_toolkit.gp_resgroup_status_per_segment;
+-- end_ignore

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -2,6 +2,7 @@ test: resgroup/enable_resgroup_validate
 test: resgroup/enable_resgroup
 
 # basic syntax
+test: resgroup/resgroup_views
 test: resgroup/resgroup_syntax
 test: resgroup/resgroup_transaction
 test: resgroup/resgroup_name_convention

--- a/src/test/isolation2/sql/resgroup/resgroup_views.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_views.sql
@@ -1,0 +1,45 @@
+select *
+  from gp_toolkit.gp_resgroup_config
+ where groupname='default_group';
+
+select rsgname
+     , groupid
+     , num_running
+     , num_queueing
+     , num_queued
+     , num_executed
+     , cpu_usage->'-1' as qd_cpu_usage
+     , memory_usage->'-1'->'used' as qd_memory_used
+     , memory_usage->'-1'->'shared_used' as qd_memory_shared_used
+  from gp_toolkit.gp_resgroup_status
+ where rsgname='default_group';
+
+select rsgname
+     , groupid
+     , cpu
+     , memory_used
+     , memory_shared_used
+  from gp_toolkit.gp_resgroup_status_per_host s
+  join gp_segment_configuration c
+    on s.hostname=c.hostname and c.content=-1
+ where rsgname='default_group';
+
+select rsgname
+     , groupid
+     , segment_id
+     , cpu
+     , memory_used
+     , memory_shared_used
+  from gp_toolkit.gp_resgroup_status_per_segment
+ where rsgname='default_group'
+   and segment_id=-1;
+
+-- also log the raw output of the views, if any of above tests failed it is
+-- easier to find out the causes with these logs.
+
+-- start_ignore
+select * from gp_toolkit.gp_resgroup_config;
+select * from gp_toolkit.gp_resgroup_status;
+select * from gp_toolkit.gp_resgroup_status_per_host;
+select * from gp_toolkit.gp_resgroup_status_per_segment;
+-- end_ignore


### PR DESCRIPTION
Resource group comes with a view gp_toolkit.gp_resgroup_status to get
the running status of all the resource groups.  The cpu and memory
usages as displayed in json format, they are hard to parse and
understand by human.  To make it more user friendly we now provide two
new views on the status, the cpu and memory usages are flatten into
multiple columns.  They also group the status by segment or host so it
is easier to find out the usages at different levels.

## Background
The views were previously added in https://github.com/greenplum-db/gpdb/pull/6697, but the tests for the views failed on the master pipelines so we reverted the changes.

About the failures.  These views are used to query the per host or per segment resource group status information, they are sensitive to cluster layout such as the number of hosts and number of segments.  The resource group pipelines put the cluster on 2 hosts, each contains 1 segment, this is different than a local demo cluster.

To make them stable we added some filters on the query in this v2 PR, we only show the status of master segment/host so they should always be the same on different cluster layouts.

This change is verified locally, as well as on a devel pipeline.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
