### PR TITLE
Parent partition and children partition table must have same columns

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4290,7 +4290,12 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 			 * recursing.
 			 */
 			ATExternalPartitionCheck(cmd->subtype, rel, recursing);
-			ATPartitionCheck(cmd->subtype, rel, false, recursing);
+
+			/*
+			 * (!recurse) indicate that we can not only add column to root
+			 * partition
+			 */
+			ATPartitionCheck(cmd->subtype, rel, !recurse, recursing);
 			/* Performs own recursion */
 			ATPrepAddColumn(wqueue, rel, recurse, recursing, cmd, lockmode);
 			/* Recursion occurs during execution phase */
@@ -4376,7 +4381,12 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 						 ATT_TABLE | ATT_COMPOSITE_TYPE | ATT_FOREIGN_TABLE);
 			ATPrepDropColumn(wqueue, rel, recurse, recursing, cmd, lockmode);
 			ATExternalPartitionCheck(cmd->subtype, rel, recursing);
-			ATPartitionCheck(cmd->subtype, rel, false, recursing);
+
+			/*
+			 * (!recurse) indicate that we can not only drop column to root
+			 * partition
+			 */
+			ATPartitionCheck(cmd->subtype, rel, !recurse, recursing);
 			/* Recursion occurs during execution phase */
 			pass = AT_PASS_DROP;
 			break;
@@ -4470,7 +4480,12 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 			ATSimplePermissions(rel,
 						 ATT_TABLE | ATT_COMPOSITE_TYPE | ATT_FOREIGN_TABLE);
 			ATExternalPartitionCheck(cmd->subtype, rel, recursing);
-			ATPartitionCheck(cmd->subtype, rel, false, recursing);
+
+			/*
+			 * (!recurse) indicate that we can not only alter type to root
+			 * partition
+			 */
+			ATPartitionCheck(cmd->subtype, rel, !recurse, recursing);
 			/* Performs own recursion */
 			ATPrepAlterColumnType(wqueue, tab, rel, recurse, recursing, cmd, lockmode);
 			pass = AT_PASS_ALTER_TYPE;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4295,7 +4295,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 			 * (!recurse) indicate that we can not only add column to root
 			 * partition
 			 */
-			ATPartitionCheck(cmd->subtype, rel, !recurse, recursing);
+			ATPartitionCheck(cmd->subtype, rel, !recurse /* rejectroot */, recursing);
 			/* Performs own recursion */
 			ATPrepAddColumn(wqueue, rel, recurse, recursing, cmd, lockmode);
 			/* Recursion occurs during execution phase */
@@ -4386,7 +4386,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 			 * (!recurse) indicate that we can not only drop column to root
 			 * partition
 			 */
-			ATPartitionCheck(cmd->subtype, rel, !recurse, recursing);
+			ATPartitionCheck(cmd->subtype, rel, !recurse /* rejectroot */, recursing);
 			/* Recursion occurs during execution phase */
 			pass = AT_PASS_DROP;
 			break;
@@ -4485,7 +4485,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 			 * (!recurse) indicate that we can not only alter type to root
 			 * partition
 			 */
-			ATPartitionCheck(cmd->subtype, rel, !recurse, recursing);
+			ATPartitionCheck(cmd->subtype, rel, !recurse /* rejectroot */, recursing);
 			/* Performs own recursion */
 			ATPrepAlterColumnType(wqueue, tab, rel, recurse, recursing, cmd, lockmode);
 			pass = AT_PASS_ALTER_TYPE;

--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -121,3 +121,258 @@ SELECT * FROM altable ORDER BY 1;
 -- (There used to be a quoting bug in the internal query this issues.)
 create table "foo'bar" (id int4, t text);
 alter table "foo'bar" alter column t type integer using length(t);
