### PR TITLE
Remove stale replication slots on  mirrors

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
+++ b/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
@@ -9,6 +9,7 @@ Feature: Replication Slots
     Given a preferred primary has failed
     When primary and mirror switch to non-preferred roles
     Then the primaries and mirrors should be replicating using replication slots
+    And the mirrors should not have replication slots
 
     When the user runs "gprecoverseg -ra"
     Then gprecoverseg should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
@@ -114,6 +114,18 @@ def step_impl(context):
                 (content_id, result[0])
             )
 
+@then(u'the mirrors should not have replication slots')
+def step_impl(context):
+    result_cursor = execute_sql(
+        "postgres",
+        "select datadir from gp_segment_configuration where role='m';"
+    )
+
+    for content_id, result in enumerate(result_cursor.fetchall()):
+        path_to_replslot = os.path.join(result[0], 'pg_replslot')
+        if len(os.listdir(path_to_replslot)) > 0:
+            raise Exception("expected replication slot directory to be empty")
+
 
 @given(u'a preferred primary has failed')
 def step_impl(context):

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6827,6 +6827,11 @@ StartupXLOG(void)
 	 */
 	StartupReplicationSlots();
 
+	if (ArchiveRecoveryRequested)
+	{
+		ReplicationSlotDropIfExists(INTERNAL_WAL_REPLICATION_SLOT_NAME);
+	}
+
 	/*
 	 * Startup logical state, needs to be setup now so we have proper data
 	 * during crash recovery.

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6828,9 +6828,7 @@ StartupXLOG(void)
 	StartupReplicationSlots();
 
 	if (ArchiveRecoveryRequested)
-	{
 		ReplicationSlotDropIfExists(INTERNAL_WAL_REPLICATION_SLOT_NAME);
-	}
 
 	/*
 	 * Startup logical state, needs to be setup now so we have proper data

--- a/src/backend/replication/slot.c
+++ b/src/backend/replication/slot.c
@@ -1382,6 +1382,12 @@ ReplicationSlotDropIfExists(const char *name)
 	bool exists = false;
 	int i;
 
+	/*
+	 * There exists a race condition if multiple callers check the existence of
+	 * replication slot at the same time. Then we may incorrectly try to drop
+	 * the same slot twice.  Currently this is not an issue as this function is
+	 * only called once at startup from StartupXLOG.
+	 */
 	LWLockAcquire(ReplicationSlotControlLock, LW_SHARED);
 	for (i = 0; i < max_replication_slots; i++)
 	{

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -95,8 +95,6 @@ enum probe_transition_e
 /* buffer size for SQL command */
 #define SQL_CMD_BUF_SIZE     1024
 
-#define INTERNAL_WAL_REPLICATION_SLOT_NAME	"internal_wal_replication_slot"
-
 /*
  * STRUCTURES
  */

--- a/src/include/replication/slot.h
+++ b/src/include/replication/slot.h
@@ -128,6 +128,8 @@ typedef struct ReplicationSlot
 #define SlotIsPhysical(slot) (slot->data.database == InvalidOid)
 #define SlotIsLogical(slot) (slot->data.database != InvalidOid)
 
+#define INTERNAL_WAL_REPLICATION_SLOT_NAME	"internal_wal_replication_slot"
+
 /*
  * Shared memory control area for all of replication slots.
  */
@@ -178,5 +180,7 @@ extern Datum pg_create_physical_replication_slot(PG_FUNCTION_ARGS);
 extern Datum pg_create_logical_replication_slot(PG_FUNCTION_ARGS);
 extern Datum pg_drop_replication_slot(PG_FUNCTION_ARGS);
 extern Datum pg_get_replication_slots(PG_FUNCTION_ARGS);
+
+extern void ReplicationSlotDropIfExists(const char *name);
 
 #endif   /* SLOT_H */


### PR DESCRIPTION
Stale replication slots can exist on mirrors that were once acting as
primaries. In this case restart_lsn is non-zero value used in past
replication slot setup. Currently there is no scenario using replication
slots on mirrors. The stale replication slots may cause problems. Since
it is referencing a potentially old LSN, if mirror is not connected then
it can collect older WAL logs than necessary. This is only a problem if
mirror is promoted back to primary.

This patch drops internal replication slot on startup as mirror.  There is a known possible race condition in `ReplicationSlotDropIfExists()`, however given that this should only be called once at `StartupXLOG()` this isn't a problem, _yet_..

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>
Co-authored-by: Alexandra Wang <lewang@pivotal.io>