### PR TITLE
Remove FIXME, there's nothing to do here.

### DIFF
--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -1134,12 +1134,6 @@ ExecEvalWholeRowSlow(WholeRowVarExprState *wrvstate, ExprContext *econtext,
 		*isDone = ExprSingleResult;
 	*isNull = false;
 
-	/*
-	 * GPDB_92_MERGE_FIXME: Previous code does not have the code block below, 
-	 * but in theory this is needed. So why there is not test failure on gpdb master?
-	 * Besides, we should consider to follow pg to use ExecEvalVar() for Var code entrance.
-	 */
-
 	/* Get the input slot we want */
 	switch (variable->varno)
 	{


### PR DESCRIPTION
The point of this FIXME was that the code before the 9.2 merge was
possibly broken, because it was missing this code to get the input slot.
I think it was missing before the 9.2 merge, because of a bungled merge
of commit 7fc0f06221, during the 9.0 merge, but now the code in GPDB
master is identical to upstream, and there's nothing to do. Also,
comparing the 8.2 and 5X_STABLE code, it looks correct in 5X_STABLE, as
well, so there's nothing to do there either.
