### PR TITLE
docs - gphdfs deprecation notices for 5X

### DIFF
--- a/gpdb-doc/dita/admin_guide/external/g-accessing-ext-files-custom-protocol.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-accessing-ext-files-custom-protocol.xml
@@ -4,7 +4,7 @@
   <title>Using a Custom Protocol</title>
   <shortdesc>A custom protocol allows you to connect Greenplum Database to a data source that cannot
     be accessed with the <codeph>file://</codeph>, <codeph>gpfdist://</codeph>, or
-      <codeph>gphdfs://</codeph> protocols.</shortdesc>
+      <codeph>gphdfs://</codeph> (deprecated) protocols.</shortdesc>
   <body>
     <p>Creating a custom protocol requires that you implement a set of C functions with specified
       interfaces, declare the functions in Greenplum Database, and then use the <codeph>CREATE

--- a/gpdb-doc/dita/admin_guide/external/g-example-5-text-format-on-a-hadoop-distributed-file-server.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-example-5-text-format-on-a-hadoop-distributed-file-server.xml
@@ -4,6 +4,8 @@
 <topic id="topic49">
    <title>Example 5—TEXT Format on a Hadoop Distributed File Server</title>
    <body>
+      <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be
+        removed in the next major release of Greenplum Database.</note>
       <p>Creates a readable external table, <i>ext_expenses,</i> using the
                             <codeph>gphdfs</codeph> protocol. The column delimiter is a pipe ( |
                         ).</p>

--- a/gpdb-doc/dita/admin_guide/external/g-external-tables.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-external-tables.xml
@@ -20,23 +20,23 @@
             <li><codeph>gpfdists://</codeph> is the secure version of <codeph>gpfdist</codeph>. See
                   <xref href="g-gpfdists-protocol.xml#topic_sny_yph_kr"/>.</li>
             <li><codeph>gphdfs://</codeph> accesses files on a Hadoop Distributed File System
-               (HDFS). See <xref href="g-gphdfs-protocol.xml#topic_z5g_l5h_kr"/>.<p>The files can be
-                  stored on an Amazon EMR instance HDFS. See <xref
-                     href="g-hdfs-emr-config.xml#amazon-emr"/>.</p></li>
+               (HDFS). See <xref href="g-gphdfs-protocol.xml#topic_z5g_l5h_kr"/>.
+               <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will
+                 be removed in the next major release of Greenplum Database.</note>      </li>
             <li><codeph>s3://</codeph> accesses files in an Amazon S3 bucket. See <xref
                   href="g-s3-protocol.xml#amazon-emr"/>.</li>
 
             <li>The <codeph>pxf://</codeph> protocol accesses external HDFS files and HBase and Hive tables using the Greenplum Platform Extension Framework (PXF). See <xref href="g-pxf-protocol.xml"></xref>.</li>
          </ul></p>
       <note>
-         <p>The <codeph>gphdfs://</codeph>, <codeph>s3://</codeph>, and <codeph>pxf://</codeph>
+         <p>The <codeph>gphdfs://</codeph> (deprecated), <codeph>s3://</codeph>, and <codeph>pxf://</codeph>
             protocols are custom data access protocols, where the <codeph>file://</codeph>,
                <codeph>gpfdist://</codeph>, and <codeph>gpfdists://</codeph> protocols are
             implemented internally in Greenplum Database. The custom and internal protocols differ
             in these ways:</p>
          <ul id="ul_ifb_crh_qfb">
             <li>Custom protocols must be registered using the <codeph>CREATE PROTOCOL</codeph>
-               command. The <codeph>gphdfs://</codeph> protocol is preregistered when you install
+               command. The <codeph>gphdfs://</codeph> protocol (deprecated) is preregistered when you install
                Greenplum Database. Registering the PXF extension in a database creates the
                   <codeph>pxf://</codeph> protocol. (See <xref
                   href="pxf-overview.xml#topic_u14_wtd_dbb"/>.) You can optionally register the
@@ -58,10 +58,10 @@
       </note>
       <p>External tables access external files from within the database as if they are regular
          database tables. External tables defined with the
