### PR TITLE
Re-declare necessary Perl dependencies for running tap tests in ./configure

### DIFF
--- a/configure
+++ b/configure
@@ -19703,6 +19703,8 @@ done
 
 
 
+
+
 # Make sure we have perl
 if test -z "$PERL"; then
 # Extract the first word of "perl", so it can be a program name with args.
@@ -19746,7 +19748,7 @@ fi
 
 if test "x$PERL" != x; then
   ax_perl_modules_failed=0
-  for ax_perl_module in 'IPC::Run' ; do
+  for ax_perl_module in 'IPC::Run' 'Test::More 0.82' ; do
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for perl module $ax_perl_module" >&5
 $as_echo_n "checking for perl module $ax_perl_module... " >&6; }
 
@@ -19768,7 +19770,7 @@ $as_echo "ok" >&6; };
 
   else
     :
-    as_fn_error $? "Perl module IPC::Run is required to run TAP tests" "$LINENO" 5
+    as_fn_error $? "Perl modules IPC::Run and Test::More 0.82 are required to run TAP tests" "$LINENO" 5
   fi
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: could not find perl" >&5

--- a/configure.in
+++ b/configure.in
@@ -2500,8 +2500,8 @@ if test "$enable_tap_tests" = yes; then
     AC_MSG_ERROR([Perl not found])
   fi
   # Check for necessary modules
-  AX_PROG_PERL_MODULES(IPC::Run, ,
-    AC_MSG_ERROR([Perl module IPC::Run is required to run TAP tests]))
+  AX_PROG_PERL_MODULES([IPC::Run Test::More=0.82], ,
+    AC_MSG_ERROR([Perl modules IPC::Run and Test::More 0.82 are required to run TAP tests]))
 fi
 
 # Thread testing


### PR DESCRIPTION
This reverts commit 848733b6edb113b1c5c5cd2b8f039bbf439a6994.

Ran a dev pipeline to tests that compilation steps work, which they do.