### PR TITLE
docs - update util ref pages for 9.0beta3

### DIFF
--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
@@ -26,7 +26,7 @@
 
 <b>gpinitsystem</b> <b>-v | --version</b>
 
-<b>gpinitsystem</b> <b>-? | -h</b></codeblock>
+<b>gpinitsystem</b> <b>-? | --help</b></codeblock>
         </section>
         <section id="section3">
             <title>Description</title>
@@ -271,7 +271,7 @@
                     <pd>Print the <codeph>gpinitsystem</codeph> version and exit.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-? | -h</pt>
+                    <pt>-? | --help</pt>
                     <pd>Show help about <codeph>gpinitsystem</codeph> command line arguments, and exit.</pd>
                 </plentry>
             </parml>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
@@ -24,7 +24,9 @@
             [<b>-I</b> <varname>input_configuration_file</varname>]
             [<b>-O</b> <varname>output_configuration_file</varname>]
 
-<b>gpinitsystem</b> <b>-v</b></codeblock>
+<b>gpinitsystem</b> <b>-v | --version</b>
+
+<b>gpinitsystem</b> <b>-? | -h</b></codeblock>
         </section>
         <section id="section3">
             <title>Description</title>
@@ -265,12 +267,12 @@
                         than the number of segment instances.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-v</pt>
-                    <pd>Displays the version of this utility.</pd>
+                    <pt>-v | --version</pt>
+                    <pd>Print the <codeph>gpinitsystem</codeph> version and exit.</pd>
                 </plentry>
                 <plentry>
-                    <pt>-h</pt>
-                    <pd>Displays the online help.</pd>
+                    <pt>-? | -h</pt>
+                    <pd>Show help about <codeph>gpinitsystem</codeph> command line arguments, and exit.</pd>
                 </plentry>
             </parml>
         </section>

--- a/gpdb-doc/dita/utility_guide/client_utilities/clusterdb.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/clusterdb.xml
@@ -16,8 +16,8 @@ SQL command, and clusters them again on the same index that was last
 used. Tables that have never been clustered are not affected. </p><p><codeph>clusterdb</codeph> is a wrapper around the SQL command <codeph>CLUSTER</codeph>.
 Although clustering a table in this way is supported in Greenplum Database,
 it is not recommended because the <codeph>CLUSTER</codeph> operation
-itself is extremely slow. </p><p>If you do need to order a table in this way to improve your query performance, Greenplum
-        recommends using a <codeph>CREATE TABLE AS</codeph> statement to reorder the table on disk
+itself is extremely slow. </p><p>If you do need to order a table in this way to improve your query performance,
+        use a <codeph>CREATE TABLE AS</codeph> statement to reorder the table on disk
         rather than using <codeph>CLUSTER</codeph>. If you do 'cluster' a table in this way, then
           <codeph>clusterdb</codeph> would not be relevant.</p></section><section id="section4"><title>Options</title><parml><plentry><pt>-a | --all</pt><pd>Cluster all databases. </pd></plentry><plentry><pt>[-d | --dbname] <varname>dbname</varname> | [--dbname] <varname>dbname</varname></pt><pd>Specifies the name of the database to be clustered. If this is not
 specified, the database name is read from the environment variable <codeph>PGDATABASE</codeph>.

--- a/gpdb-doc/dita/utility_guide/client_utilities/clusterdb.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/clusterdb.xml
@@ -5,9 +5,9 @@
 
 <b>clusterdb</b> [<varname>connection-option</varname> ...] [<b>--all | -a</b>] [<b>--verbose | -v</b>]
 
-<b>clusterdb</b> <b>--help</b>
+<b>clusterdb</b> <b>-? | --help</b>
 
-<b>clusterdb</b> <b>--version</b></codeblock></section><section id="section3"><title>Description</title><p>To cluster a table means to physically reorder a table on disk according
+<b>clusterdb</b> <b>-V | --version</b></codeblock></section><section id="section3"><title>Description</title><p>To cluster a table means to physically reorder a table on disk according
 to an index so that index scan operations can access data on disk in
 a somewhat sequential order, thereby improving index seek performance
 for queries that use that index. </p><p>The <codeph>clusterdb</codeph> utility will find any tables in a database
@@ -22,7 +22,15 @@ itself is extremely slow. </p><p>If you do need to order a table in this way to 
           <codeph>clusterdb</codeph> would not be relevant.</p></section><section id="section4"><title>Options</title><parml><plentry><pt>-a | --all</pt><pd>Cluster all databases. </pd></plentry><plentry><pt>[-d | --dbname] <varname>dbname</varname> | [--dbname] <varname>dbname</varname></pt><pd>Specifies the name of the database to be clustered. If this is not
 specified, the database name is read from the environment variable <codeph>PGDATABASE</codeph>.
 If that is not set, the user name specified for the connection is used.</pd></plentry><plentry><pt>-e | --echo</pt><pd>Echo the commands that <codeph>clusterdb</codeph> generates and sends
-to the server.</pd></plentry><plentry><pt>-q | --quiet</pt><pd>Do not display a response.</pd></plentry><plentry><pt>-t <varname>table</varname> | --table <varname>table</varname></pt><pd>Cluster the named table only.</pd></plentry><plentry><pt>-v | --verbose</pt><pd>Print detailed information during processing.</pd></plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
+to the server.</pd></plentry><plentry><pt>-q | --quiet</pt><pd>Do not display a response.</pd></plentry><plentry><pt>-t <varname>table</varname> | --table <varname>table</varname></pt><pd>Cluster the named table only.</pd></plentry><plentry><pt>-v | --verbose</pt><pd>Print detailed information during processing.</pd></plentry>
+        <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>clusterdb</codeph> version and exit.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help</pt>
+          <pd>Show help about <codeph>clusterdb</codeph> command line arguments, and exit.</pd>
+        </plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
 server is running. If not specified, reads from the environment variable
 <codeph>PGHOST</codeph> or defaults to localhost.</pd></plentry><plentry><pt>-p <varname>port</varname> | --port <varname>port</varname></pt><pd>The TCP port on which the Greenplum master database server is listening
 for connections. If not specified, reads from the environment variable
@@ -33,3 +41,4 @@ and a password is not available by other means such as a <codeph>.pgpass</codeph
 file, the connection attempt will fail. This option can be useful in
 batch jobs and scripts where no user is present to enter a password.</pd></plentry><plentry><pt>-W | --password</pt><pd>Force a password prompt.</pd></plentry></parml></sectiondiv></section><section id="section6"><title>Examples</title><p>To cluster the database <codeph>test</codeph>:</p><codeblock>clusterdb test</codeblock><p>To cluster a single table <codeph>foo</codeph> in a database named <codeph>xyzzy</codeph>:</p><codeblock>clusterdb --table foo xyzzyb</codeblock></section><section id="section7"><title>See Also</title><p><ph otherprops="op-print"><codeph>CLUSTER</codeph> in the <i>Greenplum Database Reference
             Guide</i></ph><ph otherprops="op-help"><codeph><xref href="../../ref_guide/sql_commands/CLUSTER.xml#topic1"/></codeph></ph></p></section></body></topic>
+

--- a/gpdb-doc/dita/utility_guide/client_utilities/createdb.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/createdb.xml
@@ -3,6 +3,7 @@
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic1"><title id="oz137116">createdb</title><body><p id="client_util_desc">Creates a new database.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>createdb</b> [<varname>connection-option</varname> ...] [<b>-D</b> <varname>tablespace</varname>] [<b>-E</b> <varname>encoding</varname>] 
         [<b>-O</b> <varname>owner</varname>] [<b>-T</b> <varname>template</varname>] [<b>-e</b>] [<varname>dbname</varname> ['<varname>description</varname>']]
+        [<b>{-l | --locale}</b> <varname>locale</varname>] [<b>--lc-collate</b> <varname>locale</varname>] [<b>--lc-type</b> <varname>locale</varname>]
 
 <b>createdb</b> <b>-? | --help</b>
 
@@ -18,7 +19,7 @@ containing white space must be enclosed in quotes.</pd></plentry><plentry><pt>-D
         <plentry>
           <pt>-l <varname>locale</varname> | --locale <varname>locale</varname></pt>
           <pd>Specifies the locale to be used in this database. This is equivalent to specifying
-            both <codeph>--lc-collate</codeph> and <codeph>lc-ctype</codeph>.</pd>
+            both <codeph>--lc-collate</codeph> and <codeph>--lc-ctype</codeph>.</pd>
         </plentry>
         <plentry>
           <pt>--lc-collate <varname>locale</varname></pt>
