### PR TITLE
Fix compiler warning

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2907,8 +2907,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_agg_skew_avoidance,
-		true,
-		NULL, NULL, NULL
+		true, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
Fixes the below warning :

```
guc_gp.c:2911:15: warning: incompatible pointer to integer conversion initializing 'bool' (aka 'char') with an expression of type 'void *' [-Wint-conversion]
                NULL, NULL, NULL
                            ^~~~
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
