### PR TITLE
Fix "cache lookup failed" errors when reshuffling table with enum.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1597,7 +1597,7 @@ make_reshuffle(PlannerInfo *root,
 		Oid			typeoid = exprType((Node *) tle->expr);
 		Oid			hashFunc;
 
-		hashFunc = get_opfamily_proc(opfamily, typeoid, typeoid, HASHPROC);
+		hashFunc = cdb_hashproc_in_opfamily(opfamily, typeoid);
 
 		reshufflePlan->policyAttrs[i] = policy->attrs[i];
 		reshufflePlan->policyHashFuncs[i] = hashFunc;

--- a/src/test/regress/expected/reshuffle.out
+++ b/src/test/regress/expected/reshuffle.out
@@ -1012,3 +1012,38 @@ DETAIL:  drop cascades to table inherit_t1_p2
 drop cascades to table inherit_t1_p4
 drop cascades to table inherit_t1_p3
 drop cascades to table inherit_t1_p5
+--
+-- Test expanding a table with a domain type as distribution key.
+--
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+create domain myintdomain as int4;
+create table expand_domain_tab(d myintdomain, oldseg int4) distributed by(d);
+insert into expand_domain_tab select generate_series(1,10);
+update expand_domain_tab set oldseg = gp_segment_id;
+select gp_segment_id, count(*) from expand_domain_tab group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |     8
+             1 |     2
+(2 rows)
+
+alter table expand_domain_tab expand table;
+select gp_segment_id, count(*) from expand_domain_tab group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             0 |     5
+             1 |     1
+             2 |     4
+(3 rows)
+
+select numsegments from gp_distribution_policy where localoid='expand_domain_tab'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+


### PR DESCRIPTION
The code to look up the hash functions for a Reshuffle plan used
get_opfamily_proc() instead of the more versatile
cdb_hashproc_in_family() function, which is used in other similar places
where we need to look up the hash functions for a distribution key. Like
in makeCdbHashForRelation(). That lead to errors if the datatype didn't
have a hash function defined directly for the datatype, but only via a
binary-coercible cast. Enum types were one such case.

Fixes https://github.com/greenplum-db/gpdb/issues/6901
