### PR TITLE
docs - remove filespace from docs

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
@@ -4,130 +4,29 @@
   <title id="im140259">Creating and Managing Tablespaces</title>
   <body>
     <p>Tablespaces allow database administrators to have multiple file systems per machine and
-      decide how to best use physical storage to store database objects. They are named locations
-      within a filespace in which you can create objects. Tablespaces allow you to assign different
-      storage for frequently and infrequently used database objects or to control the I/O
-      performance on certain database objects. For example, place frequently-used tables on file
-      systems that use high performance solid-state drives (SSD), and place other tables on standard
-      hard drives.</p>
-    <p>A tablespace requires a file system location to store its database files. In Greenplum
-      Database, the master and each segment (primary and mirror) require a distinct storage
-      location. The collection of file system locations for all components in a Greenplum system is
-      a <i>filespace</i>. Filespaces can be used by one or more tablespaces.</p>
+      decide how to best use physical storage to store database objects. Tablespaces allow you to
+      assign different storage for frequently and infrequently used database objects or to control
+      the I/O performance on certain database objects. For example, place frequently-used tables on
+      file systems that use high performance solid-state drives (SSD), and place other tables on
+      standard hard drives.</p>
+    <p>A tablespace requires a host file system location to store its database files. In Greenplum
+      Database, the file system location must exist on all hosts including the hosts running the
+      master, standby master, each primary segment, and each mirror segment. </p>
+    <p>A tablespace is Greemplum Database system object (a global object), you can use a tablespace
+      from any database if you have appropriate privileges.</p>
   </body>
-  <topic id="topic10" xml:lang="en">
-    <title id="im199401">Creating a Filespace</title>
-    <body>
-      <p>A filespace sets aside storage for your Greenplum system. A filespace is a symbolic storage
-        identifier that maps onto a set of locations in your Greenplum hosts' file systems. To
-        create a filespace, prepare the logical file systems on all of your Greenplum hosts, then
-        use the <codeph>gpfilespace</codeph> utility to define the filespace. You must be a database
-        superuser to create a filespace.</p>
-      <note type="note">Greenplum Database is not directly aware of the file system boundaries on
-        your underlying systems. It stores files in the directories that you tell it to use. You
-        cannot control the location on disk of individual files within a logical file system.</note>
-      <section id="im178954">
-        <title>To create a filespace using gpfilespace</title>
-        <ol id="ol_ojl_hvy_sp">
-          <li id="im178990">Log in to the Greenplum Database master as the <codeph>gpadmin</codeph>
-            user.<codeblock>$ su - <codeph>gpadmin</codeph></codeblock></li>
-          <li id="im178959">Create a filespace configuration
-            file:<codeblock>$ gpfilespace -o gpfilespace_config</codeblock></li>
-          <li id="im179004">At the prompt, enter a name for the filespace, the primary segment file
-            system locations, the mirror segment file system locations, and a master file system
-            location. Primary and mirror locations refer to directories on segment hosts; the master
-            location refers to a directory on the master host and standby master, if configured. For
-            example, if your configuration has 2 primary and 2 mirror segments per
-            host:<codeblock>Enter a name for this filespace&gt; fastdisk
-primary location 1&gt; <i>/gpfs1/seg1
-</i>primary location 2&gt; <i>/gpfs1/seg2
-</i>mirror location 1&gt; <i>/gpfs2/mir1
-</i>mirror location 2&gt; <i>/gpfs2/mir2
-</i>master location&gt; <i>/gpfs1/master
-</i></codeblock></li>
-          <li id="im179011">gpfilespace creates a configuration file. Examine the file to verify
-            that the gpfilespace configuration is correct. </li>
-          <li id="im179508">Run gpfilespace again to create the filespace based on the configuration file:<p>
-              <codeblock>$ gpfilespace -c gpfilespace_config</codeblock>
-            </p></li>
-        </ol>
-      </section>
-    </body>
-  </topic>
-  <topic id="topic11" xml:lang="en">
-    <title>Moving the Location of Temporary or Transaction Files</title>
-    <body>
-      <p>You can move temporary or transaction files to a specific filespace to improve database
-        performance when running queries, creating backups, and to store data more sequentially. </p>
-      <p>The dedicated filespace for temporary and transaction files is tracked in two separate flat
-        files called gp_temporary_files_filespace and gp_transaction_files_filespace. These are
-        located in the pg_system directory on each primary and mirror segment, and on master and
-        standby. You must be a superuser to move temporary or transaction files. Only the
-          <codeph>gpfilespace</codeph> utility can write to this file.</p>
-    </body>
-    <topic id="topic12" xml:lang="en">
-      <title>About Temporary and Transaction Files</title>
-      <body>
-        <p>Unless otherwise specified, temporary and transaction files are stored together with all
-          user data. The default location of temporary files,
-            <i>&lt;filespace_directory&gt;</i>/<i>&lt;tablespace_oid&gt;</i>/<i>&lt;database_oid&gt;</i>/pgsql_tmp
-          is changed when you use <codeph>gpfilespace --movetempfiles</codeph> for the first time. </p>
-        <p>Also note the following information about temporary or transaction files:</p>
-        <ul id="ul_gkl_hvy_sp">
-          <li id="im198887">You can dedicate only one filespace for temporary or transaction files,
-            although you can use the same filespace to store other types of files.</li>
-          <li id="im198888">You cannot drop a filespace if it used by temporary files.</li>
-          <li id="im198892">You must create the filespace in advance. See <xref href="#topic10"
-              type="topic" format="dita"/>.</li>
-        </ul>
-        <section id="im198893">
-          <title>To move temporary files using gpfilespace</title>
-          <ol id="ol_bll_hvy_sp">
-            <li id="im198894">Check that the filespace exists and is different from the filespace
-              used to store all other user data.</li>
-            <li id="im198895">Issue smart shutdown to bring the Greenplum Database offline.<p>If any
-                connections are still in progress, the gpfilespace --movetempfiles utility will
-                fail.</p></li>
-            <li id="im198897">Bring Greenplum Database online with no active session and run the
-              following command:<p>
-                <codeblock>gpfilespace --movetempfilespace filespace_name</codeblock>
-              </p><p>The location of the temporary files is stored in the segment configuration
-                shared memory (PMModuleState) and used whenever temporary files are created, opened,
-                or dropped.</p></li>
-          </ol>
-        </section>
-        <section>
-          <title>To move transaction files using gpfilespace</title>
-          <ol id="ol_vll_hvy_sp">
-            <li id="im198901">Check that the filespace exists and is different from the filespace
-              used to store all other user data.</li>
-            <li id="im198902">Issue smart shutdown to bring the Greenplum Database offline.<p>If any
-                connections are still in progress, the <codeph>gpfilespace --movetransfiles</codeph>
-                utility will fail.</p></li>
-            <li id="im198904">Bring Greenplum Database online with no active session and run the
-              following command:<p>
-                <codeblock>gpfilespace --movetransfilespace filespace_name</codeblock>
-              </p><p>The location of the transaction files is stored in the segment configuration
-                shared memory (PMModuleState) and used whenever transaction files are created,
-                opened, or dropped.</p></li>
-          </ol>
-        </section>
-      </body>
-    </topic>
-  </topic>
   <topic id="topic13" xml:lang="en">
     <title>Creating a Tablespace</title>
     <body>
