### PR TITLE
Improve logging option in RemoteOperation (port from 5X_STABLE)

### DIFF
--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
@@ -10,7 +10,7 @@ from gppylib.operations.test_utils_helper import TestOperation, RaiseOperation, 
     RaiseOperation_Unsafe, RaiseOperation_Unpicklable, RaiseOperation_Safe, MyException, ExceptionWithArgs
 from operations.unix import ListFiles
 from test.unit.gp_unittest import GpTestCase, run_tests
-
+from mock import patch, MagicMock
 
 class UtilsTestCase(GpTestCase):
     """
@@ -101,6 +101,17 @@ class UtilsTestCase(GpTestCase):
         with self.assertRaises(Exception):
             ParallelOperation([ListFiles("/tmp")], 0).run()
 
+    @patch('gppylib.commands.base.logger.debug')
+    @patch('pickle.loads')
+    @patch('gppylib.operations.utils.Command')
+    @patch('os.path.split', return_value = '/')
+    def test_RemoteOperation_logger_debug(self, mock_split, mock_cmd, mock_lods, mock_debug):
+        mock_cmd.run = MagicMock()
+        mockRemoteOperation = RemoteOperation(operation=TestOperation(), host="sdw1", msg_ctx="dbid 2")
+        mockRemoteOperation.execute()
+        mock_debug.assert_called()
+        first_call_args, fist_call_kwargs = mock_debug.call_args_list[0]
+        self.assertTrue(first_call_args[0].startswith("Output for dbid 2 on host sdw1:"))
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Currently, when a RemoteOperation call fails, there is no indication as to which segment failed. This PR adds the ability to pass a message context to the RemoteOperation to improve its error logging.  Unlike in 5X_STABLE, we did not have to modify any callers to RemoteOperation to pass a dbid because all users in MASTER use the RemoteOperation at the host level.  However, we want to port to 6 for consistency and future use.

(port from 5X_STABLE to MASTER of https://github.com/greenplum-db/gpdb/pull/6750)
