### PR TITLE
Add segment identifying information to RemoteOperation

### DIFF
--- a/gpMgmt/bin/gppylib/operations/dump.py
+++ b/gpMgmt/bin/gppylib/operations/dump.py
@@ -775,7 +775,7 @@ class PostDumpDatabase(Operation):
             dbid = seg.getSegmentDbId()
             status_file = self.context.generate_filename("status", timestamp=timestamp, dbid=dbid)
             dump_file = self.context.generate_filename("dump", timestamp=timestamp, dbid=dbid)
-            operations.append(RemoteOperation(PostDumpSegment(self.context, status_file, dump_file), seg.getSegmentHostName(), dbid))
+            operations.append(RemoteOperation(PostDumpSegment(self.context, status_file, dump_file), seg.getSegmentHostName(), "dbid %s"%dbid))
 
         ParallelOperation(operations, self.context.batch_default).run()
 
@@ -789,14 +789,14 @@ class PostDumpDatabase(Operation):
             try:
                 remote.get_ret()
             except NoStatusFile, e:
-                logger.warn('Status file %s not found on %s for dbid %d' % (status_file, host, remote.dbid))
-                failed_dbids.append(remote.dbid)
+                logger.warn('Status file %s not found on %s for %s' % (status_file, host, remote.msg_ctx))
+                failed_dbids.append(remote.msg_ctx)
             except StatusFileError, e:
-                logger.warn('Status file %s on %s indicates errors for dbid %d' % (status_file, host, remote.dbid))
-                failed_dbids.append(remote.dbid)
+                logger.warn('Status file %s on %s indicates errors for %s' % (status_file, host, remote.msg_ctx))
+                failed_dbids.append(remote.msg_ctx)
             except NoDumpFile, e:
-                logger.warn('Dump file %s not found on %s for dbid %d' % (dump_file, host, remote.dbid))
-                failed_dbids.append(remote.dbid)
+                logger.warn('Dump file %s not found on %s for %s' % (dump_file, host, remote.msg_ctx))
+                failed_dbids.append(remote.msg_ctx)
             else:
                 success += 1
 
@@ -805,7 +805,6 @@ class PostDumpDatabase(Operation):
             logger.warn("The following segments had failed checks: %s" % str(failed_dbids))
             return {'exit_status': 1, 'timestamp': timestamp}
         return {'exit_status': 0, 'timestamp': timestamp}
-
 
 class PostDumpSegment(Operation):
     def __init__(self, context, status_file, dump_file):

--- a/gpMgmt/bin/gppylib/operations/filespace.py
+++ b/gpMgmt/bin/gppylib/operations/filespace.py
@@ -303,7 +303,7 @@ class CheckFilespaceConsistency(Operation):
                                               flat_file)
             logger.debug('flat file location = %s' % flat_file_location)
             operations.append(RemoteOperation(CheckFilespaceOidLocally(flat_file_location),
-                                              seg.getSegmentHostName(), dbid
+                                              seg.getSegmentHostName(), "dbid %d"%dbid
                                               )
                               )
         ParallelOperation(operations, NUM_WORKERS).run()
@@ -345,7 +345,7 @@ class CheckFilespaceConsistency(Operation):
             operation_list.append(RemoteOperation(
                 CheckFilespaceEntriesLocally(cur_filespace_entry, peer_filespace_entry,
                                              pg_system_fs_entries[dbid][2], self.file_type),
-                seg.getSegmentHostName(), dbid
+                seg.getSegmentHostName(), "dbid %d"%dbid
                 )
                                   )
 
@@ -483,7 +483,7 @@ class UpdateFlatFiles(Operation):
                                                                              cur_filespace_entry,
                                                                              peer_filespace_entry
                                                                              ),
-                                                      seg.getSegmentHostName(), dbid)
+                                                      seg.getSegmentHostName(), "dbid %d"%dbid)
                                       )
 
             ParallelOperation(operation_list, NUM_WORKERS).run()
@@ -517,7 +517,7 @@ class UpdateFlatFiles(Operation):
                                                                              cur_filespace_entry,
                                                                              peer_filespace_entry
                                                                              ),
-                                                      seg.getSegmentHostName(), dbid)
+                                                      seg.getSegmentHostName(), "dbid %d"%dbid)
                                       )
 
             ParallelOperation(operation_list, NUM_WORKERS).run()
@@ -908,7 +908,7 @@ class RollBackFilespaceChanges(Operation):
                                                               self.pg_system_filespace_entries[dbid],
                                                               rollback=True
                                                               ),
-                                    seg.getSegmentHostName(), dbid
+                                    seg.getSegmentHostName(), "dbid %d"%dbid
                                     ),
                     )
             elif self.file_type == FileType.TEMPORARY_FILES:
@@ -920,7 +920,7 @@ class RollBackFilespaceChanges(Operation):
                                                              self.pg_system_filespace_entries[seg.getSegmentDbId()],
                                                              rollback=True
                                                              ),
-                                    seg.getSegmentHostName(), dbid
+                                    seg.getSegmentHostName(), "dbid %d"%dbid
                                     ),
                     )
 