-      <p>After you create a filespace, use the <codeph>CREATE TABLESPACE</codeph> command to define
-        a tablespace that uses that filespace. For example:</p>
+      <p>The <codeph>CREATE TABLESPACE</codeph> command defines a tablespace. For example:</p>
       <p>
-        <codeblock>=# CREATE TABLESPACE fastspace FILESPACE fastdisk;
+        <codeblock>CREATE TABLESPACE fastspace LOCATION '/fastdisk/gpdb';
 </codeblock>
       </p>
       <p>Database superusers define tablespaces and grant access to database users with the
           <codeph>GRANT</codeph><codeph>CREATE </codeph><ph>command</ph>. For example:</p>
       <p>
-        <codeblock>=# GRANT CREATE ON TABLESPACE fastspace TO admin;
+        <codeblock>GRANT CREATE ON TABLESPACE fastspace TO admin;
 </codeblock>
       </p>
     </body>
@@ -160,11 +59,12 @@ CREATE TABLE foo(i int);
           <codeph>TABLESPACE</codeph> is specified when the objects are created. If you do not
         specify a tablespace when you create a database, the database uses the same tablespace used
         by its template database.</p>
-      <p>You can use a tablespace from any database if you have appropriate privileges.</p>
+      <p>You can use a tablespace from any database in the Greenplum Database system if you have
+        appropriate privileges.</p>
     </body>
   </topic>
   <topic id="topic15" xml:lang="en">
-    <title>Viewing Existing Tablespaces and Filespaces</title>
+    <title>Viewing Existing Tablespaces</title>
     <body>
       <p>Every Greenplum Database system has the following default tablespaces.</p>
       <ul id="ul_mml_hvy_sp">
@@ -172,34 +72,84 @@ CREATE TABLE foo(i int);
         <li id="im200067"><codeph>pg_default</codeph>, the default tablespace. Used by the
             <i>template1</i> and <i>template0</i> databases. </li>
       </ul>
-      <p>These tablespaces use the system default filespace, <codeph>pg_system</codeph>, the data
-        directory location created at system initialization.</p>
-      <p>To see filespace information, look in the <i>pg_filespace</i> and <i>pg_filespace_entry</i>
-        catalog tables. You can join these tables with <i>pg_tablespace</i> to see the full
-        definition of a tablespace. For example:</p>
+      <p>These tablespaces use the default system location, the data directory locations created at
+        system initialization.</p>
+      <p>To see tablespace information, use the <codeph>pg_tablespace</codeph> catalog table to get
+        the objecct ID (OID) of the tablespace and then use
+          <codeph>gp_tablespace_location()</codeph> function to display the tablespace directories.
+        This is an example that lists one user-defined tablespace, <codeph>myspace</codeph>:</p>
       <p>
-        <codeblock>=# SELECT spcname as tblspc, fsname as filespc, 
-          fsedbid as seg_dbid, fselocation as datadir 
-   FROM   pg_tablespace pgts, pg_filespace pgfs, 
-          pg_filespace_entry pgfse 
-   WHERE  pgts.spcfsoid=pgfse.fsefsoid 
-          AND pgfse.fsefsoid=pgfs.oid 
-   ORDER BY tblspc, seg_dbid;
+        <codeblock>SELECT oid, * FROM pg_tablespace ;
+
+  oid  |  spcname   | spcowner | spcacl | spcoptions
+-------+------------+----------+--------+------------
+  1663 | pg_default |       10 |        |
+  1664 | pg_global  |       10 |        |
+ 16391 | myspace    |       10 |        |
+(3 rows)
 </codeblock>
+      </p>
+      <p>The OID for the tablespace <codeph>myspace</codeph> is <codeph>16391</codeph>. Run
+          <codeph>gp_tablespace_location()</codeph> to display the tablespace locations for a system
+        that consists of two segment instances and the master.
+        <codeblock># SELECT * FROM gp_tablespace_location(16391);
+ gp_segment_id |    tblspc_loc
+---------------+------------------
+             0 | /data/mytblspace
+             1 | /data/mytblspace
+            -1 | /data/mytblspace
+(3 rows)
+</codeblock></p>
+      <p>This query uses <codeph>gp_tablespace_location()</codeph> the
+          <codeph>gp_segment_configuration</codeph> catalog table to display segment instance
+        information with the file system location for the <codeph>myspace</codeph>
+        tablespace.<codeblock>WITH spc AS (SELECT * FROM  gp_tablespace_location(16391))
+  SELECT seg.role, spc.gp_segment_id as seg_id, seg.hostname, seg.datadir, tblspc_loc 
+    FROM spc, gp_segment_configuration AS seg 
+    WHERE spc.gp_segment_id = seg.content ORDER BY seg_id;
+</codeblock></p>
+      <p>This is information for a test system that consists of two segment instances and the master
+        on a single host. </p>
+      <p>
+        <codeblock> role | seg_id | hostname |       datadir        |    tblspc_loc
+------+--------+----------+----------------------+------------------
+ p    |     -1 | testhost | /data/master/gpseg-1 | /data/mytblspace
+ p    |      0 | testhost | /data/data1/gpseg0   | /data/mytblspace
+ p    |      1 | testhost | /data/data2/gpseg1   | /data/mytblspace
+(3 rows)</codeblock>
       </p>
     </body>
   </topic>
   <topic id="topic16" xml:lang="en">
-    <title>Dropping Tablespaces and Filespaces</title>
+    <title>Dropping Tablespaces</title>
     <body>
       <p>To drop a tablespace, you must be the tablespace owner or a superuser. You cannot drop a
         tablespace until all objects in all databases using the tablespace are removed.</p>
-      <p>Only a superuser can drop a filespace. A filespace cannot be dropped until all tablespaces
-        using that filespace are removed.</p>
       <p>The <codeph>DROP TABLESPACE</codeph> command removes an empty tablespace.</p>
-      <p>The <codeph>DROP FILESPACE</codeph> command removes an empty filespace.</p>
-      <note type="note">You cannot drop a filespace if it stores temporary or transaction
-        files.</note>
+      <note type="note">You cannot drop a tablespace if it is not empty or if it stores temporary or
+        transaction files.</note>
+    </body>
+  </topic>
+  <topic id="topic11" xml:lang="en">
+    <title>Moving the Location of Temporary or Transaction Files</title>
+    <body>
+      <p>You can move temporary or transaction files to a specific tablespace to improve database
+        performance when running queries, creating backups, and to store data more sequentially. </p>
+      <p>Unless otherwise specified, temporary and transaction files are stored together with all
+        user data. The default location of temporary files,
+          &lt;<varname>data_dir</varname>>/&lt;<varname>seg_ID</varname>>/base/pgsql_tmp.</p>
+      <p>The Greenplum Database server configuration parameter <codeph>temp_tablespaces</codeph>
+        controls the location for temporary files.</p>
+      <p>This variable specifies tablespaces in which to create temporary objects (temp tables and
+        indexes on temp tables) when a <codeph>CREATE</codeph> command does not explicitly specify a
+        tablespace. Temporary files for purposes such as sorting large data sets are also created in
+        these tablespaces.</p>
+      <p>Also note the following information about temporary or transaction files:</p>
+      <ul id="ul_z3v_51j_lfb">
+        <li>You can dedicate only one tablespace for temporary or transaction files, although you
+          can use the same tablespace to store other types of files.</li>
+        <li>You cannot drop a tablespace if it used by temporary files.</li>
+      </ul>
     </body>
   </topic>
 </topic>