+--
+-- ADD/DROP/ALTER COLUMN on root partition is approved.
+--
+-- Heap table
+DROP TABLE IF EXISTS test_part_col;
+NOTICE:  table "test_part_col" does not exist, skipping
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b" for table "test_part_col"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c" for table "test_part_col_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2" for table "test_part_col_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3" for table "test_part_col_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2" for table "test_part_col"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c" for table "test_part_col_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2" for table "test_part_col_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_one" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_two" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_three" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3" for table "test_part_col_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_one" for table "test_part_col_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_two" for table "test_part_col_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_three" for table "test_part_col_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_3"
+ALTER TABLE ONLY test_part_col ADD COLUMN f int; --error
+ERROR:  can't add a column to "test_part_col"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col ADD COLUMN f int;
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT; --error
+ERROR:  can't alter a column datatype of "test_part_col"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE ONLY test_part_col DROP COLUMN f; --error
+ERROR:  can't drop a column from "test_part_col"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col DROP COLUMN f;
+ALTER TABLE ONLY test_part_col_1_prt_other_b ADD COLUMN f int;
+ERROR:  can't add a column to "test_part_col_1_prt_other_b"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col_1_prt_other_b ADD COLUMN f int;
+ERROR:  can't add a column to "test_part_col_1_prt_other_b"; it is part of a partitioned table
+HINT:  You may be able to perform the operation on the partitioned table as a whole.
+ALTER TABLE ONLY test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT; --error
+ERROR:  can't alter a column datatype of "test_part_col_1_prt_other_b"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT;
+ERROR:  can't alter a column datatype of "test_part_col_1_prt_other_b"; it is part of a partitioned table
+HINT:  You may be able to perform the operation on the partitioned table as a whole.
+ALTER TABLE ONLY test_part_col_1_prt_other_b DROP COLUMN e; --error
+ERROR:  can't drop a column from "test_part_col_1_prt_other_b"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col_1_prt_other_b DROP COLUMN e;
+ERROR:  can't drop a column from "test_part_col_1_prt_other_b"; it is part of a partitioned table
+HINT:  You may be able to perform the operation on the partitioned table as a whole.
+DROP TABLE test_part_col;
+-- Non-partition heap table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int) DISTRIBUTED BY(a);
+ALTER TABLE ONLY test_part_col ADD COLUMN f int;
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE ONLY test_part_col DROP COLUMN f;
+ALTER TABLE test_part_col ADD COLUMN f int;
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE test_part_col DROP COLUMN f;
+DROP TABLE test_part_col;
+-- AO table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+WITH (appendonly=true)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b" for table "test_part_col"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c" for table "test_part_col_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2" for table "test_part_col_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3" for table "test_part_col_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2" for table "test_part_col"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c" for table "test_part_col_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2" for table "test_part_col_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_one" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_two" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_three" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3" for table "test_part_col_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_one" for table "test_part_col_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_two" for table "test_part_col_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_three" for table "test_part_col_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_3"
+ALTER TABLE ONLY test_part_col ADD COLUMN f int; --error
+ERROR:  can't add a column to "test_part_col"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col ADD COLUMN f int;
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT; --error
+ERROR:  can't alter a column datatype of "test_part_col"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE ONLY test_part_col DROP COLUMN f; --error
+ERROR:  can't drop a column from "test_part_col"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col DROP COLUMN f;
+ALTER TABLE ONLY test_part_col_1_prt_other_b ADD COLUMN f int;
+ERROR:  can't add a column to "test_part_col_1_prt_other_b"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col_1_prt_other_b ADD COLUMN f int;
+ERROR:  can't add a column to "test_part_col_1_prt_other_b"; it is part of a partitioned table
+HINT:  You may be able to perform the operation on the partitioned table as a whole.
+ALTER TABLE ONLY test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT; --error
+ERROR:  can't alter a column datatype of "test_part_col_1_prt_other_b"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT;
+ERROR:  can't alter a column datatype of "test_part_col_1_prt_other_b"; it is part of a partitioned table
+HINT:  You may be able to perform the operation on the partitioned table as a whole.
+ALTER TABLE ONLY test_part_col_1_prt_other_b DROP COLUMN e; --error
+ERROR:  can't drop a column from "test_part_col_1_prt_other_b"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col_1_prt_other_b DROP COLUMN e;
+ERROR:  can't drop a column from "test_part_col_1_prt_other_b"; it is part of a partitioned table
+HINT:  You may be able to perform the operation on the partitioned table as a whole.
+DROP TABLE test_part_col;
+-- Non-partition AO table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+WITH (appendonly=true) DISTRIBUTED BY(a);
+ALTER TABLE ONLY test_part_col ADD COLUMN f int;
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE ONLY test_part_col DROP COLUMN f;
+ALTER TABLE test_part_col ADD COLUMN f int;
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE test_part_col DROP COLUMN f;
+DROP TABLE test_part_col;
+-- AOCS table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+WITH (appendonly=true, orientation=column)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b" for table "test_part_col"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c" for table "test_part_col_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2" for table "test_part_col_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3" for table "test_part_col_1_prt_other_b"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2" for table "test_part_col"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c" for table "test_part_col_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_others_c"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2" for table "test_part_col_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_one" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_two" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_three" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3" for table "test_part_col_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_one" for table "test_part_col_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_two" for table "test_part_col_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_three" for table "test_part_col_1_prt_2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_3"
+ALTER TABLE ONLY test_part_col ADD COLUMN f int; --error
+ERROR:  can't add a column to "test_part_col"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col ADD COLUMN f int;
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT; --error
+ERROR:  can't alter a column datatype of "test_part_col"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE ONLY test_part_col DROP COLUMN f; --error
+ERROR:  can't drop a column from "test_part_col"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col DROP COLUMN f;
+ALTER TABLE ONLY test_part_col_1_prt_other_b ADD COLUMN f int;
+ERROR:  can't add a column to "test_part_col_1_prt_other_b"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col_1_prt_other_b ADD COLUMN f int;
+ERROR:  can't add a column to "test_part_col_1_prt_other_b"; it is part of a partitioned table
+HINT:  You may be able to perform the operation on the partitioned table as a whole.
+ALTER TABLE ONLY test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT; --error
+ERROR:  can't alter a column datatype of "test_part_col_1_prt_other_b"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT;
+ERROR:  can't alter a column datatype of "test_part_col_1_prt_other_b"; it is part of a partitioned table
+HINT:  You may be able to perform the operation on the partitioned table as a whole.
+ALTER TABLE ONLY test_part_col_1_prt_other_b DROP COLUMN e; --error
+ERROR:  can't drop a column from "test_part_col_1_prt_other_b"; it is a partitioned table or part thereof
+ALTER TABLE test_part_col_1_prt_other_b DROP COLUMN e;
+ERROR:  can't drop a column from "test_part_col_1_prt_other_b"; it is part of a partitioned table
+HINT:  You may be able to perform the operation on the partitioned table as a whole.
+DROP TABLE test_part_col;
+-- Non-partition AOCS table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+WITH (appendonly=true, orientation=column) DISTRIBUTED BY(a);
+ALTER TABLE ONLY test_part_col ADD COLUMN f int;
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE ONLY test_part_col DROP COLUMN f;
+ALTER TABLE test_part_col ADD COLUMN f int;
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE test_part_col DROP COLUMN f;
+DROP TABLE test_part_col;

