### PR TITLE
 Rename all HLL functions (and structs) in GPDB

### DIFF
--- a/src/backend/utils/hyperloglog/Makefile
+++ b/src/backend/utils/hyperloglog/Makefile
@@ -11,6 +11,6 @@ subdir = src/backend/utils/hyperloglog
 top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 
-OBJS = hyperloglog.o
+OBJS = gp_hyperloglog.o
 
 include $(top_srcdir)/src/backend/common.mk


### PR DESCRIPTION
They are renamed to start with a gp_/GP_/Gp prefix (as appropriate).
This will prevent any namespace clashes when building & running external
HLL-related GPDB extensions.

NOTE: This is a PR on 5X_STABLE.

## TODOs
- [ ] Document changes
- [x] Port on master.
- [x] Pass `make installcheck`
