### PR TITLE
Propagate column projection information to external tables

### DIFF
--- a/gpcontrib/pxf/src/pxfbridge.c
+++ b/gpcontrib/pxf/src/pxfbridge.c
@@ -50,6 +50,12 @@ gpbridge_cleanup(gphadoop_context *context)
 		freeGPHDUri(context->gphd_uri);
 		context->gphd_uri = NULL;
 	}
+
+	if (context->filterstr != NULL)
+	{
+		pfree(context->filterstr);
+		context->filterstr = NULL;
+	}
 }
 
 /*
@@ -193,10 +199,12 @@ add_querydata_to_http_headers(gphadoop_context *context)
 {
 	PxfInputData inputData = {0};
 
-	inputData.headers = context->churl_headers;
-	inputData.gphduri = context->gphd_uri;
-	inputData.rel = context->relation;
+	inputData.headers   = context->churl_headers;
+	inputData.gphduri   = context->gphd_uri;
+	inputData.rel       = context->relation;
 	inputData.filterstr = context->filterstr;
+	inputData.proj_info = context->proj_info;
+	inputData.quals     = context->quals;
 	build_http_headers(&inputData);
 }
 

--- a/gpcontrib/pxf/src/pxfbridge.h
+++ b/gpcontrib/pxf/src/pxfbridge.h
@@ -33,14 +33,16 @@
  */
 typedef struct
 {
-	CHURL_HEADERS churl_headers;
-	CHURL_HANDLE churl_handle;
-	GPHDUri    *gphd_uri;
+	CHURL_HEADERS  churl_headers;
+	CHURL_HANDLE   churl_handle;
+	GPHDUri        *gphd_uri;
 	StringInfoData uri;
-	ListCell   *current_fragment;
+	ListCell       *current_fragment;
 	StringInfoData write_file_name;
-	Relation	relation;
-	char *filterstr;
+	Relation       relation;
+	char           *filterstr;
+	ProjectionInfo *proj_info;
+	List           *quals;
 } gphadoop_context;
 
 /*

--- a/gpcontrib/pxf/src/pxffragment.c
+++ b/gpcontrib/pxf/src/pxffragment.c
@@ -27,10 +27,14 @@ static void pxf_array_element_end(void *state, bool isnull);
  * Returns selected fragments that have been allocated to the current segment
  */
 void
