### PR TITLE
pg_basebackup and pg_rewind: exclude pg_log and pg_replslot.

### DIFF
--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -962,18 +962,33 @@ SELECT pg_stop_backup();
    </para>
 
    <para>
-    It's also worth noting that the <function>pg_start_backup</> function
-    makes a file named <filename>backup_label</> in the database cluster
-    directory, which is removed by <function>pg_stop_backup</>.
-    This file will of course be archived as a part of your backup dump file.
-    The backup label file includes the label string you gave to
-    <function>pg_start_backup</>, as well as the time at which
-    <function>pg_start_backup</> was run, and the name of the starting WAL
-    file.  In case of confusion it is therefore possible to look inside a
-    backup dump file and determine exactly which backup session the dump file
-    came from.  However, this file is not merely for your information; its
-    presence and contents are critical to the proper operation of the system's
-    recovery process.
+    The contents of the directories <filename>pg_dynshmem/</>,
+    <filename>pg_notify/</>, <filename>pg_serial/</>,
+    <filename>pg_snapshots/</>, <filename>pg_stat_tmp/</>,
+    and <filename>pg_subtrans/</> (but not the directories themselves) can be
+    omitted from the backup as they will be initialized on postmaster startup.
+    If <xref linkend="guc-stats-temp-directory"> is set and is under the data
+    directory then the contents of that directory can also be omitted.
+   </para>
+
+   <para>
+    Any file or directory beginning with <filename>pgsql_tmp</filename> can be
+    omitted from the backup.  These files are removed on postmaster start and
+    the directories will be recreated as needed.
+   </para>
+
+   <para>
+    The backup label
+    file includes the label string you gave to <function>pg_start_backup</>,
+    as well as the time at which <function>pg_start_backup</> was run, and
+    the name of the starting WAL file.  In case of confusion it is therefore
+    possible to look inside a backup file and determine exactly which
+    backup session the dump file came from.  The tablespace map file includes
+    the symbolic link names as they exist in the directory
+    <filename>pg_tblspc/</> and the full path of each symbolic link.
+    These files are not merely for your information; their presence and
+    contents are critical to the proper operation of the system's recovery
+    process.
    </para>
 
    <para>

--- a/doc/src/sgml/protocol.sgml
+++ b/doc/src/sgml/protocol.sgml
@@ -2067,7 +2067,9 @@ The commands accepted in walsender mode are:
        </listitem>
        <listitem>
         <para>
-         various temporary files created during the operation of the PostgreSQL server
+         Various temporary files and directories created during the operation
+         of the PostgreSQL server, such as any file or directory beginning
+         with <filename>pgsql_tmp</>.
         </para>
        </listitem>
        <listitem>
@@ -2080,13 +2082,18 @@ The commands accepted in walsender mode are:
        </listitem>
        <listitem>
         <para>
-         <filename>pg_replslot</> is copied as an empty directory.
+         <filename>pg_dynshmem</>, <filename>pg_notify</>,
+         <filename>pg_replslot</>, <filename>pg_serial</>,
+         <filename>pg_snapshots</>, <filename>pg_stat_tmp</>, and
+         <filename>pg_subtrans</> are copied as empty directories (even if
+         they are symbolic links).
         </para>
        </listitem>
        <listitem>
         <para>
          Files other than regular files and directories, such as symbolic
-         links and special device files, are skipped.  (Symbolic links
+         links (other than for the directories listed above) and special
+         device files, are skipped.  (Symbolic links
          in <filename>pg_tblspc</filename> are maintained.)
         </para>
        </listitem>

--- a/doc/src/sgml/ref/pg_basebackup.sgml
+++ b/doc/src/sgml/ref/pg_basebackup.sgml
@@ -600,10 +600,12 @@ PostgreSQL documentation
   <para>
    The backup will include all files in the data directory and tablespaces,
    including the configuration files and any additional files placed in the
-   directory by third parties. But only regular files and directories are
-   copied.  Symbolic links (other than those used for tablespaces) and special
-   device files are skipped.  (See <xref linkend="protocol-replication"> for
-   the precise details.)
+   directory by third parties, except certain temporary files managed by
+   PostgreSQL.  But only regular files and directories are copied, except that
+   symbolic links used for tablespaces are preserved.  Symbolic links pointing
+   to certain directories known to PostgreSQL are copied as empty directories.
+   Other symbolic links and special device files are skipped.
+   See <xref linkend="protocol-replication"> for the precise details.
   </para>
 
   <para>

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -203,8 +203,6 @@ class PgBaseBackup(Command):
             cmd_tokens.append('./gpperfmon/logs')
             cmd_tokens.append('-E')
             cmd_tokens.append('./promote')
-            cmd_tokens.append('-E')
-            cmd_tokens.append('./internal.auto.conf')
         else:
             for path in excludePaths:
                 cmd_tokens.append('-E')

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -162,6 +162,9 @@ static const char *excludeDirContents[] =
 	/* Contents zeroed on startup, see StartupSUBTRANS(). */
 	"pg_subtrans",
 
+	/* Contents unique to each segment instance. */
+	"pg_log",
+
 	/* end of list */
 	NULL
 };
