### PR TITLE
initTM() should not change the role to superuser temporarily

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -880,7 +880,13 @@ cdb_setup(void)
 		InitMotionLayerIPC();
 	}
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	/*
+	 * initTM() goes through all in-doubt transactions and resolve them
+	 * which need to be under a superuser context. Meanwhile, in-doubt
+	 * transactions occur with a crash or PANIC, so normally startup
+	 * process (superuser) takes the responsibility.
+	 */
+	if (Gp_role == GP_ROLE_DISPATCH && IsAuthenticatedUserSuperUser())
 	{
 		/* initialize TM */
 		initTM();


### PR DESCRIPTION
This is found when reviewing https://github.com/greenplum-db/gpdb/pull/6853

When a GPDB server start, initTM() is called to goes through all
in-doubt transactions and resolve them, however, it need to be under
a superuser context somehow. Previously, GPDB uses a hacky way which
temporary change the role to superuser and then restore it back after
resolving in-doubt transactions, the old solution might involve security
issues in one hand, in another hand it strongly dependes on MyProcPort
structure which is not always available,

We know initTM() is always called when a server start after a crash or
PANIC and now the first 'QD' will try to call initTM(), so to fix this,
we let the first 'QD' whose authenticated user is superuser to do the
initTM(), we know startup process is always started and it is under
superuser context, so initTM() can be called for sure.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
