### PR TITLE
docs - update template database information.

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-database.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-database.xml
@@ -14,22 +14,22 @@
       databases.</p>
   </body>
   <topic id="topic3" xml:lang="en">
-    <title id="im140508">About Template Databases</title>
+    <title id="im140508">About Template and Default Databases</title>
     <body>
-      <p>Greenplum Database provides some default template databases, <i>template1</i>,
-          <i>postgres</i>, and <i>template0</i>.</p>
-      <p>Each new database you create is based on a <i>template</i> database. Greenplum Database
-        uses <i>template1</i> to create databases unless you specify another template. Creating
-        objects in <i>template1</i> is not recommended. The objects will be in every database you
-        create using the default template database. </p>
-      <p>You can use <i>postgres</i> database to connect to Greenplum Database for the first time.
-        Greenplum Database uses <i>postgres</i> as the default database for administrative
-        connections. For example, <i>postgres</i> is used by startup processes, the Global Deadlock
-        Detector process, and the FTS (Fault Tolerance Server) process for catalog access.</p>
+      <p>Greenplum Database provides some template databases and a default database,
+          <i>template1</i>, <i>template0</i>, and <i>postgres</i>.</p>
+      <p>By default, each new database you create is based on a <i>template</i> database. Greenplum
+        Database uses <i>template1</i> to create databases unless you specify another template.
+        Creating objects in <i>template1</i> is not recommended. The objects will be in every
+        database you create using the default template database. </p>
       <p>Greenplum Database uses another database template, <i>template0</i>, internally. Do not
         drop or modify <i>template0</i>. You can use <i>template0</i> to create a completely clean
         database containing only the standard objects predefined by Greenplum Database at
         initialization.</p>
+      <p>You can use <i>postgres</i> database to connect to Greenplum Database for the first time.
+        Greenplum Database uses <i>postgres</i> as the default database for administrative
+        connections. For example, <i>postgres</i> is used by startup processes, the Global Deadlock
+        Detector process, and the FTS (Fault Tolerance Server) process for catalog access.</p>
     </body>
   </topic>
   <topic id="topic4" xml:lang="en">

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-database.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-database.xml
@@ -4,26 +4,32 @@
 <topic id="topic1" xml:lang="en">
   <title id="im140249">Creating and Managing Databases</title>
   <body>
-    <p rev="true">A Greenplum Database system is a single instance of Greenplum Database. There can be several separate Greenplum Database
-      systems installed, but usually just one is selected by environment variable settings. See your
-        Greenplum administrator for details.</p>
-    <p>There can be multiple databases in a Greenplum Database system. This is
-      different from some database management systems (such as Oracle) where the database instance
-        <i>is</i> the database. Although you can create many databases in a Greenplum system, client programs can connect to and access only one
-      database at a time — you cannot cross-query between databases.</p>
+    <p>A Greenplum Database system is a single instance of Greenplum Database. There can be several
+      separate Greenplum Database systems installed, but usually just one is selected by environment
+      variable settings. See your Greenplum administrator for details.</p>
+    <p>There can be multiple databases in a Greenplum Database system. This is different from some
+      database management systems (such as Oracle) where the database instance <i>is</i> the
+      database. Although you can create many databases in a Greenplum system, client programs can
+      connect to and access only one database at a time — you cannot cross-query between
+      databases.</p>
   </body>
   <topic id="topic3" xml:lang="en">
     <title id="im140508">About Template Databases</title>
     <body>
-      <p>Each new database you create is based on a <i>template</i>. Greenplum provides a default database, <i>template1</i>. Use
-          <i>postgres</i> to connect to Greenplum Database for the first time.
-          Greenplum Database uses <i>template1</i> to create databases unless you
-        specify another template. Do not create any objects in <i>template1</i> unless you want
-        those objects to be in every database you create. </p>
-      <p>Greenplum Database uses another database templates, <i>template0</i>, internally. Do not drop or
-          modify <i>template0</i>. You can use <i>template0</i> to create a completely clean
-          database containing only the standard objects predefined by Greenplum Database at
-          initialization, especially if you modified <i>template1</i>.</p>
+      <p>Greenplum Database provides some default template databases, <i>template1</i>,
+          <i>postgres</i>, and <i>template0</i>.</p>
+      <p>Each new database you create is based on a <i>template</i> database. Greenplum Database
+        uses <i>template1</i> to create databases unless you specify another template. Creating
+        objects in <i>template1</i> is not recommended. The objects will be in every database you
+        create using the default template database. </p>
+      <p>You can use <i>postgres</i> database to connect to Greenplum Database for the first time.
+        Greenplum Database uses <i>postgres</i> as the default database for administrative
+        connections. For example, <i>postgres</i> is used by startup processes, the Global Deadlock
+        Detector process, and the FTS (Fault Tolerance Server) process for catalog access.</p>
+      <p>Greenplum Database uses another database template, <i>template0</i>, internally. Do not
+        drop or modify <i>template0</i>. You can use <i>template0</i> to create a completely clean
+        database containing only the standard objects predefined by Greenplum Database at
+        initialization.</p>
     </body>
   </topic>
   <topic id="topic4" xml:lang="en">
