### PR TITLE
Align transaction log manager (xlog.c and xlog.h) to upstream.

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -112,8 +112,6 @@ int			max_prepared_xacts = 0;
  */
 #define GIDSIZE 200
 
-extern List *expectedTLIs;
-
 typedef struct GlobalTransactionData
 {
 	GlobalTransaction next;		/* list link for free list */
@@ -1414,15 +1412,6 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
 		 "FinishPreparedTransaction(): got xid %d for gid '%s'", xid, gid);
-
-    /*
-     * Check for recovery control file, and if so set up state for offline
-     * recovery
-     */
-	readRecoveryCommandFile();
-
-    /* Now we can determine the list of expected TLIs */
-    expectedTLIs = readTimeLineHistory(ThisTimeLineID);
 
     /* get the two phase information from the xlog */
 	/*

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -293,7 +293,6 @@ static bool recoveryStopAfter;
  */
 static TimeLineID recoveryTargetTLI;
 static bool recoveryTargetIsLatest = false; // GPDB_93_MERGE_FIXME: should this be set somewhere?
-List *expectedTLIs;
 
 static List *expectedTLEs;
 static TimeLineID curFileTLI;
@@ -800,6 +799,7 @@ static bool bgwriterLaunched = false;
 static int	MyLockNo = 0;
 static bool holdingAllLocks = false;
 
+static void readRecoveryCommandFile(void);
 static void exitArchiveRecovery(TimeLineID endTLI, XLogSegNo endLogSegNo);
 static bool recoveryStopsBefore(XLogRecord *record);
 static bool recoveryStopsAfter(XLogRecord *record);
@@ -5215,7 +5215,7 @@ str_time(pg_time_t tnow)
  *
  * The file is parsed using the main configuration parser.
  */
-void
+static void
 readRecoveryCommandFile(void)
 {
 	FILE	   *fd;

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2172,21 +2172,6 @@ initMasks(fd_set *rmask)
 }
 
 /*
- * Check to see if we're a mirror, and if we are: (1) Assume that we are
- * running as superuser; (2) No data pages need to be accessed by this backend
- * - no snapshot / transaction needed.
- *
- * The recovery.conf file is renamed to recovery.done at the end of xlog
- * replay.  Normal backends can be created thereafter.
- */
-static bool
-IsRoleMirror(void)
-{
-	struct stat stat_buf;
-	return (stat(RECOVERY_COMMAND_FILE, &stat_buf) == 0);
-}
-
-/*
  * Once the flag is reset, libpq connections (e.g. FTS probe requests) should
  * not get CAC_MIRROR_READY response.  This flag is needed during GPDB startup
  * to enable "pg_ctl -w".  It need not interfere during or after promotion.
@@ -5775,20 +5760,6 @@ sigusr1_handler(SIGNAL_ARGS)
 	PG_SETMASK(&UnBlockSig);
 
 	errno = save_errno;
-}
-
-/*
- * GPDB_90_MERGE_FIXME: This function should be removed once hot
- * standby can and will be enabled for mirrors.
- */
-void SignalPromote(void)
-{
-	FILE *fd;
-	if ((fd = fopen(PROMOTE_SIGNAL_FILE, "w")))
-	{
-		fclose(fd);
-		kill(PostmasterPid, SIGUSR1);
-	}
 }
 
 /*

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -373,7 +373,6 @@ extern void do_pg_abort_backup(void);
 #define BACKUP_LABEL_OLD		"backup_label.old"
 
 /* Greenplum additions */
-extern void readRecoveryCommandFile(void);
 extern List *XLogReadTimeLineHistory(TimeLineID targetTLI);
 extern bool IsStandbyMode(void);
 extern DBState GetCurrentDBState(void);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -66,19 +66,9 @@ typedef struct XLogRecord
 #define XLogRecGetData(record)	((char*) (record) + SizeOfXLogRecord)
 
 /*
- * XLOG uses only low 4 bits of xl_info. High 4 bits may be used by rmgr.
- * XLR_CHECK_CONSISTENCY bits can be passed by XLogInsert caller.
+ * XLOG uses only low 4 bits of xl_info.  High 4 bits may be used by rmgr.
  */
 #define XLR_INFO_MASK			0x0F
