### PR TITLE
Comment out dead upstream code

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1174,6 +1174,13 @@ hash_ok_operator(OpExpr *expr)
 }
 
 
+#if 0
+/*
+ * GPDB doesn't use initplan + CteScan, so running SS_process_ctes will only
+ * generate unused initplans. Keep commented out to avoid merge conflicts with
+ * upstream.
+ */
+
 /*
  * SS_process_ctes: process a query's WITH list
  *
@@ -1290,6 +1297,7 @@ SS_process_ctes(PlannerInfo *root)
 		cost_subplan(root, splan, plan);
 	}
 }
+#endif
 
 /*
  * convert_ANY_sublink_to_join: try to convert an ANY SubLink to a join

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -17,7 +17,10 @@
 #include "nodes/plannodes.h"
 #include "nodes/relation.h"
 
+#if 0
+/* Not used in GPDB */
 extern void SS_process_ctes(PlannerInfo *root);
+#endif
 extern Node *convert_testexpr(PlannerInfo *root,
 				 Node *testexpr,
 				 List *subst_nodes);


### PR DESCRIPTION
Since GPDB is planning CTEs quite differently from upstream, the initplan generation in SS_process_ctes() is not required and has been commented out. This extends the commenting to the function and not just the caller to assist code reading and understanding (reading the function without inspecting the caller can easily lead to incorrect assumptions).
