### PR TITLE
Add GUC to enable / disable eager agg transformation

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.26.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.27.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.26.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.27.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.26.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.27.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.26.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.27.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.26.0@gpdb/stable
+orca/v3.27.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.26.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.27.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -521,6 +521,9 @@ CConfigParamMapping::PackConfigParamInBitset
 		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfJoinAssociativity));
 	}
 
+	// disable eager agg xform
+	traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::EopttraceEnableEagerAgg));
+
 	return traceflag_bitset;
 }
 


### PR DESCRIPTION
In 5X, eager agg is disabled by default. This is a developer GUC.

Bump ORCA to v3.27.0

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