@@ -33,18 +39,22 @@
       <p>
         <codeblock>=&gt; CREATE DATABASE <i>new_dbname</i>;</codeblock>
       </p>
-      <p>To create a database, you must have privileges to create a database or be a Greenplum Database superuser. If you do not have the correct privileges, you cannot
-        create a database. Contact your Greenplum Database administrator to either
-        give you the necessary privilege or to create a database for you.</p>
+      <p>To create a database, you must have privileges to create a database or be a Greenplum
+        Database superuser. If you do not have the correct privileges, you cannot create a database.
+        Contact your Greenplum Database administrator to either give you the necessary privilege or
+        to create a database for you.</p>
       <p>You can also use the client program <codeph>createdb</codeph> to create a database. For
-        example, running the following command in a command line terminal connects to Greenplum Database using the provided host name and port and creates a database named
+        example, running the following command in a command line terminal connects to Greenplum
+        Database using the provided host name and port and creates a database named
           <i>mydatabase</i>:</p>
       <p>
         <codeblock>$ createdb -h masterhost -p 5432 mydatabase</codeblock>
       </p>
-      <p>The host name and port must match the host name and port of the installed Greenplum Database system.</p>
-      <p>Some objects, such as roles, are shared by all the databases in a Greenplum Database system. Other objects, such as tables that you create, are known
-        only in the database in which you create them.</p>
+      <p>The host name and port must match the host name and port of the installed Greenplum
+        Database system.</p>
+      <p>Some objects, such as roles, are shared by all the databases in a Greenplum Database
+        system. Other objects, such as tables that you create, are known only in the database in
+        which you create them.</p>
       <note type="warning">The <codeph>CREATE DATABASE</codeph> command is not transactional.</note>
     </body>
     <topic id="topic5" xml:lang="en">
@@ -74,9 +84,9 @@
     <body>
       <p>If you are working in the <codeph>psql</codeph> client program, you can use the
           <codeph>\l</codeph> meta-command to show the list of databases and templates in your
-          Greenplum Database system. If using another client program and you are a
-        superuser, you can query the list of databases from the <codeph>pg_database</codeph> system
-        catalog table. For example:</p>
+        Greenplum Database system. If using another client program and you are a superuser, you can
+        query the list of databases from the <codeph>pg_database</codeph> system catalog table. For
+        example:</p>
       <p>
         <codeblock>=&gt; SELECT datname from pg_database;</codeblock>
       </p>
@@ -109,13 +119,13 @@
 =&gt; DROP DATABASE mydatabase;</codeblock>
       </p>
       <p>You can also use the client program <codeph>dropdb</codeph> to drop a database. For
-        example, the following command connects to Greenplum Database using the
-        provided host name and port and drops the database <i>mydatabase</i>:</p>
+        example, the following command connects to Greenplum Database using the provided host name
+        and port and drops the database <i>mydatabase</i>:</p>
       <p>
         <codeblock>$ dropdb -h masterhost -p 5432 mydatabase</codeblock>
       </p>
-      <note type="warning">Dropping a database cannot be undone.
-          <p>The <codeph>DROP DATABASE</codeph> command is not transactional.</p></note>
+      <note type="warning">Dropping a database cannot be undone. <p>The <codeph>DROP
+            DATABASE</codeph> command is not transactional.</p></note>
     </body>
   </topic>
 </topic>

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-database.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-database.xml
@@ -26,7 +26,7 @@
         drop or modify <i>template0</i>. You can use <i>template0</i> to create a completely clean
         database containing only the standard objects predefined by Greenplum Database at
         initialization.</p>