@@ -43,10 +44,10 @@ to the user executing this command. </pd></plentry><plentry><pt>-T <varname>temp
         </plentry>
         </parml>
       <p>The options <codeph>-D</codeph>, <codeph>-l</codeph>, <codeph>-E</codeph>, 
-          <codeph>-O</codeph>, and <codeph>-T</codeph> correspond to options of the the underlying
-        SQL command <codeph>CREATE DATABASE</codeph>; see <ph><xref
+          <codeph>-O</codeph>, and <codeph>-T</codeph> correspond to options of the underlying
+        SQL command <codeph>CREATE DATABASE</codeph>; see <ph><codeph><xref
             href="../../ref_guide/sql_commands/CREATE_DATABASE.xml#topic1" otherprops="op-help"
-          /></ph><ph otherprops="op-print"><codeph>CREATE DATABASE</codeph> in the <i>Greenplum
+          /></codeph></ph><ph otherprops="op-print"><codeph>CREATE DATABASE</codeph> in the <i>Greenplum
             Database Reference Guide</i></ph> for more information about them. </p><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
               server is running. If not specified, reads from the environment variable
                 <codeph>PGHOST</codeph> or defaults to localhost.</pd></plentry><plentry><pt>-p <varname>port</varname> | --port <varname>port</varname></pt><pd>The TCP port on which the Greenplum master database server is

--- a/gpdb-doc/dita/utility_guide/client_utilities/createdb.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/createdb.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="oz137116">createdb</title><body><p id="client_util_desc">Creates a new database.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>createdb</b> [<varname>connection_option</varname> ...] [<b>-D</b> <varname>tablespace</varname>] [<b>-E</b> <varname>encoding</varname>] 
+<topic id="topic1"><title id="oz137116">createdb</title><body><p id="client_util_desc">Creates a new database.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>createdb</b> [<varname>connection-option</varname> ...] [<b>-D</b> <varname>tablespace</varname>] [<b>-E</b> <varname>encoding</varname>] 
         [<b>-O</b> <varname>owner</varname>] [<b>-T</b> <varname>template</varname>] [<b>-e</b>] [<varname>dbname</varname> ['<varname>description</varname>']]
 
-<b>createdb</b> <b>--help</b> 
+<b>createdb</b> <b>-? | --help</b>
 
-<b>createdb</b> <b>--version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>createdb</codeph> creates a new database in a Greenplum Database system. </p><p>Normally, the database user who executes this command becomes the
-owner of the new database. However a different owner can be specified
+<b>createdb</b> <b>-V | --version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>createdb</codeph> creates a new database in a Greenplum Database system. </p><p>Normally, the database user who executes this command becomes the
+owner of the new database. However, a different owner can be specified
 via the <codeph>-O</codeph> option, if the executing user has appropriate
 privileges.</p><p><codeph>createdb</codeph> is a wrapper around the SQL command <codeph>CREATE
 DATABASE</codeph>.</p></section><section id="section4"><title>Options</title><parml><plentry><pt>dbname</pt><pd>The name of the database to be created. The name must be unique among all other databases in the
@@ -32,8 +32,17 @@ containing white space must be enclosed in quotes.</pd></plentry><plentry><pt>-D
             use the default encoding. <ph>See the Greenplum Database Reference
               Guide for information about supported character sets.</ph></pd></plentry><plentry><pt>-O <varname>owner</varname> | --owner <varname>owner</varname></pt><pd>The name of the database user who will own the new database. Defaults
 to the user executing this command. </pd></plentry><plentry><pt>-T <varname>template</varname> | --template <varname>template</varname></pt><pd>The name of the template from which to create the new database. Defaults to
-              <codeph>template1</codeph>. </pd></plentry></parml>
-      <p>The options <codeph>-D</codeph>, <codeph>-E</codeph>, <codeph>-l</codeph>,
+              <codeph>template1</codeph>. </pd></plentry>
+        <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>createdb</codeph> version and exit.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help</pt>
+          <pd>Show help about <codeph>createdb</codeph> command line arguments, and exit.</pd>
+        </plentry>
+        </parml>
+      <p>The options <codeph>-D</codeph>, <codeph>-l</codeph>, <codeph>-E</codeph>, 
           <codeph>-O</codeph>, and <codeph>-T</codeph> correspond to options of the the underlying
         SQL command <codeph>CREATE DATABASE</codeph>; see <ph><xref
             href="../../ref_guide/sql_commands/CREATE_DATABASE.xml#topic1" otherprops="op-help"
@@ -53,5 +62,6 @@ batch jobs and scripts where no user is present to enter a password.</pd></plent
       <title>See Also</title>
       <p><ph otherprops="op-print"><codeph>CREATE DATABASE</codeph> in the <i>Greenplum Database
             Reference Guide</i></ph><ph otherprops="op-help"><codeph><xref
-              href="../../ref_guide/sql_commands/CREATE_DATABASE.xml#topic1"/></codeph></ph></p>
+              href="../../ref_guide/sql_commands/CREATE_DATABASE.xml#topic1"/></codeph>,
+            <codeph><xref href="dropdb.xml#topic1"/></codeph></ph></p>
     </section></body></topic>

--- a/gpdb-doc/dita/utility_guide/client_utilities/createlang.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/createlang.xml
@@ -11,9 +11,9 @@
 
 <b>createlang</b> [<varname>connection-option</varname> ...] <b>-l</b> <varname>dbname</varname>
 
-<b>createlang</b> <b>--help</b> 
+<b>createlang</b> <b>-? | --help</b>
 
-<b>createlang</b> <b>--version</b></codeblock>
+<b>createlang</b> <b>-V | --version</b></codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -41,7 +41,7 @@
         </plentry>
         <plentry>
           <pt>[-d] <varname>dbname</varname> | [--dbname] <varname>dbname</varname></pt>
-          <pd>Specifies to which database the language should be added. The default is to use the
+          <pd>Specifies the database to which the language should be added. The default is to use the
               <codeph>PGDATABASE</codeph> environment variable setting, or the same name as the
             current system user.</pd>
         </plentry>
@@ -53,6 +53,14 @@
         <plentry>
           <pt>-l <varname>dbname</varname> | --list <varname>dbname</varname></pt>
           <pd>Show a list of already installed languages in the target database. </pd>
+        </plentry>
+        <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>createlang</codeph> version and exit.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help</pt>
+          <pd>Show help about <codeph>createlang</codeph> command line arguments, and exit.</pd>
         </plentry>
       </parml><sectiondiv id="section5"><b>Connection Options</b><parml>
           <plentry>
@@ -97,7 +105,8 @@
           otherprops="op-help"><codeph><xref
               href="../../ref_guide/sql_commands/CREATE_LANGUAGE.xml#topic1"/></codeph>,
               <codeph><xref href="../../ref_guide/sql_commands/DROP_LANGUAGE.xml#topic1"
-          /></codeph></ph></p>
+          /></codeph>,
+              <codeph><xref href="droplang.xml#topic1"/></codeph></ph></p>
     </section>
   </body>
 </topic>

--- a/gpdb-doc/dita/utility_guide/client_utilities/createlang.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/createlang.xml
@@ -30,9 +30,11 @@
       <p>The <codeph>PL/pgSQL</codeph> language is registered in all databases by default.</p>
       <p>Greenplum Database also has language handlers for <codeph>PL/Java</codeph> and
           <codeph>PL/R</codeph>, but those languages are not pre-installed with Greenplum Database.
-        See the <xref href="https://www.postgresql.org/docs/8.3/xplang.html" scope="external"
-          format="html">Procedural Languages</xref> section in the PostgreSQL documentation for more
-        information.</p>
+        See the <xref href="../../ref_guide/extensions/pl_java.xml" scope="peer"
+          format="dita">Greenplum PL/Java Language Extension</xref> and
+          <xref href="../../ref_guide/extensions/pl_r.xml" scope="peer"
+          format="dita">Greenplum PL/R Language Extension</xref> sections in the
+          documentation for more information.</p>
     </section>
     <section id="section4"><title>Options</title><parml>
         <plentry>

--- a/gpdb-doc/dita/utility_guide/client_utilities/createuser.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/createuser.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="pb141029">createuser</title><body><p id="client_util_desc">Creates a new database role.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>createuser</b> [<varname>connection_option</varname> ...] [<varname>role_attribute</varname> ...] [<b>-e</b>] <varname>role_name</varname>
+<topic id="topic1"><title id="pb141029">createuser</title><body><p id="client_util_desc">Creates a new database role.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>createuser</b> [<varname>connection-option</varname> ...] [<varname>role_attribute</varname> ...] [<b>-e</b>] <varname>role_name</varname>
 
