### PR TITLE
Fix qual pushdown through Set Operation with window functions.

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -79,8 +79,8 @@ static bool recurse_pushdown_safe(Node *setOp, Query *topquery,
 					  bool *differentTypes);
 static void compare_tlist_datatypes(List *tlist, List *colTypes,
 						bool *differentTypes);
-static bool qual_is_pushdown_safe(Query *subquery, RangeTblEntry *rte,
-						Index rti, Node *qual, bool *differentTypes);
+static bool qual_is_pushdown_safe(Query *subquery, Index rti, Node *qual,
+					  bool *differentTypes);
 static bool qual_is_pushdown_safe_window_func(Query *subquery, Query *topquery,
 						AttrNumber resno);
 static bool recurse_qual_pushdown_safe_window_func(Node *setOp, Query *topquery,
@@ -1362,7 +1362,7 @@ push_down_restrict(PlannerInfo *root, RelOptInfo *rel,
 			Node	   *clause = (Node *) rinfo->clause;
 
 			if (!rinfo->pseudoconstant &&
-				qual_is_pushdown_safe(subquery, rte, rti, clause, differentTypes))
+				qual_is_pushdown_safe(subquery, rti, clause, differentTypes))
 			{
 				/* Push it down */
 				subquery_push_qual(subquery, rte, rti, clause);
@@ -1522,80 +1522,6 @@ compare_tlist_datatypes(List *tlist, List *colTypes,
 		elog(ERROR, "wrong number of tlist entries");
 }
 
-
-/*
- * does qual include a reference to window function node?
- */
-static bool
-qual_contains_window_function(Query *subquery, RangeTblEntry *rte, Index rti, Node *qual)
-{
-	bool result = false;
-	if (NULL != subquery && NIL != subquery->windowClause)
-	{
-		/*
-		 * qual needs to be resolved first to map qual columns
-		 * to the underlying set of produced columns,
-		 * e.g., if we work on a setop child
-		 */
-		Node *qualNew = ResolveNew(qual, rti, 0, rte,
-								   subquery->targetList,
-								   CMD_SELECT, 0);
-
-		result = contain_window_functions(qualNew);
-		pfree(qualNew);
-	}
-
-	return result;
-}
-
-
-/*
- * is a particular qual safe to push down under set operation?
- * if the qual contains references to windowref node, its not
- * safe to push it down.
- */
-static bool
-qual_is_pushdown_safe_set_operation(Query *query, RangeTblEntry *rte, Index rti, Node *qual)
-{
-
-	Query *subquery = NULL;
-	/* 
-	 * In case of CTE, cte->query is passed in as query, so the vars
-	 * should be resolved via the input query
-	 */
-	if (rte->rtekind == RTE_CTE)
-		subquery = query;
-	else
-		subquery = rte->subquery;
-	Assert(subquery);
-
-	SetOperationStmt *setop = (SetOperationStmt *)subquery->setOperations;
-	Assert(setop);
-
-	/*
-	 * for queries of the form:
-	 *   SELECT * from (SELECT max(i) over () as w from X Union Select 1 as w) as foo where w > 0
-	 * the qual (w > 0) is not push_down_safe since it uses a window function
-	 *
-	 * we check if this is the case for either left or right set operation inputs.
-	 * The check for window function is only at the top level of the set
-	 * operation inputs. It does not recurse deep inside the set operation
-	 * child for resolving the qual reference for queries of the form:
-	 *  SELECT w FROM ( (SELECT w FROM Y, Z, (SELECT max(i) over () as w from X) AS bar) UNION SELECT 1 AS w) AS foo WHERE w > 0;
-	 */
-	RangeTblEntry *rteLeft = rt_fetch(((RangeTblRef *)setop->larg)->rtindex, subquery->rtable);
-	RangeTblEntry *rteRight = rt_fetch(((RangeTblRef *)setop->rarg)->rtindex, subquery->rtable);
-	if (qual_contains_window_function(rteLeft->subquery, rte, rti, qual) ||
-		qual_contains_window_function(rteRight->subquery, rte, rti, qual))
-	{
-		return false;
-	}
-
-	return true;
-}
-
-
-
 /*
  * qual_is_pushdown_safe - is a particular qual safe to push down?
  *
@@ -1635,7 +1561,7 @@ qual_is_pushdown_safe_set_operation(Query *query, RangeTblEntry *rte, Index rti,
  * to multiple evaluation of a volatile function.
  */
 static bool
-qual_is_pushdown_safe(Query *subquery, RangeTblEntry *rte, Index rti, Node *qual,
+qual_is_pushdown_safe(Query *subquery, Index rti, Node *qual,
 					  bool *differentTypes)
 {
 	bool		safe = true;
@@ -1647,16 +1573,7 @@ qual_is_pushdown_safe(Query *subquery, RangeTblEntry *rte, Index rti, Node *qual
 	if (contain_subplans(qual))
 		return false;
 
-	/*
-	 * (point 2)
-	 * if we try to push quals below set operation, make
-	 * sure that qual is pushable to below set operation children
-	 */
-	if (NULL != subquery->setOperations &&
-		!qual_is_pushdown_safe_set_operation(subquery, rte, rti, qual))
-	{
-		return false;
-	}
+	Assert(!contain_window_functions(qual));
 
 	/*
 	 * Examine all Vars used in clause; since it's a restriction clause, all

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10600,8 +10600,14 @@ NOTICE:  CREATE TABLE will create partition "rewrite_rules_1_prt_extra" for tabl
 NOTICE:  CREATE TABLE will create partition "rewrite_rules_1_prt_2" for table "rewrite_rules"
 create rule "_RETURN" as on select to rewrite_rules_1_prt_2 do instead 
 select 1 as id, current_date as stamp, 1 as amount;
+-- start_matchsubs
+-- m/^ERROR:  plan contains range table with relstorage='v'/
+-- s/allpaths.c:\d*/allpaths.c/
+-- m/^ERROR:  undefined table type for storage format: v/
+-- s/execScan.c:\d*/execScan.c/
+-- end_matchsubs
 select * from rewrite_rules;
-ERROR:  plan contains range table with relstorage='v' (allpaths.c:346)
+ERROR:  plan contains range table with relstorage='v' (allpaths.c)
 set allow_system_table_mods='dml';
 delete from gp_distribution_policy where localoid='rewrite_rules_1_prt_2'::regclass;
 reset allow_system_table_mods;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10667,6 +10667,12 @@ NOTICE:  CREATE TABLE will create partition "rewrite_rules_1_prt_extra" for tabl
 NOTICE:  CREATE TABLE will create partition "rewrite_rules_1_prt_2" for table "rewrite_rules"
 create rule "_RETURN" as on select to rewrite_rules_1_prt_2 do instead 
 select 1 as id, current_date as stamp, 1 as amount;
+-- start_matchsubs
+-- m/^ERROR:  plan contains range table with relstorage='v'/
+-- s/allpaths.c:\d*/allpaths.c/
+-- m/^ERROR:  undefined table type for storage format: v/
+-- s/execScan.c:\d*/execScan.c/
+-- end_matchsubs
 select * from rewrite_rules;
 ERROR:  undefined table type for storage format: v (execScan.c:414)
 set allow_system_table_mods='dml';

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -8515,27 +8515,31 @@ explain insert into window_preds select k from ( select k from (select row_numbe
 
 insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
 explain with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where i = 1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=1.02..2.08 rows=2 width=8)
-   ->  Append  (cost=1.02..2.08 rows=1 width=8)
-         ->  Subquery Scan "*SELECT* 1"  (cost=1.02..1.04 rows=1 width=8)
-               ->  Window  (cost=1.02..1.03 rows=1 width=8)
-                     Partition By: public.window_preds.j
-                     ->  Sort  (cost=1.02..1.03 rows=1 width=8)
-                           Sort Key: public.window_preds.j
-                           ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=8)
-                                 Filter: i = 1
-         ->  Subquery Scan "*SELECT* 2"  (cost=1.02..1.04 rows=1 width=8)
-               ->  Window  (cost=1.02..1.03 rows=1 width=8)
-                     Partition By: public.window_preds.j
-                     ->  Sort  (cost=1.02..1.03 rows=1 width=8)
-                           Sort Key: public.window_preds.j
-                           ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=8)
-                                 Filter: i = 1
- Settings:  gp_enable_sequential_window_plans=on; optimizer=off
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..0.04 rows=1 width=12)
+   ->  Subquery Scan cte  (cost=0.00..0.04 rows=1 width=12)
+         Filter: cte.i = 1
+         ->  Append  (cost=1.04..2.11 rows=1 width=8)
+               ->  Subquery Scan "*SELECT* 1"  (cost=1.04..1.06 rows=1 width=8)
+                     ->  Window  (cost=1.04..1.05 rows=1 width=8)
+                           Partition By: public.window_preds.j
+                           ->  Sort  (cost=1.04..1.04 rows=1 width=8)
+                                 Sort Key: public.window_preds.j
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+                                       Hash Key: public.window_preds.j
+                                       ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=8)
+               ->  Subquery Scan "*SELECT* 2"  (cost=1.04..1.06 rows=1 width=8)
+                     ->  Window  (cost=1.04..1.05 rows=1 width=8)
+                           Partition By: public.window_preds.j
+                           ->  Sort  (cost=1.04..1.04 rows=1 width=8)
+                                 Sort Key: public.window_preds.j
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+                                       Hash Key: public.window_preds.j
+                                       ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=8)
+ Settings:  gp_enable_sequential_window_plans=on
  Optimizer status: legacy query optimizer
-(18 rows)
+(22 rows)
 
 insert into window_preds with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where i = 1;
 --

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1633,6 +1633,12 @@ partition by range (stamp) (
 );
 create rule "_RETURN" as on select to rewrite_rules_1_prt_2 do instead 
 select 1 as id, current_date as stamp, 1 as amount;
+-- start_matchsubs
+-- m/^ERROR:  plan contains range table with relstorage='v'/
+-- s/allpaths.c:\d*/allpaths.c/
+-- m/^ERROR:  undefined table type for storage format: v/
+-- s/execScan.c:\d*/execScan.c/
+-- end_matchsubs
 select * from rewrite_rules;
 set allow_system_table_mods='dml';
 delete from gp_distribution_policy where localoid='rewrite_rules_1_prt_2'::regclass;


### PR DESCRIPTION
Previously when checking if it is safe to push down a qual through
window functions in qual_is_pushdown_safe(), we did not consider the
case with Set Operations. As a result, qual would be incorrectly pushed
down through Set Operations with window functions.

In this patch, we recurse through setOperations tree when check for
window functions.

This patch fixes #5762 .

Co-authored-by: Melanie Plageman <mplageman@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