-      <p>You can use <i>postgres</i> database to connect to Greenplum Database for the first time.
+      <p>You can use the <i>postgres</i> database to connect to Greenplum Database for the first time.
         Greenplum Database uses <i>postgres</i> as the default database for administrative
         connections. For example, <i>postgres</i> is used by startup processes, the Global Deadlock
         Detector process, and the FTS (Fault Tolerance Server) process for catalog access.</p>

--- a/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
@@ -6,8 +6,6 @@
   <shortdesc>Use the <codeph>gpexpand</codeph> utility to create and initialize the new segment
     instances and create the expansion schema. </shortdesc>
   <body>
-    <draft-comment author="msk">GPDB 6 -online expand <p>remove change of distribution
-      policy</p></draft-comment>
     <p>The first time you run <codeph><xref href="../../utility_guide/admin_utilities/gpexpand.xml"
           >gpexand</xref></codeph> with a valid input file it creates and initializes segment
       instances and creates the expansion schema. After these steps are completed, running
@@ -220,7 +218,6 @@ sdw5:sdw5-1:60012:/gpdata/mirror/gp10:14:10:m</codeblock>
   <topic id="topic27" xml:lang="en">
     <title>Rolling Back a Failed Expansion Setup</title>
     <body>
-      <draft-comment author="msk">Is rollback true for online expand?</draft-comment>
       <p>You can roll back an expansion setup operation (adding segment instances and segment hosts)
         only if the operation fails. </p>
       <p>If the expansion fails during the initialization step, while the database is down, you must

--- a/gpdb-doc/dita/admin_guide/expand/expand-nodes.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-nodes.xml
@@ -6,7 +6,6 @@
   <shortdesc>Verify your new host systems are ready for integration into the existing Greenplum
     system. </shortdesc>
   <body>
-    <draft-comment author="msk">GPDB 6 updates for online expand</draft-comment>
     <p>To prepare new host systems for expansion, install the Greenplum Database software binaries,
       exchange the required SSH keys, and run performance tests. </p>
     <p>Run performance tests first on the new hosts and then all hosts. Run the tests on all hosts

--- a/gpdb-doc/dita/admin_guide/expand/expand-redistribute.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-redistribute.xml
@@ -59,8 +59,6 @@
   <topic id="topic30" xml:lang="en">
     <title>Redistributing Tables Using gpexpand</title>
     <body>
-      <draft-comment author="msk">There are two redistribute methods see GUC
-        gp_expand_method</draft-comment>
       <section id="no162282">
         <title>To redistribute tables with gpexpand</title>
         <ol>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_tablespace.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_tablespace.xml
@@ -4,7 +4,6 @@
 <topic id="topic1" xml:lang="en">
   <title id="hx156255">pg_tablespace</title>
   <body>
-    <draft-comment author="msk">6.0 remove spclocation, spcfsoid add spcoptions</draft-comment>
     <p>The <codeph>pg_tablespace</codeph> system catalog table stores information about the
       available tablespaces. Tables can be placed in particular tablespaces to aid administration of
       disk layout. Unlike most system catalogs, <codeph>pg_tablespace</codeph> is shared across all

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
@@ -4,7 +4,6 @@
 <topic id="topic1">
   <title id="kt20941">gpexpand</title>
   <body>
-    <draft-comment author="msk">GPDB 6 - online expand</draft-comment>
     <p>Expands an existing Greenplum Database across new hosts in the system.</p>
     <section id="section2">
       <title>Synopsis</title>
@@ -69,8 +68,6 @@
         to rebalance the data across the old and new segment instances.</p>
       <note>Data redistribution should be performed during low-use hours. Redistribution can divided
         into batches over an extended period.</note>
-      <draft-comment author="msk">Reference to time is for default expand method. mention
-        gp_expand_method GUC. Recommendations? </draft-comment>
       <p>To begin the redistribution phase, run <codeph>gpexpand</codeph> with either the
           <codeph>-d</codeph> (duration) or <codeph>-e</codeph> (end time) options, or with no
         options. If you specify an end time or duration, then the utility redistributes tables in


### PR DESCRIPTION
Updated ddl-database.xml topic section "About Template Databases"
Clarify use of postgres template database. 

Also removed draft text from expand topics, gpexpand and pg_tablespace

This is a doc change for PR https://github.com/greenplum-db/gpdb/pull/6601
