### PR TITLE
Error out on multiple writers in CTE

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -414,6 +414,18 @@ transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt)
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+
+		/*
+		 * Since GPDB currently only support a single writer gang, only one
+		 * writable clause is permitted per CTE. Once we get flexible gangs
+		 * with more than one writer gang we can lift this restriction.
+		 */
+		if (pstate->p_hasModifyingCTE)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("writable CTE queries cannot be themselves writable"),
+					 errdetail("Greenplum Database currently only support CTEs with one writable clause, called in a non-writable context."),
+					 errhint("Rewrite the query to only include one writable clause.")));
 	}
 
 	/* set up range table with just the result rel */
@@ -500,6 +512,18 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+
+		/*
+		 * Since GPDB currently only support a single writer gang, only one
+		 * writable clause is permitted per CTE. Once we get flexible gangs
+		 * with more than one writer gang we can lift this restriction.
+		 */
+		if (pstate->p_hasModifyingCTE)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("writable CTE queries cannot be themselves writable"),
+					 errdetail("Greenplum Database currently only support CTEs with one writable clause, called in a non-writable context."),
+					 errhint("Rewrite the query to only include one writable clause.")));
 	}
 
 	/*
@@ -2941,6 +2965,18 @@ transformUpdateStmt(ParseState *pstate, UpdateStmt *stmt)
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
+
+		/*
+		 * Since GPDB currently only support a single writer gang, only one
+		 * writable clause is permitted per CTE. Once we get flexible gangs
+		 * with more than one writer gang we can lift this restriction.
+		 */
+		if (pstate->p_hasModifyingCTE)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("writable CTE queries cannot be themselves writable"),
+					 errdetail("Greenplum Database currently only support CTEs with one writable clause, called in a non-writable context."),
+					 errhint("Rewrite the query to only include one writable clause.")));
 	}
 
 	qry->resultRelation = setTargetTable(pstate, stmt->relation,

--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -146,6 +146,19 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 				   IsA(cte->ctequery, UpdateStmt) ||
 				   IsA(cte->ctequery, DeleteStmt));
 
+
+			/*
+			 * Since GPDB currently only support a single writer gang, only one
+			 * writable clause is permitted per CTE. Once we get flexible gangs
+			 * with more than one writer gang we can lift this restriction.
+			 */
+			if (pstate->p_hasModifyingCTE)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("only one modifying WITH clause allowed per query"),
+						 errdetail("Greenplum Database currently only support CTEs with one writable clause."),
+						 errhint("Rewrite the query to only include one writable CTE clause.")));
+
 			pstate->p_hasModifyingCTE = true;
 		}
 	}


### PR DESCRIPTION
While Greenplum can plan a CTE query with multiple writable expressions,
it can't execute it as there is a limitation on using a single writer
gang. Until we can support multiple writer gangs, let's error out with
a graceful error message rather than failing during exeucution with a
more cryptic internal error. Ideally this will be reverted in GPDB 7.X
but right now it's much too close to release for attacking this.