### PR TITLE
Pull libsigar from GCS for Centos{6,7}

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -422,6 +422,13 @@ resources:
     json_key: ((gcs-key))
     regexp: centos6/libquicklz-devel-(\d.*)\.el6\.x86_64\.rpm
 
+- name: libsigar-centos6-gcs
+  type: gcs
+  source:
+    bucket: ((pivotal-gp-internal-artifacts-gcs-bucket))
+    json_key: ((gcs-key))
+    regexp: centos6/sigar-rhel6_x86_64-(.*)\.targz
+
 {% endif %}
 {% if "centos7" in os_types %}
 - name: libquicklz-centos7
@@ -437,6 +444,13 @@ resources:
     bucket: ((pivotal-gp-internal-artifacts-gcs-bucket))
     json_key: ((gcs-key))
     regexp: centos7/libquicklz-devel-(\d.*)\.el7\.x86_64\.rpm
+
+- name: libsigar-centos7-gcs
+  type: gcs
+  source:
+    bucket: ((pivotal-gp-internal-artifacts-gcs-bucket))
+    json_key: ((gcs-key))
+    regexp: centos7/sigar-rhel7_x86_64-(.*)\.targz
 
 {% endif %}
 {% if "centos6" in os_types %}
@@ -840,6 +854,8 @@ jobs:
       resource: libquicklz-centos6
     - get: libquicklz-devel-installer
       resource: libquicklz-devel-centos6
+    - get: libsigar-gcs
+      resource: libsigar-centos6-gcs
     - get: python-tarball
       resource: python-centos6
   - task: sync_tools
@@ -882,6 +898,8 @@ jobs:
       resource: libquicklz-centos7
     - get: libquicklz-devel-installer
       resource: libquicklz-devel-centos7
+    - get: libsigar-gcs
+      resource: libsigar-centos7-gcs
     - get: python-tarball
       resource: python-centos7
   - task: sync_tools

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -422,7 +422,7 @@ resources:
     json_key: ((gcs-key))
     regexp: centos6/libquicklz-devel-(\d.*)\.el6\.x86_64\.rpm
 
-- name: libsigar-centos6-gcs
+- name: libsigar-centos6
   type: gcs
   source:
     bucket: ((pivotal-gp-internal-artifacts-gcs-bucket))
@@ -445,7 +445,7 @@ resources:
     json_key: ((gcs-key))
     regexp: centos7/libquicklz-devel-(\d.*)\.el7\.x86_64\.rpm
 
-- name: libsigar-centos7-gcs
+- name: libsigar-centos7
   type: gcs
   source:
     bucket: ((pivotal-gp-internal-artifacts-gcs-bucket))
@@ -854,8 +854,8 @@ jobs:
       resource: libquicklz-centos6
     - get: libquicklz-devel-installer
       resource: libquicklz-devel-centos6
-    - get: libsigar-gcs
-      resource: libsigar-centos6-gcs
+    - get: libsigar-installer
+      resource: libsigar-centos6
     - get: python-tarball
       resource: python-centos6
   - task: sync_tools
@@ -898,8 +898,8 @@ jobs:
       resource: libquicklz-centos7
     - get: libquicklz-devel-installer
       resource: libquicklz-devel-centos7
-    - get: libsigar-gcs
-      resource: libsigar-centos7-gcs
+    - get: libsigar-installer
+      resource: libsigar-centos7
     - get: python-tarball
       resource: python-centos7
   - task: sync_tools

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -15,18 +15,21 @@ function expand_glob_ensure_exists() {
   echo "${glob[0]}"
 }
 
-function install_deps_for_centos() {
-  # quicklz is proprietary code that we cannot put in our public Docker images.
-  rpm -i libquicklz-installer/libquicklz-*.rpm
-  rpm -i libquicklz-devel-installer/libquicklz-*.rpm
-}
-
 function prep_env_for_centos() {
   case "${TARGET_OS_VERSION}" in
     6|7) BLD_ARCH=rhel${TARGET_OS_VERSION}_x86_64 ;;
     *) echo "TARGET_OS_VERSION not set or recognized for Centos/RHEL" ; exit 1 ;;
   esac
 }