-<b>createuser</b> <b>--help</b> 
+<b>createuser</b> <b>-? | --help</b> 
 
-<b>createuser</b> <b>--version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>createuser</codeph> creates a new Greenplum Database role. You must be a
+<b>createuser</b> <b>-V | --version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>createuser</codeph> creates a new Greenplum Database role. You must be a
                                 superuser or have the <codeph>CREATEROLE</codeph> privilege to
                                 create new roles. You must connect to the database as a superuser to
                                 create new superusers.</p><p>Superusers can bypass all access permission checks within the database,
 so superuser privileges should not be granted lightly. </p><p><codeph>createuser</codeph> is a wrapper around the SQL command <codeph>CREATE
 ROLE</codeph>.</p></section><section id="section4"><title>Options</title><parml><plentry><pt>role_name</pt><pd>The name of the role to be created. This name must be different from all existing roles in this
                                                   Greenplum Database installation. </pd></plentry><plentry><pt>-c <varname>number</varname> | --connection-limit <varname>number</varname></pt><pd>Set a maximum number of connections for the new role. The default
-is to set no limit. </pd></plentry><plentry><pt>-D | --no-createdb</pt><pd>The new role will not be allowed to create databases. This is the
-default. </pd></plentry><plentry><pt>-d | --createdb</pt><pd>The new role will be allowed to create databases. </pd></plentry><plentry><pt>-e | --echo</pt><pd>Echo the commands that <codeph>createuser</codeph> generates and
+is to set no limit. </pd></plentry>
+<plentry><pt>-d | --createdb</pt><pd>The new role will be allowed to create databases. </pd></plentry>
+<plentry><pt>-D | --no-createdb</pt><pd>The new role will not be allowed to create databases. This is the
+default. </pd></plentry>
+<plentry><pt>-e | --echo</pt><pd>Echo the commands that <codeph>createuser</codeph> generates and
 sends to the server. </pd></plentry><plentry><pt>-E | --encrypted</pt><pd>Encrypts the role's password stored in the database. If not specified,
 the default password behavior is used. </pd></plentry><plentry><pt>-i | --inherit</pt><pd>The new role will automatically inherit privileges of roles it is
 a member of. This is the default.</pd></plentry><plentry><pt>-I | --no-inherit</pt><pd>The new role will not automatically inherit privileges of roles it
@@ -22,7 +25,16 @@ not specified, the default password behavior is used. </pd></plentry><plentry><p
 password of the new role. This is not necessary if you do not plan on
 using password authentication. </pd></plentry><plentry><pt>-r | --createrole</pt><pd>The new role will be allowed to create new roles (<codeph>CREATEROLE</codeph>
 privilege). </pd></plentry><plentry><pt>-R | --no-createrole</pt><pd>The new role will not be allowed to create new roles. This is the
-default. </pd></plentry><plentry><pt>-s | --superuser</pt><pd>The new role will be a superuser. </pd></plentry><plentry><pt>-S | --no-superuser</pt><pd>The new role will not be a superuser. This is the default. </pd></plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
+default. </pd></plentry><plentry><pt>-s | --superuser</pt><pd>The new role will be a superuser. </pd></plentry><plentry><pt>-S | --no-superuser</pt><pd>The new role will not be a superuser. This is the default. </pd></plentry>
+        <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>createuser</codeph> version and exit.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help</pt>
+          <pd>Show help about <codeph>createuser</codeph> command line arguments, and exit.</pd>
+        </plentry>
+      </parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
                                                   server is running. If not specified, reads from
                                                   the environment variable <codeph>PGHOST</codeph>
                                                   or defaults to localhost.</pd></plentry><plentry><pt>-p <varname>port</varname> | --port <varname>port</varname></pt><pd>The TCP port on which the Greenplum master database server is
@@ -55,5 +67,7 @@ CREATE ROLE</codeblock><p>In the above example, the new password is not actually
                                                 <i>Greenplum Database Reference Guide</i></ph><ph
                                         otherprops="op-help"><codeph><xref
                                                   href="../../ref_guide/sql_commands/CREATE_ROLE.xml#topic1"
-                                                /></codeph></ph></p>
+                                                /></codeph>,
+                        <codeph><xref
+                                                  href="dropuser.xml#topic1"/></codeph></ph></p>
                 </section></body></topic>

--- a/gpdb-doc/dita/utility_guide/client_utilities/dropdb.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/dropdb.xml
@@ -1,17 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="pc137116">dropdb</title><body><p id="client_util_desc">Removes a database.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>dropdb</b> [<varname>connection_option</varname> ...] [<b>-e</b>] [<b>-i</b>] <varname>dbname</varname>
+<topic id="topic1"><title id="pc137116">dropdb</title><body><p id="client_util_desc">Removes a database.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>dropdb</b> [<varname>connection-option</varname> ...] [<b>-e</b>] [<b>-i</b>] <varname>dbname</varname>
 
-<b>dropdb</b> <b>--help</b> 
+<b>dropdb</b> <b>-? | --help</b>
 
-<b>dropdb</b> <b>--version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>dropdb</codeph> destroys an existing database. The user who
+<b>dropdb</b> <b>-V | --version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>dropdb</codeph> destroys an existing database. The user who
 executes this command must be a superuser or the owner of the database
 being dropped. </p><p><codeph>dropdb</codeph> is a wrapper around the SQL command <codeph>DROP DATABASE</codeph>. <ph
                                        >See the <i>Greenplum Database Reference
                                                 Guide</i> for information about <codeph>DROP
                                                 DATABASE.</codeph></ph></p></section><section id="section4"><title>Options</title><parml><plentry><pt><varname>dbname</varname></pt><pd>The name of the database to be removed.</pd></plentry><plentry><pt>-e | --echo</pt><pd>Echo the commands that <codeph>dropdb</codeph> generates and sends
-to the server. </pd></plentry><plentry><pt>-i | --interactive</pt><pd>Issues a verification prompt before doing anything destructive. </pd></plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
+to the server. </pd></plentry><plentry><pt>-i | --interactive</pt><pd>Issues a verification prompt before doing anything destructive. </pd></plentry>
+       <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>dropdb</codeph> version and exit.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help</pt>
+          <pd>Show help about <codeph>dropdb</codeph> command line arguments, and exit.</pd>
+        </plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
                                                   server is running. If not specified, reads from
                                                   the environment variable <codeph>PGHOST</codeph>
                                                   or defaults to localhost.</pd></plentry><plentry><pt>-p <varname>port</varname> | --port <varname>port</varname></pt><pd>The TCP port on which the Greenplum master database server is
@@ -32,6 +40,7 @@ DROP DATABASE</codeblock></section><section id="section7">
                         <p><ph otherprops="op-print"><codeph>DROP DATABASE</codeph> in the
                                                 <i>Greenplum Database Reference Guide</i></ph><ph
                                         otherprops="op-help"><codeph><xref
+                                                  href="createdb.xml#topic1"/></codeph>, <codeph><xref
                                                   href="../../ref_guide/sql_commands/DROP_DATABASE.xml#topic1"
                                                 /></codeph></ph></p>
                 </section></body></topic>

--- a/gpdb-doc/dita/utility_guide/client_utilities/droplang.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/droplang.xml
@@ -5,9 +5,9 @@
 
 <b>droplang</b> [<varname>connection-option</varname> ...] [-e] <b>-l</b> <varname>dbname</varname>
 
-<b>droplang</b> <b>--help</b> 
+<b>droplang</b> <b>-? | --help</b> 
 
-<b>droplang</b> <b>--version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>droplang</codeph> removes an existing programming language from
+<b>droplang</b> <b>-V | --version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>droplang</codeph> removes an existing programming language from
 a database. <codeph>droplang</codeph> can drop any procedural language,
 even those not supplied by the Greenplum Database distribution. </p><p>Although programming languages can be removed directly using several
 SQL commands, it is recommended to use <codeph>droplang</codeph> because
@@ -16,7 +16,15 @@ LANGUAGE</codeph>.</p></section><section id="section4"><title>Options</title><pa
 default is to use the <codeph>PGDATABASE</codeph> environment variable
 setting, or the same name as the current system user.</pd></plentry><plentry><pt>-e | --echo</pt><pd>Echo the commands that <codeph>droplang</codeph> generates and sends
 to the server.</pd></plentry><plentry><pt>-l | --list</pt><pd>Show a list of already installed languages in the target database.
