### PR TITLE
Fix replication slots test

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
@@ -59,8 +59,8 @@ def expand(context):
     run_command(context, "createdb expansion_database")
 
     expansion_command = """gpexpand -D expansion_database --input <(echo '
-    localhost:localhost:55432:/tmp/behave_test_expansion_primary:8:3:p
-    localhost:localhost:55433:/tmp/behave_test_expansion_mirror:9:3:m
+    localhost:localhost:25438:/tmp/behave_test_expansion_primary:8:3:p
+    localhost:localhost:25439:/tmp/behave_test_expansion_mirror:9:3:m
 ')
 """
     # Initialize


### PR DESCRIPTION
There is a hardcoded port in the test. If it is used by another process
then the test will fail. This commit dynamically fetches free ports and
uses those instead.

Co-authored-by: Alexandra Wang <lewang@pivotal.io>
