### PR TITLE
Support MCV based cardinality estimation for text columns in ORCA

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.27.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.28.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.27.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.28.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13994,7 +13994,7 @@ int
 main ()
 {
 
-return strncmp("3.27.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.28.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -14004,7 +14004,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.27.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.28.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.27.0@gpdb/stable
+orca/v3.28.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -87,7 +87,7 @@ sync_tools: opt_write_test
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.27.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.28.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -3220,4 +3220,25 @@ gpdb::MakeGpPolicy
 	}
 	GP_WRAP_END;
 }
+
+uint32
+gpdb::HashBpChar(Datum d)
+{
+	GP_WRAP_START;
+	{
+		return DatumGetUInt32(DirectFunctionCall1(hashbpchar, d));
+	}
+	GP_WRAP_END;
+}
+
+uint32
+gpdb::HashText(Datum d)
+{
+	GP_WRAP_START;
+	{
+		return DatumGetUInt32(DirectFunctionCall1(hashtext, d));
+	}
+	GP_WRAP_END;
+}
+
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -2462,14 +2462,17 @@ CTranslatorScalarToDXL::ExtractLintValueFromDatum
 		}
 		else
 		{
-			hash = gpos::HashValue<BYTE>(bytes);
-			for (ULONG ul = 1; ul < length; ul++)
+			if (mdid->Equals(&CMDIdGPDB::m_mdid_bpchar))
 			{
-				hash = gpos::CombineHashes(hash, gpos::HashValue<BYTE>(&bytes[ul]));
+				hash = gpdb::HashBpChar((Datum) bytes);
+			}
+			else
+			{
+				hash = gpdb::HashText((Datum) bytes);
 			}
 		}
 
-		lint_value = (LINT) (hash / 4);
+		lint_value = (LINT) hash;
 	}
 
 	return lint_value;

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2744,18 +2744,4 @@ CTranslatorUtils::GetNumNonSystemColumns
 	return num_non_system_cols;
 }
 
-// Function to check if we should create stats bucket in DXL
-// Returns true if column datatype is not text/char/varchar/bpchar
-BOOL
-CTranslatorUtils::ShouldCreateStatsBucket
-	(
-	OID att_type_oid
-	)
-{
-	if (att_type_oid != TEXTOID && att_type_oid != CHAROID && att_type_oid != VARCHAROID && att_type_oid != BPCHAROID)
-		return true;
-
-	return false;
-}
-
 // EOF

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -655,6 +655,11 @@ namespace gpdb {
 	GpPolicy *MakeGpPolicy(GpPolicyType ptype, int nattrs,
 						   int numsegments);
 
+
+	uint32 HashBpChar(Datum d);
+
+	uint32 HashText(Datum d);
+
 } //namespace gpdb
 
 #define ForEach(cell, l)	\

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -407,9 +407,6 @@ namespace gpdxl
 			static
 			ULONG GetNumNonSystemColumns(const IMDRelation *mdrel);
 
-			// check if we need to create stats buckets in DXL for the column attribute
-			static
-			BOOL ShouldCreateStatsBucket(OID att_type_oid);
 	};
 }
 

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -801,6 +801,8 @@ extern Datum bpchar_pattern_le(PG_FUNCTION_ARGS);
 extern Datum bpchar_pattern_gt(PG_FUNCTION_ARGS);
 extern Datum bpchar_pattern_ge(PG_FUNCTION_ARGS);
 extern Datum btbpchar_pattern_cmp(PG_FUNCTION_ARGS);
+extern Datum hashtext(PG_FUNCTION_ARGS);
+extern Datum hashvarlena(PG_FUNCTION_ARGS);
 
 extern Datum varcharin(PG_FUNCTION_ARGS);
 extern Datum varcharout(PG_FUNCTION_ARGS);


### PR DESCRIPTION
Prior to this patch, the MCVs for text columns was not being passed to ORCA.
Hence the cardinality estimation for predicates involving text was inaccurate
and led to sub optimal plans being picked. This patch allows the MCVs to be
passed in to ORCA so that it can now estimate the cardinality using MCVs equal
and not equal operators for text columns.

Co-authored-by: Abhijit Subramanya <asubramanya@pivotal.io>
Co-authored-by: Bhuvnesh Chaudhary <bchaudhary@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
