### PR TITLE
Fix gppkg error when master and standby master are in the same node

### DIFF
--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -1037,7 +1037,10 @@ class InstallPackage(Operation):
     def __init__(self, gppkg, master_host, standby_host, segment_host_list):
         self.gppkg = gppkg
         self.master_host = master_host
-        self.standby_host = standby_host
+        if master_host != standby_host:
+            self.standby_host = standby_host
+        else:
+            self.standby_host = []
         self.segment_host_list = segment_host_list
 
     def execute(self):
@@ -1118,7 +1121,10 @@ class PerformHooks(Operation):
         """
         self.hooks = hooks
         self.master_host = master_host
-        self.standby_host = standby_host
+        if master_host != standby_host:
+            self.standby_host = standby_host
+        else:
+            self.standby_host = []
         self.segment_host_list = segment_host_list
 
     def execute(self):
@@ -1149,7 +1155,10 @@ class UninstallPackage(Operation):
     def __init__(self, gppkg, master_host, standby_host, segment_host_list):
         self.gppkg = gppkg
         self.master_host = master_host
-        self.standby_host = standby_host
+        if master_host != standby_host:
+            self.standby_host = standby_host
+        else:
+            self.standby_host = []
         self.segment_host_list = segment_host_list
 
     def execute(self):
@@ -1186,7 +1195,7 @@ class UninstallPackage(Operation):
 
             UninstallPackageLocally(self.gppkg.pkg).run()
 
-        # perform any pre-installation steps
+        # perform any post-installation steps
         PerformHooks(hooks=self.gppkg.postuninstall,
                      master_host=self.master_host,
                      standby_host=self.standby_host,
@@ -1375,7 +1384,10 @@ class UpdatePackage(Operation):
     def __init__(self, gppkg, master_host, standby_host, segment_host_list):
         self.gppkg = gppkg
         self.master_host = master_host
-        self.standby_host = standby_host
+        if master_host != standby_host:
+            self.standby_host = standby_host
+        else:
+            self.standby_host = []
         self.segment_host_list = segment_host_list
 
     def execute(self):


### PR DESCRIPTION
If both master and standby master are set in the same
node, the gppkg utility will report error when uninstall a gppkg.
This is because, gppkg utility assume master and standby master
are in the different node, which is not be true in test environment.

This patch fixed this issue, when master and standby master are in
the same node, we skip to install/uninstall gppkg on standby master
node.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
