### PR TITLE
Update snapshot of segments configuration for a local transaction

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -532,9 +532,8 @@ cdbcomponent_cleanupIdleQEs(bool includeWriter)
 }
 
 /* 
- * This function is called when current global transaction is set,
- * the snapshot of segments info will not changed within a global
- * transaction
+ * This function is called when a transaction is started and the snapshot of
+ * segments info will not changed until the end of transaction
  */
 void
 cdbcomponent_updateCdbComponents(void)


### PR DESCRIPTION
Previously, we updated snapshot of newest segments configuration at the start of a
global transaction and never change it until the end of global transaction even a
segment is down in the middle which makes things simple. The problem is, some
backends, like FTS & GDD, are never a part of a distributed transaction, so they
are missing the chance of updating segments snapshot. FTS is not problematic
now because it explicitly destroys the segments snapshot and gets a new one every
iteration to always resolve newest hostnames, GDD and other potential backends
still be problematic.

After a thought, there is no harm to update segments snapshot even for a local
transaction except that we need to take care a local transaction that started
without a database be selected. Another idea is just letting GDD to do a explicit
update for every loop, but it would be forgettable when a similar backend is added.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
