### PR TITLE
(master) Rename all HLL functions (and structs) in GPDB

### DIFF
--- a/src/backend/utils/hyperloglog/Makefile
+++ b/src/backend/utils/hyperloglog/Makefile
@@ -11,6 +11,6 @@ subdir = src/backend/utils/hyperloglog
 top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 
-OBJS = hyperloglog.o
+OBJS = gp_hyperloglog.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -47,8 +47,8 @@
 
 
 /* This file contains internal functions and several functions exposed to the
- * outside via hyperloglog.h. The functions are for the manipulation/creation/
- * evaluation of HLLCounters that are necessary for implementing incremental
+ * outside via gp_hyperloglog.h. The functions are for the manipulation/creation/
+ * evaluation of GpHLLCounters that are necessary for implementing incremental
  * analyze in GPDB. This file is modified from its original content and we removed
  * the code that was unnecessary for our purpose.
  */
@@ -67,39 +67,39 @@
 #include "lib/stringinfo.h"
 #include "libpq/pqformat.h"
 
-#include "utils/hyperloglog/hyperloglog.h"
+#include "utils/hyperloglog/gp_hyperloglog.h"
 
 
 /* ------------- function declarations for local functions --------------- */
-static double hll_estimate_dense(HLLCounter hloglog);
-static double error_estimate(double E,int b);
+static double gp_hll_estimate_dense(GpHLLCounter hloglog);
+static double gp_error_estimate(double E,int b);
 
-static HLLCounter hll_add_hash_dense(HLLCounter hloglog, uint64_t hash);
+static GpHLLCounter gp_hll_add_hash_dense(GpHLLCounter hloglog, uint64_t hash);
 
-static HLLCounter hll_compress_dense(HLLCounter hloglog);
-static HLLCounter hll_compress_dense_unpacked(HLLCounter hloglog);
-static HLLCounter hll_decompress_unpacked(HLLCounter hloglog);
-static HLLCounter hll_decompress_dense(HLLCounter hloglog);
-static HLLCounter hll_decompress_dense_unpacked(HLLCounter hloglog);
+static GpHLLCounter gp_hll_compress_dense(GpHLLCounter hloglog);
+static GpHLLCounter gp_hll_compress_dense_unpacked(GpHLLCounter hloglog);
+static GpHLLCounter gp_hll_decompress_unpacked(GpHLLCounter hloglog);
+static GpHLLCounter gp_hll_decompress_dense(GpHLLCounter hloglog);
+static GpHLLCounter gp_hll_decompress_dense_unpacked(GpHLLCounter hloglog);
 
 /* ---------------------- function definitions --------------------------- */
 