@@ -966,7 +966,7 @@ class GetMoveOperationList(Operation):
                                                               peer_filespace_entry,
                                                               self.pg_system_filespace_entries[dbid]
                                                               ),
-                                    seg.getSegmentHostName(), dbid))
+                                    seg.getSegmentHostName(), "dbid %d"%dbid))
             elif self.file_type == FileType.TEMPORARY_FILES:
                 operations.append(
                     RemoteOperation(MoveTempFilespaceLocally(self.cur_filespace_entries[dbid],
@@ -975,7 +975,7 @@ class GetMoveOperationList(Operation):
                                                              peer_filespace_entry,
                                                              self.pg_system_filespace_entries[dbid]
                                                              ),
-                                    seg.getSegmentHostName(), dbid))
+                                    seg.getSegmentHostName(), "dbid %d"%dbid))
         return operations
 
 

--- a/gpMgmt/bin/gppylib/operations/persistent_rebuild.py
+++ b/gpMgmt/bin/gppylib/operations/persistent_rebuild.py
@@ -971,9 +971,9 @@ class RebuildTable:
         logger.info('Starting persistent table rebuild operation')
         for di in valid_dbid_info:
             if di.content != -1:
-                operation_list.append(RemoteOperation(RebuildTableOperation(di, self.has_mirrors), di.hostname))
+                operation_list.append(RemoteOperation(RebuildTableOperation(di, self.has_mirrors), di.hostname, di.dbid))
             else:
-                operation_list.append(RemoteOperation(RebuildTableOperation(di, False), di.hostname))
+                operation_list.append(RemoteOperation(RebuildTableOperation(di, False), di.hostname, di.dbid))
 
         try:
             ParallelOperation(operation_list, self.batch_size).run()

--- a/gpMgmt/bin/gppylib/operations/persistent_rebuild.py
+++ b/gpMgmt/bin/gppylib/operations/persistent_rebuild.py
@@ -971,9 +971,9 @@ class RebuildTable:
         logger.info('Starting persistent table rebuild operation')
         for di in valid_dbid_info:
             if di.content != -1:
-                operation_list.append(RemoteOperation(RebuildTableOperation(di, self.has_mirrors), di.hostname, di.dbid))
+                operation_list.append(RemoteOperation(RebuildTableOperation(di, self.has_mirrors), di.hostname, "dbid %d"%di.dbid))
             else:
-                operation_list.append(RemoteOperation(RebuildTableOperation(di, False), di.hostname, di.dbid))
+                operation_list.append(RemoteOperation(RebuildTableOperation(di, False), di.hostname, "dbid %d"%di.dbid))
 
         try:
             ParallelOperation(operation_list, self.batch_size).run()

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
@@ -1166,7 +1166,7 @@ class DumpTestCase(unittest.TestCase):
                                                             mockListFilesByPattern):
         post_dump = PostDumpDatabase(self.context, "20190101010101")
         post_dump.execute()
-        mock_warn.assert_called_with("The following segments had failed checks: [3]")
+        mock_warn.assert_called_with("The following segments had failed checks: ['dbid 3']")
 
     @patch('gppylib.operations.unix.ListFilesByPattern.run', return_value=["gp_dump_20190101010101.rpt"])
     @patch('gppylib.operations.dump.PostDumpSegment.run', return_value=None)
@@ -1178,7 +1178,7 @@ class DumpTestCase(unittest.TestCase):
                                                             mockListFilesByPattern):
         post_dump = PostDumpDatabase(self.context, "20190101010101")
         post_dump.execute()
-        mock_warn.assert_called_with("The following segments had failed checks: [2, 3]")
+        mock_warn.assert_called_with("The following segments had failed checks: ['dbid 2', 'dbid 3']")
 
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
@@ -107,11 +107,11 @@ class UtilsTestCase(GpTestCase):
     @patch('os.path.split', return_value = '/')
     def test_RemoteOperation_logger_debug(self, mock_split, mock_cmd, mock_lods, mock_debug):
         mock_cmd.run = MagicMock()
-        mockRemoteOperation = RemoteOperation(operation=TestOperation(), host="sdw1", dbid=2)
+        mockRemoteOperation = RemoteOperation(operation=TestOperation(), host="sdw1", msg_ctx="dbid 2")
         mockRemoteOperation.execute()
         mock_debug.assert_called()
-        first_call = mock_debug.call_args_list[0]
-        self.assertTrue(first_call.startswith("Output for dbid 2 for host sdw1:"))
+        first_call_args, fist_call_kwargs = mock_debug.call_args_list[0]
+        self.assertTrue(first_call_args[0].startswith("Output for dbid 2 on host sdw1:"))
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
@@ -10,7 +10,7 @@ from gppylib.operations.test_utils_helper import TestOperation, RaiseOperation, 
     RaiseOperation_Unsafe, RaiseOperation_Unpicklable, RaiseOperation_Safe, MyException, ExceptionWithArgs
 from operations.unix import ListFiles
 from test.unit.gp_unittest import GpTestCase, run_tests