-            <codeph>gpfdist</codeph>/<codeph>gpfdists</codeph>, <codeph>gphdfs</codeph>, and
+            <codeph>gpfdist</codeph>/<codeph>gpfdists</codeph>, <codeph>gphdfs</codeph> (deprecated), and
             <codeph>s3</codeph> protocols utilize Greenplum parallelism by using the resources of
          all Greenplum Database segments to load or unload data. The <codeph>gphdfs</codeph>
-         protocol leverages the parallel architecture of the Hadoop Distributed File System to
+         protocol (deprecated) leverages the parallel architecture of the Hadoop Distributed File System to
          access files on that system. The <codeph>s3</codeph> protocol utilizes the Amazon Web
          Services (AWS) capabilities. </p>
       <p>You can query external table data directly and in parallel using SQL commands such as
@@ -76,7 +76,7 @@
                <li id="du220318">Start the Greenplum Database file server(s) when using the
                      <codeph>gpfdist</codeph> or <codeph>gpdists</codeph> protocols. </li>
                <li id="du220319">Verify that you have already set up the required one-time
-                  configuration for the <codeph>gphdfs</codeph> protocol.</li>
+                  configuration for the <codeph>gphdfs</codeph> protocol (deprecated).</li>
                <li>Verify the Greenplum Database configuration for the <codeph>s3</codeph>
                   protocol.</li>
             </ul></li>

--- a/gpdb-doc/dita/admin_guide/external/g-gphdfs-protocol.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-gphdfs-protocol.xml
@@ -7,8 +7,8 @@
   <body>
     <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be removed
       in the next major release of Greenplum Database. Consider using the Greenplum Platform
-      Extension Framework (PXF) <codeph>pxf</codeph> external table protocol to access data
-      stored in a Hadoop file system.</note>
+      Extension Framework (PXF) <codeph><xref href="g-pxf-protocol.xml" >pxf</xref></codeph>
+      external table protocol to access data stored in a Hadoop file system.</note>
     <p>The protocol allows specifying external files in Hadoop clusters configured with or without
       Hadoop HA (high availability) and in MapR clusters. File names may contain wildcard characters
       and the files can be in <codeph>CSV</codeph>, <codeph>TEXT</codeph>, or custom formats. </p>

--- a/gpdb-doc/dita/admin_guide/external/g-gphdfs-protocol.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-gphdfs-protocol.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_z5g_l5h_kr">
-  <title>gphdfs:// Protocol</title>
+  <title>gphdfs:// Protocol (Deprecated)</title>
   <shortdesc>The <codeph>gphdfs://</codeph> protocol specifies an external file path on a Hadoop
     Distributed File System (HDFS). </shortdesc>
   <body>
+    <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be removed
+      in the next major release of Greenplum Database. Consider using the Greenplum Platform
+      Extension Framework (PXF) <codeph>pxf</codeph> external table protocol to access data
+      stored in a Hadoop file system.</note>
     <p>The protocol allows specifying external files in Hadoop clusters configured with or without
       Hadoop HA (high availability) and in MapR clusters. File names may contain wildcard characters
       and the files can be in <codeph>CSV</codeph>, <codeph>TEXT</codeph>, or custom formats. </p>

--- a/gpdb-doc/dita/admin_guide/external/g-grant-privileges-for-the-hdfs-protocol.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-grant-privileges-for-the-hdfs-protocol.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic21">
-   <title>Grant Privileges for the gphdfs Protocol</title>
+   <title>Grant Privileges for the gphdfs Protocol (Deprecated)</title>
    <body>
       <p>To enable privileges required to create external tables that access files on HDFS using
             <codeph>gphdfs</codeph>:</p>

--- a/gpdb-doc/dita/admin_guide/external/g-hdfs-avro-format.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-hdfs-avro-format.xml
@@ -2,8 +2,11 @@
 <!DOCTYPE dita PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <dita>
   <topic id="topic_fstrm">
-    <title>Support for Avro Files</title>
+    <title>gphdfs Support for Avro Files (Deprecated)</title>
     <body>
