### PR TITLE
Set VARTAG_ONDISK to the appropriate value for Greenplum

### DIFF
--- a/src/include/postgres.h
+++ b/src/include/postgres.h
@@ -98,11 +98,17 @@ typedef struct varatt_indirect
  * Type tag for the various sorts of "TOAST pointer" datums.  The peculiar
  * value for VARTAG_ONDISK comes from a requirement for on-disk compatibility
  * with a previous notion that the tag field was the pointer datum's length.
+ *
+ * GPDB: In PostgreSQL VARTAG_ONDISK is set to 18 in order to match the
+ * historic (VARHDRSZ_EXTERNAL + sizeof(struct varatt_external)) value of the
+ * pointer datum's length. In Greenplum VARHDRSZ_EXTERNAL is two bytes longer
+ * than PostgreSQL due to extra padding in varattrib_1b_e, so VARTAG_ONDISK has
+ * to be set to 20.
  */
 typedef enum vartag_external
 {
 	VARTAG_INDIRECT = 1,
-	VARTAG_ONDISK = 18
+	VARTAG_ONDISK = 20
 } vartag_external;
 
 #define VARTAG_SIZE(tag) \
@@ -140,11 +146,7 @@ typedef struct
 	char		va_data[1];		/* Data begins here */
 } varattrib_1b;
 
-/* NOT Like Postgres! ...In GPDB, We waste a few bytes of padding, and don't always set the va_len_1be to anything */
-/* GPDB_94_MERGE_FIXME: The va_len_1be field was changed to va_tag in PostgreSQL 9.4.
- * There were comments here that va_len_1be was ignored in GPDB. Does this change to
- * va_tag work correctly with pg_upgrade in GPDB?
- */
+/* NOT Like Postgres! ...In GPDB, We waste a few bytes of padding */
 typedef struct
 {
 	uint8		va_header;		/* Always 0x80  */


### PR DESCRIPTION
Upstream added support for multiple kinds of external toast datums (commit
3682025015390a). In the heart of the implementation, the representation of the
inline portion of a short varlena was modified to store a tag describing the
location of the datum pointed to, namely memory or disk. The tag took the place
of the member which was describing the length of the datum pointed to. Since in
upstream the length, for on disk datums, was always set to (VARHDRSZ_EXTERNAL +
sizeof(struct varatt_external)), the enum for the corresponding tag was chosen
to be exactly that, i.e. 18.

In Greenplum, the exact same thing happens. However, due to historic reasons,
there is an additional two byte padding in the struct. That representation has
(and still is) been reflected in VARHDRSZ_EXTERNAL, which means that Greenplum
has been storing a value for length two bytes longer than upstream.

This commit updates the value of VARTAG_ONDISK to match the value that Greenplum
has been historically storing. The other solution would have been to re-write
the data during upgrade, but it seems unreasonably risky and evasive to do so.

This commit also removes a comment that stated that Greenplum did not always set
the length of the datum pointed to. Extensive search in the latest 5 and 4
versions of Greenplum did not found this to be true anymore. If it were, then
some data rewriting would have been required while upgrading Greenplum.

Previous versions of Greenplum, (pre-2009) have not been checked and it should
be considered that data from those versions will break if binary upgraded to the current
version.

Removes a GPDB_94_MERGE_FIXME.

Co-authored-by: Daniel Gustafsson <dgustafsson@pivotal.io>
