### PR TITLE
Gracefully error out on incorrect partition type addition request

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -4899,6 +4899,9 @@ get_part_rule(Relation rel,
 	char		relnamBuf[(NAMEDATALEN * 2)];
 	char	   *relname;
 
+	if (!pid)
+		return NULL;
+
 	snprintf(relnamBuf, sizeof(relnamBuf), "relation \"%s\"",
 			 RelationGetRelationName(rel));
 
@@ -4912,9 +4915,6 @@ get_part_rule(Relation rel,
 							  pid,
 							  bExistError, bMustExist,
 							  pSearch, pNode, relname, NULL);
-
-	if (!pid)
-		return NULL;
 
 	if (pid->idtype == AT_AP_IDRule)
 	{
@@ -4932,20 +4932,8 @@ get_part_rule(Relation rel,
 
 		pid2 = (AlterPartitionId *) lfirst(lc);
 
-		prule2 = get_part_rule1(rel,
-								pid2,
-								bExistError, bMustExist,
-								pSearch, pNode, pstrdup(prule2->relname), &pNode2);
-
-		pNode = pNode2;
-
-		if (!pNode)
-		{
-			if (prule2 && prule2->topRule && prule2->topRule->children)
-				pNode = prule2->topRule->children;
-		}
-
-		return prule2;
+		return get_part_rule1(rel, pid2, bExistError, bMustExist, pSearch,
+							  pNode, pstrdup(prule2->relname), &pNode2);
 	}
 
 	if (pid->idtype == AT_AP_IDList)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16251,6 +16251,11 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 
 		if ('r' == pNode->part->parkind)
 		{
+			if (!pelem->isDefault && pelem->boundSpec && !IsA(pelem->boundSpec, PartitionBoundSpec))
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("cannot add list partition to range partitioned table")));
+
 			pSubSpec =
 			atpxPartAddList(rel, is_split, colencs, pNode,
 							(locPid->idtype == AT_AP_IDName) ?
@@ -16264,6 +16269,11 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 		}
 		else if ('l' == pNode->part->parkind)
 		{
+			if (!pelem->isDefault && pelem->boundSpec && !IsA(pelem->boundSpec, PartitionValuesSpec))
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("cannot add range partition to list partitioned table")));
+
 			pSubSpec =
 			atpxPartAddList(rel, is_split, colencs, pNode,
 							(locPid->idtype == AT_AP_IDName) ?

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16138,7 +16138,6 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 	AlterPartitionId 	*pid 		= (AlterPartitionId *)pc->partid;
 	PgPartRule   		*prule 		= NULL;
 	PartitionNode  		*pNode 		= NULL;
-	char           		*parTypName = NULL;
 	char			 	 namBuf[NAMEDATALEN];
 	AlterPartitionId 	*locPid 	= NULL;	/* local pid if IDRule */
 	PgPartRule* 		 par_prule 	= NULL;	/* prule for parent if IDRule */
@@ -16172,22 +16171,6 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("%s is not partitioned", lrelname)));
 
-	switch (pNode->part->parkind)
-	{
-		case 'r': /* range */
-			parTypName = "RANGE";
-			break;
-		case 'l': /* list */
-			parTypName = "LIST";
-			break;
-		default:
-			elog(ERROR, "unrecognized partitioning kind '%c'",
-				 pNode->part->parkind);
-			Assert(false);
-			break;
-	} /* end switch */
-
-
 	if (locPid->idtype == AT_AP_IDName)
 		snprintf(namBuf, sizeof(namBuf), " \"%s\"", strVal(locPid->partiddef));
 	else
