### PR TITLE
gpexpand: do not redistribute temp tables

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1462,6 +1462,7 @@ WHERE
     AND pr.parchildrelid is NULL
     AND n.nspname != 'gpexpand'
     AND n.nspname != 'pg_bitmapindex'
+    AND c.relpersistence != 't'
     AND c.relstorage != 'x';
 
                   """ % (src_bytes_str)

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -176,6 +176,8 @@ Feature: expand the cluster by adding more segments
         And the database is not running
         And the cluster is generated with "1" primaries only
         And database "gptest" exists
+        And the user connects to "gptest" with named connection "default"
+        And the user executes "CREATE TEMP TABLE temp_t1 (c1 int) DISTRIBUTED BY (c1)" with named connection "default"
         And the user runs psql with "-c 'CREATE TABLE public.redistribute (i int) DISTRIBUTED BY (i)'" against database "gptest"
         And the user runs psql with "-c 'INSERT INTO public.redistribute SELECT generate_series(1, 10000)'" against database "gptest"
         And distribution information from table "public.redistribute" with data in "gptest" is saved
@@ -185,6 +187,7 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 3 new segments
+         And the user drops the named connection "default"
         When the user runs gpexpand against database "gptest" to redistribute
         Then distribution information from table "public.redistribute" with data in "gptest" is verified against saved data
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -141,6 +141,30 @@ def impl(context, dbname, psql_cmd):
         raise Exception('%s' % context.error_message)
 
 
+@given('the user connects to "{dbname}" with named connection "{cname}"')
+def impl(context, dbname, cname):
+    if not hasattr(context, 'named_conns'):
+        context.named_conns = {}
+    if cname in context.named_conns:
+        context.named_conns[cname].close()
+        del context.named_conns[cname]
+    context.named_conns[cname] = dbconn.connect(dbconn.DbURL(dbname=dbname))
+
+
+@given('the user executes "{sql}" with named connection "{cname}"')
+def impl(context, cname, sql):
+    conn = context.named_conns[cname]
+    dbconn.execSQL(conn, sql)
+    conn.commit()
+
+
+@then('the user drops the named connection "{cname}"')
+def impl(context, cname):
+    if cname in context.named_conns:
+        context.named_conns[cname].close()
+        del context.named_conns[cname]
+
+
 @given('the database is running')
 @then('the database is running')
 def impl(context):


### PR DESCRIPTION
Most temp tables won't live for long, there is no need to redistribute
them.

On the other hand if they are populated in gpexpand.status_detail and
disappeared before redistribution, an error is reported to the user,
this just causes unnecessary panic.

Also fixed the issue that gpexpand redistribution failures are not caught by behave tests.

This fixes https://github.com/greenplum-db/gpdb/issues/6887, https://github.com/greenplum-db/gpdb/issues/6982.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Pass `make installcheck`
