### PR TITLE
Update comment for postponing qual for SEMI JOIN

### DIFF
--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -1021,6 +1021,11 @@ deconstruct_recurse(PlannerInfo *root, Node *jtnode, bool below_outer_join,
 				 *
 				 * select * from A where exists (select * from B where A.i in
 				 * (select C.i from C where C.i = B.i));
+				 *
+				 * We are unsure if postponing quals past a semi-join is always
+				 * semantically correct, see discussion on mailing list here:
+				 * "Regarding postponing quals past an semi join"
+				 * https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/YHYNIUZnecI/Rlum0VD3FwAJ
 				 */
 				Assert(j->jointype == JOIN_INNER || j->jointype == JOIN_SEMI);
 				*postponed_qual_list = lappend(*postponed_qual_list, pq);


### PR DESCRIPTION
We added to the FIXME comment a link to an outstanding discussion on gpdb-dev mailing list about whether or not it is correct for semi-join to have quals deferred like this. If it is not, then the code should be changed and the assert can go back to the same as upstream. If it is, then the assert is right.

Co-authored-by: Melanie Plageman <mplageman@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
