### PR TITLE
docs - add some ADL/WASBS/GC pxf external table DDL examples

### DIFF
--- a/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
@@ -66,27 +66,27 @@ CREATE EXTERNAL TABLE pxf_s3_text(location text, month text, num_orders int, tot
 FORMAT 'TEXT' (delimiter=E',');
 </pre>
 
-The following command creates an external table referencing a text file on Azure Blob Storage. It specifies the profile named `wasbs:text` and the server configuration named `wasbs_srvcfg`:
+The following command creates an external table referencing a text file on Azure Blob Storage. It specifies the profile named `wasbs:text` and the server configuration named `wasbssrvcfg`. You would provide the Azure Blob Storage container identifier and your Azure Blob Storage account name.
 
 <pre>
 CREATE EXTERNAL TABLE pxf_wasbs_text(location text, month text, num_orders int, total_sales float8)
-  LOCATION ('pxf://AZURE_CONTAINER@YOUR_AZURE_BLOB_STORAGE_ACCOUNT_NAME.blob.core.windows.net/path/to/blob?<b>PROFILE=wasbs:text&SERVER=wasbs_srvcfg</b>')
+  LOCATION ('pxf://<b>AZURE_CONTAINER@YOUR_AZURE_BLOB_STORAGE_ACCOUNT_NAME</b>.blob.core.windows.net/path/to/blob/file?<b>PROFILE=wasbs:text&SERVER=wasbssrvcfg</b>')
 FORMAT 'TEXT';
 </pre>
 
-The following command creates an external table referencing a text file on Azure Data Lake. It specifies the profile named `adl:text` and the server configuration named `adl_srvcfg`:
+The following command creates an external table referencing a text file on Azure Data Lake. It specifies the profile named `adl:text` and the server configuration named `adlsrvcfg`. You would provide your Azure Data Lake account name.
 
 <pre>
 CREATE EXTERNAL TABLE pxf_adl_text(location text, month text, num_orders int, total_sales float8)
-  LOCATION ('pxf://YOUR_ADL_ACCOUNT_NAME.azuredatalakestore.net/path/to/file?<b>PROFILE=adl:text&SERVER=adl_srvcfg</b>')
+  LOCATION ('pxf://<b>YOUR_ADL_ACCOUNT_NAME</b>.azuredatalakestore.net/path/to/file?<b>PROFILE=adl:text&SERVER=adlsrvcfg</b>')
 FORMAT 'TEXT';
 </pre>
 
-The following command creates an external table referencing a JSON file on Google Cloud Storage. It specifies the profile named `gs:json` and the server configuration named `gcs_srvcfg`:
+The following command creates an external table referencing a JSON file on Google Cloud Storage. It specifies the profile named `gs:json` and the server configuration named `gcssrvcfg`:
 
 <pre>
 CREATE EXTERNAL TABLE pxf_gsc_json(location text, month text, num_orders int, total_sales float8)
-  LOCATION ('pxf://dir/subdir/file.json?<b>PROFILE=gs:json&SERVER=gcs_srvcfg</b>')
+  LOCATION ('pxf://dir/subdir/file.json?<b>PROFILE=gs:json&SERVER=gcssrvcfg</b>')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 </pre>
 

--- a/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
@@ -58,7 +58,7 @@ You provide the profile name when you specify the `pxf` protocol on a `CREATE EX
 
 ## <a id="sample_ddl"></a>Sample CREATE EXTERNAL TABLE Commands
 
-The following command creates an external table referencing a text file on S3. It specifies the profile named `s3:text` and the server configuration named `s3srvcfg`:
+The following command creates an external table that references a text file on S3. It specifies the profile named `s3:text` and the server configuration named `s3srvcfg`:
 
 <pre>
 CREATE EXTERNAL TABLE pxf_s3_text(location text, month text, num_orders int, total_sales float8)
@@ -66,7 +66,7 @@ CREATE EXTERNAL TABLE pxf_s3_text(location text, month text, num_orders int, tot
 FORMAT 'TEXT' (delimiter=E',');
 </pre>
 
-The following command creates an external table referencing a text file on Azure Blob Storage. It specifies the profile named `wasbs:text` and the server configuration named `wasbssrvcfg`. You would provide the Azure Blob Storage container identifier and your Azure Blob Storage account name.
+The following command creates an external table that references a text file on Azure Blob Storage. It specifies the profile named `wasbs:text` and the server configuration named `wasbssrvcfg`. You would provide the Azure Blob Storage container identifier and your Azure Blob Storage account name.
 
 <pre>
 CREATE EXTERNAL TABLE pxf_wasbs_text(location text, month text, num_orders int, total_sales float8)
@@ -74,7 +74,7 @@ CREATE EXTERNAL TABLE pxf_wasbs_text(location text, month text, num_orders int, 
 FORMAT 'TEXT';
 </pre>
 
-The following command creates an external table referencing a text file on Azure Data Lake. It specifies the profile named `adl:text` and the server configuration named `adlsrvcfg`. You would provide your Azure Data Lake account name.
+The following command creates an external table that references a text file on Azure Data Lake. It specifies the profile named `adl:text` and the server configuration named `adlsrvcfg`. You would provide your Azure Data Lake account name.
 
 <pre>
 CREATE EXTERNAL TABLE pxf_adl_text(location text, month text, num_orders int, total_sales float8)
@@ -82,7 +82,7 @@ CREATE EXTERNAL TABLE pxf_adl_text(location text, month text, num_orders int, to
 FORMAT 'TEXT';
 </pre>
 
-The following command creates an external table referencing a JSON file on Google Cloud Storage. It specifies the profile named `gs:json` and the server configuration named `gcssrvcfg`:
+The following command creates an external table that references a JSON file on Google Cloud Storage. It specifies the profile named `gs:json` and the server configuration named `gcssrvcfg`:
 
 <pre>
 CREATE EXTERNAL TABLE pxf_gsc_json(location text, month text, num_orders int, total_sales float8)

--- a/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
@@ -54,12 +54,40 @@ The PXF connectors to Azure, Google Cloud Storage, Minio, and S3 expose the foll
 | AvroSequenceFile | wasbs:AvroSequenceFile | adl:AvroSequenceFile | gs:AvroSequenceFile | s3:AvroSequenceFile |
 | [SequenceFile](objstore_seqfile.html) | wasbs:SequenceFile | adl:SequenceFile | gs:SequenceFile | s3:SequenceFile |
 
-You provide the profile name when you specify the `pxf` protocol on a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table that references a file or directory in the specific object store. For example, the following command creates an external table that specifies the profile named `s3:text`:
+You provide the profile name when you specify the `pxf` protocol on a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table that references a file or directory in the specific object store.
+
+## <a id="sample_ddl"></a>Sample CREATE EXTERNAL TABLE Commands
+
+The following command creates an external table referencing a text file on S3. It specifies the profile named `s3:text` and the server configuration named `s3srvcfg`:
 
 <pre>
 CREATE EXTERNAL TABLE pxf_s3_text(location text, month text, num_orders int, total_sales float8)
-  LOCATION ('pxf://S3_BUCKET/pxf_examples/pxf_s3_simple.txt?<b>PROFILE=s3:text</b>&SERVER=s3srvcfg')
+  LOCATION ('pxf://S3_BUCKET/pxf_examples/pxf_s3_simple.txt?<b>PROFILE=s3:text&SERVER=s3srvcfg</b>')
 FORMAT 'TEXT' (delimiter=E',');
+</pre>
+
+The following command creates an external table referencing a text file on Azure Blob Storage. It specifies the profile named `wasbs:text` and the server configuration named `wasbs_srvcfg`:
+
+<pre>
+CREATE EXTERNAL TABLE pxf_wasbs_text(location text, month text, num_orders int, total_sales float8)
+  LOCATION ('pxf://AZURE_CONTAINER@YOUR_AZURE_BLOB_STORAGE_ACCOUNT_NAME.blob.core.windows.net/path/to/blob?<b>PROFILE=wasbs:text&SERVER=wasbs_srvcfg</b>')
+FORMAT 'TEXT';
+</pre>
+
+The following command creates an external table referencing a text file on Azure Data Lake. It specifies the profile named `adl:text` and the server configuration named `adl_srvcfg`:
+
+<pre>
+CREATE EXTERNAL TABLE pxf_adl_text(location text, month text, num_orders int, total_sales float8)
+  LOCATION ('pxf://YOUR_ADL_ACCOUNT_NAME.azuredatalakestore.net/path/to/file?<b>PROFILE=adl:text&SERVER=adl_srvcfg</b>')
+FORMAT 'TEXT';
+</pre>
+
+The following command creates an external table referencing a JSON file on Google Cloud Storage. It specifies the profile named `gs:json` and the server configuration named `gcs_srvcfg`:
+
+<pre>
+CREATE EXTERNAL TABLE pxf_gsc_json(location text, month text, num_orders int, total_sales float8)
+  LOCATION ('pxf://dir/subdir/file.json?<b>PROFILE=gs:json&SERVER=gcs_srvcfg</b>')
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 </pre>
 
 ## <a id="s3_override"></a>Overriding the S3 Server Configuration

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -78,7 +78,7 @@ The template configuration file for Azure Data Lake is `$PXF_CONF/templates/adl-
 |----------------|--------------------------------------------|-------|
 | dfs.adls.oauth2.access.token.provider.type | The type of token. | Must specify `ClientCredential`. |
 | dfs.adls.oauth2.refresh.url | The Azure endpoint to which to connect. | Your refresh URL. |
-| dfs.adls.oauth2.client.id | The Azure account client ID. | Your client ID. |
+| dfs.adls.oauth2.client.id | The Azure account client ID. | Your client ID (UUID). |
 | dfs.adls.oauth2.credential | The password for the Azure account client ID. | Your password. |
 
 


### PR DESCRIPTION
the examples in the PXF object store docs use S3.  add a sample CREATE EXTERNAL TABLE DDL for each of azure data lake, azure blob storage, and google cloud storage.