--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -130,50 +130,10 @@ NOTICE:  table "test_part_col" does not exist, skipping
 CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
 DISTRIBUTED BY(a)
 PARTITION BY RANGE (b)
-    SUBPARTITION BY RANGE (c)
-        SUBPARTITION TEMPLATE (
-            START(1) END (3) EVERY(1),
-            DEFAULT SUBPARTITION others_c)
-    SUBPARTITION BY LIST (d)
-        SUBPARTITION TEMPLATE (
-            SUBPARTITION one VALUES (1),
-            SUBPARTITION two VALUES (2),
-            SUBPARTITION three VALUES (3),
-            DEFAULT SUBPARTITION others_d)
 ( START (1) END (2) EVERY (1),
     DEFAULT PARTITION other_b);
 NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b" for table "test_part_col"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c" for table "test_part_col_1_prt_other_b"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2" for table "test_part_col_1_prt_other_b"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3" for table "test_part_col_1_prt_other_b"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_3"
 NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2" for table "test_part_col"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c" for table "test_part_col_1_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2" for table "test_part_col_1_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_one" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_two" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_three" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3" for table "test_part_col_1_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_one" for table "test_part_col_1_prt_2_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_two" for table "test_part_col_1_prt_2_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_three" for table "test_part_col_1_prt_2_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_3"
 ALTER TABLE ONLY test_part_col ADD COLUMN f int; --error
 ERROR:  can't add a column to "test_part_col"; it is a partitioned table or part thereof
 ALTER TABLE test_part_col ADD COLUMN f int;
