### PR TITLE
Remove merge fixme's

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1818,7 +1818,13 @@ shareinput_walker(SHAREINPUT_MUTATOR f, Node *node, PlannerInfo *root)
 			if (root->glob->finalrtable == NULL)
 			{
 				rel = find_base_rel(root, subqscan->scan.scanrelid);
-				Assert(rel->subplan == subqscan->subplan);
+				/*
+				 * The Assert() on RelOptInfo's subplan being
+				 * same as the subqueryscan's subplan, is valid
+				 * in Upstream but for not for GPDB, since we
+				 * create a new copy of the subplan if two
+				 * SubPlans refer to the same initplan.
+				 */
 				subroot = rel->subroot;
 				glob->share.curr_rtable = subroot->parse->rtable;
 			}

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1149,9 +1149,6 @@ inheritance_planner(PlannerInfo *root)
 	{
 		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 
-		/*
-		 * GPDB_94_STABLE_MERGE_FIXME: Is CTE handled right here?
-		 */
 		if (rte->rtekind == RTE_SUBQUERY || rte->rtekind == RTE_CTE)
 			subqueryRTindexes = bms_add_member(subqueryRTindexes, rti);
 		rti++;

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1336,7 +1336,12 @@ set_subqueryscan_references(PlannerInfo *root,
 
 	/* Need to look up the subquery's RelOptInfo, since we need its subroot */
 	rel = find_base_rel(root, plan->scan.scanrelid);
-	Assert(rel->subplan == plan->subplan);
+	/*
+	 * The Assert() on RelOptInfo's subplan being same as the
+	 * subqueryscan's subplan, is valid in Upstream but not for GPDB,
+	 * since we create a new copy of the subplan if two SubPlans refer to
+	 * the same initplan inside adjust_appendrel_attrs_mutator().
+	 */
 
 	/* Recursively process the subplan */
 	plan->subplan = set_plan_references(rel->subroot, plan->subplan);

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -2025,7 +2025,6 @@ adjust_appendrel_attrs_mutator(Node *node,
 			Plan *newsubplan = (Plan *) copyObject(planner_subplan_get_plan(root, sp));
 			PlannerInfo *newsubroot = makeNode(PlannerInfo);
 
-			/* GPDB_92_MERGE_FIXME: Do we just need a reference or maybe deep copy instead? */
 			memcpy(newsubroot, planner_subplan_get_root(root, sp), sizeof(PlannerInfo));
 
 			/*

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -1387,6 +1387,113 @@ SELECT * FROM subselect_tab3 WHERE (NOT EXISTS(SELECT c FROM subselect_tab2)) IN
  200 | falseg | 1
 (1 row)
 
+-- Test to verify that planner for subqueries, generates different copy of SubPlans referring to the same initplan
+-- and does not Assert on the subplan's being same
+-- start_ignore
+drop table if exists append_rel2;
+NOTICE:  table "append_rel2" does not exist, skipping
+drop table if exists append_rel1;
+NOTICE:  table "append_rel1" does not exist, skipping
+drop table if exists append_rel;
+NOTICE:  table "append_rel" does not exist, skipping
+-- end_ignore
+create table append_rel(att1 int, att2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'att1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table append_rel1(att3 int) INHERITS (append_rel);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table append_rel2(att4 int) INHERITS(append_rel);
+NOTICE:  table has parent, setting distribution columns to match parent table
+insert into append_rel values(1,10),(2,20),(3,30);
+explain with test as (select * from (select * from append_rel) p where att1 in (select att1 from append_rel where att2 >= 19) ) select att2 from append_rel where att1 in (select att1 from test where att2 <= 21);
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=584.27..3902.34 rows=77902 width=4)
+   ->  Append  (cost=584.27..3902.34 rows=25968 width=4)
+         ->  Seq Scan on append_rel  (cost=584.27..586.31 rows=1 width=4)
+               Filter: (hashed SubPlan 1)
+               SubPlan 1  (slice4; segments: 3)
+                 ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
+                             ->  Subquery Scan on test  (cost=0.00..519.35 rows=8656 width=4)
+                                   ->  Hash Join  (cost=2301.87..4905.84 rows=8656 width=8)
+                                         Hash Cond: (append_rel_1.att1 = append_rel_2.att1)
+                                         ->  Append  (cost=0.00..2149.54 rows=17312 width=8)
+                                               ->  Seq Scan on append_rel append_rel_1  (cost=0.00..2.04 rows=1 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel1 append_rel1_1  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel2 append_rel2_1  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                         ->  Hash  (cost=2289.37..2289.37 rows=334 width=4)
+                                               ->  HashAggregate  (cost=2279.37..2289.37 rows=334 width=4)
+                                                     Group Key: append_rel_2.att1
+                                                     ->  Append  (cost=0.00..2149.54 rows=17312 width=4)
+                                                           ->  Seq Scan on append_rel append_rel_2  (cost=0.00..2.04 rows=1 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel1 append_rel1_2  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel2 append_rel2_2  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+         ->  Seq Scan on append_rel1  (cost=584.27..1658.02 rows=12984 width=4)
+               Filter: (hashed SubPlan 1)
+               SubPlan 1  (slice4; segments: 3)
+                 ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
+                             ->  Subquery Scan on test_1  (cost=0.00..519.35 rows=8656 width=4)
+                                   ->  Hash Join  (cost=2301.87..4905.84 rows=8656 width=8)
+                                         Hash Cond: (append_rel_3.att1 = append_rel_4.att1)
+                                         ->  Append  (cost=0.00..2149.54 rows=17312 width=8)
+                                               ->  Seq Scan on append_rel append_rel_3  (cost=0.00..2.04 rows=1 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel1 append_rel1_3  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel2 append_rel2_3  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                         ->  Hash  (cost=2289.37..2289.37 rows=334 width=4)
+                                               ->  HashAggregate  (cost=2279.37..2289.37 rows=334 width=4)
+                                                     Group Key: append_rel_4.att1
+                                                     ->  Append  (cost=0.00..2149.54 rows=17312 width=4)
+                                                           ->  Seq Scan on append_rel append_rel_4  (cost=0.00..2.04 rows=1 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel1 append_rel1_4  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel2 append_rel2_4  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+         ->  Seq Scan on append_rel2  (cost=584.27..1658.02 rows=12984 width=4)
+               Filter: (hashed SubPlan 1)
+               SubPlan 1  (slice4; segments: 3)
+                 ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
+                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
+                             ->  Subquery Scan on test_2  (cost=0.00..519.35 rows=8656 width=4)
+                                   ->  Hash Join  (cost=2301.87..4905.84 rows=8656 width=8)
+                                         Hash Cond: (append_rel_5.att1 = append_rel_6.att1)
+                                         ->  Append  (cost=0.00..2149.54 rows=17312 width=8)
+                                               ->  Seq Scan on append_rel append_rel_5  (cost=0.00..2.04 rows=1 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel1 append_rel1_5  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel2 append_rel2_5  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                         ->  Hash  (cost=2289.37..2289.37 rows=334 width=4)
+                                               ->  HashAggregate  (cost=2279.37..2289.37 rows=334 width=4)
+                                                     Group Key: append_rel_6.att1
+                                                     ->  Append  (cost=0.00..2149.54 rows=17312 width=4)
+                                                           ->  Seq Scan on append_rel append_rel_6  (cost=0.00..2.04 rows=1 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel1 append_rel1_6  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel2 append_rel2_6  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+ Optimizer: legacy query optimizer
+(78 rows)
+
+with test as (select * from (select * from append_rel) p where att1 in (select att1 from append_rel where att2 >= 19) ) select att2 from append_rel where att1 in (select att1 from test where att2 <= 21);
+ att2 
+------
+   20
+(1 row)
+
 -- start_ignore
 drop schema qp_subquery cascade;
 -- end_ignore

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1390,6 +1390,113 @@ SELECT * FROM subselect_tab3 WHERE (NOT EXISTS(SELECT c FROM subselect_tab2)) IN
  200 | falseg | 1
 (1 row)
 
+-- Test to verify that planner for subqueries, generates different copy of SubPlans referring to the same initplan
+-- and does not Assert on the subplan's being same
+-- start_ignore
+drop table if exists append_rel2;
+NOTICE:  table "append_rel2" does not exist, skipping
+drop table if exists append_rel1;
+NOTICE:  table "append_rel1" does not exist, skipping
+drop table if exists append_rel;
+NOTICE:  table "append_rel" does not exist, skipping
+-- end_ignore
+create table append_rel(att1 int, att2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'att1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table append_rel1(att3 int) INHERITS (append_rel);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table append_rel2(att4 int) INHERITS(append_rel);
+NOTICE:  table has parent, setting distribution columns to match parent table
+insert into append_rel values(1,10),(2,20),(3,30);
+explain with test as (select * from (select * from append_rel) p where att1 in (select att1 from append_rel where att2 >= 19) ) select att2 from append_rel where att1 in (select att1 from test where att2 <= 21);
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=584.27..3902.34 rows=77902 width=4)
+   ->  Append  (cost=584.27..3902.34 rows=25968 width=4)
+         ->  Seq Scan on append_rel  (cost=584.27..586.31 rows=1 width=4)
+               Filter: (hashed SubPlan 1)
+               SubPlan 1  (slice4; segments: 3)
+                 ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
+                             ->  Subquery Scan on test  (cost=0.00..519.35 rows=8656 width=4)
+                                   ->  Hash Join  (cost=2301.87..4905.84 rows=8656 width=8)
+                                         Hash Cond: (append_rel_1.att1 = append_rel_2.att1)
+                                         ->  Append  (cost=0.00..2149.54 rows=17312 width=8)
+                                               ->  Seq Scan on append_rel append_rel_1  (cost=0.00..2.04 rows=1 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel1 append_rel1_1  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel2 append_rel2_1  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                         ->  Hash  (cost=2289.37..2289.37 rows=334 width=4)
+                                               ->  HashAggregate  (cost=2279.37..2289.37 rows=334 width=4)
+                                                     Group Key: append_rel_2.att1
+                                                     ->  Append  (cost=0.00..2149.54 rows=17312 width=4)
+                                                           ->  Seq Scan on append_rel append_rel_2  (cost=0.00..2.04 rows=1 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel1 append_rel1_2  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel2 append_rel2_2  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+         ->  Seq Scan on append_rel1  (cost=584.27..1658.02 rows=12984 width=4)
+               Filter: (hashed SubPlan 1)
+               SubPlan 1  (slice4; segments: 3)
+                 ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
+                             ->  Subquery Scan on test_1  (cost=0.00..519.35 rows=8656 width=4)
+                                   ->  Hash Join  (cost=2301.87..4905.84 rows=8656 width=8)
+                                         Hash Cond: (append_rel_3.att1 = append_rel_4.att1)
+                                         ->  Append  (cost=0.00..2149.54 rows=17312 width=8)
+                                               ->  Seq Scan on append_rel append_rel_3  (cost=0.00..2.04 rows=1 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel1 append_rel1_3  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel2 append_rel2_3  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                         ->  Hash  (cost=2289.37..2289.37 rows=334 width=4)
+                                               ->  HashAggregate  (cost=2279.37..2289.37 rows=334 width=4)
+                                                     Group Key: append_rel_4.att1
+                                                     ->  Append  (cost=0.00..2149.54 rows=17312 width=4)
+                                                           ->  Seq Scan on append_rel append_rel_4  (cost=0.00..2.04 rows=1 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel1 append_rel1_4  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel2 append_rel2_4  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+         ->  Seq Scan on append_rel2  (cost=584.27..1658.02 rows=12984 width=4)
+               Filter: (hashed SubPlan 1)
+               SubPlan 1  (slice4; segments: 3)
+                 ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
+                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
+                             ->  Subquery Scan on test_2  (cost=0.00..519.35 rows=8656 width=4)
+                                   ->  Hash Join  (cost=2301.87..4905.84 rows=8656 width=8)
+                                         Hash Cond: (append_rel_5.att1 = append_rel_6.att1)
+                                         ->  Append  (cost=0.00..2149.54 rows=17312 width=8)
+                                               ->  Seq Scan on append_rel append_rel_5  (cost=0.00..2.04 rows=1 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel1 append_rel1_5  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                               ->  Seq Scan on append_rel2 append_rel2_5  (cost=0.00..1073.75 rows=8656 width=8)
+                                                     Filter: (att2 <= 21)
+                                         ->  Hash  (cost=2289.37..2289.37 rows=334 width=4)
+                                               ->  HashAggregate  (cost=2279.37..2289.37 rows=334 width=4)
+                                                     Group Key: append_rel_6.att1
+                                                     ->  Append  (cost=0.00..2149.54 rows=17312 width=4)
+                                                           ->  Seq Scan on append_rel append_rel_6  (cost=0.00..2.04 rows=1 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel1 append_rel1_6  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+                                                           ->  Seq Scan on append_rel2 append_rel2_6  (cost=0.00..1073.75 rows=8656 width=4)
+                                                                 Filter: (att2 >= 19)
+ Optimizer: legacy query optimizer
+(78 rows)
+
+with test as (select * from (select * from append_rel) p where att1 in (select att1 from append_rel where att2 >= 19) ) select att2 from append_rel where att1 in (select att1 from test where att2 <= 21);
+ att2 
+------
+   20
+(1 row)
+
 -- start_ignore
 drop schema qp_subquery cascade;
 -- end_ignore


### PR DESCRIPTION
This PR addresses the following:
- Remove GPDB_94_STABLE_MERGE_FIXME for CTE 
Here the check for `RTE_CTE` is correct since in GPDB, while planning, CTE is
considered similar to subquery. Hence, removing the FIXME. 
- Remove GPDB_92_MERGE_FIXME from prepunion.c 
The GPDB_92_MERGE_FIXME for whether we need to deep copy or memcopy
suffices in case of subroot can be removed as from the subroot all we
care about is the `parse->rtable`, therefore, creating a deep copy for
it is unnecessary.
While debugging the removal of the above GPDB_94_STABLE_MERGE_FIXME,
we came across a query which would trip the Assert removed as part of this PR.
 The `Assert()` which is valid in Upstream but for GPDB, since we create a 
new copy of the subplan if two SubPlans refer to the same initplan.
Therefore, when we try to set references for subqueryscans
in plans with copies of subplans referring to same
initplan, we cannot directly Assert on the RelOptInfo's subplan being
same as the subqueryscan's subplan.

Added a test case for the same, which will ensure we do not merge back
the Assert back from Upstream in future merges.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