+      <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be
+        removed in the next major release of Greenplum Database. You can use the Greenplum
+        Platform Extension Framework (PXF) to access Avro-format data.</note>
       <p>You can use the Greenplum Database <codeph>gphdfs</codeph> protocol to access Avro files on
         a Hadoop file system (HDFS).</p>
     </body>

--- a/gpdb-doc/dita/admin_guide/external/g-hdfs-emr-config.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-hdfs-emr-config.xml
@@ -2,8 +2,10 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="amazon-emr">
-   <title>Using Amazon EMR with Greenplum Database installed on AWS </title>
+   <title>Using Amazon EMR with Greenplum Database installed on AWS (Deprecated) </title>
    <body>
+      <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be
+        removed in the next major release of Greenplum Database.</note>
       <p>Amazon Elastic MapReduce (EMR) is a managed cluster platform that can run big data
          frameworks, such as Apache Hadoop and Apache Spark, on Amazon Web Services (AWS) to process
          and analyze data. For a Greenplum Database system that is installed on Amazon Web Services

--- a/gpdb-doc/dita/admin_guide/external/g-hdfs-parquet-format.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-hdfs-parquet-format.xml
@@ -2,8 +2,11 @@
 <!DOCTYPE dita PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <dita>
   <topic id="topic_fstrm">
-    <title>Support for Parquet Files</title>
+    <title>gphdfs Support for Parquet Files (Deprecated)</title>
     <body>
+      <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be
+        removed in the next major release of Greenplum Database. You can use the Greenplum
+        Platform Extension Framework (PXF) to access Parquet-format data.</note>
       <p>You can use the Greenplum Database <codeph>gphdfs</codeph> protocol to access Parquet files
         on a Hadoop file system (HDFS).</p>
     </body>

--- a/gpdb-doc/dita/admin_guide/external/g-hdfs-readable-and-writable-external-table-examples.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-hdfs-readable-and-writable-external-table-examples.xml
@@ -2,8 +2,10 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic24">
-   <title>HDFS Readable and Writable External Table Examples</title>
+   <title>HDFS Readable and Writable External Table Examples (Deprecated)</title>
    <body>
+      <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be
+        removed in the next major release of Greenplum Database.</note>
       <p>The following code defines a readable external table for an HDFS file named
             <codeph>filename.txt</codeph> on port 8081.</p>
       <p>

--- a/gpdb-doc/dita/admin_guide/external/g-one-time-hdfs-protocol-installation.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-one-time-hdfs-protocol-installation.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic20">
-   <title>One-time gphdfs Protocol Installation</title>
+   <title>One-time gphdfs Protocol Installation (Deprecated)</title>
    <body>
       <p>Install and configure Hadoop for use with <codeph>gphdfs</codeph> as follows:<ol
             id="ol_whb_fxz_h4">

--- a/gpdb-doc/dita/admin_guide/external/g-reading-and-writing-custom-formatted-hdfs-data.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-reading-and-writing-custom-formatted-hdfs-data.xml
@@ -2,8 +2,10 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic25">
-    <title>Reading and Writing Custom-Formatted HDFS Data</title>
+    <title>Reading and Writing Custom-Formatted HDFS Data with gphdfs (Deprecated)</title>
     <body>
+        <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be
+        removed in the next major release of Greenplum Database.</note>
         <p>Use MapReduce and the <codeph>CREATE EXTERNAL TABLE</codeph> command to read and write
             data with custom formats on HDFS.</p>
         <p>To read custom-formatted data:</p>

--- a/gpdb-doc/dita/admin_guide/external/g-specify-hdfs-data-in-an-external-table-definition.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-specify-hdfs-data-in-an-external-table-definition.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic22">
-   <title>Specify gphdfs Protocol in an External Table Definition</title>
+   <title>Specify gphdfs Protocol in an External Table Definition (Deprecated)</title>
    <body>
       <p>The <codeph>gphdfs</codeph>
          <codeph>LOCATION</codeph> clause of the <codeph>CREATE EXTERNAL TABLE</codeph> command for