-</pd></plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
+</pd></plentry>
+        <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>droplang</codeph> version and exit.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help</pt>
+          <pd>Show help about <codeph>droplang</codeph> command line arguments, and exit.</pd>
+        </plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
 server is running. If not specified, reads from the environment variable
 <codeph>PGHOST</codeph> or defaults to localhost.</pd></plentry><plentry><pt>-p <varname>port</varname> | --port <varname>port</varname></pt><pd>The TCP port on which the Greenplum master database server is listening
 for connections. If not specified, reads from the environment variable
@@ -26,4 +34,4 @@ system role name.</pd></plentry><plentry><pt>-w | --no-password</pt><pd>Never is
 and a password is not available by other means such as a <codeph>.pgpass</codeph>
 file, the connection attempt will fail. This option can be useful in
 batch jobs and scripts where no user is present to enter a password.</pd></plentry><plentry><pt>-W | --password</pt><pd>Force a password prompt.</pd></plentry></parml></sectiondiv></section><section id="section6"><title>Examples</title><p>To remove the language <codeph>pltcl</codeph> from the <codeph>mydatabase</codeph> database:</p><codeblock>droplang pltcl mydatabase</codeblock></section><section id="section7"><title>See Also</title><p><ph otherprops="op-print"><codeph>DROP LANGUAGE</codeph> in the <i>Greenplum Database
-            Reference Guide</i></ph><ph otherprops="op-help"><codeph><xref href="../../ref_guide/sql_commands/DROP_LANGUAGE.xml#topic1"/></codeph></ph></p></section></body></topic>
+            Reference Guide</i></ph><ph otherprops="op-help"><codeph><xref href="createlang.xml#topic1"/></codeph>, <codeph><xref href="../../ref_guide/sql_commands/DROP_LANGUAGE.xml#topic1"/></codeph></ph></p></section></body></topic>

--- a/gpdb-doc/dita/utility_guide/client_utilities/dropuser.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/dropuser.xml
@@ -1,16 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="pe137116">dropuser</title><body><p id="client_util_desc">Removes a database role.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>dropuser</b> [<varname>connection_option</varname> ...] [<b>-e</b>] [<b>-i</b>] <varname>role_name</varname>
+<topic id="topic1"><title id="pe137116">dropuser</title><body><p id="client_util_desc">Removes a database role.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>dropuser</b> [<varname>connection-option</varname> ...] [<b>-e</b>] [<b>-i</b>] <varname>role_name</varname>
 
-<b>dropuser</b> <b>--help</b> 
+<b>dropuser</b> <b>-? | --help</b> 
 
-<b>dropuser</b> <b>--version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>dropuser</codeph> removes an existing role from Greenplum Database. Only
+<b>dropuser</b> <b>-V | --version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>dropuser</codeph> removes an existing role from Greenplum Database. Only
         superusers and users with the <codeph>CREATEROLE</codeph> privilege can remove roles. To
         remove a superuser role, you must yourself be a superuser.</p><p><codeph>dropuser</codeph> is a wrapper around the SQL command <codeph>DROP
 ROLE</codeph>.</p></section><section id="section4"><title>Options</title><parml><plentry><pt><varname>role_name</varname></pt><pd>The name of the role to be removed. You will be prompted for a name
 if not specified on the command line. </pd></plentry><plentry><pt>-e | --echo</pt><pd>Echo the commands that <codeph>dropuser</codeph> generates and sends
-to the server. </pd></plentry><plentry><pt>-i | --interactive</pt><pd>Prompt for confirmation before actually removing the role.</pd></plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
+to the server. </pd></plentry><plentry><pt>-i | --interactive</pt><pd>Prompt for confirmation before actually removing the role.</pd></plentry>
+       <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>dropuser</codeph> version and exit.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help</pt>
+          <pd>Show help about <codeph>dropuser</codeph> command line arguments, and exit.</pd>
+        </plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
               server is running. If not specified, reads from the environment variable
                 <codeph>PGHOST</codeph> or defaults to localhost.</pd></plentry><plentry><pt>-p <varname>port</varname> | --port <varname>port</varname></pt><pd>The TCP port on which the Greenplum master database server is
               listening for connections. If not specified, reads from the environment variable
@@ -29,5 +37,6 @@ DROP ROLE</codeblock></section><section id="section7">
       <title>See Also</title>
       <p><ph otherprops="op-print"><codeph>DROP ROLE</codeph> in the <i>Greenplum Database Reference
             Guide</i></ph><ph otherprops="op-help"><codeph><xref
+              href="createuser.xml#topic1"/></codeph>, <codeph><xref
               href="../../ref_guide/sql_commands/DROP_ROLE.xml#topic1"/></codeph></ph></p>
     </section></body></topic>

--- a/gpdb-doc/dita/utility_guide/client_utilities/pg_config.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/pg_config.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="pf137116">pg_config</title><body><p id="client_util_desc">Retrieves information about the installed version of Greenplum Database.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>pg_config</b> [<varname>option</varname> ...]</codeblock></section><section id="section3"><title>Description</title><p>The <codeph>pg_config</codeph> utility prints configuration parameters
+<topic id="topic1"><title id="pf137116">pg_config</title><body><p id="client_util_desc">Retrieves information about the installed version of Greenplum Database.</p><section id="section2"><title>Synopsis</title><codeblock id="client_util_synopsis"><b>pg_config</b> [<varname>option</varname> ...]
+
+<b>pg_config</b> <b>-? | --help</b>
+
+<b>pg_config</b> <b>--version</b></codeblock></section><section id="section3"><title>Description</title><p>The <codeph>pg_config</codeph> utility prints configuration parameters
 of the currently installed version of Greenplum Database. It is intended,
 for example, to be used by software packages that want to interface to
 Greenplum Database to facilitate finding the required header files and
@@ -21,9 +25,11 @@ used for building Greenplum Database. This shows C compiler switches.
 </pd></plentry><plentry><pt>--cflags_sl</pt><pd>Print the value of the <codeph>CFLAGS_SL</codeph> variable that was
 used for building Greenplum Database. This shows extra C compiler switches
 used for building shared libraries. </pd></plentry><plentry><pt>--ldflags</pt><pd>Print the value of the <codeph>LDFLAGS</codeph> variable that was
-used for building Greenplum Database. This shows linker switches. </pd></plentry><plentry><pt>--ldflags_sl</pt><pd>Print the value of the <codeph>LDFLAGS_SL</codeph> variable that
+used for building Greenplum Database. This shows linker switches. </pd></plentry>
+         <plentry><pt>--ldflags_ex</pt><pd>Print the value of the <codeph>LDFLAGS_EX</codeph> variable that was
+used for building Greenplum Database. This shows linker switches that were used for building executables only. </pd></plentry><plentry><pt>--ldflags_sl</pt><pd>Print the value of the <codeph>LDFLAGS_SL</codeph> variable that
 was used for building Greenplum Database. This shows linker switches
-used for building shared libraries. </pd></plentry><plentry><pt>--libs</pt><pd>Print the value of the <codeph>LIBS</codeph> variable that was used
+used for building shared libraries only. </pd></plentry><plentry><pt>--libs</pt><pd>Print the value of the <codeph>LIBS</codeph> variable that was used
 for building Greenplum Database. This normally contains <codeph>-l</codeph>
 switches for external libraries linked into Greenplum Database. </pd></plentry><plentry><pt>--version</pt><pd>Print the version of Greenplum Database. </pd></plentry></parml></section><section id="section5"><title>Examples</title><p>To reproduce the build configuration of the current Greenplum Database
 installation, run the following command:</p><codeblock>eval ./configure 'pg_config --configure'</codeblock><p>The output of <codeph>pg_config --configure</codeph> contains shell quotation

--- a/gpdb-doc/dita/utility_guide/client_utilities/pg_dump.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/pg_dump.xml
@@ -8,7 +8,11 @@
       file.</p>
     <section id="section2">
       <title>Synopsis</title>
-      <codeblock id="client_util_synopsis"><b>pg_dump</b> [<varname>connection_option</varname> ...] [<varname>dump_option</varname> ...] <varname>dbname</varname></codeblock>
+      <codeblock id="client_util_synopsis"><b>pg_dump</b> [<varname>connection-option</varname> ...] [<varname>dump_option</varname> ...] <varname>dbname</varname>
+
+<b>pg_dump</b> <b>-? | --help</b>
+
+<b>pg_dump</b> <b>-V | --version</b></codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -49,7 +53,7 @@
         of the database are to be restored. The most flexible output file format is the
           <varname>custom</varname> format (<codeph>-Fc</codeph>). It allows for selection and
         reordering of all archived items, and is compressed by default. The tar format
