### PR TITLE
Add tests for `CREATE TABLE... compresstype` for all available compression types

### DIFF
--- a/gpcontrib/quicklz/.gitignore
+++ b/gpcontrib/quicklz/.gitignore
@@ -1,0 +1,10 @@
+# Generated subdirectories
+/tmp_check/
+/results/
+/log/
+
+regression.diffs
+regression.out
+
+stdin
+stdout

--- a/gpcontrib/quicklz/Makefile
+++ b/gpcontrib/quicklz/Makefile
@@ -5,7 +5,7 @@ OBJS = quicklz_compression.o
 CFLAGS_SL += -lquicklz
 LDFLAGS_SL += -lquicklz
 
-REGRESS = compression_quicklz
+REGRESS = AORO_quicklz AOCO_quicklz quicklz_column_compression compression_quicklz
 
 ifdef USE_PGXS
   PGXS := $(shell pg_config --pgxs)

--- a/gpcontrib/quicklz/expected/AOCO_quicklz.out
+++ b/gpcontrib/quicklz/expected/AOCO_quicklz.out
@@ -1,0 +1,24 @@
+-- Given that we built with and have quicklz compression available
+-- Test basic create table for AO/CO table succeeds for quicklz compression
+-- Given a column-oriented table with compresstype quicklz
+CREATE TABLE a_aoco_table_with_quicklz_compression(col text) WITH (APPENDONLY=true, COMPRESSTYPE=quicklz, compresslevel=1, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Before I insert data, the size is 0 and compression ratio is unavailable (-1)
+SELECT pg_size_pretty(pg_relation_size('a_aoco_table_with_quicklz_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_quicklz_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 0 bytes        |                       -1
+(1 row)
+
+-- When I insert data
+INSERT INTO a_aoco_table_with_quicklz_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+SELECT pg_size_pretty(pg_relation_size('a_aoco_table_with_quicklz_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_quicklz_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 72 bytes       |                     1.33
+(1 row)
+

--- a/gpcontrib/quicklz/expected/AORO_quicklz.out
+++ b/gpcontrib/quicklz/expected/AORO_quicklz.out
@@ -1,0 +1,24 @@
+-- Given that we built with and have quicklz compression available
+-- Test basic create table for AO/RO table succeeds for quicklz compression
+-- Given a row-oriented table with compresstype quicklz
+create table a_aoro_table_with_quicklz_compression(col text) WITH (APPENDONLY=true, COMPRESSTYPE=quicklz, compresslevel=1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Before inserting data, the size is 0 and ratio is 1 (for a row-oriented table, ends up being 1)
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_quicklz_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_quicklz_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 0 bytes        |                        1
+(1 row)
+
+-- When I insert data
+insert into a_aoro_table_with_quicklz_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_quicklz_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_quicklz_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 64 bytes       |                     1.38
+(1 row)
+

--- a/gpcontrib/quicklz/expected/compression_quicklz.out
+++ b/gpcontrib/quicklz/expected/compression_quicklz.out
@@ -1,36 +1,49 @@
 -- Tests for quicklz compression.
+-- Check that callbacks are registered
+SELECT * FROM pg_compression WHERE compname = 'quicklz';
+ compname |    compconstructor     |    compdestructor     |   compcompressor    |   compdecompressor    |    compvalidator     | compowner 
+----------+------------------------+-----------------------+---------------------+-----------------------+----------------------+-----------
+ quicklz  | gp_quicklz_constructor | gp_quicklz_destructor | gp_quicklz_compress | gp_quicklz_decompress | gp_quicklz_validator |        10
+(1 row)
+
 -- Test for appendonly row oriented
 CREATE TABLE quicklztest_row (id int4, t text) WITH (appendonly=true, compresstype=quicklz, orientation=row);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Check that the reloptions on the table shows compression type
+-- This is order sensitive to base on the order that the options were declared in the DDL of the table.
+SELECT reloptions[2] FROM pg_class WHERE relname = 'quicklztest_row';
+      reloptions      
+----------------------
+ compresstype=quicklz
+(1 row)
+
 INSERT INTO quicklztest_row SELECT g, 'foo' || g FROM generate_series(1, 100) g;
 INSERT INTO quicklztest_row SELECT g, 'bar' || g FROM generate_series(1, 100) g;
 -- Check contents, at the beginning of the table and at the end.
-SELECT * FROM quicklztest_row ORDER BY id LIMIT 5;
+SELECT * FROM quicklztest_row ORDER BY id LIMIT 4;
  id |  t   
 ----+------
-  1 | bar1
   1 | foo1
-  2 | bar2
+  1 | bar1
   2 | foo2
-  3 | foo3
-(5 rows)
+  2 | bar2
+(4 rows)
 
-SELECT * FROM quicklztest_row ORDER BY id DESC LIMIT 5;
+SELECT * FROM quicklztest_row ORDER BY id DESC LIMIT 4;
  id  |   t    
 -----+--------
  100 | bar100
  100 | foo100
   99 | bar99
   99 | foo99
-  98 | foo98
-(5 rows)
+(4 rows)
 
 -- Check that we actually compressed data
-SELECT get_ao_compression_ratio('quicklztest_row') > 1;
- ?column? 
-----------
- t
+SELECT get_ao_compression_ratio('quicklztest_row');
+ get_ao_compression_ratio 
+--------------------------
+                      1.8
 (1 row)
 
 -- Test for appendonly column oriented
@@ -40,31 +53,29 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 INSERT INTO quicklztest_column SELECT g, 'foo' || g FROM generate_series(1, 100) g;
 INSERT INTO quicklztest_column SELECT g, 'bar' || g FROM generate_series(1, 100) g;
 -- Check contents, at the beginning of the table and at the end.
-SELECT * FROM quicklztest_column ORDER BY id LIMIT 5;
+SELECT * FROM quicklztest_column ORDER BY id LIMIT 4;
  id |  t   
 ----+------
-  1 | bar1
   1 | foo1
-  2 | bar2
+  1 | bar1
   2 | foo2
-  3 | foo3
-(5 rows)
+  2 | bar2
+(4 rows)
 
-SELECT * FROM quicklztest_column ORDER BY id DESC LIMIT 5;
+SELECT * FROM quicklztest_column ORDER BY id DESC LIMIT 4;
  id  |   t    
 -----+--------
  100 | bar100
  100 | foo100
   99 | bar99
   99 | foo99
-  98 | foo98
-(5 rows)
+(4 rows)
 
 -- Check that we actually compressed data
-SELECT get_ao_compression_ratio('quicklztest_column') > 1;
- ?column? 
-----------
- t
+SELECT get_ao_compression_ratio('quicklztest_column');
+ get_ao_compression_ratio 
+--------------------------
+                     1.29
 (1 row)
 
 -- Test the bounds of compresslevel. QuickLZ compresslevel 1 is the only one that should work.
@@ -72,6 +83,12 @@ CREATE TABLE quicklztest_invalid (id int4) WITH (appendonly=true, compresstype=q
 ERROR:  value -1 out of bounds for option "compresslevel"
 DETAIL:  Valid values are between "0" and "19".
 CREATE TABLE quicklztest_invalid (id int4) WITH (appendonly=true, compresstype=quicklz, compresslevel=0);
-ERROR:  compresstype can't be used with compresslevel 0
+ERROR:  compresstype "quicklz" can't be used with compresslevel 0
 CREATE TABLE quicklztest_invalid (id int4) WITH (appendonly=true, compresstype=quicklz, compresslevel=3);
 ERROR:  compresslevel=3 is out of range for quicklz (should be 1)
+-- CREATE TABLE for heap table with compresstype=quicklz should fail
+CREATE TABLE quicklztest_heap (id int4, t text) WITH (compresstype=quicklz);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  invalid option "compresstype" for base relation
+HINT:  "compresstype" is only valid for Append Only relations, create an AO relation to use "compresstype".

--- a/gpcontrib/quicklz/expected/quicklz_column_compression.out
+++ b/gpcontrib/quicklz/expected/quicklz_column_compression.out
@@ -1,0 +1,99 @@
+PREPARE attribute_encoding_check AS
+SELECT attrelid::regclass AS relname,
+attnum, attoptions FROM pg_class c, pg_attribute_encoding e
+WHERE c.relname = $1 AND c.oid=e.attrelid
+ORDER BY relname, attnum;
+create type int42;
+CREATE FUNCTION int42_in(cstring)
+RETURNS int42
+AS 'int4in'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type int42 is only a shell
+CREATE FUNCTION int42_out(int42)
+RETURNS cstring
+AS 'int4out'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type int42 is only a shell
+CREATE TYPE int42 (
+internallength = 4,
+input = int42_in,
+output = int42_out,
+alignment = int4,
+default = 42,
+passedbyvalue,
+compresstype="zlib",
+blocksize=65536,
+compresslevel=1
+);
+-- Ensure type has been created with compresstype zlib
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+                     typoptions                      
+-----------------------------------------------------
+ {compresstype=zlib,blocksize=65536,compresslevel=1}
+(1 row)
+
+alter type int42 set default encoding (compresstype=quicklz);
+-- Ensure compresstype for type has been modified to be quicklz
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+                       typoptions                       
+--------------------------------------------------------
+ {compresstype=quicklz,compresslevel=1,blocksize=32768}
+(1 row)
+
+-- Given an AO/CO table using the int42 type with quicklz compresstype
+create table aoco_table_compressed_type (i int42) with(appendonly = true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+-- Attribute should show as compressed
+execute attribute_encoding_check('aoco_table_compressed_type');
+          relname           | attnum |                       attoptions                       
+----------------------------+--------+--------------------------------------------------------
+ aoco_table_compressed_type |      1 | {compresstype=quicklz,compresslevel=1,blocksize=32768}
+(1 row)
+
+-- When I insert data
+insert into aoco_table_compressed_type select '123456'::int42 from generate_series(1, 1000)i;
+-- Then the data should be compressed and return a consistent compression ratio
+select get_ao_compression_ratio('aoco_table_compressed_type') as quicklz_compress_ratio;
+ quicklz_compress_ratio 
+------------------------
+                   17.2
+(1 row)
+
+-- Given an AO/RO table using the int42 type with quicklz compresstype
+CREATE TABLE aoro_table_compressed_type (i int42) with(appendonly = true, orientation=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+-- No results are returned from the attribute encoding check, as compression with quicklz is not supported for row-oriented tables
+execute attribute_encoding_check('aoro_table_compressed_type');
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
+
+-- Given a heap table using the int42 type with quicklz compresstype
+CREATE TABLE heap_table_compressed_type (i int42);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+-- No results are returned from the attribute encoding check, as compression with quicklz is not supported for heap tables
+EXECUTE attribute_encoding_check('heap_table_compressed_type');
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
+
+-- Given an AO/CO table with a regular int column and a default column encoding of compresstype quicklz
+CREATE TABLE aoco_table_default_encoding (i int, default column encoding (compresstype=quicklz, compresslevel=1)) with(appendonly = true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Attribute should show as compressed
+execute attribute_encoding_check('aoco_table_default_encoding');
+           relname           | attnum |                       attoptions                       
+-----------------------------+--------+--------------------------------------------------------
+ aoco_table_default_encoding |      1 | {compresstype=quicklz,compresslevel=1,blocksize=32768}
+(1 row)
+
+-- When I insert data
+INSERT into aoco_table_default_encoding select 1 from generate_series(1, 100);
+-- Then the data should be compressed and return a consistent compression ratio
+SELECT get_ao_compression_ratio('aoco_table_default_encoding') as quicklz_compress_ratio;
+ quicklz_compress_ratio 
+------------------------
+                   6.88
+(1 row)
+

--- a/gpcontrib/quicklz/sql/AOCO_quicklz.sql
+++ b/gpcontrib/quicklz/sql/AOCO_quicklz.sql
@@ -1,0 +1,13 @@
+-- Given that we built with and have quicklz compression available
+-- Test basic create table for AO/CO table succeeds for quicklz compression
+
+-- Given a column-oriented table with compresstype quicklz
+CREATE TABLE a_aoco_table_with_quicklz_compression(col text) WITH (APPENDONLY=true, COMPRESSTYPE=quicklz, compresslevel=1, ORIENTATION=column);
+-- Before I insert data, the size is 0 and compression ratio is unavailable (-1)
+SELECT pg_size_pretty(pg_relation_size('a_aoco_table_with_quicklz_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_quicklz_compression');
+-- When I insert data
+INSERT INTO a_aoco_table_with_quicklz_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+SELECT pg_size_pretty(pg_relation_size('a_aoco_table_with_quicklz_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_quicklz_compression');

--- a/gpcontrib/quicklz/sql/AORO_quicklz.sql
+++ b/gpcontrib/quicklz/sql/AORO_quicklz.sql
@@ -1,0 +1,14 @@
+-- Given that we built with and have quicklz compression available
+-- Test basic create table for AO/RO table succeeds for quicklz compression
+
+-- Given a row-oriented table with compresstype quicklz
+create table a_aoro_table_with_quicklz_compression(col text) WITH (APPENDONLY=true, COMPRESSTYPE=quicklz, compresslevel=1);
+-- Before inserting data, the size is 0 and ratio is 1 (for a row-oriented table, ends up being 1)
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_quicklz_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_quicklz_compression');
+-- When I insert data
+insert into a_aoro_table_with_quicklz_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_quicklz_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_quicklz_compression');
+

--- a/gpcontrib/quicklz/sql/compression_quicklz.sql
+++ b/gpcontrib/quicklz/sql/compression_quicklz.sql
@@ -1,17 +1,24 @@
 -- Tests for quicklz compression.
 
+-- Check that callbacks are registered
+SELECT * FROM pg_compression WHERE compname = 'quicklz';
+
 -- Test for appendonly row oriented
 CREATE TABLE quicklztest_row (id int4, t text) WITH (appendonly=true, compresstype=quicklz, orientation=row);
+
+-- Check that the reloptions on the table shows compression type
+-- This is order sensitive to base on the order that the options were declared in the DDL of the table.
+SELECT reloptions[2] FROM pg_class WHERE relname = 'quicklztest_row';
 
 INSERT INTO quicklztest_row SELECT g, 'foo' || g FROM generate_series(1, 100) g;
 INSERT INTO quicklztest_row SELECT g, 'bar' || g FROM generate_series(1, 100) g;
 
 -- Check contents, at the beginning of the table and at the end.
-SELECT * FROM quicklztest_row ORDER BY id LIMIT 5;
-SELECT * FROM quicklztest_row ORDER BY id DESC LIMIT 5;
+SELECT * FROM quicklztest_row ORDER BY id LIMIT 4;
+SELECT * FROM quicklztest_row ORDER BY id DESC LIMIT 4;
 
 -- Check that we actually compressed data
-SELECT get_ao_compression_ratio('quicklztest_row') > 1;
+SELECT get_ao_compression_ratio('quicklztest_row');
 
 -- Test for appendonly column oriented
 CREATE TABLE quicklztest_column (id int4, t text) WITH (appendonly=true, compresstype=quicklz, orientation=column);
@@ -20,13 +27,16 @@ INSERT INTO quicklztest_column SELECT g, 'foo' || g FROM generate_series(1, 100)
 INSERT INTO quicklztest_column SELECT g, 'bar' || g FROM generate_series(1, 100) g;
 
 -- Check contents, at the beginning of the table and at the end.
-SELECT * FROM quicklztest_column ORDER BY id LIMIT 5;
-SELECT * FROM quicklztest_column ORDER BY id DESC LIMIT 5;
+SELECT * FROM quicklztest_column ORDER BY id LIMIT 4;
+SELECT * FROM quicklztest_column ORDER BY id DESC LIMIT 4;
 
 -- Check that we actually compressed data
-SELECT get_ao_compression_ratio('quicklztest_column') > 1;
+SELECT get_ao_compression_ratio('quicklztest_column');
 
 -- Test the bounds of compresslevel. QuickLZ compresslevel 1 is the only one that should work.
 CREATE TABLE quicklztest_invalid (id int4) WITH (appendonly=true, compresstype=quicklz, compresslevel=-1);
 CREATE TABLE quicklztest_invalid (id int4) WITH (appendonly=true, compresstype=quicklz, compresslevel=0);
 CREATE TABLE quicklztest_invalid (id int4) WITH (appendonly=true, compresstype=quicklz, compresslevel=3);
+
+-- CREATE TABLE for heap table with compresstype=quicklz should fail
+CREATE TABLE quicklztest_heap (id int4, t text) WITH (compresstype=quicklz);

--- a/gpcontrib/quicklz/sql/quicklz_column_compression.sql
+++ b/gpcontrib/quicklz/sql/quicklz_column_compression.sql
@@ -1,0 +1,63 @@
+PREPARE attribute_encoding_check AS
+SELECT attrelid::regclass AS relname,
+attnum, attoptions FROM pg_class c, pg_attribute_encoding e
+WHERE c.relname = $1 AND c.oid=e.attrelid
+ORDER BY relname, attnum;
+
+create type int42;
+CREATE FUNCTION int42_in(cstring)
+RETURNS int42
+AS 'int4in'
+LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE FUNCTION int42_out(int42)
+RETURNS cstring
+AS 'int4out'
+LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE TYPE int42 (
+internallength = 4,
+input = int42_in,
+output = int42_out,
+alignment = int4,
+default = 42,
+passedbyvalue,
+compresstype="zlib",
+blocksize=65536,
+compresslevel=1
+);
+
+-- Ensure type has been created with compresstype zlib
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+
+alter type int42 set default encoding (compresstype=quicklz);
+-- Ensure compresstype for type has been modified to be quicklz
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+
+-- Given an AO/CO table using the int42 type with quicklz compresstype
+create table aoco_table_compressed_type (i int42) with(appendonly = true, orientation=column);
+-- Attribute should show as compressed
+execute attribute_encoding_check('aoco_table_compressed_type');
+-- When I insert data
+insert into aoco_table_compressed_type select '123456'::int42 from generate_series(1, 1000)i;
+-- Then the data should be compressed and return a consistent compression ratio
+select get_ao_compression_ratio('aoco_table_compressed_type') as quicklz_compress_ratio;
+
+-- Given an AO/RO table using the int42 type with quicklz compresstype
+CREATE TABLE aoro_table_compressed_type (i int42) with(appendonly = true, orientation=row);
+-- No results are returned from the attribute encoding check, as compression with quicklz is not supported for row-oriented tables
+execute attribute_encoding_check('aoro_table_compressed_type');
+
+-- Given a heap table using the int42 type with quicklz compresstype
+CREATE TABLE heap_table_compressed_type (i int42);
+-- No results are returned from the attribute encoding check, as compression with quicklz is not supported for heap tables
+EXECUTE attribute_encoding_check('heap_table_compressed_type');
+
+-- Given an AO/CO table with a regular int column and a default column encoding of compresstype quicklz
+CREATE TABLE aoco_table_default_encoding (i int, default column encoding (compresstype=quicklz, compresslevel=1)) with(appendonly = true, orientation=column);
+-- Attribute should show as compressed
+execute attribute_encoding_check('aoco_table_default_encoding');
+-- When I insert data
+INSERT into aoco_table_default_encoding select 1 from generate_series(1, 100);
+-- Then the data should be compressed and return a consistent compression ratio
+SELECT get_ao_compression_ratio('aoco_table_default_encoding') as quicklz_compress_ratio;

--- a/gpcontrib/zstd/.gitignore
+++ b/gpcontrib/zstd/.gitignore
@@ -1,0 +1,10 @@
+# Generated subdirectories
+/tmp_check/
+/results/
+/log/
+
+regression.diffs
+regression.out
+
+stdin
+stdout

--- a/gpcontrib/zstd/Makefile
+++ b/gpcontrib/zstd/Makefile
@@ -5,7 +5,7 @@ OBJS = zstd_compression.o
 CFLAGS_SL += -lzstd
 LDFLAGS_SL += -lzstd
 
-REGRESS = compression_zstd zstd_abort_leak
+REGRESS = zstd_column_compression compression_zstd zstd_abort_leak AOCO_zstd AORO_zstd
 
 ifdef USE_PGXS
   PGXS := $(shell pg_config --pgxs)

--- a/gpcontrib/zstd/expected/AOCO_zstd.out
+++ b/gpcontrib/zstd/expected/AOCO_zstd.out
@@ -1,0 +1,26 @@
+-- Given that we built with and have zstd compression available
+-- Test basic create table for AO/CO table succeeds for zstd compression
+-- Given a column-oriented table with compresstype zstd
+DROP TABLE IF EXISTS a_aoco_table_with_zstd_compression;
+NOTICE:  table "a_aoco_table_with_zstd_compression" does not exist, skipping
+CREATE TABLE a_aoco_table_with_zstd_compression(col text) WITH (APPENDONLY=true, COMPRESSTYPE=zstd, compresslevel=1, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Before I insert data, the size is 0 and compression ratio is unavailable (-1)
+SELECT pg_size_pretty(pg_relation_size('a_aoco_table_with_zstd_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_zstd_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 0 bytes        |                       -1
+(1 row)
+
+-- After I insert data
+INSERT INTO a_aoco_table_with_zstd_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoco_table_with_zstd_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_zstd_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 64 bytes       |                      1.5
+(1 row)
+

--- a/gpcontrib/zstd/expected/AORO_zstd.out
+++ b/gpcontrib/zstd/expected/AORO_zstd.out
@@ -1,0 +1,24 @@
+-- Given that we built with and have zstd compression available
+-- Test basic create table for AO/RO table succeeds for zstd compression
+-- Given a row-oriented table with compresstype zstd
+create table a_aoro_table_with_zstd_compression(col text) WITH (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zstd, compresslevel=1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Before inserting data, the size is 0 and ratio is 1 (for a row-oriented table, ends up being 1)
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_zstd_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_zstd_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 0 bytes        |                        1
+(1 row)
+
+-- After I insert data
+insert into a_aoro_table_with_zstd_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_zstd_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_zstd_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 64 bytes       |                     1.38
+(1 row)
+

--- a/gpcontrib/zstd/expected/compression_zstd.out
+++ b/gpcontrib/zstd/expected/compression_zstd.out
@@ -1,9 +1,31 @@
 -- Tests for zstd compression.
+-- Check that callbacks are registered
+SELECT * FROM pg_compression WHERE compname = 'zstd';
+ compname |   compconstructor   |   compdestructor   |  compcompressor  |  compdecompressor  |   compvalidator   | compowner 
+----------+---------------------+--------------------+------------------+--------------------+-------------------+-----------
+ zstd     | gp_zstd_constructor | gp_zstd_destructor | gp_zstd_compress | gp_zstd_decompress | gp_zstd_validator |        10
+(1 row)
+
 CREATE TABLE zstdtest (id int4, t text) WITH (appendonly=true, compresstype=zstd, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Check that the reloptions on the table shows compression type
+-- This is order sensitive to base on the order that the options were declared in the DDL of the table.
+SELECT reloptions[2] FROM pg_class WHERE relname = 'zstdtest';
+    reloptions     
+-------------------
+ compresstype=zstd
+(1 row)
+
 INSERT INTO zstdtest SELECT g, 'foo' || g FROM generate_series(1, 100000) g;
 INSERT INTO zstdtest SELECT g, 'bar' || g FROM generate_series(1, 100000) g;
+-- Check that we actually compressed data
+SELECT get_ao_compression_ratio('zstdtest');
+ get_ao_compression_ratio 
+--------------------------
+                     2.62
+(1 row)
+
 -- Check contents, at the beginning of the table and at the end.
 SELECT * FROM zstdtest ORDER BY (id, t) LIMIT 5;
  id |  t   
@@ -88,3 +110,9 @@ ERROR:  compresstype "zstd" can't be used with compresslevel 0
 CREATE TABLE zstdtest_invalid (id int4) WITH (appendonly=true, compresstype=zstd, compresslevel=20);
 ERROR:  value 20 out of bounds for option "compresslevel"
 DETAIL:  Valid values are between "0" and "19".
+-- CREATE TABLE for heap table with compresstype=zstd should fail
+CREATE TABLE zstdtest_heap (id int4, t text) WITH (compresstype=zstd);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  invalid option "compresstype" for base relation
+HINT:  "compresstype" is only valid for Append Only relations, create an AO relation to use "compresstype".

--- a/gpcontrib/zstd/expected/zstd_column_compression.out
+++ b/gpcontrib/zstd/expected/zstd_column_compression.out
@@ -1,0 +1,106 @@
+DROP DATABASE IF EXISTS zstd_column_compression;
+CREATE DATABASE zstd_column_compression;
+\c zstd_column_compression
+PREPARE attribute_encoding_check AS
+SELECT attrelid::regclass AS relname,
+attnum, attoptions FROM pg_class c, pg_attribute_encoding e
+WHERE c.relname = $1 AND c.oid=e.attrelid
+ORDER BY relname, attnum;
+drop type if exists int42 cascade;
+NOTICE:  type "int42" does not exist, skipping
+create type int42;
+CREATE FUNCTION int42_in(cstring)
+RETURNS int42
+AS 'int4in'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type int42 is only a shell
+CREATE FUNCTION int42_out(int42)
+RETURNS cstring
+AS 'int4out'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type int42 is only a shell
+CREATE TYPE int42 (
+internallength = 4,
+input = int42_in,
+output = int42_out,
+alignment = int4,
+default = 42,
+passedbyvalue,
+compresstype="zlib",
+blocksize=65536,
+compresslevel=1
+);
+-- Ensure type has been created with compresstype zlib
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+                     typoptions                      
+-----------------------------------------------------
+ {compresstype=zlib,blocksize=65536,compresslevel=1}
+(1 row)
+
+alter type int42 set default encoding (compresstype=zstd);
+-- Ensure compresstype for type has been modified to be zstd
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+                     typoptions                      
+-----------------------------------------------------
+ {compresstype=zstd,compresslevel=1,blocksize=32768}
+(1 row)
+
+-- Given an AO/CO table using the int42 type with zstd compresstype
+CREATE TABLE IF NOT EXISTS aoco_table_compressed_type (i int42) with(appendonly = true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+-- Attribute should show as compressed
+EXECUTE attribute_encoding_check ('aoco_table_compressed_type');
+          relname           | attnum |                     attoptions                      
+----------------------------+--------+-----------------------------------------------------
+ aoco_table_compressed_type |      1 | {compresstype=zstd,compresslevel=1,blocksize=32768}
+(1 row)
+
+-- When I insert data
+insert into aoco_table_compressed_type select '123456'::int42 from generate_series(1, 1000)i;
+-- Then the data should be compressed and return a consistent compression ratio
+-- Because the ratio varies depending on the version, use > here instead of checking the exact ratio.
+select get_ao_compression_ratio('aoco_table_compressed_type') > 21 as zstd_compress_ratio;
+ zstd_compress_ratio 
+---------------------
+ t
+(1 row)
+
+-- Given an AO/RO table using the int42 type with zstd compresstype
+CREATE TABLE IF NOT EXISTS aoro_table_compressed_type (i int42) WITH (appendonly=true, orientation=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+-- No results are returned from the attribute encoding check, as compression with zstd is not supported for row-oriented tables
+EXECUTE attribute_encoding_check ('aoro_table_compressed_type');
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
+
+-- Given a heap table using the int42 type with zstd compresstype
+CREATE TABLE IF NOT EXISTS heap_table_compressed_type (i int42);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+-- No results are returned from the attribute encoding check, as compression with zstd is not supported for heap tables
+EXECUTE attribute_encoding_check ('heap_table_compressed_type');
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
+
+-- Given an AO/CO table with a regular int column and a default column encoding of compresstype zstd
+CREATE TABLE IF NOT EXISTS aoco_table_default_encoding (i int, default column encoding (compresstype=zstd, compresslevel=1)) with(appendonly = true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Attribute should show as compressed
+EXECUTE attribute_encoding_check ('aoco_table_default_encoding');
+           relname           | attnum |                     attoptions                      
+-----------------------------+--------+-----------------------------------------------------
+ aoco_table_default_encoding |      1 | {compresstype=zstd,compresslevel=1,blocksize=32768}
+(1 row)
+
+-- When I insert data
+INSERT into aoco_table_default_encoding select 1 from generate_series(1, 100);
+-- Then the data should be compressed and return a consistent compression ratio
+-- Because the ratio varies depending on the version, use > here instead of checking the exact ratio.
+SELECT get_ao_compression_ratio('aoco_table_default_encoding') > 7 as zstd_compress_ratio;
+ zstd_compress_ratio 
+---------------------
+ t
+(1 row)
+

--- a/gpcontrib/zstd/sql/AOCO_zstd.sql
+++ b/gpcontrib/zstd/sql/AOCO_zstd.sql
@@ -1,0 +1,14 @@
+-- Given that we built with and have zstd compression available
+-- Test basic create table for AO/CO table succeeds for zstd compression
+
+-- Given a column-oriented table with compresstype zstd
+DROP TABLE IF EXISTS a_aoco_table_with_zstd_compression;
+CREATE TABLE a_aoco_table_with_zstd_compression(col text) WITH (APPENDONLY=true, COMPRESSTYPE=zstd, compresslevel=1, ORIENTATION=column);
+-- Before I insert data, the size is 0 and compression ratio is unavailable (-1)
+SELECT pg_size_pretty(pg_relation_size('a_aoco_table_with_zstd_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_zstd_compression');
+-- After I insert data
+INSERT INTO a_aoco_table_with_zstd_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoco_table_with_zstd_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_zstd_compression');

--- a/gpcontrib/zstd/sql/AORO_zstd.sql
+++ b/gpcontrib/zstd/sql/AORO_zstd.sql
@@ -1,0 +1,13 @@
+-- Given that we built with and have zstd compression available
+-- Test basic create table for AO/RO table succeeds for zstd compression
+
+-- Given a row-oriented table with compresstype zstd
+create table a_aoro_table_with_zstd_compression(col text) WITH (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zstd, compresslevel=1);
+-- Before inserting data, the size is 0 and ratio is 1 (for a row-oriented table, ends up being 1)
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_zstd_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_zstd_compression');
+-- After I insert data
+insert into a_aoro_table_with_zstd_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_zstd_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_zstd_compression');

--- a/gpcontrib/zstd/sql/compression_zstd.sql
+++ b/gpcontrib/zstd/sql/compression_zstd.sql
@@ -1,9 +1,19 @@
 -- Tests for zstd compression.
 
+-- Check that callbacks are registered
+SELECT * FROM pg_compression WHERE compname = 'zstd';
+
 CREATE TABLE zstdtest (id int4, t text) WITH (appendonly=true, compresstype=zstd, orientation=column);
+
+-- Check that the reloptions on the table shows compression type
+-- This is order sensitive to base on the order that the options were declared in the DDL of the table.
+SELECT reloptions[2] FROM pg_class WHERE relname = 'zstdtest';
 
 INSERT INTO zstdtest SELECT g, 'foo' || g FROM generate_series(1, 100000) g;
 INSERT INTO zstdtest SELECT g, 'bar' || g FROM generate_series(1, 100000) g;
+
+-- Check that we actually compressed data
+SELECT get_ao_compression_ratio('zstdtest');
 
 -- Check contents, at the beginning of the table and at the end.
 SELECT * FROM zstdtest ORDER BY (id, t) LIMIT 5;
@@ -30,3 +40,6 @@ SELECT * FROM zstdtest_19 ORDER BY (id, t) DESC LIMIT 5;
 CREATE TABLE zstdtest_invalid (id int4) WITH (appendonly=true, compresstype=zstd, compresslevel=-1);
 CREATE TABLE zstdtest_invalid (id int4) WITH (appendonly=true, compresstype=zstd, compresslevel=0);
 CREATE TABLE zstdtest_invalid (id int4) WITH (appendonly=true, compresstype=zstd, compresslevel=20);
+
+-- CREATE TABLE for heap table with compresstype=zstd should fail
+CREATE TABLE zstdtest_heap (id int4, t text) WITH (compresstype=zstd);

--- a/gpcontrib/zstd/sql/zstd_column_compression.sql
+++ b/gpcontrib/zstd/sql/zstd_column_compression.sql
@@ -1,0 +1,70 @@
+DROP DATABASE IF EXISTS zstd_column_compression;
+CREATE DATABASE zstd_column_compression;
+\c zstd_column_compression
+
+PREPARE attribute_encoding_check AS
+SELECT attrelid::regclass AS relname,
+attnum, attoptions FROM pg_class c, pg_attribute_encoding e
+WHERE c.relname = $1 AND c.oid=e.attrelid
+ORDER BY relname, attnum;
+
+drop type if exists int42 cascade;
+create type int42;
+CREATE FUNCTION int42_in(cstring)
+RETURNS int42
+AS 'int4in'
+LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE FUNCTION int42_out(int42)
+RETURNS cstring
+AS 'int4out'
+LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE TYPE int42 (
+internallength = 4,
+input = int42_in,
+output = int42_out,
+alignment = int4,
+default = 42,
+passedbyvalue,
+compresstype="zlib",
+blocksize=65536,
+compresslevel=1
+);
+
+-- Ensure type has been created with compresstype zlib
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+
+alter type int42 set default encoding (compresstype=zstd);
+-- Ensure compresstype for type has been modified to be zstd
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+
+-- Given an AO/CO table using the int42 type with zstd compresstype
+CREATE TABLE IF NOT EXISTS aoco_table_compressed_type (i int42) with(appendonly = true, orientation=column);
+-- Attribute should show as compressed
+EXECUTE attribute_encoding_check ('aoco_table_compressed_type');
+-- When I insert data
+insert into aoco_table_compressed_type select '123456'::int42 from generate_series(1, 1000)i;
+-- Then the data should be compressed and return a consistent compression ratio
+-- Because the ratio varies depending on the version, use > here instead of checking the exact ratio.
+select get_ao_compression_ratio('aoco_table_compressed_type') > 21 as zstd_compress_ratio;
+
+-- Given an AO/RO table using the int42 type with zstd compresstype
+CREATE TABLE IF NOT EXISTS aoro_table_compressed_type (i int42) WITH (appendonly=true, orientation=row);
+-- No results are returned from the attribute encoding check, as compression with zstd is not supported for row-oriented tables
+EXECUTE attribute_encoding_check ('aoro_table_compressed_type');
+
+-- Given a heap table using the int42 type with zstd compresstype
+CREATE TABLE IF NOT EXISTS heap_table_compressed_type (i int42);
+-- No results are returned from the attribute encoding check, as compression with zstd is not supported for heap tables
+EXECUTE attribute_encoding_check ('heap_table_compressed_type');
+
+-- Given an AO/CO table with a regular int column and a default column encoding of compresstype zstd
+CREATE TABLE IF NOT EXISTS aoco_table_default_encoding (i int, default column encoding (compresstype=zstd, compresslevel=1)) with(appendonly = true, orientation=column);
+-- Attribute should show as compressed
+EXECUTE attribute_encoding_check ('aoco_table_default_encoding');
+-- When I insert data
+INSERT into aoco_table_default_encoding select 1 from generate_series(1, 100);
+-- Then the data should be compressed and return a consistent compression ratio
+-- Because the ratio varies depending on the version, use > here instead of checking the exact ratio.
+SELECT get_ao_compression_ratio('aoco_table_default_encoding') > 7 as zstd_compress_ratio;

--- a/gpcontrib/zstd/zstd_compression.c
+++ b/gpcontrib/zstd/zstd_compression.c
@@ -31,7 +31,9 @@ PG_FUNCTION_INFO_V1(zstd_compress);
 PG_FUNCTION_INFO_V1(zstd_decompress);
 PG_FUNCTION_INFO_V1(zstd_validator);
 
+#ifndef UNIT_TESTING
 PG_MODULE_MAGIC;
+#endif
 
 /* Internal state for zstd */
 typedef struct zstd_state

--- a/src/test/regress/expected/AOCO_Compression.out
+++ b/src/test/regress/expected/AOCO_Compression.out
@@ -3907,6 +3907,7 @@ Select count(*) from co_create_type_rle_type_8192_4;
     32
 (1 row)
 
+-- Given an AO/CO with zlib type compression
 Drop table if exists mpp17012_compress_test2;
 NOTICE:  table "mpp17012_compress_test2" does not exist, skipping
 create table mpp17012_compress_test2 (
@@ -3937,7 +3938,9 @@ Checksum: t
 Distributed by: (col1)
 Options: appendonly=true, orientation=column
 
+-- When I insert data
 insert into mpp17012_compress_test2 values('a',generate_series(1,250),'ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh','bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+-- Then the data will be compressed according to a consistent compression ratio
 select pg_size_pretty(pg_relation_size('mpp17012_compress_test2')),
 get_ao_compression_ratio('mpp17012_compress_test2');
  pg_size_pretty | get_ao_compression_ratio 
@@ -3945,11 +3948,46 @@ get_ao_compression_ratio('mpp17012_compress_test2');
  712 bytes      |                    36.75
 (1 row)
 
--- compute compression ratio on empty aorow table
-create table empty_aorow_table (c int) with (appendonly=true) distributed by (c);
-select get_ao_compression_ratio('empty_aorow_table');
- get_ao_compression_ratio 
---------------------------
-                        1
+-- Test that an AO/CO table with compresstype zlib and invalid compress level will error at create
+create table a_aoco_table_with_zlib_and_invalid_compression_level(col text) WITH (APPENDONLY=true, COMPRESSTYPE=zlib, compresslevel=-1, ORIENTATION=column);
+ERROR:  value -1 out of bounds for option "compresslevel"
+DETAIL:  Valid values are between "0" and "19".
+-- Check that callbacks are registered
+SELECT * FROM pg_compression WHERE compname='zlib';
+ compname |   compconstructor   |   compdestructor   |  compcompressor  |  compdecompressor  |   compvalidator   | compowner 
+----------+---------------------+--------------------+------------------+--------------------+-------------------+-----------
+ zlib     | gp_zlib_constructor | gp_zlib_destructor | gp_zlib_compress | gp_zlib_decompress | gp_zlib_validator |        10
+(1 row)
+
+-- Given an AO/CO with RLE type compression
+create table a_aoco_table_with_rle_type_compression(col int) WITH (APPENDONLY=true, COMPRESSTYPE=rle_type, compresslevel=1, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select pg_size_pretty(pg_relation_size('a_aoco_table_with_rle_type_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_rle_type_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 0 bytes        |                       -1
+(1 row)
+
+-- When I insert data
+insert into a_aoco_table_with_rle_type_compression select i from generate_series(1,100)i;
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoco_table_with_rle_type_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_rle_type_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 296 bytes      |                     1.81
+(1 row)
+
+-- Test that an AO/CO table with compresstype rle and invalid compress level will error at create
+create table a_aoco_table_with_rle_type_and_invalid_compression_level(col int) WITH (APPENDONLY=true, COMPRESSTYPE=rle_type, compresslevel=-1, ORIENTATION=column);
+ERROR:  value -1 out of bounds for option "compresslevel"
+DETAIL:  Valid values are between "0" and "19".
+-- Check that callbacks are registered
+SELECT * FROM pg_compression WHERE compname='rle_type';
+ compname |     compconstructor     |     compdestructor     |    compcompressor    |    compdecompressor    |     compvalidator     | compowner 
+----------+-------------------------+------------------------+----------------------+------------------------+-----------------------+-----------
+ rle_type | gp_rle_type_constructor | gp_rle_type_destructor | gp_rle_type_compress | gp_rle_type_decompress | gp_rle_type_validator |        10
 (1 row)
 

--- a/src/test/regress/expected/AORO_Compression.out
+++ b/src/test/regress/expected/AORO_Compression.out
@@ -1,0 +1,27 @@
+-- Test basic create table for AO/RO table succeeds for zlib compression
+-- Given a row-oriented table with compresstype zlib
+CREATE TABLE a_aoro_table_with_zlib_compression(col int) WITH (APPENDONLY=true, COMPRESSTYPE=zlib, COMPRESSLEVEL=1, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT pg_size_pretty(pg_relation_size('a_aoro_table_with_zlib_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_zlib_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 0 bytes        |                        1
+(1 row)
+
+-- When I insert data
+INSERT INTO a_aoro_table_with_zlib_compression SELECT i from generate_series(1, 100)i;
+-- Then the data will be compressed according to a consistent compression ratio
+SELECT pg_size_pretty(pg_relation_size('a_aoro_table_with_zlib_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_zlib_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 544 bytes      |                     2.04
+(1 row)
+
+-- Test basic create table for AO/RO table fails for rle compression. rle is only supported for columnar tables.
+CREATE TABLE a_aoro_table_with_rle_type_compression(col int) WITH (APPENDONLY=true, COMPRESSTYPE=rle_type, COMPRESSLEVEL=1, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  rle_type cannot be used with Append Only relations row orientation

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -421,6 +421,8 @@ drop table ccddl_co, ccddl;
 -- Expect: failure
 -----------------------------------------------------------------------
 -- only support CO tables
+create table ccddl (i int encoding (compresstype=RLE_TYPE));
+ERROR:  ENCODING clause only supported with column oriented tables
 create table ccddl (i int encoding (compresstype=zlib));
 ERROR:  ENCODING clause only supported with column oriented tables
 create table ccddl (i int encoding (compresstype=zlib))
@@ -1742,6 +1744,15 @@ execute ccddlcheck;
 (2 rows)
 
 drop table ccddl;
+create table ccddl (i int42) with(appendonly = true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+execute ccddlcheck;
+ relname | attnum |                     attoptions                      
+---------+--------+-----------------------------------------------------
+ ccddl   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(1 row)
+
+drop table ccddl;
 -- Shouldn't apply type default encoding in these cases
 create table ccddl (i int42);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
@@ -1762,11 +1773,36 @@ drop table ccddl;
 create table ccddl (i int42) with (appendonly = true, orientation=column,
 compresstype=none);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+alter type int42 set default encoding (compresstype=RLE_TYPE);
+alter table ccddl add column j int42 default '1'::int42;
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
+ relname | attnum |                       attoptions                        
+---------+--------+---------------------------------------------------------
  ccddl   |      1 | {compresstype=none,compresslevel=0,blocksize=32768}
-(1 row)
+ ccddl   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(2 rows)
+
+drop table ccddl;
+create table ccddl (i int42) with(appendonly = true, orientation=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+alter type int42 set default encoding (compresstype=RLE_TYPE);
+alter table ccddl add column j int42 default '1'::int42;
+-- No results are returned from the attribute encoding check, as compression with rle is not supported for row tables
+execute ccddlcheck;
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
+
+drop table ccddl;
+create table ccddl (i int42) with(appendonly = true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+alter type int42 set default encoding (compresstype=RLE_TYPE);
+alter table ccddl add column j int42 default '1'::int42;
+-- No results are returned from the attribute encoding check, as compression with rle is not supported for heap tables
+execute ccddlcheck;
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
 
 drop table ccddl;
 -- We used to accept SQL standard aliases for the built-in types,

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -224,7 +224,7 @@ test: vacuum_full_freeze_heap
 test: vacuum_full_heap
 test: vacuum_full_heap_bitmapindex
 
-test: ao_checksum_corruption AOCO_Compression2 table_statistics fts_error
+test: ao_checksum_corruption AOCO_Compression AORO_Compression table_statistics fts_error
 test: metadata_track
 test: workfile_mgr_test
 test: session_reset

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -503,8 +503,7 @@ insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'
 insert into aocs_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
 insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'), pg_relation_size('aocs_compress_id_index'), pg_relation_size('aocs_compress_v_index'));
 
--- compression ratio should be between 1.2 and 1.3
-select get_ao_compression_ratio('aocs_compress_table') > 1.2 and get_ao_compression_ratio('aocs_compress_table') < 1.3;
+select get_ao_compression_ratio('aocs_compress_table');
 select get_ao_distribution('aocs_compress_table');
 
 truncate table aocs_compress_table; -- after truncate, reclaim space from the table and index

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -550,8 +550,7 @@ insert into ao_compress_results values (pg_relation_size('ao_compress_table'), p
 insert into ao_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
 insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
 
--- compression ratio should be between 1.2 and 1.3
-select get_ao_compression_ratio('ao_compress_table') > 1.2 and get_ao_compression_ratio('ao_compress_table') < 1.3;
+select get_ao_compression_ratio('ao_compress_table');
 select get_ao_distribution('ao_compress_table');
 
 truncate table ao_compress_table; -- after truncate, reclaim space from the table and index

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1015,11 +1015,10 @@ create index aocs_compress_v_index on aocs_compress_table (v);
 insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'), pg_relation_size('aocs_compress_id_index'), pg_relation_size('aocs_compress_v_index'));
 insert into aocs_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
 insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'), pg_relation_size('aocs_compress_id_index'), pg_relation_size('aocs_compress_v_index'));
--- compression ratio should be between 1.2 and 1.3
-select get_ao_compression_ratio('aocs_compress_table') > 1.2 and get_ao_compression_ratio('aocs_compress_table') < 1.3;
- ?column? 
-----------
- t
+select get_ao_compression_ratio('aocs_compress_table');
+ get_ao_compression_ratio 
+--------------------------
+                     1.26
 (1 row)
 
 select get_ao_distribution('aocs_compress_table');

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1185,11 +1185,10 @@ create index ao_compress_v_index on ao_compress_table (v);
 insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
 insert into ao_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
 insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
--- compression ratio should be between 1.2 and 1.3
-select get_ao_compression_ratio('ao_compress_table') > 1.2 and get_ao_compression_ratio('ao_compress_table') < 1.3;
- ?column? 
-----------
- t
+select get_ao_compression_ratio('ao_compress_table');
+ get_ao_compression_ratio 
+--------------------------
+                     1.27
 (1 row)
 
 select get_ao_distribution('ao_compress_table');

--- a/src/test/regress/sql/AORO_Compression.sql
+++ b/src/test/regress/sql/AORO_Compression.sql
@@ -1,0 +1,13 @@
+-- Test basic create table for AO/RO table succeeds for zlib compression
+-- Given a row-oriented table with compresstype zlib
+CREATE TABLE a_aoro_table_with_zlib_compression(col int) WITH (APPENDONLY=true, COMPRESSTYPE=zlib, COMPRESSLEVEL=1, ORIENTATION=row);
+SELECT pg_size_pretty(pg_relation_size('a_aoro_table_with_zlib_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_zlib_compression');
+-- When I insert data
+INSERT INTO a_aoro_table_with_zlib_compression SELECT i from generate_series(1, 100)i;
+-- Then the data will be compressed according to a consistent compression ratio
+SELECT pg_size_pretty(pg_relation_size('a_aoro_table_with_zlib_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_zlib_compression');
+
+-- Test basic create table for AO/RO table fails for rle compression. rle is only supported for columnar tables.
+CREATE TABLE a_aoro_table_with_rle_type_compression(col int) WITH (APPENDONLY=true, COMPRESSTYPE=rle_type, COMPRESSLEVEL=1, ORIENTATION=row);

--- a/src/test/regress/sql/column_compression.sql
+++ b/src/test/regress/sql/column_compression.sql
@@ -139,6 +139,7 @@ drop table ccddl_co, ccddl;
 -----------------------------------------------------------------------
 
 -- only support CO tables
+create table ccddl (i int encoding (compresstype=RLE_TYPE));
 create table ccddl (i int encoding (compresstype=zlib));
 create table ccddl (i int encoding (compresstype=zlib))
 	with (appendonly = true);
@@ -556,6 +557,10 @@ execute ccddlcheck;
 
 drop table ccddl;
 
+create table ccddl (i int42) with(appendonly = true, orientation=column);
+execute ccddlcheck;
+drop table ccddl;
+
 -- Shouldn't apply type default encoding in these cases
 create table ccddl (i int42);
 execute ccddlcheck;
@@ -567,6 +572,23 @@ drop table ccddl;
 
 create table ccddl (i int42) with (appendonly = true, orientation=column,
 compresstype=none);
+alter type int42 set default encoding (compresstype=RLE_TYPE);
+alter table ccddl add column j int42 default '1'::int42;
+execute ccddlcheck;
+
+drop table ccddl;
+
+create table ccddl (i int42) with(appendonly = true, orientation=row);
+alter type int42 set default encoding (compresstype=RLE_TYPE);
+alter table ccddl add column j int42 default '1'::int42;
+-- No results are returned from the attribute encoding check, as compression with rle is not supported for row tables
+execute ccddlcheck;
+drop table ccddl;
+
+create table ccddl (i int42) with(appendonly = true);
+alter type int42 set default encoding (compresstype=RLE_TYPE);
+alter table ccddl add column j int42 default '1'::int42;
+-- No results are returned from the attribute encoding check, as compression with rle is not supported for heap tables
 execute ccddlcheck;
 drop table ccddl;
 


### PR DESCRIPTION
We added functional tests that ensure we have coverage for `CREATE TABLE` with the compression types offered in GPDB. 
We also added unit-tests of our zstd compression code (not the zstd library but the gpcontrib module which uses it). As part of this, we added a new directory in cmockery which has a utils file where we put a convenience macro which was also used in the runaway_cleaner_test.