### PR TITLE
Bring memaccounting dump memory usage back

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -166,6 +166,7 @@ char	   *memory_profiler_run_id = "none";
 char	   *memory_profiler_dataset_id = "none";
 char	   *memory_profiler_query_id = "none";
 int			memory_profiler_dataset_size = 0;
+bool		gp_dump_memory_usage = FALSE;
 
 bool		rle_type_compression_stats = false;
 
@@ -878,6 +879,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&gp_enable_explain_allstat,
 		false,
 		NULL, NULL, NULL
+	},
+
+	{
+			{"gp_dump_memory_usage", PGC_USERSET, CLIENT_CONN_OTHER,
+			 gettext_noop("Save memory usage in each segment."),
+			 NULL,
+			 GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			},
+			&gp_dump_memory_usage,
+			false, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -250,6 +250,11 @@ MemoryAccounting_Reset()
 	 */
 	if (MemoryAccounting_IsInitialized())
 	{
+		if (gp_dump_memory_usage)
+		{
+			MemoryAccounting_SaveToFile(currentSliceId);
+		}
+
 		/* No one should create child context under MemoryAccountMemoryContext */
 		Assert(MemoryAccountMemoryContext->firstchild == NULL);
 
@@ -1513,7 +1518,7 @@ SaveMemoryBufToDisk(struct StringInfoData *memoryBuf, char *prefix)
 	Assert((strlen("pg_log/") + strlen("memory_") + strlen(prefix) + strlen(".mem")) < MEMORY_REPORT_FILE_NAME_LENGTH);
 	snprintf(fileName, MEMORY_REPORT_FILE_NAME_LENGTH, "%s/memory_%s.mem", "pg_log", prefix);
 
-	FILE *file = fopen(fileName, "w");
+	FILE *file = AllocateFile(fileName, "w");
 
 	if (file == NULL)
 		elog(ERROR, "Could not write memory usage information. Failed to open file: %s", fileName);
@@ -1523,7 +1528,7 @@ SaveMemoryBufToDisk(struct StringInfoData *memoryBuf, char *prefix)
 	if (bytes != memoryBuf->len)
 		elog(ERROR, "Could not write memory usage information. Attempted to write %d", memoryBuf->len);
 
-	fclose(file);
+	FreeFile(file);
 }
 
 /*

--- a/src/backend/utils/mmgr/test/Makefile
+++ b/src/backend/utils/mmgr/test/Makefile
@@ -39,7 +39,8 @@ redzone_handler.t: \
 memaccounting.t: \
 	$(MOCK_DIR)/backend/access/transam/xact_mock.o \
 	$(MOCK_DIR)/backend/utils/error/assert_mock.o \
-	$(MOCK_DIR)/backend/utils/error/elog_mock.o
+	$(MOCK_DIR)/backend/utils/error/elog_mock.o \
+	$(MOCK_DIR)/backend/storage/file/fd_mock.o
 
 runaway_cleaner.t: \
 	$(MOCK_DIR)/backend/utils/error/elog_mock.o \

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -1211,8 +1211,19 @@ test__MemoryAccounting_SaveToFile__GeneratesCorrectString(void **state)
 	memory_profiler_dataset_id = "unittest";
 	memory_profiler_query_id = "q";
 	memory_profiler_dataset_size = INT_MAX;
+	statement_mem = 0;
+	gp_session_id = 0;
 
 	GpIdentity.segindex = CHAR_MAX;
+
+
+
+	expect_string(AllocateFile, name, "pg_log/memory_test,unittest,q,2147483647,0,0,999,10,127.mem");
+	expect_any(AllocateFile, mode);
+	will_return(AllocateFile, 0xabcdee);
+
+	expect_any(FreeFile, file);
+	will_return(FreeFile, 0);
 
 	MemoryAccounting_SaveToFile(10 /* Arbitrary slice id */);
 

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -64,6 +64,10 @@ extern char* memory_profiler_query_id;
  */
 extern int memory_profiler_dataset_size;
 
+/*
+ * Should we save the memory usage information before resetting the memory accounting?
+ */
+extern bool gp_dump_memory_usage;
 
 /*
  * Each memory account can assume one of the following memory


### PR DESCRIPTION
Add gp_dump_memory_usage guc back, and add MemoryAccounting_SaveToFile
back to MemoryAccounting_Reset.
Use AllocateFile and FreeFile to replace fopen and fclose. It could
avoid leaking the file descriptor on error.

We already have unittest to cover the code.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
