### PR TITLE
Docs/psql9.0 docs merge a

### DIFF
--- a/gpdb-doc/dita/ref_guide/GPReferenceSQLSummaryLOP.xml
+++ b/gpdb-doc/dita/ref_guide/GPReferenceSQLSummaryLOP.xml
@@ -30,6 +30,13 @@
 		<codeblock conref="sql_commands/ALTER_DATABASE.xml#topic1/sql_command_synopsis"/>
 		<p otherprops="op-html">See <xref href="sql_commands/ALTER_DATABASE.xml"/> for more
 			information.</p>
+		<section>
+			<title>ALTER DEFAULT PRIVILEGES</title>
+		</section>
+		<p conref="sql_commands/ALTER_DEFAULT_PRIVILEGES.xml#topic1/sql_command_desc"/>
+		<codeblock conref="sql_commands/ALTER_DEFAULT_PRIVILEGES.xml#topic1/sql_command_synopsis"/>
+		<p otherprops="op-html">See <xref href="sql_commands/ALTER_DEFAULT_PRIVILEGES.xml"/> for
+			more information.</p>
 		<section id="ae1903335">
 			<title>ALTER DOMAIN</title>
 		</section>

--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -12,6 +12,7 @@
 			<topicref href="sql_commands/ALTER_AGGREGATE.xml"/>
 			<topicref href="sql_commands/ALTER_CONVERSION.xml"/>
 			<topicref href="sql_commands/ALTER_DATABASE.xml"/>
+			<topicref href="sql_commands/ALTER_DEFAULT_PRIVILEGES.xml"/>
 			<topicref href="sql_commands/ALTER_DOMAIN.xml"/>
 			<topicref href="sql_commands/ALTER_EXTENSION.xml"/>
 			<topicref href="sql_commands/ALTER_EXTERNAL_TABLE.xml"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_DEFAULT_PRIVILEGES.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_DEFAULT_PRIVILEGES.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1">
