### PR TITLE
Fix the math in AllocSizeIsValid. (5X_STABLE)

### DIFF
--- a/src/backend/lib/stringinfo.c
+++ b/src/backend/lib/stringinfo.c
@@ -305,14 +305,8 @@ enlargeStringInfo(StringInfo str, int needed)
 	 * here that MaxAllocSize <= INT_MAX/2, else the above loop could
 	 * overflow.  We will still have newlen >= needed.
 	 */
-	if (newlen >= (int) MaxAllocSize)
-	{
-		/*
-		 * Currently we support allocations only up to MaxAllocSize - 1
-		 * (see AllocSizeIsValid()).
-		 */
-		newlen = (int) MaxAllocSize - 1;
-	}
+	if (newlen > (int) MaxAllocSize)
+		newlen = (int) MaxAllocSize;
 
 	str->data = (char *) repalloc(str->data, newlen);
 

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -39,10 +39,7 @@
  */
 #define MaxAllocSize	((Size) 0x3fffffff)		/* 1 gigabyte - 1 */
 
-static inline bool AllocSizeIsValid(Size sz)
-{
-        return (sz < MaxAllocSize);
-}
+#define AllocSizeIsValid(size)	((Size) (size) <= MaxAllocSize)
 
 /*
  * Multiple chunks can share a SharedChunkHeader if their shared information


### PR DESCRIPTION
GPDB's AllocSizeIsValid() was off by one byte, compared to upstream's.
If the argument was exactly MaxAllocSize, the GPDB version would return
false, whereas upstream's would return true.

We had compensated for this in enlargeStringInfo(). But it wasn't quite
right: if the caller needed exactly MaxAllocSize bytes (including the null
terminator), the code would truncate it down to MaxAllocSize - 1, and
therefore allocate one byte too little. That's unlikely to cause any real
trouble on production systems, because in practice malloc() will round up
the allocation to some alignment boundary. But with assertions enabled, it
is easy to demonstrate e.g. with this:

postgres=# select repeat('x', 1073741816);
WARNING:  detected write past chunk end in printtup 0x7f8eabfff040 (aset.c:1505)

Reviewed-by: Georgios Kokolatos <gkokolatos@pivotal.io>
Reviewed-by: Melanie Plageman <mplageman@pivotal.io>

(This is a backport of db730a6fa3 to 5X_STABLE)