### PR TITLE
Fix mem leak in ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -2772,12 +2772,11 @@ CTranslatorQueryToDXL::TranslateSetOpChild
 			Query *query_derived_tbl = CTranslatorUtils::FixUnknownTypeConstant(rte->subquery, target_list);
 			GPOS_ASSERT(NULL != query_derived_tbl);
 
-			CMappingVarColId *var_colid_mapping = m_var_to_colid_map->CopyMapColId(m_mp);
 			CTranslatorQueryToDXL query_to_dxl_translator
 					(
 					m_context,
 					m_md_accessor,
-					var_colid_mapping,
+					m_var_to_colid_map,
 					query_derived_tbl,
 					m_query_level + 1,
 					IsDMLQuery(),
@@ -3505,13 +3504,11 @@ CTranslatorQueryToDXL::TranslateDerivedTablesToDXL
 	Query *query_derived_tbl = rte->subquery;
 	GPOS_ASSERT(NULL != query_derived_tbl);
 
-	CMappingVarColId *var_colid_mapping = m_var_to_colid_map->CopyMapColId(m_mp);
-
 	CTranslatorQueryToDXL query_to_dxl_translator
 		(
 		m_context,
 		m_md_accessor,
-		var_colid_mapping,
+		m_var_to_colid_map,
 		query_derived_tbl,
 		m_query_level + 1,
 		IsDMLQuery(),
@@ -4199,13 +4196,12 @@ CTranslatorQueryToDXL::ConstructCTEProducerList
 		
 		// the query representing the cte can only access variables defined in the current level as well as
 		// those defined at prior query levels
-		CMappingVarColId *var_colid_mapping = m_var_to_colid_map->CopyMapColId(cte_query_level);
 
 		CTranslatorQueryToDXL query_to_dxl_translator
 			(
 			m_context,
 			m_md_accessor,
-			var_colid_mapping,
+			m_var_to_colid_map,
 			cte_query,
 			cte_query_level + 1,
 			IsDMLQuery(),


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`

Before:
```
bhuvneshchaudhary=# explain SELECT * from (values (2))v;
LOG:  statement: explain SELECT * from (values (2))v;
LOG:  2019-01-16 13:49:50:953081 PST,THD000,ERROR,"../libgpos/src/memory/CMemoryPool.cpp:215: Failed assertion: !"leak detected"",
LOG:  Planner produced plan :0
                         QUERY PLAN
-------------------------------------------------------------
 Values Scan on "*VALUES*"  (cost=0.00..0.01 rows=1 width=4)
 Optimizer: legacy query optimizer
(2 rows)
```

After the fix
```
bhuvneshchaudhary=# explain SELECT * from (values (2))v;
                QUERY PLAN
------------------------------------------
 Result  (cost=0.00..0.00 rows=1 width=4)
 Optimizer: PQO version 3.23.1
```