-
-/*
- * Enforces consistency checks of replayed WAL at recovery. If enabled,
- * each record will log a full-page write for each block modified by the
- * record and will reuse it afterwards for consistency checks. The caller
- * of XLogInsert can use this value if necessary, but if
- * wal_consistency_checking is enabled for a rmgr this is set unconditionally.
- */
-#define XLR_CHECK_CONSISTENCY 0x02
 
 /*
  * If we backed up any disk blocks with the XLOG record, we use flag bits in
@@ -207,9 +197,6 @@ extern char *XLogArchiveCommand;
 extern bool EnableHotStandby;
 extern bool gp_keep_all_xlog;
 
-extern bool *wal_consistency_checking;
-extern char *wal_consistency_checking_string;
-
 extern bool fullPageWrites;
 extern bool wal_log_hints;
 extern bool log_checkpoints;
@@ -300,12 +287,6 @@ typedef struct CheckpointStatsData
 
 extern CheckpointStatsData CheckpointStats;
 
-/* File path names (all relative to $PGDATA) */
-#define RECOVERY_COMMAND_FILE	"recovery.conf"
-#define RECOVERY_COMMAND_DONE	"recovery.done"
-#define PROMOTE_SIGNAL_FILE "promote"
-#define FALLBACK_PROMOTE_SIGNAL_FILE "fallback_promote"
-
 extern XLogRecPtr XLogInsert(RmgrId rmid, uint8 info, XLogRecData *rdata);
 extern XLogRecPtr XLogInsert_OverrideXid(RmgrId rmid, uint8 info, XLogRecData *rdata, TransactionId overrideXid);
 extern XLogRecPtr XLogLastInsertBeginLoc(void);
@@ -334,7 +315,6 @@ extern void UnpackCheckPointRecord(struct XLogRecord *record, CheckpointExtended
 
 extern void issue_xlog_fsync(int fd, XLogSegNo segno);
 
-
 extern bool RecoveryInProgress(void);
 extern bool HotStandbyActive(void);
 extern bool HotStandbyActiveInReplay(void);
@@ -357,8 +337,6 @@ extern Size XLOGShmemSize(void);
 extern void XLOGShmemInit(void);
 extern void BootStrapXLOG(void);
 extern void StartupXLOG(void);
-extern bool XLogStartupMultipleRecoveryPassesNeeded(void);
-extern bool XLogStartupIntegrityCheckNeeded(void);
 extern void ShutdownXLOG(int code, Datum arg);
 extern void InitXLOGAccess(void);
 extern void CreateCheckPoint(int flags);
@@ -401,5 +379,8 @@ extern bool IsStandbyMode(void);
 extern DBState GetCurrentDBState(void);
 extern XLogRecPtr last_xlog_replay_location(void);
 extern void wait_for_mirror(void);
+extern bool IsRoleMirror(void);
+extern void SignalPromote(void);
+
 
 #endif   /* XLOG_H */

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -60,7 +60,6 @@ extern int	MaxLivePostmasterChildren(void);
 extern int	GetNumShmemAttachedBgworkers(void);
 extern bool PostmasterMarkPIDForWorkerNotify(int);
 
-extern void SignalPromote(void);
 extern void ResetMirrorReadyFlag(void);
 
 #ifdef EXEC_BACKEND


### PR DESCRIPTION
Lot of differences collected over the years compared to upstream. Some
confusing or redundant code as well hence better to make it match
upstream.

Also have this as separate commit " Avoid FinishPreparedTransaction() calling readRecoveryCommandFile()" to seek special attention.
Not sure why we had FinishPreparedTransaction() calling readRecoveryCommandFile(), seems serves no purpose to me. Seems to exist from ages and wasn't able to find the rational for the same, definitely not with current code. Seems unnecessary performance hit on every commit to read and parse the file. Any ideas please let me know.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
