### PR TITLE
Speed up gpstate

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -7,6 +7,7 @@
 TODO: docs!
 """
 import os, pickle, base64, time
+import os.path
 
 import re, socket
 
@@ -1307,13 +1308,8 @@ def chk_local_db_running(datadir, port):
         finally:
             f.close()
 
-    cmd=FileDirExists('check for /tmp/.s.PGSQL file file', "/tmp/.s.PGSQL.%d" % port)
-    cmd.run(validateAfter=True)
-    tmpfile_exists = cmd.filedir_exists()
-
-    cmd=FileDirExists('check for lock file', get_lockfile_name(port))
-    cmd.run(validateAfter=True)
-    lockfile_exists = cmd.filedir_exists()
+    tmpfile_exists = os.path.exists("/tmp/.s.PGSQL.%d" % port)
+    lockfile_exists = os.path.exists(get_lockfile_name(port))
 
     netstat_port_active = PgPortIsActive.local('check netstat for postmaster port',"/tmp/.s.PGSQL.%d" % port, port)
 

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -740,10 +740,7 @@ class Echo(Command):
 # --------------get user id ----------------------
 class UserId(Command):
     def __init__(self, name, ctxt=LOCAL, remoteHost=None):
-        idCmd = findCmdInPath('id')
-        trCmd = findCmdInPath('tr')
-        awkCmd = findCmdInPath('awk')
-        cmdStr = "%s|%s '(' ' '|%s ')' ' '|%s '{print $2}'" % (idCmd, trCmd, trCmd, awkCmd)
+        cmdStr = "%s -un" % findCmdInPath('id')
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     @staticmethod

--- a/gpMgmt/bin/gppylib/db/dbconn.py
+++ b/gpMgmt/bin/gppylib/db/dbconn.py
@@ -114,7 +114,10 @@ class DbURL:
             self.pgdb = dbname
 
         if username is None:
-            self.pguser = os.environ.get('PGUSER', os.environ.get('USER', UserId.local('Get uid')))
+            self.pguser = os.environ.get('PGUSER', os.environ.get('USER', None))
+            if self.pguser is None:
+                # fall back to /usr/bin/id
+                self.pguser = UserId.local('Get uid')
             if self.pguser is None or self.pguser == '':
                 raise Exception('Both $PGUSER and $USER env variables are not set!')
         else:


### PR DESCRIPTION
The recent gpstate work exposed some performance issues. Here are some of the low-hanging fruit.

- Don't use another Python interpreter to check for the existence of a file.
- Don't call `/usr/bin/id` if we're not going to use the output.
- Don't process `/usr/bin/id` output through an awk pipeline when there are options that will do it for us.

When combined with #6958, gpstate execution time goes from roughly 2.5 seconds to 1 second on my laptop. Achieving subsecond execution (which is incredibly helpful for `watch` loops) will probably require some more scrutiny of `gpgetstatususingtransition.py`, which is running `netstat` calls serially for some sort of work.

## Checklist
- [x] Pass `make installcheck`