-          (<codeph>-Ft</codeph>) is not compressed and it is not possible to reorder data when
+          (<codeph>-Ft</codeph>) is not compressed and has restrictions on reordering data when
         loading, but it is otherwise quite flexible. It can be manipulated with standard UNIX tools
         such as <codeph>tar</codeph>.</p>
       <note>The <codeph>--ignore-version</codeph> option is deprecated and will be removed in a
@@ -117,7 +121,7 @@
             <pt>--inserts</pt>
             <pd>Dump data as <codeph>INSERT</codeph> commands (rather than <codeph>COPY</codeph>).
               This will make restoration very slow; it is mainly useful for making dumps that can be
-              loaded into non-PostgreSQL-based databases. Also, since this option generates a
+              loaded into non-PostgreSQL-based databases. However, since this option generates a
               separate command for each row, an error in reloading a row causes only that row to be
               lost rather than the entire table contents. Note that the restore may fail altogether
               if you have rearranged column order. The <codeph>--column-inserts</codeph> option is
@@ -129,7 +133,7 @@
                 <codeph>(INSERT
                 INTO</codeph><varname>table</varname><codeph>(</codeph><varname>column</varname><codeph>,
                 ...) VALUES ...)</codeph>. This will make restoration very slow; it is mainly useful
-              for making dumps that can be loaded into non-PostgreSQL-based databases. Also, since
+              for making dumps that can be loaded into non-PostgreSQL-based databases. However, since
               this option generates a separate command for each row, an error in reloading a row
               causes only that row to be lost rather than the entire table contents.</pd>
           </plentry>
@@ -151,13 +155,15 @@
             <pd>p | plain — Output a plain-text SQL script file (the default). </pd>
             <pd>c | custom — Output a custom archive suitable for input into <codeph><xref
                   href="./pg_restore.xml#topic1" type="topic" format="dita"/></codeph>. This is the
-              most flexible format in that it allows reordering of loading data as well as object
-              definitions. This format is also compressed by default. </pd>
-            <pd>t | tar — Output a tar archive suitable for input into <codeph><xref
-                  href="./pg_restore.xml#topic1" type="topic" format="dita"/></codeph>. Using this
-              archive format allows reordering and/or exclusion of database objects at the time the
-              database is restored. It is also possible to limit which data is reloaded at restore
-              time. </pd>
+              most flexible format in that it allows manual selection and reordering
+              of archived items during restore. This format is also compressed by default. </pd>
+            <pd>t | tar — Output a tar-format archive suitable for input into <codeph><xref
+                  href="./pg_restore.xml#topic1" type="topic" format="dita"/></codeph>.
+              This output format allows manual selection and reordering of
+              archived items during restore, but there is a restriction: the
+              relative order of table data items cannot be changed during
+              restore.  Also, tar format does not support compression
+              and has a limit of 8 GB on the size of individual tables.</pd>
           </plentry>
           <plentry>
             <pt>-i | --ignore-version</pt>
@@ -263,6 +269,10 @@
               standard error.</pd>
           </plentry>
           <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>pg_dump</codeph> version and exit.</pd>
+        </plentry>
+          <plentry>
             <pt>-x | --no-privileges | --no-acl</pt>
             <pd>Prevent dumping of access privileges (<codeph>GRANT/REVOKE</codeph> commands).</pd>
           </plentry>
@@ -303,7 +313,7 @@
             <pt>--use-set-session-authorization</pt>
             <pd>Output SQL-standard <codeph>SET SESSION AUTHORIZATION</codeph> commands instead of
                 <codeph>ALTER OWNER</codeph> commands to determine object ownership. This makes the
-              dump more standards compatible, but depending on the history of the objects in the
+              dump more standards-compatible, but depending on the history of the objects in the
               dump, may not restore properly. A dump using <codeph>SET SESSION
                 AUTHORIZATION</codeph> will require superuser privileges to restore correctly,
               whereas <codeph>ALTER OWNER</codeph> requires lesser privileges.</pd>
@@ -341,6 +351,10 @@
               file to be compressed, as though it had been fed through <codeph>gzip</codeph>; but
               the default is not to compress. The tar archive format currently does not support
               compression at all.</pd>
+          </plentry>
+          <plentry>
+            <pt>-? | --help</pt>
+            <pd>Show help about <codeph>pg_dump</codeph> command line arguments, and exit.</pd>
           </plentry>
         </parml>
       </sectiondiv>
@@ -401,7 +415,7 @@
         operating system.</p>
       <p>The dump file produced by <codeph>pg_dump</codeph> does not contain the statistics used by
         the optimizer to make query planning decisions. Therefore, it is wise to run
-          <codeph>ANALYZE</codeph> after restoring from a dump file to ensure good performance.</p>
+          <codeph>ANALYZE</codeph> after restoring from a dump file to ensure optimal performance.</p>
       <p>The database activity of <codeph>pg_dump</codeph> is normally collected by the statistics
         collector. If this is undesirable, you can set parameter <codeph>track_counts</codeph> to
         false via <codeph>PGOPTIONS</codeph> or the <codeph>ALTER USER</codeph> command.</p>

--- a/gpdb-doc/dita/utility_guide/client_utilities/pg_dumpall.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/pg_dumpall.xml
@@ -8,7 +8,11 @@
             to a single script file or other archive file.</p>
         <section id="section2">
             <title>Synopsis</title>
-            <codeblock id="client_util_synopsis"><b>pg_dumpall</b> [<varname>connection_option</varname> ...] [<varname>dump_option</varname> ...]</codeblock>
+            <codeblock id="client_util_synopsis"><b>pg_dumpall</b> [<varname>connection-option</varname> ...] [<varname>dump_option</varname> ...]
+
+<b>pg_dumpall</b> <b>-? | --help</b>
+
+<b>pg_dumpall</b> <b>-V | --version</b></codeblock>
         </section>
         <section id="section3">
             <title>Description</title>
@@ -31,7 +35,8 @@
                 likely have to connect as a database superuser in order to produce a complete dump.
                 Also you will need superuser privileges to execute the saved script in order to be
                 allowed to add users and groups, and to create databases.</p>
-            <p>The SQL script will be written to the standard output. Shell operators should be used
+            <p>The SQL script will be written to the standard output. Use the
+              <codeph>[-f | --file]</codeph> option or shell operators
                 to redirect it into a file.</p>
             <p><codeph>pg_dumpall</codeph> needs to connect several times to the Greenplum Database master server (once per database). If you use password
                 authentication it is likely to ask for a password each time. It is convenient to
@@ -112,10 +117,10 @@
                         <pd>Do not wait forever to acquire shared table locks at the beginning of
                             the dump. Instead, fail if unable to lock a table within the specified
                                 <varname>timeout</varname>. The timeout may be specified in any of
-                            the formats accepted by <codeph>SET statement_timeout</codeph>. (Allowed
+                            the formats accepted by <codeph>SET statement_timeout</codeph>. Allowed
                             values vary depending on the server version you are dumping from, but an
                             integer number of milliseconds is accepted by all Greenplum Database
-                            versions.)</pd>
+                            versions.</pd>
                     </plentry>
                     <plentry>
                         <pt>-o | --oids</pt>
@@ -162,6 +167,10 @@
                                     href="pg_dump.xml#topic1" type="topic" format="dita"/></codeph>
                             to output detailed object comments and start/stop times to the dump
                             file, and progress messages to standard error.</pd>
+                    </plentry>
+                    <plentry>
+                      <pt>-V | --version</pt>
+                      <pd>Print the <codeph>pg_dumpall</codeph> version and exit.</pd>
                     </plentry>
                     <plentry>
                         <pt>-x | --no-privileges | --no-acl</pt>
@@ -226,6 +235,10 @@
                         <pt>--no-gp-syntax</pt>
                         <pd>Do not output the table distribution clauses in the <codeph>CREATE
                                 TABLE</codeph> statements. </pd>
+                    </plentry>
+                    <plentry>
+                      <pt>-? | --help</pt>
+                      <pd>Show help about <codeph>pg_dumpall</codeph> command line arguments, and exit.</pd>
                     </plentry>
                 </parml>
             </sectiondiv>
@@ -293,14 +306,14 @@
                 query planner has useful statistics. You can also run <codeph>vacuumdb -a
                     -z</codeph> to analyze all databases. </p>
             <p><codeph>pg_dumpall</codeph> requires all needed tablespace directories to
-                exist before the restore or database creation will fail for databases in non-default
-                locations.</p>
+                exist before the restore; otherwise database creation will fail for
+                databases in non-default locations.</p>
         </section>
         <section id="section8">
             <title>Examples</title>
             <p>To dump all databases: </p>
             <codeblock>pg_dumpall &gt; db.out</codeblock>
