### PR TITLE
Removed FIXME comment from test suite.

### DIFF
--- a/src/test/regress/expected/event_trigger.out
+++ b/src/test/regress/expected/event_trigger.out
@@ -144,7 +144,7 @@ BEGIN
 		RETURN;
 	END IF;
 
-	-- GPDB_93_MERGE_FIXME: This query has been modified from upstream's,
+	-- This query has been modified from upstream's,
 	-- to not do a join, because with the original query, the planner would
 	-- execute the pg_event_trigger_dropped_objects() function in an entry DB
 	-- worker process, not the QD process. That doesn't work, the function

--- a/src/test/regress/sql/event_trigger.sql
+++ b/src/test/regress/sql/event_trigger.sql
@@ -155,7 +155,7 @@ BEGIN
 		RETURN;
 	END IF;
 
-	-- GPDB_93_MERGE_FIXME: This query has been modified from upstream's,
+	-- This query has been modified from upstream's,
 	-- to not do a join, because with the original query, the planner would
 	-- execute the pg_event_trigger_dropped_objects() function in an entry DB
 	-- worker process, not the QD process. That doesn't work, the function


### PR DESCRIPTION
We left the comment explaining the difference between GPDB
and upstream, as it will be useful for future merge work.

pg_event_trigger_dropped_objects should observe events run
on the QD when tables are dropped and have the same behavior
as upstream.

There's a possible race-condition because the query no longer
joins, so there's a gap between the lookup of dropped objects
and the query for undroppable objects, but because theres no
other queries using this table or function, it is not a concern.

Co-authored-by: Georgios Kokolatos <gkokolatos@pivotal.io>