### PR TITLE
Remove unwanted stacktrace from gpstate warning

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -904,10 +904,10 @@ class GpSystemStateProgram:
                     )
                     rewinding = result > 0
 
-        except pgdb.InternalError as ie:
+        except pgdb.InternalError:
             logger.warning('could not query segment {} ({}:{})'.format(
                     primary.dbid, primary.hostname, primary.port
-            ), exc_info=ie)
+            ))
             return
 
         # Successfully queried pg_stat_replication. If there are any backup


### PR DESCRIPTION
Since this is a warning, the stack trace is excessive.

Example stacktrace:
```
20190207:18:03:51:011185 gpstate:mdw:gpadmin-[INFO]:-Starting gpstate with args: -s
20190207:18:03:51:011185 gpstate:mdw:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.15784.g8e23831 build dev-oss'
20190207:18:03:51:011185 gpstate:mdw:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.20 (Greenplum Database 6.0.0-alpha.0+dev.15784.g8e23831 build dev-oss)
 on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-28), 64-bit compiled on Feb  7 2019 16:36:46'
20190207:18:03:51:011185 gpstate:mdw:gpadmin-[INFO]:-Obtaining Segment details from master...
20190207:18:03:51:011185 gpstate:mdw:gpadmin-[INFO]:-Gathering data from segments...
.....
20190207:18:03:56:011185 gpstate:mdw:gpadmin-[WARNING]:-pg_stat_replication shows no standby connections
20190207:18:03:56:011185 gpstate:mdw:gpadmin-[WARNING]:-could not query segment 3 (mdw:20001)
Traceback (most recent call last):
  File "/usr/local/greenplum-db/lib/python/gppylib/programs/clsSystemState.py", line 879, in _add_replication_info
    conn = dbconn.connect(url, utility=True)
  File "/usr/local/greenplum-db/lib/python/gppylib/db/dbconn.py", line 203, in connect
    cnx  = pgdb._connect_(cstr, dbhost, dbport, dbopt, dbtty, dbuser, dbpasswd)
InternalError: could not connect to server: Connection refused
        Is the server running on host "mdw" (172.31.6.188) and accepting
        TCP/IP connections on port 20001?

20190207:18:03:56:011185 gpstate:mdw:gpadmin-[INFO]:-----------------------------------------------------
20190207:18:03:56:011185 gpstate:mdw:gpadmin-[INFO]:--Master Configuration & Status
20190207:18:03:56:011185 gpstate:mdw:gpadmin-[INFO]:-----------------------------------------------------
```