### PR TITLE
Fix path tree discrepancy for multireference recursive CTE

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1718,10 +1718,17 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			 * Push down quals, like we do in set_subquery_pathlist()
 			 */
 			subquery = push_down_restrict(root, rel, rte, rel->relid, subquery);
-		}
 
-		subplan = subquery_planner(cteroot->glob, subquery, root, cte->cterecursive,
-								   tuple_fraction, &subroot, config);
+			subplan = subquery_planner(cteroot->glob, subquery, root,
+									   cte->cterecursive,
+									   tuple_fraction, &subroot, config);
+		}
+		else
+		{
+			subplan = subquery_planner(cteroot->glob, subquery, cteroot,
+									   cte->cterecursive,
+									   tuple_fraction, &subroot, config);
+		}
 
 		/*
 		 * Do not store the subplan in cteplaninfo, since we will not share

--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -538,3 +538,33 @@ select * from recursive_table_4 where a > ALL (
  1 | 2
 (1 row)
 
+with recursive x(i) as (
+    select 1
+),
+y(i) as (
+    select sum(i) from x
+    union all
+    select i + 1 from y
+),
+z(i) as (
+    select avg(i) from x
+    union all
+    select i + 1 from z
+)
+(select * from y limit 5)
+union
+(select * from z limit 10);
+            i            
+-------------------------
+                       1
+                       2
+                       3
+                       4
+                       5
+  6.00000000000000000000
+  7.00000000000000000000
+  8.00000000000000000000
+  9.00000000000000000000
+ 10.00000000000000000000
+(10 rows)
+

--- a/src/test/regress/sql/gp_recursive_cte.sql
+++ b/src/test/regress/sql/gp_recursive_cte.sql
@@ -384,3 +384,20 @@ select * from recursive_table_4 where a > ALL (
 	)
 	select * from r
 );
+
+with recursive x(i) as (
+    select 1
+),
+y(i) as (
+    select sum(i) from x
+    union all
+    select i + 1 from y
+),
+z(i) as (
+    select avg(i) from x
+    union all
+    select i + 1 from z
+)
+(select * from y limit 5)
+union
+(select * from z limit 10);


### PR DESCRIPTION
The planner wasn't correctly anchoring the path tree for queries which included multiple recursive CTE self-referential terms. Fix by anchoring to the appropriate parent root when invoking the subquery planner.

Adds a testcase illustrating the query, previously the test query would error with:

	ERROR:  could not find CTE "x" (allpaths.c:<lineno>)

Co-authored-by: Georgios Kokolatos <gkokolatos@pivotal.io>