### PR TITLE
Do not attempt to Squelch a ModifyTable node

### DIFF
--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -615,6 +615,10 @@ ExecSquelchNode(PlanState *node)
 			ExecSquelchMotion((MotionState *) node);
 			break;
 
+		case T_ModifyTableState:
+			ExecSquelchModifyTable((ModifyTableState *) node);
+			return;
+
 			/*
 			 * Node types that need custom code to recurse.
 			 */

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2321,3 +2321,22 @@ ExecReScanModifyTable(ModifyTableState *node)
 	 */
 	elog(ERROR, "ExecReScanModifyTable is not implemented");
 }
+
+void
+ExecSquelchModifyTable(ModifyTableState *node)
+{
+	/*
+	 * ModifyTable nodes must run to completion when asked to Squelch so
+	 * that we don't risk losing modifications which should be performed
+	 * regardless of any LIMIT's or other forms for projections which could
+	 * end up causing a squelch to happen.
+	 */
+	for (;;)
+	{
+		TupleTableSlot *result;
+
+		result = ExecModifyTable(node);
+		if (!result)
+			break;
+	}
+}

--- a/src/include/executor/nodeModifyTable.h
+++ b/src/include/executor/nodeModifyTable.h
@@ -19,5 +19,6 @@ extern ModifyTableState *ExecInitModifyTable(ModifyTable *node, EState *estate, 
 extern TupleTableSlot *ExecModifyTable(ModifyTableState *node);
 extern void ExecEndModifyTable(ModifyTableState *node);
 extern void ExecReScanModifyTable(ModifyTableState *node);
+extern void ExecSquelchModifyTable(ModifyTableState *node);
 
 #endif   /* NODEMODIFYTABLE_H */

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2126,3 +2126,40 @@ select * from x, yy;
  2 | 20
 (4 rows)
 
+-- Check that WITH query is run to completion even if outer query isn't.
+-- This is a test which exists in the upstream 'with' test suite in a section
+-- which is currently under an ignore block. It has been copied here to avoid
+-- merge conflicts since enabling it in the upstream test suite would require
+-- altering the test output (as it depends on earlier tests which are failing
+-- in GPDB currently).
+DELETE FROM y;
+INSERT INTO y SELECT generate_series(1,15) m;
+WITH t AS (
+    UPDATE y SET m = m * 100 RETURNING *
+)
+SELECT m BETWEEN 100 AND 1500 FROM t LIMIT 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT * FROM y;
+  m   | n 
+------+---
+  600 |  
+  900 |  
+ 1200 |  
+  300 |  
+ 1000 |  
+  400 |  
+  700 |  
+  800 |  
+  100 |  
+ 1300 |  
+ 1400 |  
+ 1500 |  
+  200 |  
+  500 |  
+ 1100 |  
+(15 rows)
+

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2125,3 +2125,40 @@ select * from x, yy;
  2 | 20
 (4 rows)
 
+-- Check that WITH query is run to completion even if outer query isn't.
+-- This is a test which exists in the upstream 'with' test suite in a section
+-- which is currently under an ignore block. It has been copied here to avoid
+-- merge conflicts since enabling it in the upstream test suite would require
+-- altering the test output (as it depends on earlier tests which are failing
+-- in GPDB currently).
+DELETE FROM y;
+INSERT INTO y SELECT generate_series(1,15) m;
+WITH t AS (
+    UPDATE y SET m = m * 100 RETURNING *
+)
+SELECT m BETWEEN 100 AND 1500 FROM t LIMIT 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT * FROM y;
+  m   | n 
+------+---
+  600 |  
+  900 |  
+ 1200 |  
+  300 |  
+ 1000 |  
+  400 |  
+  700 |  
+  800 |  
+  100 |  
+ 1300 |  
+ 1400 |  
+ 1500 |  
+  200 |  
+  500 |  
+ 1100 |  
+(15 rows)
+

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -326,3 +326,18 @@ with yy as (
    where n = iv.p
 )
 select * from x, yy;
+
+-- Check that WITH query is run to completion even if outer query isn't.
+-- This is a test which exists in the upstream 'with' test suite in a section
+-- which is currently under an ignore block. It has been copied here to avoid
+-- merge conflicts since enabling it in the upstream test suite would require
+-- altering the test output (as it depends on earlier tests which are failing
+-- in GPDB currently).
+DELETE FROM y;
+INSERT INTO y SELECT generate_series(1,15) m;
+WITH t AS (
+    UPDATE y SET m = m * 100 RETURNING *
+)
+SELECT m BETWEEN 100 AND 1500 FROM t LIMIT 1;
+
+SELECT * FROM y;


### PR DESCRIPTION
An inner `ModifyTable` node must run to completion even if the outer node can be satisfied with a squelched inner, break out early from `ExecSquelchNode()` when that's the case.

This adds a testcase from the upstream with test suite to the GPDB with_clause suite. The original test is under an ignore block, but even with lifting that the output is different due to state being set up by prior tests which happen to fail in GPDB.