### PR TITLE
Remove BitmapHeapPath and UniquePath check in cdbpath_cost_motion()

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -50,13 +50,7 @@ cdbpath_cost_motion(PlannerInfo *root, CdbMotionPath *motionpath)
 	double		recvrows;
 	double		sendrows;
 
-	/* GPDB_94_MERGE_FIXME: I removed the IndexPath check in pg 94 stable merge.
-	 * It seems that we should remove checking code for BitmapHeapPath,
-	 * BitmapAppendOnlyPath and UniquePath also?
-	 */
-	if (! IsA(subpath, BitmapHeapPath) &&
-		! IsA(subpath, UniquePath) &&
-		CdbPathLocus_IsReplicated(motionpath->path.locus))
+	if (CdbPathLocus_IsReplicated(motionpath->path.locus))
 		/* FIXME: should use other.numsegments instead of cdbpath_segments */
 		motionpath->path.rows = subpath->rows * root->config->cdbpath_segments;
 	else

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -284,10 +284,10 @@ select * from t, pt where t1 = pt1 and ptid = tid;
 -- in and exists clauses
 --
 explain select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=2.10..21.39 rows=54 width=31)
-   ->  Hash Join  (cost=2.10..21.39 rows=18 width=31)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.09..21.45 rows=54 width=31)
+   ->  Hash Semi Join  (cost=2.09..21.45 rows=18 width=31)
          Hash Cond: (pt_1_prt_junk_data.ptid = t.tid)
          ->  Append  (cost=0.00..18.54 rows=18 width=31)
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
@@ -308,18 +308,14 @@ explain select * from pt where ptid in (select tid from t where t1 = 'hello' || 
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
                      One-Time Filter: PartSelected
                      ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.09 rows=3 width=31)
-         ->  Hash  (cost=2.09..2.09 rows=1 width=11)
-               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=2.06..2.09 rows=1 width=11)
+         ->  Hash  (cost=2.07..2.07 rows=1 width=4)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..2.07 rows=1 width=4)
                      Filter: t.tid
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=2.06..2.09 rows=1 width=11)
-                           ->  HashAggregate  (cost=2.06..2.07 rows=1 width=36)
-                                 Group Key: t.tid
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.06 rows=1 width=11)
-                                       Hash Key: t.tid
-                                       ->  Seq Scan on t  (cost=0.00..2.04 rows=1 width=11)
-                                             Filter: (t1 = ('hello'::text || (tid)::text))
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.07 rows=1 width=4)
+                           ->  Seq Scan on t  (cost=0.00..2.04 rows=1 width=4)
+                                 Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: legacy query optimizer
-(33 rows)
+(29 rows)
 
 select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -348,10 +344,10 @@ select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
 -- Known_opt_diff: MPP-21320
 -- end_ignore
 explain select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=2.10..21.39 rows=54 width=31)
-   ->  Hash Join  (cost=2.10..21.39 rows=18 width=31)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.09..21.45 rows=54 width=31)
+   ->  Hash Semi Join  (cost=2.09..21.45 rows=18 width=31)
          Hash Cond: (pt_1_prt_junk_data.ptid = t.tid)
          ->  Append  (cost=0.00..18.54 rows=18 width=31)
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
@@ -372,18 +368,14 @@ explain select * from pt where exists (select 1 from t where tid = ptid and t1 =
                ->  Result  (cost=0.00..3.09 rows=3 width=31)
                      One-Time Filter: PartSelected
                      ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.09 rows=3 width=31)
-         ->  Hash  (cost=2.09..2.09 rows=1 width=11)
-               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=2.06..2.09 rows=1 width=11)
+         ->  Hash  (cost=2.07..2.07 rows=1 width=4)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..2.07 rows=1 width=4)
                      Filter: t.tid
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=2.06..2.09 rows=1 width=11)
-                           ->  HashAggregate  (cost=2.06..2.07 rows=1 width=36)
-                                 Group Key: t.tid
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.06 rows=1 width=11)
-                                       Hash Key: t.tid
-                                       ->  Seq Scan on t  (cost=0.00..2.04 rows=1 width=11)
-                                             Filter: (t1 = ('hello'::text || (tid)::text))
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.07 rows=1 width=4)
+                           ->  Seq Scan on t  (cost=0.00..2.04 rows=1 width=4)
+                                 Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: legacy query optimizer
-(33 rows)
+(29 rows)
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1496,25 +1496,26 @@ EXPLAIN SELECT '' AS three, f1, f2
 ANALYZE tenk1;
 EXPLAIN SELECT * FROM tenk1 a, tenk1 b
 WHERE (a.unique1,b.unique2) IN (SELECT unique1,unique2 FROM tenk1 c);
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=864.30..1635.81 rows=9955 width=488)
-   ->  Hash Join  (cost=864.30..1635.81 rows=3319 width=488)
-         Hash Cond: c.unique1 = a.unique1
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=551.31..1185.94 rows=3319 width=248)
-               Hash Key: c.unique1
-               ->  Hash Join  (cost=551.31..986.84 rows=3319 width=248)
-                     Hash Cond: c.unique2 = b.unique2
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=238.33..536.98 rows=3319 width=8)
-                           ->  HashAggregate  (cost=238.33..337.88 rows=3319 width=8)
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=974.00..1636.00 rows=10000 width=488)
+   ->  Hash Join  (cost=974.00..1636.00 rows=3334 width=488)
+         Hash Cond: (c.unique2 = b.unique2)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=462.00..986.50 rows=3334 width=248)
+               Hash Key: c.unique2
+               ->  Hash Join  (cost=462.00..786.50 rows=3334 width=248)
+                     Hash Cond: (a.unique1 = c.unique1)
+                     ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=244)
+                     ->  Hash  (cost=337.00..337.00 rows=3334 width=8)
+                           ->  HashAggregate  (cost=237.00..337.00 rows=3334 width=8)
                                  Group Key: c.unique1, c.unique2
