### PR TITLE
Change gppylib xargs call to use -I flag

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1202,7 +1202,7 @@ def is_pid_postmaster(datadir, pid, remoteHost=None):
     is_postmaster = True
     if (validate_command ('pgrep', datadir, ctxt, remoteHost) and
             validate_command ('pwdx', datadir, ctxt, remoteHost)):
-        cmdStr = 'pgrep postgres | xargs -i pwdx {} | grep "%s" | grep "^%s:" | cat' % (datadir, pid)
+        cmdStr = 'pgrep postgres | xargs -I{} pwdx {} | grep "%s" | grep "^%s:" | cat' % (datadir, pid)
         cmd = Command("search for postmaster process", cmdStr, ctxt=ctxt, remoteHost=remoteHost)
         res = None
         try:


### PR DESCRIPTION
The -i flag is deprecated and only available on Linux systems.  On
MacOS and other BSD systems, xargs does not have the -i flag.  Since
we do not give an argument to -i, it is basically doing -I{} so change
it to be explicit and proper.

From http://man7.org/linux/man-pages/man1/xargs.1.html:
```
-i[replace-str], --replace[=replace-str]
              This option is a synonym for -Ireplace-str if replace-str is
              specified.  If the replace-str argument is missing, the effect
              is the same as -I{}.  This option is deprecated; use -I
              instead.
```