### PR TITLE
Vacuum in utility mode in QD not resets pg_class.relpages/reltuples

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1664,13 +1664,19 @@ vac_update_relstats(Relation relation,
 
 	/* Apply statistical updates, if any, to copied tuple */
 
+	/* GPDB-specific not allow change relpages and reltuples when vacuum in utility mode on QD
+	 * Because there's a chance that we overwrite perfectly good stats with zeros
+	 */
+
+	bool ifUpdate = ! (IS_QUERY_DISPATCHER() && Gp_role == GP_ROLE_UTILITY);
+
 	dirty = false;
-	if (pgcform->relpages != (int32) num_pages)
+	if (pgcform->relpages != (int32) num_pages && ifUpdate)
 	{
 		pgcform->relpages = (int32) num_pages;
 		dirty = true;
 	}
-	if (pgcform->reltuples != (float4) num_tuples)
+	if (pgcform->reltuples != (float4) num_tuples && ifUpdate)
 	{
 		pgcform->reltuples = (float4) num_tuples;
 		dirty = true;


### PR DESCRIPTION
Try to fix github issue https://github.com/greenplum-db/gpdb/issues/6287

Add WIP because do not figure out why only utility mode in QD matters, not other conditions.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
