### PR TITLE
docs - appendoptimized is an alias for appendonly storage option

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
@@ -692,7 +692,7 @@ PARTITION other;
           swap the loaded table into your partition design. You can use partition exchange to change
           the storage type of older partitions to append-optimized tables. For example:</p>
         <p>
-          <codeblock>CREATE TABLE jan12 (LIKE sales) WITH (appendonly=true);
+          <codeblock>CREATE TABLE jan12 (LIKE sales) WITH (appendoptimized=true);
 INSERT INTO jan12 SELECT * FROM sales_1_prt_1 ;
 ALTER TABLE sales EXCHANGE PARTITION FOR (DATE '2012-01-01') 
 WITH TABLE jan12;

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -76,7 +76,7 @@
         </p>
         <note>You use the <codeph>appendoptimized=<varname>value</varname></codeph> syntax to
           specify the append-optimized table storage type. <codeph>appendoptimized</codeph> is
-          a thin alias for the <codeph>appendonly</codeph> storage option. Greenplum Database
+          a thin alias for the <codeph>appendonly</codeph> legacy storage option. Greenplum Database
           stores <codeph>appendonly</codeph> in the catalog, and displays the same when 
           listing storage options for append-optimized tables.</note>
         <p><codeph>UPDATE</codeph> and <codeph>DELETE</codeph> are not allowed on append-optimized
@@ -359,7 +359,7 @@
           <tbody>
             <row>
               <entry colname="col1">
-                <codeph>COMPRESSTYPE</codeph>
+                <codeph>compresstype</codeph>
               </entry>
               <entry colname="col2">Type of compression.</entry>
               <entry colname="col3"><codeph>zstd: </codeph>ZStandard
@@ -371,7 +371,7 @@
             </row>
             <row>
               <entry colname="col1" morerows="3">
-                <codeph>COMPRESSLEVEL</codeph>
+                <codeph>compresslevel</codeph>
               </entry>
               <entry colname="col2" morerows="3">Compression level.</entry>
               <entry colname="col3"><codeph>zlib</codeph> compression:
@@ -404,7 +404,7 @@
             </row>
             <row>
               <entry colname="col1">
-                <codeph>BLOCKSIZE</codeph>
+                <codeph>blocksize</codeph>
               </entry>
               <entry colname="col2">The size in bytes for each block in the table</entry>
               <entry colname="col3">
@@ -554,7 +554,7 @@
       <topic id="topic51" xml:lang="en">
         <title>Example 4</title>
         <body>
-          <p>In this example, <codeph>CREATE TABLE</codeph> assigns the <codeph>zlib</codeph> compresstype storage
+          <p>In this example, <codeph>CREATE TABLE</codeph> assigns the <codeph>zlib</codeph> <codeph>compresstype</codeph> storage
             directive to <codeph>c1</codeph>. Column <codeph>c2</codeph> has no storage directive
             and inherits the compression type (<codeph>quicklz</codeph>) and block size
               (<codeph>65536</codeph>) from the <codeph>DEFAULT COLUMN ENCODING</codeph> clause.</p>
@@ -634,7 +634,7 @@
         <p>When you specify <codeph>int33</codeph> as a column type in a <codeph>CREATE TABLE</codeph>
           command, the column is created with the storage directives you specified for the type:</p>
         <codeblock>CREATE TABLE t2 (c1 int33)
-    WITH (APPENDOPTIMIZED=true, ORIENTATION=column);</codeblock>
+    WITH (appendoptimized=true, orientation=column);</codeblock>
         <p>Table- or column- level storage attributes that you specify in a table definition override
            type-level storage attributes. For information about creating and adding compression
            attributes to a type, see
@@ -755,7 +755,7 @@ GRANT SELECT ON sales TO guest;
           <p>
             <codeblock>ALTER TABLE T1
       ADD COLUMN c4 int DEFAULT 0
-      ENCODING (COMPRESSTYPE=zlib);
+      ENCODING (compresstype=zlib);
 </codeblock>
           </p>
         </body>
@@ -771,15 +771,15 @@ GRANT SELECT ON sales TO guest;
           <p>
             <codeblock>CREATE TABLE ccddl (i int, j int, k int, l int)
   WITH
-    (APPENDOPTIMIZED = TRUE, ORIENTATION=COLUMN)
+    (appendoptimized = TRUE, orientation=COLUMN)
   PARTITION BY range(j)
   SUBPARTITION BY list (k)
   SUBPARTITION template(
     SUBPARTITION sp1 values(1, 2, 3, 4, 5),
-    COLUMN i ENCODING(COMPRESSTYPE=ZLIB),
-    COLUMN j ENCODING(COMPRESSTYPE=QUICKLZ),
-    COLUMN k ENCODING(COMPRESSTYPE=ZLIB),
-    COLUMN l ENCODING(COMPRESSTYPE=ZLIB))
+    COLUMN i ENCODING(compresstype=ZLIB),
+    COLUMN j ENCODING(compresstype=QUICKLZ),
+    COLUMN k ENCODING(compresstype=ZLIB),
+    COLUMN l ENCODING(compresstype=ZLIB))
   (PARTITION p1 START(1) END(10),
    PARTITION p2 START(10) END(20))
 ;

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -71,9 +71,14 @@
           compression:</p>
         <p>
           <codeblock>=&gt; CREATE TABLE bar (a int, b text) 
-    WITH (appendonly=true)
+    WITH (appendoptimized=true)
     DISTRIBUTED BY (a);</codeblock>
         </p>
+        <note>You use the <codeph>appendoptimized=<varname>value</varname></codeph> syntax to
+          specify the append-optimized table storage type. <codeph>appendoptimized</codeph> is
+          a thin alias for the <codeph>appendonly</codeph> storage option. Greenplum Database
+          stores <codeph>appendonly</codeph> in the catalog, and displays the same when 
+          listing storage options for append-optimized tables.</note>
         <p><codeph>UPDATE</codeph> and <codeph>DELETE</codeph> are not allowed on append-optimized
           tables in a repeatable read  or serizalizable transaction and will cause the transaction
           to abort. <codeph>CLUSTER</codeph>, <codeph>DECLARE...FOR UPDATE</codeph>, and triggers
@@ -138,7 +143,7 @@
           example, to create a column-oriented table:</p>
         <p>
           <codeblock>=&gt; CREATE TABLE bar (a int, b text) 
-    WITH (appendonly=true, orientation=column)
+    WITH (appendoptimized=true, orientation=column)
     DISTRIBUTED BY (a);
 </codeblock>
         </p>
@@ -232,7 +237,7 @@
           level of 5:</p>
         <p>
           <codeblock>=&gt; CREATE TABLE foo (a int, b text) 
