### PR TITLE
Remove disabled code in set_plan_references_input_asserts()

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -182,7 +182,6 @@ static void set_plan_references_input_asserts(PlannerGlobal *glob, Plan *plan, L
 	/* Ensure that plan refers to vars that have varlevelsup = 0 AND varno is in the rtable */
 	List *allVars = extract_nodes(glob, (Node *) plan, T_Var);
 	ListCell *lc = NULL;
-	List *allParams;
 
 	foreach (lc, allVars)
 	{
@@ -220,41 +219,6 @@ static void set_plan_references_input_asserts(PlannerGlobal *glob, Plan *plan, L
 		}
 
 	}
-
-	/* Ensure that all params that the plan refers to has a corresponding subplan */
-	allParams = extract_nodes(glob, (Node *) plan, T_Param);
-
-	// GPDB_93_MERGE_FIXME: this stopped working, when 'paramlist' was removed from
-	// PlannerGlobal. I think list_length(glob->paramlist) should now be glob->nParamExec,
-	// but how do you get the individal params? In boundParams perhaps?
-#if 0
-	foreach (lc, allParams)
-	{
-		Param *param = lfirst(lc);
-		if (param->paramkind == PARAM_EXEC)
-		{
-			Assert(param->paramid < list_length(glob->paramlist) && "Parameter ID outside range of parameters known at the global level.");
-			PlannerParamItem *paramItem = list_nth(glob->paramlist, param->paramid);
-			Assert(paramItem);
-
-			if (IsA(paramItem->item, Var))
-			{
-				Var *var = (Var *) paramItem->item;
-				Assert(param->paramtype == var->vartype && "Parameter type and var type do not match!");
-			}
-			else if (IsA(paramItem->item, Aggref))
-			{
-				Aggref *aggRef = (Aggref *) paramItem->item;
-				Assert(param->paramtype == aggRef->aggtype && "Param type and aggref type do not match!");
-			}
-			else
-			{
-				Assert("Global PlannerParamItem is not a var or an aggref node");
-			}
-		}
-	}
-#endif
-
 }
 
 /**


### PR DESCRIPTION
This commit removes GPDB_93_MERGE_FIXME introduced while including
46c508fbcf from upstream. The intention of the upstream commit is
to keep planner params separated so that they don't get reused
incorrectly. In doing so, it removed the need for a global list of
PlannerParamItems.

The removed assertion in this commit was verifying that each Param
in the tree was included in a global list of PlannerParamItems, and
that each datatype of each Param matches that in the global list.

At the time of the assertion, we simply don't have the necessary
information to be able to verify properly. An argument could be made
for re-introducing such a global list PlannerParamItems. However
this assertion would not verify that a parameter is ancored in the
right place and it would introduce additional code to maintain.