--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-master-mirroring.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-master-mirroring.xml
@@ -18,8 +18,8 @@
       <ol id="ol_x55_3gs_rcb">
         <li id="ki160206">Ensure the standby master host is installed and configured:
             <codeph>gpadmin</codeph> system user created, Greenplum Database binaries installed,
-          environment variables set, SSH keys exchanged, and data directory, and tablespace
-          directories if needed, are created.</li>
+          environment variables set, SSH keys exchanged, and that the data directories and
+          tablespace directories, if needed, are created.</li>
         <li id="ki155475">Run the <codeph>gpinitstandby</codeph> utility on the currently active
             <i>primary</i> master host to add a standby master host to your Greenplum Database
           system. For example:<codeblock>$ gpinitstandby -s smdw</codeblock> Where

--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-master-mirroring.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-master-mirroring.xml
@@ -18,7 +18,8 @@
       <ol id="ol_x55_3gs_rcb">
         <li id="ki160206">Ensure the standby master host is installed and configured:
             <codeph>gpadmin</codeph> system user created, Greenplum Database binaries installed,
-          environment variables set, SSH keys exchanged, and data directory created.</li>
+          environment variables set, SSH keys exchanged, and data directory, and tablespace
+          directories if needed, are created.</li>
         <li id="ki155475">Run the <codeph>gpinitstandby</codeph> utility on the currently active
             <i>primary</i> master host to add a standby master host to your Greenplum Database
           system. For example:<codeblock>$ gpinitstandby -s smdw</codeblock> Where

--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-segment-mirroring.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-segment-mirroring.xml
@@ -34,7 +34,8 @@
         <li id="ki155416">Ensure the Greenplum Database software is installed on all hosts. <ph>See
             the <i>Greenplum Database Installation Guide</i> for detailed installation
             instructions.</ph></li>
-        <li id="ki161799">Allocate the data storage area for mirror data on all segment hosts.</li>
+        <li id="ki161799">Allocate the data storage area for mirror data, and tablespaces if needed,
+          on all segment hosts.</li>
         <li id="ki160816">Use <codeph>gpssh-exkeys</codeph> to ensure the segment hosts can SSH and
           SCP to each other without a password prompt.</li>
         <li id="ki155422">Create a configuration file that lists the host names, ports, and data
@@ -42,11 +43,13 @@
           starting point,
             run:<codeblock>$ gpaddmirrors -o <i>filename</i>          </codeblock><p>The format of
             the mirror configuration file is:
-            </p><codeblock>mirror[<varname>content</varname>]=<varname>content</varname>:<varname>address</varname>:<varname>port</varname>:<varname>fselocation</varname>[:<varname>fselocation</varname>:...]</codeblock><p>Where
-              <varname>content</varname> is the segment instance content ID,
-              <varname>address</varname> is the host name or IP address of the segment host, and
-              <varname>port</varname> is the communication port.</p><p>For example, a mirror
-            configuration file for two segment hosts and two segment instances per
+            </p><codeblock>mirror<varname>row_id</varname>=<varname>contentID</varname>:<varname>address</varname>:<varname>port</varname>:<varname>data_dir</varname></codeblock><p>Where
+              <codeph>row_id</codeph> is the row in the file, <varname>contentID</varname> is the
+            segment instance content ID, <varname>address</varname> is the host name or IP address
+            of the segment host, <varname>port</varname> is the communication port, and
+              <codeph>data_dir</codeph> is the segment instance data directory.</p><p>For example,
+            this is contents of a mirror configuration file for two segment hosts and two segment
+            instances per
           host:</p><codeblock>mirror0=2:sdw1-1:41000:/data/mirror1/gp2
 mirror1=3:sdw1-2:41001:/data/mirror2/gp3
 mirror2=0:sdw2-1:41000:/data/mirror1/gp0

--- a/gpdb-doc/dita/best_practices/ha.xml
+++ b/gpdb-doc/dita/best_practices/ha.xml
@@ -216,18 +216,17 @@
                 from sources.</p>
             </li>
             <li dir="ltr">
-              <p dir="ltr">Use the <codeph>gpbackup</codeph>
-                  command to specify only the schema and tables that you want
-                backed up. See the <xref
+              <p dir="ltr">Use the <codeph>gpbackup</codeph> command to specify only the schema and
+                tables that you want backed up. See the <xref
                   href="https://gpdb.docs.pivotal.io/latest/utility_guide/admin_utilities/gpbackup.html"
                   format="html" scope="external">gpbackup</xref> reference in the <cite>Greenplum
                   Database Utility Reference Guide</cite> for more information.</p>
             </li>
             <li dir="ltr">
-              <p dir="ltr"><codeph>gpbackup</codeph> places SHARED ACCESS locks on the set of
-                tables to back up.  Backups with fewer tables
-                are more efficient for selectively restoring schemas and tables, since
-                  <codeph>gprestore</codeph> does not have to search through the entire database.</p>
+              <p dir="ltr"><codeph>gpbackup</codeph> places SHARED ACCESS locks on the set of tables
+                to back up. Backups with fewer tables are more efficient for selectively restoring
+                schemas and tables, since <codeph>gprestore</codeph> does not have to search through
+                the entire database.</p>
             </li>
             <li dir="ltr">If backups are saved to local cluster storage, move the files to a safe,
               off-cluster location when the backup is complete. Backup files and database files that
@@ -309,14 +308,15 @@
       <p>The two standard mirroring arrangements are <i>group mirroring</i> and <i>spread
           mirroring</i>:<ul id="ul_uwr_gkv_tt">
           <li><b>Group mirroring</b> — Each host mirrors another host's primary segments. This is
-            the default for <codeph>gpinitsystem</codeph> and <codeph>gpaddmirrors</codeph>.</li>
+            the default for <codeph><xref href="../utility_guide/admin_utilities/gpinitsystem.xml"
+                >gpinitsystem</xref></codeph> and <codeph>gpaddmirrors</codeph>.</li>
           <li><b>Spread mirroring</b> — Mirrors are spread across the available hosts. This requires
             that the number of hosts in the cluster is greater than the number of segments per
             host.</li>
         </ul></p>
-      <p>You can design a custom mirroring configuration and use the Greenplum
-          <codeph>gpaddmirrors</codeph> or <codeph>gpmovemirrors</codeph> utilities to set up the
-        configuration.</p>
+      <p>You can design a custom mirroring configuration and use the Greenplum <codeph><xref
+            href="../utility_guide/admin_utilities/gpaddmirrors.xml">gpaddmirrors</xref></codeph> or
+          <codeph>gpmovemirrors</codeph> utilities to set up the configuration.</p>
       <p><i>Block mirroring</i> is a custom mirror configuration that divides hosts in the cluster
         into equally sized blocks and distributes mirrors evenly to hosts within the block. If a
         primary segment fails, its mirror on another host within the same block becomes the active
@@ -399,8 +399,8 @@
             <codeph>gpaddmirrors -i <varname>mirror_config_file</varname></codeph> with a custom
           mirror configuration file to create the mirrors for each block. You must create the file
           system locations for the mirror segments before you run <codeph>gpaddmirrors</codeph>. See
