### PR TITLE
Assert OldestXmin is valid in heap_page_prune_opt.

### DIFF
--- a/src/backend/access/heap/pruneheap.c
+++ b/src/backend/access/heap/pruneheap.c
@@ -98,15 +98,7 @@ heap_page_prune_opt(Relation relation, Buffer buffer)
 	else
 		OldestXmin = RecentGlobalDataXmin;
 
-	/*
-	 * In GPDB we may call into here without having a local snapshot and thus
-	 * no valid OldestXmin transaction id. Exit early if so.
-	 *
-	 * GPDB_94_MERGE_FIXME: Is that still true, or could we turn this back
-	 * into an assertion?
-	 */
-	if (!TransactionIdIsValid(OldestXmin))
-		return;
+	Assert(TransactionIdIsValid(OldestXmin));
 
 	/*
 	 * Let's see if we really need pruning.


### PR DESCRIPTION
I cann't think of a scenario that GPDB will call into
heap_page_prune_opt without having a local snapshot. So assert the
OldestXmin is valid at this point to keep the same with upstream.

Open this PR for discussion about whether the assertion makes sense.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
