### PR TITLE
Fix bug: zombie record in gp_distribution_policy

### DIFF
--- a/src/test/regress/expected/gp_rules.out
+++ b/src/test/regress/expected/gp_rules.out
@@ -8,6 +8,23 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE rule "_RETURN" as on select to table_to_view_test1
         do instead select * from table_to_view_test2;
+-- relkind and relstorage have been changed to 'v'
+SELECT relkind, relstorage FROM pg_class
+    WHERE oid = 'table_to_view_test1'::regclass;
+ relkind | relstorage 
+---------+------------
+ v       | v
+(1 row)
+
+-- distribution policy record has been deleted
+SELECT 1 FROM gp_distribution_policy
+    WHERE localoid = 'table_to_view_test1'::regclass;
+ ?column? 
+----------
+(0 rows)
+
+DROP VIEW table_to_view_test1;
+DROP TABLE table_to_view_test2;
 -- Same for an Append-Only table. It is currently not supported.
 CREATE table aotable_to_view_test1 (a int) with (appendonly=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/sql/gp_rules.sql
+++ b/src/test/regress/sql/gp_rules.sql
@@ -7,6 +7,16 @@ CREATE table table_to_view_test2 (a int);
 CREATE rule "_RETURN" as on select to table_to_view_test1
         do instead select * from table_to_view_test2;
 
+-- relkind and relstorage have been changed to 'v'
+SELECT relkind, relstorage FROM pg_class
+    WHERE oid = 'table_to_view_test1'::regclass;
+-- distribution policy record has been deleted
+SELECT 1 FROM gp_distribution_policy
+    WHERE localoid = 'table_to_view_test1'::regclass;
+
+DROP VIEW table_to_view_test1;
+DROP TABLE table_to_view_test2;
+
 -- Same for an Append-Only table. It is currently not supported.
 
 CREATE table aotable_to_view_test1 (a int) with (appendonly=true);


### PR DESCRIPTION
When a table has been transformed to a view by creating ON SELECT
rule, the record in gp_distribution_policy should be deleted also,
for there is no such record for a view.
Also, the relstorage in pg_class should be changed to 'v'.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