+ <title>ALTER DEFAULT PRIVILEGES</title>
+<body>
+  <p id="sql_command_desc">Changes default access privileges.</p>
+<section id="section2">
+ <title>Synopsis</title>
+<codeblock id="sql_command_synopsis">
+ALTER DEFAULT PRIVILEGES
+    [ FOR { ROLE | USER } <varname>target_role</varname> [, ...] ]
+    [ IN SCHEMA <varname>schema_name</varname> [, ...] ]
+    <varname>abbreviated_grant_or_revoke</varname>
+
+where <varname>abbreviated_grant_or_revoke</varname> is one of:
+
+GRANT { { SELECT | INSERT | UPDATE | DELETE | TRUNCATE | REFERENCES | TRIGGER }
+    [, ...] | ALL [ PRIVILEGES ] }
+    ON TABLES
+    TO { [ GROUP ] <varname>role_name</varname> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+
+GRANT { { USAGE | SELECT | UPDATE }
+    [, ...] | ALL [ PRIVILEGES ] }
+    ON SEQUENCES
+    TO { [ GROUP ] <varname>role_name</varname> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+
+GRANT { EXECUTE | ALL [ PRIVILEGES ] }
+    ON FUNCTIONS
+    TO { [ GROUP ] <varname>role_name</varname> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+
+GRANT { USAGE | ALL [ PRIVILEGES ] }
+    ON TYPES
+    TO { [ GROUP ] <varname>role_name</varname> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+
+REVOKE [ GRANT OPTION FOR ]
+    { { SELECT | INSERT | UPDATE | DELETE | TRUNCATE | REFERENCES | TRIGGER }
+    [, ...] | ALL [ PRIVILEGES ] }
+    ON TABLES
+    FROM { [ GROUP ] <varname>role_name</varname> | PUBLIC } [, ...]
+    [ CASCADE | RESTRICT ]
+
+REVOKE [ GRANT OPTION FOR ]
+    { { USAGE | SELECT | UPDATE }
+    [, ...] | ALL [ PRIVILEGES ] }
+    ON SEQUENCES
+    FROM { [ GROUP ] <varname>role_name</varname> | PUBLIC } [, ...]
+    [ CASCADE | RESTRICT ]
+
+REVOKE [ GRANT OPTION FOR ]
+    { EXECUTE | ALL [ PRIVILEGES ] }
+    ON FUNCTIONS
+    FROM { [ GROUP ] <varname>role_name</varname> | PUBLIC } [, ...]
+    [ CASCADE | RESTRICT ]
+
+REVOKE [ GRANT OPTION FOR ]
+    { USAGE | ALL [ PRIVILEGES ] }
+    ON TYPES
+    FROM { [ GROUP ] <varname>role_name</varname> | PUBLIC } [, ...]
+    [ CASCADE | RESTRICT ]
+</codeblock>
+</section>
+ <section id="section3">
+  <title>Description</title>
+
+  <p>
+   <codeph>ALTER DEFAULT PRIVILEGES</codeph> allows you to set the privileges
+   that will be applied to objects created in the future.  (It does not
+   affect privileges assigned to already-existing objects.)  Currently,
+   only the privileges for tables (including views and foreign tables),
+   sequences, functions, and types (including domains) can be altered.
+  </p>
+
+  <p>
+   You can change default privileges only for objects that will be created by
+   yourself or by roles that you are a member of.  The privileges can be set
+   globally (i.e., for all objects created in the current database),
+   or just for objects created in specified schemas.  Default privileges
+   that are specified per-schema are added to whatever the global default
+   privileges are for the particular object type.
+  </p>
+
+  <p>
+   As explained under <xref href="GRANT.xml" format="dita"/>,
+   the default privileges for any object type normally grant all grantable
+   permissions to the object owner, and may grant some privileges to
+   <codeph>PUBLIC</codeph> as well.  However, this behavior can be changed by
+   altering the global default privileges with
+   <codeph>ALTER DEFAULT PRIVILEGES</codeph>.
+  </p>
+ </section>
+ <section>
+  <title>Parameters</title>
+
+  <parml>
+   <plentry>
+    <pt><varname>target_role</varname></pt>
+    <pd>
+      The name of an existing role of which the current role is a member.
+      If <codeph>FOR ROLE</codeph> is omitted, the current role is assumed.
+    </pd>
+   </plentry>
+
+   <plentry>
+    <pt><varname>schema_name</varname></pt>
+    <pd> The name of an existing schema. If specified, the default privileges are altered for
+      objects later created in that schema. If <codeph>IN SCHEMA</codeph> is omitted, the global
+      default privileges are altered. </pd>
+   </plentry>
+
+   <plentry>
+    <pt><varname>role_name</varname></pt>
+    <pd> The name of an existing role to grant or revoke privileges for. This parameter, and all the
+      other parameters in <varname>abbreviated_grant_or_revoke</varname>, act as described under
+       <xref href="GRANT.xml" format="dita"/> or <xref href="REVOKE.xml" format="dita"/>, except
+      that one is setting permissions for a whole class of objects rather than specific named
+      objects. </pd>
+   </plentry>
+  </parml>
+ </section>
+
+
+ <section id="sql-alterdefaultprivileges-notes">
+  <title>Notes</title>
+
+  <p> Use <xref href="../../utility_guide/client_utilities/psql.xml" scope="peer" format="dita">psql</xref>'s
+     <codeph>\ddp</codeph> command to obtain information about existing assignments of default
+    privileges. The meaning of the privilege values is the same as explained for
+     <codeph>\dp</codeph> under <xref href="GRANT.xml"/>. </p>
+
+  <p>
+   If you wish to drop a role for which the default privileges have been
+   altered, it is necessary to reverse the changes in its default privileges
+   or use <codeph>DROP OWNED BY</codeph> to get rid of the default privileges entry
+   for the role.
+  </p>
+ </section>
+
+ <section id="sql-alterdefaultprivileges-examples">
+  <title>Examples</title>
+
+  <p>
+   Grant SELECT privilege to everyone for all tables (and views) you
+   subsequently create in schema <codeph>myschema</codeph>, and allow
+   role <codeph>webuser</codeph> to INSERT into them too:
+
+<codeblock>
+ALTER DEFAULT PRIVILEGES IN SCHEMA myschema GRANT SELECT ON TABLES TO PUBLIC;
+ALTER DEFAULT PRIVILEGES IN SCHEMA myschema GRANT INSERT ON TABLES TO webuser;
+</codeblock>
+  </p>
+
+  <p>
+   Undo the above, so that subsequently-created tables won't have any
+   more permissions than normal:
+
+<codeblock>
+ALTER DEFAULT PRIVILEGES IN SCHEMA myschema REVOKE SELECT ON TABLES FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES IN SCHEMA myschema REVOKE INSERT ON TABLES FROM webuser;
+</codeblock>
+  </p>
+
+  <p>
+   Remove the public EXECUTE permission that is normally granted on functions,
+   for all functions subsequently created by role <codeph>admin</codeph>:
+
+<codeblock>
+ALTER DEFAULT PRIVILEGES FOR ROLE admin REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+</codeblock></p>
+ </section>
+
+ <section>
+  <title>Compatibility</title>
+
+  <p>
+   There is no <codeph>ALTER DEFAULT PRIVILEGES</codeph> statement in the SQL
+   standard.
+  </p>
+ </section>
+
+ <section id="see-also">
+  <title>See Also</title>
+
+  <p>
+   <codeph><xref href="GRANT.xml" format="dita"/></codeph>, 
+   <codeph><xref href="REVOKE.xml" format="dita"/></codeph>
+  </p>
+ </section>
+</body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_ROLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_ROLE.xml
@@ -26,11 +26,12 @@ ALTER ROLE <varname>name</varname> [ [WITH] <varname>option</varname> [ ... ] ]<
     | CREATEUSER | NOCREATEUSER
     | CREATEEXTTABLE | NOCREATEEXTTABLE 
       [ ( <varname>attribute</varname>='<varname>value</varname>'[, ...] ) ]
-           where <varname>attributes</varname> and <varname>value</varname> are:
+           where <varname>attribute</varname> and <varname>value</varname> are:
            type='readable'|'writable'
            protocol='gpfdist'|'http'
     | INHERIT | NOINHERIT
     | LOGIN | NOLOGIN
+    | REPLICATE | NOREPLICATION
     | CONNECTION LIMIT <varname>connlimit</varname>
     | [ENCRYPTED | UNENCRYPTED] PASSWORD '<varname>password</varname>'
     | VALID UNTIL '<varname>timestamp</varname>'
@@ -106,16 +107,17 @@ ALTER ROLE <varname>name</varname> [ [WITH] <varname>option</varname> [ ... ] ]<
         </plentry>
         <plentry>
           <pt><varname>config_parameter=value</varname></pt>
-          <pd>Set this role's session default for the specified configuration
-            parameter to the given value. If <varname>value</varname> is
-              <codeph>DEFAULT</codeph> or if <codeph>RESET</codeph> is used, the
-            role-specific variable setting is removed, so the role will inherit
-            the system-wide default setting in new sessions. Use <codeph>RESET
-              ALL</codeph> to clear all role-specific settings. <codeph>SET FROM
-              CURRENT</codeph> saves the session's current value of the
-            parameter as the role-specific value. If <codeph>IN
-              DATABASE</codeph> is specified, the configuration parameter is set
-            or removed for the given role and database only. </pd>
+          <pd>Set this role's session default for the specified configuration parameter to the given
+            value. If <varname>value</varname> is <codeph>DEFAULT</codeph> or if
+              <codeph>RESET</codeph> is used, the role-specific parameter setting is removed, so the
+            role will inherit the system-wide default setting in new sessions. Use <codeph>RESET
+              ALL</codeph> to clear all role-specific settings. <codeph>SET FROM CURRENT</codeph>
+            saves the session's current value of the parameter as the role-specific value. If
+              <codeph>IN DATABASE</codeph> is specified, the configuration parameter is set or
+            removed for the given role and database only.  Whenever the role subsequently starts a
+            new session, the specified value becomes the session default, overriding whatever
+            setting is present in <codeph>postgresql.conf</codeph> or has been received from the
+            command line.</pd>
           <pd>Role-specific variable settings take effect only at login;
               <codeph>SET ROLE</codeph> does not process role-specific variable
             settings. </pd>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -29,14 +29,14 @@ ALTER TABLE <varname>name</varname>
                         <codeblock>  ADD [COLUMN] <varname>column_name type</varname> [ DEFAULT <varname>default_expr</varname> ]
       [<varname>column_constraint</varname> [ ... ]]
       [ ENCODING ( <varname>storage_directive</varname> [,...] ) ]
-  DROP [COLUMN] <varname>column</varname> [RESTRICT | CASCADE]
+  DROP [COLUMN] [IF EXISTS] <varname>column</varname> [RESTRICT | CASCADE]
   ALTER [COLUMN] <varname>column</varname> [ SET DATA ] TYPE <varname>type</varname> [USING <varname>expression</varname>]
   ALTER [COLUMN] <varname>column</varname> SET DEFAULT <varname>expression</varname>
   ALTER [COLUMN] <varname>column</varname> DROP DEFAULT
   ALTER [COLUMN] <varname>column</varname> { SET | DROP } NOT NULL
   ALTER [COLUMN] <varname>column</varname> SET STATISTICS <varname>integer</varname>
   ADD <varname>table_constraint</varname>
-  DROP CONSTRAINT <varname>constraint_name</varname> [RESTRICT | CASCADE]
+  DROP CONSTRAINT [IF EXISTS] <varname>constraint_name</varname> [RESTRICT | CASCADE]
   DISABLE TRIGGER [<varname>trigger_name</varname> | ALL | USER]
   ENABLE TRIGGER [<varname>trigger_name</varname> | ALL | USER]
   CLUSTER ON <varname>index_name</varname>
@@ -119,14 +119,16 @@ ALTER TABLE <varname>name</varname>
                                                 TABLE</xref></codeph>. The <codeph>ENCODING</codeph>
                                         clause is valid only for append-optimized, column-oriented
                                         tables.</li>
-                                <li><b>DROP COLUMN</b> — Drops a column from a table. Note that if
-                                        you drop table columns that are being used as the Greenplum
-                                        Database distribution key, the distribution policy for the
-                                        table will be changed to <codeph>DISTRIBUTED
-                                                RANDOMLY</codeph>. Indexes and table constraints
-                                        involving the column will be automatically dropped as well.
-                                        You will need to say <codeph>CASCADE</codeph> if anything
-                                        outside the table depends on the column (such as views). </li>
+                                <li><b>DROP COLUMN [IF EXISTS]</b> — Drops a column from a table. 
+                                        Note that if you drop table columns that are being used as 
+                                        the Greenplum Database distribution key, the distribution 
+                                        policy for the table will be changed to <codeph>DISTRIBUTED
+                                        RANDOMLY</codeph>. Indexes and table constraints
+                                        involving the column are automatically dropped as well.
+                                        You need to say <codeph>CASCADE</codeph> if anything
+                                        outside the table depends on the column (such as views). If 
+                                        <codeph>IF EXISTS</codeph> is specified and the column does 
+                                        not exist, no error is thrown; a notice is issued instead.</li>
                                 <li id="ay136879"><b>SET DATA TYPE</b> — This form changes the data
                                         type of a column of a table. Note that you cannot alter
                                         column data types that are being used as distribution or
@@ -154,14 +156,33 @@ ALTER TABLE <varname>name</varname>
                                 <li id="ay136944"><b>SET STATISTICS</b> — Sets the per-column
                                         statistics-gathering target for subsequent
                                                 <codeph>ANALYZE</codeph> operations. The target can
-                                        be set in the range 1 to 1000, or set to -1 to revert to
+                                        be set in the range 100 to 10000, or set to -1 to revert to
                                         using the system default statistics target
                                                 (<codeph>default_statistics_target</codeph>).</li>
+                                <li><b>SET STATISTICS DISTINCT</b> — Overrides the
+                                        number-of-distinct-values estimate made by subsequent
+                                                <codeph>ANALYZE</codeph> operations. When set to a
+                                        positive value, <codeph>ANALYZE</codeph> will assume that
+                                        the column contains exactly the specified number of distinct
+                                        non-null values. When set to a negative value, which must be
+                                        greater than or equal to -1, <codeph>ANALYZE</codeph> will
+                                        assume that the number of distinct non-null values in the
+                                        column is linear in the size of the table; the exact count
+                                        is to be computed by multiplying the estimated table size by
+                                        the absolute value of the given number. For example, a value
+                                        of -1 implies that all values in the column are distinct,
+                                        while a value of -0.5 implies that each value appears twice
+                                        on the average. This can be useful when the size of the
+                                        table changes over time, since the multiplication by the
+                                        number of rows in the table is not performed until query
+                                        planning time. Specify a value of 0 to revert to estimating
+                                        the number of distinct values normally.</li>
                                 <li id="ay137022"><b>ADD <varname>table_constraint</varname></b> —
                                         Adds a new constraint to a table (not just a partition)
                                         using the same syntax as <codeph>CREATE TABLE</codeph>. </li>
-                                <li id="ay137038"><b>DROP CONSTRAINT</b> — Drops the specified
-                                        constraint on a table.</li>
+                                <li id="ay137038"><b>DROP CONSTRAINT [IF EXISTS]</b> — Drops the
+                                        specified constraint on a table. If <codeph>IF EXISTS</codeph> is specified and the constraint
+                                        does not exist, no error is thrown. In this case a notice is issued instead.</li>
                                 <li id="ay137055"><b>DISABLE/ENABLE TRIGGER</b> — Disables or
                                         enables trigger(s) belonging to the table. A disabled
                                         trigger is still known to the system, but is not executed
@@ -306,7 +327,11 @@ ALTER TABLE <varname>name</varname>
                                                 If the <codeph>ONLY</codeph> keyword is not used,
                                                 the operation will be performed on the named table
                                                 and any child table partitions associated with that
-                                                table.</pd>
+                                                table. Adding or dropping a column, or changing a
+                                                column's type in a parent or descendant table only
+                                                is not permitted. The parent table and its
+                                                descendents must always have the same columns and
+                                                types.</pd>
                                 </plentry>
                                 <plentry>
                                         <pt>
@@ -339,7 +364,7 @@ ALTER TABLE <varname>name</varname>
                                         <pt>
                                                 <varname>new_column</varname>
                                         </pt>
-                                        <pd>New name for an existing column. </pd>
+                                        <pd>New name for an existing column.</pd>
                                 </plentry>
                                 <plentry>
                                         <pt>
@@ -760,9 +785,10 @@ ALTER TABLE <varname>name</varname>
                                 semantically-visible change in the table, but the command forces
                                 rewriting, which gets rid of no-longer-useful data.</p>
                         <p>If a table is partitioned or has any descendant tables, it is not
-                                permitted to add, rename, or change the type of a column in the
-                                parent table without doing the same to the descendants. This ensures
-                                that the descendants always have columns matching the parent. </p>
+                                permitted to add or drop a column, to rename a column, or to change
+                                the type of a column in the parent table without doing the same to
+                                the descendants. This ensures that the descendants always have
+                                columns matching the parent. </p>
                         <p>To see the structure of a partitioned table, you can use the view
                                                 <codeph><xref
                                                 href="../system_catalogs/pg_partitions.xml"

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -327,11 +327,11 @@ ALTER TABLE <varname>name</varname>
                                                 If the <codeph>ONLY</codeph> keyword is not used,
                                                 the operation will be performed on the named table
                                                 and any child table partitions associated with that
-                                                table. Adding or dropping a column, or changing a
-                                                column's type in a parent or descendant table only
-                                                is not permitted. The parent table and its
-                                                descendents must always have the same columns and
-                                                types.</pd>
+                                                table. <note>Adding or dropping a column, or
+                                                  changing a column's type, in a parent or
+                                                  descendant table only is not permitted. The parent
+                                                  table and its descendents must always have the
+                                                  same columns and types.</note></pd>
                                 </plentry>
                                 <plentry>
                                         <pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_CAST.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_CAST.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic1"><title id="bn20941">CREATE CAST</title><body><p id="sql_command_desc">Defines a new cast.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">CREATE CAST (<varname>sourcetype</varname> AS <varname>targettype</varname>) 
-       WITH FUNCTION <varname>funcname</varname> (<varname>argtypes</varname>) 
+       WITH FUNCTION <varname>funcname</varname> (<varname>argtype</varname> [, ...]) 
        [AS ASSIGNMENT | AS IMPLICIT]
 
 CREATE CAST (<varname>sourcetype</varname> AS <varname>targettype</varname>)
@@ -83,7 +83,8 @@ made explicit-only. </p>
 <p>To be able to create a cast, you must own the source or the target
   data type and have <codeph>USAGE</codeph> privilege on the other type. To
   create a binary-coercible cast, you must be superuser.</p></section>
-<section id="section4"><title>Parameters</title><parml><plentry><pt><varname>sourcetype</varname></pt><pd>The name of the source data type of the cast. </pd></plentry><plentry><pt><varname>targettype</varname></pt><pd>The name of the target data type of the cast. </pd></plentry><plentry><pt><varname>funcname(argtypes)</varname></pt><pd>The function used to perform the cast. The function name may be schema-qualified.
+<section id="section4"><title>Parameters</title><parml><plentry><pt><varname>sourcetype</varname></pt><pd>The name of the source data type of the cast. </pd></plentry><plentry><pt><varname>targettype</varname></pt><pd>The name of the target data type of the cast. </pd></plentry><plentry><pt><varname>funcname</varname>(<varname>argtype</varname> [, ...])</pt>
+  <pd>The function used to perform the cast. The function name may be schema-qualified.
 If it is not, Greenplum Database looks for the function in the schema search path.
 The function's result data type must match the target type of the cast.</pd><pd>Cast implementation functions may have one to three arguments. The first argument type must be
             identical to or binary-coercible from the cast's source type. The second

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_DATABASE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_DATABASE.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="bp20941">CREATE DATABASE</title><body><p id="sql_command_desc">Creates a new database.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">CREATE DATABASE name [ [WITH] [OWNER [=] <varname>dbowner</varname>]
+<topic id="topic1"><title id="bp20941">CREATE DATABASE</title><body><p id="sql_command_desc">Creates a new database.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">CREATE DATABASE name [ [WITH] [OWNER [=] <varname>user_name</varname>]
                      [TEMPLATE [=] <varname>template</varname>]
                      [ENCODING [=] <varname>encoding</varname>]
                      [LC_COLLATE [=] <varname>lc_collate</varname>]
@@ -18,7 +18,7 @@ only create databases owned by themselves.</p><p>By default, the new database wi
           <codeph>TEMPLATE <varname>name</varname></codeph>. In particular, by writing <codeph>TEMPLATE
           template0</codeph>, you can create a clean database containing only the standard objects
         predefined by Greenplum Database. This is useful if you wish to avoid copying any
-        installation-local objects that may have been added to <codeph>template1</codeph>. </p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name of a database to create.</pd></plentry><plentry><pt><varname>dbowner</varname></pt><pd>The name of the database user who will own the new database, or <codeph>DEFAULT</codeph>
+        installation-local objects that may have been added to <codeph>template1</codeph>. </p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name of a database to create.</pd></plentry><plentry><pt><varname>user_name</varname></pt><pd>The name of the database user who will own the new database, or <codeph>DEFAULT</codeph>
 to use the default owner (the user executing the command). </pd></plentry><plentry><pt><varname>template</varname></pt><pd>The name of the template from which to create the new database, or
 <codeph>DEFAULT</codeph> to use the default template (<varname>template1</varname>).
 </pd></plentry><plentry><pt><varname>encoding</varname></pt><pd>Character set encoding to use in the new database. Specify a string constant (such as

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FUNCTION.xml
@@ -7,10 +7,9 @@
         <p id="sql_command_desc">Defines a new function.</p>
         <section id="section2"
             ><title>Synopsis</title><codeblock id="sql_command_synopsis">CREATE [OR REPLACE] FUNCTION <varname>name</varname>    
-    ( [ [<varname>argmode</varname>] [<varname>argname</varname>] <varname>argtype</varname> [ { DEFAULT | = } <varname>defexpr</varname> ] [, ...] ] )
-      [ RETURNS { [ SETOF ] rettype 
-        | TABLE ([{ <varname>column_name</varname> <varname>column_type</varname> [, ...] ] | LIKE <varname>other_table</varname> } )
-        } ]
+    ( [ [<varname>argmode</varname>] [<varname>argname</varname>] <varname>argtype</varname> [ { DEFAULT | = } <varname>default_expr</varname> ] [, ...] ] )
+      [ RETURNS <varname>rettype</varname> 
+        | RETURNS TABLE ( <varname>column_name</varname> <varname>column_type</varname> [, ...] ) ]
     { LANGUAGE <varname>langname</varname>
     | WINDOW
     | IMMUTABLE | STABLE | VOLATILE
@@ -27,15 +26,17 @@
                     FUNCTION</codeph> will either create a new function, or replace an existing
                 definition.</p><p>The name of the new function must not match any existing function with the same input argument
                 types in the same schema. However, functions of different argument types may share a
-                name (overloading). </p><p>To update the definition of an existing function, use
-                    <codeph>CREATE OR REPLACE FUNCTION</codeph>. It is not possible to change the
-                name or argument types of a function this way (this would actually create a new,
-                distinct function). Also, <codeph>CREATE OR REPLACE FUNCTION</codeph> will not let
-                you change the return type of an existing function. To do that, you must drop and
-                recreate the function. If you drop and then recreate a function, you will have to
-                drop existing objects (rules, views, triggers, and so on) that refer to the old
-                function. Use <codeph>CREATE OR REPLACE FUNCTION</codeph> to change a function
-                definition without breaking objects that refer to the function.</p><p>For more
+                name (overloading). </p><p>To update the definition of an existing function, use <codeph>CREATE OR REPLACE
+                FUNCTION</codeph>. It is not possible to change the name or argument types of a
+                function this way (this would actually create a new, distinct function). Also,
+                    <codeph>CREATE OR REPLACE FUNCTION</codeph> will not let you change the return
+                type of an existing function. To do that, you must drop and recreate the function.
+                When using <codeph>OUT</codeph> parameters, that means you cannot chnge the types of
+                any <codeph>OUT</codeph> parameters except by dropping the function.  If you drop
+                and then recreate a function, you will have to drop existing objects (rules, views,
+                triggers, and so on) that refer to the old function. Use <codeph>CREATE OR REPLACE
+                    FUNCTION</codeph> to change a function definition without breaking objects that
+                refer to the function.</p><p>For more
                 information about creating functions, see the <xref
                     href="https://www.postgresql.org/docs/8.3/xfunc.html" scope="external"
                     format="html">User Defined Functions</xref> section of the PostgreSQL
@@ -100,10 +101,12 @@ SELECT foo();</codeblock><p>In
                     <pt><varname>argname</varname></pt>
                     <pd>The name of an argument. Some languages (currently only PL/pgSQL) let you
                         use the name in the function body. For other languages the name of an input
-                        argument is just extra documentation. But the name of an output argument is
-                        significant, since it defines the column name in the result row type. (If
-                        you omit the name for an output argument, the system will choose a default
-                        column name.) </pd>
+                        argument is just extra documentation, so far as
+                        the function itself is concerned; but you can use input argument names
+                        when calling a function to improve readability. In any case, the name of 
+                        an output argument is significant, since it defines the column name in the 
+                        result row type. (If you omit the name for an output argument, the system 
+                        will choose a default column name.) </pd>
                 </plentry>
                 <plentry>
                     <pt><varname>argtype</varname></pt>
@@ -120,7 +123,7 @@ SELECT foo();</codeblock><p>In
                         to the definition of a table. </pd>
                 </plentry>
                 <plentry>
-                    <pt><varname>defexpr</varname></pt>
+                    <pt><varname>default_expr</varname></pt>
                     <pd>An expression to be used as the default value if the parameter is not
                         specified. The expression must be coercible to the argument type of the
                         parameter. Only <codeph>IN</codeph> and <codeph>INOUT</codeph> parameters
@@ -358,6 +361,16 @@ $SomeTag$Dianne's horse$SomeTag$</codeblock>
                     <codeph>STRICT</codeph>, the strictness check tests that the variadic array as a
                 whole is non-null. PL/pgSQL will still call the function if the array has null
                 elements.</p>
+            <p>When replacing an existing function with <codeph>CREATE OR REPLACE
+                FUNCTION</codeph>, there are restrictions on changing parameter names.
+                You cannot change the name already assigned to any input parameter
+                (although you can add names to parameters that had none before).
+                If there is more than one output parameter, you cannot change the
+                names of the output parameters, because that would change the
+                column names of the anonymous composite type that describes the
+                function's result. These restrictions are made to ensure that
+                existing calls of the function do not stop working when it is replaced.
+            </p>
             <sectiondiv id="section7"><b>Using Functions with Queries on Distributed Data</b><p>In
                     some cases, Greenplum Database does not support using functions in a query where
                     the data in a table specified in the <codeph>FROM</codeph> clause is distributed

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
@@ -26,6 +26,8 @@
     | IN ROLE <varname>rolename</varname> [, ...]
     | ROLE <varname>rolename</varname> [, ...]
     | ADMIN <varname>rolename</varname> [, ...]
+    | USER <varname>rolename</varname> [, ...]
+    | SYSID <varname>uid</varname> [, ...]
     | RESOURCE QUEUE <varname>queue_name</varname>
     | RESOURCE GROUP <varname>group_name</varname>
     | [ DENY <varname>deny_point</varname> ]
@@ -298,7 +300,7 @@
                 do in the standard. </p>
             <p><codeph>CREATE ROLE</codeph> is in the SQL standard, but the standard only requires
                 the syntax:</p>
-            <codeblock>CREATE ROLE name [WITH ADMIN rolename]</codeblock>
+            <codeblock>CREATE ROLE <varname>name</varname> [WITH ADMIN <varname>rolename</varname>]</codeblock>
             <p>Allowing multiple initial administrators, and all the other options of <codeph>CREATE
                     ROLE</codeph>, are Greenplum Database extensions.</p>
             <p>The behavior specified by the SQL standard is most closely approximated by giving

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -11,13 +11,11 @@
       <title>Synopsis</title>
       <codeblock id="sql_command_synopsis">CREATE [[GLOBAL | LOCAL] {TEMPORARY | TEMP}] TABLE <varname>table_name</varname> ( 
 [ { <varname>column_name</varname> <varname>data_type</varname> [ DEFAULT <varname>default_expr</varname> ] 
-   [<varname>column_constraint</varname> [ ... ]
-[ ENCODING ( <varname>storage_directive</varname> [,...] ) ]
+   [<varname>column_constraint</varname> [ ... ] [ ENCODING ( <varname>storage_directive</varname> [,...] ) ]
 ] 
    | <varname>table_constraint</varname>
-   | LIKE <varname>other_table</varname> [{INCLUDING | EXCLUDING} 
-                      {DEFAULTS | CONSTRAINTS}] ...}
-   [, ... ] ]
+   | LIKE <varname>other_table</varname> [ <varname>like_option</varname> ... }
+     [, ... ] ]
    )
    [ INHERITS ( <varname>parent_table</varname> [, ... ] ) ]
    [ WITH ( <varname>storage_parameter</varname>=<varname>value</varname> [, ... ] )
@@ -71,10 +69,13 @@
                  [WITH ( FILLFACTOR=<varname>value</varname> )] 
    | CHECK ( <varname>expression</varname> )
    | FOREIGN KEY ( <varname>column_name</varname> [, ... ] )
-            REFERENCES table_name [ ( column_name [, ... ] ) ]
+            REFERENCES <varname>table_name</varname> [ ( <varname>column_name</varname> [, ... ] ) ]
             [ <varname>key_match_type</varname> ]
             [ <varname>key_action</varname> ]
             [ <varname>key_checking_mode</varname> ]</codeblock>
+      <p>where <i>like_option</i>
+        is:<codeblock>{ INCLUDING | EXCLUDING } 
+         { DEFFAULTS | CONSTRAINTS | INDEXES | STORAGE | COMMENTS | ALL }</codeblock></p>
       <p>where <varname>key_match_type</varname> is:</p>
       <codeblock>    MATCH FULL
   | SIMPLE</codeblock>
@@ -273,12 +274,14 @@
             expression will be merged into one copy. Notice that an unnamed <codeph>CHECK</codeph>
             constraint in the new table will never be merged, since a unique name will always be
             chosen for it.</pd>
+          <pd>Column <codeph>STORAGE</codeph> settings are also copied from parent tables.</pd>
         </plentry>
         <plentry>
-          <pt>LIKE <varname>other_table</varname> [{INCLUDING | EXCLUDING} {DEFAULTS |
-            CONSTRAINTS}]</pt>
+          <pt>LIKE <varname>other_table</varname>
+            <varname>like_option</varname>
+            <codeph>...</codeph>]</pt>
           <pd>The <codeph>LIKE</codeph> clause specifies a table from which the new table
-            automatically copies all column names, data types, not-null constraints, and
+            automatically copies all column names, their data types, not-null constraints, and
             distribution policy. Storage properties like append-optimized or partition structure are
             not copied. Unlike <codeph>INHERITS</codeph>, the new table and original table are
             completely decoupled after creation is complete.</pd>
@@ -291,10 +294,33 @@
             other types of constraints will <varname>never</varname> be copied. Also, no distinction
             is made between column constraints and table constraints — when constraints are
             requested, all check constraints are copied. </pd>
-          <pd>Note also that unlike <codeph>INHERITS</codeph>, copied columns and constraints are
-            not merged with similarly named columns and constraints. If the same name is specified
-            explicitly or in another <codeph>LIKE</codeph> clause an error is signalled. </pd>
-        </plentry>
+          <pd>Any indexes on the original table will not be created on the new table, unless the
+              <codeph>INCLUDING INDEXES</codeph> clause is specified.</pd>
+          <pd><codeph>STORAGE</codeph> settings for the copied column definitions will only
+            be copied if <codeph>INCLUDING STORAGE</codeph> is specified. The
+            default behavior is to exclude <codeph>STORAGE</codeph> settings, resulting
+            in the copied columns in the new table having type-specific default
+            settings. 
+           </pd>
+           <pd>
+             Comments for the copied columns, constraints, and indexes
+             will only be copied if <codeph>INCLUDING COMMENTS</codeph>
+             is specified. The default behavior is to exclude comments, resulting in
+             the copied columns and constraints in the new table having no comments.
+           </pd>
+           <pd>
+             <codeph>INCLUDING ALL</codeph> is an abbreviated form of
+             <codeblock>INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES 
+               INCLUDING STORAGE INCLUDING COMMENTS</codeblock>
+            </pd>
+            <pd>
+              Note also that unlike <codeph>INHERITS</codeph>, columns and
+              constraints copied by <codeph>LIKE</codeph> are not merged with similarly
+              named columns and constraints.
+              If the same name is specified explicitly or in another
+              <codeph>LIKE</codeph> clause, an error is signalled.
+            </pd>
+          </plentry>
         <plentry>
           <pt>CONSTRAINT <varname>constraint_name</varname></pt>
           <pd>An optional name for a column or table constraint. If the constraint is violated, the
@@ -313,6 +339,24 @@
               <codeph>NULL</codeph> is the default.</pd>
         </plentry>
         <plentry>
+          <pt>CHECK( <varname>expression</varname> )</pt>
+          <pd>The <varname>CHECK</varname> clause specifies an expression producing a
+            Boolean result which new or updated rows must satisfy for an
+            insert or update operation to succeed. Expressions evaluating
+            to TRUE or UNKNOWN succeed. Should any row of an insert or
+            update operation produce a FALSE result an error exception is
+            raised and the insert or update does not alter the database.  A
+            check constraint specified as a column constraint should
+            reference that column's value only, while an expression
+            appearing in a table constraint can reference multiple columns.
+          </pd>
+          <pd>
+            Currently, <varname>CHECK</varname> expressions cannot contain
+            subqueries nor refer to variables other than columns of the
+            current row.
+          </pd>
+        </plentry>          
+        <plentry>
           <pt>UNIQUE ( <varname>column constraint</varname> )</pt>
           <pt>UNIQUE ( <varname>column_name</varname> [, ... ] ) ( <varname>table
               constraint</varname> )</pt>
@@ -327,6 +371,45 @@
             simple <codeph>UNIQUE INDEX</codeph>.</pd>
           <pd>For information about unique constraint management and limitations, see <xref
               href="#topic1/section5" format="dita"/>.</pd>
+        </plentry>
+        <plentry>
+          <pt>EXCLUDE [ USING <varname>index_method</varname> ] ( <varname>exclude_element</varname> WITH <varname>operator</varname> [, ... ] ) <varname>index_parameters</varname> [ WHERE ( <varname>predicate</varname> ) ]</pt>
+          <pd>The <codeph>EXCLUDE</codeph> clause defines an exclusion
+            constraint, which guarantees that if
+            any two rows are compared on the specified column(s) or
+            expression(s) using the specified operator(s), not all of these
+            comparisons will return <codeph>TRUE</codeph>. If all of the
+            specified operators test for equality, this is equivalent to a
+              <codeph>UNIQUE</codeph> constraint, although an ordinary unique constraint
+            will be faster. However, exclusion constraints can specify
+            constraints that are more general than simple equality.
+            For example, you can specify a constraint that
+            no two rows in the table contain overlapping circles
+            by using the <codeph>&amp;&amp;</codeph> operator.
+          </pd>
+          <pd>
+            Exclusion constraints are implemented using
+            an index, so each specified operator must be associated with an
+            appropriate operator class for the index access
+            method <codeph>index_method</codeph>.
+            The operators are required to be commutative.
+            Each <codeph>exclude_element</codeph>
+            can optionally specify an operator class and/or ordering options;
+            these are described fully under
+            <xref href="CREATE_INDEX.xml" format="dita"></xref>.
+          </pd>
+          <pd>
+            The access method must support <codeph>amgettuple</codeph>; at present this means GIN
+            cannot be used.  Although it's allowed, there is little point in using
+            btree or hash indexes with an exclusion constraint, because this
+            does nothing that an ordinary unique constraint doesn't do better.
+            So in practice the access method will always be GiST.
+          </pd>
+          <pd>
+             The <codeph>predicate</codeph> allows you to specify an
+             exclusion constraint on a subset of the table; internally this creates a
+             partial index. Note that parentheses are required around the predicate.                     
+          </pd>
         </plentry>
         <plentry>
           <pt>PRIMARY KEY ( <varname>column constraint</varname> )</pt>
@@ -347,26 +430,12 @@
               href="#topic1/section5" format="dita"/>.</pd>
         </plentry>
         <plentry>
-          <pt>CHECK ( <varname>expression</varname> )</pt>
-          <pd>The <codeph>CHECK</codeph> clause specifies an expression producing a Boolean result
-            which new or updated rows must satisfy for an insert or update operation to succeed.
-            Expressions evaluating to <codeph>TRUE</codeph> or <codeph>UNKNOWN</codeph> succeed.
-            Should any row of an insert or update operation produce a <codeph>FALSE</codeph> result
-            an error exception is raised and the insert or update does not alter the database. A
-            check constraint specified as a column constraint should reference that column's value
-            only, while an expression appearing in a table constraint may reference multiple
-            columns. <codeph>CHECK</codeph> expressions cannot contain subqueries nor refer to
-            variables other than columns of the current row.</pd>
-        </plentry>
-        <plentry>
           <pt>REFERENCES <varname>table_name</varname> [ ( <varname>column_name</varname> [, ... ] )
             ]</pt>
-          <pt>[<varname> key_match_type </varname>] [ <varname>key_action</varname> ]</pt>
-          <pt>FOREIGN KEY ( <varname>column_name</varname> [, ... ] )</pt>
-          <pt>   REFERENCES <varname>table_name</varname> [ ( <varname>column_name</varname> [, ...
-            ] )</pt>
-          <pt> [<varname> key_match_type </varname>] [ <varname>key_action</varname> [
-              <varname>key_checking_mode</varname> ]</pt>
+          <pt>[<varname>key_match_type</varname>] [<varname>key_action</varname>]</pt>
+          <pt>FOREIGN KEY (<varname>column_name</varname> [, ...])</pt>
+          <pt>  REFERENCES <varname>table_name</varname> [(<varname>column_name</varname> [, ...])</pt>
+          <pt>  [key_match_type] [key_action] [key_checking_mode]</pt>
           <pd>The <codeph>REFERENCES</codeph> and <codeph>FOREIGN KEY</codeph> clauses specify
             referential integrity constraints (foreign key constraints). Greenplum accepts
             referential integrity constraints as specified in PostgreSQL syntax but does not enforce
@@ -375,8 +444,9 @@
         </plentry>
         <plentry id="with_storage">
           <pt>WITH ( <varname>storage_option=value</varname> )</pt>
-          <pd>The <codeph>WITH</codeph> clause can be used to set storage options for the table or
-            its indexes. Note that you can also set storage parameters on a particular partition or
+          <pd>The <codeph>WITH</codeph> clause can specify storage parameters for tables, and for
+            indexes associated with a <codeph>UNIQUE</codeph>, <codeph>PRIMARY</codeph>, or
+            <codeph>EXCLUDE</codeph> constraint. Note that you can also set storage parameters on a particular partition or
             subpartition by declaring the <codeph>WITH</codeph> clause in the partition
             specification. The lowest-level settings have priority.</pd>
           <pd>The defaults for some of the table storage options can be specified with the server
@@ -387,7 +457,7 @@
           <pd><b>APPENDONLY</b> — Set to <codeph>TRUE</codeph> to create the table as an
             append-optimized table. If <codeph>FALSE</codeph> or not declared, the table will be
             created as a regular heap-storage table.</pd>
-          <pd><b>BLOCKSIZE</b> — Set to the size, in bytes for each block in a table. The
+          <pd><b>BLOCKSIZE</b> — Set to the size, in bytes, for each block in a table. The
               <codeph>BLOCKSIZE</codeph> must be between 8192 and 2097152 bytes, and be a multiple
             of 8192. The default is 32768.</pd>
           <pd><b>ORIENTATION</b> — Set to <codeph>column</codeph> for column-oriented storage, or
@@ -463,7 +533,8 @@
         <plentry>
           <pt>USING INDEX TABLESPACE <varname>tablespace</varname></pt>
           <pd>This clause allows selection of the tablespace in which the index associated with a
-              <codeph>UNIQUE</codeph> or <codeph>PRIMARY KEY</codeph> constraint will be created. If
+              <codeph>UNIQUE</codeph>, <codeph>PRIMARY KEY</codeph>, or <codeph>EXCLUDE</codeph> 
+            constraint will be created. If
             not specified, the database's default tablespace is used. </pd>
         </plentry>
         <plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/REVOKE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/REVOKE.xml
@@ -5,27 +5,27 @@
        | REFERENCES | TRIGGER | TRUNCATE } [,...] | ALL [PRIVILEGES] }
        ON { [TABLE] <varname>tablename</varname> [, ...]
             | ALL TABLES IN SCHEMA schemaname [, ...] }
-       FROM {<varname>rolename</varname> | PUBLIC} [, ...]
+       FROM { [ GROUP ] <varname>rolename</varname> | PUBLIC} [, ...]
        [CASCADE | RESTRICT]
 
 REVOKE [ GRANT OPTION FOR ] { { SELECT | INSERT | UPDATE 
        | REFERENCES } ( <varname>columnname</varname> [, ...] )
        [,...] | ALL [ PRIVILEGES ] ( <varname>columnname</varname> [, ...] ) }
        ON [ TABLE ] <varname>tablename</varname> [, ...]
-       FROM { <varname>rolename</varname> | PUBLIC } [, ...]
+       FROM { [ GROUP ] <varname>rolename</varname> | PUBLIC } [, ...]
        [ CASCADE | RESTRICT ]
 
 REVOKE [GRANT OPTION FOR] { {USAGE | SELECT | UPDATE} [,...] 
        | ALL [PRIVILEGES] }
        ON { SEQUENCE <varname>sequencename</varname> [, ...]
             | ALL SEQUENCES IN SCHEMA schemaname [, ...] }
-       FROM { <varname>rolename</varname> | PUBLIC } [, ...]
+       FROM { [ GROUP ] <varname>rolename</varname> | PUBLIC } [, ...]
        [CASCADE | RESTRICT]
 
 REVOKE [GRANT OPTION FOR] { {CREATE | CONNECT 
        | TEMPORARY | TEMP} [,...] | ALL [PRIVILEGES] }
        ON DATABASE <varname>dbname</varname> [, ...]
-       FROM {rolename | PUBLIC} [, ...]
+       FROM { [ GROUP ] rolename | PUBLIC} [, ...]
        [CASCADE | RESTRICT]
 
 REVOKE [ GRANT OPTION FOR ]
@@ -44,18 +44,18 @@ REVOKE [GRANT OPTION FOR] {EXECUTE | ALL [PRIVILEGES]}
        ON { FUNCTION <varname>funcname</varname> ( [[<varname>argmode</varname>] [<varname>argname</varname>] <varname>argtype</varname>
                               [, ...]] ) [, ...]
             | ALL FUNCTIONS IN SCHEMA schemaname [, ...] }
-       FROM {<varname>rolename</varname> | PUBLIC} [, ...]
+       FROM { [ GROUP ] <varname>rolename</varname> | PUBLIC} [, ...]
        [CASCADE | RESTRICT]
 
 REVOKE [GRANT OPTION FOR] {USAGE | ALL [PRIVILEGES]}
        ON LANGUAGE <varname>langname</varname> [, ...]
-       FROM {<varname>rolename</varname> | PUBLIC} [, ...]
+       FROM { [ GROUP ] <varname>rolename</varname> | PUBLIC} [, ...]
        [ CASCADE | RESTRICT ]
 
 REVOKE [GRANT OPTION FOR] { {CREATE | USAGE} [,...] 
        | ALL [PRIVILEGES] }
        ON SCHEMA <varname>schemaname</varname> [, ...]
-       FROM {<varname>rolename</varname> | PUBLIC} [, ...]
+       FROM { [ GROUP ] <varname>rolename</varname> | PUBLIC} [, ...]
        [CASCADE | RESTRICT]
 
 REVOKE [GRANT OPTION FOR] { CREATE | ALL [PRIVILEGES] }

--- a/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
@@ -467,15 +467,23 @@ WINDOW mywindow AS (ORDER BY sum(prc*qty));</codeblock><p>A
           <plentry>
             <pt>PARTITION BY</pt>
             <pd>The <codeph>PARTITION BY</codeph> clause organizes the result set into logical
-              groups based on the unique values of the specified expression. This clause is
-              interpreted in much the same fashion as elements of a <codeph>GROUP BY</codeph>
-              clause, except that they are always simple expressions and never the name or number of
-              an output column. Another difference is that these expressions can contain aggregate
-              function calls, which are not allowed in a regular <codeph>GROUP BY</codeph> clause.
-              When used with window functions, the functions are applied to each partition
-              independently. For example, if you follow <codeph>PARTITION BY</codeph> with a column
-              name, the result set is partitioned by the distinct values of that column. If omitted,
-              the entire result set is considered one partition. </pd>
+              groups based on the unique values of the specified expression. The elements of the
+                <codeph>PARTITION BY</codeph> clause are interpreted in much the same fashion as
+              elements of a <codeph>GROUP BY</codeph> clause, except that they are always simple
+              expressions and never the name or number of an output column. Another difference is
+              that these expressions can contain aggregate function calls, which are not allowed in
+              a regular <codeph>GROUP BY</codeph> clause. They are allowed here because windowing 
+              occurs after grouping and aggregation. When used with window functions, the
+              functions are applied to each partition independently. For example, if you follow
+                <codeph>PARTITION BY</codeph> with a column name, the result set is partitioned by
+              the distinct values of that column. If omitted, the entire result set is considered
+              one partition.</pd>
+            <pd>Similarly, the elements of the <codeph>ORDER BY</codeph> list are interpreted
+              in much the same fashion as elements of an
+              <codeph>ORDER BY</codeph> clause, except that
+                the expressions are always taken as simple expressions and never the name
+                or number of an output column.
+            </pd>
           </plentry>
           <plentry>
             <pt>ORDER BY</pt>
@@ -746,9 +754,11 @@ OFFSET <varname>start</varname></codeblock><p>where
             <codeph>OFFSET 0</codeph>.</p><p>SQL:2008 introduced a different syntax to achieve the same
           result, which Greenplum Database also supports. It is:
           <codeblock>OFFSET <varname>start</varname> [ ROW | ROWS ]
-FETCH { FIRST | NEXT } [ <varname>count</varname> ] { ROW | ROWS } ONLY</codeblock></p><p>Both
-          clauses are optional, but if present the <codeph>OFFSET</codeph> clause must come before
-          the <codeph>FETCH</codeph> clause. <codeph>ROW</codeph> and <codeph>ROWS</codeph>, as well
+            FETCH { FIRST | NEXT } [ <varname>count</varname> ] { ROW | ROWS } ONLY</codeblock></p>
+        <p>According to the standard, the <codeph>OFFSET</codeph> clause must come
+          before the <codeph>FETCH</codeph> clause if both are present; but
+          Greenplum Database is laxer and allows either order.    
+            <codeph>ROW</codeph> and <codeph>ROWS</codeph>, as well
           as <codeph>FIRST</codeph> and <codeph>NEXT</codeph>, are noise words that do not influence
           the effects of these clauses. When using expressions other than constants for the offset
           or fetch count, parentheses will be necessary in most cases. If the fetch count is
@@ -770,42 +780,79 @@ FETCH { FIRST | NEXT } [ <varname>count</varname> ] { ROW | ROWS } ONLY</codeblo
           form:</p><codeblock>FOR UPDATE [OF <varname>table_name</varname> [, ...]] [NOWAIT]</codeblock><p>The
           closely related <codeph>FOR SHARE</codeph> clause has this
             form:</p><codeblock>FOR SHARE [OF <varname>table_name</varname> [, ...]] [NOWAIT]</codeblock><p><codeph>FOR
-            UPDATE</codeph> causes the tables accessed by the <codeph>SELECT</codeph> statement to
-          be locked as though for update. This prevents the table from being modified or deleted by
-          other transactions until the current transaction ends. That is, other transactions that
-          attempt <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or <codeph>SELECT FOR
-            UPDATE</codeph> of this table will be blocked until the current transaction ends. Also,
-          if an <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or <codeph>SELECT FOR
-            UPDATE</codeph> from another transaction has already locked a selected table,
-            <codeph>SELECT FOR UPDATE</codeph> will wait for the other transaction to complete, and
-          will then lock and return the updated table.</p><p>To prevent the operation from waiting
-          for other transactions to commit, use the <codeph>NOWAIT</codeph> option. <codeph>SELECT
-            FOR UPDATE NOWAIT</codeph> reports an error, rather than waiting, if a selected row
-          cannot be locked immediately. Note that <codeph>NOWAIT</codeph> applies only to the
-          row-level lock(s) — the required <codeph>ROW SHARE</codeph> table-level lock is still
-          taken in the ordinary way. You can use the <codeph>NOWAIT</codeph> option of
-            <codeph>LOCK</codeph> if you need to acquire the table-level lock without waiting (see
-              <codeph><xref href="LOCK.xml#topic1" type="topic" format="dita"/></codeph>).
-            </p><p><codeph>FOR SHARE</codeph> behaves similarly, except that it acquires a shared
-          rather than exclusive lock on the table. A shared lock blocks other transactions from
-          performing <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or <codeph>SELECT FOR
-            UPDATE</codeph> on the table, but it does not prevent them from performing
-            <codeph>SELECT FOR SHARE</codeph>.</p><p>If specific tables are named in <codeph>FOR
+            UPDATE</codeph> causes the rows accessed by the <codeph>SELECT</codeph> statement to be
+          locked as though for update. This prevents them from being modified or deleted by other
+          transactions until the current transaction ends. That is, other transactions that attempt
+            <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or <codeph>SELECT FOR UPDATE</codeph>
+          of these rows will be blocked until the current transaction ends. Also, if an
+            <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or <codeph>SELECT FOR UPDATE</codeph>
+          from another transaction has already locked a selected row or rows, <codeph>SELECT FOR
+            UPDATE</codeph> will wait for the other transaction to complete, and will then lock and
+          return the updated row (or no row, if the row was deleted).</p><p><codeph>FOR
+            SHARE</codeph> behaves similarly, except that it acquires a shared rather than exclusive
+          lock on each retrieved row. A shared lock blocks other transactions from performing
+            <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or <codeph>SELECT FOR UPDATE</codeph>
+          on the table, but it does not prevent them from performing <codeph>SELECT FOR
+            SHARE</codeph>.</p><p>To prevent the operation from waiting for other transactions to
+          commit, use the <codeph>NOWAIT</codeph> option. With <codeph>NOWAIT</codeph>, the
+          statement reports an error, rather than waiting, if a selected row cannot be locked
+          immediately. Note that <codeph>NOWAIT</codeph> applies only to the row-level lock(s) — the
+          required <codeph>ROW SHARE</codeph> table-level lock is still taken in the ordinary way.
+          You can use LOCK with the <codeph>NOWAIT</codeph> option first, if you need to acquire the
+          table-level lock without waiting.</p><p>If specific tables are named in <codeph>FOR
             UPDATE</codeph> or <codeph>FOR SHARE</codeph>, then only those tables are locked; any
           other tables used in the <codeph>SELECT</codeph> are simply read as usual. A <codeph>FOR
             UPDATE</codeph> or <codeph>FOR SHARE</codeph> clause without a table list affects all
-          tables used in the command. If <codeph>FOR UPDATE</codeph> or <codeph>FOR SHARE</codeph>
-          is applied to a view or subquery, it affects all tables used in the view or
-          subquery.</p><codeph>FOR UPDATE</codeph> or <codeph>FOR SHARE</codeph> do not apply to a
-          <varname>with_query</varname> referenced by the primary query. If you want row locking to
-        occur within a <varname>with_query</varname>, specify <codeph>FOR UPDATE</codeph> or
-          <codeph>FOR SHARE</codeph> within the <varname>with_query</varname>.<p>Multiple
+          tables used in the statement. If <codeph>FOR UPDATE</codeph> or <codeph>FOR SHARE</codeph>
+          is applied to a view or subquery, it affects all tables used in the view or subquery.
+          However, <codeph>FOR UPDATE</codeph>/<codeph>FOR SHARE</codeph> do not apply to
+            <codeph>WITH</codeph> queries referenced by the primary query. If you want row locking
+          to occur within a <codeph>WITH</codeph> query, specify <codeph>FOR UPDATE</codeph> or
+            <codeph>FOR SHARE</codeph> within the <codeph>WITH</codeph> query.</p><p><codeph>FOR
+            UPDATE</codeph> or <codeph>FOR SHARE</codeph> do not apply to a
+            <varname>with_query</varname> referenced by the primary query. If you want row locking
+          to occur within a <varname>with_query</varname>, specify <codeph>FOR UPDATE</codeph> or
+            <codeph>FOR SHARE</codeph> within the <varname>with_query</varname>.</p><p>Multiple
             <codeph>FOR UPDATE</codeph> and <codeph>FOR SHARE</codeph> clauses can be written if it
           is necessary to specify different locking behavior for different tables. If the same table
           is mentioned (or implicitly affected) by both <codeph>FOR UPDATE</codeph> and <codeph>FOR
             SHARE</codeph> clauses, then it is processed as <codeph>FOR UPDATE</codeph>. Similarly,
           a table is processed as <codeph>NOWAIT</codeph> if that is specified in any of the clauses
-          affecting it.</p></sectiondiv>
+          affecting it.</p><p><codeph>FOR UPDATE</codeph> and <codeph>FOR SHARE</codeph> cannot be
+          used in contexts where returned rows cannot be clearly identified with individual table
+          rows; for example they cannot be used with aggregation.</p><p>When <codeph>FOR
+            UPDATE</codeph> or <codeph>FOR SHARE</codeph> appears at the top level of a
+            <codeph>SELECT</codeph> query, the rows that are locked are exactly those that are
+          returned by the query; in the case of a join query, the rows locked are those that
+          contribute to returned join rows. In addition, rows that satisfied the query conditions as
+          of the query snapshot will be locked, although they will not be returned if they have
+          since been updated to not satisfy the query conditions. If a <codeph>LIMIT</codeph> is
+          used, locking stops once enough rows have been returned to satisfy the limit (but note
+          that rows skipped over by <codeph>OFFSET</codeph> will get locked). Similarly, if
+            <codeph>FOR UPDATE</codeph> or <codeph>FOR SHARE</codeph> is used in a cursor's query,
+          only rows actually fetched or stepped past by the cursor will be locked.</p><p>When
+            <codeph>FOR UPDATE</codeph> or <codeph>FOR SHARE</codeph> appears in a
+            sub-<codeph>SELECT</codeph>, the rows locked are those returned to the outer query by
+          the sub-query. This might involve fewer rows than inspection of the sub-query alone would
+          suggest, since conditions from the outer query might be used to optimize execution of the
+          sub-query. For example,
+          <codeblock>SELECT * FROM (SELECT * FROM mytable FOR UPDATE) ss WHERE col1 = 5;</codeblock>
+          will lock only rows having <codeph>col1 = 5</codeph>, even though that condition is not
+          textually within the sub-query. </p><p>It is possible for a <codeph>SELECT</codeph>
+          command using <codeph>ORDER BY</codeph> and <codeph>FOR UPDATE/SHARE</codeph> to return
+          rows out of order. This is because <codeph>ORDER BY</codeph> is applied first. The command
+          sorts the result, but might then block trying to obtain a lock on one or more of the rows.
+          Once the <codeph>SELECT</codeph> unblocks, some of the ordering column values might have
+          been modified, leading to those rows appearing to be out of order (though they are in
+          order in terms of the original column values). This can be worked around at need by
+          placing the <codeph>FOR UPDATE/SHARE</codeph> clause in a sub-query, for example
+          <codeblock>SELECT * FROM (SELECT * FROM mytable FOR UPDATE) ss ORDER BY column1;</codeblock>
+          Note that this will result in locking all rows of <codeph>mytable</codeph>, whereas
+            <codeph>FOR UPDATE</codeph> at the top level would lock only the actually returned rows.
+          This can make for a significant performance difference, particularly if the <codeph>ORDER
+            BY</codeph> is combined with <codeph>LIMIT</codeph> or other restrictions. So this
+          technique is recommended only if concurrent updates of the ordering columns are expected
+          and a strictly sorted result is required. </p></sectiondiv>
     </section>
     <section>
       <title>The TABLE Command</title>
@@ -910,14 +957,18 @@ SELECT distance, employee_name FROM employee_recursive;</codeblock>
     </section>
     <section id="section19"><title>Compatibility</title><p>The <codeph>SELECT</codeph> statement is
         compatible with the SQL standard, but there are some extensions and some missing features.
-        </p><sectiondiv id="section20"><b>Omitted FROM Clauses</b><p>Greenplum Database allows one
-          to omit the <codeph>FROM</codeph> clause. It has a straightforward use to compute the
-          results of simple expressions. For example:</p><codeblock>SELECT 2+2;</codeblock><p>Some
-          other SQL databases cannot do this except by introducing a dummy one-row table from which
-          to do the <codeph>SELECT</codeph>. </p><p>Note that if a <codeph>FROM</codeph> clause is
-          not specified, the query cannot reference any database tables. For compatibility with
-          applications that rely on this behavior the <varname>add_missing_from</varname>
-            configuration variable can be enabled.</p></sectiondiv><sectiondiv id="section21"><b>Omitting the AS Key Word</b><p>In the SQL standard, the optional key
+        </p><sectiondiv id="section20"><b>Omitted FROM Clauses</b><p>Greenplum Database allows one to omit the
+            <codeph>FROM</codeph> clause. It has a straightforward use to compute the results of
+          simple expressions. For example:</p><codeblock>SELECT 2+2;</codeblock><p>Some other SQL
+          databases cannot do this except by introducing a dummy one-row table from which to do the
+            <codeph>SELECT</codeph>. </p><p>Note that if a <codeph>FROM</codeph> clause is not
+          specified, the query cannot reference any database tables. For example, the following
+          query is
+          invalid:<codeblock>SELECT distributors.* WHERE distributors.name = 'Westward';</codeblock>In
+          earlier releases, setting a server configuration parameter,
+            <varname>add_missing_from</varname>, to true allowed Greenplum Database to add an
+          implicit entry to the query's <codeph>FROM</codeph> clause for each table referenced by
+          the query. This is no longer allowed. </p></sectiondiv><sectiondiv id="section21"><b>Omitting the AS Key Word</b><p>In the SQL standard, the optional key
           word <codeph>AS</codeph> can be omitted before an output column name whenever the new
           column name is a valid column name (that is, not the same as any reserved keyword).
           Greenplum Database is slightly more restrictive: <codeph>AS</codeph> is required if the
@@ -945,10 +996,18 @@ SELECT distance, employee_name FROM employee_recursive;</codeblock>
       <sectiondiv><b>LIMIT and OFFSET</b><p>The clauses <codeph>LIMIT</codeph> and
             <codeph>OFFSET</codeph> are Greenplum Database-specific syntax, also used by MySQL. The
           SQL:2008 standard has introduced the clauses <codeph>OFFSET .. FETCH {FIRST|NEXT}
-            ...</codeph> for the same functionality, as shown above, and this syntax is also used by
-          IBM DB2. (Applications for Oracle frequently use a workaround involving the automatically
-          generated <codeph>rownum</codeph> column, not available in Greenplum Database, to
-          implement the effects of these clauses.)</p></sectiondiv><sectiondiv id="section23"><b>Nonstandard Clauses</b><p>The clause <codeph>DISTINCT ON</codeph> is
+            ...</codeph> for the same functionality, as shown above. This syntax is also used by IBM
+          DB2. (Applications for Oracle frequently use a workaround involving the automatically
+          generated <codeph>rownum</codeph> column, which is not available in Greenplum Database, to
+          implement the effects of these clauses.)</p></sectiondiv>
+      <sectiondiv><b>FOR UPDATE and FOR SHARE</b>
+        <p>Although <codeph>FOR UPDATE</codeph> appears in the SQL standard, the
+        standard allows it only as an option of <codeph>DECLARE CURSOR</codeph>.
+        Greenplum Database allows it in any <codeph>SELECT</codeph> query as well as in 
+        sub-<codeph>SELECT</codeph>s, but this is an extension.
+        The <codeph>FOR SHARE</codeph> variant, and the <codeph>NOWAIT</codeph> option,
+        do not appear in the standard.
+      </p></sectiondiv><sectiondiv id="section23"><b>Nonstandard Clauses</b><p>The clause <codeph>DISTINCT ON</codeph> is
           not defined in the SQL standard.</p></sectiondiv><sectiondiv id="section24"><b>Limited Use
           of STABLE and VOLATILE Functions</b><p>To prevent data from becoming out-of-sync across
           the segments in Greenplum Database, any function classified as <codeph>STABLE</codeph> or

--- a/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
@@ -779,37 +779,46 @@ OFFSET <varname>start</varname></codeblock><p>where
             UPDATE</codeph> clause has this
           form:</p><codeblock>FOR UPDATE [OF <varname>table_name</varname> [, ...]] [NOWAIT]</codeblock><p>The
           closely related <codeph>FOR SHARE</codeph> clause has this
-            form:</p><codeblock>FOR SHARE [OF <varname>table_name</varname> [, ...]] [NOWAIT]</codeblock><p><codeph>FOR
-            UPDATE</codeph> causes the rows accessed by the <codeph>SELECT</codeph> statement to be
-          locked as though for update. This prevents them from being modified or deleted by other
-          transactions until the current transaction ends. That is, other transactions that attempt
-            <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or <codeph>SELECT FOR UPDATE</codeph>
-          of these rows will be blocked until the current transaction ends. Also, if an
-            <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or <codeph>SELECT FOR UPDATE</codeph>
-          from another transaction has already locked a selected row or rows, <codeph>SELECT FOR
-            UPDATE</codeph> will wait for the other transaction to complete, and will then lock and
-          return the updated row (or no row, if the row was deleted).</p><p><codeph>FOR
-            SHARE</codeph> behaves similarly, except that it acquires a shared rather than exclusive
-          lock on each retrieved row. A shared lock blocks other transactions from performing
-            <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or <codeph>SELECT FOR UPDATE</codeph>
-          on the table, but it does not prevent them from performing <codeph>SELECT FOR
-            SHARE</codeph>.</p><p>To prevent the operation from waiting for other transactions to
-          commit, use the <codeph>NOWAIT</codeph> option. With <codeph>NOWAIT</codeph>, the
-          statement reports an error, rather than waiting, if a selected row cannot be locked
-          immediately. Note that <codeph>NOWAIT</codeph> applies only to the row-level lock(s) — the
-          required <codeph>ROW SHARE</codeph> table-level lock is still taken in the ordinary way.
-          You can use LOCK with the <codeph>NOWAIT</codeph> option first, if you need to acquire the
-          table-level lock without waiting.</p><p>If specific tables are named in <codeph>FOR
-            UPDATE</codeph> or <codeph>FOR SHARE</codeph>, then only those tables are locked; any
-          other tables used in the <codeph>SELECT</codeph> are simply read as usual. A <codeph>FOR
-            UPDATE</codeph> or <codeph>FOR SHARE</codeph> clause without a table list affects all
-          tables used in the statement. If <codeph>FOR UPDATE</codeph> or <codeph>FOR SHARE</codeph>
-          is applied to a view or subquery, it affects all tables used in the view or subquery.
-          However, <codeph>FOR UPDATE</codeph>/<codeph>FOR SHARE</codeph> do not apply to
-            <codeph>WITH</codeph> queries referenced by the primary query. If you want row locking
-          to occur within a <codeph>WITH</codeph> query, specify <codeph>FOR UPDATE</codeph> or
-            <codeph>FOR SHARE</codeph> within the <codeph>WITH</codeph> query.</p><p><codeph>FOR
-            UPDATE</codeph> or <codeph>FOR SHARE</codeph> do not apply to a
+          form:</p><codeblock>FOR SHARE [OF <varname>table_name</varname> [, ...]] [NOWAIT]</codeblock><note>
+          By default, Greenplum Database acquires an <codeph>EXCLUSIVE</codeph> lock on tables for
+            <codeph>DELETE</codeph> and <codeph>UPDATE</codeph> operations on heap tables. When the
+          Global Deadlock Detector is enabled  the lock mode for <codeph>DELETE</codeph> and
+            <codeph>UPDATE</codeph> operations on heap tables is <codeph>ROW EXCLUSIVE</codeph>. The
+          Global Deadlock Detector is enabled by setting the <xref
+            href="../config_params/guc-list.xml#gp_global_deadlock_detector_period"
+            >gp_enable_global_deadlock_detector</xref> configuration parameter to true. See<xref
+            href="../../admin_guide/dml.xml#topic_gdd"> Global Deadlock Detector</xref> in the
+            <cite>Greenplum Database Administrator Guide</cite> for information about the Global
+          Deadlock Detector.</note><p><codeph>FOR UPDATE</codeph> causes the rows accessed by the
+            <codeph>SELECT</codeph> statement to be locked as though for update. This prevents them
+          from being modified or deleted by other transactions until the current transaction ends.
+          That is, other transactions that attempt <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>,
+          or <codeph>SELECT FOR UPDATE</codeph> of these rows will be blocked until the current
+          transaction ends. Also, if an <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or
+            <codeph>SELECT FOR UPDATE</codeph> from another transaction has already locked a
+          selected row or rows, <codeph>SELECT FOR UPDATE</codeph> will wait for the other
+          transaction to complete, and will then lock and return the updated row (or no row, if the
+          row was deleted).</p><p><codeph>FOR SHARE</codeph> behaves similarly, except that it
+          acquires a shared rather than exclusive lock on each retrieved row. A shared lock blocks
+          other transactions from performing <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, or
+            <codeph>SELECT FOR UPDATE</codeph> on the table, but it does not prevent them from
+          performing <codeph>SELECT FOR SHARE</codeph>.</p><p>To prevent the operation from waiting
+          for other transactions to commit, use the <codeph>NOWAIT</codeph> option. With
+            <codeph>NOWAIT</codeph>, the statement reports an error, rather than waiting, if a
+          selected row cannot be locked immediately. Note that <codeph>NOWAIT</codeph> applies only
+          to the row-level lock(s) — the required <codeph>ROW SHARE</codeph> table-level lock is
+          still taken in the ordinary way. You can use LOCK with the <codeph>NOWAIT</codeph> option
+          first, if you need to acquire the table-level lock without waiting.</p><p>If specific
+          tables are named in <codeph>FOR UPDATE</codeph> or <codeph>FOR SHARE</codeph>, then only
+          those tables are locked; any other tables used in the <codeph>SELECT</codeph> are simply
+          read as usual. A <codeph>FOR UPDATE</codeph> or <codeph>FOR SHARE</codeph> clause without
+          a table list affects all tables used in the statement. If <codeph>FOR UPDATE</codeph> or
+            <codeph>FOR SHARE</codeph> is applied to a view or subquery, it affects all tables used
+          in the view or subquery. However, <codeph>FOR UPDATE</codeph>/<codeph>FOR SHARE</codeph>
+          do not apply to <codeph>WITH</codeph> queries referenced by the primary query. If you want
+          row locking to occur within a <codeph>WITH</codeph> query, specify <codeph>FOR
+            UPDATE</codeph> or <codeph>FOR SHARE</codeph> within the <codeph>WITH</codeph>
+          query.</p><p><codeph>FOR UPDATE</codeph> or <codeph>FOR SHARE</codeph> do not apply to a
             <varname>with_query</varname> referenced by the primary query. If you want row locking
           to occur within a <varname>with_query</varname>, specify <codeph>FOR UPDATE</codeph> or
             <codeph>FOR SHARE</codeph> within the <varname>with_query</varname>.</p><p>Multiple

--- a/gpdb-doc/dita/ref_guide/sql_commands/VACUUM.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/VACUUM.xml
@@ -7,7 +7,9 @@
     <p id="sql_command_desc">Garbage-collects and optionally analyzes a database.</p>
     <section id="section2">
       <title>Synopsis</title>
-      <codeblock id="sql_command_synopsis">VACUUM [FULL] [FREEZE] [VERBOSE] [<varname>table</varname>]
+      <codeblock id="sql_command_synopsis">VACUUM [({ FULL | FREEZE | VERBOSE | ANALYZE } [, ...])] [<varname>table</varname> [(<varname>column</varname> [, ...] )]]
+        
+ VACUUM [FULL] [FREEZE] [VERBOSE] [<varname>table</varname>]
 
 VACUUM [FULL] [FREEZE] [VERBOSE] ANALYZE
               [<varname>table</varname> [(<varname>column</varname> [, ...] )]]</codeblock>
@@ -43,7 +45,14 @@ VACUUM [FULL] [FREEZE] [VERBOSE] ANALYZE
         across blocks to try to compact the table to the minimum number of disk blocks. This form is
         much slower and requires an Access Exclusive lock on each table while it is being processed.
         The Access Exclusive lock guarantees that the holder is the only transaction accessing the
-        table in any way.</p>
+        table in any way.
+      </p>
+      <p>When the option list is surrounded by parentheses, the options can be
+        written in any order.  Without parentheses, options must be specified
+        in exactly the order shown above.
+        In earlier Greenplum Database releases, the unparenthesized syntax was the only supported 
+        syntax. It is expected that all new options will be supported only with the parenthesized syntax.
+      </p>
       <note type="important">For information on the use of <codeph>VACUUM</codeph>, <codeph>VACUUM
           FULL</codeph>, and <codeph>VACUUM ANALYZE</codeph>, see <xref href="#topic1/section6"
           type="section" format="dita"/>
@@ -90,7 +99,8 @@ VACUUM [FULL] [FREEZE] [VERBOSE] ANALYZE
           <pt>
             <varname>column</varname>
           </pt>
-          <pd>The name of a specific column to analyze. Defaults to all columns.</pd>
+          <pd>The name of a specific column to analyze. Defaults to all columns. If a column list is 
+            specified, <codeph>ANALYZE</codeph> is implied.</pd>
         </plentry>
       </parml>
     </section>
@@ -143,10 +153,11 @@ VACUUM [FULL] [FREEZE] [VERBOSE] ANALYZE
     </section>
     <section id="section7">
       <title>Examples</title>
+      <codeblock>VACUUM (VERBOSE, ANALYZE) onek;</codeblock>
       <p>Vacuum all tables in the current database:</p>
       <codeblock>VACUUM;</codeblock>
       <p>Vacuum a specific table only:</p>
-      <codeblock>VACUUM mytable;</codeblock>
+      <codeblock>VACUUM (VERBOSE, ANALYZE) mytable;</codeblock>
       <p>Vacuum all tables in the current database and collect statistics for the query
         optimizer:</p>
       <codeblock>VACUUM ANALYZE;</codeblock>

--- a/gpdb-doc/dita/ref_guide/sql_commands/sql_ref.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/sql_ref.xml
@@ -18,6 +18,7 @@
       <li id="ad139890">
         <xref href="./ALTER_DATABASE.xml#topic1" type="topic" format="dita"/>
       </li>
+      <li><xref href="ALTER_DEFAULT_PRIVILEGES.xml#topic1"/></li>
       <li id="ad139891">
         <xref href="./ALTER_DOMAIN.xml#topic1" type="topic" format="dita"/>
       </li>

--- a/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
@@ -429,6 +429,20 @@ testdb=#</codeblock>
             shown.</pd>
         </plentry>
         <plentry>
+          <pt>\ddp [<varname>pattern</varname>]</pt>
+          <pd> Lists default access privilege settings.  An entry is shown for
+            each role (and schema, if applicable) for which the default
+            privilege settings have been changed from the built-in defaults.
+            If <varname>pattern</varname> is
+            specified, only entries whose role name or schema name matches
+            the pattern are listed.
+          </pd>
+          <pd>The <xref href="../../ref_guide/sql_commands/ALTER_DEFAULT_PRIVILEGES.xml#topic1"
+              >ALTER DEFAULT PRIVILEGES</xref> command is used to set default access privileges. The
+            meaning of the privilege display is explained under <xref
+              href="../../ref_guide/sql_commands/GRANT.xml#topic1">GRANT</xref>. </pd>
+        </plentry>
+        <plentry>
           <pt>\dD [<varname>domain_pattern</varname>]</pt>
           <pd>Lists all available domains. If pattern is specified, only matching domains are
             shown.</pd>
@@ -495,6 +509,19 @@ testdb=#</codeblock>
             access privileges. If pattern is specified, only tables, views and sequences whose names
             match the pattern are listed. The <codeph>GRANT</codeph> and <codeph>REVOKE</codeph>
             commands are used to set access privileges. </pd>
+        </plentry>
+        <plentry>
+          <pt>\drds [<varname>role-pattern</varname></pt>
+          <pd>Lists defined configuration settings.  These settings can be role-specific,
+            database-specific, or both.  <varname>role-pattern</varname> and
+            <varname>database-pattern</varname> are used to select
+            specific roles and database to list, respectively; if omitted, or * is specified,
+            all settings are listed, including those not role-specific or database-specific,
+            respectively.
+          </pd>
+          <pd>The <xref format="dita" href="../../ref_guide/sql_commands/ALTER_ROLE.xml">ALTER ROLE</xref> and <xref format="dita"
+              href="../../ref_guide/sql_commands/ALTER_DATABASE.xml">ALTER DATABASE</xref> commands
+            are used to define per-database role configuration settings. </pd>
         </plentry>
         <plentry>
           <pt>\dT [<varname>datatype_pattern</varname>] | \dT+

--- a/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
@@ -511,7 +511,7 @@ testdb=#</codeblock>
             commands are used to set access privileges. </pd>
         </plentry>
         <plentry>
-          <pt>\drds [<varname>role-pattern</varname></pt>
+          <pt>\drds [<varname>role-pattern</varname>]</pt>
           <pd>Lists defined configuration settings.  These settings can be role-specific,
             database-specific, or both.  <varname>role-pattern</varname> and
             <varname>database-pattern</varname> are used to select


### PR DESCRIPTION
Edits GPDB docs from sgml files updated by the first postgresql 9.0 merge 
https://github.com/greenplum-db/gpdb/pull/4528

Staged docs are here:

Commands: https://docs-litzell-psql90-merge-a.cfapps.io/600/ref_guide/sql_commands/sql_ref.html

psql: https://docs-litzell-psql90-merge-a.cfapps.io/600/utility_guide/client_utilities/psql.html


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
