### PR TITLE
Enforce Constraint and Index names to Match for Partitions

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -2998,6 +2998,29 @@
     </varlistentry>
 
     <varlistentry>
+     <term><symbol>DEPENDENCY_INTERNAL_AUTO</symbol> (<literal>I</literal>)</term>
+     <listitem>
+      <para>
+       The dependent object was created as part of creation of the
+       referenced object, and is really just a part of its internal
+       implementation.  A <command>DROP</command> of the dependent object
+       will be disallowed outright (we'll tell the user to issue a
+       <command>DROP</command> against the referenced object, instead).
+       While a regular internal dependency will prevent
+       the dependent object from being dropped while any such dependencies
+       remain, <literal>DEPENDENCY_INTERNAL_AUTO</literal> will allow such
+       a drop as long as the object can be found by following any of such
+       dependencies.
+       Example: an index on a partition is made internal-auto-dependent on
+       both the partition itself as well as on the index on the parent
+       partitioned table; so the partition index is dropped together with
+       either the partition it indexes, or with the parent index it is
+       attached to.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
      <term><symbol>DEPENDENCY_EXTENSION</> (<literal>e</>)</term>
      <listitem>
       <para>

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -621,7 +621,7 @@ findDependentObjects(const ObjectAddress *object,
 				/* FALL THRU */
 
 			case DEPENDENCY_INTERNAL:
-
+			case DEPENDENCY_INTERNAL_AUTO:
 				/*
 				 * This object is part of the internal implementation of
 				 * another object, or is part of the extension that is the
@@ -672,6 +672,14 @@ findDependentObjects(const ObjectAddress *object,
 				 * transform this deletion request into a delete of this
 				 * owning object.
 				 *
+				 * For INTERNAL_AUTO dependencies, we don't enforce this;
+				 * in other words, we don't follow the links back to the
+				 * owning object.
+				 */
+				if (foundDep->deptype == DEPENDENCY_INTERNAL_AUTO)
+					break;
+
+				/* 
 				 * First, release caller's lock on this object and get
 				 * deletion lock on the owning object.  (We must release
 				 * caller's lock to avoid deadlock against a concurrent
@@ -799,6 +807,7 @@ findDependentObjects(const ObjectAddress *object,
 			case DEPENDENCY_AUTO:
 				subflags = DEPFLAG_AUTO;
 				break;
+			case DEPENDENCY_INTERNAL_AUTO:
 			case DEPENDENCY_INTERNAL:
 				subflags = DEPFLAG_INTERNAL;
 				break;

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -1749,6 +1749,8 @@ ChooseRelationNameWithCache(const char *name1, const char *name2,
 	char		modlabel[NAMEDATALEN];
 	bool		found = false;
 
+	Assert(GP_ROLE_EXECUTE != Gp_role);
+
 	/* try the unmodified label first */
 	StrNCpy(modlabel, label, sizeof(modlabel));
 
@@ -1789,6 +1791,8 @@ ChooseIndexName(const char *tabname, Oid namespaceId,
 {
 	char	   *indexname;
 
+	
+	
 	if (primary)
 	{
 		/* the primary key's name does not depend on the specific column(s) */

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -2597,8 +2597,10 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 {
 	IndexStmt  *index;
 	ListCell   *lc;
+	Oid namespaceId = 0;
 
 	index = makeNode(IndexStmt);
+	
 
 	index->unique = (constraint->contype != CONSTR_EXCLUSION);
 	index->primary = (constraint->contype == CONSTR_PRIMARY);
@@ -2624,11 +2626,13 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 	/*
 	 * We used to force the index name to be the constraint name, but they
 	 * are in different namespaces and so have different  requirements for
-	 * uniqueness. Here we leave the index name alone and put the constraint
-	 * name in the IndexStmt, for use in DefineIndex.
+	 * uniqueness. At one point we were choosing the name in DefineIndex, 
+	 * but that doesn't work if we want to point to this table in an
+	 * AlterTableStmt in the same dispatch.
 	 */
-	index->idxname = NULL;	/* DefineIndex will choose name */
+	index->idxname = NULL;	/* ChooseIndexName will choose name below */
 	index->altconname = constraint->conname; /* User may have picked the name. */
+
 
 	index->relation = cxt->relation;
 	index->accessMethod = constraint->access_method ? constraint->access_method : DEFAULT_INDEX_TYPE;
@@ -2642,6 +2646,15 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 	index->oldNode = InvalidOid;
 	index->concurrent = false;
 
+
+	/*
+	 * Get the namespaceId for use in 
+	 */
+	if (cxt->relation->schemaname != NULL) 
+		namespaceId = GetSysCacheOid(NAMESPACENAME,
+									 CStringGetDatum(cxt->relation->schemaname),
+									 0, 0, 0);
+	
 	/*
 	 * If it's ALTER TABLE ADD CONSTRAINT USING INDEX, look up the index and
 	 * verify it's usable, then extract the implied column name list.  (We
@@ -2832,6 +2845,17 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 			index->excludeOpNames = lappend(index->excludeOpNames, opname);
 		}
 
+
+		/*
+		 * Select name for index if it is a partitioned table
+		 */
+		if (cxt->iscreatepart || cxt->issplitpart)
+			index->idxname = ChooseIndexName(cxt->relation->relname,
+											 namespaceId,
+											 ChooseIndexColumnNames(index->indexParams),
+											 index->excludeOpNames,
+											 index->primary,
+											 index->isconstraint);
 		return index;
 	}
 
@@ -2965,6 +2989,16 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 		index->indexParams = lappend(index->indexParams, iparam);
 	}
 
+	/*
+	 * Select name for index if it is a partitioned table
+	 */
+	if (cxt->iscreatepart || cxt->issplitpart)
+		index->idxname = ChooseIndexName(cxt->relation->relname,
+										 namespaceId,
+										 ChooseIndexColumnNames(index->indexParams),
+										 index->excludeOpNames,
+										 index->primary,
+										 index->isconstraint);
 	return index;
 }
 
@@ -3690,6 +3724,7 @@ transformAlterTableStmt(Oid relid, AlterTableStmt *stmt,
 	cxt.inhRelations = NIL;
 	cxt.isalter = true;
 	cxt.iscreatepart = false;
+	cxt.issplitpart = false;
 	cxt.hasoids = false;		/* need not be right */
 	cxt.columns = NIL;
 	cxt.ckconstraints = NIL;

--- a/src/include/catalog/dependency.h
+++ b/src/include/catalog/dependency.h
@@ -49,6 +49,20 @@
  * Example: a trigger that's created to enforce a foreign-key constraint
  * is made internally dependent on the constraint's pg_constraint entry.
  *
+ * DEPENDENCY_INTERNAL_AUTO ('I'): the dependent object was created as
+ * part of creation of the referenced object, and is really just a part
+ * of its internal implementation.  A DROP of the dependent object will
+ * be disallowed outright (we'll tell the user to issue a DROP against the
+ * referenced object, instead).  While a regular internal dependency will
+ * prevent the dependent object from being dropped while any such
+ * dependencies remain, DEPENDENCY_INTERNAL_AUTO will allow such a drop as
+ * long as the object can be found by following any of such dependencies.
+ * Example: an index on a partition is made internal-auto-dependent on
+ * both the partition itself as well as on the index on the parent
+ * partitioned table; so the partition index is dropped together with
+ * either the partition it indexes, or with the parent index it is attached
+ * to.
+ * 
  * DEPENDENCY_EXTENSION ('e'): the dependent object is a member of the
  * extension that is the referenced object.  The dependent object can be
  * dropped only via DROP EXTENSION on the referenced object.  Functionally
@@ -69,6 +83,7 @@ typedef enum DependencyType
 	DEPENDENCY_NORMAL = 'n',
 	DEPENDENCY_AUTO = 'a',
 	DEPENDENCY_INTERNAL = 'i',
+	DEPENDENCY_INTERNAL_AUTO = 'I',
 	DEPENDENCY_EXTENSION = 'e',
 	DEPENDENCY_PIN = 'p'
 } DependencyType;


### PR DESCRIPTION
**Enforce Constraint and Index names to Match for Partitions**

This PR will not be merged.  We are submitting this PR for design feedback. 

In order to align with upstream Postgres and to enable upgrading, this PR enforces Greenplum constraint and index names to match as described in this  [proposal](https://docs.google.com/document/d/1E_pFWbzWOgBgHQIXX6yuOxZqMtTnpKbE51UUiAJaEI4/edit#). For example, alter table drop constraint currently assumes that partition constraint names are identical across all partitions which diverges from upstream and makes upgrading a challenge. Our fix for this introduces a new pg_depend type called [internal_auto (I)](https://www.postgresql.org/docs/11/catalog-pg-depend.html) taken from upstream (postgres/postgres@8b08f7d4820). Internal auto allows for greater flexibility in dropping dependent objects without needing to first drop the referenced object. See the following example:

dependency_internal:
idx_child    --- internal --- >    idx_root
idx_child    --- internal --- >    tbl_child

Not allowed to drop idx_root or tbl_child. 

If we want to drop the child partition dependency_internal requires the root index to be dropped first. Whereas internal_auto gives more flexibility in dropping the child partition without needing to first drop the root index.

dependency_internal_auto:
idx_child    --- internal_auto --- >    idx_root
idx_child    --- internal_auto --- >    tbl_child

Allowed to drop idx_root or tbl_child.

---

Before merging this PR we plan to implement the following to fully support constraint and index name matching. Internally we have to explicitly attach a child index to its parent index. This proposed fix should work for the following three key scenarios. 

We are struggling with how a child index knows which parent index to attach to especially in complex partition scenarios.

**Scenario 1**: Creating a root table with a child partition containing a unique index backed constraint

CREATE TABLE root (a int, unique(a)) PARTITION BY range(a) (PARTITION child start (0) END (5));

1. create table root
2. create root index
3. create child partition table
4. child partition table inherits root table
5. create child index

We are proposing adding the following step for every child index:
6. child index inherits root index

**Scenario 2**: Adding a unique index to a partition table

CREATE TABLE root (a int) PARTITION BY range(a) (PARTITION child start (0) END (5));
CREATE UNIQUE INDEX ON root (a);

Similar steps above with the following:
1. create root index
2. create child index

We are proposing adding the following step for every child index:
3. child index inherits root index

**Scenario 3**: adding a unique index to a partition table

CREATE TABLE root (a int, unique(a)) PARTITION BY range(a) (PARTITION child start (0) END (5));
ALTER TABLE root ADD PARTITION sister START (5) END (10);

Similar steps above with the following:
1. create sister table
2. sister table inherits root partition table
3. create sister index

We are proposing adding the following step for every child index:
4. sister index inherits root index

---

Visually the final state of the pg_denpend’s from executing the following SQL:

![internalautodiagram](https://user-images.githubusercontent.com/42985115/51416713-85941c80-1b2f-11e9-9df5-a246a6c5ab11.png)

---

# Constraint and Index Name Matching

# Issue
Constraint and index names in Greenplum present a challenge when upgrading. Specifically, pg_dump’s generated DDL's are not specific enough to generate the expected constraint and index name. That is, the generation of the constraint and index names during upgrade (ie: runtime) do not match the intended state of the old cluster. See [proposal](https://docs.google.com/document/d/1E_pFWbzWOgBgHQIXX6yuOxZqMtTnpKbE51UUiAJaEI4/edit#) for details.

# Goal
- Remove altconanme which is the a field on index statements that identifies the name of the constraint for the index it is creating.
Removing this will more closely align Greenplum with Postgres, and making future merging and feature parity easier.
- Have pg_dump and pg_restore work for unique and primary constraint names for non-partition tables.
- Have pg_dump and pg_restore work for unique and primary constraint names for partitioned tables.
- Note: exclusion constraints are being removed in GPDB6 and do not need to be considered. See server tracker story [#163395781](https://www.pivotaltracker.com/n/projects/989808/stories/163395781).

# Overall Approach

Create a `constraint-issues-pgdump.sql` script, which creates a database with all the known cases where pg_dump & restore currently goes wrong. Then use this script to ensure we reached our goal and guide our decision making.

During our investigation we discovered the need for the QD to be explicit to the QE in creating index names, 
so that the the index OIDs match on the QD and QE. This will prevent any issues in which the QD and QE create different named indexes. The QE should not be choosing its own index name since it needs to be a consistent and match the index name on the other segments.

Our approach is divided into the following main sections: 1) index and constraint naming matching, 2) index dependencies on partitioned hierarchies, 3) pg_dump and pg_restore for partitioned tables with unqiue and primary constraints.


---


# Index and Constraint Naming Matching Approaches
For index and constraint names to match the QD/QE dispatch needs to be explicit when creating indexes.

### Aggressive Dispatch
Create indexes on the QD and dispatch them as soon as possible to the QE. This enables us to re-use the generated name on all segments and not rely on the QE to choose a consistent name that matches on the other segments. This has worked in GPDB4 and GPDB5, so it should continue to work going forward.

**Considerations:**<br>
When implementing aggressive dispatch, regression failures in ICG occurred due to `ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE ...` on an indexed colum. However, altering the data type on indexed column is not actual regression since it was never supported in GPDB4 and GPDB5 to begin with, and is not needed in GPDB6. If we proceed we will need to improve the end-user error message.

### Emulate OID dispatching as implemented in oid_dispatch.c
When generating index names on QD, record what names were generated and dispatch those to the QE. Thus, the QE can chose the index name itself. If there is a name collision and error is thrown and returned to the QD. This approach may potentially be flaky. This approach relies on the fact that we generate names in a relatively stable fashion (based on the state of the database). If there are no pre-existing naming issues (ie: name squatting), the same database state, and the names are generated in the same order with the same parameters - then the generated names should consistent. In theory, this approach will not break existing queries that are broken from the "aggressive dispatch" approach. Specifically, `ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE ...`. This approach would keep Greenplum closer to upstream postgres since we eliminated much of the dispatching code.

**Considerations:**<br>
This requires upfront work and could ultimately turn out to be a non-viable option.

### Pre-process DDL statements to split out explicit constraint index statements
Split DDL statements to extract out the individual CREATE INDEX statements which will always have a name specified from the QD, which would avoid conflicts between QD/QE and segments. Any DDL that will implicitly create an index statement will be pre-processed to add an explicit CREATE INDEX after the initial operation is complete. The initial operation will no longer create the index, which may be challenging to implement.

**Considerations:**<br>
This would need to be done for every statement that creates a constraint. This might result in greater divergence from upstream since it touches so many DDLs. Possible large code changes and time may be needed since what occurs on the QE will be drastically different than on the QD.

### Logical Catalog replication between QD and QE's
Catalog changes in greenplum need to be dispatched to the segments. The catalog should be the same between QD and QE, thus use logical replication to sync the catalog changes to the segments.

**Considerations:**<br>
This may require a large amount of custom code for the receiver (QE) of logical replication to correctly interpret and utilize the logical catalog replication. It may also require a new model of synchronization.

We may need to implement synchronous logical replication because it can start replication from different points.

---

# Index Dependencies on Partitioned Hierarchies Approaches

### Adding internal auto and removing altconname to match upstream constraints
See `slari/161729893-upstream-alignment-cascading` branch to see how altconname was removed, and choose a different approach to creating index dependency hierarchies. 

When creating a partition table we call transformCreateStmt() which generates the following statements for every partition: 1) a create table statement, 2) a create index statement for every unique or primary constraint, 3) an alter table statement to add the inheritance and partition.

