### PR TITLE
Fix getopt() call in aux process initialization.

### DIFF
--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -174,6 +174,7 @@ typedef struct _IndexList
 
 static IndexList *ILHead = NULL;
 
+
 /*
  *	 AuxiliaryProcessMain
  *
@@ -230,7 +231,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 	/* If no -x argument, we are a CheckerProcess */
 	MyAuxProcType = CheckerProcess;
 
-	while ((flag = getopt(argc, argv, "B:c:d:D:Fkr:x:y:-:")) != -1)
+	while ((flag = getopt(argc, argv, "B:c:d:D:Fkr:x:-:")) != -1)
 	{
 		switch (flag)
 		{
@@ -435,7 +436,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 			proc_exit(1);		/* should never return */
 
 		case CheckpointerProcess:
-			/* don't set signals, checkpointer is similar to bgwriter and has its own agenda */
+			/* don't set signals, checkpointer has its own agenda */
 			CheckpointerMain();
 			proc_exit(1);		/* should never return */
 
@@ -448,7 +449,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 		case WalReceiverProcess:
 			/* don't set signals, walreceiver has its own agenda */
 			WalReceiverMain();
-			proc_exit(1);
+			proc_exit(1);		/* should never return */
 
 		default:
 			elog(PANIC, "unrecognized process type: %d", (int) MyAuxProcType);


### PR DESCRIPTION
The 'y' option was removed in PostgreSQL 8.3 already, but we missed that in
the merge. While we're at it, fix the comments and whitespace to match
upstream, so that bootstrap.c is now 100% identical to the 9.4.20 version.
