### PR TITLE
 Update the default value of optimizer_penalize_broadcast_threshold

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.21.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.22.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.21.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.22.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13927,7 +13927,7 @@ int
 main ()
 {
 
-return strncmp("3.21.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.22.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13937,7 +13937,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.21.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.22.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.21.0@gpdb/stable
+orca/v3.22.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -109,7 +109,7 @@ sync_tools: opt_write_test
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.21.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.22.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4156,7 +4156,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_penalize_broadcast_threshold,
-		10000000, 0, INT_MAX,
+		100000, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
    This commit sets the default value of the guc optimizer_penalize_broadcast_threshold
    to 100000. We have seen a lot of cases where a plan with broadcast was chosen
    due to underestimation of  cardinality. In such cases a Redistribute motion
    would have been better. So this commit will penalize broadcast when the number
    of rows is greater than 100000 so that Redistribute is favored more in this
    case. We have tested the change on the perf pipeline and do not see any
    regression.