-   WITH (appendonly=true, compresstype=zlib, compresslevel=5);
+   WITH (appendoptimized=true, compresstype=zlib, compresslevel=5);
 </codeblock>
         </p>
       </section>
@@ -507,7 +512,7 @@
             system.</p>
           <codeblock>CREATE TABLE T1 (c1 int ENCODING (compresstype=zstd),
                   c2 char ENCODING (compresstype=quicklz, blocksize=65536),
-                  c3 char)    WITH (appendonly=true, orientation=column);</codeblock>
+                  c3 char)    WITH (appendoptimized=true, orientation=column);</codeblock>
         </body>
       </topic>
       <topic id="topic49" xml:lang="en">
@@ -523,7 +528,7 @@
                   c3 char,
                   COLUMN c3 ENCODING (compresstype=RLE_TYPE)
                   )
-    WITH (appendonly=true, orientation=column);</codeblock>
+    WITH (appendoptimized=true, orientation=column);</codeblock>
         </body>
       </topic>
       <topic id="topic50" xml:lang="en">
@@ -540,7 +545,7 @@
           <codeblock>CREATE TABLE T3 (c1 int ENCODING (compresstype=zlib),
                   c2 char ENCODING (compresstype=quicklz, blocksize=65536),
                   c3 text, COLUMN c3 ENCODING (compresstype=RLE_TYPE) )
-    WITH (appendonly=true, orientation=column)
+    WITH (appendoptimized=true, orientation=column)
     PARTITION BY RANGE (c3) (START ('1900-01-01'::DATE)          
                              END ('2100-12-31'::DATE),
                              COLUMN c3 ENCODING (compresstype=zlib));</codeblock>
@@ -567,7 +572,7 @@
                                              blocksize=65536),
                   COLUMN c3 ENCODING (compresstype=RLE_TYPE)
                   ) 
-   WITH (appendonly=true, orientation=column);</codeblock>
+   WITH (appendoptimized=true, orientation=column);</codeblock>
         </body>
       </topic>
       <topic id="topic52" xml:lang="en">
@@ -587,7 +592,7 @@
               the default value. Column <codeph>k</codeph> uses the default compression and its
               block size is
               8192.<codeblock>CREATE TABLE T5(i int, j int, k int, l int) 
