### PR TITLE
gpstate: Display absolute value of PID for negative PIDs

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -1044,7 +1044,7 @@ class GpSystemStateProgram:
                 data.addValue(VALUE__LOCK_FILES_EXIST, "t" if found else "f", isWarning=not found)
 
                 if pidData['error'] is None:
-                    data.addValue(VALUE__ACTIVE_PID, pidData["pid"])
+                    data.addValue(VALUE__ACTIVE_PID, abs(pidData["pid"]))
                     data.addValue(VALUE__ACTIVE_PID_INT, pidValueForSql)
                 else:
                     data.addValue(VALUE__ACTIVE_PID, "Not found", True)


### PR DESCRIPTION
The gpstate utility opens up the postmaster.pid file to read and
display its contents to the user in a nice way.  One of those items
from postmaster.pid is the pid of the postmaster process.  When the
postmaster is in the single-user mode (e.g. pg_rewind ensuring clean
shutdown), the pid in the postmaster.pid file is negative.  This is
intentional, but we should display it as positive to the user to avoid
any confusion.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>
Co-authored-by: Shoaib Lari <slari@pivotal.io>