@@ -16218,7 +16201,7 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 		ereport(ERROR,
 			(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 			 errmsg("cannot add %s partition%s to %s with DEFAULT partition \"%s\"",
-					parTypName,
+					pNode->part->parkind == 'r' ? "RANGE" : "LIST",
 					namBuf,
 					lrelname,
 					pNode->default_part->parname),

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16144,7 +16144,6 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 	PgPartRule* 		 par_prule 	= NULL;	/* prule for parent if IDRule */
 	char 		 		 lRelNameBuf[(NAMEDATALEN*2)];
 	char 				*lrelname   = NULL;
-	Node 				*pSubSpec 	= NULL;
 	bool				 is_split = false;
 	bool				 bSetTemplate = (att == AT_PartSetTemplate);
 	PartitionElem *pelem;
@@ -16211,81 +16210,75 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 		prule = get_part_rule(rel, pid, true, false, NULL, false);
 	}
 
-	if (!prule)
+	Assert(!prule);
+
+	/* DEFAULT checks */
+	if (!pelem->isDefault && (pNode->default_part) &&
+		!is_split && !bSetTemplate) /* MPP-6093: ok to reset template */
+		ereport(ERROR,
+			(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+			 errmsg("cannot add %s partition%s to %s with DEFAULT partition \"%s\"",
+					parTypName,
+					namBuf,
+					lrelname,
+					pNode->default_part->parname),
+			 errhint("need to SPLIT partition \"%s\"",
+					 pNode->default_part->parname)));
+
+	if (pelem->isDefault && !is_split)
 	{
-		bool isDefault = pelem->isDefault;
-
-		/* DEFAULT checks */
-		if (!isDefault && (pNode->default_part) &&
-			!is_split && !bSetTemplate) /* MPP-6093: ok to reset template */
+		/* MPP-6093: ok to reset template */
+		if (pNode->default_part && !bSetTemplate)
 			ereport(ERROR,
-				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-				 errmsg("cannot add %s partition%s to %s with DEFAULT partition \"%s\"",
-						parTypName,
-						namBuf,
+					(errcode(ERRCODE_DUPLICATE_OBJECT),
+					 errmsg("DEFAULT partition \"%s\" for %s already exists",
+							pNode->default_part->parname,
+							lrelname)));
+
+		/* XXX XXX: move this check to gram.y ? */
+		if (pelem->boundSpec)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+					 errmsg("invalid use of boundary specification for DEFAULT partition%s of %s",
+							namBuf,
+							lrelname)));
+	}
+
+	/* Do the real work for add ... */
+
+	if ('r' == pNode->part->parkind)
+	{
+		if (!pelem->isDefault && pelem->boundSpec && !IsA(pelem->boundSpec, PartitionBoundSpec))
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("cannot add list partition to range partitioned table")));
+
+		(void) atpxPartAddList(rel, is_split, colencs, pNode,
+						(locPid->idtype == AT_AP_IDName) ?
+						strVal(locPid->partiddef) : NULL, /* partition name */
+						pelem->isDefault, pelem,
+						PARTTYP_RANGE,
+						par_prule,
 						lrelname,
-						pNode->default_part->parname),
-				 errhint("need to SPLIT partition \"%s\"",
-						 pNode->default_part->parname)));
+						bSetTemplate,
+						rel->rd_rel->relowner);
+	}
+	else if ('l' == pNode->part->parkind)
+	{
+		if (!pelem->isDefault && pelem->boundSpec && !IsA(pelem->boundSpec, PartitionValuesSpec))
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("cannot add range partition to list partitioned table")));
 
