### PR TITLE
Misc gpexpand cleanup, including fix for 'distkeys' failure

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -282,7 +282,6 @@ status_table_sql = """CREATE TABLE gpexpand.status
 status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
                         ( dbname text,
                           fq_name text,
-                          schema_oid oid,
                           table_oid oid,
                           root_partition_name text,
                           storage_options text,
@@ -1572,7 +1571,6 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
         src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
         sql = """SELECT
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
-    n.oid as schemaoid,
     c.oid as tableoid,
     now() as last_updated,
     %s,
@@ -1601,15 +1599,14 @@ WHERE
             fp = open(sql_file, 'w')
             for row in rows:
                 fqname = row[0]
-                schema_oid = row[1]
-                table_oid = row[2]
-                rel_bytes = int(row[4])
-                root_partition_name = row[5]
+                table_oid = row[1]
+                rel_bytes = int(row[3])
+                root_partition_name = row[4]
                 full_name = '%s.%s' % (dbname, fqname)
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
-                fp.write("""%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
-                    dbname, fqname, schema_oid, table_oid,
+                fp.write("""%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
+                    dbname, fqname, table_oid,
                     root_partition_name, rank, undone_status, rel_bytes))
         except Exception, e:
             raise ExpansionError(e)
@@ -1654,7 +1651,6 @@ WHERE
         sql = """
 SELECT
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
-    n.oid as schemaoid,
     c.oid as tableoid,
     now() as last_updated,
     %s,
@@ -1683,15 +1679,14 @@ ORDER BY fq_name, tableoid desc;
 
             for row in rows:
                 fqname = row[0]
-                schema_oid = row[1]
-                table_oid = row[2]
-                rel_bytes = int(row[4])
-                root_partition_name = row[5]
+                table_oid = row[1]
+                rel_bytes = int(row[3])
+                root_partition_name = row[4]
                 full_name = '%s.%s' % (dbname, fqname)
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
-                fp.write("""%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
-                    dbname, fqname, schema_oid, table_oid,
+                fp.write("""%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
+                    dbname, fqname, table_oid,
                     root_partition_name, rank, undone_status, rel_bytes))
         except Exception:
             raise
@@ -1932,7 +1927,7 @@ class ExpandTable():
         self.options = options
         self.is_root_partition = False
         if row is not None:
-            (self.dbname, self.fq_name, self.schema_oid, self.table_oid,
+            (self.dbname, self.fq_name, self.table_oid,
              self.root_partition_name,
              self.storage_options, self.rank, self.status,
              self.expansion_started, self.expansion_finished,
@@ -1942,9 +1937,9 @@ class ExpandTable():
 
     def add_table(self, conn):
         insertSQL = """INSERT INTO gpexpand.status_detail
-                            VALUES ('%s','%s',%s,%s,
+                            VALUES ('%s','%s',%s,
                                     '%s','%s',%d,'%s','%s','%s',%d)
-                    """ % (self.dbname, self.fq_name.replace("\'", "\'\'"), self.schema_oid, self.table_oid,
+                    """ % (self.dbname, self.fq_name.replace("\'", "\'\'"), self.table_oid,
                            self.root_partition_name,
                            self.storage_options, self.rank, self.status,
                            self.expansion_started, self.expansion_finished,
@@ -1965,10 +1960,10 @@ class ExpandTable():
         sql = """UPDATE gpexpand.status_detail
                   SET status = '%s', expansion_started='%s',
                       source_bytes = %d
-                  WHERE dbname = '%s' AND schema_oid = %s
+                  WHERE dbname = '%s'
                         AND table_oid = %s """ % (start_status, start_time,
                                                   src_bytes, self.dbname,
-                                                  self.schema_oid, self.table_oid)
+                                                  self.table_oid)
 
         logger.debug("Mark Started: " + sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
@@ -1977,9 +1972,9 @@ class ExpandTable():
     def reset_started(self, status_conn):
         sql = """UPDATE gpexpand.status_detail
                  SET status = '%s', expansion_started=NULL, expansion_finished=NULL
-                 WHERE dbname = '%s' AND schema_oid = %s
+                 WHERE dbname = '%s'
                  AND table_oid = %s """ % (undone_status,
-                                           self.dbname, self.schema_oid, self.table_oid)
+                                           self.dbname, self.table_oid)
 
         logger.debug('Resetting detailed_status: %s' % sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
@@ -2020,9 +2015,9 @@ class ExpandTable():
     def mark_finished(self, status_conn, start_time, finish_time):
         sql = """UPDATE gpexpand.status_detail
                   SET status = '%s', expansion_started='%s', expansion_finished='%s'
-                  WHERE dbname = '%s' AND schema_oid = %s
+                  WHERE dbname = '%s'
                   AND table_oid = %s """ % (done_status, start_time, finish_time,
-                                            self.dbname, self.schema_oid, self.table_oid)
+                                            self.dbname, self.table_oid)
         logger.debug(sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
         status_conn.commit()
@@ -2030,9 +2025,9 @@ class ExpandTable():
     def mark_does_not_exist(self, status_conn, finish_time):
         sql = """UPDATE gpexpand.status_detail
                   SET status = '%s', expansion_finished='%s'
-                  WHERE dbname = '%s' AND schema_oid = %s
+                  WHERE dbname = '%s'
                   AND table_oid = %s """ % (does_not_exist_status, finish_time,
-                                            self.dbname, self.schema_oid, self.table_oid)
+                                            self.dbname, self.table_oid)
         logger.debug(sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
         status_conn.commit()
@@ -2141,9 +2136,7 @@ class ExpandCommand(SQLCommand):
         # validate table hasn't been dropped
         start_time = None
         try:
-            sql = """select * from pg_class c, pg_namespace n
-            where c.oid = %d and n.oid = c.relnamespace and n.oid=%d""" % (self.table.table_oid,
-                                                                           self.table.schema_oid)
+            sql = """select * from pg_class c where c.oid = %d """ % (self.table.table_oid)
 
             cursor = dbconn.execSQL(table_conn, sql)
 

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -276,17 +276,14 @@ start_status = "IN PROGRESS"
 done_status = "COMPLETED"
 does_not_exist_status = 'NO LONGER EXISTS'
 
-gpexpand_schema = 'gpexpand'
-create_schema_sql = "CREATE SCHEMA " + gpexpand_schema
-drop_schema_sql = "DROP schema IF EXISTS %s CASCADE" % gpexpand_schema
+create_schema_sql = "CREATE SCHEMA gpexpand"
+drop_schema_sql = "DROP SCHEMA IF EXISTS gpexpand CASCADE"
 
-status_table = 'status'
-status_table_sql = """CREATE TABLE %s.%s
+status_table_sql = """CREATE TABLE gpexpand.status
                         ( status text,
-                          updated timestamp ) """ % (gpexpand_schema, status_table)
+                          updated timestamp ) """
 
-status_detail_table = 'status_detail'
-status_detail_table_sql = """CREATE TABLE %s.%s
+status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
                         ( dbname text,
                           fq_name text,
                           schema_oid oid,
@@ -301,20 +298,18 @@ status_detail_table_sql = """CREATE TABLE %s.%s
                           status text,
                           expansion_started timestamp,
                           expansion_finished timestamp,
-                          source_bytes numeric ) """ % (gpexpand_schema, status_detail_table)
+                          source_bytes numeric ) """
 # gpexpand views
-progress_view = 'expansion_progress'
-progress_view_simple_sql = """CREATE VIEW %s.%s AS
+progress_view_simple_sql = """CREATE VIEW gpexpand.expansion_progress AS
 SELECT
     CASE status
         WHEN '%s' THEN 'Tables Expanded'
         WHEN '%s' THEN 'Tables Left'
     END AS Name,
     count(*)::text AS Value
-FROM %s.%s GROUP BY status""" % (gpexpand_schema, progress_view,
-                                 done_status, undone_status, gpexpand_schema, status_detail_table)
+FROM gpexpand.status_detail GROUP BY status""" % (done_status, undone_status)
 
-progress_view_sql = """CREATE VIEW %s.%s AS
+progress_view_sql = """CREATE VIEW gpexpand.expansion_progress AS
 SELECT
     CASE status
         WHEN '%s' THEN 'Tables Expanded'
@@ -322,7 +317,7 @@ SELECT
         WHEN '%s' THEN 'Tables In Progress'
     END AS Name,
     count(*)::text AS Value
-FROM %s.%s GROUP BY status
+FROM gpexpand.status_detail GROUP BY status
 
 UNION
 
@@ -333,17 +328,17 @@ SELECT
         WHEN '%s' THEN 'Bytes In Progress'
     END AS Name,
     SUM(source_bytes)::text AS Value
-FROM %s.%s GROUP BY status
+FROM gpexpand.status_detail GROUP BY status
 
 UNION
 
 SELECT
     'Estimated Expansion Rate' AS Name,
     (SUM(source_bytes) / (1 + extract(epoch FROM (max(expansion_finished) - min(expansion_started)))) / 1024 / 1024)::text || ' MB/s' AS Value
-FROM %s.%s
+FROM gpexpand.status_detail
 WHERE status = '%s'
 AND
-expansion_started > (SELECT updated FROM %s.%s WHERE status = '%s' ORDER BY updated DESC LIMIT 1)
+expansion_started > (SELECT updated FROM gpexpand.status WHERE status = '%s' ORDER BY updated DESC LIMIT 1)
 
 UNION
 
@@ -351,27 +346,19 @@ SELECT
 'Estimated Time to Completion' AS Name,
 CAST((SUM(source_bytes) / (
 SELECT 1 + SUM(source_bytes) / (1 + (extract(epoch FROM (max(expansion_finished) - min(expansion_started)))))
-FROM %s.%s
+FROM gpexpand.status_detail
 WHERE status = '%s'
 AND
-expansion_started > (SELECT updated FROM %s.%s WHERE status = '%s' ORDER BY
+expansion_started > (SELECT updated FROM gpexpand.status WHERE status = '%s' ORDER BY
 updated DESC LIMIT 1)))::text || ' seconds' as interval)::text AS Value
-FROM %s.%s
+FROM gpexpand.status_detail
 WHERE status = '%s'
-  OR status = '%s'""" % (gpexpand_schema, progress_view,
+  OR status = '%s'""" % (done_status, undone_status, start_status,
                          done_status, undone_status, start_status,
-                         gpexpand_schema, status_detail_table,
-                         done_status, undone_status, start_status,
-                         gpexpand_schema, status_detail_table,
-                         gpexpand_schema, status_detail_table,
                          done_status,
-                         gpexpand_schema, status_table,
                          'EXPANSION STARTED',
-                         gpexpand_schema, status_detail_table,
                          done_status,
-                         gpexpand_schema, status_table,
                          'EXPANSION STARTED',
-                         gpexpand_schema, status_detail_table,
                          start_status, undone_status)
 
 unalterable_table_sql = """
@@ -1554,7 +1541,7 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
             self.gparray = GpArray.initFromCatalog(self.dburl)
 
         nowStr = datetime.datetime.now()
-        statusSQL = "INSERT INTO %s.%s VALUES ( 'SETUP', '%s' ) " % (gpexpand_schema, status_table, nowStr)
+        statusSQL = "INSERT INTO gpexpand.status VALUES ( 'SETUP', '%s' ) " % (nowStr)
 
         dbconn.execSQL(self.conn, statusSQL)
 
@@ -1564,14 +1551,14 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
             dbname = db[0]
             if dbname == 'template0':
                 continue
-            self.logger.info('Populating %s.%s with data from database %s' % (
-                gpexpand_schema, status_detail_table, dbname.decode('utf-8')))
+            self.logger.info('Populating gpexpand.status_detail with data from database %s' % (
+                dbname.decode('utf-8')))
             self._populate_regular_tables(dbname)
             self._populate_partitioned_tables(dbname)
             inject_fault('gpexpand MPP-14620 fault injection')
 
         nowStr = datetime.datetime.now()
-        statusSQL = "INSERT INTO %s.%s VALUES ( 'SETUP DONE', '%s' ) " % (gpexpand_schema, status_table, nowStr)
+        statusSQL = "INSERT INTO gpexpand.status VALUES ( 'SETUP DONE', '%s' ) " % (nowStr)
         dbconn.execSQL(self.conn, statusSQL)
 
         self.conn.commit()
@@ -1619,7 +1606,7 @@ WHERE
         curs = dbconn.execSQL(table_conn, sql)
         rows = curs.fetchall()
         try:
-            sql_file = os.path.abspath('./%s.dat' % status_detail_table)
+            sql_file = os.path.abspath('./status_detail.dat')
             self.logger.debug('status_detail data file: %s' % sql_file)
             fp = open(sql_file, 'w')
             for row in rows:
@@ -1652,7 +1639,7 @@ WHERE
             if fp: fp.close()
 
         try:
-            copySQL = """COPY %s.%s FROM '%s' NULL AS 'NULL'""" % (gpexpand_schema, status_detail_table, sql_file)
+            copySQL = """COPY gpexpand.status_detail FROM '%s' NULL AS 'NULL'""" % (sql_file)
 
             self.logger.debug(copySQL)
             dbconn.execSQL(self.conn, copySQL)
@@ -1713,7 +1700,7 @@ ORDER BY fq_name, tableoid desc;
         rows = curs.fetchall()
 
         try:
-            sql_file = os.path.abspath('./%s.dat' % status_detail_table)
+            sql_file = os.path.abspath('./status_detail.dat')
             self.logger.debug('status_detail data file: %s' % sql_file)
             fp = open(sql_file, 'w')
 
@@ -1747,7 +1734,7 @@ ORDER BY fq_name, tableoid desc;
             if fp: fp.close()
 
         try:
-            copySQL = """COPY %s.%s FROM '%s' NULL AS 'NULL'""" % (gpexpand_schema, status_detail_table, sql_file)
+            copySQL = """COPY gpexpand.status_detail FROM '%s' NULL AS 'NULL'""" % (sql_file)
 
             self.logger.debug(copySQL)
             dbconn.execSQL(self.conn, copySQL)
@@ -1793,8 +1780,8 @@ ORDER BY fq_name, tableoid desc;
 
         # go through and reset any "IN PROGRESS" tables
         self.conn = dbconn.connect(self.dburl, encoding='UTF8')
-        sql = "INSERT INTO %s.%s VALUES ( 'EXPANSION STARTED', '%s' ) " % (
-            gpexpand_schema, status_table, expansionStart)
+        sql = "INSERT INTO gpexpand.status VALUES ( 'EXPANSION STARTED', '%s' ) " % (
+            expansionStart)
         dbconn.execSQL(self.conn, sql)
         self.conn.commit()
 
@@ -1803,7 +1790,7 @@ ORDER BY fq_name, tableoid desc;
         self.conn.commit()
 
         # read schema and queue up commands
-        sql = "SELECT * FROM %s.%s WHERE status = 'NOT STARTED' ORDER BY rank" % (gpexpand_schema, status_detail_table)
+        sql = "SELECT * FROM gpexpand.status_detail WHERE status = 'NOT STARTED' ORDER BY rank"
         cursor = dbconn.execSQL(self.conn, sql)
 
         for row in cursor:
@@ -1845,8 +1832,8 @@ ORDER BY fq_name, tableoid desc;
 
         if stoppedEarly:
             logger.info('End time reached.  Stopping expansion.')
-            sql = "INSERT INTO %s.%s VALUES ( 'EXPANSION STOPPED', '%s' ) " % (
-                gpexpand_schema, status_table, expansionStopped)
+            sql = "INSERT INTO gpexpand.status VALUES ( 'EXPANSION STOPPED', '%s' ) " % (
+                expansionStopped)
             cursor = dbconn.execSQL(self.conn, sql)
             self.conn.commit()
             logger.info('You can resume expansion by running gpexpand again')
@@ -1860,15 +1847,15 @@ ORDER BY fq_name, tableoid desc;
             # going into read only mode, this will fail.  That's ok though as
             # gpexpand will resume next run
             try:
-                sql = "INSERT INTO %s.%s VALUES ( 'EXPANSION STOPPED', '%s' ) " % (
-                    gpexpand_schema, status_table, expansionStopped)
+                sql = "INSERT INTO gpexpand.status VALUES ( 'EXPANSION STOPPED', '%s' ) " % (
+                    expansionStopped)
                 cursor = dbconn.execSQL(self.conn, sql)
                 self.conn.commit()
             except:
                 pass
         else:
-            sql = "INSERT INTO %s.%s VALUES ( 'EXPANSION COMPLETE', '%s' ) " % (
-                gpexpand_schema, status_table, expansionStopped)
+            sql = "INSERT INTO gpexpand.status VALUES ( 'EXPANSION COMPLETE', '%s' ) " % (
+                expansionStopped)
             cursor = dbconn.execSQL(self.conn, sql)
             self.conn.commit()
             logger.info("EXPANSION COMPLETED SUCCESSFULLY")
@@ -1886,8 +1873,8 @@ ORDER BY fq_name, tableoid desc;
 
         try:
             expansionStopped = datetime.datetime.now()
-            sql = "INSERT INTO %s.%s VALUES ( 'EXPANSION STOPPED', '%s' ) " % (
-                gpexpand_schema, status_table, expansionStopped)
+            sql = "INSERT INTO gpexpand.status VALUES ( 'EXPANSION STOPPED', '%s' ) " % (
+                expansionStopped)
             cursor = dbconn.execSQL(self.conn, sql)
             self.conn.commit()
 
@@ -1915,8 +1902,7 @@ ORDER BY fq_name, tableoid desc;
             c = dbconn.connect(self.dburl, encoding='UTF8')
             self.logger.warn('Expansion has not yet completed.  Removing the expansion')
             self.logger.warn('schema now will leave the following tables unexpanded:')
-            unexpanded_tables_sql = "SELECT fq_name FROM %s.%s WHERE status = 'NOT STARTED' ORDER BY rank" % (
-                gpexpand_schema, status_detail_table)
+            unexpanded_tables_sql = "SELECT fq_name FROM gpexpand.status_detail WHERE status = 'NOT STARTED' ORDER BY rank"
 
             cursor = dbconn.execSQL(c, unexpanded_tables_sql)
             unexpanded_tables_text = ''.join("\t%s\n" % row[0] for row in cursor)
@@ -2016,11 +2002,10 @@ class ExpandTable():
             self.is_root_partition = True
 
     def add_table(self, conn):
-        insertSQL = """INSERT INTO %s.%s
+        insertSQL = """INSERT INTO gpexpand.status_detail
                             VALUES ('%s','%s',%s,%s,
                                     '%s','%s', '%s', '%s', '%s','%s',%d,'%s','%s','%s',%d)
-                    """ % (gpexpand_schema, status_detail_table,
-                           self.dbname, self.fq_name.replace("\'", "\'\'"), self.schema_oid, self.table_oid,
+                    """ % (self.dbname, self.fq_name.replace("\'", "\'\'"), self.schema_oid, self.table_oid,
                            self.distrib_policy, self.distrib_policy_names, self.distrib_policy_coloids,
                            self.distrib_policy_type, self.root_partition_name,
                            self.storage_options, self.rank, self.status,
@@ -2039,12 +2024,11 @@ class ExpandTable():
         src_bytes = int(row[0])
         logger.debug(" Table: %s has %d bytes" % (self.fq_name.decode('utf-8'), src_bytes))
 
-        sql = """UPDATE %s.%s
+        sql = """UPDATE gpexpand.status_detail
                   SET status = '%s', expansion_started='%s',
                       source_bytes = %d
                   WHERE dbname = '%s' AND schema_oid = %s
-                        AND table_oid = %s """ % (gpexpand_schema, status_detail_table,
-                                                  start_status, start_time,
+                        AND table_oid = %s """ % (start_status, start_time,
                                                   src_bytes, self.dbname,
                                                   self.schema_oid, self.table_oid)
 
@@ -2053,10 +2037,10 @@ class ExpandTable():
         status_conn.commit()
 
     def reset_started(self, status_conn):
-        sql = """UPDATE %s.%s
+        sql = """UPDATE gpexpand.status_detail
                  SET status = '%s', expansion_started=NULL, expansion_finished=NULL
                  WHERE dbname = '%s' AND schema_oid = %s
-                 AND table_oid = %s """ % (gpexpand_schema, status_detail_table, undone_status,
+                 AND table_oid = %s """ % (undone_status,
                                            self.dbname, self.schema_oid, self.table_oid)
 
         logger.debug('Resetting detailed_status: %s' % sql.decode('utf-8'))
@@ -2096,22 +2080,20 @@ class ExpandTable():
         return False
 
     def mark_finished(self, status_conn, start_time, finish_time):
-        sql = """UPDATE %s.%s
+        sql = """UPDATE gpexpand.status_detail
                   SET status = '%s', expansion_started='%s', expansion_finished='%s'
                   WHERE dbname = '%s' AND schema_oid = %s
-                  AND table_oid = %s """ % (gpexpand_schema, status_detail_table,
-                                            done_status, start_time, finish_time,
+                  AND table_oid = %s """ % (done_status, start_time, finish_time,
                                             self.dbname, self.schema_oid, self.table_oid)
         logger.debug(sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
         status_conn.commit()
 
     def mark_does_not_exist(self, status_conn, finish_time):
-        sql = """UPDATE %s.%s
+        sql = """UPDATE gpexpand.status_detail
                   SET status = '%s', expansion_finished='%s'
                   WHERE dbname = '%s' AND schema_oid = %s
-                  AND table_oid = %s """ % (gpexpand_schema, status_detail_table,
-                                            does_not_exist_status, finish_time,
+                  AND table_oid = %s """ % (does_not_exist_status, finish_time,
                                             self.dbname, self.schema_oid, self.table_oid)
         logger.debug(sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -44,10 +44,6 @@ except ImportError, e:
 MAX_PARALLEL_EXPANDS = 96
 MAX_BATCH_SIZE = 128
 
-GPDB_STOPPED = 1
-GPDB_STARTED = 2
-GPDB_UTILITY = 3
-
 SEGMENT_CONFIGURATION_BACKUP_FILE = "gpexpand.gp_segment_configuration"
 
 #global var
@@ -1753,7 +1749,7 @@ ORDER BY fq_name, tableoid desc;
 
         namedict = {}
         oiddict = {}
-        sql = "select attnum, attname, attrelid from pg_attribute where attrelid =  %s and attnum > 0" % table_oid
+        sql = "select attnum, attname, attrelid from pg_attribute where attrelid = %s and attnum > 0" % table_oid
         cursor = dbconn.execSQL(conn, sql)
         for row in cursor:
             namedict[row[0]] = row[1]

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -284,10 +284,6 @@ status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
                           fq_name text,
                           schema_oid oid,
                           table_oid oid,
-                          distribution_policy smallint[],
-                          distribution_policy_names text,
-                          distribution_policy_coloids text,
-                          distribution_policy_type text,
                           root_partition_name text,
                           storage_options text,
                           rank int,
@@ -1578,10 +1574,8 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
     n.oid as schemaoid,
     c.oid as tableoid,
-    p.distkey as distribution_policy,
     now() as last_updated,
     %s,
-    p.policytype as distribution_policy_type,
     NULL as root_partition_name
 FROM
             pg_class c
@@ -1609,26 +1603,14 @@ WHERE
                 fqname = row[0]
                 schema_oid = row[1]
                 table_oid = row[2]
-                if row[3]:
-                    self.logger.debug("dist policy raw: %s " % row[3].decode('utf-8'))
-                else:
-                    self.logger.debug("dist policy raw: NULL")
-                dist_policy = row[3]
-                (policy_name, policy_oids) = self.form_dist_policy_name(table_conn, row[3], table_oid)
-                rel_bytes = int(row[5])
-
-                if dist_policy is None:
-                    dist_policy = 'NULL'
-
-                dist_policy_type = row[6];
-                root_partition_name = row[7]
+                rel_bytes = int(row[4])
+                root_partition_name = row[5]
                 full_name = '%s.%s' % (dbname, fqname)
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
-                fp.write("""%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
+                fp.write("""%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
                     dbname, fqname, schema_oid, table_oid,
-                    dist_policy, policy_name, policy_oids,
-                    dist_policy_type, root_partition_name, rank, undone_status, rel_bytes))
+                    root_partition_name, rank, undone_status, rel_bytes))
         except Exception, e:
             raise ExpansionError(e)
         finally:
@@ -1674,7 +1656,6 @@ SELECT
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
     n.oid as schemaoid,
     c.oid as tableoid,
-    d.distkey as distributed_policy,
     now() as last_updated,
     %s,
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as root_partition_name
@@ -1704,26 +1685,14 @@ ORDER BY fq_name, tableoid desc;
                 fqname = row[0]
                 schema_oid = row[1]
                 table_oid = row[2]
-                if row[3]:
-                    self.logger.debug("dist policy raw: %s " % row[3])
-                else:
-                    self.logger.debug("dist policy raw: NULL")
-                dist_policy = row[3]
-                (policy_name, policy_oids) = self.form_dist_policy_name(table_conn, row[3], table_oid)
-                rel_bytes = int(row[5])
-
-                if dist_policy is None:
-                    dist_policy = 'NULL'
-
-                dist_policy_type = 'p';
-                root_partition_name = row[6]
+                rel_bytes = int(row[4])
+                root_partition_name = row[5]
                 full_name = '%s.%s' % (dbname, fqname)
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
-                fp.write("""%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
+                fp.write("""%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
                     dbname, fqname, schema_oid, table_oid,
-                    dist_policy, policy_name, policy_oids,
-                    dist_policy_type, root_partition_name, rank, undone_status, rel_bytes))
+                    root_partition_name, rank, undone_status, rel_bytes))
         except Exception:
             raise
         finally:
@@ -1741,31 +1710,6 @@ ORDER BY fq_name, tableoid desc;
 
         table_conn.commit()
         table_conn.close()
-
-    def form_dist_policy_name(self, conn, rs_val, table_oid):
-        if rs_val is None:
-            return (None, None)
-        rs_val = rs_val.lstrip('{').rstrip('}').strip()
-
-        namedict = {}
-        oiddict = {}
-        sql = "select attnum, attname, attrelid from pg_attribute where attrelid = %s and attnum > 0" % table_oid
-        cursor = dbconn.execSQL(conn, sql)
-        for row in cursor:
-            namedict[row[0]] = row[1]
-            oiddict[row[0]] = row[2]
-
-        name_list = []
-        oid_list = []
-
-        if rs_val != "":
-            rs_list = rs_val.split(',')
-
-            for colnum in rs_list:
-                name_list.append(namedict[int(colnum)])
-                oid_list.append(str(oiddict[int(colnum)]))
-
-        return (' , '.join(name_list), ' , '.join(oid_list))
 
     def perform_expansion(self):
         """Performs the actual table re-organizations"""
@@ -1989,8 +1933,7 @@ class ExpandTable():
         self.is_root_partition = False
         if row is not None:
             (self.dbname, self.fq_name, self.schema_oid, self.table_oid,
-             self.distrib_policy, self.distrib_policy_names, self.distrib_policy_coloids,
-             self.distrib_policy_type, self.root_partition_name,
+             self.root_partition_name,
              self.storage_options, self.rank, self.status,
              self.expansion_started, self.expansion_finished,
              self.source_bytes) = row
@@ -2000,10 +1943,9 @@ class ExpandTable():
     def add_table(self, conn):
         insertSQL = """INSERT INTO gpexpand.status_detail
                             VALUES ('%s','%s',%s,%s,
-                                    '%s','%s', '%s', '%s', '%s','%s',%d,'%s','%s','%s',%d)
+                                    '%s','%s',%d,'%s','%s','%s',%d)
                     """ % (self.dbname, self.fq_name.replace("\'", "\'\'"), self.schema_oid, self.table_oid,
-                           self.distrib_policy, self.distrib_policy_names, self.distrib_policy_coloids,
-                           self.distrib_policy_type, self.root_partition_name,
+                           self.root_partition_name,
                            self.storage_options, self.rank, self.status,
                            self.expansion_started, self.expansion_finished,
                            self.source_bytes)

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -284,7 +284,6 @@ status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
                           fq_name text,
                           table_oid oid,
                           root_partition_name text,
-                          storage_options text,
                           rank int,
                           status text,
                           expansion_started timestamp,
@@ -1605,7 +1604,7 @@ WHERE
                 full_name = '%s.%s' % (dbname, fqname)
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
-                fp.write("""%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
+                fp.write("""%s\t%s\t%s\t%s\t%d\t%s\tNULL\tNULL\t%d\n""" % (
                     dbname, fqname, table_oid,
                     root_partition_name, rank, undone_status, rel_bytes))
         except Exception, e:
@@ -1685,7 +1684,7 @@ ORDER BY fq_name, tableoid desc;
                 full_name = '%s.%s' % (dbname, fqname)
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
-                fp.write("""%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
+                fp.write("""%s\t%s\t%s\t%s\t%d\t%s\tNULL\tNULL\t%d\n""" % (
                     dbname, fqname, table_oid,
                     root_partition_name, rank, undone_status, rel_bytes))
         except Exception:
@@ -1929,7 +1928,7 @@ class ExpandTable():
         if row is not None:
             (self.dbname, self.fq_name, self.table_oid,
              self.root_partition_name,
-             self.storage_options, self.rank, self.status,
+             self.rank, self.status,
              self.expansion_started, self.expansion_finished,
              self.source_bytes) = row
         if self.fq_name == self.root_partition_name:
@@ -1938,10 +1937,10 @@ class ExpandTable():
     def add_table(self, conn):
         insertSQL = """INSERT INTO gpexpand.status_detail
                             VALUES ('%s','%s',%s,
-                                    '%s','%s',%d,'%s','%s','%s',%d)
+                                    '%s',%d,'%s','%s','%s',%d)
                     """ % (self.dbname, self.fq_name.replace("\'", "\'\'"), self.table_oid,
                            self.root_partition_name,
-                           self.storage_options, self.rank, self.status,
+                           self.rank, self.status,
                            self.expansion_started, self.expansion_finished,
                            self.source_bytes)
         logger.info('Added table %s.%s' % (self.dbname.decode('utf-8'), self.fq_name.decode('utf-8')))
@@ -1987,10 +1986,6 @@ class ExpandTable():
             only_str = ""
         else:
             only_str = "ONLY"
-
-        new_storage_options = ''
-        if self.storage_options:
-            new_storage_options = ',' + self.storage_options
 
         sql = 'ALTER TABLE %s %s EXPAND TABLE' % (only_str, self.fq_name)
 


### PR DESCRIPTION
See commit messages for details.

The other commits are just cosmetic cleanup, but the "Remove unused distribution policy fields in gpexpand status table" commit should fix the current pipeline failure. The same one that Jacob fixed in PR https://github.com/greenplum-db/gpdb/pull/6878, but I think this is a better fix.