### PR TITLE
Change formatting of AO checksums in error messages.

### DIFF
--- a/src/backend/cdb/cdbappendonlystorageformat.c
+++ b/src/backend/cdb/cdbappendonlystorageformat.c
@@ -196,7 +196,7 @@ AppendOnlyStorageFormat_AddBlockHeaderChecksums(
 			case AoHeaderKind_NonBulkDenseContent:
 				elog(LOG,
 					 "Append-Only storage make with checksums block header result: block_bytes_0_3 0x%X, block_bytes_4_7 0x%X, "
-					 "header checksum 0x%X, block checksum 0x%X, overallBlockLen %d",
+					 "header checksum 0x%08X, block checksum 0x%08X, overallBlockLen %d",
 					 blockHeader->smallcontent_bytes_0_3,
 					 blockHeader->smallcontent_bytes_4_7,
 					 *headerChecksumPtr,
@@ -217,7 +217,7 @@ AppendOnlyStorageFormat_AddBlockHeaderChecksums(
 						 "Append-Only storage make with checksums Bulk Dense Content header result: "
 						 "bulkdensecontent_bytes_0_3 0x%X, bulkdensecontent_bytes_4_7 0x%X "
 						 "bulkdensecontent_ext_bytes_0_3 0x%X, bulkdensecontent_ext_bytes_4_7 0x%X, "
-						 "header checksum 0x%X, block checksum 0x%X, overallBlockLen %d",
+						 "header checksum 0x%08X, block checksum 0x%08X, overallBlockLen %d",
 						 bulkDenseHeader->bulkdensecontent_bytes_0_3,
 						 bulkDenseHeader->bulkdensecontent_bytes_4_7,
 						 bulkDenseHeaderExt->bulkdensecontent_ext_bytes_0_3,
@@ -384,7 +384,7 @@ AppendOnlyStorageFormat_SmallContentHeaderStr(
 					"smallcontent_bytes_0_3 0x%X, smallcontent_bytes_4_7 0x%X, "
 					"headerKind = %d, "
 					"executorBlockKind = %d, "
-					"rowCount = %d, usingChecksums = %s, header checksum 0x%X, block checksum 0x%X, "
+					"rowCount = %d, usingChecksums = %s, header checksum 0x%08X, block checksum 0x%08X, "
 					"dataLength %d, compressedLength %d, overallBlockLen %d",
 					blockHeader->smallcontent_bytes_0_3,
 					blockHeader->smallcontent_bytes_4_7,
@@ -458,7 +458,7 @@ AppendOnlyStorageFormat_LargeContentHeaderStr(
 					"largecontent_bytes_0_3 0x%X, largecontent_bytes_4_7 0x%X, "
 					"headerKind = %d, "
 					"executorBlockKind = %d, "
-					"rowCount = %d, usingChecksums = %s, header checksum 0x%X, block checksum 0x%X, "
+					"rowCount = %d, usingChecksums = %s, header checksum 0x%08X, block checksum 0x%08X, "
 					"largeContentLength %d, overallBlockLen %d",
 					blockHeader->largecontent_bytes_0_3,
 					blockHeader->largecontent_bytes_4_7,
@@ -534,7 +534,7 @@ AppendOnlyStorageFormat_NonBulkDenseContentHeaderStr(
 					"nonbulkdensecontent_bytes_0_3 0x%X, nonbulkdensecontent_bytes_4_7 0x%X, "
 					"headerKind = %d, "
 					"executorBlockKind = %d, "
-					"rowCount = %d, usingChecksums = %s, header checksum 0x%X, block checksum 0x%X, "
+					"rowCount = %d, usingChecksums = %s, header checksum 0x%08X, block checksum 0x%08X, "
 					"dataLength %d, overallBlockLen %d",
 					blockHeader->nonbulkdensecontent_bytes_0_3,
 					blockHeader->nonbulkdensecontent_bytes_4_7,
@@ -626,7 +626,7 @@ AppendOnlyStorageFormat_BulkDenseContentHeaderStr(
 					"bulkdensecontent_ext_bytes_0_3 0x%X, bulkdensecontent_ext_bytes_4_7 0x%X, "
 					"headerKind = %d, "
 					"executorBlockKind = %d, "
-					"rowCount = %d, usingChecksums = %s, header checksum 0x%X, block checksum 0x%X, "
+					"rowCount = %d, usingChecksums = %s, header checksum 0x%08X, block checksum 0x%08X, "
 					"dataLength %d, compressedLength %d, overallBlockLen %d",
 					blockHeader->bulkdensecontent_bytes_0_3,
 					blockHeader->bulkdensecontent_bytes_4_7,

--- a/src/backend/cdb/cdbappendonlystorageread.c
+++ b/src/backend/cdb/cdbappendonlystorageread.c
@@ -833,7 +833,7 @@ AppendOnlyStorageRead_ReadNextBlock(AppendOnlyStorageRead *storageRead)
 														  &computedChecksum))
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),
-					 errmsg("header checksum does not match, expected 0x%X and found 0x%X",
+					 errmsg("header checksum does not match, expected 0x%08X and found 0x%08X",
 							storedChecksum, computedChecksum),
 					 errdetail_appendonly_read_storage_content_header(storageRead),
 					 errcontext_appendonly_read_storage_block(storageRead)));
@@ -1175,7 +1175,7 @@ AppendOnlyStorageRead_InternalGetBuffer(AppendOnlyStorageRead *storageRead,
 														 &computedChecksum))
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),
-					 errmsg("block checksum does not match, expected 0x%X and found 0x%X",
+					 errmsg("block checksum does not match, expected 0x%08X and found 0x%08X",
 							storedChecksum,
 							computedChecksum),
 					 errdetail_appendonly_read_storage_content_header(storageRead),

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -880,7 +880,7 @@ AppendOnlyStorageWrite_VerifyWriteBlock(AppendOnlyStorageWrite *storageWrite,
 														  &storedChecksum,
 														  &computedChecksum))
 			ereport(ERROR,
-					(errmsg("Verify block during write found header checksum does not match.  Expected 0x%X and found 0x%X",
+					(errmsg("Verify block during write found header checksum does not match.  Expected 0x%08X and found 0x%08X",
 							storedChecksum,
 							computedChecksum),
 					 errdetail_appendonly_write_storage_block_header(storageWrite),

--- a/src/test/regress/expected/ao_checksum_corruption.out
+++ b/src/test/regress/expected/ao_checksum_corruption.out
@@ -104,7 +104,7 @@ INFO:  corrupting file base/107062/107070.1 at 8  (seg2 slice1 127.0.0.1:40002 p
 (1 row)
 
 SELECT COUNT(*) FROM corrupt_header_large_co;
-ERROR:  header checksum does not match, expected 0xBA9CC649 and found 0xC997AE7   (seg0 slice1 127.0.0.1:40000 pid=28137)
+ERROR:  header checksum does not match, expected 0xBA9CC649 and found 0x0C997AE7   (seg0 slice1 127.0.0.1:40000 pid=28137)
 -- Large content, corrupt content
 create table corrupt_content_large_co(comment bytea ) with (appendonly=true, orientation=column, checksum=true) DISTRIBUTED RANDOMLY;
 insert into corrupt_content_large_co select ("decode"(repeat('a',33554432),'escape')) from generate_series(1,8)  ;
@@ -118,7 +118,7 @@ INFO:  corrupting file base/107062/107080.1 at -3  (seg2 slice1 127.0.0.1:40002 
 (1 row)
 
 SELECT COUNT(*) FROM corrupt_content_large_co;
-ERROR:  block checksum does not match, expected 0x9C02F450 and found 0xA78638C   (seg0 slice1 127.0.0.1:40000 pid=28137)
+ERROR:  block checksum does not match, expected 0x9C02F450 and found 0x0A78638C   (seg0 slice1 127.0.0.1:40000 pid=28137)
 -- Small content, corrupt block header
 create table corrupt_header_small_co(a int) with (appendonly=true, orientation=column, checksum=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.


### PR DESCRIPTION
The gpdiff rule in 'ao_checksum_corruption' test assumed that the
checksums were 8 characters wide. That was not always true, however,
because the checksums were not padded with zeros. Padding them with zeros
seems nicer, so change the error messages to do that.

This should fix these buildfarm failures we've been seeing recently:

-ERROR:  header checksum does not match, expected 0xXXXXXXXX and found 0xXXXXXXXX
+ERROR:  header checksum does not match, expected 0x21B733 and found 0x44C333F8

I'm not sure why we started seeing this now, and I didn't see those errors
on my laptop. But it's pure chance whether a checksum happens to begin
with a 0 or not, so it's not that surprising that some completely
unrelated change changed the physical contents of the table. This commit
should make the failure go away.
