### PR TITLE
Ensure that Motion nodes in parameterized plans are not rescanned.

### DIFF
--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -269,6 +269,19 @@ ExecInitMaterial(Material *node, EState *estate, int eflags)
 		eflags |= EXEC_FLAG_REWIND;
 
 	/*
+	 * If the Material node was inserted to protect the child node from rescanning, don't
+	 * eager free.
+	 *
+	 * XXX: The planner doesn't always set the flag for Material nodes that are put
+	 * directly on top of Motion nodes, so check for that, too. (Or is this for ORCA?)
+	 */
+	if (node->cdb_shield_child_from_rescans ||
+		IsA(outerPlan((Plan *) node), Motion))
+	{
+		eflags |= EXEC_FLAG_REWIND;
+	}
+
+	/*
 	 * We must have a tuplestore buffering the subplan output to do backward
 	 * scan or mark/restore.  We also prefer to materialize the subplan output
 	 * if we might be called on to rewind and replay it many times. However,
@@ -347,15 +360,6 @@ ExecInitMaterial(Material *node, EState *estate, int eflags)
 	if (list_length(node->plan.targetlist) != list_length(outerPlan->targetlist))
 		elog(ERROR, "Material operator does not support projection");
 	outerPlanState(matstate) = ExecInitNode(outerPlan, estate, eflags);
-
-	/*
-	 * If the child node of a Material is a Motion, then this Material node is
-	 * not eager free safe.
-	 */
-	if (IsA(outerPlan((Plan *)node), Motion))
-	{
-		matstate->delayEagerFree = true;
-	}
 
 	/*
 	 * initialize tuple type.  no need to initialize projection info because

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1000,7 +1000,8 @@ _copyMaterial(const Material *from)
 	 * copy node superclass fields
 	 */
 	CopyPlanFields((const Plan *) from, (Plan *) newnode);
