### PR TITLE
WorkerPool: improve waiting behavior and API

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -1297,12 +1297,13 @@ class AnalyzeWorkerPool(WorkerPool):
         self.work_queue = Queue()
         self.completed_queue = Queue()
         self.should_stop = False
-        self.num_assigned = 0
+        self._assigned = 0
         self.daemonize = False
+        self.logger = logger
+
         if items is not None:
             for item in items:
-                self.work_queue.put(item)
-                self.num_assigned += 1
+                self.addCommand(item)
 
         for i in range(0, numWorkers):
             # use AnalyzeWorker instead of Worker
@@ -1310,7 +1311,6 @@ class AnalyzeWorkerPool(WorkerPool):
             self.workers.append(w)
             w.start()
         self.numWorkers = numWorkers
-        self.logger = logger
 
 
 class AnalyzeWorker(Worker):

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1620,7 +1620,7 @@ ORDER BY fq_name, tableoid desc;
         # wait till done.
         while not self.queue.isDone():
             logger.debug(
-                "woke up.  queue: %d finished %d  " % (self.queue.num_assigned, self.queue.completed_queue.qsize()))
+                "woke up.  queue: %d finished %d  " % (self.queue.assigned, self.queue.completed_queue.qsize()))
             if stopTime and datetime.datetime.now() >= stopTime:
                 stoppedEarly = True
                 break

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -91,17 +91,6 @@ class WorkerPool(object):
         self.work_queue.put(cmd)
         self.num_assigned += 1
 
-    def wait_and_printdots(self, command_count, quiet=True):
-        while self.completed_queue.qsize() < command_count:
-            time.sleep(1)
-
-            if not quiet:
-                sys.stdout.write(".")
-                sys.stdout.flush()
-        if not quiet:
-            print " "
-        self.join()
-
     def print_progress(self, command_count):
         while True:
             num_completed = self.completed_queue.qsize()
@@ -196,6 +185,25 @@ class WorkerPool(object):
         for w in self.workers:
             w.haltWork()
             self.work_queue.put(self.halt_command)
+
+
+def join_and_indicate_progress(pool, outfile=sys.stdout, interval=1):
+    """
+    Waits for a WorkerPool to complete its work, flushing dots to stdout every
+    second. If any dots are printed (i.e. the work takes longer than the
+    printing interval), a newline is also printed upon completion.
+
+    The file to print to and the interval between printings can be overridden.
+    """
+    printed = False
+
+    while not pool.join(interval):
+        outfile.write('.')
+        outfile.flush()
+        printed = True
+
+    if printed:
+        outfile.write('\n')
 
 
 class OperationWorkerPool(WorkerPool):

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -91,17 +91,6 @@ class WorkerPool(object):
         self.work_queue.put(cmd)
         self._assigned += 1
 