@@ -1200,20 +1203,6 @@ sendDir(char *path, int basepathlen, bool sizeonly, List *tablespaces,
 			size += 512;		/* Size of the header just added */
 
 			continue;			/* don't recurse into pg_xlog */
-		}
-
-		/*
-		 * We can skip pg_log because the segment logs should be unique to
-		 * each segment. However, include pg_log as an empty directory because
-		 * it is required to start the segment.
-		 */
-		if (strcmp(pathbuf, "./pg_log") == 0)
-		{
-			if (!sizeonly)
-				_tarWriteHeader(pathbuf + basepathlen + 1, NULL, &statbuf);
-			size += 512;        /* Size of the header just added */
-
-			continue;
 		}
 
 		/* Skip if client does not want */

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -124,6 +124,9 @@ typedef struct
  * The contents of these directories are removed or recreated during server
  * start so they are not included in backups.  The directories themselves are
  * kept and included as empty to preserve access permissions.
+ *
+ * Note: this list should be kept in sync with the filter lists in pg_rewind's
+ * filemap.c.
  */
 static const char *excludeDirContents[] =
 {

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -188,6 +188,8 @@ static const char *excludeFiles[] =
 	"postmaster.pid",
 	"postmaster.opts",
 
+	GP_INTERNAL_AUTO_CONF_FILE_NAME,
+
 	/* end of list */
 	NULL
 };

--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -108,6 +108,8 @@ static const char *excludeFiles[] =
 	"postmaster.pid",
 	"postmaster.opts",
 
+	GP_INTERNAL_AUTO_CONF_FILE_NAME,
+
 	/* end of list */
 	NULL
 };
