### PR TITLE
Update GDD to not assign global transaction ids

### DIFF
--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -222,13 +222,6 @@ GlobalDeadLockDetectorMain(int argc, char *argv[])
 	InitBufferPoolBackend();
 	InitXLOGAccess();
 
-	/*
-	 * This is tricky, adding SharedLocalSnapshotSlot to make GDD to be a dispatcher,
-	 * see isDtxQueryDispatcher(), so GDD can get newest segment configuration.
-	 * see setCurrentGxact()
-	 */ 
-	addSharedSnapshot("GDD Dispatcher", gp_session_id);
-
 	SetProcessingMode(NormalProcessing);
 
 	/* Allocate MemoryContext */

--- a/src/backend/utils/gdd/gddfuncs.c
+++ b/src/backend/utils/gdd/gddfuncs.c
@@ -132,7 +132,7 @@ pg_dist_wait_status(PG_FUNCTION_ARGS)
 			int			i;
 
 			CdbDispatchCommand("SELECT * FROM pg_catalog.pg_dist_wait_status()",
-							   DF_WITH_SNAPSHOT, &ctx->cdb_pgresults);
+							   DF_NONE, &ctx->cdb_pgresults);
 
 			if (ctx->cdb_pgresults.numResults == 0)
 				elog(ERROR, "pg_dist_wait_status() didn't get back any data from the segDBs");


### PR DESCRIPTION
Currently GDD sets DistributedTransactionContext to
DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE and as a result allocates distributed
transaction id. It creates entry in ProcGlobal->allTmGxact with state
DTX_STATE_ACTIVE_NOT_DISTRIBUTED. The effect of this is that any query
taking a snapshot will see this transaction as in progress. Since GDD
transaction is short lived it is not an issue in general, but in CI it
causes flaky behavior for some of the vacuum tests. The flaky behavior
shows up as unvacuumed tables where the vacuum snapshot was taken while
GDD transaction was running thereby forcing vacuum to lower its oldest
XMIN. Current behavior of GDD consuming a distributed transaction id
(every 2 minutes by default) is also wasteful behavior.

Currently GDD also sends a snapshot to QE, but this isn't required and
is wasteful as well.

In this change for GDD we keep DistributedTransactionContext as
DTX_CONTEXT_LOCAL_ONLY and avoid dispatching snapshots to QEs.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
