### PR TITLE
gpcheckcat: fix gp_distribution_policy.distkey comparisons

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -461,7 +461,7 @@ def checkDistribPolicy():
       join pg_class rel on (pk.conrelid = rel.oid)
       join pg_namespace n on (rel.relnamespace = n.oid)
       join gp_distribution_policy d on (rel.oid = d.localoid)
-    where pk.contype in('p', 'u') and d.policytype = 'p' and d.distkey is null
+    where pk.contype in('p', 'u') and d.policytype = 'p' and d.distkey = ''
     '''
 
     db = connect2(GV.cfg[1])
@@ -503,7 +503,7 @@ def checkDistribPolicy():
       join  pg_namespace n on (rel.relnamespace = n.oid)
       join  gp_distribution_policy d on (rel.oid = d.localoid)
     where pk.contype in ('p', 'u') and d.policytype = 'p' and
-          (d.distkey is null or not
+          (d.distkey = '' or not
            d.distkey::int2[] operator(pg_catalog.<@) pk.conkey)
     '''
     try:
@@ -678,7 +678,7 @@ def checkPartitionIntegrity():
       ) p
     join gp_distribution_policy d1 on (d1.localoid = p.parrelid)
     join gp_distribution_policy d2 on (d2.localoid = p.parchildrelid)
-    where d2.distkey is not null
+    where d2.distkey <> ''
     '''
     try:
         curs = db.query(qry)

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_invalid_constraint.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_invalid_constraint.sql
@@ -1,3 +1,3 @@
 set allow_system_table_mods=true;
 create table foo(i int primary key);
-update gp_distribution_policy  set distkey=NULL where localoid='foo'::regclass::oid;
+update gp_distribution_policy  set distkey='' where localoid='foo'::regclass::oid;


### PR DESCRIPTION
_I plan to quick-merge this to fix up the gpcheckcat redness (edit: this was done in 1486e528f), but I want to leave the PR open for reviews -- I'm happy to apply any necessary followups._

Follow-up to 69ec6926. distkey is no longer a nullable column, so comparisons against `NULL` (to check for random distribution) need to be replaced with checks for an empty `int2vector`.

Although this change causes the currently failing master tests to pass on my machine, I'm not sure if

    distkey = ''

is really an idiomatic way to check for an empty vector. Does it make more sense to do something like

    array_length(distkey, 1) = 0

?