### PR TITLE
Save and restore tablespace info for gpexpand

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -682,6 +682,7 @@ class SegmentTemplate:
         """Builds segment template tar file"""
         self.statusLogger.set_status('BUILD_SEGMENT_TEMPLATE_STARTED', self.tempDir)
         self._create_template()
+        self._handle_tablespace_for_template()
         self._fixup_template()
         self._tar_template()
         self.statusLogger.set_status('BUILD_SEGMENT_TEMPLATE_DONE')
@@ -829,6 +830,55 @@ class SegmentTemplate:
         self.pool.check_results()
 
         self._stop_new_primary_segments()
+
+    def _handle_tablespace_for_template(self):
+        """
+        dump the tablespace info into the template
+
+        Master's tablespace info directory picture:
+        MASTER_DATA_DIR
+              \__ pg_tblspc
+                   \__ oid1 ----symlink to----> tablespace_location
+                                                  \_ GDPBxxx_db1
+
+        dumped tablespace info in the template dir
+        TemplateDir
+            \__ gpexpand_tablespace_info
+                 \__ oid1
+                      \__ spacelocation (text file to save the path to space)
+                         | GDPBxxx_db1
+
+        the restore process has to be consistent with the dumping design,
+        the restore tablespace code is in internal utility `gpconfigurenewsegment`
+        """
+
+        def _get_qd_tblspc_dbdir(spacedir):
+            fns = os.listdir(spacedir)
+            for fn in fns:
+                if fn.endswith("_db1"):
+                    return fn
+
+        self.logger.info("Copy Tablespace from master into template")
+
+        qd_datadir = self.gparray.master.getSegmentDataDirectory()
+        qd_tblspc_dir = os.path.join(qd_datadir, "pg_tblspc")
+        tblspc_oids = os.listdir(qd_tblspc_dir)
+        tblspc_info_dir = os.path.join(self.tempDir, "gpexpand_tablespace_info")
+
+        for tblspc_oid in tblspc_oids:
+            symlink_fullpath = os.path.join(qd_tblspc_dir, tblspc_oid)
+            space_path = os.readlink(symlink_fullpath)
+            qd_dbdir = _get_qd_tblspc_dbdir(space_path)
+            dbdir_in_template = os.path.join(tblspc_info_dir, tblspc_oid)
+            os.makedirs(dbdir_in_template)
+            with open(os.path.join(dbdir_in_template, "spacelocation"), "w") as f:
+                print >>f, space_path
+            cpCmd = Scp(name="Copy tablespace(%s) db dir into template",
+                        srcFile=os.path.join(space_path, qd_dbdir),
+                        dstFile=dbdir_in_template,
+                        dstHost=self.gparray.master.getSegmentHostName(),
+                        recursive=True)
+            cpCmd.run(validateAfter=True)
 
     def _fixup_template(self):
         """Copies postgresql.conf and pg_hba.conf files from a valid segment on the system.

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import shutil
 from optparse import Option, OptionGroup, OptionParser, OptionValueError, SUPPRESS_USAGE
 
 from gppylib.gpparseopts import OptParser, OptChecker
@@ -156,6 +157,35 @@ class ConfExpSegCmd(Command):
                         logger.error(extractTarCmd.get_results())
                         raise
 
+                # Restore tablespace if there exists info in template
+                tblspc_info_dir = os.path.join(self.datadir, "gpexpand_tablespace_info")
+                if os.path.exists(tblspc_info_dir):
+                    # template dir contains tablespace dump info
+                    # have to restore it on new segment
+                    # the dumped info struct is defined in
+                    # the utility `gpexpand.SegmentTemplate._handle_tablespace_for_template`
+                    # the restore process is:
+                    #     1. build the space dir if not exists
+                    #     2. copy the template into the space dir and rename it using seg.dbid
+                    logger.info("restore tablespace")
+                    tblspc_oids = os.listdir(tblspc_info_dir)
+                    for tblspc_oid in tblspc_oids:
+                        with open(os.path.join(tblspc_info_dir,
+                                               tblspc_oid,
+                                               "spacelocation")) as f:
+                            spacelocation = f.read().strip()
+                        if not os.path.exists(spacelocation):
+                            os.makedirs(spacelocation)
+                        fns = os.listdir(os.path.join(tblspc_info_dir,
+                                                      tblspc_oid))
+                        tblspc_dbdir = [fn for fn in fns if fn.endswith("_db1")][0]
+                        new_tblspc_dbdir = tblspc_dbdir[:-1] + str(self.dbid)
+                        cpCmd = unix.Scp(name="Restore Tablespace",
+                                         srcFile=os.path.join(tblspc_info_dir, tblspc_oid, tblspc_dbdir),
+                                         dstFile=os.path.join(spacelocation, new_tblspc_dbdir),
+                                         recursive=True)
+                        cpCmd.run(validateAfter=True)
+                    shutil.rmtree(tblspc_info_dir)
                 # Create pg_log for new segment in case it dosen't exist.
                 try:
                     self.makeOrUpdatePathAsNeeded(os.path.join(self.datadir, "pg_log"))


### PR DESCRIPTION
Previous gpexpand does not handle tablespace expansion (when gpdb
remove filespace  long before).

this commit adds the logic:
  * saving tablespace info into template when build_segment_templat
  * restore tablespace in new segment when configurenewsegment


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- ~[ ] Document changes~
- ~[ ] Communicate in the mailing list if needed~
- [x] Pass `make installcheck`