@@ -213,50 +173,10 @@ CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
 WITH (appendonly=true)
 DISTRIBUTED BY(a)
 PARTITION BY RANGE (b)
-    SUBPARTITION BY RANGE (c)
-        SUBPARTITION TEMPLATE (
-            START(1) END (3) EVERY(1),
-            DEFAULT SUBPARTITION others_c)
-    SUBPARTITION BY LIST (d)
-        SUBPARTITION TEMPLATE (
-            SUBPARTITION one VALUES (1),
-            SUBPARTITION two VALUES (2),
-            SUBPARTITION three VALUES (3),
-            DEFAULT SUBPARTITION others_d)
 ( START (1) END (2) EVERY (1),
     DEFAULT PARTITION other_b);
 NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b" for table "test_part_col"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c" for table "test_part_col_1_prt_other_b"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2" for table "test_part_col_1_prt_other_b"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3" for table "test_part_col_1_prt_other_b"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_3"
 NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2" for table "test_part_col"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c" for table "test_part_col_1_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2" for table "test_part_col_1_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_one" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_two" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_three" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3" for table "test_part_col_1_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_one" for table "test_part_col_1_prt_2_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_two" for table "test_part_col_1_prt_2_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_three" for table "test_part_col_1_prt_2_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_3"
 ALTER TABLE ONLY test_part_col ADD COLUMN f int; --error
 ERROR:  can't add a column to "test_part_col"; it is a partitioned table or part thereof
 ALTER TABLE test_part_col ADD COLUMN f int;
@@ -297,50 +217,10 @@ CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
 WITH (appendonly=true, orientation=column)
 DISTRIBUTED BY(a)
 PARTITION BY RANGE (b)
-    SUBPARTITION BY RANGE (c)
-        SUBPARTITION TEMPLATE (
-            START(1) END (3) EVERY(1),
-            DEFAULT SUBPARTITION others_c)
-    SUBPARTITION BY LIST (d)
-        SUBPARTITION TEMPLATE (
-            SUBPARTITION one VALUES (1),
-            SUBPARTITION two VALUES (2),
-            SUBPARTITION three VALUES (3),
-            DEFAULT SUBPARTITION others_d)
 ( START (1) END (2) EVERY (1),
     DEFAULT PARTITION other_b);
 NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b" for table "test_part_col"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c" for table "test_part_col_1_prt_other_b"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2" for table "test_part_col_1_prt_other_b"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3" for table "test_part_col_1_prt_other_b"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_one" for table "test_part_col_1_prt_other_b_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_two" for table "test_part_col_1_prt_other_b_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_three" for table "test_part_col_1_prt_other_b_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_other_b_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_other_b_2_prt_3"
 NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2" for table "test_part_col"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c" for table "test_part_col_1_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_one" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_two" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_three" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_others_c_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_others_c"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2" for table "test_part_col_1_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_one" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_two" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_three" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_2_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3" for table "test_part_col_1_prt_2"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_one" for table "test_part_col_1_prt_2_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_two" for table "test_part_col_1_prt_2_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_three" for table "test_part_col_1_prt_2_2_prt_3"
-NOTICE:  CREATE TABLE will create partition "test_part_col_1_prt_2_2_prt_3_3_prt_others_d" for table "test_part_col_1_prt_2_2_prt_3"
 ALTER TABLE ONLY test_part_col ADD COLUMN f int; --error
 ERROR:  can't add a column to "test_part_col"; it is a partitioned table or part thereof
 ALTER TABLE test_part_col ADD COLUMN f int;

--- a/src/test/regress/expected/gp_upgrade_cornercases.out
+++ b/src/test/regress/expected/gp_upgrade_cornercases.out
@@ -39,6 +39,7 @@ NOTICE:  CREATE TABLE will create partition "part_1_prt_part_1" for table "part"
 INSERT INTO part VALUES (1, 2, 3), (4, 5, 6);
 ALTER TABLE part DROP COLUMN c;
 ALTER TABLE ONLY part DROP COLUMN b; -- note the ONLY here!
