### PR TITLE
Remove fixme "does numPureOrderedAggs include WITHIN GROUP aggs? Shou…

### DIFF
--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -67,8 +67,7 @@ typedef struct AggClauseCosts
 {
 	int			numAggs;		/* total number of aggregate functions */
 	int			numOrderedAggs; /* number w/ DISTINCT/ORDER BY/WITHIN GROUP */
-	/* GPDB_94_MERGE_FIXME: does numPureOrderedAggs include WITHIN GROUP aggs? Should it? */
-	int			numPureOrderedAggs; /* CDB: number that use ORDER BY, not counting DISTINCT */
+	int			numPureOrderedAggs; /* CDB: number that use ORDER BY/WITHIN GROUP, not counting DISTINCT */
 	bool		hasNonCombine;	/* CDB: any agg func w/o a combine func? */
 	bool		hasNonSerial;	/* CDB: is any partial agg non-serializable? */
 	QualCost	transCost;		/* total per-input-row execution costs */


### PR DESCRIPTION

Because order-set aggs always have nonempty aggorder, numPureOrderedAggs
currently contains WITHIN GROUP aggs. I think this is reasonable. The reason
why we add numPureOrderedAggs in AggClauseCosts is that the group aggregate
cost is much higher than hash aggregate, and we usually use hash aggregate with
DISTINCT and group aggregate with ORDER BY. With within group, we must
also use the group aggregate. So, we need to add numPureOrderedAggs when
the query cantains a within group agg.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