--- a/gpdb-doc/dita/admin_guide/external/g-using-hadoop-distributed-file-system--hdfs--tables.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-using-hadoop-distributed-file-system--hdfs--tables.xml
@@ -3,10 +3,14 @@
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic19">
    <!-- hack for HTML/PDF -->
-   <title>Accessing HDFS Data with gphdfs</title>
+   <title>Accessing HDFS Data with gphdfs (Deprecated)</title>
    <shortdesc>Greenplum Database leverages the parallel architecture of a Hadoop Distributed File
       System to read and write data files efficiently using the <codeph>gphdfs</codeph> protocol. </shortdesc>
    <body>
+      <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be removed
+      in the next major release of Greenplum Database. Consider using the Greenplum Platform
+      Extension Framework (PXF) <codeph>pxf</codeph> external table protocol to access data
+      stored in a Hadoop file system.</note>
       <p>There are three steps to using the gphdfs protocol with HDFS:</p>
       <ul otherprops="op-print">
          <li id="du228490">

--- a/gpdb-doc/dita/admin_guide/load/topics/g-defining-a-file-based-writable-external-table.xml
+++ b/gpdb-doc/dita/admin_guide/load/topics/g-defining-a-file-based-writable-external-table.xml
@@ -6,7 +6,7 @@
     <body>
         <p>Writable external tables that output data to files use the Greenplum parallel file server program,
                 <cmdname>gpfdist</cmdname>, or the Hadoop Distributed File System interface,
-                <codeph>gphdfs</codeph>. </p>
+                <codeph>gphdfs</codeph> (deprecated). </p>
         <p>Use the <codeph>CREATE WRITABLE EXTERNAL TABLE</codeph> command to define the external
             table and specify the location and format of the output files. <ph>See <xref
                     href="../../external/g-using-the-greenplum-parallel-file-server--gpfdist-.xml#topic13"

--- a/gpdb-doc/dita/admin_guide/load/topics/g-example-2-hadoop-file-server-gphdfs.xml
+++ b/gpdb-doc/dita/admin_guide/load/topics/g-example-2-hadoop-file-server-gphdfs.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic70">
-   <title>Example 2—Hadoop file server (gphdfs)</title>
+   <title>Example 2—Hadoop file server (gphdfs (Deprecated))</title>
    <body>
       <p>
          <codeblock>=# CREATE WRITABLE EXTERNAL TABLE unload_expenses 

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4178,7 +4178,7 @@
     <title>gp_hadoop_home</title>
     <body>
       <p>Specifies the installation directory for the Greenplum Database <codeph>gphdfs</codeph>
-        Hadoop target.</p>
+        protocol (deprecated) Hadoop target.</p>
       <table id="gp_hadoop_home_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -4205,7 +4205,8 @@
   <topic id="gp_hadoop_target_version">
     <title>gp_hadoop_target_version</title>
     <body>
-      <p>The installed version of the Greenplum Database <codeph>gphdfs</codeph> Hadoop target.</p>
+      <p>The installed version of the Greenplum Database <codeph>gphdfs</codeph> protocol
+        (deprecated) Hadoop target.</p>
       <table id="gp_hadoop_target_version_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
@@ -213,7 +213,7 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
         </plentry>
         <plentry>
           <pt>LOCATION <varname>('protocol://host[:port]/path/file' [, ...])</varname></pt>
-          <pd>If you use the <codeph>gphdfs</codeph> protocol to read or write a file to a Hadoop
+          <pd>If you use the <codeph>gphdfs</codeph> protocol (deprecated) to read or write a file to a Hadoop
             file system (HDFS), refer to <xref
           href="../../admin_guide/external/g-specify-hdfs-data-in-an-external-table-definition.xml"/> for additional information about
          the <codeph>gphdfs</codeph> protocol <codeph>LOCATION</codeph> clause syntax.</pd>
@@ -231,7 +231,7 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
             allow the <codeph>http</codeph> protocol. If <codeph>port</codeph> is omitted, port
               <codeph>8080</codeph> is assumed for <codeph>http</codeph> and
               <codeph>gpfdist</codeph> protocols, and port 9000 for the <codeph>gphdfs</codeph>