-
+from mock import patch, MagicMock
 
 class UtilsTestCase(GpTestCase):
     """
@@ -101,6 +101,17 @@ class UtilsTestCase(GpTestCase):
         with self.assertRaises(Exception):
             ParallelOperation([ListFiles("/tmp")], 0).run()
 
+    @patch('gppylib.commands.base.logger.debug')
+    @patch('pickle.loads')
+    @patch('gppylib.operations.utils.Command')
+    @patch('os.path.split', return_value = '/')
+    def test_RemoteOperation_logger_debug(self, mock_split, mock_cmd, mock_lods, mock_debug):
+        mock_cmd.run = MagicMock()
+        mockRemoteOperation = RemoteOperation(operation=TestOperation(), host="sdw1", dbid=2)
+        mockRemoteOperation.execute()
+        mock_debug.assert_called()
+        first_call = mock_debug.call_args_list[0]
+        self.assertTrue(first_call.startswith("Output for dbid 2 for host sdw1:"))
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/operations/utils.py
+++ b/gpMgmt/bin/gppylib/operations/utils.py
@@ -35,7 +35,7 @@ class RemoteOperation(Operation):
        reside in the __main__ module as opposed to gppylib.test_something. Again, this can be circumvented by invoking unit tests
        through PyUnit or python -m unittest, etc. 
     """
-    def __init__(self, operation, host, dbid=-1):
+    def __init__(self, operation, host, dbid=0):
         super(RemoteOperation, self).__init__()
         self.operation = operation
         self.host = host
@@ -47,7 +47,12 @@ class RemoteOperation(Operation):
         cmd = Command('pickling an operation', '$GPHOME/sbin/gpoperation.py',
                       ctxt=REMOTE, remoteHost=self.host, stdin = pickled_execname + pickled_operation)
         cmd.run(validateAfter=True)
-        logger.debug(cmd.get_results().stdout)
+        msg = "for host %s: %s" % (self.host, cmd.get_results().stdout)
+        if self.dbid > 0:
+            msg = "Output for dbid %d %s" % (self.dbid, msg)
+        else:
+            msg = "Output %s" % (msg)
+        logger.debug(msg)
         ret = self.operation.ret = pickle.loads(cmd.get_results().stdout)
         if isinstance(ret, Exception):
             raise ret

--- a/gpMgmt/bin/gppylib/operations/utils.py
+++ b/gpMgmt/bin/gppylib/operations/utils.py
@@ -35,10 +35,11 @@ class RemoteOperation(Operation):
        reside in the __main__ module as opposed to gppylib.test_something. Again, this can be circumvented by invoking unit tests
        through PyUnit or python -m unittest, etc. 
     """
-    def __init__(self, operation, host):
+    def __init__(self, operation, host, dbid=-1):
         super(RemoteOperation, self).__init__()
         self.operation = operation
         self.host = host
+        self.dbid = dbid
     def execute(self):
         execname = os.path.split(sys.argv[0])[-1]
         pickled_execname = pickle.dumps(execname) 

--- a/gpMgmt/bin/gppylib/operations/utils.py
+++ b/gpMgmt/bin/gppylib/operations/utils.py
@@ -35,11 +35,11 @@ class RemoteOperation(Operation):
        reside in the __main__ module as opposed to gppylib.test_something. Again, this can be circumvented by invoking unit tests
        through PyUnit or python -m unittest, etc. 
     """
-    def __init__(self, operation, host, dbid=0):
+    def __init__(self, operation, host, msg_ctx=""):
         super(RemoteOperation, self).__init__()
         self.operation = operation
         self.host = host
-        self.dbid = dbid
+        self.msg_ctx = msg_ctx
     def execute(self):
         execname = os.path.split(sys.argv[0])[-1]
         pickled_execname = pickle.dumps(execname) 
@@ -47,11 +47,11 @@ class RemoteOperation(Operation):
         cmd = Command('pickling an operation', '$GPHOME/sbin/gpoperation.py',
                       ctxt=REMOTE, remoteHost=self.host, stdin = pickled_execname + pickled_operation)
         cmd.run(validateAfter=True)
-        msg = "for host %s: %s" % (self.host, cmd.get_results().stdout)
-        if self.dbid > 0:
-            msg = "Output for dbid %d %s" % (self.dbid, msg)
+        msg = "on host %s: %s" % (self.host, cmd.get_results().stdout)
+        if self.msg_ctx:
+            msg = "Output for %s %s" % (self.msg_ctx, msg)
         else:
-            msg = "Output %s" % (msg)
+            msg = "Output %s" %(msg)
         logger.debug(msg)
         ret = self.operation.ret = pickle.loads(cmd.get_results().stdout)
         if isinstance(ret, Exception):


### PR DESCRIPTION
Currently, when a RemoteOperation call fails, there is no indication as to which segment failed.  This PR adds the ability to pass a dbid to the RemoteOperation to improve its error logging, and modifies callers of RemoteOperation to pass a dbid where necessary.