### PR TITLE
Remove fixme comment as it is not relative to the merge itself

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -368,8 +368,6 @@ SetTransactionIdLimit(TransactionId oldest_datfrozenxid, Oid oldest_datoid)
 	 * clients that won't pay attention to warnings. (No, we're not gonna make
 	 * this configurable.  If you know enough to configure it, you know enough
 	 * to not get in this kind of trouble in the first place.)
-	 *
-	 * GPDB_94_MERGE_FIXME: well, we've made it configurable anyway. Not sure why.
 	 */
 	xidWarnLimit = xidStopLimit  - (TransactionId)xid_warn_limit;
 	if (xidWarnLimit < FirstNormalTransactionId)


### PR DESCRIPTION
However, it correctly identifies that xidWarnLimit should not be
configurable. The same should also apply for xidStopLimit. The GUCs
for those were added in time immemorial, i.e. significantly before
greenplum was opensourced, with a commit message clearly identifying
their addition as a one shot hotfix.

A proposal for their depracation has been made in the forum.

Co-authored-by: Daniel Gustafsson <dgustafsson@pivotal.io>