+ERROR:  can't drop a column from "part"; it is a partitioned table or part thereof
 -- DROP all the columns
 CREATE TABLE no_cols_left (a int, b int, c int) DISTRIBUTED RANDOMLY;
 INSERT INTO no_cols_left VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);

--- a/src/test/regress/sql/alter_table_gp.sql
+++ b/src/test/regress/sql/alter_table_gp.sql
@@ -81,3 +81,167 @@ SELECT * FROM altable ORDER BY 1;
 -- (There used to be a quoting bug in the internal query this issues.)
 create table "foo'bar" (id int4, t text);
 alter table "foo'bar" alter column t type integer using length(t);
+
+--
+-- ADD/DROP/ALTER COLUMN on root partition is approved.
+--
+-- Heap table
+DROP TABLE IF EXISTS test_part_col;
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+ALTER TABLE ONLY test_part_col ADD COLUMN f int; --error
+ALTER TABLE test_part_col ADD COLUMN f int;
+
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT; --error
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+
+ALTER TABLE ONLY test_part_col DROP COLUMN f; --error
+ALTER TABLE test_part_col DROP COLUMN f;
+
+ALTER TABLE ONLY test_part_col_1_prt_other_b ADD COLUMN f int;
+ALTER TABLE test_part_col_1_prt_other_b ADD COLUMN f int;
+
+ALTER TABLE ONLY test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT; --error
+ALTER TABLE test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT;
+
+ALTER TABLE ONLY test_part_col_1_prt_other_b DROP COLUMN e; --error
+ALTER TABLE test_part_col_1_prt_other_b DROP COLUMN e;
+
+DROP TABLE test_part_col;
+
+-- Non-partition heap table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int) DISTRIBUTED BY(a);
+
+ALTER TABLE ONLY test_part_col ADD COLUMN f int;
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE ONLY test_part_col DROP COLUMN f;
+
+ALTER TABLE test_part_col ADD COLUMN f int;
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE test_part_col DROP COLUMN f;
+
+DROP TABLE test_part_col;
+
+-- AO table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+WITH (appendonly=true)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+ALTER TABLE ONLY test_part_col ADD COLUMN f int; --error
+ALTER TABLE test_part_col ADD COLUMN f int;
+
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT; --error
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+
+ALTER TABLE ONLY test_part_col DROP COLUMN f; --error
+ALTER TABLE test_part_col DROP COLUMN f;
+
+ALTER TABLE ONLY test_part_col_1_prt_other_b ADD COLUMN f int;
+ALTER TABLE test_part_col_1_prt_other_b ADD COLUMN f int;
+
+ALTER TABLE ONLY test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT; --error
+ALTER TABLE test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT;
+
+ALTER TABLE ONLY test_part_col_1_prt_other_b DROP COLUMN e; --error
+ALTER TABLE test_part_col_1_prt_other_b DROP COLUMN e;
+
+DROP TABLE test_part_col;
+
+-- Non-partition AO table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+WITH (appendonly=true) DISTRIBUTED BY(a);
+
+ALTER TABLE ONLY test_part_col ADD COLUMN f int;
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE ONLY test_part_col DROP COLUMN f;
+
+ALTER TABLE test_part_col ADD COLUMN f int;
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE test_part_col DROP COLUMN f;
+
+DROP TABLE test_part_col;
+
+-- AOCS table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+WITH (appendonly=true, orientation=column)
+DISTRIBUTED BY(a)
+PARTITION BY RANGE (b)
+    SUBPARTITION BY RANGE (c)
+        SUBPARTITION TEMPLATE (
+            START(1) END (3) EVERY(1),
+            DEFAULT SUBPARTITION others_c)
+
+    SUBPARTITION BY LIST (d)
+        SUBPARTITION TEMPLATE (
+            SUBPARTITION one VALUES (1),
+            SUBPARTITION two VALUES (2),
+            SUBPARTITION three VALUES (3),
+            DEFAULT SUBPARTITION others_d)
+
+( START (1) END (2) EVERY (1),
+    DEFAULT PARTITION other_b);
+
+ALTER TABLE ONLY test_part_col ADD COLUMN f int; --error
+ALTER TABLE test_part_col ADD COLUMN f int;
+
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT; --error
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+
+ALTER TABLE ONLY test_part_col DROP COLUMN f; --error
+ALTER TABLE test_part_col DROP COLUMN f;
+
+ALTER TABLE ONLY test_part_col_1_prt_other_b ADD COLUMN f int;
+ALTER TABLE test_part_col_1_prt_other_b ADD COLUMN f int;
+
+ALTER TABLE ONLY test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT; --error
+ALTER TABLE test_part_col_1_prt_other_b ALTER COLUMN e TYPE TEXT;
+
+ALTER TABLE ONLY test_part_col_1_prt_other_b DROP COLUMN e; --error
+ALTER TABLE test_part_col_1_prt_other_b DROP COLUMN e;
+
+DROP TABLE test_part_col;
+
+-- Non-partition AOCS table
+CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
+WITH (appendonly=true, orientation=column) DISTRIBUTED BY(a);
+
+ALTER TABLE ONLY test_part_col ADD COLUMN f int;
+ALTER TABLE ONLY test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE ONLY test_part_col DROP COLUMN f;
+
+ALTER TABLE test_part_col ADD COLUMN f int;
+ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
+ALTER TABLE test_part_col DROP COLUMN f;
+
+DROP TABLE test_part_col;