-    WITH (appendonly=true, orientation=column)
+    WITH (appendoptimized=true, orientation=column)
     PARTITION BY range(i) SUBPARTITION BY range(j)
     (
        partition p1 start(1) end(2)
@@ -629,7 +634,7 @@
         <p>When you specify <codeph>int33</codeph> as a column type in a <codeph>CREATE TABLE</codeph>
           command, the column is created with the storage directives you specified for the type:</p>
         <codeblock>CREATE TABLE t2 (c1 int33)
-    WITH (APPENDONLY=true, ORIENTATION=column);</codeblock>
+    WITH (APPENDOPTIMIZED=true, ORIENTATION=column);</codeblock>
         <p>Table- or column- level storage attributes that you specify in a table definition override
            type-level storage attributes. For information about creating and adding compression
            attributes to a type, see
@@ -724,7 +729,7 @@
           example:</p>
         <p>
           <codeblock>CREATE TABLE sales2 (LIKE sales) 
-WITH (appendonly=true, compresstype=quicklz, 
+WITH (appendoptimized=true, compresstype=quicklz, 
       compresslevel=1, orientation=column);
 INSERT INTO sales2 SELECT * FROM sales;
 DROP TABLE sales;
@@ -766,7 +771,7 @@ GRANT SELECT ON sales TO guest;
           <p>
             <codeblock>CREATE TABLE ccddl (i int, j int, k int, l int)
   WITH
-    (APPENDONLY = TRUE, ORIENTATION=COLUMN)
+    (APPENDOPTIMIZED = TRUE, ORIENTATION=COLUMN)
   PARTITION BY range(j)
   SUBPARTITION BY list (k)
   SUBPARTITION template(

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2692,7 +2692,12 @@
     <body>
       <p>Set the default values for the following table storage options when a table is created with
         the <cmdname>CREATE TABLE</cmdname> command.<ul id="ul_r4t_nxx_5p">
-          <li><cmdname>APPENDONLY</cmdname>
+          <li><cmdname>APPENDOPTIMIZED</cmdname>
+            <note>You use the <codeph>appendoptimized=<varname>value</varname></codeph> syntax
+              to specify the append-optimized table storage type. <codeph>appendoptimized</codeph>
+              is a thin alias for the <codeph>appendonly</codeph> storage option. Greenplum
+              Database stores <codeph>appendonly</codeph> in the catalog, and displays the
+              same when listing the storage options for append-optimized tables.</note>
           </li>
           <li><cmdname>BLOCKSIZE</cmdname>
           </li>
@@ -2726,9 +2731,9 @@
           Database system with the <cmdname>gpconfig</cmdname> utility</li>
       </ol>
       <p>The parameter value is not cumulative. For example, if the parameter specifies the
-          <cmdname>APPENDONLY</cmdname> and <cmdname>COMPRESSTYPE</cmdname> options for a database
+          <cmdname>APPENDOPTIMIZED</cmdname> and <cmdname>COMPRESSTYPE</cmdname> options for a database
         and a user logs in and sets the parameter to specify the value for the
-          <cmdname>ORIENTATION</cmdname> option, the <cmdname>APPENDONLY</cmdname>, and
+          <cmdname>ORIENTATION</cmdname> option, the <cmdname>APPENDOPTIMIZED</cmdname>, and
           <cmdname>COMPRESSTYPE</cmdname> values set at the database level are ignored. </p>
       <p>This example <cmdname>ALTER DATABASE</cmdname> command sets the default
           <cmdname>ORIENTATION</cmdname> and <cmdname>COMPRESSTYPE</cmdname> table storage options
@@ -2736,11 +2741,11 @@
         <codeblock>ALTER DATABASE mytest SET gp_default_storage_options = 'orientation=column, compresstype=rle_type'</codeblock></p>
       <p>To create an append-optimized table in the <codeph>mytest</codeph> database with
         column-oriented table and RLE compression. The user needs to specify only
-          <codeph>APPENDONLY=TRUE</codeph> in the <cmdname>WITH</cmdname> clause.</p>
+          <codeph>APPENDOPTIMIZED=TRUE</codeph> in the <cmdname>WITH</cmdname> clause.</p>
       <p>This example <cmdname>gpconfig</cmdname> utility command sets the default storage option
         for a Greenplum Database system. If you set the defaults for multiple table storage options,
         the value must be enclosed in single
-        quotes.<codeblock>gpconfig -c 'gp_default_storage_options' -v 'appendonly=true, orientation=column'</codeblock></p>
+        quotes.<codeblock>gpconfig -c 'gp_default_storage_options' -v 'appendoptimized=true, orientation=column'</codeblock></p>
       <p>This example <cmdname>gpconfig</cmdname> utility command shows the value of the parameter.
         The parameter value must be consistent across the Greenplum Database master and all
         segments.<codeblock>gpconfig -s 'gp_default_storage_options'</codeblock></p>
@@ -2758,7 +2763,7 @@
           </thead>
           <tbody>
             <row>
-              <entry colname="col1"><cmdname>APPENDONLY</cmdname>= <codeph>TRUE</codeph> |
+              <entry colname="col1"><cmdname>APPENDOPTIMIZED</cmdname>= <codeph>TRUE</codeph> |
                   <codeph>FALSE</codeph><p><cmdname>BLOCKSIZE</cmdname>= integer between 8192 and
                   2097152 </p><p><cmdname>CHECKSUM</cmdname>= <codeph>TRUE</codeph> |
                     <codeph>FALSE</codeph>
@@ -2769,7 +2774,7 @@
                     19</p><p><cmdname>ORIENTATION</cmdname>= <codeph>ROW</codeph> |
                     <codeph>COLUMN</codeph>
                 </p></entry>
-              <entry colname="col2"><cmdname>APPENDONLY</cmdname>=<codeph>FALSE</codeph>
+              <entry colname="col2"><cmdname>APPENDOPTIMIZED</cmdname>=<codeph>FALSE</codeph>
                 <p><cmdname>BLOCKSIZE</cmdname>=<codeph>32768</codeph>
                 </p><p><cmdname>CHECKSUM</cmdname>=<codeph>TRUE</codeph>
                 </p><p><cmdname>COMPRESSTYPE</cmdname>=<codeph>none</codeph>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2691,62 +2691,62 @@
     <title>gp_default_storage_options</title>
     <body>
       <p>Set the default values for the following table storage options when a table is created with
-        the <cmdname>CREATE TABLE</cmdname> command.<ul id="ul_r4t_nxx_5p">
-          <li><cmdname>APPENDOPTIMIZED</cmdname>
+        the <codeph>CREATE TABLE</codeph> command.<ul id="ul_r4t_nxx_5p">
+          <li><cmdname>appendoptimized</cmdname>
             <note>You use the <codeph>appendoptimized=<varname>value</varname></codeph> syntax
               to specify the append-optimized table storage type. <codeph>appendoptimized</codeph>
-              is a thin alias for the <codeph>appendonly</codeph> storage option. Greenplum
+              is a thin alias for the <codeph>appendonly</codeph> legacy storage option. Greenplum
               Database stores <codeph>appendonly</codeph> in the catalog, and displays the
               same when listing the storage options for append-optimized tables.</note>
           </li>
-          <li><cmdname>BLOCKSIZE</cmdname>
+          <li><cmdname>blocksize</cmdname>
           </li>
-          <li><cmdname>CHECKSUM</cmdname></li>
-          <li><cmdname>COMPRESSTYPE</cmdname>
+          <li><cmdname>checksum</cmdname></li>
+          <li><cmdname>compresstype</cmdname>
           </li>
-          <li><cmdname>COMPRESSLEVEL</cmdname>
+          <li><cmdname>compresslevel</cmdname>
           </li>
-          <li><cmdname>ORIENTATION</cmdname>
+          <li><cmdname>orientation</cmdname>
           </li>
         </ul></p>
       <p>Specify multiple storage option values as a comma separated list.</p>
       <p>You can set the storage options with this parameter instead of specifying the table storage
-        options in the <cmdname>WITH</cmdname> of the <cmdname>CREATE TABLE</cmdname> command. The
-        table storage options that are specified with the <cmdname>CREATE TABLE</cmdname> command
+        options in the <codeph>WITH</codeph> of the <codeph>CREATE TABLE</codeph> command. The
+        table storage options that are specified with the <codeph>CREATE TABLE</codeph> command
         override the values specified by this parameter. </p>
       <p>Not all combinations of storage option values are valid. If the specified storage options
-        are not valid, an error is returned. See the <cmdname>CREATE TABLE</cmdname> command for
+        are not valid, an error is returned. See the <codeph>CREATE TABLE</codeph> command for
         information about table storage options. </p>
       <p>The defaults can be set for a database and user. If the server configuration parameter is
         set at different levels, this the order of precedence, from highest to lowest, of the table
         storage values when a user logs into a database and creates a table:</p>
       <ol id="ol_fy1_fty_5p">
-        <li>The values specified in a <cmdname>CREATE TABLE</cmdname> command with the
-            <cmdname>WITH</cmdname> clause or <cmdname>ENCODING</cmdname> clause</li>
+        <li>The values specified in a <codeph>CREATE TABLE</codeph> command with the
+            <codeph>WITH</codeph> clause or <codeph>ENCODING</codeph> clause</li>
         <li>The value of <codeph>gp_default_storage_options</codeph> that set for the user with the
-            <cmdname>ALTER ROLE...SET</cmdname> command</li>
+            <codeph>ALTER ROLE...SET</codeph> command</li>
         <li>The value of <codeph>gp_default_storage_options</codeph> that is set for the database
-          with the <cmdname>ALTER DATABASE...SET</cmdname> command</li>
+          with the <codeph>ALTER DATABASE...SET</codeph> command</li>
         <li>The value of <codeph>gp_default_storage_options</codeph> that is set for the Greenplum
-          Database system with the <cmdname>gpconfig</cmdname> utility</li>
+          Database system with the <codeph>gpconfig</codeph> utility</li>
       </ol>
       <p>The parameter value is not cumulative. For example, if the parameter specifies the
-          <cmdname>APPENDOPTIMIZED</cmdname> and <cmdname>COMPRESSTYPE</cmdname> options for a database
+          <codeph>appendoptimized</codeph> and <codeph>compresstype</codeph> options for a database
         and a user logs in and sets the parameter to specify the value for the
-          <cmdname>ORIENTATION</cmdname> option, the <cmdname>APPENDOPTIMIZED</cmdname>, and
-          <cmdname>COMPRESSTYPE</cmdname> values set at the database level are ignored. </p>
-      <p>This example <cmdname>ALTER DATABASE</cmdname> command sets the default
-          <cmdname>ORIENTATION</cmdname> and <cmdname>COMPRESSTYPE</cmdname> table storage options
-        for the database <codeph>mystest</codeph>.
+          <codeph>orientation</codeph> option, the <codeph>appendoptimized</codeph>, and
+          <codeph>compresstype</codeph> values set at the database level are ignored. </p>
+      <p>This example <codeph>ALTER DATABASE</codeph> command sets the default
+          <codeph>orientation</codeph> and <codeph>compresstype</codeph> table storage options
+        for the database <codeph>mytest</codeph>.
         <codeblock>ALTER DATABASE mytest SET gp_default_storage_options = 'orientation=column, compresstype=rle_type'</codeblock></p>
       <p>To create an append-optimized table in the <codeph>mytest</codeph> database with
         column-oriented table and RLE compression. The user needs to specify only
-          <codeph>APPENDOPTIMIZED=TRUE</codeph> in the <cmdname>WITH</cmdname> clause.</p>
-      <p>This example <cmdname>gpconfig</cmdname> utility command sets the default storage option
+          <codeph>appendoptimized=TRUE</codeph> in the <codeph>WITH</codeph> clause.</p>
+      <p>This example <codeph>gpconfig</codeph> utility command sets the default storage option
         for a Greenplum Database system. If you set the defaults for multiple table storage options,
         the value must be enclosed in single
         quotes.<codeblock>gpconfig -c 'gp_default_storage_options' -v 'appendoptimized=true, orientation=column'</codeblock></p>
-      <p>This example <cmdname>gpconfig</cmdname> utility command shows the value of the parameter.
+      <p>This example <codeph>gpconfig</codeph> utility command shows the value of the parameter.
         The parameter value must be consistent across the Greenplum Database master and all
         segments.<codeblock>gpconfig -s 'gp_default_storage_options'</codeblock></p>
       <table id="gp_default_storage_option_table">
@@ -2763,23 +2763,23 @@
           </thead>
           <tbody>
             <row>
-              <entry colname="col1"><cmdname>APPENDOPTIMIZED</cmdname>= <codeph>TRUE</codeph> |
-                  <codeph>FALSE</codeph><p><cmdname>BLOCKSIZE</cmdname>= integer between 8192 and
-                  2097152 </p><p><cmdname>CHECKSUM</cmdname>= <codeph>TRUE</codeph> |
+              <entry colname="col1"><codeph>appendoptimized</codeph>= <codeph>TRUE</codeph> |
+                  <codeph>FALSE</codeph><p><codeph>blocksize</codeph>= integer between 8192 and
+                  2097152 </p><p><codeph>checksum</codeph>= <codeph>TRUE</codeph> |
                     <codeph>FALSE</codeph>
-                </p><p><cmdname>COMPRESSTYPE</cmdname>= <codeph>ZLIB</codeph> |
+                </p><p><codeph>compresstype</codeph>= <codeph>ZLIB</codeph> |
                     <codeph>ZSTD</codeph> | <codeph>QUICKLZ</codeph><sup>2</sup> |
                     <codeph>RLE</codeph>_<codeph>TYPE</codeph> | <codeph>NONE</codeph>
-                </p><p><cmdname>COMPRESSLEVEL</cmdname>= integer between 0 and
-                    19</p><p><cmdname>ORIENTATION</cmdname>= <codeph>ROW</codeph> |
+                </p><p><codeph>compresslevel</codeph>= integer between 0 and
+                    19</p><p><codeph>orientation</codeph>= <codeph>ROW</codeph> |
                     <codeph>COLUMN</codeph>
                 </p></entry>
-              <entry colname="col2"><cmdname>APPENDOPTIMIZED</cmdname>=<codeph>FALSE</codeph>
-                <p><cmdname>BLOCKSIZE</cmdname>=<codeph>32768</codeph>
-                </p><p><cmdname>CHECKSUM</cmdname>=<codeph>TRUE</codeph>
-                </p><p><cmdname>COMPRESSTYPE</cmdname>=<codeph>none</codeph>
-                </p><p><cmdname>COMPRESSLEVEL</cmdname>=<codeph>0</codeph>
-                </p><p><cmdname>ORIENTATION</cmdname>=<codeph>ROW</codeph></p></entry>
+              <entry colname="col2"><codeph>appendoptimized</codeph>=<codeph>FALSE</codeph>
+                <p><codeph>blocksize</codeph>=<codeph>32768</codeph>
+                </p><p><codeph>checksum</codeph>=<codeph>TRUE</codeph>
+                </p><p><codeph>compresstype</codeph>=<codeph>none</codeph>
+                </p><p><codeph>compresslevel</codeph>=<codeph>0</codeph>
+                </p><p><codeph>orientation</codeph>=<codeph>ROW</codeph></p></entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
@@ -2787,7 +2787,7 @@
       </table>
       <note>
         <sup>1</sup>The set classification when the parameter is set at the system level with the
-          <cmdname>gpconfig</cmdname> utility.</note>
+          <codeph>gpconfig</codeph> utility.</note>
       <note>
         <sup>2</sup>QuickLZ compression is available only in the commercial release of Pivotal
         Greenplum Database.</note>

--- a/gpdb-doc/dita/ref_guide/feature_summary.xml
+++ b/gpdb-doc/dita/ref_guide/feature_summary.xml
@@ -546,7 +546,7 @@ NEXT 10 ROWS ONLY; </codeblock><p>Greenplum
                       (<i>column</i>, [ ... ] ) |</codeph></p><p><codeph>DISTRIBUTED
                     RANDOMLY</codeph></p><p><codeph>PARTITION BY <i>type</i> (<i>column</i> [, ...])
                        ( <i>partition_specification</i>, [...] )</codeph></p><p><codeph>WITH
-                    (appendonly=true      [,compresslevel=value,blocksize=value]
+                    (appendoptimized=true      [,compresslevel=value,blocksize=value]
                 )</codeph></p></entry>
             </row>
             <row>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -102,7 +102,7 @@ ALTER TABLE <varname>name</varname>
 [ WITH ( <varname>partition_storage_parameter</varname>=<varname>value</varname> [, ... ] ) ]
 [ TABLESPACE <varname>tablespace</varname> ]</codeblock>
                         <p>where <varname>storage_parameter</varname> is:</p>
-                        <codeblock>   APPENDONLY={TRUE|FALSE}
+                        <codeblock>   APPENDOPTIMIZED={TRUE|FALSE}
    BLOCKSIZE={8192-2097152}
    ORIENTATION={COLUMN|ROW}
    COMPRESSTYPE={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -102,13 +102,13 @@ ALTER TABLE <varname>name</varname>
 [ WITH ( <varname>partition_storage_parameter</varname>=<varname>value</varname> [, ... ] ) ]
 [ TABLESPACE <varname>tablespace</varname> ]</codeblock>
                         <p>where <varname>storage_parameter</varname> is:</p>
-                        <codeblock>   APPENDOPTIMIZED={TRUE|FALSE}
-   BLOCKSIZE={8192-2097152}
-   ORIENTATION={COLUMN|ROW}
-   COMPRESSTYPE={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}
-   COMPRESSLEVEL={0-9}
-   FILLFACTOR={10-100}
-   OIDS[=TRUE|FALSE]</codeblock>
+                        <codeblock>   appendoptimized={TRUE|FALSE}
+   blocksize={8192-2097152}
+   orientation={COLUMN|ROW}
+   compresstype={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}
+   compresslevel={0-9}
+   fillfactor={10-100}
+   oids[=TRUE|FALSE]</codeblock>
                 </section>
                 <section id="section3">
                         <title>Description</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -47,18 +47,18 @@
             [ key_match_type ]
             [ key_action ]</codeblock>
       <p>where <varname>storage_directive</varname> for a column is:</p>
-      <codeblock>   COMPRESSTYPE={ZLIB | ZSTD | QUICKLZ | RLE_TYPE | NONE}
-    [COMPRESSLEVEL={0-9} ]
-    [BLOCKSIZE={8192-2097152} ]</codeblock>
+      <codeblock>   compresstype={ZLIB | ZSTD | QUICKLZ | RLE_TYPE | NONE}
+    [compresslevel={0-9} ]
+    [blocksize={8192-2097152} ]</codeblock>
       <p>where <varname>storage_parameter</varname> for the table is:</p>
-      <codeblock>   APPENDOPTIMIZED={TRUE|FALSE}
-   BLOCKSIZE={8192-2097152}
-   ORIENTATION={COLUMN|ROW}
-   CHECKSUM={TRUE|FALSE}
-   COMPRESSTYPE={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}
-   COMPRESSLEVEL={0-9}
-   FILLFACTOR={10-100}
-   OIDS[=TRUE|FALSE]</codeblock>
+      <codeblock>   appendoptimized={TRUE|FALSE}
+   blocksize={8192-2097152}
+   orientation={COLUMN|ROW}
+   checksum={TRUE|FALSE}
+   compresstype={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}
+   compresslevel={0-9}
+   fillfactor={10-100}
+   oids[=TRUE|FALSE]</codeblock>
       <p>and <varname>table_constraint</varname> is:</p>
       <codeblock>   [CONSTRAINT <varname>constraint_name</varname>]
    UNIQUE ( <varname>column_name</varname> [, ... ] )
@@ -124,14 +124,14 @@
 [ WITH ( <varname>partition_storage_parameter</varname>=<varname>value</varname> [, ... ] ) ]
 [ TABLESPACE <varname>tablespace</varname> ]</codeblock>
       <p>where <varname>storage_parameter</varname> for a partition is:</p>
-      <codeblock>   APPENDOPTIMIZED={TRUE|FALSE}
-   BLOCKSIZE={8192-2097152}
-   ORIENTATION={COLUMN|ROW}
-   CHECKSUM={TRUE|FALSE}
-   COMPRESSTYPE={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}
-   COMPRESSLEVEL={1-19}
-   FILLFACTOR={10-100}
-   OIDS[=TRUE|FALSE]</codeblock>
+      <codeblock>   appendoptimized={TRUE|FALSE}
+   blocksize={8192-2097152}
+   orientation={COLUMN|ROW}
+   checksum={TRUE|FALSE}
+   compresstype={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}
+   compresslevel={1-19}
+   fillfactor={10-100}
+   oids[=TRUE|FALSE]</codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -240,8 +240,8 @@
           <pt> ENCODING ( <varname>storage_directive</varname> [, ...] ) </pt>
           <pd>For a column, the optional <codeph>ENCODING</codeph> clause specifies the type of
             compression and block size for the column data. See <xref href="#topic1/with_storage"
-              format="dita">storage_options</xref> for <codeph>COMPRESSTYPE</codeph>,
-              <codeph>COMPRESSLEVEL</codeph>, and <codeph>BLOCKSIZE</codeph> values.</pd>
+              format="dita">storage_options</xref> for <codeph>compresstype</codeph>,
+              <codeph>compresslevel</codeph>, and <codeph>blocksize</codeph> values.</pd>
           <pd>The clause is valid only for append-optimized, column-oriented tables.</pd>
           <pd>Column compression settings are inherited from the table level to the partition level
             to the subpartition level. The lowest-level settings have priority.</pd>
@@ -454,55 +454,55 @@
             about setting default storage options, see <xref href="#topic1/section5" format="dita"
             />. </pd>
           <pd>The following storage options are available:</pd>
-          <pd><b>APPENDOPTIMIZED</b> — Set to <codeph>TRUE</codeph> to create the table as an
+          <pd><b>appendoptimized</b> — Set to <codeph>TRUE</codeph> to create the table as an
             append-optimized table. If <codeph>FALSE</codeph> or not declared, the table will be
             created as a regular heap-storage table.</pd>
-          <pd><b>BLOCKSIZE</b> — Set to the size, in bytes, for each block in a table. The
-              <codeph>BLOCKSIZE</codeph> must be between 8192 and 2097152 bytes, and be a multiple
+          <pd><b>blocksize</b> — Set to the size, in bytes, for each block in a table. The
+              <codeph>blocksize</codeph> must be between 8192 and 2097152 bytes, and be a multiple
             of 8192. The default is 32768.</pd>
-          <pd><b>ORIENTATION</b> — Set to <codeph>column</codeph> for column-oriented storage, or
+          <pd><b>orientation</b> — Set to <codeph>column</codeph> for column-oriented storage, or
               <codeph>row</codeph> (the default) for row-oriented storage. This option is only valid
-            if <codeph>APPENDOPTIMIZED=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
-          <pd><b>CHECKSUM</b> — This option is valid only for append-optimized tables
-              (<codeph>APPENDOPTIMIZED=TRUE</codeph>). The value <codeph>TRUE</codeph> is the default and
+            if <codeph>appendoptimized=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
+          <pd><b>checksum</b> — This option is valid only for append-optimized tables
+              (<codeph>appendoptimized=TRUE</codeph>). The value <codeph>TRUE</codeph> is the default and
             enables CRC checksum validation for append-optimized tables. The checksum is calculated
             during block creation and is stored on disk. Checksum validation is performed during
             block reads. If the checksum calculated during the read does not match the stored
             checksum, the transaction is aborted. If you set the value to <codeph>FALSE</codeph> to
             disable checksum validation, checking the table data for on-disk corruption will not be
             performed.</pd>
-          <pd><b>COMPRESSTYPE</b> — Set to <codeph>ZLIB</codeph> (the default), <codeph>ZSTD</codeph>,
+          <pd><b>compresstype</b> — Set to <codeph>ZLIB</codeph> (the default), <codeph>ZSTD</codeph>,
               <codeph>RLE_TYPE</codeph>, or <codeph>QUICKLZ</codeph><sup>1</sup> to specify the type
               of compression used. The value <codeph>NONE</codeph> disables compression. Zstd provides
-	      for both speed or a good compression ratio, tunable with the <codeph>COMPRESSLEVEL</codeph> option.
+	      for both speed or a good compression ratio, tunable with the <codeph>compresslevel</codeph> option.
 	      QuickLZ and zlib are provided for backwards-compatibility. Zstd outperforms these
-              compression types on usual workloads. The <codeph>COMPRESSTYPE</codeph> option
-            is only valid if <codeph>APPENDOPTIMIZED=TRUE</codeph>.<p>
+              compression types on usual workloads. The <codeph>compresstype</codeph> option
+            is only valid if <codeph>appendoptimized=TRUE</codeph>.<p>
               <note type="note"><sup>1</sup>QuickLZ compression is available only in the commercial
                 release of Pivotal Greenplum Database.</note>
             </p><p>The value <codeph>RLE_TYPE</codeph> is supported only if
-                <codeph>ORIENTATION</codeph> =<codeph>column</codeph> is specified, Greenplum
+                <codeph>orientation</codeph> =<codeph>column</codeph> is specified, Greenplum
               Database uses the run-length encoding (RLE) compression algorithm. RLE compresses data
               better than the zlib or QuickLZ compression algorithm when the same data value occurs
               in many consecutive rows.</p><p>For columns of type <codeph>BIGINT</codeph>,
                 <codeph>INTEGER</codeph>, <codeph>DATE</codeph>, <codeph>TIME</codeph>, or
                 <codeph>TIMESTAMP</codeph>, delta compression is also applied if the
-                <codeph>COMPRESSTYPE</codeph> option is set to <codeph>RLE_TYPE</codeph>
+                <codeph>compresstype</codeph> option is set to <codeph>RLE_TYPE</codeph>
               compression. The delta compression algorithm is based on the delta between column
               values in consecutive rows and is designed to improve compression when data is loaded
               in sorted order or the compression is applied to column data that is in sorted
               order.</p><p>For information about using table compression, see "Choosing the Table
               Storage Model" in the <cite>Greenplum Database Administrator Guide</cite>.</p></pd>
-              <pd><b>COMPRESSLEVEL</b> — For Zstd compression of append-optimized tables, set to an
+              <pd><b>compresslevel</b> — For Zstd compression of append-optimized tables, set to an
 	      integer value from 1 (fastest compression) to 19 (highest compression ratio).
 	      For zlib compression, the valid range is from 1 to 9. QuickLZ
             compression level can only be set to 1. If not declared, the default is 1. For
               <codeph>RLE_TYPE</codeph>, the compression level can be set an integer value from 1
             (fastest compression) to 4 (highest compression ratio). </pd>
-          <pd>The <codeph>COMPRESSLEVEL</codeph> option is valid only if <codeph>APPENDOPTIMIZED=TRUE</codeph>.</pd>
-          <pd><b>FILLFACTOR</b> — See <codeph><xref href="CREATE_INDEX.xml#topic1" type="topic"
+          <pd>The <codeph>compresslevel</codeph> option is valid only if <codeph>appendoptimized=TRUE</codeph>.</pd>
+          <pd><b>fillfactor</b> — See <codeph><xref href="CREATE_INDEX.xml#topic1" type="topic"
                 format="dita"/></codeph> for more information about this index storage parameter. </pd>
-          <pd><b>OIDS</b> — Set to <codeph>OIDS=FALSE</codeph> (the default) so that rows do not
+          <pd><b>oids</b> — Set to <codeph>oids=FALSE</codeph> (the default) so that rows do not
             have object identifiers assigned to them. Greenplum strongly recommends that you do not
             enable OIDS when creating a table. On large tables, such as those in a typical Greenplum
             Database system, using OIDs for table rows can cause wrap-around of the 32-bit OID
@@ -731,22 +731,22 @@
         <li>The default values for these table storage options can be specified with the server
           configuration parameter <codeph>gp_default_storage_option</codeph>.<ul id="ul_hr1_3m1_tt">
             <li>
-              <cmdname>APPENDOPTIMIZED</cmdname>
+              <cmdname>appendoptimized</cmdname>
             </li>
             <li>
-              <cmdname>BLOCKSIZE</cmdname>
+              <cmdname>blocksize</cmdname>
             </li>
             <li>
-              <cmdname>CHECKSUM</cmdname>
+              <cmdname>checksum</cmdname>
             </li>
             <li>
-              <cmdname>COMPRESSTYPE</cmdname>
+              <cmdname>compresstype</cmdname>
             </li>
             <li>
-              <cmdname>COMPRESSLEVEL</cmdname>
+              <cmdname>compresslevel</cmdname>
             </li>
             <li>
-              <cmdname>ORIENTATION</cmdname>
+              <cmdname>orientation</cmdname>
             </li>
           </ul><p>The defaults can be set for the system, a database, or a user. For information about
             setting storage options, see the server configuration parameter <codeph><xref

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -51,7 +51,7 @@
     [COMPRESSLEVEL={0-9} ]
     [BLOCKSIZE={8192-2097152} ]</codeblock>
       <p>where <varname>storage_parameter</varname> for the table is:</p>
-      <codeblock>   APPENDONLY={TRUE|FALSE}
+      <codeblock>   APPENDOPTIMIZED={TRUE|FALSE}
    BLOCKSIZE={8192-2097152}
    ORIENTATION={COLUMN|ROW}
    CHECKSUM={TRUE|FALSE}
@@ -124,7 +124,7 @@
 [ WITH ( <varname>partition_storage_parameter</varname>=<varname>value</varname> [, ... ] ) ]
 [ TABLESPACE <varname>tablespace</varname> ]</codeblock>
       <p>where <varname>storage_parameter</varname> for a partition is:</p>
-      <codeblock>   APPENDONLY={TRUE|FALSE}
+      <codeblock>   APPENDOPTIMIZED={TRUE|FALSE}
    BLOCKSIZE={8192-2097152}
    ORIENTATION={COLUMN|ROW}
    CHECKSUM={TRUE|FALSE}
@@ -454,7 +454,7 @@
             about setting default storage options, see <xref href="#topic1/section5" format="dita"
             />. </pd>
           <pd>The following storage options are available:</pd>
-          <pd><b>APPENDONLY</b> — Set to <codeph>TRUE</codeph> to create the table as an
+          <pd><b>APPENDOPTIMIZED</b> — Set to <codeph>TRUE</codeph> to create the table as an
             append-optimized table. If <codeph>FALSE</codeph> or not declared, the table will be
             created as a regular heap-storage table.</pd>
           <pd><b>BLOCKSIZE</b> — Set to the size, in bytes, for each block in a table. The
@@ -462,9 +462,9 @@
             of 8192. The default is 32768.</pd>
           <pd><b>ORIENTATION</b> — Set to <codeph>column</codeph> for column-oriented storage, or
               <codeph>row</codeph> (the default) for row-oriented storage. This option is only valid
-            if <codeph>APPENDONLY=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
+            if <codeph>APPENDOPTIMIZED=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
           <pd><b>CHECKSUM</b> — This option is valid only for append-optimized tables
-              (<codeph>APPENDONLY=TRUE</codeph>). The value <codeph>TRUE</codeph> is the default and
+              (<codeph>APPENDOPTIMIZED=TRUE</codeph>). The value <codeph>TRUE</codeph> is the default and
             enables CRC checksum validation for append-optimized tables. The checksum is calculated
             during block creation and is stored on disk. Checksum validation is performed during
             block reads. If the checksum calculated during the read does not match the stored
@@ -477,7 +477,7 @@
 	      for both speed or a good compression ratio, tunable with the <codeph>COMPRESSLEVEL</codeph> option.
 	      QuickLZ and zlib are provided for backwards-compatibility. Zstd outperforms these
               compression types on usual workloads. The <codeph>COMPRESSTYPE</codeph> option
-            is only valid if <codeph>APPENDONLY=TRUE</codeph>.<p>
+            is only valid if <codeph>APPENDOPTIMIZED=TRUE</codeph>.<p>
               <note type="note"><sup>1</sup>QuickLZ compression is available only in the commercial
                 release of Pivotal Greenplum Database.</note>
             </p><p>The value <codeph>RLE_TYPE</codeph> is supported only if
@@ -499,7 +499,7 @@
             compression level can only be set to 1. If not declared, the default is 1. For
               <codeph>RLE_TYPE</codeph>, the compression level can be set an integer value from 1
             (fastest compression) to 4 (highest compression ratio). </pd>
-          <pd>The <codeph>COMPRESSLEVEL</codeph> option is valid only if <codeph>APPENDONLY=TRUE</codeph>.</pd>
+          <pd>The <codeph>COMPRESSLEVEL</codeph> option is valid only if <codeph>APPENDOPTIMIZED=TRUE</codeph>.</pd>
           <pd><b>FILLFACTOR</b> — See <codeph><xref href="CREATE_INDEX.xml#topic1" type="topic"
                 format="dita"/></codeph> for more information about this index storage parameter. </pd>
           <pd><b>OIDS</b> — Set to <codeph>OIDS=FALSE</codeph> (the default) so that rows do not
@@ -731,7 +731,7 @@
         <li>The default values for these table storage options can be specified with the server
           configuration parameter <codeph>gp_default_storage_option</codeph>.<ul id="ul_hr1_3m1_tt">
             <li>
-              <cmdname>APPENDONLY</cmdname>
+              <cmdname>APPENDOPTIMIZED</cmdname>
             </li>
             <li>
               <cmdname>BLOCKSIZE</cmdname>
@@ -782,7 +782,7 @@ name   varchar(40) NOT NULL CHECK (name &lt;&gt; '')
 );</codeblock>
       <p>Create a gzip-compressed, append-optimized table:</p>
       <codeblock>CREATE TABLE sales (txn_id int, qty int, date date) 
-WITH (appendonly=true, compresslevel=5) 
+WITH (appendoptimized=true, compresslevel=5) 
 DISTRIBUTED BY (txn_id);</codeblock>
       <p>Create a three level partitioned table using subpartition templates and default partitions
         at each level:</p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE_AS.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE_AS.xml
@@ -16,7 +16,7 @@
    [DISTRIBUTED BY ({<varname>column</varname> [<varname>opclass</varname>]}, [ ... ] ) | DISTRIBUTED RANDOMLY
       | DISTRIBUTED REPLICATED ]</codeblock>
       <p>where <varname>storage_parameter</varname> is:</p>
-      <codeblock>   APPENDONLY={TRUE|FALSE}
+      <codeblock>   APPENDOPTIMIZED={TRUE|FALSE}
    BLOCKSIZE={8192-2097152}
    ORIENTATION={COLUMN|ROW}
    COMPRESSTYPE={ZLIB|ZSTD|QUICKLZ}
@@ -72,7 +72,7 @@
             its indexes. Note that you can also set different storage parameters on a particular
             partition or subpartition by declaring the <codeph>WITH</codeph> clause in the partition
             specification. The following storage options are available:</pd>
-          <pd><b>APPENDONLY</b> — Set to <codeph>TRUE</codeph> to create the table as an append-optimized
+          <pd><b>APPENDOPTIMIZED</b> — Set to <codeph>TRUE</codeph> to create the table as an append-optimized
             table. If <codeph>FALSE</codeph> or not declared, the table will be created as a regular
             heap-storage table.</pd>
           <pd><b>BLOCKSIZE</b> — Set to the size, in bytes for each block in a table. The <codeph>BLOCKSIZE
@@ -80,21 +80,21 @@
             is 32768.</pd>
           <pd><b>ORIENTATION</b> — Set to <codeph>column</codeph> for column-oriented storage, or
               <codeph>row</codeph> (the default) for row-oriented storage. This option is only valid
-            if <codeph>APPENDONLY=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
+            if <codeph>APPENDOPTIMIZED=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
           <pd><b>COMPRESSTYPE</b> — Set to <codeph>ZLIB</codeph> (the default), <codeph>ZSTD</codeph>, or
               <codeph>QUICKLZ</codeph><sup>1</sup> to specify the type of compression used. The
             value <codeph>NONE</codeph> disables compression. Zstd provides for both speed or a
             good compression ratio, tunable with the <codeph>COMPRESSLEVEL</codeph> option.
             QuickLZ and zlib are provided for backwards-compatibility. Zstd outperforms these
             compression types on usual workloads. The <codeph>COMPRESSTYPE</codeph> option is
-            valid only if <codeph>APPENDONLY=TRUE</codeph>.<note
+            valid only if <codeph>APPENDOPTIMIZED=TRUE</codeph>.<note
               type="note"><sup>1</sup>QuickLZ compression is available only in the commercial
               release of Pivotal Greenplum Database.</note></pd>
           <pd><b>COMPRESSLEVEL</b> — For Zstd compression of append-optimized tables, set to an
             integer value from 1 (fastest compression) to 19 (highest compression ratio). For
             zlib compression, the valid range is from 1 to 9. QuickLZ compression level can only
             be set to 1. If not declared, the default is 1. The <codeph>COMPRESSLEVEL</codeph>
-            option is valid only if <codeph>APPENDONLY=TRUE</codeph>.</pd>
+            option is valid only if <codeph>APPENDOPTIMIZED=TRUE</codeph>.</pd>
           <pd><b>FILLFACTOR</b> — See <codeph><xref href="CREATE_INDEX.xml#topic1" type="topic"
                 format="dita"/></codeph> for more information about this index storage parameter. </pd>
           <pd><b>OIDS</b> — Set to <codeph>OIDS=FALSE</codeph> (the default) so that rows do not have

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE_AS.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE_AS.xml
@@ -16,13 +16,13 @@
    [DISTRIBUTED BY ({<varname>column</varname> [<varname>opclass</varname>]}, [ ... ] ) | DISTRIBUTED RANDOMLY
       | DISTRIBUTED REPLICATED ]</codeblock>
       <p>where <varname>storage_parameter</varname> is:</p>
-      <codeblock>   APPENDOPTIMIZED={TRUE|FALSE}
-   BLOCKSIZE={8192-2097152}
-   ORIENTATION={COLUMN|ROW}
-   COMPRESSTYPE={ZLIB|ZSTD|QUICKLZ}
-   COMPRESSLEVEL={1-19 | 1}
-   FILLFACTOR={10-100}
-   OIDS[=TRUE|FALSE]</codeblock>
+      <codeblock>   appendoptimized={TRUE|FALSE}
+   blocksize={8192-2097152}
+   orientation={COLUMN|ROW}
+   compresstype={ZLIB|ZSTD|QUICKLZ}
+   compresslevel={1-19 | 1}
+   fillfactor={10-100}
+   oids[=TRUE|FALSE]</codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -72,32 +72,32 @@
             its indexes. Note that you can also set different storage parameters on a particular
             partition or subpartition by declaring the <codeph>WITH</codeph> clause in the partition
             specification. The following storage options are available:</pd>
-          <pd><b>APPENDOPTIMIZED</b> — Set to <codeph>TRUE</codeph> to create the table as an append-optimized
+          <pd><b>appendoptimized</b> — Set to <codeph>TRUE</codeph> to create the table as an append-optimized
             table. If <codeph>FALSE</codeph> or not declared, the table will be created as a regular
             heap-storage table.</pd>
-          <pd><b>BLOCKSIZE</b> — Set to the size, in bytes for each block in a table. The <codeph>BLOCKSIZE
-            </codeph>must be between 8192 and 2097152 bytes, and be a multiple of 8192. The default
+          <pd><b>blocksize</b> — Set to the size, in bytes for each block in a table. The <codeph>blocksize
+            </codeph> must be between 8192 and 2097152 bytes, and be a multiple of 8192. The default
             is 32768.</pd>
-          <pd><b>ORIENTATION</b> — Set to <codeph>column</codeph> for column-oriented storage, or
+          <pd><b>orientation</b> — Set to <codeph>column</codeph> for column-oriented storage, or
               <codeph>row</codeph> (the default) for row-oriented storage. This option is only valid
-            if <codeph>APPENDOPTIMIZED=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
-          <pd><b>COMPRESSTYPE</b> — Set to <codeph>ZLIB</codeph> (the default), <codeph>ZSTD</codeph>, or
+            if <codeph>appendoptimized=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
+          <pd><b>compresstype</b> — Set to <codeph>ZLIB</codeph> (the default), <codeph>ZSTD</codeph>, or
               <codeph>QUICKLZ</codeph><sup>1</sup> to specify the type of compression used. The
             value <codeph>NONE</codeph> disables compression. Zstd provides for both speed or a
-            good compression ratio, tunable with the <codeph>COMPRESSLEVEL</codeph> option.
+            good compression ratio, tunable with the <codeph>compresslevel</codeph> option.
             QuickLZ and zlib are provided for backwards-compatibility. Zstd outperforms these
-            compression types on usual workloads. The <codeph>COMPRESSTYPE</codeph> option is
-            valid only if <codeph>APPENDOPTIMIZED=TRUE</codeph>.<note
+            compression types on usual workloads. The <codeph>compresstype</codeph> option is
+            valid only if <codeph>appendoptimized=TRUE</codeph>.<note
               type="note"><sup>1</sup>QuickLZ compression is available only in the commercial
               release of Pivotal Greenplum Database.</note></pd>
-          <pd><b>COMPRESSLEVEL</b> — For Zstd compression of append-optimized tables, set to an
+          <pd><b>compresslevel</b> — For Zstd compression of append-optimized tables, set to an
             integer value from 1 (fastest compression) to 19 (highest compression ratio). For
             zlib compression, the valid range is from 1 to 9. QuickLZ compression level can only
-            be set to 1. If not declared, the default is 1. The <codeph>COMPRESSLEVEL</codeph>
-            option is valid only if <codeph>APPENDOPTIMIZED=TRUE</codeph>.</pd>
-          <pd><b>FILLFACTOR</b> — See <codeph><xref href="CREATE_INDEX.xml#topic1" type="topic"
+            be set to 1. If not declared, the default is 1. The <codeph>compresslevel</codeph>
+            option is valid only if <codeph>appendoptimized=TRUE</codeph>.</pd>
+          <pd><b>fillfactor</b> — See <codeph><xref href="CREATE_INDEX.xml#topic1" type="topic"
                 format="dita"/></codeph> for more information about this index storage parameter. </pd>
-          <pd><b>OIDS</b> — Set to <codeph>OIDS=FALSE</codeph> (the default) so that rows do not have
+          <pd><b>oids</b> — Set to <codeph>oids=FALSE</codeph> (the default) so that rows do not have
             object identifiers assigned to them. Greenplum strongly recommends that you do not
             enable OIDS when creating a table. On large tables, such as those in a typical Greenplum
             Database system, using OIDs for table rows can cause wrap-around of the 32-bit OID

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpreload.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpreload.xml
@@ -12,7 +12,7 @@
 
 <b>gpreload</b> <b>--version</b></codeblock></section>
     <section id="section3"><title>Description</title><p>The <codeph>gpreload</codeph> utility reloads table data with column data sorted. For tables that
-        were created with the table storage option <codeph>APPENDOPTIMIZED=TRUE</codeph> and compression
+        were created with the table storage option <codeph>appendoptimized=TRUE</codeph> and compression
         enabled, reloading the data with sorted data can improve table compression. You specify a
         list of tables to be reloaded and the table columns to be sorted in a text file. </p><p>Compression is improved by sorting data
         when the data in the column has a relatively low number of distinct values when compared to

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpreload.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpreload.xml
@@ -12,7 +12,7 @@
 
 <b>gpreload</b> <b>--version</b></codeblock></section>
     <section id="section3"><title>Description</title><p>The <codeph>gpreload</codeph> utility reloads table data with column data sorted. For tables that
-        were created with the table storage option <codeph>APPENDONLY=TRUE</codeph> and compression
+        were created with the table storage option <codeph>APPENDOPTIMIZED=TRUE</codeph> and compression
         enabled, reloading the data with sorted data can improve table compression. You specify a
         list of tables to be reloaded and the table columns to be sorted in a text file. </p><p>Compression is improved by sorting data
         when the data in the column has a relatively low number of distinct values when compared to


### PR DESCRIPTION
in this PR:
- replace occurrences of "appendonly" with "appendoptimized"
- add Note in Defining Database Objects page, "Append-Optimized Storage" section about the alias
- add Note in gp_default_storage_options GUC description about the alias

i did not add the Note to the SQL pages updated in this PR.
