### PR TITLE
Minor enhancements to uao_crash_compaction_column and crash_recovery_dtm test.

### DIFF
--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -191,7 +191,9 @@ INSERT 10
 -- To help speedy recovery
 11: CHECKPOINT;
 CHECKPOINT
--- Set to maximum number of 2PC retries to avoid any failures.
+-- Set to maximum number of 2PC retries to avoid any failures. Alter
+-- system is required to set the GUC and can't be set on session level
+-- as session reset happens for every abort retry.
 11: alter system set dtx_phase2_retry_count to 15;
 ALTER
 11: select pg_reload_conf();
@@ -246,6 +248,10 @@ DETAIL:
 -------
  10    
 (1 row)
+13: SELECT * FROM gp_dist_random('pg_prepared_xacts');
+ transaction | gid | prepared | owner | database 
+-------------+-----+----------+-------+----------
+(0 rows)
 13: SELECT gp_inject_fault('fts_probe', 'reset', 1);
  gp_inject_fault 
 -----------------

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -568,7 +568,22 @@ UPDATE 1
 
 -- Scenario for validating mirror replays fine and doesn't crash on
 -- truncate record replay even if file is missing.
-
+-- skip FTS probes to avoid marking primary status down.
+4:SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ t                        
+(1 row)
+4:SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+4:SELECT gp_wait_until_triggered_fault('fts_probe', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t                             
+(1 row)
 4:SET gp_default_storage_options="appendonly=true,orientation=column";
 SET
 4:CREATE TABLE crash_vacuum_in_appendonly_insert_1 (a INT, b INT, c CHAR(20));
@@ -639,4 +654,9 @@ VACUUM
  wait_for_replication_replay 
 -----------------------------
  t                           
+(1 row)
+6:SELECT gp_inject_fault('fts_probe', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ t               
 (1 row)

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -103,7 +103,9 @@ $$ LANGUAGE plpgsql;
 11: INSERT INTO QE_panic_test_table SELECT * from generate_series(0, 9);
 -- To help speedy recovery
 11: CHECKPOINT;
--- Set to maximum number of 2PC retries to avoid any failures.
+-- Set to maximum number of 2PC retries to avoid any failures. Alter
+-- system is required to set the GUC and can't be set on session level
+-- as session reset happens for every abort retry.
 11: alter system set dtx_phase2_retry_count to 15;
 11: select pg_reload_conf();
 -- skip FTS probes always
@@ -117,6 +119,7 @@ $$ LANGUAGE plpgsql;
 11: SELECT pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 0;
 12<:
 13: SELECT count(*) from QE_panic_test_table;
+13: SELECT * FROM gp_dist_random('pg_prepared_xacts');
 13: SELECT gp_inject_fault('fts_probe', 'reset', 1);
 13: alter system reset dtx_phase2_retry_count;
 13: select pg_reload_conf();

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -184,7 +184,10 @@ SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 
 -- Scenario for validating mirror replays fine and doesn't crash on
 -- truncate record replay even if file is missing.
-
+-- skip FTS probes to avoid marking primary status down.
+4:SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
+4:SELECT gp_request_fts_probe_scan();
+4:SELECT gp_wait_until_triggered_fault('fts_probe', 1, 1);
 4:SET gp_default_storage_options="appendonly=true,orientation=column";
 4:CREATE TABLE crash_vacuum_in_appendonly_insert_1 (a INT, b INT, c CHAR(20));
 -- just sanity check to make sure appendonly table is created
@@ -214,3 +217,4 @@ where c.role='p' and c.content=0), 'restart');
 -- records generated and doesn't encounter the "WAL contains
 -- references to invalid pages" PANIC.
 6:SELECT * from wait_for_replication_replay(5000);
+6:SELECT gp_inject_fault('fts_probe', 'reset', 1);


### PR DESCRIPTION
- **Check prepared transaction aborted for crash_recovery_dtm test.**
This is follow-up commit to 69ebd66, incorporating Asim's review feedback.

- **Avoid fts probes in uao_crash_compaction_column test.**
This is to avoid marking primary status down during this test, while it restarts the primary.