-            <p>To reload this file:</p>
+            <p>To reload database(s) from this file, you can use:</p>
             <codeblock>psql template1 -f db.out</codeblock>
             <p>To dump only global objects (including resource queues):</p>
             <codeblock>pg_dumpall -g --resource-queues</codeblock>

--- a/gpdb-doc/dita/utility_guide/client_utilities/pg_restore.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/pg_restore.xml
@@ -8,7 +8,11 @@
         <codeph>pg_dump</codeph>.</p>
     <section id="section2">
       <title>Synopsis</title>
-      <codeblock id="client_util_synopsis"><b>pg_restore</b> [<varname>connection_option</varname> ...] [<varname>restore_option</varname> ...] <varname>filename</varname></codeblock>
+      <codeblock id="client_util_synopsis"><b>pg_restore</b> [<varname>connection-option</varname> ...] [<varname>restore_option</varname> ...] <varname>filename</varname>
+
+<b>pg_restore</b> <b>-? | --help</b>
+
+<b>pg_restore</b> <b>-V | --version</b></codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -109,7 +113,7 @@
               the number of CPU cores and the disk setup. A good place to start
               is the number of CPU cores on the server, but values larger than
               that can also lead to faster restore times in many cases. Of
-              course, values that are too high will lead to decreasing
+              course, values that are too high will lead to decreased
               performance because of thrashing. </pd>
             <pd>Only the custom archive format is supported with this option.
               The input file must be a regular file (not, for example, a pipe).
@@ -159,8 +163,8 @@
           </plentry>
           <plentry>
             <pt>-s | --schema-only</pt>
-            <pd>Restore only the schema (data definitions), not the data (table contents). Sequence
-              current values will not be restored, either. (Do not confuse this with the
+            <pd>Restore only the schema (data definitions), not the data (table contents). Current
+              sequence values will not be restored, either. (Do not confuse this with the
                 <codeph>--schema</codeph> option, which uses the word schema in a different
               meaning.) </pd>
           </plentry>
@@ -171,7 +175,8 @@
           </plentry>
           <plentry>
             <pt>-t <varname>table</varname> | --table=<varname>table</varname></pt>
-            <pd>Restore definition and/or data of named table only. </pd>
+            <pd>Restore definition and/or data of named table only. This can be
+              combined with the <codeph>-n</codeph> option to specify a schema.</pd>
           </plentry>
           <plentry>
             <pt>-T <varname>trigger</varname> | --trigger=<varname>trigger</varname></pt>
@@ -181,6 +186,10 @@
           <plentry>
             <pt>-v | --verbose</pt>
             <pd>Specifies verbose mode.</pd>
+          </plentry>
+          <plentry>
+            <pt>-V | --version</pt>
+            <pd>Print the <codeph>pg_restore</codeph> version and exit.</pd>
           </plentry>
           <plentry>
             <pt>-x | --no-privileges | --no-acl</pt>
@@ -213,6 +222,10 @@
               either all the commands complete successfully, or no changes are
               applied.</pd>
           </plentry>
+          <plentry>
+            <pt>-? | --help</pt>
+            <pd>Show help about <codeph>pg_restore</codeph> command line arguments, and exit.</pd>
+        </plentry>
         </parml>
       </sectiondiv>
       <sectiondiv id="section5">
@@ -272,7 +285,7 @@
       <codeblock>CREATE DATABASE foo WITH TEMPLATE template0;</codeblock>
       <p>When restoring data to a pre-existing table and the option
           <codeph>--disable-triggers</codeph> is used, <codeph>pg_restore</codeph> emits commands to
-        disable triggers on user tables before inserting the data then emits commands to re-enable
+        disable triggers on user tables before inserting the data, then emits commands to re-enable
         them after the data has been inserted. If the restore is stopped in the middle, the system
         catalogs may be left in the wrong state.</p>
       <p>See also the <codeph>pg_dump</codeph> documentation for details on limitations of
@@ -298,30 +311,27 @@ pg_restore -d newdb db.dump</codeblock>
         archive:</p>
       <codeblock>pg_restore -l db.dump &gt; db.list</codeblock>
       <p>The listing file consists of a header and one line for each item, for example,</p>
-      <codeblock>; Archive created at Fri Jul 28 22:28:36 2006
-;     dbname: mydb
-;     TOC Entries: 74
-;     Compression: 0
-;     Dump Version: 1.4-0
+      <codeblock>; Archive created at Mon Sep 14 13:55:39 2009
+;     dbname: DBDEMOS
+;     TOC Entries: 81
+;     Compression: 9
+;     Dump Version: 1.10-0
 ;     Format: CUSTOM
+;     Integer: 4 bytes
+;     Offset: 8 bytes
+;     Dumped from database version: 8.3.5
+;     Dumped by pg_dump version: 8.3.8
 ;
 ; Selected TOC Entries:
 ;
-2; 145344 TABLE species postgres
-3; 145344 ACL species
-4; 145359 TABLE nt_header postgres
-5; 145359 ACL nt_header
-6; 145402 TABLE species_records postgres
-7; 145402 ACL species_records
-8; 145416 TABLE ss_old postgres
-9; 145416 ACL ss_old
-10; 145433 TABLE map_resolutions postgres
-11; 145433 ACL map_resolutions
-12; 145443 TABLE hs_old postgres
-13; 145443 ACL hs_old</codeblock>
+3; 2615 2200 SCHEMA - public pasha
+1861; 0 0 COMMENT - SCHEMA public pasha
+1862; 0 0 ACL - public pasha
+317; 1247 17715 TYPE public composite pasha
+319; 1247 25899 DOMAIN public domain0 pasha2</codeblock>
       <p>Semicolons start a comment, and the numbers at the start of lines refer to the internal
         archive ID assigned to each item. Lines in the file can be commented out, deleted, and
-        reordered. For example,</p>
+        reordered. For example:</p>
       <codeblock>10; 145433 TABLE map_resolutions postgres
 ;2; 145344 TABLE species postgres
 ;4; 145359 TABLE nt_header postgres
@@ -329,7 +339,7 @@ pg_restore -d newdb db.dump</codeblock>
 ;8; 145416 TABLE ss_old postgres</codeblock>
       <p>Could be used as input to <codeph>pg_restore</codeph> and would only restore items 10 and
         6, in that order:</p>
-      <p>pg_restore -L db.list db.dump</p>
+      <codeblock>pg_restore -L db.list db.dump</codeblock>
     </section>
     <section id="section8">
       <title>See Also</title>

--- a/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
@@ -346,12 +346,14 @@ testdb=#</codeblock>
             [quote [as] 'character'] [escape [as] '<varname>character</varname>'] [force quote
             column_list] [force not null column_list]]</pt>
           <pd>Performs a frontend (client) copy. This is an operation that runs an SQL
-              <codeph>COPY</codeph> command, but instead of the server reading or writing the
+            <codeph><xref href="../../ref_guide/sql_commands/COPY.xml#topic1"/></codeph>
+            command, but instead of the server reading or writing the
             specified file, <codeph>psql</codeph> reads or writes the file and routes the data
             between the server and the local file system. This means that file accessibility and
             privileges are those of the local user, not the server, and no SQL superuser privileges
             are required.</pd>
-          <pd>The syntax of the command is similar to that of the SQL <codeph>COPY</codeph> command.
+          <pd>The syntax of the command is similar to that of the SQL
+            <codeph><xref href="../../ref_guide/sql_commands/COPY.xml#topic1"/></codeph> command.
             Note that, because of this, special parsing rules apply to the <codeph>\copy</codeph>
             command. In particular, the variable substitution rules and backslash escapes do not
             apply. </pd>
@@ -376,11 +378,10 @@ testdb=#</codeblock>
           <pd>For each relation (table, external table, view, index, or sequence) matching the
             relation pattern, show all columns, their types, the tablespace (if not the default) and
             any special attributes such as <codeph>NOT NULL</codeph> or defaults, if any. Associated
-            indexes, constraints, rules, and triggers are also shown, as is the view definition if
-            the relation is a view.<ul id="ul_qda_zxh_no">
+            indexes, constraints, rules, and triggers are also shown.<ul id="ul_qda_zxh_no">
               <li id="kb143931">The command form <codeph>\d+</codeph> is identical, except that more
                 information is displayed: any comments associated with the columns of the table are
-                shown, as is the presence of OIDs in the table.<p>For partitioned tables, the
+                shown, as is the presence of OIDs in the table, and the view definition if the relation is a view.<p>For partitioned tables, the
                   command <codeph>\d</codeph> or <codeph>\d+</codeph> specified with the root
                   partition table or child partition table displays information about the table
                   including partition keys on the current level of the partition table. The command
