### PR TITLE
Skip forward QE notice for Background workers.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -693,6 +693,13 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 void
 forwardQENotices(void)
 {
+	/*
+	 * If MyProcPort is NULL, there is no client, so no need to forward notice.
+	 * One example is that there is no client for a background worker. 
+	 */
+	if (MyProcPort == NULL)
+		return;
+
 	while (qeNotices_head)
 	{
 		QENotice *notice;;

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -512,7 +512,11 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 
 	SegmentDatabaseDescriptor *segdbDesc = (SegmentDatabaseDescriptor *) arg;
 
-	if (!res)
+	/*
+	 * If MyProcPort is NULL, there is no client, so no need to generate notice.
+	 * One example is that there is no client for a background worker.
+	 */
+	if (!res || MyProcPort == NULL) 
 		return;
 
 	strcpy(message, "missing error text");
@@ -693,12 +697,7 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 void
 forwardQENotices(void)
 {
-	/*
-	 * If MyProcPort is NULL, there is no client, so no need to forward notice.
-	 * One example is that there is no client for a background worker. 
-	 */
-	if (MyProcPort == NULL)
-		return;
+	bool hasNotices = false;
 
 	while (qeNotices_head)
 	{
@@ -706,6 +705,7 @@ forwardQENotices(void)
 		StringInfoData msgbuf;
 
 		notice = qeNotices_head;
+		hasNotices = true;
 
 		/*
 		 * Unlink it first, so that if something goes wrong in sending it to
@@ -810,6 +810,6 @@ forwardQENotices(void)
 		}
 		PG_END_TRY();
 	}
-
-	pq_flush();
+	if (hasNotices)
+		pq_flush();
 }

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -153,7 +153,6 @@ NON_EXEC_STATIC void
 GlobalDeadLockDetectorMain(int argc, char *argv[])
 {
 	sigjmp_buf	local_sigjmp_buf;
-	Port		portbuf;
 	char	   *fullpath;
 
 	IsUnderPostmaster = true;
@@ -336,12 +335,6 @@ GlobalDeadLockDetectorMain(int argc, char *argv[])
 	RelationCacheInitializePhase3();
 
 	InitializeSessionUserIdStandalone();
-
-	memset(&portbuf, 0, sizeof(portbuf));
-	MyProcPort = &portbuf;
-	MyProcPort->user_name = MemoryContextStrdup(TopMemoryContext,
-												GetUserNameFromId(GetAuthenticatedUserId()));
-	MyProcPort->database_name = DB_FOR_COMMON_ACCESS;
 
 	/* close the transaction we started above */
 	CommitTransactionCommand();


### PR DESCRIPTION
Background workers have no client at all, so no need to forward QE message.
On the other hand, MyProcPort is not initialized in background workers.
While forward notice currently assume MyProcPort is already initialized.

This is firstly detected by diskquota background worker.
It also reported by #6756 which causes GDD infinite loop.
GDD currently set the MyProcPort manually. This commit also removes MyProcPort in GDD, since there is no client in GDD process neither. So GDD and background worker will both skip generate/forward QE notice.

Co-authored-by: Zhenghua Lyu <zlv@pivotal.io>