-          the <codeph>gpaddmirrors</codeph> reference page in the <cite>Greenplum Database Management
-            Utility Guide</cite> for details. </p>
+          the <codeph>gpaddmirrors</codeph> reference page in the <cite>Greenplum Database
+            Management Utility Guide</cite> for details. </p>
         <p>If you expand a system that has block mirroring or you want to implement block mirroring
           at the same time you expand a cluster, it is recommended that you complete the expansion
           first, using the default grouping mirror configuration, and then use the
@@ -411,13 +411,8 @@
           Follow these steps: </p>
         <ol id="ol_qqn_nly_5t">
           <li>Run the following query to find the current locations of the primary and mirror
-              segments:<codeblock>SELECT dbid, content, address, port, 
-   replication_port, fselocation as datadir 
-   FROM gp_segment_configuration, pg_filespace_entry 
-   WHERE dbid=fsedbid AND content > -1
-   ORDER BY dbid;</codeblock><p>The
-                <codeph>gp_segment_configuration</codeph>, <codeph>pg_filespace</codeph>, and
-                <codeph>pg_filespace_entry</codeph> system catalog tables contain the current
+              segments:<codeblock>select dbid, content, role, port, hostname, datadir from gp_segment_configuration ;</codeblock><p>The
+                <codeph>gp_segment_configuration</codeph> system catalog table contains the current
               segment configuration.</p></li>
           <li>Create a list with the current mirror location and the desired block mirroring
             location, then remove any mirrors from the list that are already on the correct
@@ -425,17 +420,15 @@
           <li>Create an input file for the <codeph>gpmovemirrors</codeph> utility with an entry for
             each mirror that must be moved.<p>The <codeph>gpmovemirrors</codeph> input file has the
               following