+
+function install_deps_for_centos() {
+  # quicklz is proprietary code that we cannot put in our public Docker images.
+  rpm -i libquicklz-installer/libquicklz-*.rpm
+  rpm -i libquicklz-devel-installer/libquicklz-*.rpm
+  # install libsigar from tar.gz
+  tar zxf libsigar-gcs/sigar-*.targz -C gpdb_src/gpAux/ext
+}
+
 
 function link_tools_for_centos() {
   tar xf python-tarball/python-*.tar.gz -C $(pwd)/${GPDB_SRC_PATH}/gpAux/ext
@@ -161,8 +164,8 @@ function _main() {
 
   case "${TARGET_OS}" in
     centos)
-      install_deps_for_centos
       prep_env_for_centos
+      install_deps_for_centos
       link_tools_for_centos
       ;;
     sles)

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -27,7 +27,7 @@ function install_deps_for_centos() {
   rpm -i libquicklz-installer/libquicklz-*.rpm
   rpm -i libquicklz-devel-installer/libquicklz-*.rpm
   # install libsigar from tar.gz
-  tar zxf libsigar-gcs/sigar-*.targz -C gpdb_src/gpAux/ext
+  tar zxf libsigar-installer/sigar-*.targz -C gpdb_src/gpAux/ext
 }
 
 

--- a/concourse/scripts/sync_tools.bash
+++ b/concourse/scripts/sync_tools.bash
@@ -38,9 +38,14 @@ function _main() {
         ;;
   esac
 
+  # We have moved out of ivy for Centos{6,7}, so make sync_tools
+  # will not create the necessary directory for centos.
+  if [ "${TARGET_OS}" = centos ]; then
+    mkdir -p ${GPDB_SRC_PATH}/gpAux/ext/${BLD_ARCH}
+  fi
   make_sync_tools
 
-  # Move ext directory to output dir
+  # Move ext directory to output dir.
   mv ${GPDB_SRC_PATH}/gpAux/ext gpAux_ext/
 
 }

--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -7,6 +7,7 @@ inputs:
   - name: gpAux_ext
   - name: libquicklz-installer
   - name: libquicklz-devel-installer
+  - name: libsigar-gcs
   - name: python-tarball
 outputs:
   - name: gpdb_artifacts

--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -7,7 +7,7 @@ inputs:
   - name: gpAux_ext
   - name: libquicklz-installer
   - name: libquicklz-devel-installer
-  - name: libsigar-gcs
+  - name: libsigar-installer
   - name: python-tarball
 outputs:
   - name: gpdb_artifacts

--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -16,7 +16,7 @@
       <dependency org="OpenSSL"         name="openssl"         rev="1.0.2l"         conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64;aix7_ppc_64->aix7_ppc_64" />
       <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
       <dependency org="third-party"     name="ext"             rev="gpdb6_ext-4.2"  conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
-      <dependency org="Hyperic"         name="sigar"           rev="1.6.5"          conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel7_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
+      <dependency org="Hyperic"         name="sigar"           rev="1.6.5"          conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="Python"          name="python-gpdb5"    rev="2.7.12"         conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="cURL"            name="curl"            rev="7.54.0"         conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="OpenLDAP"        name="openldap"        rev="2.4.44"         conf="suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />


### PR DESCRIPTION
We now pull down the libsigar artifacts (.targz) from GCS for Centos
instead of ivy.

Co-authored-by: Nandish Jayaram <njayaram@pivotal.io>
Co-authored-by: Sambitesh Dash <sdash@pivotal.io>

## Here are some reminders before you submit the pull request
- [x ] Add tests for the change
- [x ] Document changes
- [x ] Communicate in the mailing list if needed
- [x ] Pass `make installcheck`
