### PR TITLE
Remove a FIXME related to recoveryTargetIsLatest.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -292,7 +292,7 @@ static bool recoveryStopAfter;
  * to decrease.
  */
 static TimeLineID recoveryTargetTLI;
-static bool recoveryTargetIsLatest = false; // GPDB_93_MERGE_FIXME: should this be set somewhere?
+static bool recoveryTargetIsLatest = false;
 
 static List *expectedTLEs;
 static TimeLineID curFileTLI;


### PR DESCRIPTION
The recoveryTargetIsLatest setting code was missing somehow and later
it was added back in commit 55808e18bd9177aece.
Removing the FIXME comment.

