### PR TITLE
Avoid changing rd_cdbpolicy at relcache invalidation.

### DIFF
--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -33,6 +33,7 @@
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
+#include "utils/memutils.h"
 #include "utils/tqual.h"
 #include "utils/syscache.h"
 
@@ -762,7 +763,10 @@ checkPolicyForUniqueIndex(Relation rel, AttrNumber *indattr, int nidxatts,
 		}
 
 		GpPolicyReplace(rel->rd_id, policy);
-		rel->rd_cdbpolicy = policy;
+
+		MemoryContext oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
+		rel->rd_cdbpolicy = GpPolicyCopy(policy);
+		MemoryContextSwitchTo(oldcontext);
 
 		if (Gp_role == GP_ROLE_DISPATCH)
 			elog(NOTICE, "updating distribution policy to match new %s", isprimary ? "primary key" : "unique index");


### PR DESCRIPTION
The code in CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses() would
sometimes crash or throw an error that leads to falling back to postgres
planner, if a relcache invalidation happened after fetching the
Relation->rd_cdbpolicy to a local variable. To fix, change relcache
invalidation to not change rd_cdbpolicy, if there has been no actual
change to the relation's policy. This is similar to how rd_rel is handled.

Since we're holding a lock on the table, the policy cannot change while
we're looking at it. So this doesn't just reduce the odds; it fixes the
issue for real.

Debugged-by: Ekta Khanna <ekhanna@pivotal.io>