We need to add another transform statement to attach an index to its relation and to its parent index. 
This will be implemented using upstream's internal DDL `ALTER INDEX ... ATTACH PARTITION ...`. There are two methods to use `ALTER INDEX ... ATTACH PARTITION ...` 1) use a dispatch inside defineIndex(), or 2) add an extra alter table statement inside transformCreateStmt().

**Considerations:**<br>
- In the slari branch, there is a loop in `CREATE TABLE ... PARTITION BY...` and `ALTER PARITION ...` which results in the QE's choosing its own index names, which cannot be allowed as described above in the "overall approach". Thus, this needs to be re-evaluated.
- By removing altconname, we will break the name check in `ALTER TABLE EXCHANGE PARTITION ...`, which needs to be fixed.
- When `ALTER TABLE EXCHANGE PARTITION ...` we need to remember to exchange the index dependency hierarchies. This may entail removing the old, and re-add new dependencies.
- `ALTER TABLE SPLIT PARTITION ...` will need to be addressed. Internally it is implemented as `ALTER TABLE EXCHANGE PARTITION ...`. However, it needs to be explicitly tested.

---

# pg_dump and pg_restore for partitioned tables with unique and primary constraints Approaches

### Creating Partition Tables Individually and Explicitly Attaching Indexing
....


### Emulating upstream with extra DDLs
To emulate upstream the following DDLs will be needed: `ALTER TABLE ONLY ... ADD CONSTRAINT ...` and `ALTER INDEX ... ATTACH PARTITION ...`.

**Considerations:**<br>

---
