### PR TITLE
Disable exclusion constraints

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -437,6 +437,9 @@ DefineIndex(Oid relationId,
 	else
 		shouldDispatch = false;
 
+	/* Exlusion constraint not allowed */
+	Assert(!stmt->excludeOpNames);
+
 	/*
 	 * count attributes in index
 	 */

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -800,6 +800,11 @@ transformTableConstraint(CreateStmtContext *cxt, Constraint *constraint)
 				 parser_errposition(cxt->pstate,
 									constraint->location)));
 
+	if (constraint->contype == CONSTR_EXCLUSION)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("GPDB does not support exclusion constraints.")));
+
 	switch (constraint->contype)
 	{
 		case CONSTR_PRIMARY:
@@ -2465,9 +2470,13 @@ transformIndexConstraints(CreateStmtContext *cxt, bool mayDefer)
 		Constraint *constraint = (Constraint *) lfirst(lc);
 
 		Assert(IsA(constraint, Constraint));
+		if(constraint->contype == CONSTR_EXCLUSION)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("GPDB does not support exclusion constraints.")));
+
 		Assert(constraint->contype == CONSTR_PRIMARY ||
-			   constraint->contype == CONSTR_UNIQUE ||
-			   constraint->contype == CONSTR_EXCLUSION);
+			   constraint->contype == CONSTR_UNIQUE);
 
 		index = transformIndexConstraint(constraint, cxt);
 
