### PR TITLE
Hide WITH RECURSIVE under off by default GUC

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -314,6 +314,7 @@ bool		gp_dynamic_partition_pruning = true;
 bool		gp_log_dynamic_partition_pruning = false;
 bool		gp_cte_sharing = false;
 bool		gp_enable_relsize_collection = false;
+bool		gp_recursive_cte_prototype = false;
 
 /* Optimizer related gucs */
 bool		optimizer;
@@ -2092,6 +2093,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&gp_enable_exchange_default_partition,
 		false,
 		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_recursive_cte_prototype", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Enable RECURSIVE clauses in CTE queries."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_recursive_cte_prototype,
+		false, NULL, NULL
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -741,10 +741,10 @@ extern int gp_sort_max_distinct;
  */
 extern bool gp_dynamic_partition_pruning;
 
-/**
- * Sharing of plan fragments for common table expressions
- */
+/* Sharing of plan fragments for common table expressions */
 extern bool gp_cte_sharing;
+/* Enable RECURSIVE clauses in common table expressions */
+extern bool gp_recursive_cte_prototype;
 
 /* Priority for the segworkers relative to the postmaster's priority */
 extern int gp_segworker_relative_priority;

--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -1,11 +1,21 @@
 -- Tests exercising different behaviour of the WITH RECURSIVE implementation in GPDB
 -- GPDB's distributed nature requires thorough testing of many use cases in order to ensure correctness
 -- Setup
--- WITH RECURSIVE ref in a sublink in the main query
 create schema recursive_cte;
 set search_path=recursive_cte;
 create table recursive_table_1(id int);
 insert into recursive_table_1 values (1), (2), (100);
+-- Test the featureblocking GUC for recursive CTE
+set gp_recursive_cte_prototype to off;
+with recursive r(i) as (
+   select 1
+   union all
+   select i + 1 from r
+)
+select * from recursive_table_1 where recursive_table_1.id IN (select * from r limit 10);
+ERROR:  RECURSIVE clauses in WITH queries are currently disabled
+HINT:  In order to use recursive CTEs, "gp_recursive_cte_prototype" must be turned on.
+set gp_recursive_cte_prototype to on;
 -- WITH RECURSIVE ref used with IN without correlation
 with recursive r(i) as (
    select 1

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1,4 +1,5 @@
 -- test numeric hash join
+set gp_recursive_cte_prototype to on;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1,4 +1,5 @@
 -- test numeric hash join
+set gp_recursive_cte_prototype to on;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;

--- a/src/test/regress/sql/collate.linux.utf8.sql
+++ b/src/test/regress/sql/collate.linux.utf8.sql
@@ -1,3 +1,6 @@
+-- start_ignore
+SET gp_recursive_cte_prototype TO ON;
+-- end_ignore
 /*
  * This test is for Linux/glibc systems and assumes that a full set of
  * locales is installed.  It must be run in a database with UTF-8 encoding,

--- a/src/test/regress/sql/collate.sql
+++ b/src/test/regress/sql/collate.sql
@@ -1,3 +1,6 @@
+-- start_ignore
+SET gp_recursive_cte_prototype TO ON;
+-- end_ignore
 /*
  * This test is intended to pass on all platforms supported by Postgres.
  * We can therefore only assume that the default, C, and POSIX collations

--- a/src/test/regress/sql/gp_recursive_cte.sql
+++ b/src/test/regress/sql/gp_recursive_cte.sql
@@ -1,15 +1,22 @@
 -- Tests exercising different behaviour of the WITH RECURSIVE implementation in GPDB
 -- GPDB's distributed nature requires thorough testing of many use cases in order to ensure correctness
 
+
 -- Setup
-
-
--- WITH RECURSIVE ref in a sublink in the main query
-
 create schema recursive_cte;
 set search_path=recursive_cte;
 create table recursive_table_1(id int);
 insert into recursive_table_1 values (1), (2), (100);
+
+-- Test the featureblocking GUC for recursive CTE
+set gp_recursive_cte_prototype to off;
+with recursive r(i) as (
+   select 1
+   union all
+   select i + 1 from r
+)
+select * from recursive_table_1 where recursive_table_1.id IN (select * from r limit 10);
+set gp_recursive_cte_prototype to on;
 
 -- WITH RECURSIVE ref used with IN without correlation
 with recursive r(i) as (

--- a/src/test/regress/sql/ic.sql
+++ b/src/test/regress/sql/ic.sql
@@ -1,3 +1,6 @@
+-- start_ignore
+SET gp_recursive_cte_prototype TO ON;
+-- end_ignore
 /*
  * 
  * Functional tests

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -1,3 +1,6 @@
+-- start_ignore
+SET gp_recursive_cte_prototype TO ON;
+-- end_ignore
 --
 -- Test inheritance features
 --

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -1,6 +1,8 @@
 
 -- test numeric hash join
 
+set gp_recursive_cte_prototype to on;
+
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -3,7 +3,8 @@
 --
 
 --start_ignore
-set gp_cte_sharing = on;
+set gp_cte_sharing to on;
+set gp_recursive_cte_prototype to on;
 --end_ignore
 
 -- Basic WITH


### PR DESCRIPTION
In Greenplum 5.X the recursive CTE feature was hidden behind a GUC as
it wasn't deemed of production quality just yet. Commit 20152cbf6a30e
removed that GUC in order to make stabilization work easier, there are
still enough rough edges to not consider recursive CTE a feature which
is on by default. This brings back the GUC using the same name in order
to be backwards compatible even though "prototype" is a bit misleading
as this point.

Also adds a test and tidies up a few comments in surrounding code.

Discussion: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/Lt6l3wDyxTY
Co-authored-by: Georgios Kokolatos <gkokolatos@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
