### PR TITLE
Dispatch DISCARD command to statements.

### DIFF
--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -166,3 +166,35 @@ BEGIN TRANSACTION ISOLATION LEVEL serializable;
 
 COMMIT;
 DROP TABLE test_serializable;
+--
+-- Test DISCARD TEMP.
+--
+-- There's a test like this in upstream 'guc' test, but this expanded version
+-- verifies that temp tables are dropped on segments, too.
+--
+CREATE TEMP TABLE reset_test ( data text ) ON COMMIT DELETE ROWS;
+DISCARD TEMP;
+-- Try to create a new temp table with same. Should work.
+CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;
+-- Now test that the effects of DISCARD TEMP can be rolled back
+BEGIN;
+DISCARD TEMP;
+ROLLBACK;
+-- the table should still exist.
+INSERT INTO reset_test VALUES (1);
+-- Unlike DISCARD TEMP, DISCARD ALL cannot be run in a transaction.
+BEGIN;
+DISCARD ALL;
+ERROR:  DISCARD ALL cannot run inside a transaction block
+COMMIT;
+-- the table should still exist.
+INSERT INTO reset_test VALUES (2);
+SELECT * FROM reset_test;
+ data 
+------
+ 1
+ 2
+(2 rows)
+
+DISCARD ALL;
+CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -104,3 +104,33 @@ BEGIN TRANSACTION ISOLATION LEVEL serializable;
 	SELECT * FROM test_serializable;
 COMMIT;
 DROP TABLE test_serializable;
+
+
+--
+-- Test DISCARD TEMP.
+--
+-- There's a test like this in upstream 'guc' test, but this expanded version
+-- verifies that temp tables are dropped on segments, too.
+--
+CREATE TEMP TABLE reset_test ( data text ) ON COMMIT DELETE ROWS;
+DISCARD TEMP;
+-- Try to create a new temp table with same. Should work.
+CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;
+
+-- Now test that the effects of DISCARD TEMP can be rolled back
+BEGIN;
+DISCARD TEMP;
+ROLLBACK;
+-- the table should still exist.
+INSERT INTO reset_test VALUES (1);
+
+-- Unlike DISCARD TEMP, DISCARD ALL cannot be run in a transaction.
+BEGIN;
+DISCARD ALL;
+COMMIT;
+-- the table should still exist.
+INSERT INTO reset_test VALUES (2);
+SELECT * FROM reset_test;
+
+DISCARD ALL;
+CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;


### PR DESCRIPTION
Previously, DISCARD was not dispatched, and therefore temporary tables
were only discarded on the QD, not the QEs.

Fixes https://github.com/greenplum-db/gpdb/issues/1036
