### PR TITLE
Remove 9.4 fixme comment without any code change

### DIFF
--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -1601,11 +1601,6 @@ UpdateMasterAosegTotalsFromSegments(Relation parentrel,
 
 			Assert(RelationIsAoCols(parentrel));
 
-			/* GPDB_94_MERGE_FIXME: We used to call this with SnapshotNow,
-			 * even though in the row-oriented case above, we use
-			 * appendOnlyMetaDataSnapshot. Was that on purpose?
-			 * I changed this to also use appendOnlyMetaDataSnapshot.
-			 */
 			seginfo = GetAOCSFileSegInfo(parentrel,
 										 appendOnlyMetaDataSnapshot, qe_segno);
 


### PR DESCRIPTION
In Greenplum, during vacuuming of an append optimized relation, the
query dispatcher needs to update its tupcount information from the segments.
Vacuum calls UpdateMasterAosegTotals with the appropriate snapshot as an
argument.

UpdateMasterAosegTotals was introduced in `d9415f4cc5db95` and it was
called with the special static `SnapshotNow`. Possibly due to oversight,
while gathering the information of columnar append optimized relations,
it reused the static instead of the arg, which happened to match.

In 9.4 SnapshotNow was removed in favor of MVCC catalog scans.

The comment wondered if the use of apparently different snapshots was
intentional. The conclusion is that it was not. Vacuum is holding the
appropriate snapshot which is now used in both cases.