-                                 ->  Seq Scan on tenk1 c  (cost=0.00..188.55 rows=3319 width=8)
-                     ->  Hash  (cost=188.55..188.55 rows=3319 width=244)
-                           ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=244)
-         ->  Hash  (cost=188.55..188.55 rows=3319 width=244)
-               ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=244)
+                                 ->  Seq Scan on tenk1 c  (cost=0.00..187.00 rows=3334 width=8)
+         ->  Hash  (cost=387.00..387.00 rows=3334 width=244)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..387.00 rows=3334 width=244)
+                     Hash Key: b.unique2
+                     ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=244)
  Optimizer: legacy query optimizer
-(14 rows)
+(17 rows)
 
 -- Correlated subselects
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1487,25 +1487,25 @@ EXPLAIN SELECT '' AS three, f1, f2
 ANALYZE tenk1;
 EXPLAIN SELECT * FROM tenk1 a, tenk1 b
 WHERE (a.unique1,b.unique2) IN (SELECT unique1,unique2 FROM tenk1 c);
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=864.30..1660.70 rows=9955 width=488)
-   ->  Hash Join  (cost=864.30..1660.70 rows=3319 width=488)
-         Hash Cond: c.unique1 = a.unique1
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=551.31..1198.39 rows=3319 width=248)
-               Hash Key: c.unique1
-               ->  Hash Join  (cost=551.31..999.29 rows=3319 width=248)
-                     Hash Cond: c.unique2 = b.unique2
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=238.33..536.98 rows=3319 width=8)
-                           ->  HashAggregate  (cost=238.33..337.88 rows=3319 width=8)
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=974.00..1636.00 rows=10000 width=488)
+   ->  Hash Join  (cost=974.00..1636.00 rows=3334 width=488)
+         Hash Cond: (c.unique2 = b.unique2)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=462.00..986.50 rows=3334 width=248)
+               Hash Key: c.unique2
+               ->  Hash Join  (cost=462.00..786.50 rows=3334 width=248)
+                     Hash Cond: (a.unique1 = c.unique1)
+                     ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=244)
+                     ->  Hash  (cost=337.00..337.00 rows=3334 width=8)
+                           ->  HashAggregate  (cost=237.00..337.00 rows=3334 width=8)
                                  Group Key: c.unique1, c.unique2
-                                 ->  Seq Scan on tenk1 c  (cost=0.00..188.55 rows=3319 width=8)
-                     ->  Hash  (cost=188.55..188.55 rows=3319 width=244)
-                           ->  Seq Scan on tenk1 b  (cost=0.00..188.55 rows=3319 width=244)
-         ->  Hash  (cost=188.55..188.55 rows=3319 width=244)
-               ->  Seq Scan on tenk1 a  (cost=0.00..188.55 rows=3319 width=244)
- Settings:  optimizer=on
- Optimizer status: legacy query optimizer
+                                 ->  Seq Scan on tenk1 c  (cost=0.00..187.00 rows=3334 width=8)
+         ->  Hash  (cost=387.00..387.00 rows=3334 width=244)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..387.00 rows=3334 width=244)
+                     Hash Key: b.unique2
+                     ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=244)
+ Optimizer: legacy query optimizer
 (17 rows)
 
 -- Correlated subselects


### PR DESCRIPTION
For cost estimation of MotionPath node, we calculate the rows as
(subpath->rows * cdbpath_segments) for CdbPathLocus_IsReplicated() which
do not have IndexPath, BitmapHeapPath, UniquePath, and
BitmapAppendOnlyPath (which is completely removed in db51634) in its
subpath. Previously, for the above mentioned node we always calculated
the rows as subpath->rows. The reason why the Paths mentioned above are
special is unknown, the logic has always been there, it used to be in
cdbpath_rows() and was refactored as part of commit b2411b5. Therefore
removing the checks all together, and calculating the rows for all
CdbPathLocus_IsReplicated() to be same. We have already removed
IndexPath as part of the 94_STABLE merge.


Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