-HLLCounter
-hll_unpack(HLLCounter hloglog){
+GpHLLCounter
+gp_hll_unpack(GpHLLCounter hloglog){
 
 	char entry;
 	int i, m;
-	HLLCounter htemp;
+	GpHLLCounter htemp;
 
 	if (hloglog->format == UNPACKED || hloglog->format == UNPACKED_UNPACKED)
 	{
-		return hll_copy(hloglog);
+		return gp_hll_copy(hloglog);
 	}
 
 	/* use decompress to handle compressed unpacking */
 	if (hloglog->b < 0)
 	{
-		return hll_decompress_unpacked(hloglog);
+		return gp_hll_decompress_unpacked(hloglog);
 	}
 
 	/* set format to unpacked*/
@@ -117,47 +117,44 @@ hll_unpack(HLLCounter hloglog){
 	 bins
 	*/
 	m = POW2(hloglog->b);
-	htemp = palloc(sizeof(HLLData) + m);
-	memcpy(htemp, hloglog, sizeof(HLLData));
+	htemp = palloc(sizeof(GpHLLData) + m);
+	memcpy(htemp, hloglog, sizeof(GpHLLData));
 
 	for(i=0; i < m; i++){
-		HLL_DENSE_GET_REGISTER(entry,hloglog->data,i,hloglog->binbits);
+		GP_HLL_DENSE_GET_REGISTER(entry,hloglog->data,i,hloglog->binbits);
 		htemp->data[i] = entry;
 	}
 
 	hloglog = htemp;
 
 	/* set the varsize to the appropriate length  */
-	SET_VARSIZE(hloglog, sizeof(HLLData) + m);
+	SET_VARSIZE(hloglog, sizeof(GpHLLData) + m);
 
 	return hloglog;
 }
 
 
-
-
-
-HLLCounter
-hll_decompress_unpacked(HLLCounter hloglog)
+GpHLLCounter
+gp_hll_decompress_unpacked(GpHLLCounter hloglog)
 {
 	/* make sure the data is compressed */
 	if (hloglog->b > 0) {
 		return hloglog;
 	}
 
-	hloglog = hll_decompress_dense_unpacked(hloglog);
+	hloglog = gp_hll_decompress_dense_unpacked(hloglog);
 
 	return hloglog;
 }
 
 
 /* Decompresses dense counters */
-static HLLCounter
-hll_decompress_dense_unpacked(HLLCounter hloglog)
+static GpHLLCounter
+gp_hll_decompress_dense_unpacked(GpHLLCounter hloglog)
 {
 	//char * dest;
 	int m;
-	HLLCounter htemp;
+	GpHLLCounter htemp;
 
 	/* reset b to positive value for calcs and to indicate data is
 	* decompressed */
@@ -167,9 +164,9 @@ hll_decompress_dense_unpacked(HLLCounter hloglog)
 	/* allocate and zero an array large enough to hold all the decompressed
 	* bins */
 	m = POW2(hloglog->b);
-	htemp = palloc(sizeof(HLLData) + m);
-	memset(htemp, 0, m + sizeof(HLLData));
-	memcpy(htemp, hloglog, sizeof(HLLData));
+	htemp = palloc(sizeof(GpHLLData) + m);
+	memset(htemp, 0, m + sizeof(GpHLLData));
+	memcpy(htemp, hloglog, sizeof(GpHLLData));
 
 	/* decompress the data */
 	pglz_decompress((PGLZ_Header *)hloglog->data,(char *) &htemp->data);
@@ -177,7 +174,7 @@ hll_decompress_dense_unpacked(HLLCounter hloglog)
 	hloglog = htemp;
 
 	/* set the varsize to the appropriate length  */
-	SET_VARSIZE(hloglog, sizeof(HLLData) + m);
+	SET_VARSIZE(hloglog, sizeof(GpHLLData) + m);
 
 	return hloglog;
 }
@@ -194,13 +191,13 @@ hll_decompress_dense_unpacked(HLLCounter hloglog)
  * returns:
  *      instance of HLL estimator (throws ERROR in case of failure)
  */
-HLLCounter
-hll_create(double ndistinct, float error, uint8_t format)
+GpHLLCounter
+gp_hll_create(double ndistinct, float error, uint8_t format)
 {
 
     float m;
     size_t length;
-    HLLCounter p;
+    GpHLLCounter p;
     
     /* target error rate needs to be between 0 and 1 */
     if (error <= 0 || error >= 1){
@@ -211,8 +208,8 @@ hll_create(double ndistinct, float error, uint8_t format)
     } 
 
     /* the counter is allocated as part of this memory block  */
-    length = hll_get_size(ndistinct, error);
-    p = (HLLCounter)palloc0(length);
+    length = gp_hll_get_size(ndistinct, error);
+    p = (GpHLLCounter)palloc0(length);
 
     /* set the counter struct version */
     p->version = STRUCT_VERSION;
@@ -246,12 +243,12 @@ hll_create(double ndistinct, float error, uint8_t format)
 
 /* Performs a simple 'copy' of the counter, i.e. allocates a new counter and
  * copies the state from the supplied one. */
-HLLCounter
-hll_copy(HLLCounter counter)
+GpHLLCounter
+gp_hll_copy(GpHLLCounter counter)
 {
     
     size_t length = VARSIZE_ANY(counter);
-    HLLCounter copy = (HLLCounter)palloc(length);
+    GpHLLCounter copy = (GpHLLCounter)palloc(length);
     
     memcpy(copy, counter, length);
     
@@ -267,12 +264,12 @@ hll_copy(HLLCounter counter)
  * Merging is only possible if the counters share the same parameters (number
  * of bins, bin size, ...). If the counters don't match, this throws an ERROR.
  *  */
-HLLCounter
-hll_merge(HLLCounter counter1, HLLCounter counter2)
+GpHLLCounter
+gp_hll_merge(GpHLLCounter counter1, GpHLLCounter counter2)
 {
 
 	int i;
-	HLLCounter result = counter1;
+	GpHLLCounter result = counter1;
 	int upper_bound = POW2(result->b);
 
 	/* check compatibility first */
@@ -294,7 +291,7 @@ hll_merge(HLLCounter counter1, HLLCounter counter2)
 /* Computes size of the structure, depending on the requested error rate and
  * ndistinct. */
 int 
-hll_get_size(double ndistinct, float error)
+gp_hll_get_size(double ndistinct, float error)
 {
 
     int b;
@@ -318,17 +315,17 @@ hll_get_size(double ndistinct, float error)
      *  size_in_bytes = struct_overhead + num_buckets*(bits_per_bucket/8)
      *
      * */  
-    return sizeof(HLLData) + (int)(ceil(POW2(b)) * ceil(log2(log2(ndistinct))) / 8.0);
+    return sizeof(GpHLLData) + (int)(ceil(POW2(b)) * ceil(log2(log2(ndistinct))) / 8.0);
 
 }
 
 /* Hyperloglog estimate header function */
 double 
-hll_estimate(HLLCounter hloglog)
+gp_hll_estimate(GpHLLCounter hloglog)
 {
     double E = 0;
     
-	E = hll_estimate_dense(hloglog);
+	E = gp_hll_estimate_dense(hloglog);
 
 	return E;
 }
@@ -343,7 +340,7 @@ hll_estimate(HLLCounter hloglog)
  * 
  */
 static double
-hll_estimate_dense(HLLCounter hloglog)
+gp_hll_estimate_dense(GpHLLCounter hloglog)
 {
 	double H = 0, E = 0;
 	int j, V = 0;
@@ -374,7 +371,7 @@ hll_estimate_dense(HLLCounter hloglog)
 	if (E <= (5.0 * m)) {
 
 		/* account for hloglog low cardinality bias */
-		E = E - error_estimate(E, hloglog->b);
+		E = E - gp_error_estimate(E, hloglog->b);
 
 		/* search for empty registers for linear counting */
 		for (j = 0; j < m; j++){
@@ -409,7 +406,7 @@ hll_estimate_dense(HLLCounter hloglog)
 /* Estimates the error from hyperloglog's low cardinality bias and by taking
  * a simple linear regression of the nearest 6 points */
 static double 
-error_estimate(double E,int b)
+gp_error_estimate(double E,int b)
 {
     double avg=0;
     double beta,alpha;
@@ -461,24 +458,24 @@ error_estimate(double E,int b)
 }
 
 /* Add element header function */
-HLLCounter
-hll_add_element(HLLCounter hloglog, const char * element, int elen)
+GpHLLCounter
+gp_hll_add_element(GpHLLCounter hloglog, const char * element, int elen)
 {
 
     uint64_t hash;
 
     /* compute the hash */
-    hash = MurmurHash64A(element, elen, HASH_SEED);    
+    hash = GpMurmurHash64A(element, elen, HASH_SEED);    
 
     /* add the hash to the estimator */
-    hloglog = hll_add_hash_dense(hloglog, hash);
+    hloglog = gp_hll_add_hash_dense(hloglog, hash);
 
     return hloglog;
 }
 
 /* Add the appropriate values to a dense encoded counter for a given hash */
-static HLLCounter
-hll_add_hash_dense(HLLCounter hloglog, uint64_t hash)
+static GpHLLCounter
+gp_hll_add_hash_dense(GpHLLCounter hloglog, uint64_t hash)
 {
 
     uint64_t idx;
@@ -503,7 +500,7 @@ hll_add_hash_dense(HLLCounter hloglog, uint64_t hash)
 	    addn = HASH_LENGTH;
 	    rho = (HASH_LENGTH - hloglog->b);
 	    while (addn == HASH_LENGTH && rho < POW2(hloglog->binbits)){
-		    hash = MurmurHash64A((const char * )&hash, HASH_LENGTH/8, HASH_SEED);
+		    hash = GpMurmurHash64A((const char * )&hash, HASH_LENGTH/8, HASH_SEED);
             /* zero length runs should be 1 so counter gets set */
 		    addn = __builtin_clzll(hash) + 1;
 		    rho += addn;
@@ -511,9 +508,9 @@ hll_add_hash_dense(HLLCounter hloglog, uint64_t hash)
     }
 
     /* keep the highest value */
-    HLL_DENSE_GET_REGISTER(entry,hloglog->data,idx,hloglog->binbits);
+    GP_HLL_DENSE_GET_REGISTER(entry,hloglog->data,idx,hloglog->binbits);
     if (rho > entry) {
-        HLL_DENSE_SET_REGISTER(hloglog->data,idx,rho,hloglog->binbits);
+        GP_HLL_DENSE_SET_REGISTER(hloglog->data,idx,rho,hloglog->binbits);
     }
     
     return hloglog;
@@ -523,16 +520,16 @@ hll_add_hash_dense(HLLCounter hloglog, uint64_t hash)
 /* Just reset the counter (set all the counters to 0). We do this by
  * zeroing the data array */
 void 
-hll_reset_internal(HLLCounter hloglog)
+gp_hll_reset_internal(GpHLLCounter hloglog)
 {
 
-    memset(hloglog->data, 0, VARSIZE_ANY(hloglog) - sizeof(HLLData) );
+    memset(hloglog->data, 0, VARSIZE_ANY(hloglog) - sizeof(GpHLLData) );
 
 }
 
 /* Compress header function */
-HLLCounter
-hll_compress(HLLCounter hloglog)
+GpHLLCounter
+gp_hll_compress(GpHLLCounter hloglog)
 {
 
 	/* make sure the data isn't compressed already */
@@ -541,21 +538,21 @@ hll_compress(HLLCounter hloglog)
 	}
 
 	if (hloglog->idx == -1 && hloglog->format == PACKED){
-		hloglog = hll_compress_dense(hloglog);
+		hloglog = gp_hll_compress_dense(hloglog);
 	} else if (hloglog->idx == -1 && hloglog->format == UNPACKED){
-		hloglog = hll_compress_dense_unpacked(hloglog);
+		hloglog = gp_hll_compress_dense_unpacked(hloglog);
 	} else if (hloglog->format == UNPACKED_UNPACKED){
 		hloglog->format = UNPACKED;
 	} else if (hloglog->format == PACKED_UNPACKED){
-		hloglog = hll_unpack(hloglog);
+		hloglog = gp_hll_unpack(hloglog);
 	}
 
 	return hloglog;
 }
 
 /* Compresses dense encoded counters using lz compression */
-static HLLCounter
-hll_compress_dense(HLLCounter hloglog)
+static GpHLLCounter
+gp_hll_compress_dense(GpHLLCounter hloglog)
 {
     PGLZ_Header * dest;
     char entry,*data;    
@@ -584,7 +581,7 @@ hll_compress_dense(HLLCounter hloglog)
     /* put all registers in a normal array  i.e. remove dense packing so
      * lz compression can work optimally */
     for(i=0; i < m ; i++){
-        HLL_DENSE_GET_REGISTER(entry,hloglog->data,i,hloglog->binbits);
+        GP_HLL_DENSE_GET_REGISTER(entry,hloglog->data,i,hloglog->binbits);
         data[i] = entry;
     }
 
@@ -605,7 +602,7 @@ hll_compress_dense(HLLCounter hloglog)
 
     /* resize the counter to only encompass the compressed data and the struct
      *  overhead*/
-    SET_VARSIZE(hloglog,sizeof(HLLData) + VARSIZE_ANY(dest) );
+    SET_VARSIZE(hloglog,sizeof(GpHLLData) + VARSIZE_ANY(dest) );
 
     /* invert the b value so it being < 0 can be used as a compression flag */
     hloglog->b = -1 * (hloglog->b);
@@ -623,8 +620,8 @@ hll_compress_dense(HLLCounter hloglog)
 }
 
 /* Compresses dense encoded counters using lz compression */
-static HLLCounter
-hll_compress_dense_unpacked(HLLCounter hloglog)
+static GpHLLCounter
+gp_hll_compress_dense_unpacked(GpHLLCounter hloglog)
 {
 	PGLZ_Header * dest;
 	int m;
@@ -661,7 +658,7 @@ hll_compress_dense_unpacked(HLLCounter hloglog)
 
 	/* resize the counter to only encompass the compressed data and the struct
 	*  overhead*/
-	SET_VARSIZE(hloglog, sizeof(HLLData) + VARSIZE_ANY(dest));
+	SET_VARSIZE(hloglog, sizeof(GpHLLData) + VARSIZE_ANY(dest));
 
 	/* invert the b value so it being < 0 can be used as a compression flag */
 	hloglog->b = -1 * (hloglog->b);
@@ -678,26 +675,26 @@ hll_compress_dense_unpacked(HLLCounter hloglog)
 
 
 /* Decompress header function */
-HLLCounter
-hll_decompress(HLLCounter hloglog)
+GpHLLCounter
+gp_hll_decompress(GpHLLCounter hloglog)
 {
      /* make sure the data is compressed */
     if (hloglog->b > 0) {
         return hloglog;
     }
     
-    hloglog = hll_decompress_dense(hloglog);
+    hloglog = gp_hll_decompress_dense(hloglog);
 
     return hloglog;
 }
 
 /* Decompresses dense counters */
-static HLLCounter
-hll_decompress_dense(HLLCounter hloglog)
+static GpHLLCounter
+gp_hll_decompress_dense(GpHLLCounter hloglog)
 {
     char * dest;
     int m,i;
-    HLLCounter htemp;
+    GpHLLCounter htemp;
 
     /* reset b to positive value for calcs and to indicate data is
      * decompressed */
@@ -720,18 +717,18 @@ hll_decompress_dense(HLLCounter hloglog)
 
     /* copy the struct internals but not the data into a counter with enough 
      * space for the uncompressed data  */
-    htemp = palloc(sizeof(HLLData) + (int)ceil((m * hloglog->binbits / 8.0)));
-    memcpy(htemp,hloglog,sizeof(HLLData));
+    htemp = palloc(sizeof(GpHLLData) + (int)ceil((m * hloglog->binbits / 8.0)));
+    memcpy(htemp,hloglog,sizeof(GpHLLData));
     hloglog = htemp;
 
     /* set the registers to the appropriate value based on the decompressed
      * data */
     for (i=0; i<m; i++){
-        HLL_DENSE_SET_REGISTER(hloglog->data,i,dest[i],hloglog->binbits);
+        GP_HLL_DENSE_SET_REGISTER(hloglog->data,i,dest[i],hloglog->binbits);
     }
 
     /* set the varsize to the appropriate length  */
-    SET_VARSIZE(hloglog,sizeof(HLLData) + (int)ceil((m * hloglog->binbits / 8.0)) );
+    SET_VARSIZE(hloglog,sizeof(GpHLLData) + (int)ceil((m * hloglog->binbits / 8.0)) );
     
 
     /* free allocated memory */
@@ -744,17 +741,17 @@ hll_decompress_dense(HLLCounter hloglog)
 
 /* ---------------------- function definitions --------------------------- */
 
-HLLCounter
-hyperloglog_add_item(HLLCounter hllcounter, Datum element, int16 typlen, bool typbyval, char typalign)
+GpHLLCounter
+gp_hyperloglog_add_item(GpHLLCounter hllcounter, Datum element, int16 typlen, bool typbyval, char typalign)
 {
-	HLLCounter hyperloglog;
+	GpHLLCounter hyperloglog;
 	
 	/* requires the estimator to be already created */
 	if (hllcounter == NULL)
 		elog(ERROR, "hyperloglog counter must not be NULL");
 	
 	/* estimator (we know it's not a NULL value) */
-	hyperloglog = (HLLCounter) hllcounter;
+	hyperloglog = (GpHLLCounter) hllcounter;
 	
 	/* TODO The requests for type info shouldn't be a problem (thanks to
 	 * lsyscache), but if it turns out to have a noticeable impact it's
@@ -765,24 +762,24 @@ hyperloglog_add_item(HLLCounter hllcounter, Datum element, int16 typlen, bool ty
 	/* decompress if needed */
 	if(hyperloglog->b < 0)
 	{
-		hyperloglog = hll_decompress(hyperloglog);
+		hyperloglog = gp_hll_decompress(hyperloglog);
 	}
 	
 	/* it this a varlena type, passed by reference or by value ? */
 	if (typlen == -1)
 	{
 		/* varlena */
-		hyperloglog = hll_add_element(hyperloglog, VARDATA_ANY(element), VARSIZE_ANY_EXHDR(element));
+		hyperloglog = gp_hll_add_element(hyperloglog, VARDATA_ANY(element), VARSIZE_ANY_EXHDR(element));
 	}
 	else if (typbyval)
 	{
 		/* fixed-length, passed by value */
-		hyperloglog = hll_add_element(hyperloglog, (char*)&element, typlen);
+		hyperloglog = gp_hll_add_element(hyperloglog, (char*)&element, typlen);
 	}
 	else
 	{
 		/* fixed-length, passed by reference */
-		hyperloglog = hll_add_element(hyperloglog, (char*)element, typlen);
+		hyperloglog = gp_hll_add_element(hyperloglog, (char*)element, typlen);
 	}
 	
 	return hyperloglog;
@@ -790,14 +787,14 @@ hyperloglog_add_item(HLLCounter hllcounter, Datum element, int16 typlen, bool ty
 
 
 double
-hyperloglog_estimate(HLLCounter hyperloglog)
+gp_hyperloglog_estimate(GpHLLCounter hyperloglog)
 {
 	double estimate;
 	
 	/* unpack if needed */
-	HLLCounter hyperloglog_unpacked = hll_unpack(hyperloglog);
+	GpHLLCounter hyperloglog_unpacked = gp_hll_unpack(hyperloglog);
 	
-	estimate = hll_estimate(hyperloglog_unpacked);
+	estimate = gp_hll_estimate(hyperloglog_unpacked);
 
 	/* free unpacked counter */
 	pfree(hyperloglog_unpacked);
@@ -806,8 +803,8 @@ hyperloglog_estimate(HLLCounter hyperloglog)
 	return estimate;
 }
 
-HLLCounter
-hyperloglog_merge_counters(HLLCounter counter1, HLLCounter counter2)
+GpHLLCounter
+gp_hyperloglog_merge_counters(GpHLLCounter counter1, GpHLLCounter counter2)
 {
 	if (counter1 == NULL && counter2 == NULL)
 	{
@@ -818,53 +815,53 @@ hyperloglog_merge_counters(HLLCounter counter1, HLLCounter counter2)
 	{
 		/* if first counter is null just copy the second estimator into the
 		 * first one */
-		return hll_copy(counter2);
+		return gp_hll_copy(counter2);
 	}
 	else if (counter2 == NULL) {
 		/* if second counter is null just return the the first estimator */
-		return hll_copy(counter1);
+		return gp_hll_copy(counter1);
 	}
 	else
 	{
 		/* ok, we already have the estimator - merge the second one into it */
 		/* unpack if needed */
-		HLLCounter counter1_new = hll_unpack(counter1);
-		HLLCounter counter2_new = hll_unpack(counter2);
+		GpHLLCounter counter1_new = gp_hll_unpack(counter1);
+		GpHLLCounter counter2_new = gp_hll_unpack(counter2);
 
 		/* perform the merge */
-		counter1_new = hll_merge(counter1_new, counter2_new);
+		counter1_new = gp_hll_merge(counter1_new, counter2_new);
 
 		/*  counter2_new is not required any more */
 		pfree(counter2_new);
 
-		/* return the updated HLLCounter */
+		/* return the updated GpHLLCounter */
 		return counter1_new;
 	}
 }
 
 
-HLLCounter
-hyperloglog_init_def()
+GpHLLCounter
+gp_hyperloglog_init_def()
 {
-	HLLCounter hyperloglog;
+	GpHLLCounter hyperloglog;
 	
-	hyperloglog = hll_create(DEFAULT_NDISTINCT, DEFAULT_ERROR, PACKED);
+	hyperloglog = gp_hll_create(DEFAULT_NDISTINCT, DEFAULT_ERROR, PACKED);
 	
 	return hyperloglog;
 }
 
 int
-hyperloglog_len(HLLCounter hyperloglog)
+gp_hyperloglog_len(GpHLLCounter hyperloglog)
 {
 	return VARSIZE_ANY(hyperloglog);
 }
 
-/* MurmurHash64A produces the fastest 64 bit hash of the MurmurHash 
+/* GpMurmurHash64A produces the fastest 64 bit hash of the MurmurHash 
  * implementations and is ~ 20x faster than md5. This version produces the
  * same hash for the same key and seed in both big and little endian systems
  * */
 uint64_t 
-MurmurHash64A (const void * key, int len, unsigned int seed) 
+GpMurmurHash64A (const void * key, int len, unsigned int seed) 
 {
     const uint64_t m = 0xc6a4a7935bd1e995;
     const int r = 47;
@@ -930,7 +927,7 @@ static const int8 b64lookup[128] = {
 
 
 int
-hll_b64_encode(const char *src, unsigned len, char *dst)
+gp_hll_b64_encode(const char *src, unsigned len, char *dst)
 {
 	char	   *p,
 		*lend = dst + 76;
@@ -978,7 +975,7 @@ hll_b64_encode(const char *src, unsigned len, char *dst)
 }
 
 int
-hll_b64_decode(const char *src, unsigned len, char *dst)
+gp_hll_b64_decode(const char *src, unsigned len, char *dst)
 {
 	const char *srcend = src + len,
 		*s = src;
@@ -1048,53 +1045,53 @@ hll_b64_decode(const char *src, unsigned len, char *dst)
 
 
 int
-b64_enc_len(const char *src, unsigned srclen)
+gp_b64_enc_len(const char *src, unsigned srclen)
 {
 	/* 3 bytes will be converted to 4, linefeed after 76 chars */
 	return (srclen + 2) * 4 / 3 + srclen / (76 * 3 / 4);
 }
 
 int
-b64_dec_len(const char *src, unsigned srclen)
+gp_b64_dec_len(const char *src, unsigned srclen)
 {
 	return (srclen * 3) >> 2;
 }
 
-/* PG_GETARG macros for HLLCounter's that does version checking */
-#define PG_GETARG_HLL_P(n) pg_check_hll_version((HLLCounter) PG_GETARG_BYTEA_P(n))
-#define PG_GETARG_HLL_P_COPY(n) pg_check_hll_version((HLLCounter) PG_GETARG_BYTEA_P_COPY(n))
+/* PG_GETARG macros for GpHLLCounter's that does version checking */
+#define PG_GETARG_HLL_P(n) pg_check_hll_version((GpHLLCounter) PG_GETARG_BYTEA_P(n))
+#define PG_GETARG_HLL_P_COPY(n) pg_check_hll_version((GpHLLCounter) PG_GETARG_BYTEA_P_COPY(n))
 
 /* shoot for 2^64 distinct items and 0.8125% error rate by default */
 #define DEFAULT_NDISTINCT   1ULL << 63
 #define DEFAULT_ERROR       0.008125
 
 /* Use the PG_FUNCTION_INFO_V! macro to pass functions to postgres */
-PG_FUNCTION_INFO_V1(hyperloglog_add_item_agg_default);
+PG_FUNCTION_INFO_V1(gp_hyperloglog_add_item_agg_default);
 
-PG_FUNCTION_INFO_V1(hyperloglog_merge);
-PG_FUNCTION_INFO_V1(hyperloglog_get_estimate);
+PG_FUNCTION_INFO_V1(gp_hyperloglog_merge);
+PG_FUNCTION_INFO_V1(gp_hyperloglog_get_estimate);
 
-PG_FUNCTION_INFO_V1(hyperloglog_in);
-PG_FUNCTION_INFO_V1(hyperloglog_out);
+PG_FUNCTION_INFO_V1(gp_hyperloglog_in);
+PG_FUNCTION_INFO_V1(gp_hyperloglog_out);
 
-PG_FUNCTION_INFO_V1(hyperloglog_comp);
+PG_FUNCTION_INFO_V1(gp_hyperloglog_comp);
 
 /* ------------- function declarations for local functions --------------- */
-extern Datum hyperloglog_add_item_agg_default(PG_FUNCTION_ARGS);
+extern Datum gp_hyperloglog_add_item_agg_default(PG_FUNCTION_ARGS);
 
-extern Datum hyperloglog_get_estimate(PG_FUNCTION_ARGS);
-extern Datum hyperloglog_merge(PG_FUNCTION_ARGS);
+extern Datum gp_hyperloglog_get_estimate(PG_FUNCTION_ARGS);
+extern Datum gp_hyperloglog_merge(PG_FUNCTION_ARGS);
 
-extern Datum hyperloglog_in(PG_FUNCTION_ARGS);
-extern Datum hyperloglog_out(PG_FUNCTION_ARGS);
+extern Datum gp_hyperloglog_in(PG_FUNCTION_ARGS);
+extern Datum gp_hyperloglog_out(PG_FUNCTION_ARGS);
 
-extern Datum hyperloglog_comp(PG_FUNCTION_ARGS);
+extern Datum gp_hyperloglog_comp(PG_FUNCTION_ARGS);
 
-static HLLCounter pg_check_hll_version(HLLCounter hloglog);
+static GpHLLCounter pg_check_hll_version(GpHLLCounter hloglog);
 
 /* ---------------------- function definitions --------------------------- */
-static HLLCounter
-pg_check_hll_version(HLLCounter hloglog)
+static GpHLLCounter
+pg_check_hll_version(GpHLLCounter hloglog)
 {
 	if (hloglog->version != STRUCT_VERSION){
 		elog(ERROR,"ERROR: The stored counter is version %u while the library is version %u. Please change library version or use upgrade function to upgrade the counter",hloglog->version,STRUCT_VERSION);
@@ -1103,10 +1100,10 @@ pg_check_hll_version(HLLCounter hloglog)
 }
 
 Datum
-hyperloglog_add_item_agg_default(PG_FUNCTION_ARGS)
+gp_hyperloglog_add_item_agg_default(PG_FUNCTION_ARGS)
 {
 
-	HLLCounter hyperloglog;
+	GpHLLCounter hyperloglog;
 
 	/* info for anyelement */
 	Oid         element_type = get_fn_expr_argtype(fcinfo->flinfo, 1);
@@ -1121,7 +1118,7 @@ hyperloglog_add_item_agg_default(PG_FUNCTION_ARGS)
 	if (PG_ARGISNULL(0) && PG_ARGISNULL(1)){
 		PG_RETURN_NULL();
 	} else if (PG_ARGISNULL(0)) {
-		hyperloglog = hll_create(DEFAULT_NDISTINCT, DEFAULT_ERROR, PACKED);
+		hyperloglog = gp_hll_create(DEFAULT_NDISTINCT, DEFAULT_ERROR, PACKED);
 	} else {
 		hyperloglog = PG_GETARG_HLL_P(0);
 	}
@@ -1138,7 +1135,7 @@ hyperloglog_add_item_agg_default(PG_FUNCTION_ARGS)
 		/* get type information for the second parameter (anyelement item) */
 		get_typlenbyvalalign(element_type, &typlen, &typbyval, &typalign);
 
-		hyperloglog = hyperloglog_add_item(hyperloglog, element, typlen, typbyval, typalign);
+		hyperloglog = gp_hyperloglog_add_item(hyperloglog, element, typlen, typbyval, typalign);
 	}
 
 	/* return the updated bytea */
@@ -1147,11 +1144,11 @@ hyperloglog_add_item_agg_default(PG_FUNCTION_ARGS)
 }
 
 Datum
-hyperloglog_merge(PG_FUNCTION_ARGS)
+gp_hyperloglog_merge(PG_FUNCTION_ARGS)
 {
-	HLLCounter counter1 = NULL;
-	HLLCounter counter2 = NULL;
-	HLLCounter counter1_merged = NULL;
+	GpHLLCounter counter1 = NULL;
+	GpHLLCounter counter2 = NULL;
+	GpHLLCounter counter1_merged = NULL;
 
 	if (PG_ARGISNULL(0) && PG_ARGISNULL(1)){
 		/* if both counters are null return null */
@@ -1171,7 +1168,7 @@ hyperloglog_merge(PG_FUNCTION_ARGS)
 		counter1 = PG_GETARG_HLL_P_COPY(0);
 		counter2 = PG_GETARG_HLL_P_COPY(1);
 
-		counter1_merged = hyperloglog_merge_counters(counter1, counter2);
+		counter1_merged = gp_hyperloglog_merge_counters(counter1, counter2);
 		pfree(counter1);
 		pfree(counter2);
 	}
@@ -1182,12 +1179,12 @@ hyperloglog_merge(PG_FUNCTION_ARGS)
 }
 
 Datum
-hyperloglog_get_estimate(PG_FUNCTION_ARGS)
+gp_hyperloglog_get_estimate(PG_FUNCTION_ARGS)
 {
 	double estimate;
-	HLLCounter hyperloglog = PG_GETARG_HLL_P_COPY(0);
+	GpHLLCounter hyperloglog = PG_GETARG_HLL_P_COPY(0);
 
-	estimate = hyperloglog_estimate(hyperloglog);
+	estimate = gp_hyperloglog_estimate(hyperloglog);
 
 	/* free the hll counter copy */
 	pfree(hyperloglog);
@@ -1197,16 +1194,16 @@ hyperloglog_get_estimate(PG_FUNCTION_ARGS)
 }
 
 Datum
-hyperloglog_out(PG_FUNCTION_ARGS)
+gp_hyperloglog_out(PG_FUNCTION_ARGS)
 {
 	int16   datalen, resultlen, res;
 	char     *result;
 	bytea    *data = PG_GETARG_BYTEA_P(0);
 
 	datalen = VARSIZE_ANY_EXHDR(data);
-	resultlen = b64_enc_len(VARDATA_ANY(data), datalen);
+	resultlen = gp_b64_enc_len(VARDATA_ANY(data), datalen);
 	result = palloc(resultlen + 1);
-	res = hll_b64_encode(VARDATA_ANY(data),datalen, result);
+	res = gp_hll_b64_encode(VARDATA_ANY(data),datalen, result);
 
 	/* Make this FATAL 'cause we've trodden on memory ... */
 	if (res > resultlen)
@@ -1218,16 +1215,16 @@ hyperloglog_out(PG_FUNCTION_ARGS)
 }
 
 Datum
-hyperloglog_in(PG_FUNCTION_ARGS)
+gp_hyperloglog_in(PG_FUNCTION_ARGS)
 {
 	bytea      *result;
 	char       *data = PG_GETARG_CSTRING(0);
 	int16      datalen, resultlen, res;
 
 	datalen = strlen(data);
-	resultlen = b64_dec_len(data,datalen);
+	resultlen = gp_b64_dec_len(data,datalen);
 	result = palloc(VARHDRSZ + resultlen);
-	res = hll_b64_decode(data, datalen, VARDATA(result));
+	res = gp_hll_b64_decode(data, datalen, VARDATA(result));
 
 	/* Make this FATAL 'cause we've trodden on memory ... */
 	if (res > resultlen)
@@ -1239,9 +1236,9 @@ hyperloglog_in(PG_FUNCTION_ARGS)
 }
 
 Datum
-hyperloglog_comp(PG_FUNCTION_ARGS)
+gp_hyperloglog_comp(PG_FUNCTION_ARGS)
 {
-	HLLCounter hyperloglog;
+	GpHLLCounter hyperloglog;
 
 	if (PG_ARGISNULL(0) ){
 		PG_RETURN_NULL();
@@ -1249,7 +1246,7 @@ hyperloglog_comp(PG_FUNCTION_ARGS)
 
 	hyperloglog =  PG_GETARG_HLL_P_COPY(0);
 
-	hyperloglog = hll_compress(hyperloglog);
+	hyperloglog = gp_hll_compress(hyperloglog);
 
 	PG_RETURN_BYTEA_P(hyperloglog);
 }

--- a/src/include/catalog/pg_aggregate.h
+++ b/src/include/catalog/pg_aggregate.h
@@ -348,7 +348,7 @@ DATA(insert ( 3538	n 0 string_agg_transfn				string_agg_finalfn						-	-	-	-		-	
 DATA(insert ( 3545	n 0 bytea_string_agg_transfn		bytea_string_agg_finalfn				-	-	-	-		-		-		f f	0	2281	0	0		0	_null_ _null_ ));
 
 /* hyperloglog */
-DATA(insert ( 7164	n 0 hyperloglog_add_item_agg_default hyperloglog_comp		hyperloglog_merge	-	-	-		-		-		f f 0	7157	0	0		0	_null_ _null_ ));
+DATA(insert ( 7164	n 0 gp_hyperloglog_add_item_agg_default gp_hyperloglog_comp		gp_hyperloglog_merge	-	-	-		-		-		f f 0	7157	0	0		0	_null_ _null_ ));
 
 /* json */
 DATA(insert ( 3175	n 0 json_agg_transfn				json_agg_finalfn						-	-	-	-		-		-		f f 0	2281	0	0		0	_null_ _null_ ));

--- a/src/include/catalog/pg_proc.sql
+++ b/src/include/catalog/pg_proc.sql
@@ -407,19 +407,19 @@
 
  CREATE FUNCTION complex_gte(complex, complex) RETURNS bool  LANGUAGE internal IMMUTABLE STRICT AS 'complex_gte' WITH (OID=7596);
 
-CREATE FUNCTION hyperloglog_in(value cstring) RETURNS hyperloglog_estimator  LANGUAGE internal IMMUTABLE STRICT AS 'hyperloglog_in' WITH (OID=7158, DESCRIPTION="Decode a bytea into hyperloglog_counter");
+CREATE FUNCTION gp_hyperloglog_in(value cstring) RETURNS gp_hyperloglog_estimator  LANGUAGE internal IMMUTABLE STRICT AS 'gp_hyperloglog_in' WITH (OID=7158, DESCRIPTION="Decode a bytea into gp_hyperloglog_counter");
 
-CREATE FUNCTION hyperloglog_out(counter hyperloglog_estimator) RETURNS cstring  LANGUAGE internal IMMUTABLE STRICT AS 'hyperloglog_out' WITH (OID=7159, DESCRIPTION="Encode an hyperloglog_counter into a bytea");
+CREATE FUNCTION gp_hyperloglog_out(counter gp_hyperloglog_estimator) RETURNS cstring  LANGUAGE internal IMMUTABLE STRICT AS 'gp_hyperloglog_out' WITH (OID=7159, DESCRIPTION="Encode an gp_hyperloglog_counter into a bytea");
 
-CREATE FUNCTION hyperloglog_comp(counter hyperloglog_estimator) RETURNS hyperloglog_estimator  LANGUAGE internal IMMUTABLE STRICT AS 'hyperloglog_comp' WITH (OID=7160, DESCRIPTION="Compress an hyperloglog counter");
+CREATE FUNCTION gp_hyperloglog_comp(counter gp_hyperloglog_estimator) RETURNS gp_hyperloglog_estimator  LANGUAGE internal IMMUTABLE STRICT AS 'gp_hyperloglog_comp' WITH (OID=7160, DESCRIPTION="Compress an hyperloglog counter");
 
-CREATE FUNCTION hyperloglog_merge(estimator1 hyperloglog_estimator, estimator2 hyperloglog_estimator) RETURNS hyperloglog_estimator  LANGUAGE internal IMMUTABLE AS 'hyperloglog_merge' WITH (OID=7161, DESCRIPTION="Merge two hyperloglog counters into one");
+CREATE FUNCTION gp_hyperloglog_merge(estimator1 gp_hyperloglog_estimator, estimator2 gp_hyperloglog_estimator) RETURNS gp_hyperloglog_estimator  LANGUAGE internal IMMUTABLE AS 'gp_hyperloglog_merge' WITH (OID=7161, DESCRIPTION="Merge two hyperloglog counters into one");
 
-CREATE FUNCTION hyperloglog_get_estimate(counter hyperloglog_estimator) RETURNS float8  LANGUAGE internal IMMUTABLE STRICT AS 'hyperloglog_get_estimate' WITH (OID=7162, DESCRIPTION="Estimates the number of distinct values stored in an hyperloglog counter");
+CREATE FUNCTION gp_hyperloglog_get_estimate(counter gp_hyperloglog_estimator) RETURNS float8  LANGUAGE internal IMMUTABLE STRICT AS 'gp_hyperloglog_get_estimate' WITH (OID=7162, DESCRIPTION="Estimates the number of distinct values stored in an hyperloglog counter");
 
-CREATE FUNCTION hyperloglog_add_item_agg_default(counter hyperloglog_estimator, item anyelement) RETURNS hyperloglog_estimator  LANGUAGE internal IMMUTABLE AS 'hyperloglog_add_item_agg_default' WITH (OID=7163, DESCRIPTION="Includes a data value into a hyperloglog counter");
+CREATE FUNCTION gp_hyperloglog_add_item_agg_default(counter gp_hyperloglog_estimator, item anyelement) RETURNS gp_hyperloglog_estimator  LANGUAGE internal IMMUTABLE AS 'gp_hyperloglog_add_item_agg_default' WITH (OID=7163, DESCRIPTION="Includes a data value into a hyperloglog counter");
 
-CREATE FUNCTION hyperloglog_accum(anyelement) RETURNS hyperloglog_estimator LANGUAGE internal IMMUTABLE AS 'aggregate_dummy' WITH (OID=7164, proisagg="t", DESCRIPTION="Adds every data value to a hyperloglog counter and returns the counter");
+CREATE FUNCTION gp_hyperloglog_accum(anyelement) RETURNS gp_hyperloglog_estimator LANGUAGE internal IMMUTABLE AS 'aggregate_dummy' WITH (OID=7164, proisagg="t", DESCRIPTION="Adds every data value to a hyperloglog counter and returns the counter");
 
 CREATE FUNCTION pg_get_table_distributedby(oid) RETURNS text LANGUAGE internal STABLE STRICT AS 'pg_get_table_distributedby' WITH (OID=6232, DESCRIPTION="deparse DISTRIBUTED BY clause for a given relation");
 

--- a/src/include/catalog/pg_proc_gp.h
+++ b/src/include/catalog/pg_proc_gp.h
@@ -805,32 +805,32 @@ DATA(insert OID = 6595 ( complex_lte  PGNSP PGUID 12 1 0 0 0 f f f f t f i 2 0 1
 /* complex_gte(complex, complex) => bool */
 DATA(insert OID = 7596 ( complex_gte  PGNSP PGUID 12 1 0 0 0 f f f f t f i 2 0 16 "7198 7198" _null_ _null_ _null_ _null_ complex_gte _null_ _null_ _null_ n a ));
 
-/* hyperloglog_in(value cstring) => hyperloglog_estimator */
-DATA(insert OID = 7158 ( hyperloglog_in  PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 7157 "2275" _null_ _null_ "{value}" _null_ hyperloglog_in _null_ _null_ _null_ n a ));
-DESCR("Decode a bytea into hyperloglog_counter");
+/* gp_hyperloglog_in(value cstring) => gp_hyperloglog_estimator */
+DATA(insert OID = 7158 ( gp_hyperloglog_in  PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 7157 "2275" _null_ _null_ "{value}" _null_ gp_hyperloglog_in _null_ _null_ _null_ n a ));
+DESCR("Decode a bytea into a hyperloglog counter");
 
-/* hyperloglog_out(counter hyperloglog_estimator) => cstring */
-DATA(insert OID = 7159 ( hyperloglog_out  PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 2275 "7157" _null_ _null_ "{counter}" _null_ hyperloglog_out _null_ _null_ _null_ n a ));
-DESCR("Encode an hyperloglog_counter into a bytea");
+/* gp_hyperloglog_out(counter gp_hyperloglog_estimator) => cstring */
+DATA(insert OID = 7159 ( gp_hyperloglog_out  PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 2275 "7157" _null_ _null_ "{counter}" _null_ gp_hyperloglog_out _null_ _null_ _null_ n a ));
+DESCR("Encode a hyperloglog counter into a bytea");
 
-/* hyperloglog_comp(counter hyperloglog_estimator) => hyperloglog_estimator */
-DATA(insert OID = 7160 ( hyperloglog_comp  PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 7157 "7157" _null_ _null_ "{counter}" _null_ hyperloglog_comp _null_ _null_ _null_ n a ));
-DESCR("Compress an hyperloglog counter");
+/* gp_hyperloglog_comp(counter gp_hyperloglog_estimator) => gp_hyperloglog_estimator */
+DATA(insert OID = 7160 ( gp_hyperloglog_comp  PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 7157 "7157" _null_ _null_ "{counter}" _null_ gp_hyperloglog_comp _null_ _null_ _null_ n a ));
+DESCR("Compress a hyperloglog counter");
 
-/* hyperloglog_merge(estimator1 hyperloglog_estimator, estimator2 hyperloglog_estimator) => hyperloglog_estimator */
-DATA(insert OID = 7161 ( hyperloglog_merge  PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 7157 "7157 7157" _null_ _null_ "{estimator1,estimator2}" _null_ hyperloglog_merge _null_ _null_ _null_ n a ));
+/* gp_hyperloglog_merge(estimator1 gp_hyperloglog_estimator, estimator2 gp_hyperloglog_estimator) => gp_hyperloglog_estimator */
+DATA(insert OID = 7161 ( gp_hyperloglog_merge  PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 7157 "7157 7157" _null_ _null_ "{estimator1,estimator2}" _null_ gp_hyperloglog_merge _null_ _null_ _null_ n a ));
 DESCR("Merge two hyperloglog counters into one");
 
-/* hyperloglog_get_estimate(counter hyperloglog_estimator) => float8 */
-DATA(insert OID = 7162 ( hyperloglog_get_estimate  PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 701 "7157" _null_ _null_ "{counter}" _null_ hyperloglog_get_estimate _null_ _null_ _null_ n a ));
+/* gp_hyperloglog_get_estimate(counter gp_hyperloglog_estimator) => float8 */
+DATA(insert OID = 7162 ( gp_hyperloglog_get_estimate  PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 701 "7157" _null_ _null_ "{counter}" _null_ gp_hyperloglog_get_estimate _null_ _null_ _null_ n a ));
 DESCR("Estimates the number of distinct values stored in an hyperloglog counter");
 
-/* hyperloglog_add_item_agg_default(counter hyperloglog_estimator, item anyelement) => hyperloglog_estimator */
-DATA(insert OID = 7163 ( hyperloglog_add_item_agg_default  PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 7157 "7157 2283" _null_ _null_ "{counter,item}" _null_ hyperloglog_add_item_agg_default _null_ _null_ _null_ n a ));
+/* gp_hyperloglog_add_item_agg_default(counter gp_hyperloglog_estimator, item anyelement) => gp_hyperloglog_estimator */
+DATA(insert OID = 7163 ( gp_hyperloglog_add_item_agg_default  PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 7157 "7157 2283" _null_ _null_ "{counter,item}" _null_ gp_hyperloglog_add_item_agg_default _null_ _null_ _null_ n a ));
 DESCR("Includes a data value into a hyperloglog counter");
 
-/* hyperloglog_accum(anyelement) => hyperloglog_estimator */
-DATA(insert OID = 7164 ( hyperloglog_accum  PGNSP PGUID 12 1 0 0 0 t f f f f f i 1 0 7157 "2283" _null_ _null_ _null_ _null_ aggregate_dummy _null_ _null_ _null_ n a ));
+/* gp_hyperloglog_accum(anyelement) => gp_hyperloglog_estimator */
+DATA(insert OID = 7164 ( gp_hyperloglog_accum  PGNSP PGUID 12 1 0 0 0 t f f f f f i 1 0 7157 "2283" _null_ _null_ _null_ _null_ aggregate_dummy _null_ _null_ _null_ n a ));
 DESCR("Adds every data value to a hyperloglog counter and returns the counter");
 
 /* pg_get_table_distributedby(oid) => text */

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -708,9 +708,9 @@ DESCR("Represents a generic TABLE value expression");
 #define ANYTABLEOID     7053
 
 /* hyperloglog */
-DATA(insert OID = 7157 ( hyperloglog_estimator		PGNSP PGUID -1 f b X f t \054 0    0 7165 hyperloglog_in hyperloglog_out - - - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
-DESCR("hyperloglog_estimator’s internal bytea representation for hyperloglog counter");
-DATA(insert OID = 7165 ( _hyperloglog_estimator		PGNSP PGUID -1 f b A f t \054 0	7157 0 array_in array_out array_recv array_send - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
+DATA(insert OID = 7157 ( gp_hyperloglog_estimator		PGNSP PGUID -1 f b X f t \054 0    0 7165 gp_hyperloglog_in gp_hyperloglog_out - - - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
+DESCR("gp_hyperloglog_estimator’s internal bytea representation for hyperloglog counter");
+DATA(insert OID = 7165 ( _gp_hyperloglog_estimator		PGNSP PGUID -1 f b A f t \054 0	7157 0 array_in array_out array_recv array_send - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
 
 /*
  * macros

--- a/src/test/regress/expected/type_sanity.out
+++ b/src/test/regress/expected/type_sanity.out
@@ -425,12 +425,12 @@ WHERE t.typbasetype = 0 AND
     (t.typanalyze = 'array_typanalyze'::regproc) !=
     (typelem != 0 AND typlen < 0)
 ORDER BY 1;
- oid  |        typname         | typanalyze 
-------+------------------------+------------
-   22 | int2vector             | -
-   30 | oidvector              | -
- 7165 | _hyperloglog_estimator | -
- 7199 | _complex               | -
+ oid  |          typname          | typanalyze 
+------+---------------------------+------------
+   22 | int2vector                | -
+   30 | oidvector                 | -
+ 7165 | _gp_hyperloglog_estimator | -
+ 7199 | _complex                  | -
 (4 rows)
 
 -- **************** pg_class ****************


### PR DESCRIPTION
Ported changes from https://github.com/greenplum-db/gpdb/pull/6931 to master. There were a couple of conflicts - mostly trivial, but I'd like a second review.
