### PR TITLE
retryAbortPrepared only if previous attempt failed.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -873,8 +873,8 @@ doNotifyingAbort(void)
 
 			setCurrentGxactState(DTX_STATE_RETRY_ABORT_PREPARED);
 			setDistributedTransactionContext(DTX_CONTEXT_QD_RETRY_PHASE_2);
+			retryAbortPrepared();
 		}
-		retryAbortPrepared();
 	}
 
 	SIMPLE_FAULT_INJECTOR(DtmBroadcastAbortPrepared);


### PR DESCRIPTION
This was spotted by Pengzhou Tang, during code inspection. So, fixing
this, I don't think had any ill effect but definitely is unnecessary.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
