### PR TITLE
Include nodetag type in squelching error

### DIFF
--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -23,7 +23,6 @@
  *		ExecInitNode	-		initialize a plan node and its subplans
  *		ExecProcNode	-		get a tuple by executing the plan node
  *		ExecEndNode		-		shut down a plan node and its subplans
- *		ExecSquelchNode		-	notify subtree that no more tuples are needed
  *
  *	 NOTES
  *		This used to be three files.  It is now all combined into
@@ -948,7 +947,8 @@ ExecProcNode(PlanState *node)
 		ExecReScan(node);		/* let ReScan handle this */
 
 	if (node->squelched)
-		elog(ERROR, "cannot execute squelched plan node");
+		elog(ERROR, "cannot execute squelched plan node of type: %d",
+			 (int) nodeTag(node));
 
 	if (node->instrument)
 		InstrStartNode(node->instrument);


### PR DESCRIPTION
When poking at the Squelching code recently, this diff was quite helpful so I figured I'd see if anyone else feels the same. This mimicks the error messaging in ExecSquelchNode() for when the node type is unknown, to aid debugging.

Also removes a header comment which was made obsolete in commit 6195b96780.
