### PR TITLE
CI: Remove extra sles11 task input for RC job

### DIFF
--- a/concourse/tasks/verify_gpdb_versions.yml
+++ b/concourse/tasks/verify_gpdb_versions.yml
@@ -11,7 +11,7 @@ inputs:
   - name: gpdb_src
   - name: bin_gpdb_centos6
   - name: bin_gpdb_centos7
-  - name: bin_gpdb_sles11
+  # - name: bin_gpdb_sles11
 
 run:
   path: gpdb_src/concourse/scripts/verify_gpdb_versions.sh


### PR DESCRIPTION
For GPDB 6 Beta, only Centos 6/7 need to be passing for the same commit
to be a valid release candidate.

This was originally done in this commit: fa63e7abd6add8b3a1eb8bc9e56bef0f1be1bb5e
Reference: https://github.com/greenplum-db/gpdb/pull/6738

But the commit was missing an update to the task yaml for the
Release_Candidate job to accomodate removal of the sles11 input.

Authored-by: Kris Macoskey <kmacoskey@pivotal.io>
