### PR TITLE
Remove standby master during PT rebuild Behave test

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
@@ -49,6 +49,7 @@ Feature: persistent rebuild tests
 
     Scenario: Persistent rebuild should work on small shared_buffers value
         Given the database is running
+        And the standby is not initialized
         And there is a "ao" table "public.ao_part_table" in "bkdb" having "1000" partitions
         And a checkpoint is taken
         And the user runs "gpconfig -c shared_buffers -v 512kB"


### PR DESCRIPTION
This particular PT rebuild Behave scenario creates a 1000 AO partition
table. Even with the explicit checkpoint after to create a restart
point, the standby master can take a long time to do replay (e.g. lots
of disk IO contention) when the database is stopped and restarted. The
lengthy replay time has been the cause of intermittent failures in our
CI. Since a standby master is not needed for this test scenario, let's
remove it to eliminate further intermittent failures.