-		if (isDefault && !is_split)
-		{
-			/* MPP-6093: ok to reset template */
-			if (pNode->default_part && !bSetTemplate)
-				ereport(ERROR,
-						(errcode(ERRCODE_DUPLICATE_OBJECT),
-						 errmsg("DEFAULT partition \"%s\" for %s already exists",
-								pNode->default_part->parname,
-								lrelname)));
-
-			/* XXX XXX: move this check to gram.y ? */
-			if (pelem->boundSpec)
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-						 errmsg("invalid use of boundary specification for DEFAULT partition%s of %s",
-								namBuf,
-								lrelname)));
-		}
-
-		/* Do the real work for add ... */
-
-		if ('r' == pNode->part->parkind)
-		{
-			if (!pelem->isDefault && pelem->boundSpec && !IsA(pelem->boundSpec, PartitionBoundSpec))
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("cannot add list partition to range partitioned table")));
-
-			pSubSpec =
-			atpxPartAddList(rel, is_split, colencs, pNode,
-							(locPid->idtype == AT_AP_IDName) ?
-							strVal(locPid->partiddef) : NULL, /* partition name */
-							isDefault, pelem,
-							PARTTYP_RANGE,
-							par_prule,
-							lrelname,
-							bSetTemplate,
-							rel->rd_rel->relowner);
-		}
-		else if ('l' == pNode->part->parkind)
-		{
-			if (!pelem->isDefault && pelem->boundSpec && !IsA(pelem->boundSpec, PartitionValuesSpec))
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("cannot add range partition to list partitioned table")));
-
-			pSubSpec =
-			atpxPartAddList(rel, is_split, colencs, pNode,
-							(locPid->idtype == AT_AP_IDName) ?
-							strVal(locPid->partiddef) : NULL, /* partition name */
-							isDefault, pelem,
-							PARTTYP_LIST,
-							par_prule,
-							lrelname,
-							bSetTemplate,
-							rel->rd_rel->relowner);
-		}
-
+		(void) atpxPartAddList(rel, is_split, colencs, pNode,
+						(locPid->idtype == AT_AP_IDName) ?
+						strVal(locPid->partiddef) : NULL, /* partition name */
+						pelem->isDefault, pelem,
+						PARTTYP_LIST,
+						par_prule,
+						lrelname,
+						bSetTemplate,
+						rel->rd_rel->relowner);
 	}
 
 	/* MPP-6929: metadata tracking */

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -8228,3 +8228,12 @@ select oid::regclass, relkind, relstorage, reloptions from pg_class where oid = 
  pt_tab_encode_1_prt_s_xyz | r       | c          | {appendonly=true,orientation=column,compresstype=zlib,compresslevel=1}
 (1 row)
 
+-- Ensure that only the correct type of partitions can be added
+create table at_range (a int) partition by range (a) (start(1) end(5));
+NOTICE:  CREATE TABLE will create partition "at_range_1_prt_1" for table "at_range"
+create table at_list (i int) partition by list(i) (partition p1 values(1));
+NOTICE:  CREATE TABLE will create partition "at_list_1_prt_p1" for table "at_list"
+alter table at_list add partition foo2 start(6) end (10);
+ERROR:  cannot add range partition to list partitioned table
+alter table at_range add partition test values(5);
+ERROR:  cannot add list partition to range partitioned table

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -8226,3 +8226,12 @@ select oid::regclass, relkind, relstorage, reloptions from pg_class where oid = 
  pt_tab_encode_1_prt_s_xyz | r       | c          | {appendonly=true,orientation=column,compresstype=zlib,compresslevel=1}
 (1 row)
 
+-- Ensure that only the correct type of partitions can be added
+create table at_range (a int) partition by range (a) (start(1) end(5));
+NOTICE:  CREATE TABLE will create partition "at_range_1_prt_1" for table "at_range"
+create table at_list (i int) partition by list(i) (partition p1 values(1));
+NOTICE:  CREATE TABLE will create partition "at_list_1_prt_p1" for table "at_list"
+alter table at_list add partition foo2 start(6) end (10);
+ERROR:  cannot add range partition to list partitioned table
+alter table at_range add partition test values(5);
+ERROR:  cannot add list partition to range partitioned table

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3929,3 +3929,10 @@ select gp_segment_id, attrelid::regclass, attnum, attoptions from gp_dist_random
 
 select oid::regclass, relkind, relstorage, reloptions from pg_class where oid = 'pt_tab_encode_1_prt_s_abc'::regclass;
 select oid::regclass, relkind, relstorage, reloptions from pg_class where oid = 'pt_tab_encode_1_prt_s_xyz'::regclass;
+
+-- Ensure that only the correct type of partitions can be added
+create table at_range (a int) partition by range (a) (start(1) end(5));
+create table at_list (i int) partition by list(i) (partition p1 values(1));
+
+alter table at_list add partition foo2 start(6) end (10);
+alter table at_range add partition test values(5);


### PR DESCRIPTION
When altering a partitioned table and adding an incorrectly specified partition, an assertion was hit rather than gracefully erroring out. Make sure that the requested partition matches the underlying relation definition before continuing down into the altering code. This also adds a testcase for this.

Reported-by: Kalen Krempely in #6967