### PR TITLE
Enable, fix, and run pg_basebackup TAP tests.

### DIFF
--- a/src/bin/pg_basebackup/Makefile
+++ b/src/bin/pg_basebackup/Makefile
@@ -52,8 +52,8 @@ clean distclean maintainer-clean:
 	rm -rf tmp_check
 
 check: all
-	echo "pg_basebackup check temporarily disabled"
+	$(prove_check)
 
 installcheck:
-	echo "pg_basebackup installcheck temporarily disabled"
+	$(prove_installcheck)
 

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1316,7 +1316,7 @@ ReceiveAndUnpackTarFile(PGconn *conn, PGresult *res, int rownum)
 
 					bool is_gp_tablespace_directory = strncmp(gp_tablespace_filename, filename, strlen(filename)) == 0;
 					if (is_gp_tablespace_directory && !forceoverwrite) {
-						/* 
+						/*
 						 * This directory has already been created during beginning of BaseBackup().
 						 */
 						continue;

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -11,10 +11,10 @@ program_options_handling_ok('pg_basebackup');
 my $tempdir = tempdir;
 start_test_server $tempdir;
 
-command_fails(['pg_basebackup'],
+command_fails(['pg_basebackup', '--target-gp-dbid', '123'],
 	'pg_basebackup needs target directory specified');
 command_fails(
-	[ 'pg_basebackup', '-D', "$tempdir/backup" ],
+	[ 'pg_basebackup', '-D', "$tempdir/backup", '--target-gp-dbid', '123' ],
 	'pg_basebackup fails because of hba');
 
 # Some Windows ANSI code pages may reject this filename, in which case we
@@ -28,39 +28,38 @@ if (open BADCHARS, ">>$tempdir/pgdata/FOO\xe0\xe0\xe0BAR")
 configure_hba_for_replication "$tempdir/pgdata";
 system_or_bail 'pg_ctl', '-D', "$tempdir/pgdata", 'reload';
 
-# GPDB: The value of max_wal_senders defaults to 1 in GPDB, instead of 0 in Postgres.
 open CONF, ">>$tempdir/pgdata/postgresql.conf";
 print CONF "max_wal_senders = 0\n";
 close CONF;
 restart_test_server;
 
 command_fails(
-	[ 'pg_basebackup', '-D', "$tempdir/backup" ],
+	[ 'pg_basebackup', '-D', "$tempdir/backup", '--target-gp-dbid', '123' ],
 	'pg_basebackup fails because of WAL configuration');
 
 #
-# TODO: When we re-enable pg_basebackup TAP tests, we need to make sure
-# this configuration variable matches the actual default guc value for
-# max_wal_senders, which increased with the addition of replication slots.
+# GPDB: The minimum value of max_wal_senders is 2 in GPDB
+# instead of 0 in Postgres.
 #
 open CONF, ">>$tempdir/pgdata/postgresql.conf";
-print CONF "max_wal_senders = 1\n";
+print CONF "max_wal_senders = 2\n";
 print CONF "wal_level = archive\n";
 close CONF;
 restart_test_server;
 
-command_ok([ 'pg_basebackup', '-D', "$tempdir/backup" ],
+command_ok([ 'pg_basebackup', '-D', "$tempdir/backup", '--target-gp-dbid', '123'],
 	'pg_basebackup runs');
 ok(-f "$tempdir/backup/PG_VERSION", 'backup was created');
 
 command_ok(
 	[   'pg_basebackup', '-D', "$tempdir/backup2", '--xlogdir',
-		"$tempdir/xlog2" ],
+		"$tempdir/xlog2", '--target-gp-dbid', '123' ],
 	'separate xlog directory');
 ok(-f "$tempdir/backup2/PG_VERSION", 'backup was created');
 ok(-d "$tempdir/xlog2/",             'xlog directory was created');
 
-command_ok([ 'pg_basebackup', '-D', "$tempdir/tarbackup", '-Ft' ],
+command_ok([ 'pg_basebackup', '-D', "$tempdir/tarbackup", '-Ft',
+			 '--target-gp-dbid', '123' ],
 	'tar format');
 ok(-f "$tempdir/tarbackup/base.tar", 'backup tar was created');
 
@@ -79,19 +78,23 @@ SKIP: {
 	mkdir "$tempdir/tblspc1";
 	psql 'postgres', "CREATE TABLESPACE tblspc1 LOCATION '$shorter_tempdir/tblspc1';";
 	psql 'postgres', "CREATE TABLE test1 (a int) TABLESPACE tblspc1;";
-	command_ok([ 'pg_basebackup', '-D', "$tempdir/tarbackup2", '-Ft' ],
+	command_ok([ 'pg_basebackup', '-D', "$tempdir/tarbackup2", '-Ft',
+			   '--target-gp-dbid', '123'],
 		'tar format with tablespaces');
 	ok(-f "$tempdir/tarbackup2/base.tar", 'backup tar was created');
 	my @tblspc_tars = glob "$tempdir/tarbackup2/[0-9]*.tar";
 	is(scalar(@tblspc_tars), 1, 'one tablespace tar was created');
 
 	command_fails(
-		[ 'pg_basebackup', '-D', "$tempdir/backup1", '-Fp' ],
+		[ 'pg_basebackup', '-D', "$tempdir/backup1", '-Fp',
+		  '--target-gp-dbid', '-1'
+		],
 		'plain format with tablespaces fails without tablespace mapping');
 
 	command_ok(
 		[   'pg_basebackup',    '-D',
 			"$tempdir/backup1", '-Fp',
+			'--target-gp-dbid', '1',
 			"-T$shorter_tempdir/tblspc1=$tempdir/tbackup/tblspc1" ],
 		'plain format with tablespaces succeeds with tablespace mapping');
 		ok(-d "$tempdir/tbackup/tblspc1", 'tablespace was relocated');
@@ -112,6 +115,7 @@ SKIP: {
 	command_ok(
 		[   'pg_basebackup',    '-D',
 			"$tempdir/backup3", '-Fp',
+			'--target-gp-dbid', '123',
 			"-T$shorter_tempdir/tbl\\=spc2=$tempdir/tbackup/tbl\\=spc2" ],
 		'mapping tablespace with = sign in path');
 	ok(-d "$tempdir/tbackup/tbl=spc2", 'tablespace with = sign was relocated');

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Cwd;
 use TestLib;
-use Test::More tests => 33;
+use Test::More tests => 34;
 
 program_help_ok('pg_basebackup');
 program_version_ok('pg_basebackup');
@@ -27,6 +27,9 @@ if (open BADCHARS, ">>$tempdir/pgdata/FOO\xe0\xe0\xe0BAR")
 
 configure_hba_for_replication "$tempdir/pgdata";
 system_or_bail 'pg_ctl', '-D', "$tempdir/pgdata", 'reload';
+
+command_fails(['pg_basebackup', '-D', "$tempdir/backup"],
+	'pg_basebackup fails without specifiying the target greenplum db id');
 
 open CONF, ">>$tempdir/pgdata/postgresql.conf";
 print CONF "max_wal_senders = 0\n";

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Cwd;
 use TestLib;
-use Test::More tests => 34;
+use Test::More tests => 33;
 
 program_help_ok('pg_basebackup');
 program_version_ok('pg_basebackup');
@@ -31,19 +31,24 @@ system_or_bail 'pg_ctl', '-D', "$tempdir/pgdata", 'reload';
 command_fails(['pg_basebackup', '-D', "$tempdir/backup"],
 	'pg_basebackup fails without specifiying the target greenplum db id');
 
-open CONF, ">>$tempdir/pgdata/postgresql.conf";
-print CONF "max_wal_senders = 0\n";
-close CONF;
-restart_test_server;
-
-command_fails(
-	[ 'pg_basebackup', '-D', "$tempdir/backup", '--target-gp-dbid', '123' ],
-	'pg_basebackup fails because of WAL configuration');
 
 #
 # GPDB: The minimum value of max_wal_senders is 2 in GPDB
 # instead of 0 in Postgres.
 #
+# This test is disabled because it is difficult to
+# set up an environment that consumes all of the slots
+# without setting up mirrors.
+#
+# open CONF, ">>$tempdir/pgdata/postgresql.conf";
+# print CONF "max_wal_senders = 0\n";
+# close CONF;
+# restart_test_server;
+
+# command_fails(
+# 	[ 'pg_basebackup', '-D', "$tempdir/backup", '--target-gp-dbid', '123' ],
+# 	'pg_basebackup fails because of WAL configuration');
+
 open CONF, ">>$tempdir/pgdata/postgresql.conf";
 print CONF "max_wal_senders = 2\n";
 print CONF "wal_level = archive\n";

--- a/src/test/perl/TestLib.pm
+++ b/src/test/perl/TestLib.pm
@@ -207,7 +207,9 @@ sub restart_test_server
 {
 	print("### Restarting test server\n");
 	system_log('pg_ctl', '-D', $test_server_datadir, '-w', '-l',
-	  $test_server_logfile, 'restart');
+	  $test_server_logfile, '-o',
+	  "--log-statement=all -c gp_role=utility --gp_dbid=-1 --gp_contentid=-1 --logging-collector=off",
+	  'restart');
 }
 
 END


### PR DESCRIPTION
Previously these tests were commented out because they were broken.

We needed to add `--target-gp-dbid` to all of the `pg_basebackup` invocations as it is a required parameter in GPDB.

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>