### PR TITLE
Drop libstdcxx from Ivy and copy it from /opt/gcc-6*/lib64

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -117,6 +117,14 @@ function include_quicklz() {
   popd
 }
 
+function include_libstdcxx() {
+  pushd /opt/gcc-6*/lib64
+    if [ "${TARGET_OS}" == "centos" ] ; then
+      cp libstdc++.so.* ${GREENPLUM_INSTALL_DIR}/lib/.
+    fi
+  popd
+}
+
 function export_gpdb() {
   TARBALL="${GPDB_ARTIFACTS_DIR}/${GPDB_BIN_FILENAME}"
   pushd ${GREENPLUM_INSTALL_DIR}
@@ -203,6 +211,7 @@ function _main() {
   fi
   include_zstd
   include_quicklz
+  include_libstdcxx
   export_gpdb
   export_gpdb_extensions
   export_gpdb_win32_ccl

--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -14,7 +14,7 @@
       <dependency org="apache"          name="apr"             rev="1.5.2"          conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="apache"          name="apr-util"        rev="1.2.12"         conf="suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />
       <dependency org="OpenSSL"         name="openssl"         rev="1.0.2l"         conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64;aix7_ppc_64->aix7_ppc_64" />
-      <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
+      <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
       <dependency org="third-party"     name="ext"             rev="gpdb6_ext-4.2"  conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="Hyperic"         name="sigar"           rev="1.6.5"          conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel7_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="Python"          name="python-gpdb5"    rev="2.7.12"         conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />


### PR DESCRIPTION
We can copy the libstdc++.so.* that is baked in the image to gpdb install directory.
We assume that the docker image has only one version of gcc in /opt (which is
gcc-6.4.0 at the moment), so it is okay to blob for the minor version while copying.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
