### PR TITLE
Join path creating does not handle parameterized paths correctly.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -1292,8 +1292,10 @@ cdbpath_motion_for_join(PlannerInfo *root,
 		/* If the bottlenecked rel can't be moved, bring the other rel to it. */
 		if (single_immovable)
 		{
-			Assert(!other_immovable);
-			other->move_to = single->locus;
+			if (other_immovable)
+				goto fail;
+			else
+				other->move_to = single->locus;
 		}
 
 		/* Redistribute single rel if joining on other rel's partitioning key */

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -759,3 +759,42 @@ select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t
 (4 rows)
 
 drop table t1, t2, t3;
+--
+-- Test a bug that nestloop path previously can not generate motion above
+-- index path, which sometimes is wrong (this test case is an example).
+-- We now depend on parameterized path related variables to judge instead.
+-- We conservatively disallow motion when there is parameter requirement
+-- for either outer or inner at this moment though there could be room
+-- for further improvement (e.g. referring subplan code to do broadcast
+-- for base rel if needed, which needs much effort and does not seem to
+-- be deserved given we will probably refactor related code for the lateral
+-- support in the near future). For the query and guc settings below, legacy
+-- planner can not generate a plan.
+set enable_nestloop = 1;
+set enable_material = 0;
+set enable_seqscan = 0;
+set enable_bitmapscan = 0;
+explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.32..0.38 rows=1 width=4)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.32..0.38 rows=1 width=4)
+         ->  Limit  (cost=0.32..0.36 rows=1 width=4)
+               ->  Nested Loop Left Join  (cost=0.32..3520104.27 rows=33333334 width=4)
+                     ->  Index Only Scan using tenk1_unique2 on tenk1  (cost=0.16..1650.16 rows=3334 width=4)
+                     ->  Materialize  (cost=0.16..18479.11 rows=10000 width=0)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.16..18329.11 rows=10000 width=0)
+                                 ->  Index Only Scan using tenk2_unique2 on tenk2  (cost=0.16..17929.11 rows=3334 width=0)
+ Optimizer: legacy query optimizer
+(9 rows)
+
+select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+reset enable_nestloop;
+reset enable_material;
+reset enable_seqscan;
+reset enable_bitmapscan;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -810,3 +810,44 @@ select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t
 (4 rows)
 
 drop table t1, t2, t3;
+--
+-- Test a bug that nestloop path previously can not generate motion above
+-- index path, which sometimes is wrong (this test case is an example).
+-- We now depend on parameterized path related variables to judge instead.
+-- We conservatively disallow motion when there is parameter requirement
+-- for either outer or inner at this moment though there could be room
+-- for further improvement (e.g. referring subplan code to do broadcast
+-- for base rel if needed, which needs much effort and does not seem to
+-- be deserved given we will probably refactor related code for the lateral
+-- support in the near future). For the query and guc settings below, legacy
+-- planner can not generate a plan.
+set enable_nestloop = 1;
+set enable_material = 0;
+set enable_seqscan = 0;
+set enable_bitmapscan = 0;
+explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1885517.36 rows=1 width=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1885517.36 rows=1 width=1)
+         ->  Limit  (cost=0.00..1885517.36 rows=1 width=1)
+               ->  Result  (cost=0.00..1885517.36 rows=33336667 width=1)
+                     ->  Nested Loop Left Join  (cost=0.00..1885484.02 rows=33336667 width=4)
+                           Join Filter: true
+                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
+                           ->  Materialize  (cost=0.00..431.70 rows=10000 width=1)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.69 rows=10000 width=1)
+                                       ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=1)
+ Optimizer: PQO version 3.23.0
+(11 rows)
+
+select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+reset enable_nestloop;
+reset enable_material;
+reset enable_seqscan;
+reset enable_bitmapscan;

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -1557,6 +1557,7 @@ select count(*) from tenk1 a,
 -- these will get fixed once we catch up to those. Or if not, at least it will be
 -- nicer to work on the code, knowing that there aren't going to be a dozen commits
 -- coming up, touching the same area.
+-- FAIL with ERROR:  could not devise a query plan for the given query (pathnode.c:416)
 explain (costs off)
   select * from int8_tbl a,
     int8_tbl x left join lateral (select a.q1 from int4_tbl y) ss(z)


### PR DESCRIPTION
    Handle parameterized paths correctly when creating a join path.

    After we have parameterized path since pg 9.2 and lateral (since pg9.3 although we do not support the full functionality), merge join path and hash join path need to consider that. Besides, for nestloop path, the previous code is wrong.

    1. It did not allow motion for paths include index (path_contains_inner_index()).
       That is wrong.  Here are two examples of index paths which allow motion.

    ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.17..24735.67 rows=86100 width=0)
        ->  Index Only Scan using t2i on t2  (cost=0.17..21291.67 rows=28700 width=0)

    ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.17..6205.12 rows=259 width=8)
        ->  Index Scan using t2i on t2  (cost=0.17..6201.67 rows=29 width=8)
            Index Cond: (4 = a)

    2. The inner path and outer path might require upper nodes for parameterized
       paths so current code code
         bms_overlap(inner_req_outer, outer_path->parent->relids)
       is definitely not sufficient, besides, outer_path could have paramterized
       paths also.

    For nestloop join, case 1 is covered by the test case added in join_gp.
    For case 2, the test case in join.sql (although ignored) in this patch
    actually partially tested.

    Note the change in this patch is conservative. In theory, we could refer
    subplan code to allow broadcast for base rel if needed (for this solution
    no motion is needed), but that needs much effort and does not seem
    to be deserved given we will probably refactor related code for the
    lateral support in the near future.