### PR TITLE
Docs: update pg_class relkind entries

### DIFF
--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_class.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_class.xml
@@ -169,11 +169,12 @@
             <entry colname="col2">char</entry>
             <entry colname="col3"/>
             <entry colname="col4">The type of object<p><codeph>r</codeph> = heap or append-optimized
-                table, <codeph>i</codeph> = index, <codeph>S</codeph> = sequence, <codeph>v</codeph>
-                = view, <codeph>c</codeph> = composite type, <codeph>t</codeph> = TOAST value,
-                  <codeph>o</codeph> = internal append-optimized segment files and EOFs,
-                  <codeph>c</codeph> = composite type, <codeph>u</codeph> = uncataloged temporary
-                heap table</p></entry>
+                table, <codeph>i</codeph> = index, <codeph>S</codeph> = sequence, <codeph>t</codeph>
+                = TOAST value, <codeph>v</codeph> = view, <codeph>c</codeph> = composite type,
+                  <codeph>f</codeph> = foreign table, <codeph>u</codeph> = uncatalogued temporary
+                heap table, <codeph>o</codeph> = internal append-optimized segment files and EOFs,
+                  <codeph>c</codeph> = composite type, <codeph>b</codeph> = append-only block
+                directory, <codeph>M</codeph> = append-only visibility map</p></entry>
           </row>
           <row>
             <entry colname="col1">


### PR DESCRIPTION
add missing relkind entries for AOVISIMAP, AOBLOCKDIR, and FOREIGN_TABLE.  Leaving out MATVIEW as it's unsupported.