### PR TITLE
Add libzstd to CentOS dependencies README

### DIFF
--- a/README.CentOS.bash
+++ b/README.CentOS.bash
@@ -16,6 +16,7 @@ sudo yum install -y \
     libkadm5 \
     libyaml-devel \
     libxml2-devel \
+    libzstd-devel \
     openssl-devel \
     perl-ExtUtils-Embed \
     python-devel \


### PR DESCRIPTION
Missing documentation on newly required `libzstd` dependency.
