### PR TITLE
Fix nonfunctional gpcheckcat constraint Behave test

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -212,10 +212,9 @@ Feature: gpcheckcat tests
         When the user runs "gpcheckcat -R distribution_policy constraint_db"
         Then gpcheckcat should return a return code of 1
         Then validate and run gpcheckcat repair
-        When the user runs "gpcheckcat -R constraint constraint_db"
-        Then the path "gpcheckcat.repair.*" is found in cwd "0" times
+        When the user runs "gpcheckcat -R distribution_policy constraint_db"
+        Then gpcheckcat should return a return code of 0
         And the user runs "dropdb constraint_db"
-        And the path "gpcheckcat.repair.*" is removed from current working directory
 
     @policy
     Scenario: gpcheckcat should report and repair invalid policy issues

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_invalid_constraint.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_invalid_constraint.sql
@@ -1,3 +1,3 @@
 set allow_system_table_mods=true;
 create table foo(i int primary key);
-update gp_distribution_policy  set distkey='' where localoid='foo'::regclass::oid;
+update pg_constraint set conkey='{}' where conname = 'foo_pkey';

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1585,9 +1585,12 @@ def impl(context, path, num):
 
 @then('run all the repair scripts in the dir "{dir}"')
 def impl(context, dir):
-    command = "cd {0} ; for i in *.sh ; do bash $i; done".format(dir)
-    run_command(context, command)
+    bash_files = glob.glob("%s/*.sh" % dir)
+    for file in bash_files:
+        run_command(context, "bash %s" % file)
 
+        if context.ret_code != 0:
+            raise Exception("Error running repair script %s: %s" % (file, context.stdout_message))
 
 @when(
     'the entry for the table "{user_table}" is removed from "{catalog_table}" with key "{primary_key}" in the database "{db_name}"')


### PR DESCRIPTION
One of the Behave tests was calling gpcheckcat -R with an invalid
check name, causing the test to silently fail.  This commit corrected
that call.

Additionally, the SQL script used to generate the error for that test
was making a catalog change that would be nearly impossible to hit "in
the wild," and was causing the repair script to encounter an assertion
failure.  The script has been changed to generate a more reasonable
error, one that is more relevant to what we want to test.

Finally, the Behave step for running repair scripts has been modified
to actually error out if a repair script encounters a non-zero return
code (when it was silently failing before) and give the user a
descriptive error message.

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>
