### PR TITLE
Re-enable SSL TAP tests

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -148,6 +148,14 @@ $(call recurse,installcheck-world, \
 			   gpcontrib \
 			   src/bin/ \
 			   gpMgmt/bin,installcheck)
+
+# GPDB: Postgres disables the SSL tests during ICW because of the TCP port that
+# it opens to other users on the same machine during testing. GPDB makes no such
+# security guarantees during tests: currently, it is unsafe to run
+# installcheck-world on a machine with untrusted users.
+$(call recurse,installcheck-world, \
+			   src/test/ssl,check)
+
 .PHONY: installcheck-gpcheckcat
 installcheck-world: installcheck-gpcheckcat
 installcheck-gpcheckcat:

--- a/src/test/ssl/Makefile
+++ b/src/test/ssl/Makefile
@@ -131,4 +131,8 @@ clean distclean maintainer-clean:
 	rm -rf tmp_check
 
 check:
-	echo "ssl check temporarily disabled."
+ifeq ($(with_openssl),yes)
+	$(prove_check)
+else
+	@echo "SSL is disabled for this build"
+endif


### PR DESCRIPTION
To fix the SSL TAP tests, revert most of the implementation to upstream 9.6 (commit https://github.com/postgres/postgres/commit/41740b9ef, right before a major refactor to `ServerSetup.pm`). This removes the GPDB-specific implementations of the test node setup, which weren't really setting up a new node anyway; they were modifying whatever GPDB cluster they found in the environment. Since the SSL tests don't need a full cluster to run, we can stop carrying that diff.

Notable remaining differences from 9.6 include

- the commenting out of the `wal_retrieve_retry_interval` GUC, which is not yet supported in GPDB

- the addition of GPDB-specific options to `pg_ctl start` to create a standalone segment, and the use of utility mode to connect to it

- the use of `note()` instead of `diag()` in the test suite, for cosmetic reasons (we can probably remove that diff once we catch up to 9.6)

- the continued commenting-out of SAN tests, which we plan to reinstate in a future commit

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