-              format:<codeblock>filespaceOrder=[filespace1_fsname[:filespace2_fsname:...]
-old_address:port:fselocation new_address:port:replication_port:fselocation[:fselocation:...]</codeblock></p><p>The
-              first non-comment line must be a line beginning with <codeph>filespaceOrder=</codeph>.
-              Do not include the default <codeph>pg_system</codeph> filespace in the list of
-              filespaces. Leave the list empty if you are using only the <codeph>pg_system</codeph>
-              filespace.</p><p>The following example <codeph>gpmovemirrors</codeph> input file
-              specifies three mirror segments to move.
-              <codeblock>filespaceOrder=
-sdw2:50001:/data2/mirror/gpseg1 sdw3:50000:51000:/data/mirror/gpseg1
-sdw2:50001:/data2/mirror/gpseg2 sdw4:50000:51000:/data/mirror/gpseg2
-sdw3:50001:/data2/mirror/gpseg3 sdw1:50000:51000:/data/mirror/gpseg3
+              format:<codeblock><varname>contentID</varname>:<varname>address</varname>:<varname>port</varname>:<varname>data_dir</varname> <varname>new_address</varname>:<varname>port</varname>:<varname>data_dir</varname></codeblock></p>Where
+              <varname>contentID</varname> is the segment instance content ID,
+              <varname>address</varname> is the host name or IP address of the segment host,
+              <varname>port</varname> is the communication port, and <codeph>data_dir</codeph> is
+            the segment instance data directory.<p>The following example
+                <codeph>gpmovemirrors</codeph> input file specifies three mirror segments to move.
+              <codeblock>1:sdw2:50001:/data2/mirror/gpseg1 sdw3:50001:/data/mirror/gpseg1
+2:sdw2:50001:/data2/mirror/gpseg2 sdw4:50001:/data/mirror/gpseg2
+3:sdw3:50001:/data2/mirror/gpseg3 sdw1:50001:/data/mirror/gpseg3
 </codeblock></p></li>
           <li>Run <codeph>gpmovemirrors</codeph> with a command like the
             following:<codeblock>gpmovemirrors -i <varname>mirror_config_file</varname></codeblock></li>

--- a/gpdb-doc/dita/best_practices/ha.xml
+++ b/gpdb-doc/dita/best_practices/ha.xml
@@ -411,7 +411,7 @@
           Follow these steps: </p>
         <ol id="ol_qqn_nly_5t">
           <li>Run the following query to find the current locations of the primary and mirror
-              segments:<codeblock>select dbid, content, role, port, hostname, datadir from gp_segment_configuration ;</codeblock><p>The
+              segments:<codeblock>SELECT dbid, content, role, port, hostname, datadir FROM gp_segment_configuration WHERE content > -1 ;</codeblock><p>The
                 <codeph>gp_segment_configuration</codeph> system catalog table contains the current
               segment configuration.</p></li>
           <li>Create a list with the current mirror location and the desired block mirroring

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_distribution_policy.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_distribution_policy.xml
@@ -4,9 +4,10 @@
 <topic id="topic1" xml:lang="en">
   <title id="ey142834">gp_distribution_policy</title>
   <body>
-    <p>The <codeph>gp_distribution_policy</codeph> table contains information about Greenplum Database tables and their policy for distributing table data across the
-      segments. This table is populated only on the master. This table is not globally shared,
-      meaning each database has its own copy of this table.</p>
+    <p>The <codeph>gp_distribution_policy</codeph> table contains information about Greenplum
+      Database tables and their policy for distributing table data across the segments. This table
+      is populated only on the master. This table is not globally shared, meaning each database has
+      its own copy of this table.</p>
     <table id="ey142842">
       <title>pg_catalog.gp_distribution_policy</title>
       <tgroup cols="4">
@@ -25,7 +26,7 @@
         <tbody>
           <row>
             <entry colname="col1">
-              <codeph id="ey142864">localoid</codeph>
+              <codeph>localoid</codeph>
             </entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_class.oid</entry>
@@ -33,7 +34,7 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph id="ey142874">attrnums</codeph>
+              <codeph>attrnums</codeph>
             </entry>
             <entry colname="col2">smallint[]</entry>
             <entry colname="col3">pg_attribute.attnum</entry>
@@ -41,15 +42,21 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph id="ey142874">policytype</codeph>
+              <codeph>policytype</codeph>
             </entry>
             <entry colname="col2">char</entry>
-            <entry colname="col3"></entry>
+            <entry colname="col3"/>
             <entry colname="col4">The table distribution policy:<ul>
-              <li><codeph>p</codeph> - The table has a partitioned
-                distribution policy.</li>
-              <li><codeph>r</codeph> - The table has a replicated distribution
-                policy.</li></ul></entry>
+                <li><codeph>p</codeph> - Table data is distributed among segment instances.</li>
+                <li><codeph>r</codeph> - Table data is replicated on each segment instance.</li>
+              </ul></entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>numsegments</codeph></entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The number of segment instances the table data is distributed
+              on.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_distribution_policy.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_distribution_policy.xml
@@ -55,8 +55,8 @@
             <entry colname="col1"><codeph>numsegments</codeph></entry>
             <entry colname="col2">integer</entry>
             <entry colname="col3"/>
-            <entry colname="col4">The number of segment instances the table data is distributed
-              on.</entry>
+            <entry colname="col4">The number of segment instances on which the table data is
+              distributed.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
@@ -75,7 +75,8 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Column names for the hash distribution key.</entry>
+            <entry colname="col4">Column names for the hash distribution key. Value is
+                <codeph>None</codeph> if the table does not have a distribution key column.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -83,7 +84,27 @@
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
-            <entry colname="col4">Column IDs for the distribution keys of the table.</entry>
+            <entry colname="col4">Column OIDs for the distribution keys of the table. Value is
+                <codeph>None</codeph> if the table does not have a distribution key column.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>distribution_policy _type</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Table data distribution. Valid values are: <codeph>p</codeph> -
+              table data is distributed among segment instances, <codeph>r</codeph> table data is
+              replicated on each segment instance.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>root_partition_name</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">For a partitioned table, the name of the root partition.
+              Otherwise, <codeph>None</codeph>.</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
@@ -94,7 +94,7 @@
             <entry colname="col2">text</entry>
             <entry colname="col3"/>
             <entry colname="col4">Table data distribution. Valid values are: <codeph>p</codeph> -
-              table data is distributed among segment instances, <codeph>r</codeph> table data is
+              table data is distributed among segment instances, <codeph>r</codeph> - table data is
               replicated on each segment instance.</entry>
           </row>
           <row>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_database.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_database.xml
@@ -52,6 +52,18 @@
               name.</entry>
           </row>
           <row>
+            <entry colname="col1"><codeph>datcollate</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4"><codeph>LC_COLLATE</codeph> for this database.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>datctype</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4"><codeph>LC_CTYPE</codeph> for this database.</entry>
+          </row>
+          <row>
             <entry colname="col1">
               <codeph>datistemplate</codeph>
             </entry>
@@ -93,11 +105,22 @@
             </entry>
             <entry colname="col2">xid</entry>
             <entry colname="col3"/>
-            <entry colname="col4">All transaction IDs before this one have been replaced with a
-              permanent (frozen) transaction ID in this database. This is used to track whether the
-              database needs to be vacuumed in order to prevent transaction ID wraparound or to
+            <entry colname="col4">All transaction IDs (XIDs) before this one have been replaced with
+              a permanent (frozen) transaction ID in this database. This is used to track whether
+              the database needs to be vacuumed in order to prevent transaction ID wraparound or to
               allow pg_clog to be shrunk. It is the minimum of the per-table
                 <i>pg_class.relfrozenxid</i> values.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>datminmxid</codeph></entry>
+            <entry colname="col2">xid</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">A <i>Multixact ID</i> is used to support row locking by multiple
+              transactions. All multixact IDs before this one have been replaced with a transaction
+              ID in this database. This is used to track whether the database needs to be vacuumed
+              in order to prevent multixact ID wraparound or to allow <codeph>pg_multixact</codeph>
+              to be shrunk. It is the minimum of the per-table <i>pg_class.relminmxid</i>
+              values.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -108,6 +131,15 @@
             <entry colname="col4">The default tablespace for the database. Within this database, all
               tables for which <i>pg_class.reltablespace</i> is zero will be stored in this
               tablespace. All non-shared system catalogs will also be there.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>hashmethod</codeph></entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">
+              <p>The value is either <codeph>1</codeph> for jump consistent hash or
+                  <codeph>0</codeph> for modulo hash.</p>
+            </entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_tablespace.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_tablespace.xml
@@ -1,11 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1" xml:lang="en"><title id="hx156255">pg_tablespace</title><body><p>The <codeph>pg_tablespace</codeph> system catalog table stores information about the available
-      tablespaces. Tables can be placed in particular tablespaces to aid administration of disk
-      layout. Unlike most system catalogs, <codeph>pg_tablespace</codeph> is shared across all
-      databases of a Greenplum system: there is only one copy of
-        <codeph>pg_tablespace</codeph> per system, not one per database.</p><table id="hx156260"><title>pg_catalog.pg_tablespace</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>spcname</codeph></entry><entry colname="col2">name</entry><entry colname="col3"/><entry colname="col4">Tablespace name.</entry></row><row><entry colname="col1"><codeph>spcowner</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_authid.oid</entry><entry colname="col4">Owner of the tablespace, usually the user who
-created it.</entry></row><row><entry colname="col1"><codeph>spclocation</codeph></entry><entry colname="col2">text[]</entry><entry colname="col3"/><entry colname="col4">Unused.</entry></row><row><entry colname="col1"><codeph>spcacl </codeph></entry><entry colname="col2">aclitem[] </entry><entry colname="col3"/><entry colname="col4">Tablespace access privileges.</entry></row><row><entry colname="col1"><codeph>spcfsoid</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_filespace.oid</entry><entry colname="col4">The object id of the filespace used by this
-tablespace. A filespace defines directory locations on the primary, mirror
-and master segments.</entry></row></tbody></tgroup></table></body></topic>
+<topic id="topic1" xml:lang="en">
+  <title id="hx156255">pg_tablespace</title>
+  <body>
+    <p>The <codeph>pg_tablespace</codeph> system catalog table stores information about the
+      available tablespaces. Tables can be placed in particular tablespaces to aid administration of
+      disk layout. Unlike most system catalogs, <codeph>pg_tablespace</codeph> is shared across all
+      databases of a Greenplum system: there is only one copy of <codeph>pg_tablespace</codeph> per
+      system, not one per database.</p>
+    <table id="hx156260">
+      <title>pg_catalog.pg_tablespace</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>spcname</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Tablespace name.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>spcowner</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_authid.oid</entry>
+            <entry colname="col4">Owner of the tablespace, usually the user who created it.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>spcacl</codeph></entry>
+            <entry colname="col2">aclitem[] </entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Tablespace access privileges.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>spcoptions</codeph></entry>
+            <entry colname="col2">text[]</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Segment instance specific tablespace locations listed as
+                <codeph>keyword=value</codeph>. The entries from the <codeph>WITH</codeph> clause of
+                <codeph>CREATE TABLESPACE</codeph>.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpaddmirrors.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpaddmirrors.xml
@@ -53,10 +53,14 @@ Enter mirror segment data directory location 2 of 2 &gt; /gpdb/m2</codeblock>
                 detailed configuration file using the <codeph>-i</codeph> option. This is useful if
                 you want your mirror segments on a completely different set of hosts than your
                 primary segments. The format of the mirror configuration file is:</p>
-            <codeblock>mirror[<varname>content</varname>]=<varname>content</varname>:<varname>address</varname>:<varname>port</varname>:<varname>fselocation</varname></codeblock>
-            <p>For example:</p>
-            <codeblock>mirror0=0:sdw1-1:60000:/gpdata/mir1/gp0
-mirror1=1:sdw1-1:60001:/gpdata/mir2/gp1</codeblock>
+            <codeblock>mirror<varname>&lt;row_id></varname>=<varname>&lt;contentID></varname>:<varname>&lt;address></varname>:<varname>&lt;port></varname>:<varname>&lt;data_dir></varname></codeblock>
+            <p>Where <codeph>row_id</codeph> is the row in the file, <varname>contentID</varname> is
+                the segment instance content ID, <varname>address</varname> is the host name or IP
+                address of the segment host, <varname>port</varname> is the communication port, and
+                    <codeph>data_dir</codeph> is the segment instance data directory.</p>
+            <p>For
+                example:<codeblock>mirror0=0:sdw1-1:60000:/gpdata/mir1/gp0
+mirror1=1:sdw1-1:60001:/gpdata/mir2/gp1</codeblock></p>
             <p>The <codeph>gp_segment_configuration</codeph> system catalog table can help you
                 determine your current primary segment configuration so that you can plan your
                 mirror segment configuration. For example, run the following query:</p>
@@ -106,7 +110,15 @@ mirror1=1:sdw1-1:60001:/gpdata/mir2/gp1</codeblock>
                         the system. The format of this file is as follows (as per attributes in the
                             <codeph>gp_segment_configuration</codeph> catalog table):</pd>
                     <pd>
-                        <codeblock>mirror[<varname>content</varname>]=<varname>content</varname>:<varname>address</varname>:<varname>port</varname>:<varname/></codeblock>
+                        <codeblock>mirror<varname>&lt;row_id></varname>=<varname>&lt;contentID></varname>:<varname>&lt;address></varname>:<varname>&lt;port></varname>:<varname>&lt;data_dir></varname></codeblock>
+                    </pd>
+                    <pd>
+                        <p>Where <codeph>row_id</codeph> is the row in the file,
+                                <varname>contentID</varname> is the segment instance content ID,
+                                <varname>address</varname> is the host name or IP address of the
+                            segment host, <varname>port</varname> is the communication port, and
+                                <codeph>data_dir</codeph> is the segment instance data
+                            directory.</p>
                     </pd>
                 </plentry>
                 <plentry>
@@ -179,12 +191,12 @@ mirror1=1:sdw1-1:60001:/gpdata/mir2/gp1</codeblock>
                 from your primary data:</p>
             <codeblock>$ gpaddmirrors -i mirror_config_file</codeblock>
             <p>Where <codeph>mirror_config_file</codeph> looks something like this:</p>
-            <codeblock>mirror0=0:sdw1-1:52001:53001:54001:/gpdata/mir1/gp0
+            <codeblock>mirror0=0:sdw1-1:52001:/gpdata/mir1/gp0
 mirror1=1:sdw1-2:52002:/gpdata/mir2/gp1
 mirror2=2:sdw2-1:52001:/gpdata/mir1/gp2
 mirror3=3:sdw2-2:52002:/gpdata/mir2/gp3</codeblock>
-            <p>Output a sample mirror configuration file to use with <codeph>gpaddmirrors
-                    -i</codeph>:</p>
+            <p>Generate a sample mirror configuration file with the <codeph>-o</codeph> option to
+                use with <codeph>gpaddmirrors -i</codeph>:</p>
             <codeblock>$ gpaddmirrors -o /home/gpadmin/sample_mirror_config</codeblock>
         </section>
         <section id="section6">

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpcopy.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpcopy.xml
@@ -97,8 +97,8 @@
                 can use a tool such as the Linux <codeph>netperf</codeph> utility. </p>
             <p>When the <codeph>--full</codeph> option is specified, resource groups and table
                 spaces are copied, however, the utility does not configure the destination system.
-                You must configure the system to use resource groups and create filespaces for the
-                tablespaces. </p>
+                For example, you must configure the system to use resource groups and create the
+                host directories for the tablespaces. </p>
         </section>
         <section id="section6">
             <title>Options</title>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitstandby.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitstandby.xml
@@ -5,12 +5,10 @@
     <!--install_guide/refs/gpinitstandby.xml has a conref to this topic. -->
     <title id="js140845">gpinitstandby</title>
     <body>
-        <p>Adds and/or initializes a standby master host for a Greenplum Database
-            system.</p>
+        <p>Adds and/or initializes a standby master host for a Greenplum Database system.</p>
         <section id="section2">
             <title>Synopsis</title>
-            <codeblock><b>gpinitstandby</b> { <b>-s</b> <varname>standby_hostname</varname> [<b>-P</b> port] 
-      [<b>-F</b> <varname>list_of_filespaces</varname>] | <b>-r</b> | <b>-n</b> } 
+            <codeblock><b>gpinitstandby</b> { <b>-s</b> <varname>standby_hostname</varname> [<b>-P</b> port] | <b>-r</b> | <b>-n</b> } 
       [<b>-a</b>] [<b>-q</b>] [<b>-D</b>] [<b>-l</b> <varname>logfile_directory</varname>]
 
 <b>gpinitstandby</b> <b>-v</b> 
@@ -20,25 +18,24 @@
         <section id="section3">
             <title>Description</title>
             <p>The <codeph>gpinitstandby</codeph> utility adds a backup, standby master host to your
-                    Greenplum Database system. If your system has an existing standby
-                master host configured, use the <codeph>-r</codeph> option to remove it before
-                adding the new standby master host. </p>
-            <p>Before running this utility, make sure that the Greenplum Database
-                software is installed on the standby master host and that you have exchanged SSH
-                keys between the hosts. It is recommended that the master port is set to the same
-                port number on the master host and the backup master host. </p>
-            <p>This utility should be run on the currently active <i>primary</i> master host.<ph
-                   > See the <i>Greenplum Database Installation Guide</i> for
-                    instructions.</ph></p>
+                Greenplum Database system. If your system has an existing standby master host
+                configured, use the <codeph>-r</codeph> option to remove it before adding the new
+                standby master host. </p>
+            <p>Before running this utility, make sure that the Greenplum Database software is
+                installed on the standby master host and that you have exchanged SSH keys between
+                the hosts. It is recommended that the master port is set to the same port number on
+                the master host and the backup master host. </p>
+            <p>This utility should be run on the currently active <i>primary</i> master host.<ph>
+                    See the <i>Greenplum Database Installation Guide</i> for instructions.</ph></p>
             <p>The utility performs the following steps:</p>
             <ul>
-                <li id="js138559">Updates the Greenplum Database system catalog to
-                    remove the existing standby master host information (if the <codeph>-r</codeph>
-                    option is supplied) </li>
-                <li id="js138555">Updates the Greenplum Database system catalog to add
-                    the new standby master host information </li>
-                <li id="js138431">Edits the <codeph>pg_hba.conf</codeph> file of the Greenplum Database master to allow access from the newly added standby
-                    master.</li>
+                <li id="js138559">Updates the Greenplum Database system catalog to remove the
+                    existing standby master host information (if the <codeph>-r</codeph> option is
+                    supplied) </li>
+                <li id="js138555">Updates the Greenplum Database system catalog to add the new
+                    standby master host information </li>
+                <li id="js138431">Edits the <codeph>pg_hba.conf</codeph> file of the Greenplum
+                    Database master to allow access from the newly added standby master.</li>
                 <li id="js137684">Sets up the standby master instance on the alternate master
                     host</li>
                 <li id="js137686">Starts the synchronization process</li>
@@ -53,8 +50,8 @@
                     <codeph>gpactivatestandby</codeph> utility. Upon activation of the standby
                 master, the replicated logs are used to reconstruct the state of the master host at
                 the time of the last successfully committed transaction. </p>
-            <p>The activated standby master effectively becomes the Greenplum Database
-                master, accepting client connections on the master port and performing normal master
+            <p>The activated standby master effectively becomes the Greenplum Database master,
+                accepting client connections on the master port and performing normal master
                 operations such as SQL command processing and resource management. </p>
             <note type="important">If the <codeph>gpinitstandby</codeph> utility previously failed
                 to initialize the standby master, you must delete the files in the standby master
@@ -77,38 +74,24 @@
                     <pd>Sets logging level to debug.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-F <varname>list_of_filespaces</varname></pt>
-                    <pd>A list of filespace names and the associated locations. Each filespace name
-                        and its location is separated by a colon. If there is more than one file
-                        space name, each pair (name and location) is separated by a comma. For
-                        example: </pd>
-                    <pd>
-                        <codeblock>filespace1_name:fs1_location,filespace2_name:fs2_location</codeblock>
-                    </pd>
-                    <pd>If this option is not specified, <codeph>gpinitstandby</codeph> prompts the
-                        user for the filespace names and locations.</pd>
-                    <pd>If the list is not formatted correctly or number of filespaces do not match
-                        the number of filespaces already created in the system,
-                            <codeph>gpinitstandby</codeph> returns an error.</pd>
-                </plentry>
-                <plentry>
                     <pt>-l <varname>logfile_directory</varname></pt>
                     <pd>The directory to write the log file. Defaults to
                             <codeph>~/gpAdminLogs</codeph>.</pd>
                 </plentry>
                 <plentry>
                     <pt>-n (restart standby master)</pt>
-                    <pd>Specify this option to start a Greenplum Database standby
-                        master that has been configured but has stopped for some reason.</pd>
+                    <pd>Specify this option to start a Greenplum Database standby master that has
+                        been configured but has stopped for some reason.</pd>
                 </plentry>
                 <plentry>
                     <pt>-P <varname>port</varname></pt>
-                    <pd>This option specifies the port that is used by the Greenplum Database standby master. The default is the same port
-                        used by the active Greenplum Database master. </pd>
-                    <pd>If the Greenplum Database standby master is on the same host
-                        as the active master, the ports must be different. If the ports are the same
-                        for the active and standby master and the host is the same, the utility
-                        returns an error. </pd>
+                    <pd>This option specifies the port that is used by the Greenplum Database
+                        standby master. The default is the same port used by the active Greenplum
+                        Database master. </pd>
+                    <pd>If the Greenplum Database standby master is on the same host as the active
+                        master, the ports must be different. If the ports are the same for the
+                        active and standby master and the host is the same, the utility returns an
+                        error. </pd>
                 </plentry>
                 <plentry>
                     <pt>-q (no screen output)</pt>
@@ -117,7 +100,8 @@
                 </plentry>
                 <plentry>
                     <pt>-r (remove standby master)</pt>
-                    <pd>Removes the currently configured standby master host from your Greenplum Database system.</pd>
+                    <pd>Removes the currently configured standby master host from your Greenplum
+                        Database system.</pd>
                 </plentry>
                 <plentry>
                     <pt>-s standby_hostname</pt>
@@ -136,23 +120,20 @@
         </section>
         <section id="section5">
             <title>Examples</title>
-            <p>Add a standby master host to your Greenplum Database system and start
-                the synchronization process:</p>
+            <p>Add a standby master host to your Greenplum Database system and start the
+                synchronization process:</p>
             <codeblock>gpinitstandby -s host09</codeblock>
             <p>Start an existing standby master host and synchronize the data with the current
                 primary master host:</p>
             <codeblock>gpinitstandby -n</codeblock>
             <note type="note">Do not specify the -n and -s options in the same command.</note>
-            <p>Add a standby master host to your Greenplum Database system specifying
-                a different port:</p>
+            <p>Add a standby master host to your Greenplum Database system specifying a different
+                port:</p>
             <codeblock>gpinitstandby -s myhost -P 2222</codeblock>
-            <p>If you specify the same host name as the active Greenplum Database
-                master, the installed Greenplum Database software that is used as a
-                standby master must be in a separate location from the active Greenplum Database master. Also, filespace locations that are used by the
-                standby master must be different than the filespace locations used by the active
-                    Greenplum Database master. </p>
-            <p>Remove the existing standby master from your Greenplum
-                system configuration:</p>
+            <p>If you specify the same host name as the active Greenplum Database master, the
+                installed Greenplum Database software that is used as a standby master must be in a
+                separate location from the active Greenplum Database master. </p>
+            <p>Remove the existing standby master from your Greenplum system configuration:</p>
             <codeblock>gpinitstandby -r</codeblock>
         </section>
         <section id="section6">

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpmovemirrors.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpmovemirrors.xml
@@ -1,40 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="ot133181">gpmovemirrors</title><body><p>Moves mirror segment instances to new locations.</p><section id="section2"><title>Synopsis</title><codeblock><b>gpmovemirrors</b> <b>-i</b> <varname>move_config_file</varname> [<b>-d</b> <varname>master_data_directory</varname>] 
+<topic id="topic1">
+  <title id="ot133181">gpmovemirrors</title>
+  <body>
+    <p>Moves mirror segment instances to new locations.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock><b>gpmovemirrors</b> <b>-i</b> <varname>move_config_file</varname> [<b>-d</b> <varname>master_data_directory</varname>] 
           [<b>-l</b> <varname>logfile_directory</varname>] 
           [<b>-B</b> <varname>parallel_processes</varname>] [<b>-v</b>]
 
 <b>gpmovemirrors</b> <b>-?</b> 
 
-<b>gpmovemirrors</b> <b>--version</b></codeblock></section><section id="section3"><title>Description</title><p>The <codeph>gpmovemirrors</codeph> utility moves mirror segment instances
-to new locations. You may want to move mirrors to new locations to optimize
-distribution or data storage.</p><p>Before moving segments, the utility verifies that they are mirrors,
-and that their corresponding primary segments are up and are in synchronizing
-or resynchronizing mode.</p><p>By default, the utility will prompt you for the file system location(s)
-where it will move the mirror segment data directories.</p><p>You must make sure that the user who runs <codeph>gpmovemirrors</codeph> (the
+<b>gpmovemirrors</b> <b>--version</b></codeblock>
+    </section>
+    <section id="section3">
+      <title>Description</title>
+      <p>The <codeph>gpmovemirrors</codeph> utility moves mirror segment instances to new locations.
+        You may want to move mirrors to new locations to optimize distribution or data storage.</p>
+      <p>Before moving segments, the utility verifies that they are mirrors, and that their
+        corresponding primary segments are up and are in synchronizing or resynchronizing mode.</p>
+      <p>By default, the utility will prompt you for the file system location(s) where it will move
+        the mirror segment data directories.</p>
+      <p>You must make sure that the user who runs <codeph>gpmovemirrors</codeph> (the
           <codeph>gpadmin</codeph> user) has permissions to write to the data directory locations
         specified. You may want to create these directories on the segment hosts and
           <codeph>chown</codeph> them to the appropriate user before running
-          <codeph>gpmovemirrors</codeph>.</p></section><section id="section4"><title>Options</title><parml><plentry><pt>-B <varname>parallel_processes</varname></pt><pd>The number of mirror segments to move in parallel. If not specified,
-the utility will start up to 4 parallel processes depending on how many
-mirror segment instances it needs to move.</pd></plentry><plentry><pt>-d <varname>master_data_directory</varname></pt><pd>The master data directory. If not specified, the value set for <codeph>$MASTER_DATA_DIRECTORY</codeph>
-will be used.</pd></plentry><plentry><pt>-i <varname>move_config_file</varname></pt><pd>A configuration file containing information about which mirror segments
-to move, and where to move them. </pd><pd>You must have one mirror segment listed for each primary segment in the system. Each line inside
-            the configuration file has the following format (as per attributes in the
-              <codeph>gp_segment_configuration</codeph>, <codeph>pg_filespace</codeph>, and
-              <codeph>pg_filespace_entry</codeph> catalog tables):</pd><pd><codeblock>filespaceOrder=[<varname>filespace1_fsname</varname>[:<varname>filespace2_fsname</varname>:...]
-<varname>old_address</varname>:<varname>port</varname>:<i>fselocation</i> \ 
-[<i>new_address</i>:<varname>port</varname>:<i>replication_port</i>:<i>fselocation</i>[:<varname>fselocation</varname>:...]]</codeblock></pd><pd>Note that you only need to specify a name for <codeph>filespaceOrder</codeph> if your system has
-            multiple filespaces configured. If your system does not have additional filespaces
-            configured besides the default <codeph>pg_system</codeph> filespace, this file will only
-            have one location (for the default data directory filespace,
-            <codeph>pg_system</codeph>). <codeph>pg_system</codeph> does not need to be listed in
-            the <codeph>filespaceOrder</codeph> line. It will always be the first
-              <varname>fselocation</varname> listed after <varname>replication_port</varname>.</pd></plentry><plentry><pt>-l <varname>logfile_directory</varname></pt><pd>The directory to write the log file. Defaults to <codeph>~/gpAdminLogs</codeph>.</pd></plentry><plentry><pt>-v (verbose)</pt><pd>Sets logging output to verbose.</pd></plentry><plentry><pt>--version (show utility version)</pt><pd>Displays the version of this utility.</pd></plentry><plentry><pt>-? (help)</pt><pd>Displays the online help.</pd></plentry></parml></section><section id="section5"><title>Examples</title><p>Moves mirrors from an existing Greenplum Database system to a different
-set of hosts:</p><codeblock>$ gpmovemirrors -i move_config_file</codeblock><p>Where the <codeph>move_config_file</codeph> looks something like this (if you do not have
-        additional filespaces configured besides the default <codeph>pg_system</codeph>
-        filespace):</p><codeblock>filespaceOrder=filespacea
-sdw1-1:61001:/data/mirrors/database/dbfast22/gp1 
-sdw2-1:61001:43001:/data/mirrors/database/dbfast222/gp1:
-/data/mirrors/database/dbfast222fs1</codeblock></section></body></topic>
+          <codeph>gpmovemirrors</codeph>.</p>
+    </section>
+    <section id="section4">
+      <title>Options</title>
+      <parml>
+        <plentry>
+          <pt>-B <varname>parallel_processes</varname></pt>
+          <pd>The number of mirror segments to move in parallel. If not specified, the utility will
+            start up to 4 parallel processes depending on how many mirror segment instances it needs
+            to move.</pd>
+        </plentry>
+        <plentry>
+          <pt>-d <varname>master_data_directory</varname></pt>
+          <pd>The master data directory. If not specified, the value set for
+              <codeph>$MASTER_DATA_DIRECTORY</codeph> will be used.</pd>
+        </plentry>
+        <plentry>
+          <pt>-i <varname>move_config_file</varname></pt>
+          <pd>A configuration file containing information about which mirror segments to move, and
+            where to move them. </pd>
+          <pd>You must have one mirror segment listed for each primary segment in the system. Each
+            line inside the configuration file has the following format (as per attributes in the
+              <codeph>gp_segment_configuration</codeph> catalog table):</pd>
+          <pd>
+            <codeblock><varname>contentID</varname>:<varname>address</varname>:<varname>port</varname>:<varname>data_dir</varname> <varname>new_address</varname>:<varname>port</varname>:<varname>data_dir</varname></codeblock>
+          </pd>
+          <pd>Where <varname>contentID</varname> is the segment instance content ID,
+              <varname>address</varname> is the host name or IP address of the segment host,
+              <varname>port</varname> is the communication port, and <codeph>data_dir</codeph> is
+            the segment instance data directory.</pd>
+        </plentry>
+        <plentry>
+          <pt>-l <varname>logfile_directory</varname></pt>
+          <pd>The directory to write the log file. Defaults to <codeph>~/gpAdminLogs</codeph>.</pd>
+        </plentry>
+        <plentry>
+          <pt>-v (verbose)</pt>
+          <pd>Sets logging output to verbose.</pd>
+        </plentry>
+        <plentry>
+          <pt>--version (show utility version)</pt>
+          <pd>Displays the version of this utility.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? (help)</pt>
+          <pd>Displays the online help.</pd>
+        </plentry>
+      </parml>
+    </section>
+    <section id="section5">
+      <title>Examples</title>
+      <p>Moves mirrors from an existing Greenplum Database system to a different set of hosts:</p>
+      <codeblock>$ gpmovemirrors -i move_config_file</codeblock>
+      <p>Where the <codeph>move_config_file</codeph> looks something like this:</p>
+      <codeblock>1:sdw2:50001:/data2/mirror/gpseg1 sdw3:50001:/data/mirror/gpseg1
+2:sdw2:50001:/data2/mirror/gpseg2 sdw4:50001:/data/mirror/gpseg2
+3:sdw3:50001:/data2/mirror/gpseg3 sdw1:50001:/data/mirror/gpseg3
+</codeblock>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gptransfer.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gptransfer.xml
@@ -134,8 +134,8 @@
             <p>The source and destination Greenplum Database segment hosts need to be able to
                 communicate with each other. To ensure that the segment hosts can communicate, you
                 can use a tool such as the Linux <codeph>netperf</codeph> utility. </p>
-            <p>If a filespace has been created for a source Greenplum Database system, a
-                corresponding filespace must exist on the target system. </p>
+            <p>If a tablespace has been created for a source Greenplum Database system, the
+                corresponding tablespace must exist on the target system. </p>
             <p>SSH keys must be exchanged between the two systems before using
                     <codeph>gptransfer</codeph>. The <codeph>gptransfer</codeph> utility connects to
                 the source system with SSH to create the named pipes and start the


### PR DESCRIPTION
Replace references of filespace to tablespace.
Update format of gpaddmirror and gpmovemirror config file to remove filespace.

Other misc updates.
system_catalogs/gp_distribution_policy.xml
  - Update policytype description

system_catalogs/pg_database.xml
   - add datminmxid column

Notes
currently gpmovemirrors does not work, reference doc for utility is hidden.

In ddl-tablespace.xml
   - Moving the Location of Temporary or Transaction Files -  does not work

For gpinitstandby the -F option is remove however it can be used as the data directory for the standby master.
Should -F be documented?

Link to HTML format of updated docs on a temporary GPDB review site.

Admin Guide
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/admin_guide/ddl/ddl-tablespace.html
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/admin_guide/highavail/topics/g-enabling-master-mirroring.html
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/admin_guide/highavail/topics/g-enabling-segment-mirroring.html

Best Practices
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/best_practices/ha.html

System Catalog changes
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/ref_guide/system_catalogs/gp_distribution_policy.html
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/ref_guide/system_catalogs/gp_expansion_tables.html
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/ref_guide/system_catalogs/pg_database.html
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/ref_guide/system_catalogs/pg_tablespace.html

GPDB Utilities
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/utility_guide/admin_utilities/gpaddmirrors.html
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/utility_guide/admin_utilities/gpcopy.html
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/utility_guide/admin_utilities/gpinitstandby.html
https://docs-msk-gpdb6-fspace-dev.cfapps.io/600/utility_guide/admin_utilities/gptransfer.html