@@ -2595,6 +2604,8 @@ transformIndexConstraints(CreateStmtContext *cxt, bool mayDefer)
 static IndexStmt *
 transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 {
+	Assert(constraint->contype !=  CONSTR_EXCLUSION);
+
 	IndexStmt  *index;
 	ListCell   *lc;
 

--- a/src/test/regress/expected/exclusion_constraints.out
+++ b/src/test/regress/expected/exclusion_constraints.out
@@ -1,0 +1,16 @@
+-- Given a create table specifying a constraint
+create table exclusion_constraints_t1(a int, b int, EXCLUDE (a WITH =));
+ERROR:  GPDB does not support exclusion constraints.
+-- Then we errored out
+-- Given a create partiton table table specifying a constraint
+create table exclusion_constraints_pt1(a int, b int, EXCLUDE (b WITH =)) partition by range(a) (start(1) end(4) every(1));
+ERROR:  GPDB does not support exclusion constraints.
+-- Then we errored out
+-- Given a table without constraints
+create table exclusion_constraints_t2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- And we alter table to add constraints
+ALTER TABLE exclusion_constraints_t2 ADD CONSTRAINT constraint_on_t2 EXCLUDE USING btree (b WITH =);
+ERROR:  GPDB does not support exclusion constraints.
+-- Then we errored out

--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -1095,6 +1095,8 @@ Distributed by: (val1, val2)
 
 DROP TABLE test_constraints_inh;
 DROP TABLE test_constraints;
+-- start_ignore
+-- GPDB does not support exclusion constraints, so no need to run this test
 CREATE TABLE test_ex_constraints (
     c circle,
     EXCLUDE USING gist (c WITH &&)
@@ -1129,6 +1131,7 @@ Distributed randomly
 
 DROP TABLE test_ex_constraints_inh;
 DROP TABLE test_ex_constraints;
+-- end_ignore
 -- Test non-inheritable foreign key contraints
 CREATE TABLE test_primary_constraints(id int PRIMARY KEY);
 CREATE TABLE test_foreign_constraints(id1 int REFERENCES test_primary_constraints(id));

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1093,6 +1093,8 @@ Distributed by: (val1, val2)
 
 DROP TABLE test_constraints_inh;
 DROP TABLE test_constraints;
+-- start_ignore
+-- GPDB does not support exclusion constraints, so no need to run this test
 CREATE TABLE test_ex_constraints (
     c circle,
     EXCLUDE USING gist (c WITH &&)
@@ -1127,6 +1129,7 @@ Distributed randomly
 
 DROP TABLE test_ex_constraints_inh;
 DROP TABLE test_ex_constraints;
+-- end_ignore
 -- Test non-inheritable foreign key contraints
 CREATE TABLE test_primary_constraints(id int PRIMARY KEY);
 CREATE TABLE test_foreign_constraints(id1 int REFERENCES test_primary_constraints(id));

--- a/src/test/regress/expected/rangetypes.out
+++ b/src/test/regress/expected/rangetypes.out
@@ -1097,6 +1097,8 @@ drop table test_range_elem;
 -- constraints with range types, use singleton int ranges for the "="
 -- portion of the constraint.
 --
+-- start_ignore
+-- GPDB does not support exclusion constraints, so no need to run this test
 create table test_range_excl(
   id int4,
   room int4range,
@@ -1119,6 +1121,7 @@ insert into test_range_excl
   values(1, int4range(125, 125, '[]'), int4range(1, 1, '[]'), '[2010-01-02 10:10, 2010-01-02 11:00)');
 ERROR:  conflicting key value violates exclusion constraint "test_range_excl_speaker_during_excl"  (seg0 127.0.0.1:25432 pid=8632)
 DETAIL:  Key (speaker, during)=([1,2), ["Sat Jan 02 10:10:00 2010","Sat Jan 02 11:00:00 2010")) conflicts with existing key (speaker, during)=([1,2), ["Sat Jan 02 10:00:00 2010","Sat Jan 02 11:00:00 2010")).
+-- end_ignore
 -- test bigint ranges
 select int8range(10000000000::int8, 20000000000::int8,'(]');
          int8range         

--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -455,6 +455,8 @@ DROP TABLE unique_tbl;
 -- EXCLUDE constraints
 --
 
+-- start_ignore
+-- GPDB does not support exclusion constraints, so no need to run these tests
 CREATE TABLE circles (
   c1 CIRCLE,
   c2 TEXT,
@@ -462,14 +464,6 @@ CREATE TABLE circles (
     (c1 WITH &&, (c2::circle) WITH &&)
     WHERE (circle_center(c1) <> '(0,0)')
 );
-
--- start_ignore
--- In Greenplum, exclusion constraints only enfore exclusion for rows that
--- land in the same segment. Force all the rows to be stored on the same
--- segment, so that the rest of this upstream test works unmodified.
-ALTER TABLE circles ADD COLUMN distkey integer;
-ALTER TABLE circles SET DISTRIBUTED BY (distkey);
--- end_ignore
 
 -- these should succeed because they don't match the index predicate
 INSERT INTO circles VALUES('<(0,0), 5>', '<(0,0), 5>');
@@ -526,17 +520,10 @@ ALTER TABLE deferred_excl DROP CONSTRAINT deferred_excl_con;
 -- This should fail, but worth testing because of HOT updates
 UPDATE deferred_excl SET f1 = 3;
 
--- In the original postgres test, both the tuples in this table will be updated
--- (probably by HOT update) in the previous statement, and would now be equal. In
--- greenplum, the planner does not support updating distribution keys, so we need
--- to add in these tuples manually to make the next queries in this test valid.
--- ORCA actually DOES support updating the distribution key of tables, so if using
--- the optimizer, this is technically not necessary.  
-INSERT INTO deferred_excl VALUES(3);
-INSERT INTO deferred_excl VALUES(3);
 ALTER TABLE deferred_excl ADD EXCLUDE (f1 WITH =);
 
 DROP TABLE deferred_excl;
+-- end_ignore
 
 --
 -- Test foreign key constraints

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -623,6 +623,8 @@ DROP TABLE unique_tbl;
 --
 -- EXCLUDE constraints
 --
+-- start_ignore
+-- GPDB does not support exclusion constraints, so no need to run these tests
 CREATE TABLE circles (
   c1 CIRCLE,
   c2 TEXT,
@@ -689,18 +691,11 @@ SELECT * FROM deferred_excl;
 ALTER TABLE deferred_excl DROP CONSTRAINT deferred_excl_con;
 -- This should fail, but worth testing because of HOT updates
 UPDATE deferred_excl SET f1 = 3;
--- In the original postgres test, both the tuples in this table will be updated
--- (probably by HOT update) in the previous statement, and would now be equal. In
--- greenplum, the planner does not support updating distribution keys, so we need
--- to add in these tuples manually to make the next queries in this test valid.
--- ORCA actually DOES support updating the distribution key of tables, so if using
--- the optimizer, this is technically not necessary.  
-INSERT INTO deferred_excl VALUES(3);
-INSERT INTO deferred_excl VALUES(3);
 ALTER TABLE deferred_excl ADD EXCLUDE (f1 WITH =);
 ERROR:  could not create exclusion constraint "deferred_excl_f1_excl"
 DETAIL:  Key (f1)=(3) conflicts with key (f1)=(3).
 DROP TABLE deferred_excl;
+-- end_ignore
 --
 -- Test foreign key constraints
 --

--- a/src/test/regress/sql/exclusion_constraints.sql
+++ b/src/test/regress/sql/exclusion_constraints.sql
@@ -1,0 +1,13 @@
+-- Given a create table specifying a constraint
+create table exclusion_constraints_t1(a int, b int, EXCLUDE (a WITH =));
+-- Then we errored out
+
+-- Given a create partiton table table specifying a constraint
+create table exclusion_constraints_pt1(a int, b int, EXCLUDE (b WITH =)) partition by range(a) (start(1) end(4) every(1));
+-- Then we errored out
+
+-- Given a table without constraints
+create table exclusion_constraints_t2(a int, b int);
+-- And we alter table to add constraints
+ALTER TABLE exclusion_constraints_t2 ADD CONSTRAINT constraint_on_t2 EXCLUDE USING btree (b WITH =);
+-- Then we errored out

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -338,6 +338,8 @@ ALTER TABLE ONLY test_constraints DROP CONSTRAINT test_constraints_val1_val2_key
 DROP TABLE test_constraints_inh;
 DROP TABLE test_constraints;
 
+-- start_ignore
+-- GPDB does not support exclusion constraints, so no need to run this test
 CREATE TABLE test_ex_constraints (
     c circle,
     EXCLUDE USING gist (c WITH &&)
@@ -349,6 +351,7 @@ ALTER TABLE test_ex_constraints DROP CONSTRAINT test_ex_constraints_c_excl;
 \d+ test_ex_constraints_inh
 DROP TABLE test_ex_constraints_inh;
 DROP TABLE test_ex_constraints;
+-- end_ignore
 
 -- Test non-inheritable foreign key contraints
 CREATE TABLE test_primary_constraints(id int PRIMARY KEY);

--- a/src/test/regress/sql/rangetypes.sql
+++ b/src/test/regress/sql/rangetypes.sql
@@ -311,6 +311,8 @@ drop table test_range_elem;
 -- portion of the constraint.
 --
 
+-- start_ignore
+-- GPDB does not support exclusion constraints, so no need to run this test
 create table test_range_excl(
   id int4,
   room int4range,
@@ -330,6 +332,7 @@ insert into test_range_excl
   values(1, int4range(124, 124, '[]'), int4range(3, 3, '[]'), '[2010-01-02 10:10, 2010-01-02 11:10)');
 insert into test_range_excl
   values(1, int4range(125, 125, '[]'), int4range(1, 1, '[]'), '[2010-01-02 10:10, 2010-01-02 11:00)');
+-- end_ignore
 
 -- test bigint ranges
 select int8range(10000000000::int8, 20000000000::int8,'(]');


### PR DESCRIPTION
Currently exclusion constraints do not work correctly in MPP environment.
For example, if the exclusion constraint is on a column which is not the
table's distribution key, then it is possible to get wrong results.

Following statements should give 1 row because first tuple should
exclude the second.
```
CREATE TABLE t(a int, b int, EXCLUDE (b WITH =)) DISTIBUTED BY (a);
INSERT INTO t values (1, 1), (2, 1);
```

However, that is not currently the case if the distribution key hashes
to different segments. This commit removes exclusion constraints feature
entirely until there is a way to coordinate exclusion constraints
between the segments.

Co-authored-by: Adam Berlin <aberlin@pivotal.io>
Co-authored-by: Melanie Plageman <melanieplageman@gmail.com>
Co-authored-by: David Kimura <dkimura@pivotal.io>