-            protocol. If using the <codeph>gpfdist</codeph> protocol, the <codeph>path</codeph> is
+            protocol (deprecated). If using the <codeph>gpfdist</codeph> protocol, the <codeph>path</codeph> is
             relative to the directory from which <codeph>gpfdist</codeph> is serving files (the
             directory specified when you started the <codeph>gpfdist</codeph> program). Also,
               <codeph>gpfdist</codeph> can use wildcards or other C-style pattern matching (for
@@ -271,7 +271,7 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
           <pd>Restricts all table-related operations to the Greenplum master segment. Permitted only
             on readable and writable external tables created with the <codeph>s3</codeph> or custom
             protocols. The <codeph>gpfdist</codeph>, <codeph>gpfdists</codeph>,
-              <codeph>gphdfs</codeph>, <codeph>pxf</codeph>, and <codeph>file</codeph> protocols do not support <codeph>ON
+              <codeph>gphdfs</codeph> (deprecated), <codeph>pxf</codeph>, and <codeph>file</codeph> protocols do not support <codeph>ON
               MASTER</codeph>. <note>Be aware of potential resource impacts when reading from or
               writing to external tables you create with the <codeph>ON MASTER</codeph> clause. You
               may encounter performance issues when you restrict table operations solely to the
@@ -328,7 +328,7 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
         using a custom format, see "Loading and Unloading Data" in the <cite>Greenplum Database
           Administrator Guide</cite>.</pd>
           <pd>The <codeph>AVRO</codeph> and <codeph>PARQUET</codeph> formats are supported only when 
-            you specify the <codeph>gphdfs</codeph> protocol. Refer to <xref
+            you specify the <codeph>gphdfs</codeph> protocol (deprecated). Refer to <xref
           href="../../admin_guide/external/g-using-hadoop-distributed-file-system--hdfs--tables.xml"/>
          for detailed information about the <codeph>gphdfs</codeph> protocol <codeph>FORMAT</codeph>
          clause syntax.</pd>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_PROTOCOL.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_PROTOCOL.xml
@@ -66,7 +66,7 @@
             <title>Notes</title>
             <p>Greenplum Database handles external tables of type <codeph>file</codeph>,
                     <codeph>gpfdist</codeph>, and <codeph>gpfdists</codeph> internally. The custom
-                protocol <codeph>gphdfs</codeph> is registered in Greenplum Database by default. See
+                protocol <codeph>gphdfs</codeph> (deprecated) is registered in Greenplum Database by default. See
                     <xref href="../../admin_guide/external/g-s3-protocol.xml#amazon-emr/s3_prereq"/>
                 for information about enabling the <codeph>S3</codeph> protocol. See the <xref
                     href="../../pxf/overview_pxf.html" type="topic" format="html">Greenplum Platform

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
@@ -97,7 +97,7 @@
                         created by superusers. </pd>
                     <pd>Use the <codeph>GRANT...ON PROTOCOL</codeph> command to allow users to
                         create and use external tables with a custom protocol type, including the
-                            <codeph>gphdfs</codeph>, <codeph>s3</codeph>, and <codeph>pxf</codeph>
+                            <codeph>gphdfs</codeph> (deprecated), <codeph>s3</codeph>, and <codeph>pxf</codeph>
                         protocols included with Greenplum Database.</pd>
                 </plentry>
                 <plentry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_authid.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_authid.xml
@@ -168,7 +168,7 @@
             <entry colname="col2">boolean</entry>
             <entry colname="col3"/>
             <entry colname="col4">Privilege to create read external tables with the
-                <codeph>gphdfs</codeph> protocol</entry>
+                <codeph>gphdfs</codeph> protocol (deprecated)</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -177,7 +177,7 @@
             <entry colname="col2">boolean</entry>
             <entry colname="col3"/>
             <entry colname="col4">Privilege to create write external tables with the
-                <codeph>gphdfs</codeph> protocol</entry>
+                <codeph>gphdfs</codeph> protocol (deprecated)</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_roles.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_roles.xml
@@ -165,14 +165,14 @@
             <entry colname="col2">bool</entry>
             <entry colname="col3"/>
             <entry colname="col4">Role may create readable external tables that use the gphdfs
-              protocol.</entry>
+              protocol (deprecated).</entry>
           </row>
           <row>
             <entry colname="col1">rolcreatewexthdfs</entry>
             <entry colname="col2">bool</entry>
             <entry colname="col3"/>
             <entry colname="col4">Role may create writable external tables that use the gphdfs
-              protocol.</entry>
+              protocol (deprecated).</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/security-guide/topics/SecuringGPDB.xml
+++ b/gpdb-doc/dita/security-guide/topics/SecuringGPDB.xml
@@ -26,8 +26,11 @@
       <title>Accessing a Kerberized Hadoop Cluster</title>
       <p>Greenplum Database can read or write external tables in a Hadoop file system. If the Hadoop
         cluster is secured with Kerberos ("Kerberized"), Greenplum Database must be configured to
-        allow external table owners to authenticate with Kerberos. See <xref
-          href="kerberos-hdfs.xml#topic_lhr_yrf_qr"/> for the steps to perform this setup. </p>
+        allow external table owners to authenticate with Kerberos. See <xref 
+          href="../../pxf/pxf_kerbhdfs.html" format="html" scope="peer">Configuring PXF for Secure HDFS</xref>
+        for the configuration procedure for PXF. See <xref
+          href="kerberos-hdfs.xml#topic_lhr_yrf_qr"/> for the steps to perform this setup for
+        <codeph>gphdfs</codeph> (deprecated). </p>
     </section>
     <section>
       <title>Platform Hardening</title>

--- a/gpdb-doc/dita/security-guide/topics/kerberos-hdfs.xml
+++ b/gpdb-doc/dita/security-guide/topics/kerberos-hdfs.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_lhr_yrf_qr">
-  <title>Enabling gphdfs Authentication with a Kerberos-secured Hadoop Cluster</title>
+  <title>Enabling gphdfs Authentication with a Kerberos-secured Hadoop Cluster (Deprecated)</title>
   <shortdesc>Provides steps for configuring Greenplum Database to access external tables in a Hadoop
     cluster secured with Kerberos. </shortdesc>
   <body>
+    <note>The <codeph>gphdfs</codeph> external table protocol is deprecated and will be removed
+      in the next major release of Greenplum Database. Consider using the Greenplum Platform
+      Extension Framework (PXF) <codeph>pxf</codeph> external table protocol to access data
+      stored in a Hadoop file system.</note>
     <p>Using external tables and the <codeph>gphdfs</codeph> protocol, Greenplum Database can read
       files from and write files to a Hadoop File System (HDFS). Greenplum segments read and write
       files in parallel from HDFS for fast performance.</p>

--- a/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
+++ b/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
@@ -148,7 +148,7 @@ MIRROR_REPLICATION_PORT_BASE = 9000</codeblock></note>
               manage the Greenplum system within the cluster. </entry>
           </row>
           <row>
-            <entry>gphdfs</entry>
+            <entry>gphdfs (deprecated)</entry>
             <entry>TCP 8020</entry>
             <entry>The gphdfs protocol allows access to data in a Hadoop file system via Greenplum
               external tables. The URL in the <codeph>LOCATION</codeph> clause of the <codeph>CREATE


### PR DESCRIPTION
in this PR:
- add notes, (Deprecated), and (deprecated) to identify deprecation of gphdfs in 5X (removed in 6) in various areas of the greenplum docs
- add note to gphdfs protocol page and "Accessing HDFS Data with gphdfs" page
- add note to pages that are completely gphdfs-specific
- add "(Deprecated)" to gphdfs page titles
- add (deprecated) to many gphdfs references
- in some cases, also include PXF mention and xrefs

not sure if this is too much, some pages have both (Deprecated) in the title and in a note at the top of the page.


5X changes for https://github.com/greenplum-db/gpdb/pull/6735.