### PR TITLE
Define Assert() et al to ((void)0) to avoid pedantic warnings.

### DIFF
--- a/src/include/c.h
+++ b/src/include/c.h
@@ -736,14 +736,14 @@ typedef NameData *Name;
  */
 #ifndef USE_ASSERT_CHECKING
 
-#define Assert(condition)
+#define Assert(condition)	((void)true)
 #define AssertMacro(condition)	((void)true)
-#define AssertArg(condition)
-#define AssertState(condition)
-#define AssertPointerAlignment(ptr, bndr)   ((void)true)
-#define AssertImply(condition1, condition2)
-#define AssertEquivalent(cond1, cond2)
-#define Trap(condition, errorType)
+#define AssertArg(condition)	((void)true)
+#define AssertState(condition)	((void)true)
+#define AssertPointerAlignment(ptr, bndr)	((void)true)
+#define AssertImply(condition1, condition2)	((void)true)
+#define AssertEquivalent(cond1, cond2)	((void)true)
+#define Trap(condition, errorType)	((void)true)
 #define TrapMacro(condition, errorType) (true)
 
 #elif defined(FRONTEND)


### PR DESCRIPTION
Backport postgres commit to fix https://github.com/greenplum-db/gpdb/issues/6869

```diff
commit 9959abb0122ca2b0e4817e20954e3083c90becdc
Author: Andres Freund <andres@anarazel.de>
Date:   Mon Dec 8 20:28:09 2014 +0100

    Define Assert() et al to ((void)0) to avoid pedantic warnings.

    gcc's -Wempty-body warns about the current usage when compiling
    postgres without --enable-cassert.

diff --git a/src/include/c.h b/src/include/c.h
index ce38d78736..93d6924c5c 100644
--- a/src/include/c.h
+++ b/src/include/c.h
@@ -578,12 +578,12 @@ typedef NameData *Name;
  */
 #ifndef USE_ASSERT_CHECKING

-#define Assert(condition)
+#define Assert(condition)   ((void)true)
 #define AssertMacro(condition)  ((void)true)
-#define AssertArg(condition)
-#define AssertState(condition)
+#define AssertArg(condition)    ((void)true)
+#define AssertState(condition)  ((void)true)
 #define AssertPointerAlignment(ptr, bndr)   ((void)true)
-#define Trap(condition, errorType)
+#define Trap(condition, errorType)  ((void)true)
 #define TrapMacro(condition, errorType) (true)

 #elif defined(FRONTEND)
```

## Here are some reminders before you submit the pull request
- [x] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
