### PR TITLE
Remove broken test for an ancient bug.

### DIFF
--- a/src/test/regress/expected/qp_bitmapscan.out
+++ b/src/test/regress/expected/qp_bitmapscan.out
@@ -21041,19 +21041,6 @@ update foo set b = 'B' where b is null;
 vacuum full foo;
 RESET ALL;
 -- ----------------------------------------------------------------------
--- Test: query09.sql
--- ----------------------------------------------------------------------
-----------------------------------------------------------------
-create table mpp8014 (i int) distributed by (i);
-create index mpp8014_bitmap_idx on mpp8014 using bitmap(i);
-select localoid::regclass, attrnums from gp_distribution_policy where localoid='mpp8014'::regclass order by localoid::regclass;
- localoid | attrnums 
-----------+----------
- mpp8014  | {1}
-(1 row)
-
-RESET ALL;
--- ----------------------------------------------------------------------
 -- Test: query10.sql
 -- ----------------------------------------------------------------------
 create table mpp7966 (i int, j int, k int);

--- a/src/test/regress/sql/qp_bitmapscan.sql
+++ b/src/test/regress/sql/qp_bitmapscan.sql
@@ -203,16 +203,6 @@ vacuum full foo;
 RESET ALL;
 
 -- ----------------------------------------------------------------------
--- Test: query09.sql
--- ----------------------------------------------------------------------
-
-----------------------------------------------------------------
-create table mpp8014 (i int) distributed by (i);
-create index mpp8014_bitmap_idx on mpp8014 using bitmap(i);
-select localoid::regclass, attrnums from gp_distribution_policy where localoid='mpp8014'::regclass order by localoid::regclass;
-RESET ALL;
-
--- ----------------------------------------------------------------------
 -- Test: query10.sql
 -- ----------------------------------------------------------------------
 


### PR DESCRIPTION
I looked up this issue in the old JIRA instance:

> MPP-8014: bitmap indexes create entries in gp_distribution_policy
>
> postgres=# \d bar
>       Table "public.bar"
>  Column |  Type   | Modifiers
> --------+---------+-----------
>  i      | integer |
> Distributed by: (i)
>
> postgres=# create index bitmap_idx on bar using bitmap(i);
> CREATE INDEX
> postgres=# select localoid::regclass, * from gp_distribution_policy;
>           localoid          | localoid | attrnums
> ----------------------------+----------+----------
>  bar                        |    16398 | {1}
>  pg_bitmapindex.pg_bm_16415 |    16416 |
> (2 rows)

So the problem was that we created gp_distribution_policy entry for the
auxiliary heap table of the bitmap index. We no longer do that, this bug
was fixed 9 years ago. But the test we have in mpp8014 would not fail,
even if the bug reappeared! Let's remove the test, as it's useless in its
current form. It would be nice to have a proper test for that bug, but it
doesn't seem very likely to re-appear any time soon, so it doesn't seem
worth the effort.

Fixes https://github.com/greenplum-db/gpdb/issues/6315