-    def print_progress(self, command_count):
-        while True:
-            num_completed = self.completed_queue.qsize()
-            num_completed_percentage = 0
-            if command_count:
-                num_completed_percentage = float(num_completed) / command_count
-            self.logger.info('%0.2f%% of jobs completed' % (num_completed_percentage * 100))
-            if num_completed >= command_count:
-                return
-            self._join_work_queue_with_timeout(10)
-
     def _join_work_queue_with_timeout(self, timeout):
         """
         Queue.join() unfortunately doesn't take a timeout (see

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
@@ -74,7 +74,3 @@ class WorkerPoolTestCase(unittest.TestCase):
         self.subject.execute(cmd)
         self.assertEquals("bar=1 && foo=1 && ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 localhost "
                           "\". gphome/greenplum_path.sh; bar=1 && foo=1 && ls /tmp\"", cmd.cmdStr)
-
-    def test_no_workders_in_WorkerPool(self):
-        with self.assertRaises(Exception):
-            WorkerPool(numWorkers=0)

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
@@ -13,26 +13,6 @@ class WorkerPoolTestCase(unittest.TestCase):
     def tearDown(self):
         Command.propagate_env_map.clear()
 
-    @patch('gppylib.commands.base.gplog.get_default_logger')
-    def test_print_progress(self, mock1):
-        w = WorkerPool(numWorkers=32)
-        c1 = Command('dummy command1', '')
-        c2 = Command('dummy command2', '')
-        w.addCommand(c1)
-        w.addCommand(c2)
-        w.join()
-        w.print_progress(2)
-        self.assertTrue(mock1.called_with('100.00% of jobs completed'))
-        w.haltWork()
-
-    @patch('gppylib.commands.base.gplog.get_default_logger')
-    def test_print_progress_none(self, mock1):
-        w = WorkerPool(numWorkers=32)
-        w.print_progress(0)
-        w.join()
-        self.assertTrue(mock1.called_with('0.00% of jobs completed'))
-        w.haltWork()
-
     def test_RemoteExecutionContext_uses_default_gphome(self):
         self.subject = RemoteExecutionContext("myhost", "my_stdin")
         cmd = Command("dummy name", "echo 'foo'")

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -395,7 +395,11 @@ class GpMirrorListToBuild:
         for cmd in cmds:
             self.__pool.addCommand(cmd)
 
-        self.__pool.wait_and_printdots(len(cmds), self.__quiet)
+        if self.__quiet:
+            self.__pool.join()
+        else:
+            base.join_and_indicate_progress(self.__pool)
+
         if not suppressErrorCheck:
             self.__pool.check_results()
         self.__pool.empty_completed_items()
@@ -456,7 +460,12 @@ class GpMirrorListToBuild:
             cmds.append(createConfigureNewSegmentCommand(hostName, 'validate blank segments', True))
         for cmd in cmds:
             self.__pool.addCommand(cmd)
-        self.__pool.wait_and_printdots(len(cmds), self.__quiet)
+
+        if self.__quiet:
+            self.__pool.join()
+        else:
+            base.join_and_indicate_progress(self.__pool)
+
         validationErrors = []
         for item in self.__pool.getCompletedItems():
             results = item.get_results()

--- a/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
+++ b/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
@@ -37,7 +37,6 @@ class GpSegmentRebalanceOperation:
         self.logger.info("Getting unbalanced segments")
         unbalanced_primary_segs = GpArray.getSegmentsByHostName(self.gpArray.get_unbalanced_primary_segdbs())
         pool = base.WorkerPool()
-        count = 0
 
         try:
             # Disable ctrl-c
@@ -54,9 +53,8 @@ class GpSegmentRebalanceOperation:
                                    remoteHost=hostname,
                                    timeout=600)
                 pool.addCommand(cmd)
-                count += 1
 
-            pool.wait_and_printdots(count, False)
+            base.join_and_indicate_progress(pool)
             
             failed_count = 0
             completed = pool.getCompletedItems()

--- a/gpMgmt/bin/gppylib/operations/startSegments.py
+++ b/gpMgmt/bin/gppylib/operations/startSegments.py
@@ -162,7 +162,6 @@ class StartSegmentsOperation:
             logger.info("Commencing parallel primary and mirror segment instance startup, please wait...")
         else:
             logger.info("Commencing parallel segment instance startup, please wait...")
-        dispatchCount=0
 
         dbIdToPeerMap = gpArray.getDbIdToPeerMap()
 
@@ -202,9 +201,11 @@ class StartSegmentsOperation:
                                    parallel=self.__parallel,
                                    logfileDirectory=self.logfileDirectory)
             self.__workerPool.addCommand(cmd)
-            dispatchCount+=1
 
-        self.__workerPool.wait_and_printdots(dispatchCount, self.__quiet)
+        if self.__quiet:
+            self.__workerPool.join()
+        else:
+            base.join_and_indicate_progress(self.__workerPool)
 
         # process results
         self.__processStartOrConvertCommands(resultOut)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_workerpool.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_workerpool.py
@@ -1,0 +1,93 @@
+import unittest
+import threading
+
+import mock
+
+from gppylib.commands.base import Command, ExecutionError, WorkerPool
+
+class WorkerPoolTest(unittest.TestCase):
+    def setUp(self):
+        self.pool = WorkerPool(numWorkers=1, logger=mock.Mock())
+
+    def tearDown(self):
+        # All background threads must be stopped, or else the test runner will
+        # hang waiting. Join the stopped threads to make sure we're completely
+        # clean for the next test.
+        self.pool.haltWork()
+        self.pool.joinWorkers()
+
+    def test_pool_must_have_some_workers(self):
+        with self.assertRaises(Exception):
+            WorkerPool(numWorkers=0)
+        
+    def test_pool_runs_added_command(self):
+        cmd = mock.Mock(spec=Command)
+
+        self.pool.addCommand(cmd)
+        self.pool.join()
+
+        cmd.run.assert_called_once_with()
+
+    def test_completed_commands_are_retrievable(self):
+        cmd = mock.Mock(spec=Command)
+
+        self.pool.addCommand(cmd) # should quickly be completed
+        self.pool.join()
+
+        self.assertEqual(self.pool.getCompletedItems(), [cmd])
+
+    def test_pool_is_not_marked_done_until_commands_finish(self):
+        cmd = mock.Mock(spec=Command)
+
+        # cmd.run() will block until this Event is set.
+        event = threading.Event()
+        def wait_for_event():
+            event.wait()
+        cmd.run.side_effect = wait_for_event
+
+        self.assertTrue(self.pool.isDone())
+
+        self.pool.addCommand(cmd)
+        self.assertFalse(self.pool.isDone())
+
+        event.set()
+        self.pool.join()
+
+        self.assertTrue(self.pool.isDone())
+
+    def test_pool_can_be_emptied_of_completed_commands(self):
+        cmd = mock.Mock(spec=Command)
+
+        self.pool.addCommand(cmd)
+        self.pool.join()
+
+        self.pool.empty_completed_items()
+        self.assertEqual(self.pool.getCompletedItems(), [])
+
+    def test_check_results_succeeds_when_no_items_fail(self):
+        cmd = mock.Mock(spec=Command)
+
+        # Command.get_results() returns a CommandResult.
+        # CommandResult.wasSuccessful() should return True if the command
+        # succeeds.
+        result = cmd.get_results.return_value
+        result.wasSuccessful.return_value = True
+
+        self.pool.addCommand(cmd)
+        self.pool.join()
+        self.pool.check_results()
+
+    def test_check_results_throws_exception_at_first_failure(self):
+        cmd = mock.Mock(spec=Command)
+
+        # Command.get_results() returns a CommandResult.
+        # CommandResult.wasSuccessful() should return False to simulate a
+        # failure.
+        result = cmd.get_results.return_value
+        result.wasSuccessful.return_value = False
+
+        self.pool.addCommand(cmd)
+        self.pool.join()
+
+        with self.assertRaises(ExecutionError):
+            self.pool.check_results()

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -530,7 +530,6 @@ class GpStart:
         # stop them, stopping primaries before mirrors
         #
         for type in ["primary", "mirror"]:
-            dispatch_count = 0
             for hostName, segments in segmentsByHost.iteritems():
 
                 if type == "primary":
@@ -546,11 +545,11 @@ class GpStart:
                                           verbose=logging_is_verbose(),
                                           ctxt=base.REMOTE, remoteHost=hostName)
                     self.pool.addCommand(cmd)
-                    dispatch_count += 1
 
-            if dispatch_count > 0:
-                self.pool.wait_and_printdots(dispatch_count, self.quiet)
-        pass
+            if self.quiet:
+                self.pool.join()
+            else:
+                base.join_and_indicate_progress(self.pool)
 
     ######
     def _print_segment_start(self, segmentStartResult, invalidSegments, willShutdownSegments):

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -60,6 +60,28 @@ class SegStopStatus:
             self.db.dbid, self.db.hostname, self.db.datadir, self.reason)
 
 
+def print_progress(pool, interval=10):
+    """
+    Waits for a WorkerPool to complete, printing a progress percentage marker
+    once at the beginning of the call, and thereafter at the provided interval
+    (default ten seconds). A final 100% marker is printed upon completion.
+    """
+    def print_completed_percentage():
+        # pool.completed can change asynchronously; save its value.
+        completed = pool.completed
+
+        pct = 0
+        if pool.assigned:
+            pct = float(completed) / pool.assigned
+
+        pool.logger.info('%0.2f%% of jobs completed' % (pct * 100))
+        return completed >= pool.assigned
+
+    # print_completed_percentage() returns True if we're done.
+    while not print_completed_percentage():
+        pool.join(interval)
+
+
 # ---------------------------------------------------------------
 class GpStop:
     ######
@@ -572,8 +594,6 @@ class GpStop:
 
     ######
     def _stopseg_cmds(self, includePrimaries, includeMirrors, segs):
-        dispatch_count = 0
-
         host_segs_map = {}
         for seg in segs:
             if seg.getSegmentHostName() in host_segs_map.keys():
@@ -603,10 +623,8 @@ class GpStop:
                                   verbose=logging_is_verbose(), ctxt=base.REMOTE, remoteHost=hostname,
                                   logfileDirectory=self.logfileDirectory)
             self.pool.addCommand(cmd)
-            dispatch_count += 1
 
-        self.pool.print_progress(dispatch_count)
-        pass
+        print_progress(self.pool)
 
     ######
     def _process_segment_stop(self, failed_seg_status):

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -743,7 +743,6 @@ class GpStop:
 
         self.pool = SighupWorkerPool(numWorkers=workers)
         dbList = self.gparray.getDbList()
-        dispatch_count = 0
         hostname = socket.gethostname()
         logger.info("Signalling all postmaster processes to reload")
         for db in dbList:
@@ -758,8 +757,12 @@ class GpStop:
                                   remoteHost=remote_host
                                   )
             self.pool.addCommand(cmd)
-            dispatch_count = dispatch_count + 1
-        self.pool.wait_and_printdots(dispatch_count, self.quiet)
+
+        if self.quiet:
+            self.pool.join()
+        else:
+            base.join_and_indicate_progress(self.pool)
+
         self.pool.check_results()
         self.pool.empty_completed_items()
 


### PR DESCRIPTION
This PR is motivated by the observation that several utilities rely on the `WorkerPool` to perform parallel work, and one of the pool's key methods (`wait_and_printdots()`) performs a hard-coded `time.sleep(1)` in its wait loop. Other utilities (such as gpexpand) also perform sleep-loops while waiting on the pool. This behavior makes it difficult to make the utilities faster: once we hit that sleep, we wait for the full duration, even if the pool completes in the next millisecond. This is common for some of the smaller utilities like gpstate. 

A new API primitive is needed. The centerpiece of this patchset is the introduction of an optional timeout to `WorkerPool.join()`, which will eventually let us replace sleep-loops with logic like this:
```python
# Display progress once a second
while not pool.join(1):
    print("Not finished yet")
    do_other_quick_work()
```
For example, the `wait_and_printdots()` sleep-loop has been moved outside the class and improved using the new API.

The latter half of the patchset adds two new properties to `WorkerPool` to make it easier for wait loop implementations to compute the `(completed / total)` progress of the pool. This allows gpstop's `print_progress()` helper to be moved outside the class itself, and it should make it pretty easy to eventually replace other the stragglers as well.

I recommend going commit-by-commit, to see which tests correspond to which functionality, but the overall diff isn't too bad either.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
