### PR TITLE
Add hooks function for diskquota extension

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -200,6 +200,14 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 					    relname)));
 	if (RelationNeedsWAL(rel))
 		xlog_ao_truncate(rel->rd_node, segFileNum, offset);
+
+	if (file_truncate_hook)
+	{
+		RelFileNodeBackend rnode;
+		rnode.node = rel->rd_node;
+		rnode.backend = rel->rd_backend;
+		(*file_truncate_hook)(rnode);
+	}
 }
 
 struct mdunlink_ao_callback_ctx {
@@ -374,6 +382,18 @@ copy_append_only_data(RelFileNode src, RelFileNode dst,
 	copyFiles.useWal = useWal;
 
     ao_foreach_extent_file(copy_append_only_data_perFile, &copyFiles);
+
+    /*
+     * copy destination relation size changed
+     * but we don't know the exact length.
+     */
+	if (file_extend_hook)
+	{
+		RelFileNodeBackend rnode;
+		rnode.node = dst;
+		rnode.backend = backendid;
+		(*file_extend_hook)(rnode, 0);
+	}
 }
 
 static bool

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -383,16 +383,12 @@ copy_append_only_data(RelFileNode src, RelFileNode dst,
 
     ao_foreach_extent_file(copy_append_only_data_perFile, &copyFiles);
 
-    /*
-     * copy destination relation size changed
-     * but we don't know the exact length.
-     */
 	if (file_extend_hook)
 	{
 		RelFileNodeBackend rnode;
 		rnode.node = dst;
 		rnode.backend = backendid;
-		(*file_extend_hook)(rnode, 0);
+		(*file_extend_hook)(rnode);
 	}
 }
 

--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -190,7 +190,7 @@ BufferedAppendWrite(BufferedAppend *bufferedAppend, bool needsWAL)
 		bytestotal += byteswritten;
 
 		if (file_extend_hook)
-			(*file_extend_hook)(bufferedAppend->relFileNode, byteswritten);
+			(*file_extend_hook)(bufferedAppend->relFileNode);
 	}
 
 	elogif(Debug_appendonly_print_append_block, LOG,

--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -188,6 +188,9 @@ BufferedAppendWrite(BufferedAppend *bufferedAppend, bool needsWAL)
 
 		bytesleft -= byteswritten;
 		bytestotal += byteswritten;
+
+		if (file_extend_hook)
+			(*file_extend_hook)(bufferedAppend->relFileNode, byteswritten);
 	}
 
 	elogif(Debug_appendonly_print_append_block, LOG,

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -33,8 +33,9 @@
 #include "utils/inval.h"
 
 /*
- * Hook for plugins to collect statistics from smgr functions
- * One example is to record the active relfilenode information.
+ * Hook for plugins to collect statistics from storage functions
+ * For example, disk quota extension will use these hooks to
+ * detect active tables.
  */
 file_create_hook_type file_create_hook = NULL;
 file_extend_hook_type file_extend_hook = NULL;
@@ -539,7 +540,7 @@ smgrextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 {
 	mdextend(reln, forknum, blocknum, buffer, skipFsync);
 	if (file_extend_hook)
-		(*file_extend_hook)(reln->smgr_rnode, BLCKSZ);
+		(*file_extend_hook)(reln->smgr_rnode);
 }
 
 /*

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -146,4 +146,20 @@ extern Datum smgrin(PG_FUNCTION_ARGS);
 extern Datum smgreq(PG_FUNCTION_ARGS);
 extern Datum smgrne(PG_FUNCTION_ARGS);
 
+/*
+ * Hooks for extensions to collect statistics from I/O functions
+ * One example is to record the active relfilenode information.
+ */
+typedef void (*file_create_hook_type)(RelFileNodeBackend rnode);
+extern PGDLLIMPORT file_create_hook_type file_create_hook;
+
+typedef void (*file_extend_hook_type)(RelFileNodeBackend rnode, int length);
+extern PGDLLIMPORT file_extend_hook_type file_extend_hook;
+
+typedef void (*file_truncate_hook_type)(RelFileNodeBackend rnode);
+extern PGDLLIMPORT file_truncate_hook_type file_truncate_hook;
+
+typedef void (*file_unlink_hook_type)(RelFileNodeBackend rnode);
+extern PGDLLIMPORT file_unlink_hook_type file_unlink_hook;
+
 #endif   /* SMGR_H */

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -147,13 +147,14 @@ extern Datum smgreq(PG_FUNCTION_ARGS);
 extern Datum smgrne(PG_FUNCTION_ARGS);
 
 /*
- * Hooks for extensions to collect statistics from I/O functions
- * One example is to record the active relfilenode information.
+ * Hook for plugins to collect statistics from storage functions
+ * For example, disk quota extension will use these hooks to
+ * detect active tables.
  */
 typedef void (*file_create_hook_type)(RelFileNodeBackend rnode);
 extern PGDLLIMPORT file_create_hook_type file_create_hook;
 
-typedef void (*file_extend_hook_type)(RelFileNodeBackend rnode, int length);
+typedef void (*file_extend_hook_type)(RelFileNodeBackend rnode);
 extern PGDLLIMPORT file_extend_hook_type file_extend_hook;
 
 typedef void (*file_truncate_hook_type)(RelFileNodeBackend rnode);


### PR DESCRIPTION
These hooks are used to detect Heap/AO/CO table change.
For Heap table, smgr related hooks will be utilized the same way as Postgresql.
For AO/CO table, we add two new hook position, TruncateAOSegmentFile() and
BufferedAppendWrite(). They are corresponding to FileWrite and FileTruncate of
AO/CO tables.
Discussion of hook positions is at:
https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/oGBAcUtTTV0/tSNliaEsCwAJ

These hooks will be used by diskquota extension to detect Active Table list.

Co-authored-by: Haozhou Wang <hawang@pivotal.io>
Co-authored-by: Hao Wu <gfphoenix78@gmail.com>