-get_fragments(GPHDUri *uri, Relation relation, char* filter_string)
+get_fragments(GPHDUri *uri,
+              Relation relation,
+              char *filter_string,
+              ProjectionInfo *proj_info,
+              List *quals)
 {
 
-	List	   *data_fragments = NIL;
+	List	   *data_fragments;
 
 	/* Context for the Fragmenter API */
 	ClientContext client_context;
@@ -46,10 +50,12 @@ get_fragments(GPHDUri *uri, Relation relation, char* filter_string)
 	/*
 	 * Enrich the curl HTTP header
 	 */
-	inputData.headers = client_context.http_headers;
-	inputData.gphduri = uri;
-	inputData.rel = relation;
+	inputData.headers   = client_context.http_headers;
+	inputData.gphduri   = uri;
+	inputData.rel       = relation;
 	inputData.filterstr = filter_string;
+	inputData.proj_info = proj_info;
+	inputData.quals     = quals;
 	build_http_headers(&inputData);
 
 	/*

--- a/gpcontrib/pxf/src/pxffragment.h
+++ b/gpcontrib/pxf/src/pxffragment.h
@@ -67,7 +67,12 @@ typedef struct FragmentData
 /*
  * Gets the fragments for the given uri location
  */
-extern void get_fragments(GPHDUri *uri, Relation relation, char* filter_string);
+extern void
+get_fragments(GPHDUri *uri,
+              Relation relation,
+              char *filter_string,
+              ProjectionInfo *proj_info,
+              List *quals);
 
 /*
  * Frees the given fragment

--- a/gpcontrib/pxf/src/pxfheaders.h
+++ b/gpcontrib/pxf/src/pxfheaders.h
@@ -26,6 +26,7 @@
 #include "libchurl.h"
 #include "pxfuriparser.h"
 
+#include "nodes/execnodes.h"
 #include "utils/rel.h"
 
 /*
@@ -33,10 +34,12 @@
  */
 typedef struct sPxfInputData
 {
-	CHURL_HEADERS headers;
-	GPHDUri    *gphduri;
-	Relation	rel;
-	char *filterstr;
+	CHURL_HEADERS  headers;
+	GPHDUri        *gphduri;
+	Relation       rel;
+	char           *filterstr;
+	ProjectionInfo *proj_info;
+	List           *quals;
 } PxfInputData;
 
 /*

--- a/gpcontrib/pxf/test/mock/pxffilters_mock.c
+++ b/gpcontrib/pxf/test/mock/pxffilters_mock.c
@@ -5,6 +5,7 @@
  */
 
 char *serializePxfFilterQuals(List *quals);
+List	   *extractPxfAttributes(List *quals, bool *qualsAreSupported);
 
 /*
  * Use for all unit tests except for tests of pxffilters
@@ -13,4 +14,13 @@ char*
 serializePxfFilterQuals(List *quals)
 {
 	return NULL;
+}
+
+List *
+extractPxfAttributes(List *quals, bool *qualsAreSupported)
+{
+	check_expected(quals);
+//	check_expected(qualsAreSupported);
+
+	return (List *) mock();
 }

--- a/gpcontrib/pxf/test/mock/pxffragment_mock.c
+++ b/gpcontrib/pxf/test/mock/pxffragment_mock.c
@@ -1,10 +1,18 @@
+
 void
-get_fragments(GPHDUri *uri, Relation relation, char* filter_string)
+get_fragments(GPHDUri *uri,
+              Relation relation,
+              char *filter_string,
+              ProjectionInfo *proj_info,
+              List *quals)
 {
 	check_expected(uri);
 	check_expected(relation);
 	optional_assignment(uri);
 	optional_assignment(relation);
+	optional_assignment(filter_string);
+	optional_assignment(proj_info);
+	optional_assignment(quals);
 	mock();
 }
 

--- a/gpcontrib/pxf/test/pxffilters_test.c
+++ b/gpcontrib/pxf/test/pxffilters_test.c
@@ -838,10 +838,15 @@ test__pxf_serialize_filter_list__manyFilters(void **state)
 
     result = pxf_serialize_filter_list(expressionItems);
     assert_string_equal(result, "a0c25s4d1984o5a1c25s13dGeorge Orwello5a2c25s7dWinstono5a3c25s6dEric-%o7a4c25s25d\"Ugly\" string with quoteso5a5c25s0do5a6o9");
-    pfree(result);
+	pfree(result);
 
-    pxf_free_expression_items_list(expressionItems);
-    expressionItems = NIL;
+	int trivialExpressionItems = expressionItems->length;
+	add_extra_and_expression_items(expressionItems, trivialExpressionItems - 1);
+
+	assert_int_equal(expressionItems->length, 2 * trivialExpressionItems - 1);
+
+	pxf_free_expression_items_list(expressionItems);
+	expressionItems = NIL;
 }
 
 void

--- a/gpcontrib/pxf/test/pxfprotocol_test.c
+++ b/gpcontrib/pxf/test/pxfprotocol_test.c
@@ -94,6 +94,11 @@ test_pxfprotocol_import_first_call(void **state)
 	((ExtProtocolData *) fcinfo->context)->prot_last_call = false;
 	((ExtProtocolData *) fcinfo->context)->prot_url = uri_param;
 
+	ExternalSelectDesc desc = (ExternalSelectDesc) palloc0(sizeof(ExternalSelectDesc));
+	desc->projInfo = NULL;
+
+	((ExtProtocolData*) fcinfo->context)->desc = desc;
+
 	Relation	relation = (Relation) palloc0(sizeof(Relation));
 
 	((ExtProtocolData *) fcinfo->context)->prot_relation = relation;
@@ -143,6 +148,7 @@ test_pxfprotocol_import_first_call(void **state)
 	assert_int_equal(context->relation, relation);
 
 	/* cleanup */
+	pfree(desc);
 	pfree(relation);
 	pfree(gphd_uri);
 	pfree(EXTPROTOCOL_GET_USER_CTX(fcinfo));
@@ -232,6 +238,11 @@ test_pxfprotocol_export_first_call(void **state)
 	((ExtProtocolData *) fcinfo->context)->prot_last_call = false;
 	((ExtProtocolData *) fcinfo->context)->prot_url = uri_param;
 
+	ExternalSelectDesc desc = (ExternalSelectDesc) palloc0(sizeof(ExternalSelectDesc));
+	desc->projInfo = NULL;
+
+	((ExtProtocolData*) fcinfo->context)->desc = desc;
+
 	Relation	relation = (Relation) palloc0(sizeof(Relation));
 
 	((ExtProtocolData *) fcinfo->context)->prot_relation = relation;
@@ -274,6 +285,7 @@ test_pxfprotocol_export_first_call(void **state)
 	assert_int_equal(context->relation, relation);
 
 	/* cleanup */
+	pfree(desc);
 	pfree(relation);
 	pfree(gphd_uri);
 	pfree(EXTPROTOCOL_GET_USER_CTX(fcinfo));

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -30,7 +30,7 @@ int readable_external_table_timeout = 0;
  * On error, ereport()s
  */
 URL_FILE *
-url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, List* filter_quals)
+url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, ExternalSelectDesc desc)
 {
 	/*
 	 * if 'url' starts with "execute:" then it's a command to execute and
@@ -43,7 +43,7 @@ url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, List* filter
 	else if (IS_HTTP_URI(url) || IS_GPFDIST_URI(url) || IS_GPFDISTS_URI(url))
 		return url_curl_fopen(url, forwrite, ev, pstate);
 	else
-		return url_custom_fopen(url, forwrite, ev, pstate, filter_quals);
+		return url_custom_fopen(url, forwrite, ev, pstate, desc);
 }
 
 /*
@@ -136,7 +136,10 @@ url_ferror(URL_FILE *file, int bytesread, char *ebuf, int ebuflen)
 }
 
 size_t
-url_fread(void *ptr, size_t size, URL_FILE *file, CopyState pstate)
+url_fread(void *ptr,
+          size_t size,
+          URL_FILE *file,
+          CopyState pstate)
 {
     switch (file->type)
     {

--- a/src/include/access/extprotocol.h
+++ b/src/include/access/extprotocol.h
@@ -23,20 +23,23 @@
 
 /* ------------------------- I/O function API -----------------------------*/
 
+struct ExternalSelectDescData;
+typedef struct ExternalSelectDescData *ExternalSelectDesc;
+
 /*
  * ExtProtocolData is the node type that is passed as fmgr "context" info
  * when a function is called by the External Table protocol manager.
  */
 typedef struct ExtProtocolData
 {
-	NodeTag			type;				  /* see T_ExtProtocolData */
-	Relation		prot_relation;
-	char*			prot_url;
-	char*			prot_databuf;
-	int				prot_maxbytes;
-	void*			prot_user_ctx;
-	bool			prot_last_call;
-	List*			filter_quals;
+	NodeTag            type;                  /* see T_ExtProtocolData */
+	Relation           prot_relation;
+	char               *prot_url;
+	char               *prot_databuf;
+	int                prot_maxbytes;
+	void               *prot_user_ctx;
+	bool               prot_last_call;
+	ExternalSelectDesc desc;
 } ExtProtocolData;
 
 typedef ExtProtocolData *ExtProtocol;
@@ -49,7 +52,7 @@ typedef ExtProtocolData *ExtProtocol;
 #define EXTPROTOCOL_GET_DATABUF(fcinfo)    (((ExtProtocolData*) fcinfo->context)->prot_databuf)
 #define EXTPROTOCOL_GET_DATALEN(fcinfo)    (((ExtProtocolData*) fcinfo->context)->prot_maxbytes)
 #define EXTPROTOCOL_GET_USER_CTX(fcinfo)   (((ExtProtocolData*) fcinfo->context)->prot_user_ctx)
-#define EXTPROTOCOL_GET_FILTER_QUALS(fcinfo) (((ExtProtocolData*) fcinfo->context)->filter_quals)
+#define EXTPROTOCOL_GET_EXTERNAL_SELECT_DESC(fcinfo) (((ExtProtocolData*) fcinfo->context)->desc)
 #define EXTPROTOCOL_IS_LAST_CALL(fcinfo)   (((ExtProtocolData*) fcinfo->context)->prot_last_call)
 
 #define EXTPROTOCOL_SET_LAST_CALL(fcinfo)  (((ExtProtocolData*) fcinfo->context)->prot_last_call = true)

--- a/src/include/access/fileam.h
+++ b/src/include/access/fileam.h
@@ -48,6 +48,17 @@ typedef struct ExternalInsertDescData
 
 typedef ExternalInsertDescData *ExternalInsertDesc;
 
+/*
+ * ExternalSelectDescData is used for storing state related
+ * to selecting data from an external table.
+ */
+typedef struct ExternalSelectDescData
+{
+	ProjectionInfo *projInfo;   /* Information for column projection */
+	List *filter_quals;         /* Information for filter pushdown */
+
+} ExternalSelectDescData;
+
 typedef enum DataLineStatus
 {
 	LINE_OK,
@@ -64,7 +75,12 @@ extern FileScanDesc external_beginscan(Relation relation,
 extern void external_rescan(FileScanDesc scan);
 extern void external_endscan(FileScanDesc scan);
 extern void external_stopscan(FileScanDesc scan);
-extern HeapTuple external_getnext(FileScanDesc scan, ScanDirection direction, List* filter_quals);
+extern ExternalSelectDesc
+external_getnext_init(PlanState *state);
+extern HeapTuple
+external_getnext(FileScanDesc scan,
+                 ScanDirection direction,
+                 ExternalSelectDesc desc);
 extern ExternalInsertDesc external_insert_init(Relation rel);
 extern Oid	external_insert(ExternalInsertDesc extInsertDesc, HeapTuple instup);
 extern void external_insert_finish(ExternalInsertDesc extInsertDesc);

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -14,6 +14,8 @@
 #ifndef URL_H
 #define URL_H
 
+#include "access/extprotocol.h"
+
 #include "commands/copy.h"
 
 /*
@@ -72,7 +74,7 @@ typedef struct extvar_t
 #define EXEC_URL_PREFIX "execute:"
 
 /* exported functions */
-extern URL_FILE *url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, List* filter_quals);
+extern URL_FILE *url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, ExternalSelectDesc desc);
 extern void url_fclose(URL_FILE *file, bool failOnError, const char *relname);
 extern bool url_feof(URL_FILE *file, int bytesread);
 extern bool url_ferror(URL_FILE *file, int bytesread, char *ebuf, int ebuflen);
@@ -102,7 +104,7 @@ extern bool url_execute_ferror(URL_FILE *file, int bytesread, char *ebuf, int eb
 extern size_t url_execute_fread(void *ptr, size_t size, URL_FILE *file, CopyState pstate);
 extern size_t url_execute_fwrite(void *ptr, size_t size, URL_FILE *file, CopyState pstate);
 
-extern URL_FILE *url_custom_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, List* filter_quals);
+extern URL_FILE *url_custom_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, ExternalSelectDesc desc);
 extern void url_custom_fclose(URL_FILE *file, bool failOnError, const char *relname);
 extern bool url_custom_feof(URL_FILE *file, int bytesread);
 extern bool url_custom_ferror(URL_FILE *file, int bytesread, char *ebuf, int ebuflen);


### PR DESCRIPTION
We introduce a new structure `ExternalSelectDesc` in ExtProtocolData
that encapsulates projection information (`ProjectionInfo`) as well
as filter qualifiers. This allows for external protocols to do filter
pushdown and column projection (which is the contribution of this PR).
We have modified the PXF protocol to make use of both these attributes.

Co-authored: Francisco Guerrero <aguerrero@pivotal.io>
Co-authored: Shivram Mani <smani@pivotal.io>