### PR TITLE
Move test partial_table to another test group to avoid deadlock

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -80,7 +80,9 @@ test: dtm_retry
 
 # The appendonly test cannot be run concurrently with tests that have
 # serializable transactions (may conflict with AO vacuum operations).
-test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish partial_table subselect_gp_indexes
+test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish  subselect_gp_indexes
+
+test: partial_table
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.


### PR DESCRIPTION
Previously, test cases `partial_table` and `subselect_gp2` are
in the same test group so that they might be running concurrently.

`partital_table` contains a statement: `update gp_distribution_policy`,
`subselect_gp2` contains a statement: `VACUUM FULL pg_authid`. These
two statements may lead to local deadlock on QD when running concurrently 
if GDD is disabled.

If GDD is disabled,

  `update gp_distribution_policy`'s lock-acquire:
  1. at parsing stage, lock `gp_distribution_policy` in Exclusive Mode
  2. later when it needs to check authentication, lock `pg_authid` in
     AccessShare Mode

  `VACUUM FULL pg_authid`'s lock-acquire:
  1. lock pg_authid in Access Exclusive Mode
  2. later when rebuilding heap, it might delete some dependencies,
     this will do GpPolicyRemove, which locks `gp_distribution_policy`
     in RowExclusive Mode

So there is a potential local deadlock.

------

I do not add test case because this is not a bug and I do not touch the code.
