### PR TITLE
Record pg_basebackup progress during gpconfigurenewsegment runs

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -723,7 +723,9 @@ class SegmentTemplate:
                                                                              primaryMirror='primary')
         self.logger.info(new_segment_info)
         for host in iter(new_segment_info):
-            segCfgCmd = ConfigureNewSegment(name='gpexpand configure new segments', confinfo=new_segment_info[host],
+            segCfgCmd = ConfigureNewSegment(name='gpexpand configure new segments',
+                                            confinfo=new_segment_info[host],
+                                            logdir=get_logger_dir(),
                                             tarFile=self.segTarFile, newSegments=True,
                                             verbose=gplog.logging_is_verbose(), batchSize=self.batch_size,
                                             ctxt=REMOTE, remoteHost=host)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -8,6 +8,7 @@ TODO: docs!
 """
 import os, pickle, base64, time
 import os.path
+import pipes
 
 import re, socket
 
@@ -852,10 +853,10 @@ class ConfigureNewSegment(Command):
       etc.
     """
 
-    def __init__(self, name, confinfo, newSegments=False, tarFile=None,
+    def __init__(self, name, confinfo, logdir, newSegments=False, tarFile=None,
                  batchSize=None, verbose=False,ctxt=LOCAL, remoteHost=None, validationOnly=False, writeGpIdFileOnly=False,
                  forceoverwrite=False):
-        cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\"' % (confinfo)
+        cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\" -l %s' % (confinfo, pipes.quote(logdir))
         if newSegments:
             cmdStr += ' -n'
         if tarFile:

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -4,6 +4,7 @@
 #
 
 import os
+import pipes
 
 from gppylib.gplog import *
 from gppylib.gparray import *
@@ -174,8 +175,7 @@ class PgControlData(Command):
 
 
 class PgBaseBackup(Command):
-    def __init__(self, pgdata, host, port, replication_slot_name=None, excludePaths=[], ctxt=LOCAL, remoteHost=None, forceoverwrite=False, target_gp_dbid=0,
-                 ):
+    def __init__(self, pgdata, host, port, replication_slot_name=None, excludePaths=[], ctxt=LOCAL, remoteHost=None, forceoverwrite=False, target_gp_dbid=0, logfile=None):
         cmd_tokens = ['pg_basebackup', '-R', '-c', 'fast']
         cmd_tokens.append('-D')
         cmd_tokens.append(pgdata)
@@ -207,6 +207,12 @@ class PgBaseBackup(Command):
             for path in excludePaths:
                 cmd_tokens.append('-E')
                 cmd_tokens.append(path)
+
+        cmd_tokens.append('--progress')
+        cmd_tokens.append('--verbose')
+
+        if logfile:
+            cmd_tokens.append('> %s 2>&1' % pipes.quote(logfile))
 
         cmd_str = ' '.join(cmd_tokens)
 

--- a/gpMgmt/bin/gppylib/gplog.py
+++ b/gpMgmt/bin/gppylib/gplog.py
@@ -57,6 +57,8 @@ def get_default_logger():
 
     return _LOGGER
 
+def get_logger_dir():
+    return os.path.dirname(_FILENAME)
 
 def get_unittest_logger():
     """
@@ -241,7 +243,6 @@ def _set_file_logging(filename):
     _FILE_HANDLER = EncodingFileHandler(filename, 'a')
     _FILE_HANDLER.setFormatter(_get_default_formatter())
     _LOGGER.addHandler(_FILE_HANDLER)
-
 
 def _get_default_formatter():
     """

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -437,8 +437,10 @@ class GpMirrorListToBuild:
         def createConfigureNewSegmentCommand(hostName, cmdLabel, validationOnly):
             segmentInfo = newSegmentInfo[hostName]
             checkNotNone("segmentInfo for %s" % hostName, segmentInfo)
+
             return gp.ConfigureNewSegment(cmdLabel,
                                           segmentInfo,
+                                          gplog.get_logger_dir(),
                                           newSegments=True,
                                           verbose=gplog.logging_is_verbose(),
                                           batchSize=self.__parallelDegree,
@@ -697,6 +699,7 @@ class GpMirrorListToBuild:
             checkNotNone("segmentInfo for %s" % hostName, segmentInfo)
             cmd = gp.ConfigureNewSegment("update gpid file",
                                          segmentInfo,
+                                         gplog.get_logger_dir(),
                                          newSegments=False,
                                          verbose=gplog.logging_is_verbose(),
                                          batchSize=self.__parallelDegree,

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import datetime
 import sys
 import os
 from optparse import Option, OptionGroup, OptionParser, OptionValueError, SUPPRESS_USAGE
@@ -121,21 +122,30 @@ class ConfExpSegCmd(Command):
                    return
 
                 if not self.isPrimary:
+                    # Log pg_basebackup output to the same directory as gpconfigurenewsegment
+                    pgbasebackup_start_time = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
+                    pgbasebackup_progress_temp_file = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
+                                                                                          pgbasebackup_start_time,
+                                                                                          self.dbid)
                     # Create a mirror based on the primary
                     cmd = PgBaseBackup(pgdata=self.datadir,
                                        host=self.syncWithSegmentHostname,
                                        port=str(self.syncWithSegmentPort),
                                        replication_slot_name=self.replicationSlotName,
                                        forceoverwrite=self.forceoverwrite,
-                                       target_gp_dbid=self.dbid)
+                                       target_gp_dbid=self.dbid,
+                                       logfile=pgbasebackup_progress_temp_file)
                     try:
+                        logger.info("Running pg_basebackup with progress output temporarily in %s" % pgbasebackup_progress_temp_file)
                         cmd.run(validateAfter=True)
+
                         self.set_results(CommandResult(0, '', '', True, False))
+                        os.remove(pgbasebackup_progress_temp_file)
                     except Exception, e:
                         self.set_results(CommandResult(1,'',e,True,False))
                         raise
 
-                    logger.info("ran pg_backbackup: %s" % cmd.cmdStr)
+                    logger.info("Successfully ran pg_basebackup: %s" % cmd.cmdStr)
                     return
 
                 logger.info("Create or update data directories for new segment")

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -236,6 +236,7 @@ def parseargs():
     parser.add_option("-V", "--validation-only", dest="validationOnly", action='store_true', default=False)
     parser.add_option("-W", "--write-gpid-file-only", dest="writeGpidFileOnly", action='store_true', default=False)
     parser.add_option('-f', '--force-overwrite', dest='forceoverwrite', action='store_true', default=False)
+    parser.add_option('-l', '--log-dir', dest="logfileDirectory", type="string")
 
     parser.set_defaults(verbose=False, filters=[], slice=(None, None))
 
@@ -284,9 +285,11 @@ def parseargs():
     return options, args, seg_info
 
 try:
-    logger = gplog.setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName())
-
     (options, args, seg_info) = parseargs()
+
+    logger = gplog.setup_tool_logging(EXECNAME, unix.getLocalHostname(), unix.getUserName(),
+                                      logdir=options.logfileDirectory)
+
     if options.verbose:
         gplog.enable_verbose_logging()
 


### PR DESCRIPTION
When running gprecoverseg, gpinitstandby, or gpaddmirrors, we actually
run gpconfigurenewsegment to execute pg_basebackup.  Log the progress
output of pg_basebackup to a temporary file for user and/or utility
consumption.

Automated tests will be added in later utility PRs (gprecoverseg, gpstate, etc) that will consume the temp file.

Example output:
```
○ → tail -f gpconfigurenewsegment_20190208.log
20190208:12:06:15:088552 gpconfigurenewsegment:aspen:pivotal-[INFO]:-Starting gpconfigurenewsegment with args: -c /Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1:25436:false:false:6:1:aspen:25433,/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2:25437:false:false:7:2:aspen:25434 -n -B 16 --validation-only --force-overwrite
20190208:12:06:15:088552 gpconfigurenewsegment:aspen:pivotal-[INFO]:-Validate data directories for new segment
20190208:12:06:15:088552 gpconfigurenewsegment:aspen:pivotal-[INFO]:-Validate data directories for new segment
20190208:12:06:16:088628 gpconfigurenewsegment:aspen:pivotal-[INFO]:-Starting gpconfigurenewsegment with args: -c /Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1:25436:false:false:6:1:aspen:25433,/Users/pivotal/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2:25437:false:false:7:2:aspen:25434 -n -B 16 --force-overwrite
20190208:12:06:16:088628 gpconfigurenewsegment:aspen:pivotal-[INFO]:-Validate data directories for new segment
20190208:12:06:16:088628 gpconfigurenewsegment:aspen:pivotal-[INFO]:-Validate data directories for new segment
20190208:12:06:16:088628 gpconfigurenewsegment:aspen:pivotal-[INFO]:-Running pg_basebackup with progress output temporarily in /tmp/pg_basebackup.20190208_120616.pid88632.dbid6.out
20190208:12:06:16:088628 gpconfigurenewsegment:aspen:pivotal-[INFO]:-Running pg_basebackup with progress output temporarily in /tmp/pg_basebackup.20190208_120616.pid88631.dbid7.out
^C

○ → tail -f /tmp/pg_basebackup.20190208_120616.pid88632.dbid6.out
pg_basebackup: initiating base backup, waiting for checkpoint to complete
pg_basebackup: checkpoint completed
transaction log start point: 0/18000028 on timeline 1
pg_basebackup: starting background WAL receiver
54436/54436 kB (100%), 1/1 tablespace
transaction log end point: 0/180000C8
pg_basebackup: waiting for background process to finish streaming ...
pg_basebackup: base backup completed
```

The temporary file will contain carriage returns as such (that users need to parse themselves if they want full output):
```
pg_basebackup: initiating base backup, waiting for checkpoint to complete
pg_basebackup: checkpoint completed
transaction log start point: 0/60000028 on timeline 1
pg_basebackup: starting background WAL receiver
    0/54426 kB (0%), 0/1 tablespace (...irror3/demoDataDir2/backup_label)^M  911/54426 kB (1%), 0/1 tablespace (...irror3/demoDataDir2/global/10120)^M 3710/54426 kB (6%), 0/1 tablespace (...irror3/demoDataDir2/global/10074)^M 6326/54426 kB (11%), 0/1 tablespace (...r3/demoDataDir2/base/12807/12624)^M 9106/54426 kB (16%), 0/1 tablespace (...demoDataDir2/base/12807/12650_vm)^M12004/54426 kB (22%), 0/1 tablespace (...r3/demoDataDir2/base/12807/10040)^M14905/54426 kB (27%), 0/1 tablespace (...r3/demoDataDir2/base/12807/12593)^M17809/54426 kB (32%), 0/1 tablespace (...r3/demoDataDir2/base/12807/10136)^M20686/54426 kB (38%), 0/1 tablespace (...r3/demoDataDir2/base/12807/10010)^M23558/54426 kB (43%), 0/1 tablespace (...irror3/demoDataDir2/base/1/10142)^M26306/54426 kB (48%), 0/1 tablespace (...irror3/demoDataDir2/base/1/12546)^M
```