### PR TITLE
Increase the fts_errors gang retry timer

### DIFF
--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -20,12 +20,12 @@ CREATE
 -- Allow extra time for mirror promotion to complete recovery to avoid
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
--- case segment is in recovery. Approximately we want to wait 30 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly;
+-- case segment is in recovery. Approximately we want to wait 120 seconds.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/sql/fts_errors.sql
+++ b/src/test/isolation2/sql/fts_errors.sql
@@ -16,9 +16,9 @@ create extension if not exists gp_inject_fault;
 -- Allow extra time for mirror promotion to complete recovery to avoid
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
--- case segment is in recovery. Approximately we want to wait 30 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly;
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly;
+-- case segment is in recovery. Approximately we want to wait 120 seconds.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
 !\retcode gpstop -u;
 
 include: helpers/server_helpers.sql;


### PR DESCRIPTION
We noticed a case in CI where it seemed like it took longer than 30
seconds to promote the mirror during recovery. We think that this 
might solve the issue, but are looking for more ideas since this seems
kinda sketch..

Co-authored-by: Melanie Plageman <mplageman@pivotal.io>

In one instance (from master logs) we saw that it seemed to take longer than 30 seconds 

starting at 10:49:33
```
2019-02-06 10:49:33.502961 UTC,"gpadmin","isolation2test",p83281,th145295328,"[local]",,2019-02-06 10:49:29 UTC,0,con904,cmd3,seg-1,,dx2727,,sx1,"LOG","00000","segment is in recovery mode (seg0 10.254.0.138:25435)",,,,,,"BEGIN;",0,,"cdbgang_async.c",206,
```
and continuing through 10:50:06
```
2019-02-06 10:50:06.674159 UTC,"gpadmin","isolation2test",p83281,th145295328,"[local]",,2019-02-06 10:49:29 UTC,0,con904,cmd3,seg-1,,dx2727,,sx1,"LOG","00000","segment is in recovery mode (seg1 10.254.0.138:25436)",,,,,,"BEGIN;",0,,"cdbgang_async.c",206
```

At 10:50:06.774486 master raises exception to user:
```
2019-02-06 10:50:06.774486 UTC,"gpadmin","isolation2test",p83281,th145295328,"[local]",,2019-02-06 10:49:29 UTC,0,con904,cmd3,seg-1,,dx2727,,sx1,"ERROR","58M01","failed to acquire resources on one or more segments","Segments are in recovery mode.",,,,,"BEGIN;",0,,"cdbgang_async.c",285
```

And finally on segment it was ready at 10:50:06.816 (after exception is sent to user)
```
2019-02-06 10:50:06.816499 UTC,,,p74351,th734136288,,,,0,,,seg1,,,,,"LOG","00000","database system is ready to accept connections","PostgreSQL 9.4.20 
```