### PR TITLE
Ensure that replication slots are still active after rebalance.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
+++ b/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
@@ -12,6 +12,7 @@ Feature: Replication Slots
 
     When the user runs "gprecoverseg -ra"
     Then gprecoverseg should return a return code of 0
+    And the primaries and mirrors should be replicating using replication slots
 
     When a mirror has crashed
     And I fully recover a mirror


### PR DESCRIPTION
Adds a test to ensure that replication slots exist and are active on each primary/mirror pair after a rebalance.