@@ -391,18 +392,18 @@ testdb=#</codeblock>
                   displayed for the table. For column-oriented tables, storage options are displayed
                   for each column. </p></li>
               <li id="kb151095">The command form <codeph>\dS</codeph> is identical, except that
-                system information is displayed as well as user information. For example,
+                system objects are displayed as well as user objects. For example,
                   <codeph>\dt</codeph> displays user tables, but not system tables;
-                  <codeph>\dtS</codeph> displays both user and system tables. Both these commands
+                  <codeph>\dtS</codeph> displays both user and system tables. Both of these commands
                 can take the <codeph>+</codeph> parameter to display additional information, as in
                   <codeph>\dt+</codeph> and <codeph>\dtS+</codeph>.<p>If <codeph>\d</codeph> is used
                   without a pattern argument, it is equivalent to <codeph>\dtvs</codeph> which will
-                  show a list of all tables, views, and sequences.</p></li>
+                  show a list of all visible tables, views, and sequences.</p></li>
             </ul></pd>
         </plentry>
         <plentry>
           <pt>\da [<varname>aggregate_pattern</varname>]</pt>
-          <pd>Lists all available aggregate functions, together with the data types they operate on.
+          <pd>Lists aggregate functions, together with the data types they operate on.
             If a pattern is specified, only aggregates whose names match the pattern are shown.
           </pd>
         </plentry>
@@ -424,9 +425,15 @@ testdb=#</codeblock>
           <pd>Lists all available type casts. </pd>
         </plentry>
         <plentry>
-          <pt>\dd [<varname>object_pattern</varname>]</pt>
-          <pd>Lists all available objects. If pattern is specified, only matching objects are
-            shown.</pd>
+          <pt>\dd[S] [<varname>pattern</varname>]</pt>
+          <pd>Shows the descriptions of objects matching the <varname>pattern</varname>,
+            or of all visible objects if no argument is given. But in either case, only
+            objects that have a description are listed. (Use the
+            <codeph><xref href="../../ref_guide/sql_commands/COMMENT.xml#topic1"/></codeph>
+            SQL command to add a description for an object.) By default, only user-created
+            objects are shown; supply a pattern or the <codeph>S</codeph> modifier to
+            include system objects. "Object" covers aggregates, functions, operators,
+            types, relations (tables, views, indexes, sequences), rules, and triggers.</pd>
         </plentry>
         <plentry>
           <pt>\dD [<varname>domain_pattern</varname>]</pt>
@@ -450,20 +457,25 @@ testdb=#</codeblock>
         <plentry>
           <pt>\dg [<varname>role_pattern</varname>]</pt>
           <pd>Lists all database roles. If pattern is specified, only those roles whose names match
-            the pattern are listed.</pd>
+            the pattern are listed. (This command is now effectively the same as
+            <codeph>\du</codeph>).  If the form <codeph>\dg+</codeph> is used,
+            additional information is shown about each role, including the comment for
+            each role.</pd>
         </plentry>
         <plentry>
-          <pt>\distPvES [<varname>index | sequence | table | parent table | view | external_table |
-              system_object</varname>] </pt>
+          <pt>\distPvEr[S+] [<varname>index | sequence | table | parent table | view | external_table |
+              foreign table</varname>] </pt>
           <pd>This is not the actual command name: the letters <codeph>i</codeph>,
               <codeph>s</codeph>, <codeph>t</codeph>, <codeph>P</codeph>, <codeph>v</codeph>,
-              <codeph>E</codeph>, <codeph>S</codeph> stand for index, sequence, table, parent table,
-            view, external table, and system table, respectively. You can specify any or all of
-            these letters, in any order, to obtain a listing of all the matching objects. The letter
-              <codeph>S</codeph> restricts the listing to system objects; without
-            <codeph>S</codeph>, only non-system objects are shown. If + is appended to the command
-            name, each object is listed with its associated description, if any. If a pattern is
-            specified, only objects whose names match the pattern are listed.</pd>
+              <codeph>E</codeph>, <codeph>r</codeph> stand for index, sequence, table, parent table,
+            view, external table, and foreign table, respectively. You can specify any or all of
+            these letters, in any order, to obtain a listing of objects of these types.
+            For example, <codeph>\dit</codeph> lists indexes and tables.  If <codeph>+</codeph> is
+            appended to the command name, each object is listed with its physical size
+            on disk and its associated description, if any. If a pattern is specified,
+            only objects whose names match the pattern are listed. By default, only
+            user-created objects are shown; supply a pattern or the <codeph>S</codeph>
+            modifier to include system objects.</pd>
         </plentry>
         <plentry>
           <pt>\dl</pt>
@@ -493,8 +505,11 @@ testdb=#</codeblock>
           <pt>\dp [<varname>relation_pattern_to_show_privileges</varname>]</pt>
           <pd>Produces a list of all available tables, views and sequences with their associated
             access privileges. If pattern is specified, only tables, views and sequences whose names
-            match the pattern are listed. The <codeph>GRANT</codeph> and <codeph>REVOKE</codeph>
-            commands are used to set access privileges. </pd>
+            match the pattern are listed. The
+            <codeph><xref href="../../ref_guide/sql_commands/GRANT.xml#topic1"/></codeph> and
+            <codeph><xref href="../../ref_guide/sql_commands/REVOKE.xml#topic1"/></codeph>
+            commands are used to set access privileges. The meaning of the privilege display
+            is explained under <codeph><xref href="../../ref_guide/sql_commands/GRANT.xml#topic1"/></codeph>.</pd>
         </plentry>
         <plentry>
           <pt>\dT [<varname>datatype_pattern</varname>] | \dT+
@@ -664,7 +679,7 @@ lo_import 152801</codeblock>
                 abbreviations are allowed. Unaligned writes all columns of a row on a line,
                 separated by the currently active field separator. This is intended to create output
                 that might be intended to be read in by other programs. Aligned mode is the
-                standard, human-readable, nicely formatted text output that is default. The HTML and
+                standard, human-readable, nicely formatted text output; this is the default. The HTML and
                 LaTeX modes put out tables that are intended to be included in documents using the
                 respective mark-up language. They are not complete documents! (This might not be so
                 dramatic in HTML, but in LaTeX you must have a complete document wrapper.) <p>The
@@ -794,7 +809,7 @@ lo_import 152801</codeblock>
           <pd>Although you are welcome to set any variable to anything you want,
               <codeph>psql</codeph> treats several variables as special. They are documented in the
             topic about variables.</pd>
-          <pd>This command is totally separate from the SQL command <codeph>SET</codeph>.</pd>
+          <pd>This command is totally separate from the SQL command <codeph><xref href="../../ref_guide/sql_commands/SET.xml#topic1"/></codeph>.</pd>
         </plentry>
         <plentry>
           <pt>\t [novalue | on | off]</pt>

--- a/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
@@ -441,6 +441,14 @@ testdb=#</codeblock>
             shown.</pd>
         </plentry>
         <plentry>
+          <pt>\det[S+] [<varname>foreign_table_pattern</varname>] </pt>
+          <pd>Lists all foreign tables. If a pattern is specified, only those foreign tables
+            whose names match the pattern are listed. If <codeph>+</codeph> is appended to
+            the command name, foreign data wrapper options and the foreign table description
+            are displayed. By default, only user-created objects are shown; supply a
+            pattern or the <codeph>S</codeph> modifier to include system objects.</pd>
+        </plentry>
+        <plentry>
           <pt>\dE [<varname>relation_pattern</varname>]</pt>
           <pd>Lists all external tables, or only those that match the pattern.</pd>
         </plentry>
@@ -463,12 +471,11 @@ testdb=#</codeblock>
             each role.</pd>
         </plentry>
         <plentry>
-          <pt>\distPvEr[S+] [<varname>index | sequence | table | parent table | view | external_table |
-              foreign table</varname>] </pt>
+          <pt>\distPvE[S+] [<varname>index | sequence | table | parent table | view | external_table</varname>] </pt>
           <pd>This is not the actual command name: the letters <codeph>i</codeph>,
               <codeph>s</codeph>, <codeph>t</codeph>, <codeph>P</codeph>, <codeph>v</codeph>,
-              <codeph>E</codeph>, <codeph>r</codeph> stand for index, sequence, table, parent table,
-            view, external table, and foreign table, respectively. You can specify any or all of
+            and <codeph>E</codeph> stand for index, sequence, table, parent table,
+            view, and external table, respectively. You can specify any or all of
             these letters, in any order, to obtain a listing of objects of these types.
             For example, <codeph>\dit</codeph> lists indexes and tables.  If <codeph>+</codeph> is
             appended to the command name, each object is listed with its physical size