--- a/src/test/regress/sql/alter_table_gp.sql
+++ b/src/test/regress/sql/alter_table_gp.sql
@@ -90,18 +90,6 @@ DROP TABLE IF EXISTS test_part_col;
 CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
 DISTRIBUTED BY(a)
 PARTITION BY RANGE (b)
-    SUBPARTITION BY RANGE (c)
-        SUBPARTITION TEMPLATE (
-            START(1) END (3) EVERY(1),
-            DEFAULT SUBPARTITION others_c)
-
-    SUBPARTITION BY LIST (d)
-        SUBPARTITION TEMPLATE (
-            SUBPARTITION one VALUES (1),
-            SUBPARTITION two VALUES (2),
-            SUBPARTITION three VALUES (3),
-            DEFAULT SUBPARTITION others_d)
-
 ( START (1) END (2) EVERY (1),
     DEFAULT PARTITION other_b);
 
@@ -143,18 +131,6 @@ CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
 WITH (appendonly=true)
 DISTRIBUTED BY(a)
 PARTITION BY RANGE (b)
-    SUBPARTITION BY RANGE (c)
-        SUBPARTITION TEMPLATE (
-            START(1) END (3) EVERY(1),
-            DEFAULT SUBPARTITION others_c)
-
-    SUBPARTITION BY LIST (d)
-        SUBPARTITION TEMPLATE (
-            SUBPARTITION one VALUES (1),
-            SUBPARTITION two VALUES (2),
-            SUBPARTITION three VALUES (3),
-            DEFAULT SUBPARTITION others_d)
-
 ( START (1) END (2) EVERY (1),
     DEFAULT PARTITION other_b);
 
@@ -197,18 +173,6 @@ CREATE TABLE test_part_col(a int, b int, c int, d int, e int)
 WITH (appendonly=true, orientation=column)
 DISTRIBUTED BY(a)
 PARTITION BY RANGE (b)
-    SUBPARTITION BY RANGE (c)
-        SUBPARTITION TEMPLATE (
-            START(1) END (3) EVERY(1),
-            DEFAULT SUBPARTITION others_c)
-
-    SUBPARTITION BY LIST (d)
-        SUBPARTITION TEMPLATE (
-            SUBPARTITION one VALUES (1),
-            SUBPARTITION two VALUES (2),
-            SUBPARTITION three VALUES (3),
-            DEFAULT SUBPARTITION others_d)
-
 ( START (1) END (2) EVERY (1),
     DEFAULT PARTITION other_b);
 


### PR DESCRIPTION
In the previous code, we can modify the parent partition's column
by `ALTER TABLE ONLY`, so the column of the parent partition 
and children partition may be different.

In order to prohibit this situation, we check the `DROP COLUMN/`
`ADD COLUMN/ALTER TYPE COLUMN` statement to prohibit the
user only modify the column of parent partition or children partitions.

There was a discussion on gpdb-dev@: 
https://groups.google.com/a/greenplum.org/forum/#!msg/gpdb-dev/0SzL_gSbqKo/d-2RpwKrFwAJ 



## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
