### PR TITLE
Ensure that Test::More is installed when --enable-tap-tests is set.

### DIFF
--- a/configure
+++ b/configure
@@ -19746,7 +19746,7 @@ fi
 
 if test "x$PERL" != x; then
   ax_perl_modules_failed=0
-  for ax_perl_module in 'IPC::Run' ; do
+  for ax_perl_module in 'IPC::Run' 'Test::More' ; do
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for perl module $ax_perl_module" >&5
 $as_echo_n "checking for perl module $ax_perl_module... " >&6; }
 
@@ -19768,7 +19768,7 @@ $as_echo "ok" >&6; };
 
   else
     :
-    as_fn_error $? "Perl module IPC::Run is required to run TAP tests" "$LINENO" 5
+    as_fn_error $? "Perl modules IPC::Run and Test::More are required to run TAP tests" "$LINENO" 5
   fi
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: could not find perl" >&5


### PR DESCRIPTION
We recently allowed enabling of TAP tests. However, we did not update the required dependencies in `./configure` to reflect the necessary dependencies to run the TAP tests.

This change adds the last of the required dependencies to the configure script.