### PR TITLE
Skip master-only table when examining distribution opclasses

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3142,7 +3142,15 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses
 	{
 		Relation rel = gpdb::GetRelation(rte->relid);
 		GpPolicy *policy = rel->rd_cdbpolicy;
-		int policy_nattrs = policy ? policy->nattrs : 0;
+
+		// master-only tables
+		if (NULL == policy)
+		{
+			gpdb::CloseRelation(rel);
+			return;
+		}
+
+		int policy_nattrs = policy->nattrs;
 		TupleDesc desc = rel->rd_att;
 		bool contains_default_hashops = false;
 		bool contains_legacy_hashops = false;


### PR DESCRIPTION
This commit fixes a subtle bug that was papered over by clever
optimizations: the compiler *often* takes the clue that a zero `nattrs`
(implied by a NULL `policy`) leads to an empty loop, and skips straight
through to closing the relation, avoiding the dereference of
`policy->opclasses`. That doesn't always happen though, if you're lucky,
the generated code *does* dereference `policy->opclasses` even when we
have a NULL policy. It seems like we had run into this before, as
evidenced by the (removed in this patch) ternary on `policy->nattrs`.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