-    COPY_SCALAR_FIELD(cdb_strict);
+	COPY_SCALAR_FIELD(cdb_strict);
+	COPY_SCALAR_FIELD(cdb_shield_child_from_rescans);
 	COPY_SCALAR_FIELD(share_type);
 	COPY_SCALAR_FIELD(share_id);
 	COPY_SCALAR_FIELD(driver_slice);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -966,7 +966,8 @@ _outMaterial(StringInfo str, const Material *node)
 {
 	WRITE_NODE_TYPE("MATERIAL");
 
-    WRITE_BOOL_FIELD(cdb_strict);
+	WRITE_BOOL_FIELD(cdb_strict);
+	WRITE_BOOL_FIELD(cdb_shield_child_from_rescans);
 
 	WRITE_ENUM_FIELD(share_type, ShareType);
 	WRITE_INT_FIELD(share_id);
@@ -2160,7 +2161,8 @@ _outMaterialPath(StringInfo str, const MaterialPath *node)
 	WRITE_NODE_TYPE("MATERIALPATH");
 
 	_outPathInfo(str, (const Path *) node);
-    WRITE_BOOL_FIELD(cdb_strict);
+	WRITE_BOOL_FIELD(cdb_strict);
+	WRITE_BOOL_FIELD(cdb_shield_child_from_rescans);
 
 	WRITE_NODE_FIELD(subpath);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2042,7 +2042,8 @@ _readMaterial(void)
 {
 	READ_LOCALS(Material);
 
-    READ_BOOL_FIELD(cdb_strict);
+	READ_BOOL_FIELD(cdb_strict);
+	READ_BOOL_FIELD(cdb_shield_child_from_rescans);
 
 	READ_ENUM_FIELD(share_type, ShareType);
 	READ_INT_FIELD(share_id);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1017,6 +1017,7 @@ create_material_plan(PlannerInfo *root, MaterialPath *best_path)
 	plan = make_material(subplan);
 
 	plan->cdb_strict = best_path->cdb_strict;
+	plan->cdb_shield_child_from_rescans = best_path->cdb_shield_child_from_rescans;
 
 	copy_path_costsize(root, &plan->plan, (Path *) best_path);
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -977,6 +977,7 @@ typedef struct Material
 {
 	Plan		plan;
 	bool		cdb_strict;
+	bool		cdb_shield_child_from_rescans;
 
 	/* Material can be shared */
 	ShareType 	share_type;

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -1219,6 +1219,14 @@ typedef struct MaterialPath
                                  *            before yielding output tuples
                                  * false => memoize tuples as they stream thru
                                  */
+
+	/*
+	 * If 'cdb_shield_child_from_rescans' is set, the sub-plan is not
+	 * rescannable, and the Material never call rescan on it. (The Material
+	 * node will keep all tuples, even if REWIND/BACKWARD/MARK executor flags
+	 * are not set.)
+	 */
+	bool		cdb_shield_child_from_rescans;
 } MaterialPath;
 
 /*

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3222,6 +3222,97 @@ select * from nlj1, nlj2 where nlj1.a is distinct from nlj2.a;
 
 reset optimizer_enable_hashjoin;
 reset enable_hashjoin; reset enable_mergejoin; reset enable_nestloop;
+--
+-- At one point, we didn't ensure that the outer side of a NestLoop path
+-- was rescannable, if the NestLoop was used on the inner side of another
+-- NestLoop.
+--
+-- See https://github.com/greenplum-db/gpdb/issues/6769.
+--
+create table a (i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table b (i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table c (i int4, j int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into a select g from generate_series(1,1) g;
+insert into b select g from generate_series(1,1) g;
+insert into c select g, g from generate_series(1, 100) g;
+create index on c (i,j);
+-- In order to get the plan we want, Index Scan on 'c' must appear
+-- much cheaper than a Seq Scan. In order to keep this test quick and small,
+-- we don't want to actually create a huge table, so cheat a little and
+-- force that stats to make it look big to the planner.
+set allow_system_table_mods = on;
+update pg_class set reltuples=10000000 where oid ='c'::regclass;
+set enable_hashjoin=off;
+set enable_mergejoin=off;
+set enable_nestloop=on;
+-- the plan should look something like this:
+--
+--                                 QUERY PLAN                                 
+-- ---------------------------------------------------------------------------
+--  Gather Motion 3:1  (slice3; segments: 3)
+--    ->  Nested Loop [1]
+--          ->  Broadcast Motion 3:3  (slice1; segments: 3)
+--                ->  Seq Scan on b
+--          ->  Materialize  [6]
+--                ->  Nested Loop [2]
+--                      Join Filter: (b.i = a.i)
+--                      ->  Materialize [5]
+--                            ->  Broadcast Motion 3:3  (slice2; segments: 3) [3]
+--                                  ->  Seq Scan on a
+--                      ->  Index Only Scan using c_i_j_idx on c
+--                            Index Cond: (j = (a.i + b.i)) [4]
+--  Optimizer: legacy query optimizer
+-- (14 rows)
+--
+-- The crucal parts are:
+--
+-- * Nested Loop join on the inner side of another Nested Loop join [1], [2]
+--
+-- * Motion on the outer side of the inner Nested Loop join (the Broadcast
+--   Motion on top of "Seq Scan on a" [3])
+--
+-- * An Index scan in the innermost path, which uses an executor parameter
+--   from the outermost path ("b.i", in the Index Cond) [4]
+--
+-- There must be a Materialize node on top of the "Broadcast Motion -> Seq Scan"
+-- path [5]. Otherwise, when the outermost scan on 'b' produces a new row, and
+-- the outer Nested Loop calls Rescan on its inner side, the Motion node would
+-- be rescanned. Note that the Materialize node at [6] does *not* shield the
+-- Motion node from rescanning! That Materialize node is rescanned, when the
+-- executor parameter 'b.i' changes.
+explain (costs off) select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)
+               ->  Seq Scan on b
+         ->  Materialize
+               ->  Nested Loop
+                     Join Filter: (b.i = a.i)
+                     ->  Materialize
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  Seq Scan on a
+                     ->  Index Only Scan using c_i_j_idx on c
+                           Index Cond: (j = (a.i + b.i))
+ Optimizer: legacy query optimizer
+(14 rows)
+
+select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
+ i | i | i | j 
+---+---+---+---
+ 1 | 1 | 2 | 2
+(1 row)
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3220,6 +3220,96 @@ select * from nlj1, nlj2 where nlj1.a is distinct from nlj2.a;
 
 reset optimizer_enable_hashjoin;
 reset enable_hashjoin; reset enable_mergejoin; reset enable_nestloop;
+--
+-- At one point, we didn't ensure that the outer side of a NestLoop path
+-- was rescannable, if the NestLoop was used on the inner side of another
+-- NestLoop.
+--
+-- See https://github.com/greenplum-db/gpdb/issues/6769.
+--
+create table a (i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table b (i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table c (i int4, j int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into a select g from generate_series(1,1) g;
+insert into b select g from generate_series(1,1) g;
+insert into c select g, g from generate_series(1, 100) g;
+create index on c (i,j);
+-- In order to get the plan we want, Index Scan on 'c' must appear
+-- much cheaper than a Seq Scan. In order to keep this test quick and small,
+-- we don't want to actually create a huge table, so cheat a little and
+-- force that stats to make it look big to the planner.
+set allow_system_table_mods = on;
+update pg_class set reltuples=10000000 where oid ='c'::regclass;
+set enable_hashjoin=off;
+set enable_mergejoin=off;
+set enable_nestloop=on;
+-- the plan should look something like this:
+--
+--                                 QUERY PLAN                                 
+-- ---------------------------------------------------------------------------
+--  Gather Motion 3:1  (slice3; segments: 3)
+--    ->  Nested Loop [1]
+--          ->  Broadcast Motion 3:3  (slice1; segments: 3)
+--                ->  Seq Scan on b
+--          ->  Materialize  [6]
+--                ->  Nested Loop [2]
+--                      Join Filter: (b.i = a.i)
+--                      ->  Materialize [5]
+--                            ->  Broadcast Motion 3:3  (slice2; segments: 3) [3]
+--                                  ->  Seq Scan on a
+--                      ->  Index Only Scan using c_i_j_idx on c
+--                            Index Cond: (j = (a.i + b.i)) [4]
+--  Optimizer: legacy query optimizer
+-- (14 rows)
+--
+-- The crucal parts are:
+--
+-- * Nested Loop join on the inner side of another Nested Loop join [1], [2]
+--
+-- * Motion on the outer side of the inner Nested Loop join (the Broadcast
+--   Motion on top of "Seq Scan on a" [3])
+--
+-- * An Index scan in the innermost path, which uses an executor parameter
+--   from the outermost path ("b.i", in the Index Cond) [4]
+--
+-- There must be a Materialize node on top of the "Broadcast Motion -> Seq Scan"
+-- path [5]. Otherwise, when the outermost scan on 'b' produces a new row, and
+-- the outer Nested Loop calls Rescan on its inner side, the Motion node would
+-- be rescanned. Note that the Materialize node at [6] does *not* shield the
+-- Motion node from rescanning! That Materialize node is rescanned, when the
+-- executor parameter 'b.i' changes.
+explain (costs off) select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)
+               ->  Hash Join
+                     Hash Cond: (a.i = b.i)
+                     ->  Seq Scan on a
+                     ->  Hash
+                           ->  Seq Scan on b
+         ->  Index Scan using c_i_j_idx on c
+               Index Cond: (j = (a.i + b.i))
+ Optimizer: PQO version 3.21.0
+(12 rows)
+
+select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
+ i | i | i | j 
+---+---+---+---
+ 1 | 1 | 2 | 2
+(1 row)
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3115,13 +3115,14 @@ where thousand = a.q1 and tenthous = b.q1 and a.q2 = 1 and b.q2 = 2;
                      Filter: (q2 = 2)
          ->  Materialize
                ->  Nested Loop
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                           ->  Seq Scan on int8_tbl a
-                                 Filter: (q2 = 1)
+                     ->  Materialize
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  Seq Scan on int8_tbl a
+                                       Filter: (q2 = 1)
                      ->  Index Scan using tenk1_thous_tenthous on tenk1
                            Index Cond: ((thousand = a.q1) AND (tenthous = b.q1))
  Optimizer: legacy query optimizer
-(13 rows)
+(14 rows)
 
 reset enable_nestloop;
 reset random_page_cost;

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -236,6 +236,79 @@ select * from nlj1, nlj2 where nlj1.a is distinct from nlj2.a;
 reset optimizer_enable_hashjoin;
 reset enable_hashjoin; reset enable_mergejoin; reset enable_nestloop;
 
+
+--
+-- At one point, we didn't ensure that the outer side of a NestLoop path
+-- was rescannable, if the NestLoop was used on the inner side of another
+-- NestLoop.
+--
+-- See https://github.com/greenplum-db/gpdb/issues/6769.
+--
+create table a (i int4);
+create table b (i int4);
+create table c (i int4, j int4);
+
+insert into a select g from generate_series(1,1) g;
+insert into b select g from generate_series(1,1) g;
+insert into c select g, g from generate_series(1, 100) g;
+
+create index on c (i,j);
+
+-- In order to get the plan we want, Index Scan on 'c' must appear
+-- much cheaper than a Seq Scan. In order to keep this test quick and small,
+-- we don't want to actually create a huge table, so cheat a little and
+-- force that stats to make it look big to the planner.
+set allow_system_table_mods = on;
+update pg_class set reltuples=10000000 where oid ='c'::regclass;
+
+set enable_hashjoin=off;
+set enable_mergejoin=off;
+set enable_nestloop=on;
+
+-- the plan should look something like this:
+--
+--                                 QUERY PLAN                                 
+-- ---------------------------------------------------------------------------
+--  Gather Motion 3:1  (slice3; segments: 3)
+--    ->  Nested Loop [1]
+--          ->  Broadcast Motion 3:3  (slice1; segments: 3)
+--                ->  Seq Scan on b
+--          ->  Materialize  [6]
+--                ->  Nested Loop [2]
+--                      Join Filter: (b.i = a.i)
+--                      ->  Materialize [5]
+--                            ->  Broadcast Motion 3:3  (slice2; segments: 3) [3]
+--                                  ->  Seq Scan on a
+--                      ->  Index Only Scan using c_i_j_idx on c
+--                            Index Cond: (j = (a.i + b.i)) [4]
+--  Optimizer: legacy query optimizer
+-- (14 rows)
+--
+-- The crucal parts are:
+--
+-- * Nested Loop join on the inner side of another Nested Loop join [1], [2]
+--
+-- * Motion on the outer side of the inner Nested Loop join (the Broadcast
+--   Motion on top of "Seq Scan on a" [3])
+--
+-- * An Index scan in the innermost path, which uses an executor parameter
+--   from the outermost path ("b.i", in the Index Cond) [4]
+--
+-- There must be a Materialize node on top of the "Broadcast Motion -> Seq Scan"
+-- path [5]. Otherwise, when the outermost scan on 'b' produces a new row, and
+-- the outer Nested Loop calls Rescan on its inner side, the Motion node would
+-- be rescanned. Note that the Materialize node at [6] does *not* shield the
+-- Motion node from rescanning! That Materialize node is rescanned, when the
+-- executor parameter 'b.i' changes.
+
+explain (costs off) select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
+
+select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';


### PR DESCRIPTION
In plans with a Nested Loop join on the inner side of another Nested Loop
join, the planner could produce a plan where a Motion node was rescanned.
That produced an error at execution time:

ERROR:  illegal rescan of motion node: invalid plan (nodeMotion.c:1604)  (seg0 slice4 127.0.0.1:40000 pid=27206) (nodeMotion.c:1604)
HINT:  Likely caused by bad NL-join, try setting enable_nestloop to off

Make sure we add a Materialize node to shield the from rescanning in such
cases.

While we're at it, add an explicit flag to MaterialPaths and plans, to
indicate that the Material node was added to shield the child node from
rescanning. There was a weaker test in ExecInitMaterial itself, which just
checked if the immediately child was a Motion node, but that feels
sketchy; what if there's a Result node in between, for example? However, I
kept the direct check for a Motion node, too, because I'm not sure if there
are other places where we add Material nodes on top of Motions, aside from
the call in create_nestloop_path() that this fixes. ORCA probably does
that, at least.

Fixes https://github.com/greenplum-db/gpdb/issues/6769
