### PR TITLE
Make alter database set tablespace MPP ready

### DIFF
--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -1392,7 +1392,7 @@ movedb(const char *dbname, const char *tblspcname)
 	/*
 	 * GPDB: GPDB uses two phase commit and pending deletes, hence cannot locally
 	 * commit here. The rest of the logic related to the non-catalog changes from
-	 * this function is extracted into DropDatabseDirectory() which is executed at
+	 * this function is extracted into DropDatabaseDirectory() which is executed at
 	 * commit time.
 	 */
 #if 0

--- a/src/include/catalog/storage.h
+++ b/src/include/catalog/storage.h
@@ -20,6 +20,7 @@
 
 extern void RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage);
 extern void RelationDropStorage(Relation rel);
+extern void DatabaseDropStorage(Oid db_id, Oid dsttablespace);
 extern void RelationPreserveStorage(RelFileNode rnode, bool atCommit);
 extern void RelationTruncate(Relation rel, BlockNumber nblocks);
 

--- a/src/include/commands/dbcommands.h
+++ b/src/include/commands/dbcommands.h
@@ -67,5 +67,6 @@ extern void dbase_redo(XLogRecPtr beginLoc  __attribute__((unused)), XLogRecPtr 
 extern void dbase_desc(StringInfo buf, XLogRecord *record);
 
 extern void check_encoding_locale_matches(int encoding, const char *collate, const char *ctype);
+extern void DropDatabaseDirectory(Oid db_id, Oid tblspcoid);
 
 #endif   /* DBCOMMANDS_H */

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -255,6 +255,8 @@ FI_IDENT(DecreaseToastMaxChunkSize, "decrease_toast_max_chunk_size")
 FI_IDENT(CleanupQE, "cleanup_qe")
 /* inject fault in xLog_ao_insert() just before writing AO xlog record */
 FI_IDENT(XLogAoInsert, "xlog_ao_insert")
+/* inject fault just before commiting alter database set tablespace */
+FI_IDENT(InsideMoveDbTransaction, "inside_move_db_transaction")
 #endif
 
 /*

--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -1,0 +1,54 @@
+-- Scenario 1: Where alter database set tablespace successfully changes the
+-- underlying tablespace directory.
+
+-- Given we create a database
+CREATE DATABASE alter_db_1;
+\c alter_db_1
+
+-- functions to help validation later
+CREATE FUNCTION rel_filepath_on_master(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  SELECT gp_execution_segment(), pg_relation_filepath($1) AS filepath
+  $fn$
+EXECUTE ON MASTER;
+
+CREATE FUNCTION rel_filepaths_on_segments(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  SELECT gp_execution_segment(), pg_relation_filepath($1) AS filepath
+  $fn$
+EXECUTE ON ALL SEGMENTS;
+
+CREATE FUNCTION rel_filepaths(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+  STRICT STABLE LANGUAGE SQL AS
+$fn$
+SELECT * FROM rel_filepath_on_master($1)
+UNION ALL
+SELECT * FROM rel_filepaths_on_segments($1);
+$fn$;
+
+-- And create a table in that database with data
+CREATE TABLE tbl_1(id int, name text);
+INSERT INTO tbl_1 VALUES (1, 'a'), (2, 'b'), (5, 'c');
+
+-- When we create a tablespace
+\! mkdir -p '@testtablespace@/alter_tblspc_1';
+CREATE TABLESPACE alter_tblspc_1 LOCATION '@testtablespace@/alter_tblspc_1';
+
+-- And alter the database to use the new tablespace
+\c regression
+ALTER DATABASE alter_db_1 SET TABLESPACE alter_tblspc_1;
+
+-- Then all the database files from QD and all QEs should be moved into the new
+-- tablespace. We use the fact that default tablespace names begin with 'base'
+-- where as user created tablespaces begin with 'pg_tblspc'
+\c alter_db_1
+
+SELECT gp_segment_id, substring(filepath FOR 5) AS filepath_prefix FROM rel_filepaths('tbl_1') WHERE filepath LIKE 'pg_tblspc%';
+SELECT gp_segment_id, substring(filepath FOR 5) AS filepath_prefix FROM rel_filepaths('tbl_1') WHERE filepath LIKE 'base%';
+SELECT * FROM tbl_1;
+
+\c regression
+DROP DATABASE alter_db_1;
+DROP TABLESPACE alter_tblspc_1;

--- a/src/test/regress/input/alter_db_set_tablespace_with_fault.source
+++ b/src/test/regress/input/alter_db_set_tablespace_with_fault.source
@@ -1,0 +1,65 @@
+-- Scenario 2: Where alter database set tablespace fails on segment. In this
+-- case we expect that the tablespace for database remains unchanged across all
+-- the segments.
+
+-- Given we create a database
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE DATABASE alter_db_2;
+\c alter_db_2
+
+-- functions to help validation later
+CREATE FUNCTION rel_filepath_on_master(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+  STRICT STABLE LANGUAGE SQL AS
+$fn$
+SELECT gp_execution_segment(), pg_relation_filepath($1) AS filepath
+$fn$
+EXECUTE ON MASTER;
+
+CREATE FUNCTION rel_filepaths_on_segments(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+  STRICT STABLE LANGUAGE SQL AS
+$fn$
+SELECT gp_execution_segment(), pg_relation_filepath($1) AS filepath
+$fn$
+EXECUTE ON ALL SEGMENTS;
+
+CREATE FUNCTION rel_filepaths(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+  STRICT STABLE LANGUAGE SQL AS
+$fn$
+SELECT * FROM rel_filepath_on_master($1)
+UNION ALL
+SELECT * FROM rel_filepaths_on_segments($1);
+$fn$;
+
+-- And create a table in that database with data
+CREATE TABLE tbl_2(id int, name text);
+INSERT INTO tbl_2 VALUES (1, 'a'), (2, 'b'), (5, 'c');
+
+-- When we create a tablespace
+\! mkdir -p '@testtablespace@/alter_tblspc_2';
+CREATE TABLESPACE alter_tblspc_2 LOCATION '@testtablespace@/alter_tblspc_2';
+
+\c regression
+-- And error on a segment while altering the database to use the new tablespace
+SELECT gp_inject_fault_infinite('inside_move_db_transaction', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ALTER DATABASE alter_db_2 SET TABLESPACE alter_tblspc_2;
+
+-- Then all the database files from QD and all QEs should continue to use the
+-- old tablespace. The physical files may still exist on the new tablespace for
+-- the segments that didn't fail, but the pg_class catalog entries point to the
+-- old tablespace
+\c alter_db_2
+SELECT count(*) from tbl_2;
+SELECT gp_segment_id, datname from pg_database
+  where datname = 'alter_db_2' and dattablespace in (select oid from pg_tablespace where spcname = 'pg_default');
+SELECT gp_segment_id, datname from gp_dist_random('pg_database')
+  where datname = 'alter_db_2' and dattablespace in (select oid from pg_tablespace where spcname = 'pg_default');
+
+SELECT gp_segment_id, substring(filepath FOR 5) AS filepath FROM rel_filepaths('tbl_2') WHERE filepath LIKE 'pg_tblspc%';
+SELECT gp_segment_id, substring(filepath FOR 5) AS filepath FROM rel_filepaths('tbl_2') WHERE filepath LIKE 'base%';
+
+-- Cleanup
+\c regression
+SELECT gp_inject_fault('inside_move_db_transaction', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+DROP DATABASE alter_db_2;
+DROP TABLESPACE alter_tblspc_2;

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -1,0 +1,65 @@
+-- Scenario 1: Where alter database set tablespace successfully changes the
+-- underlying tablespace directory.
+-- Given we create a database
+CREATE DATABASE alter_db_1;
+\c alter_db_1
+-- functions to help validation later
+CREATE FUNCTION rel_filepath_on_master(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  SELECT gp_execution_segment(), pg_relation_filepath($1) AS filepath
+  $fn$
+EXECUTE ON MASTER;
+CREATE FUNCTION rel_filepaths_on_segments(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  SELECT gp_execution_segment(), pg_relation_filepath($1) AS filepath
+  $fn$
+EXECUTE ON ALL SEGMENTS;
+CREATE FUNCTION rel_filepaths(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+  STRICT STABLE LANGUAGE SQL AS
+$fn$
+SELECT * FROM rel_filepath_on_master($1)
+UNION ALL
+SELECT * FROM rel_filepaths_on_segments($1);
+$fn$;
+-- And create a table in that database with data
+CREATE TABLE tbl_1(id int, name text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tbl_1 VALUES (1, 'a'), (2, 'b'), (5, 'c');
+-- When we create a tablespace
+\! mkdir -p '@testtablespace@/alter_tblspc_1';
+CREATE TABLESPACE alter_tblspc_1 LOCATION '@testtablespace@/alter_tblspc_1';
+-- And alter the database to use the new tablespace
+\c regression
+ALTER DATABASE alter_db_1 SET TABLESPACE alter_tblspc_1;
+-- Then all the database files from QD and all QEs should be moved into the new
+-- tablespace. We use the fact that default tablespace names begin with 'base'
+-- where as user created tablespaces begin with 'pg_tblspc'
+\c alter_db_1
+SELECT gp_segment_id, substring(filepath FOR 5) AS filepath_prefix FROM rel_filepaths('tbl_1') WHERE filepath LIKE 'pg_tblspc%';
+ gp_segment_id | filepath_prefix 
+---------------+-----------------
+            -1 | pg_tb
+             0 | pg_tb
+             1 | pg_tb
+             2 | pg_tb
+(4 rows)
+
+SELECT gp_segment_id, substring(filepath FOR 5) AS filepath_prefix FROM rel_filepaths('tbl_1') WHERE filepath LIKE 'base%';
+ gp_segment_id | filepath_prefix 
+---------------+-----------------
+(0 rows)
+
+SELECT * FROM tbl_1;
+ id | name 
+----+------
+  2 | b
+  1 | a
+  5 | c
+(3 rows)
+
+\c regression
+DROP DATABASE alter_db_1;
+DROP TABLESPACE alter_tblspc_1;

--- a/src/test/regress/output/alter_db_set_tablespace_with_fault.source
+++ b/src/test/regress/output/alter_db_set_tablespace_with_fault.source
@@ -1,0 +1,98 @@
+-- Scenario 2: Where alter database set tablespace fails on segment. In this
+-- case we expect that the tablespace for database remains unchanged across all
+-- the segments.
+-- Given we create a database
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE DATABASE alter_db_2;
+\c alter_db_2
+-- functions to help validation later
+CREATE FUNCTION rel_filepath_on_master(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+  STRICT STABLE LANGUAGE SQL AS
+$fn$
+SELECT gp_execution_segment(), pg_relation_filepath($1) AS filepath
+$fn$
+EXECUTE ON MASTER;
+CREATE FUNCTION rel_filepaths_on_segments(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+  STRICT STABLE LANGUAGE SQL AS
+$fn$
+SELECT gp_execution_segment(), pg_relation_filepath($1) AS filepath
+$fn$
+EXECUTE ON ALL SEGMENTS;
+CREATE FUNCTION rel_filepaths(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
+  STRICT STABLE LANGUAGE SQL AS
+$fn$
+SELECT * FROM rel_filepath_on_master($1)
+UNION ALL
+SELECT * FROM rel_filepaths_on_segments($1);
+$fn$;
+-- And create a table in that database with data
+CREATE TABLE tbl_2(id int, name text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tbl_2 VALUES (1, 'a'), (2, 'b'), (5, 'c');
+-- When we create a tablespace
+\! mkdir -p '@testtablespace@/alter_tblspc_2';
+CREATE TABLESPACE alter_tblspc_2 LOCATION '@testtablespace@/alter_tblspc_2';
+\c regression
+-- And error on a segment while altering the database to use the new tablespace
+SELECT gp_inject_fault_infinite('inside_move_db_transaction', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+NOTICE:  Success:  (seg0 10.64.5.114:25432 pid=88313)
+ gp_inject_fault_infinite 
+--------------------------
+ t
+(1 row)
+
+ALTER DATABASE alter_db_2 SET TABLESPACE alter_tblspc_2;
+ERROR:  fault triggered, fault name:'inside_move_db_transaction' fault type:'error'  (seg0 10.64.5.114:25432 pid=88313)
+-- Then all the database files from QD and all QEs should continue to use the
+-- old tablespace. The physical files may still exist on the new tablespace for
+-- the segments that didn't fail, but the pg_class catalog entries point to the
+-- old tablespace
+\c alter_db_2
+SELECT count(*) from tbl_2;
+ count 
+-------
+     3
+(1 row)
+
+SELECT gp_segment_id, datname from pg_database
+  where datname = 'alter_db_2' and dattablespace in (select oid from pg_tablespace where spcname = 'pg_default');
+ gp_segment_id |  datname   
+---------------+------------
+            -1 | alter_db_2
+(1 row)
+
+SELECT gp_segment_id, datname from gp_dist_random('pg_database')
+  where datname = 'alter_db_2' and dattablespace in (select oid from pg_tablespace where spcname = 'pg_default');
+ gp_segment_id |  datname   
+---------------+------------
+             1 | alter_db_2
+             2 | alter_db_2
+             0 | alter_db_2
+(3 rows)
+
+SELECT gp_segment_id, substring(filepath FOR 5) AS filepath FROM rel_filepaths('tbl_2') WHERE filepath LIKE 'pg_tblspc%';
+ gp_segment_id | filepath 
+---------------+----------
+(0 rows)
+
+SELECT gp_segment_id, substring(filepath FOR 5) AS filepath FROM rel_filepaths('tbl_2') WHERE filepath LIKE 'base%';
+ gp_segment_id | filepath 
+---------------+----------
+            -1 | base/
+             0 | base/
+             1 | base/
+             2 | base/
+(4 rows)
+
+-- Cleanup
+\c regression
+SELECT gp_inject_fault('inside_move_db_transaction', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+NOTICE:  Success:  (seg0 10.64.5.114:25432 pid=88322)
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+DROP DATABASE alter_db_2;
+DROP TABLESPACE alter_tblspc_2;


### PR DESCRIPTION
The alter database set tablesapce command should alter the tablespace on
QD and all the QEs. This patch adds dispatching of the alter database
set tablespace command to QEs. In Greenplum, the transaction should be
atomic across all the segments and master, hence need to use two phase
commit for this operation. Due to usage of 2PC, the implementation needs
to differ compared upstream, can't locally commit the transactions.
Catalog changes are committed and later using pending deletes, old
tablespace directory is removed only on commit.

Other alternative considered was using separate dispatch for deleting
the directory instead of using pending delete after commiting alter
database set tablespace transaction. But that seemed unnecessary
overhead compared to pending deletes approach.

Fixes #5643 Github issue.

Note: `dropdb()` currently is not MPP safe for similar reason, it uses 2PC but it deletes the database directory on each segment before commit. So if a segment fails, the database will remain in the catalog but on-disk files for some of the segments may be deleted. This makes the cluster inconsistent. We plan to fix `dropdb()` using the same logic proposed in this PR via pending deletes by moving the non-catalog related activities post commit. Hence, would really love to seek feedback first for its usage for alter database set tablespace.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>
Co-authored-by: David Kimura <dkimura@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