@@ -259,7 +261,7 @@ process_source_file(const char *path, file_type_t type, size_t newsize,
 				 * An exception: PG_VERSIONs should be identical, but avoid
 				 * overwriting it for paranoia.
 				 */
-				if (endswith(path, "PG_VERSION") || endswith(path, GP_INTERNAL_AUTO_CONF_FILE_NAME))
+				if (endswith(path, "PG_VERSION"))
 				{
 					action = FILE_ACTION_NONE;
 					oldsize = statbuf.st_size;

--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -76,6 +76,9 @@ static const char *excludeDirContents[] =
 	/* Contents zeroed on startup, see StartupSUBTRANS(). */
 	"pg_subtrans",
 
+	/* Contents unique to each segment instance. */
+	"pg_log",
+
 	/* end of list */
 	NULL
 };

--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -31,6 +31,83 @@ static char *datasegpath(RelFileNode rnode, ForkNumber forknum,
 static int	path_cmp(const void *a, const void *b);
 static int	final_filemap_cmp(const void *a, const void *b);
 static void filemap_list_to_array(filemap_t *map);
+static bool check_file_excluded(const char *path, const char *type);
+
+/*
+ * The contents of these directories are removed or recreated during server
+ * start so they are not included in data processed by pg_rewind.
+ *
+ * Note: those lists should be kept in sync with what basebackup.c provides.
+ * Some of the values, contrary to what basebackup.c uses, are hardcoded as
+ * they are defined in backend-only headers.  So this list is maintained
+ * with a best effort in mind.
+ */
+static const char *excludeDirContents[] =
+{
+	/*
+	 * Skip temporary statistics files. PG_STAT_TMP_DIR must be skipped even
+	 * when stats_temp_directory is set because PGSS_TEXT_FILE is always
+	 * created there.
+	 */
+	"pg_stat_tmp",	/* defined as PG_STAT_TMP_DIR */
+
+	/*
+	 * It is generally not useful to backup the contents of this directory
+	 * even if the intention is to restore to another master. See backup.sgml
+	 * for a more detailed description.
+	 */
+	"pg_replslot",
+
+	/* Contents removed on startup, see dsm_cleanup_for_mmap(). */
+	"pg_dynshmem",	/* defined as PG_DYNSHMEM_DIR */
+
+	/* Contents removed on startup, see AsyncShmemInit(). */
+	"pg_notify",
+
+	/*
+	 * Old contents are loaded for possible debugging but are not required for
+	 * normal operation, see OldSerXidInit().
+	 */
+	"pg_serial",
+
+	/* Contents removed on startup, see DeleteAllExportedSnapshotFiles(). */
+	"pg_snapshots",
+
+	/* Contents zeroed on startup, see StartupSUBTRANS(). */
+	"pg_subtrans",
+
+	/* end of list */
+	NULL
+};
+
+/*
+ * List of files excluded from filemap processing.
+ */
+static const char *excludeFiles[] =
+{
+	/* Skip auto conf temporary file. */
+	"postgresql.auto.conf.tmp", /* defined as PG_AUTOCONF_FILENAME */
+
+	/* Skip current log file temporary file */
+	"current_logfiles.tmp",		/* defined as LOG_METAINFO_DATAFILE_TMP */
+
+	/* Skip relation cache because it is rebuilt on startup */
+	"pg_internal.init",			/* defined as RELCACHE_INIT_FILENAME */
+
+	/*
+	 * If there's a backup_label or tablespace_map file, it belongs to a
+	 * backup started by the user with pg_start_backup().  It is *not* correct
+	 * for this backup.  Our backup_label is written later on separately.
+	 */
+	"backup_label",				/* defined as BACKUP_LABEL_FILE */
+	"tablespace_map",			/* defined as TABLESPACE_MAP */
+
+	"postmaster.pid",
+	"postmaster.opts",
+
+	/* end of list */
+	NULL
+};
 
 /*
  * Create a new file map (stored in the global pointer "filemap").
@@ -83,11 +160,8 @@ process_source_file(const char *path, file_type_t type, size_t newsize,
 
 	Assert(map->array == NULL);
 
-	/*
-	 * Completely ignore some special files in source and destination.
-	 */
-	if (strcmp(path, "postmaster.pid") == 0 ||
-		strcmp(path, "postmaster.opts") == 0)
+	/* ignore any path matching the exclusion filters */
+	if (check_file_excluded(path, "source"))
 		return;
 
 	/*
@@ -275,6 +349,14 @@ process_target_file(const char *path, file_type_t type, size_t oldsize,
 	filemap_t  *map = filemap;
 	file_entry_t *entry;
 
+	/*
+	 * Ignore any path matching the exclusion filters.  This is not actually
+	 * mandatory for target files, but this does not hurt and let's be
+	 * consistent with the source processing.
+	 */
+	if (check_file_excluded(path, "target"))
+		return;
+
 	snprintf(localpath, sizeof(localpath), "%s/%s", datadir_target, path);
 	if (lstat(localpath, &statbuf) < 0)
 	{
@@ -300,13 +382,6 @@ process_target_file(const char *path, file_type_t type, size_t oldsize,
 
 		qsort(map->array, map->narray, sizeof(file_entry_t *), path_cmp);
 	}
-
-	/*
-	 * Completely ignore some special files
-	 */
-	if (strcmp(path, "postmaster.pid") == 0 ||
-		strcmp(path, "postmaster.opts") == 0)
-		return;
 
 	/*
 	 * Like in process_source_file, pretend that xlog is always a  directory.
@@ -500,6 +575,51 @@ process_aofile_change(RelFileNode rnode, int segno, int64 offset)
 	}
 
 	pg_log(PG_DEBUG, "Entry for path %s has action %d\n", entry->path, entry->action);
+}
+
+/*
+ * Is this the path of file that pg_rewind can skip copying?
+ */
+static bool
+check_file_excluded(const char *path, const char *type)
+{
+	char	localpath[MAXPGPATH];
+	int		excludeIdx;
+	const char	*filename;
+
+	/* check individual files... */
+	for (excludeIdx = 0; excludeFiles[excludeIdx] != NULL; excludeIdx++)
+	{
+		filename = last_dir_separator(path);
+		if (filename == NULL)
+			filename = path;
+		else
+			filename++;
+		if (strcmp(filename, excludeFiles[excludeIdx]) == 0)
+		{
+			pg_log(PG_DEBUG, "entry \"%s\" excluded from %s file list\n",
+				   path, type);
+			return true;
+		}
+	}
+
+	/*
+	 * ... And check some directories.  Note that this includes any contents
+	 * within the directories themselves.
+	 */
+	for (excludeIdx = 0; excludeDirContents[excludeIdx] != NULL; excludeIdx++)
+	{
+		snprintf(localpath, sizeof(localpath), "%s/",
+				 excludeDirContents[excludeIdx]);
+		if (strstr(path, localpath) == path)
+		{
+			pg_log(PG_DEBUG, "entry \"%s\" excluded from %s file list\n",
+				   path, type);
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /*


### PR DESCRIPTION
This PR intends
- to have easier mechanism to exclude directories from pg_basebackup and pg_rewind
- pg_basebackup and pg_rewind to exclude same set of things in backend code
- to exclude `pg_log` greenplum specific directory used to store segment logs
- also to exclude `pg_replslot` directory. With this practically can eliminate the need for code added by commit fa09dd80f3be01fdc0464977bc6fe54c3d43cb3e. But keeping the same is no harm either but good precautionary step hence not removing the same for now.

Since upstream already has code for first 2 points (in later versions), better was to just cherry-pick those commits now from upstream. And with that last piece is just adding cherries on top.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [X] Pass `make installcheck`
