### PR TITLE
Fix aix build failure

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -159,6 +159,10 @@ ifneq "$(findstring $(BLD_ARCH),suse11_x86_64 sles11_x86_64)" ""
 APU_CONFIG=--with-apu-config=$(BLD_THIRDPARTY_BIN_DIR)/apu-1-config
 endif
 
+ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_64 aix5_ppc_32)" ""
+APR_CONFIG=--with-apr-config=$(BLD_THIRDPARTY_BIN_DIR)/apr-1-config
+endif
+
 aix7_ppc_64_CONFIGFLAGS=--disable-gpcloud --without-readline --without-libcurl --disable-orca --disable-pxf --without-zstd $(APR_CONFIG)
 win32_CONFIGFLAGS=--with-gssapi --without-libcurl --disable-orca --disable-pxf --disable-gpcloud --without-libbz2 $(APR_CONFIG)
 sol10_x86_64_CONFIGFLAGS= --with-libxml $(APR_CONFIG)


### PR DESCRIPTION
Fix for error

```
configure: error: apr-1-config is required for gpfdist, unable to find binary
```
Co-authored-by: Sambitesh Dash <sdash@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
