### PR TITLE
pg_regress: recurse input/output directory and convert files.

### DIFF
--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -59,4 +59,4 @@ installcheck: install
 	./pg_isolation2_regress --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --ao-dir=uao --schedule=$(srcdir)/isolation2_schedule --exclude-tests=$(EXCLUDE_TESTS)
 
 installcheck-resgroup: install
-	./pg_isolation2_regress --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_resgroup --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --resgroup-dir=resgroup --dbname=isolation2resgrouptest --schedule=$(srcdir)/isolation2_resgroup_schedule
+	./pg_isolation2_regress --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_resgroup --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --dbname=isolation2resgrouptest --schedule=$(srcdir)/isolation2_resgroup_schedule


### PR DESCRIPTION
Special code was written for resgroup directory in input and
output. Instead convert it to generic code to recurse if any directory
encountered in input/output directory. This hurdle was faced when
attempting to add test using template framework for walreplication,
where we wished add test in "input/segwalrep" directory. Change in this
commit now enables to add directories easily to input and output.

Since no need exist now for special resgroup directory argument,
removing the same. Given the number of files in resgroup directory is
very less and not expected to grow super large, its okay to generate
the .sql and .out files always along with generating other files.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