--- a/gpdb-doc/dita/utility_guide/client_utilities/reindexdb.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/reindexdb.xml
@@ -8,13 +8,21 @@
 
 <b>reindexdb</b> [<varname>connection-option</varname> ...] [<b>--system</b> | <b>-s</b>] [<varname>dbname</varname>]
 
-<b>reindexdb</b> <b>--help</b> 
+<b>reindexdb</b> <b>-? | --help</b>
 
-<b>reindexdb</b> <b>--version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>reindexdb</codeph> is a utility for rebuilding indexes in Greenplum Database, and is a wrapper around the SQL command <codeph>REINDEX</codeph>. </p></section><section id="section4"><title>Options</title><parml><plentry><pt>-a | --all</pt><pd>Reindex all databases.</pd></plentry><plentry><pt>[-d] <varname>dbname</varname> | [--dbname] <varname>dbname</varname></pt><pd>Specifies the name of the database to be reindexed. If this is not specified and
+<b>reindexdb</b> <b>-V | --version</b></codeblock></section><section id="section3"><title>Description</title><p><codeph>reindexdb</codeph> is a utility for rebuilding indexes in Greenplum Database, and is a wrapper around the SQL command <codeph>REINDEX</codeph>. </p></section><section id="section4"><title>Options</title><parml><plentry><pt>-a | --all</pt><pd>Reindex all databases.</pd></plentry><plentry><pt>[-d] <varname>dbname</varname> | [--dbname] <varname>dbname</varname></pt><pd>Specifies the name of the database to be reindexed. If this is not specified and
               <codeph>-all</codeph> is not used, the database name is read from the environment
             variable <codeph>PGDATABASE</codeph>. If that is not set, the user name specified for
             the connection is used.</pd></plentry><plentry><pt>-e | --echo</pt><pd>Echo the commands that <codeph>reindexdb</codeph> generates and sends
-to the server.</pd></plentry><plentry><pt>-i <varname>index</varname> | --index <varname>index</varname></pt><pd>Recreate index only.</pd></plentry><plentry><pt>-q | --quiet</pt><pd>Do not display a response.</pd></plentry><plentry><pt>-s | --system</pt><pd>Reindex system catalogs.</pd></plentry><plentry><pt>-t <varname>table</varname> | --table <varname>table</varname></pt><pd>Reindex table only.</pd></plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>Specifies the host name of the machine on which the Greenplum
+to the server.</pd></plentry><plentry><pt>-i <varname>index</varname> | --index <varname>index</varname></pt><pd>Recreate index only.</pd></plentry><plentry><pt>-q | --quiet</pt><pd>Do not display a response.</pd></plentry><plentry><pt>-s | --system</pt><pd>Reindex system catalogs.</pd></plentry><plentry><pt>-t <varname>table</varname> | --table <varname>table</varname></pt><pd>Reindex table only.</pd></plentry>
+        <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>reindexdb</codeph> version and exit.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help</pt>
+          <pd>Show help about <codeph>reindexdb</codeph> command line arguments, and exit.</pd>
+        </plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host <varname>host</varname></pt><pd>Specifies the host name of the machine on which the Greenplum
               master database server is running. If not specified, reads from the environment
               variable <codeph>PGHOST</codeph> or defaults to localhost.</pd></plentry><plentry><pt>-p <varname>port</varname> | --port <varname>port</varname></pt><pd>Specifies the TCP port on which the Greenplum master database
               server is listening for connections. If not specified, reads from the environment

--- a/gpdb-doc/dita/utility_guide/client_utilities/vacuumdb.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/vacuumdb.xml
@@ -20,8 +20,9 @@
     </section>
     <section id="section3">
       <title>Description</title>
-      <p><codeph>vacuumdb</codeph> is a utility for cleaning a PostgreSQL database. vacuumdb will
-        also generate internal statistics used by the PostgreSQL query optimizer. </p>
+      <p><codeph>vacuumdb</codeph> is a utility for cleaning a Greenplum Database database.
+        <codeph>vacuumdb</codeph> will
+        also generate internal statistics used by the Greenplum Database query optimizer.</p>
       <p><codeph>vacuumdb</codeph> is a wrapper around the SQL command <codeph>VACUUM</codeph>.
         There is no effective difference between vacuuming databases via this utility and via other
         methods for accessing the server. </p>

--- a/gpdb-doc/dita/utility_guide/client_utilities/vacuumdb.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/vacuumdb.xml
@@ -8,14 +8,15 @@
     <section id="section2">
       <title>Synopsis</title>
       <codeblock id="client_util_synopsis"><b>vacuumdb</b> [<varname>connection-option</varname>...] [--full | -f] [<b>--freeze</b> | <b>-F</b>] [<b>--verbose</b> | <b>-v</b>]
-    [<b>--analyze</b> | <b>-z</b>] [<b>--table</b> | <b>-t</b> <varname>table</varname> [( <varname>column</varname> [,...] )] ] [<varname>dbname</varname>]
+    [<b>--analyze</b> | <b>-z</b>] [<b>--analyze-only</b> | <b>-Z</b>] [<b>--table</b> | <b>-t</b> <varname>table</varname> [( <varname>column</varname> [,...] )] ] [<varname>dbname</varname>]
 
-<b>vacuumdb</b> [<varname>connection-options</varname>...] [<b>--all</b> | <b>-a</b>] [--full | -f] [<b>-F</b>] 
+<b>vacuumdb</b> [<varname>connection-option</varname>...] [<b>--all</b> | <b>-a</b>] [--full | -f] [<b>-F</b>] 
     [<b>--verbose</b> | <b>-v</b>] [<b>--analyze</b> | <b>-z</b>]
+    [<b>--analyze-only</b> | <b>-Z</b>]
 
-<b>vacuumdb</b> <b>--help</b> 
+<b>vacuumdb</b> <b>-? | --help</b>
 
-<b>vacuumdb</b> <b>--version</b></codeblock>
+<b>vacuumdb</b> <b>-V | --version</b></codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -62,7 +63,7 @@
           <pt>-t <varname>table</varname> [(<varname>column</varname>)] | --table
               <varname>table</varname> [(<varname>column</varname>)]</pt>
           <pd>Clean or analyze this table only. Column names may be specified only in conjunction
-            with the <codeph>--analyze</codeph> option. If you specify columns, you probably have to
+            with the <codeph>--analyze</codeph> or <codeph>--analyze-all</codeph> options. If you specify columns, you probably have to
             escape the parentheses from the shell.</pd>
         </plentry>
         <plentry>
@@ -72,6 +73,18 @@
         <plentry>
           <pt>-z | --analyze</pt>
           <pd>Collect statistics for use by the query planner.</pd>
+        </plentry>
+        <plentry>
+          <pt>-Z | --analyze-only</pt>
+          <pd>Only calculate statistics for use by the query planner (no vacuum).</pd>
+        </plentry>
+        <plentry>
+          <pt>-V | --version</pt>
+          <pd>Print the <codeph>vacuumdb</codeph> version and exit.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help</pt>
+          <pd>Show help about <codeph>vacuumdb</codeph> command line arguments, and exit.</pd>
         </plentry>
       </parml>
       <sectiondiv id="section5">

--- a/gpdb-doc/dita/utility_guide/utility_guide.ditamap
+++ b/gpdb-doc/dita/utility_guide/utility_guide.ditamap
@@ -60,11 +60,11 @@
             <topicref href="client_utilities/ClientUtilitySummary.xml" linking="targetonly">
                 <topicref href="client_utilities/clusterdb.xml"/>
                 <topicref href="client_utilities/createdb.xml"/>
+                <topicref href="client_utilities/createlang.xml"/>
                 <topicref href="client_utilities/createuser.xml"/>
                 <topicref href="client_utilities/dropdb.xml"/>
                 <topicref href="client_utilities/droplang.xml"/>
                 <topicref href="client_utilities/dropuser.xml"/>
-                <topicref href="client_utilities/createlang.xml"/>
                 <topicref href="client_utilities/pg_config.xml"/>
                 <topicref href="client_utilities/pg_dump.xml"/>
                 <topicref href="client_utilities/pg_dumpall.xml"/>


### PR DESCRIPTION
in this PR:
- 9.0beta3 merge updates to utility commands.  most involve adding help- and version-related options.
- the existing pg_restore ref page does not document the "--use-set-session-authorization" option.   does pg_restore support this option?
