### PR TITLE
Remove remnants of wal_consistency_checking.

### DIFF
--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -50,8 +50,7 @@ typedef struct XLogRecord
 	uint32		xl_len;			/* total len of rmgr data */
 	uint8		xl_info;		/* flag bits, see below */
 	RmgrId		xl_rmid;		/* resource manager for this record */
-	uint8       xl_extended_info; /* flag bits, see below */
-	/* 1 byte of padding here, initialize to zero */
+	/* 2 bytes of padding here, initialize to zero */
 	XLogRecPtr	xl_prev;		/* ptr to previous record in log */
 	pg_crc32	xl_crc;			/* CRC for this record */
 

--- a/src/include/access/xlog_internal.h
+++ b/src/include/access/xlog_internal.h
@@ -48,12 +48,9 @@ typedef struct BkpBlock
 	BlockNumber block;			/* block number */
 	uint16		hole_offset;	/* number of bytes before "hole" */
 	uint16		hole_length;	/* number of bytes in "hole" */
-	uint8       block_info;    /* flags, controls to apply the block or not for now */
+
 	/* ACTUAL BLOCK DATA FOLLOWS AT END OF STRUCT */
 } BkpBlock;
-
-/* Information stored in block_info */
-#define BLOCK_APPLY 0x01 /* page image should be restored during replay */
 
 /*
  * Each page of XLOG file has a header like this:


### PR DESCRIPTION
Most of the "masking" code was removed in 9.3 merge already, and the
rest in commit c9dee15b08. But these were left over.
