### PR TITLE
Enable simple DROP INDEX CONCURRENTLY tests

### DIFF
--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -2610,9 +2610,6 @@ Indexes:
 --
 -- Try some concurrent index drops
 --
--- GPDB_93_MERGE_FIXME: These are inside a big start/end-ignore block currently.
--- Even if we don't support CREATE INDEX CONCURRENTLY, we can still support, and
--- should test, DROP INDEX CONCURRENTLY.
 DROP INDEX CONCURRENTLY "concur_index2";				-- works
 ERROR:  syntax error at or near "CONCURRENTLY"
 LINE 1: DROP INDEX CONCURRENTLY "concur_index2";

--- a/src/test/regress/expected/gp_index.out
+++ b/src/test/regress/expected/gp_index.out
@@ -1,0 +1,39 @@
+--
+-- Greenplum disallows concurrent index creation. It allows concurrent index
+-- drops, so we want to test for it. Though, due to this difference with
+-- upstream we can not keep the tests completely in sync and we add them here.
+-- Original tests are in create_index.sql
+--
+CREATE TABLE tbl_drop_ind_concur (f1 text, f2 text, dk text) distributed by (dk);
+CREATE INDEX tbl_drop_index1 ON tbl_drop_ind_concur(f2,f1);
+INSERT INTO tbl_drop_ind_concur VALUES  ('a','b', '1');
+INSERT INTO tbl_drop_ind_concur VALUES  ('b','b', '1');
+INSERT INTO tbl_drop_ind_concur VALUES  ('c','c', '2');
+INSERT INTO tbl_drop_ind_concur VALUES  ('d','d', '3');
+CREATE UNIQUE INDEX tbl_drop_index2 ON tbl_drop_ind_concur(dk, f1);
+CREATE INDEX tbl_drop_index3 on tbl_drop_ind_concur(f2) WHERE f1='a';
+CREATE INDEX tbl_drop_index4 on tbl_drop_ind_concur(f2) WHERE f1='x';
+DROP INDEX CONCURRENTLY "tbl_drop_index2";				-- works
+DROP INDEX CONCURRENTLY IF EXISTS "tbl_drop_index2";		-- notice
+NOTICE:  index "tbl_drop_index2" does not exist, skipping
+-- failures
+DROP INDEX CONCURRENTLY "tbl_drop_index2", "tbl_drop_index3";
+ERROR:  DROP INDEX CONCURRENTLY does not support dropping multiple objects
+BEGIN;
+DROP INDEX CONCURRENTLY "tbl_drop_index4";
+ERROR:  DROP INDEX CONCURRENTLY cannot run inside a transaction block
+ROLLBACK;
+-- successes
+DROP INDEX CONCURRENTLY IF EXISTS "tbl_drop_index3";
+DROP INDEX CONCURRENTLY "tbl_drop_index4";
+DROP INDEX CONCURRENTLY "tbl_drop_index1";
+\d tbl_drop_ind_concur
+Table "public.tbl_drop_ind_concur"
+ Column | Type | Modifiers 
+--------+------+-----------
+ f1     | text | 
+ f2     | text | 
+ dk     | text | 
+Distributed by: (dk)
+
+DROP TABLE tbl_drop_ind_concur;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -26,7 +26,7 @@ test: instr_in_shmem_setup
 # run separately - because slot counter may influenced by other parallel queries
 test: instr_in_shmem
 
-test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp returning_gp resource_queue_with_rule gp_types
+test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp returning_gp resource_queue_with_rule gp_types gp_index
 test: spi_processed64bit
 test: python_processed64bit
 

--- a/src/test/regress/sql/create_index.sql
+++ b/src/test/regress/sql/create_index.sql
@@ -754,6 +754,7 @@ REINDEX TABLE concur_heap;
 
 --
 -- Try some concurrent index drops
+-- Greenplum: The functionality of these tests is replicated in gp_index
 --
 DROP INDEX CONCURRENTLY "concur_index2";				-- works
 DROP INDEX CONCURRENTLY IF EXISTS "concur_index2";		-- notice

--- a/src/test/regress/sql/gp_index.sql
+++ b/src/test/regress/sql/gp_index.sql
@@ -1,0 +1,33 @@
+--
+-- Greenplum disallows concurrent index creation. It allows concurrent index
+-- drops, so we want to test for it. Though, due to this difference with
+-- upstream we can not keep the tests completely in sync and we add them here.
+-- Original tests are in create_index.sql
+--
+CREATE TABLE tbl_drop_ind_concur (f1 text, f2 text, dk text) distributed by (dk);
+CREATE INDEX tbl_drop_index1 ON tbl_drop_ind_concur(f2,f1);
+INSERT INTO tbl_drop_ind_concur VALUES  ('a','b', '1');
+INSERT INTO tbl_drop_ind_concur VALUES  ('b','b', '1');
+INSERT INTO tbl_drop_ind_concur VALUES  ('c','c', '2');
+INSERT INTO tbl_drop_ind_concur VALUES  ('d','d', '3');
+CREATE UNIQUE INDEX tbl_drop_index2 ON tbl_drop_ind_concur(dk, f1);
+CREATE INDEX tbl_drop_index3 on tbl_drop_ind_concur(f2) WHERE f1='a';
+CREATE INDEX tbl_drop_index4 on tbl_drop_ind_concur(f2) WHERE f1='x';
+
+DROP INDEX CONCURRENTLY "tbl_drop_index2";				-- works
+DROP INDEX CONCURRENTLY IF EXISTS "tbl_drop_index2";		-- notice
+
+-- failures
+DROP INDEX CONCURRENTLY "tbl_drop_index2", "tbl_drop_index3";
+BEGIN;
+DROP INDEX CONCURRENTLY "tbl_drop_index4";
+ROLLBACK;
+
+-- successes
+DROP INDEX CONCURRENTLY IF EXISTS "tbl_drop_index3";
+DROP INDEX CONCURRENTLY "tbl_drop_index4";
+DROP INDEX CONCURRENTLY "tbl_drop_index1";
+
+\d tbl_drop_ind_concur
+
+DROP TABLE tbl_drop_ind_concur;


### PR DESCRIPTION
While `CREATE INDEX CONCURRENTLY` isn’t supported in Greenplum,
`DROP INDEX CONCURRENTY` is. 

This PR enables previously disabled tests for `DROP INDEX CONCURRENTLY`
for the serialised use case. Proper concurrent tests exist and are enabled
in isolation <160984c8c8>.

The exact test case with upstream could not be maintained,
due to the corresponding create index concurrently use case being
disabled. In order to keep future merge conflicts to a minimum the
tests have been moved to a greenplum specific test file. A new
file was needed because the test case did not semantically fit
the cases in the existing files.

Removes 93 merge fixme.
