### PR TITLE
Fix checks between unique/primary keys and distribution keys, and allow exclusion constraints

### DIFF
--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -332,6 +332,22 @@ transformPartitionBy(CreateStmtContext *cxt,
 
 		Constraint *ucon = (Constraint *) lfirst(lc);
 
+		/*
+		 * For now, don't allow exclusion constraints on partitioned tables at
+		 * all.
+		 *
+		 * XXX: There's no fundamental reason they couldn't be made to work.
+		 * As long as the index contains all the partitioning key columns,
+		 * with the equality operators as the exclusion operators, they would
+		 * work. These are the same conditions as with compatibility with
+		 * distribution keys. But the code to check that hasn't been written
+		 * yet.
+		 */
+		if (ucon->contype == CONSTR_EXCLUSION)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("exclusion constraints are not supported on partitioned tables")));
+
 		Insist(ucon->keys != NIL);
 
 		foreach(ilc, key_attnames)

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -875,10 +875,6 @@ transformTableConstraint(CreateStmtContext *cxt, Constraint *constraint)
 						 errmsg("exclusion constraints are not supported on foreign tables"),
 						 parser_errposition(cxt->pstate,
 											constraint->location)));
-			else
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("GPDB does not support exclusion constraints")));
 			cxt->ixconstraints = lappend(cxt->ixconstraints, constraint);
 			break;
 
@@ -2628,13 +2624,9 @@ transformIndexConstraints(CreateStmtContext *cxt, bool mayDefer)
 		Constraint *constraint = (Constraint *) lfirst(lc);
 
 		Assert(IsA(constraint, Constraint));
-		if(constraint->contype == CONSTR_EXCLUSION)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("GPDB does not support exclusion constraints")));
-
 		Assert(constraint->contype == CONSTR_PRIMARY ||
-			   constraint->contype == CONSTR_UNIQUE);
+			   constraint->contype == CONSTR_UNIQUE ||
+			   constraint->contype == CONSTR_EXCLUSION);
 
 		index = transformIndexConstraint(constraint, cxt);
 
@@ -2761,8 +2753,6 @@ transformIndexConstraints(CreateStmtContext *cxt, bool mayDefer)
 static IndexStmt *
 transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 {
-	Assert(constraint->contype !=  CONSTR_EXCLUSION);
-
 	IndexStmt  *index;
 	ListCell   *lc;
 

--- a/src/include/cdb/cdbcat.h
+++ b/src/include/cdb/cdbcat.h
@@ -19,9 +19,31 @@
 #include "access/attnum.h"
 #include "utils/relcache.h"
 
-extern void checkPolicyForUniqueIndex(Relation rel, AttrNumber *indattr,
-									  int nidxatts, bool isprimary, 
-									  bool has_exprs, bool has_pkey,
-									  bool has_ukey);
+/*
+ * Context information for index_check_policy_compatible(), used
+ * for building error message.
+ */
+typedef struct
+{
+	bool		for_alter_dist_policy;
+	bool		is_constraint;
+	bool		is_unique;
+	bool		is_primarykey;
+
+	char	   *constraint_name;
+} index_check_policy_compatible_context;
+
+extern bool index_check_policy_compatible(GpPolicy *policy,
+							  TupleDesc desc,
+							  AttrNumber *indattr,
+							  Oid *indclasses,
+							  int nidxatts,
+							  bool report_error,
+							  index_check_policy_compatible_context *error_context);
+
+extern bool change_policy_to_match_index(Relation rel,
+							 AttrNumber *indattr,
+							 Oid *indclasses,
+							 int nidxatts);
 
 #endif   /* CDBCAT_H */

--- a/src/include/cdb/cdbcat.h
+++ b/src/include/cdb/cdbcat.h
@@ -37,6 +37,7 @@ extern bool index_check_policy_compatible(GpPolicy *policy,
 							  TupleDesc desc,
 							  AttrNumber *indattr,
 							  Oid *indclasses,
+							  Oid *exclop,
 							  int nidxatts,
 							  bool report_error,
 							  index_check_policy_compatible_context *error_context);
@@ -44,6 +45,7 @@ extern bool index_check_policy_compatible(GpPolicy *policy,
 extern bool change_policy_to_match_index(Relation rel,
 							 AttrNumber *indattr,
 							 Oid *indclasses,
+							 Oid *exclop,
 							 int nidxatts);
 
 #endif   /* CDBCAT_H */

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -201,8 +201,7 @@ extern bool is_exchangeable(Relation rel, Relation oldrel, Relation newrel, bool
 extern void
 fixCreateStmtForPartitionedTable(CreateStmt *stmt);
 
-extern void
-checkUniqueConstraintVsPartitioning(Relation rel, AttrNumber *indattr, int nidxatts, bool primary);
+extern void index_check_partitioning_compatible(Relation rel, AttrNumber *indattr, Oid *exclops, int nidxatts, bool primary);
 
 extern List *
 selectPartitionMulti(PartitionNode *partnode, Datum *values, bool *isnull,

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1324,8 +1324,8 @@ ALTER TABLE public.distrib_part_test SET with (reorganize=false) DISTRIBUTED RAN
 -- case 1
 CREATE TABLE t_dist1(col1 INTEGER, col2 INTEGER, CONSTRAINT pk_t_dist1 PRIMARY KEY(col2)) DISTRIBUTED BY(col2);
 ALTER TABLE t_dist1 SET DISTRIBUTED BY(col1);
-ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be a subset of the UNIQUE INDEX columns.
+ERROR:  distribution policy is not compatible with the table's PRIMARY KEY
+DETAIL:  Distribution key column "col1" is not included in the constraint.
 -- case 2
 CREATE TABLE t_dist2(col1 INTEGER, col2 INTEGER, col3 INTEGER, col4 INTEGER) DISTRIBUTED BY(col1);
 CREATE UNIQUE INDEX idx1_t_dist2 ON t_dist2(col1, col2);
@@ -1337,14 +1337,14 @@ HINT:  Use ALTER TABLE "t_dist2" SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (col1
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col2);
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col1, col2);
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col1, col2, col3);
-ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be a subset of the UNIQUE INDEX columns.
+ERROR:  distribution policy is not compatible with UNIQUE index "idx1_t_dist2"
+DETAIL:  Distribution key column "col3" is not included in the constraint.
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col3);
-ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be a subset of the UNIQUE INDEX columns.
+ERROR:  distribution policy is not compatible with UNIQUE index "idx1_t_dist2"
+DETAIL:  Distribution key column "col3" is not included in the constraint.
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col4);
-ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be a subset of the UNIQUE INDEX columns.
+ERROR:  distribution policy is not compatible with UNIQUE index "idx1_t_dist2"
+DETAIL:  Distribution key column "col4" is not included in the constraint.
 -- Altering distribution policy for temp tables
 create temp table atsdb (c1 int, c2 int) distributed randomly;
 select * from atsdb;
@@ -1398,7 +1398,8 @@ select policytype, distkey, distclass from gp_distribution_policy where localoid
 -- have a hash opclass!
 CREATE TABLE tstab (i int4, t tsvector) distributed by (i);
 CREATE UNIQUE INDEX tstab_idx ON tstab(t);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "tstab"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "i" is not included in the constraint.
 INSERT INTO tstab VALUES (1, 'foo');
 -- ALTER TABLE SET DISTRIBUTED RANDOMLY should not work on a table
 -- that has a primary key or unique index.

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -841,7 +841,8 @@ DETAIL:  Key (test)=(2) already exists.
 insert into atacc1 select i from generate_series(3,10)i;
 -- try adding a unique oid constraint
 alter table atacc1 add constraint atacc_oid1 unique(oid);
-ERROR:  cannot create unique index on system column
+ERROR:  UNIQUE constraint must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "test" is not included in the constraint.
 -- try to create duplicates via alter table using - should fail
 -- this errors out in Greenplum for a different reason: we don't support
 -- SET DATA TYPE on an indexed column yet
@@ -884,7 +885,8 @@ drop table atacc1;
 -- lets do some naming tests
 create table atacc1 (test int, test2 int, unique(test)) distributed by (test);
 alter table atacc1 add unique (test2);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "atacc1"
+ERROR:  UNIQUE constraint must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "test" is not included in the constraint.
 -- should fail for @@ second one @@
 insert into atacc1 (test2, test) values (3, 3);
 insert into atacc1 (test2, test) values (2, 3);
@@ -916,7 +918,8 @@ ERROR:  multiple primary keys for table "atacc1" are not allowed
 alter table atacc1 drop constraint atacc_test1 restrict;
 -- try adding a primary key on oid (should fail)
 alter table atacc1 add constraint atacc_oid1 primary key(oid);
-ERROR:  cannot create primary key on system column
+ERROR:  PRIMARY KEY definition must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "test" is not included in the constraint.
 drop table atacc1;
 -- let's do one where the primary key constraint fails when added
 create table atacc1 ( test int ) distributed by (test);
@@ -2954,7 +2957,7 @@ CREATE TABLE tt8(a int);
 CREATE SCHEMA alter2;
 ALTER TABLE IF EXISTS tt8 ADD COLUMN f int;
 ALTER TABLE IF EXISTS tt8 ADD CONSTRAINT xxx PRIMARY KEY(f);
-NOTICE:  updating distribution policy to match new primary key
+NOTICE:  updating distribution policy to match new PRIMARY KEY
 ALTER TABLE IF EXISTS tt8 ADD CHECK (f BETWEEN 0 AND 10);
 ALTER TABLE IF EXISTS tt8 ALTER COLUMN f SET DEFAULT 0;
 ALTER TABLE IF EXISTS tt8 RENAME COLUMN f TO f1;

--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -209,7 +209,7 @@ CREATE TABLE r
     e DATE
 ) DISTRIBUTED BY (a,b);
 ALTER TABLE r ADD CONSTRAINT PKEY PRIMARY KEY (b);
-NOTICE:  updating distribution policy to match new primary key
+NOTICE:  updating distribution policy to match new PRIMARY KEY
 --TEST
 SELECT MAX(a) AS m FROM r GROUP BY b ORDER BY m;
  m 

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -3024,7 +3024,8 @@ SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL AND unique1 > 500;
 DROP INDEX onek_nulltest;
 -- Check initial-positioning logic too
 CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "onek_with_null"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
 SET enable_seqscan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = OFF;

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -3057,7 +3057,8 @@ SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL AND unique1 > 500;
 DROP INDEX onek_nulltest;
 -- Check initial-positioning logic too
 CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "onek_with_null"
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
 SET enable_seqscan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = OFF;

--- a/src/test/regress/expected/create_table_like.out
+++ b/src/test/regress/expected/create_table_like.out
@@ -77,15 +77,17 @@ CREATE TABLE inhg (x text, LIKE inhx INCLUDING INDEXES, PRIMARY KEY(x)); /* fail
 ERROR:  multiple primary keys for table "inhg" are not allowed
 CREATE TABLE inhz (xx text DEFAULT 'text', yy int UNIQUE);
 CREATE UNIQUE INDEX inhz_xx_idx on inhz (xx) WHERE xx <> 'test';
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "inhz"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "yy" is not included in the constraint.
 /* Ok to create multiple unique indexes */
 /* GPDB: This query will fail because unique index must contain all distribution key */
 CREATE TABLE inhg (x text UNIQUE, LIKE inhz INCLUDING INDEXES);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "inhg"
+ERROR:  UNIQUE constraint must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "x" is not included in the constraint.
 CREATE TABLE inhg (x text, LIKE inhz INCLUDING INDEXES);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  updating distribution policy to match new unique index
+NOTICE:  updating distribution policy to match new UNIQUE constraint
 INSERT INTO inhg (xx, yy, x) VALUES ('test', 5, 10);
 INSERT INTO inhg (xx, yy, x) VALUES ('test', 10, 15);
 INSERT INTO inhg (xx, yy, x) VALUES ('foo', 10, 15); -- should fail

--- a/src/test/regress/expected/gp_create_table.out
+++ b/src/test/regress/expected/gp_create_table.out
@@ -49,7 +49,7 @@ drop table distpol;
 -- now test that MPP-101 /actually/ works
 create table distpol (i int, j int, k int) distributed by (i);
 alter table distpol add primary key (j);
-NOTICE:  updating distribution policy to match new primary key
+NOTICE:  updating distribution policy to match new PRIMARY KEY
 select distkey, distclass from gp_distribution_policy where localoid = 'distpol'::regclass;
  distkey | distclass 
 ---------+-----------
@@ -58,11 +58,12 @@ select distkey, distclass from gp_distribution_policy where localoid = 'distpol'
 
 -- make sure we can't overwrite it
 create unique index distpol_uidx on distpol(k);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "distpol"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "j" is not included in the constraint.
 -- should be able to now
 alter table distpol drop constraint distpol_pkey;
 create unique index distpol_uidx on distpol(k);
-NOTICE:  updating distribution policy to match new unique index
+NOTICE:  updating distribution policy to match new UNIQUE index
 select distkey, distclass from gp_distribution_policy where localoid = 'distpol'::regclass;
  distkey | distclass 
 ---------+-----------
@@ -72,21 +73,25 @@ select distkey, distclass from gp_distribution_policy where localoid = 'distpol'
 drop index distpol_uidx;
 -- expressions shouldn't be able to update the distribution key
 create unique index distpol_uidx on distpol(ln(k));
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "distpol"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "k" is not included in the constraint.
 drop index distpol_uidx;
 ERROR:  index "distpol_uidx" does not exist
 -- lets make sure we don't change the policy when the table is full
 insert into distpol values(1, 2, 3);
 create unique index distpol_uidx on distpol(i);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "distpol"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "k" is not included in the constraint.
 alter table distpol add primary key (i);
-ERROR:  PRIMARY KEY must contain all columns in the distribution key of relation "distpol"
+ERROR:  PRIMARY KEY definition must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "k" is not included in the constraint.
 drop table distpol;
 -- if the datatype of the index column is not hashable, can't update distribution
 -- key to it.
 create table distpol_ts (i int4, t tsvector) distributed by (i);
 create unique index on distpol_ts(t);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "distpol_ts"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "i" is not included in the constraint.
 drop table distpol_ts;
 -- Make sure that distribution policy is derived correctly from PRIMARY KEY
 -- or UNIQUE index. Even with gp_create_table_random_default_distribution=on

--- a/src/test/regress/expected/gpdist_opclasses.out
+++ b/src/test/regress/expected/gpdist_opclasses.out
@@ -218,6 +218,42 @@ ALTER TABLE abs_opclass_test SET DISTRIBUTED BY (i, j); -- not allowed
 ERROR:  distribution policy is not compatible with UNIQUE index "abs_opclass_test_i_j_t_idx"
 DETAIL:  Operator class int4_ops of distribution key column "i" is not compatible with operator class abs_int_btree_ops used in the constraint.
 ALTER TABLE abs_opclass_test SET DISTRIBUTED BY (i abs_int_hash_ops, j abs_int_hash_ops);
+-- Exclusion constraints work similarly. We can enforce them, as long as the
+-- exclusion ops are the same equality ops as used in the distribution key.
+--
+-- That may seem a bit pointless, but there are some use cases for it. For
+-- example, imagine that you have a calendar system, where you can book rooms.
+-- If you distribute the bookings table by room number, you could have an
+-- exclusion constraint on (room_no WITH =, reservation WITH &&), to enforce
+-- that there are no overlapping reservations for the same room.
+--
+-- We can't use that exact example here, without the 'btree_gist' extension
+-- that would provide the = gist opclass for basic types. So we use a more
+-- contrived example using IP addresses rather than rooms.
+CREATE TABLE ip_reservations (ip_addr inet, reserved tsrange) DISTRIBUTED BY (ip_addr);
+-- these are not allowed
+ALTER TABLE ip_reservations ADD EXCLUDE USING gist (reserved WITH &&);
+ERROR:  exclusion constraint is not compatible with the table's distribution policy
+DETAIL:  Distribution key column "ip_addr" is not included in the constraint.
+HINT:  Add "ip_addr" to the constraint with the =(inet,inet) operator.
+ALTER TABLE ip_reservations ADD EXCLUDE USING gist (ip_addr inet_ops WITH &&);
+ERROR:  exclusion constraint is not compatible with the table's distribution policy
+DETAIL:  Distribution key column "ip_addr" is not included in the constraint.
+HINT:  Add "ip_addr" to the constraint with the =(inet,inet) operator.
+-- but this is.
+ALTER TABLE ip_reservations ADD EXCLUDE USING gist (ip_addr inet_ops WITH =, reserved WITH &&);
+-- new distribution is incompatible with the constraint.
+ALTER TABLE ip_reservations SET DISTRIBUTED BY (reserved);
+ERROR:  distribution policy is not compatible with exclusion constraint "ip_reservations_ip_addr_reserved_excl"
+DETAIL:  Distribution key column "reserved" is not included in the constraint.
+HINT:  Add "reserved" to the constraint with the =(anyrange,anyrange) operator.
+-- After dropping the constraint, it's allowed.
+ALTER TABLE ip_reservations DROP CONSTRAINT ip_reservations_ip_addr_reserved_excl;
+ALTER TABLE ip_reservations SET DISTRIBUTED BY (reserved);
+-- Test creating exclusion constraint on tsrange column. (The subtle
+-- difference is there is no direct =(tsrange, tsrange) operator, we rely on
+-- the implicit casts for it)
+ALTER TABLE ip_reservations ADD EXCLUDE USING gist (reserved WITH =);
 --
 -- Test scenario, where a type has a hash operator class, but not a default
 -- one.

--- a/src/test/regress/expected/gpdist_opclasses.out
+++ b/src/test/regress/expected/gpdist_opclasses.out
@@ -202,6 +202,23 @@ Table "public.abs_opclass_test"
 Distributed by: (i abs_int_hash_ops, t, j abs_int_hash_ops)
 
 --
+-- Test interaction between unique and primary key indexes and distribution keys.
+--
+-- should fail, because the default index opclass is not compatible with the |=| operator
+CREATE UNIQUE INDEX ON abs_opclass_test (i, j, t);
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Operator class abs_int_hash_ops of distribution key column "i" is not compatible with operator class int4_ops used in the constraint.
+ALTER TABLE abs_opclass_test ADD PRIMARY KEY (i, j, t);
+ERROR:  PRIMARY KEY definition must contain all columns in the table's distribution key
+DETAIL:  Operator class abs_int_hash_ops of distribution key column "i" is not compatible with operator class int4_ops used in the constraint.
+-- but this is allowed. (There is no syntax to specify the opclasses with ADD PRIMARY KEY)
+CREATE UNIQUE INDEX ON abs_opclass_test (i abs_int_btree_ops, j abs_int_btree_ops, t);
+-- ALTER TABLE should perform the same tests
+ALTER TABLE abs_opclass_test SET DISTRIBUTED BY (i, j); -- not allowed
+ERROR:  distribution policy is not compatible with UNIQUE index "abs_opclass_test_i_j_t_idx"
+DETAIL:  Operator class int4_ops of distribution key column "i" is not compatible with operator class abs_int_btree_ops used in the constraint.
+ALTER TABLE abs_opclass_test SET DISTRIBUTED BY (i abs_int_hash_ops, j abs_int_hash_ops);
+--
 -- Test scenario, where a type has a hash operator class, but not a default
 -- one.
 --

--- a/src/test/regress/expected/index_constraint_naming.out
+++ b/src/test/regress/expected/index_constraint_naming.out
@@ -172,14 +172,12 @@ ERROR:  relation "st_pk_pkey" already exists
 ALTER INDEX st_pk2_pkey_r_i RENAME TO st_pk_pkey;
 ERROR:  relation "st_pk_pkey" already exists
 -- EXCLUSION CONSTRAINT
--- EXCLUSION CONSTRAINT: GPDB does not support exclusion constraints
 CREATE TABLE st_x (a int, b int, EXCLUDE (a with =, b with =));
-ERROR:  GPDB does not support exclusion constraints
--- Should fail
 SELECT table_name,constraint_name,index_name,constraint_type FROM constraints_and_indices() WHERE (constraint_name::text=index_name::text AND constraint_type='x');
- table_name | constraint_name | index_name | constraint_type 
-------------+-----------------+------------+-----------------
-(0 rows)
+ table_name | constraint_name |  index_name   | constraint_type 
+------------+-----------------+---------------+-----------------
+ st_x       | st_x_a_b_excl   | st_x_a_b_excl | x
+(1 row)
 
 -- U_P
 ALTER TABLE st_u2 RENAME CONSTRAINT st_u2_a_b_key_r_i TO st_pk_pkey;

--- a/src/test/regress/expected/index_constraint_naming_partition.out
+++ b/src/test/regress/expected/index_constraint_naming_partition.out
@@ -718,16 +718,14 @@ SELECT * FROM partition_tables_show_all();
 --partition table. These are disallowed in GPDB.
 SELECT recreate_two_level_table();
 NOTICE:  CREATE TABLE will create partition "r_1_prt_r1" for table "r"
-CONTEXT:  SQL function "recreate_two_level_table" statement 2
 NOTICE:  CREATE TABLE will create partition "r_1_prt_r2" for table "r"
-CONTEXT:  SQL function "recreate_two_level_table" statement 2
  recreate_two_level_table 
 --------------------------
  
 (1 row)
 
 ALTER TABLE r ADD EXCLUDE (r_key WITH =,r_name WITH =);
-ERROR:  GPDB does not support exclusion constraints
+ERROR:  cannot create exclusion constraint on partitioned table "r"
 SELECT * FROM dependencies_show_for_cons_idx();
       depname       | classtype |      refname       | refclasstype |    classid    | objsubid |  refclassid   | refobjsubid | deptype 
 --------------------+-----------+--------------------+--------------+---------------+----------+---------------+-------------+---------

--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -1096,11 +1096,10 @@ Distributed by: (val1, val2)
 
 DROP TABLE test_constraints_inh;
 DROP TABLE test_constraints;
--- start_ignore
--- GPDB does not support exclusion constraints, so no need to run this test
 CREATE TABLE test_ex_constraints (
     c circle,
-    EXCLUDE USING gist (c WITH &&)
+    dkey inet,
+    EXCLUDE USING gist (dkey inet_ops WITH =, c WITH &&)
 );
 CREATE TABLE test_ex_constraints_inh () INHERITS (test_ex_constraints);
 \d+ test_ex_constraints
@@ -1108,31 +1107,33 @@ CREATE TABLE test_ex_constraints_inh () INHERITS (test_ex_constraints);
  Column |  Type  | Modifiers | Storage | Stats target | Description 
 --------+--------+-----------+---------+--------------+-------------
  c      | circle |           | plain   |              | 
+ dkey   | inet   |           | main    |              | 
 Indexes:
-    "test_ex_constraints_c_excl" EXCLUDE USING gist (c WITH &&)
+    "test_ex_constraints_dkey_c_excl" EXCLUDE USING gist (dkey inet_ops WITH =, c WITH &&)
 Child tables: test_ex_constraints_inh
-Distributed randomly
+Distributed by: (dkey)
 
-ALTER TABLE test_ex_constraints DROP CONSTRAINT test_ex_constraints_c_excl;
+ALTER TABLE test_ex_constraints DROP CONSTRAINT test_ex_constraints_dkey_c_excl;
 \d+ test_ex_constraints
                  Table "public.test_ex_constraints"
  Column |  Type  | Modifiers | Storage | Stats target | Description 
 --------+--------+-----------+---------+--------------+-------------
  c      | circle |           | plain   |              | 
+ dkey   | inet   |           | main    |              | 
 Child tables: test_ex_constraints_inh
-Distributed randomly
+Distributed by: (dkey)
 
 \d+ test_ex_constraints_inh
                Table "public.test_ex_constraints_inh"
  Column |  Type  | Modifiers | Storage | Stats target | Description 
 --------+--------+-----------+---------+--------------+-------------
  c      | circle |           | plain   |              | 
+ dkey   | inet   |           | main    |              | 
 Inherits: test_ex_constraints
-Distributed randomly
+Distributed by: (dkey)
 
 DROP TABLE test_ex_constraints_inh;
 DROP TABLE test_ex_constraints;
--- end_ignore
 -- Test non-inheritable foreign key constraints
 CREATE TABLE test_primary_constraints(id int PRIMARY KEY);
 CREATE TABLE test_foreign_constraints(id1 int REFERENCES test_primary_constraints(id));

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1094,11 +1094,10 @@ Distributed by: (val1, val2)
 
 DROP TABLE test_constraints_inh;
 DROP TABLE test_constraints;
--- start_ignore
--- GPDB does not support exclusion constraints, so no need to run this test
 CREATE TABLE test_ex_constraints (
     c circle,
-    EXCLUDE USING gist (c WITH &&)
+    dkey inet,
+    EXCLUDE USING gist (dkey inet_ops WITH =, c WITH &&)
 );
 CREATE TABLE test_ex_constraints_inh () INHERITS (test_ex_constraints);
 \d+ test_ex_constraints
@@ -1106,31 +1105,33 @@ CREATE TABLE test_ex_constraints_inh () INHERITS (test_ex_constraints);
  Column |  Type  | Modifiers | Storage | Stats target | Description 
 --------+--------+-----------+---------+--------------+-------------
  c      | circle |           | plain   |              | 
+ dkey   | inet   |           | main    |              | 
 Indexes:
-    "test_ex_constraints_c_excl" EXCLUDE USING gist (c WITH &&)
+    "test_ex_constraints_dkey_c_excl" EXCLUDE USING gist (dkey inet_ops WITH =, c WITH &&)
 Child tables: test_ex_constraints_inh
-Distributed randomly
+Distributed by: (dkey)
 
-ALTER TABLE test_ex_constraints DROP CONSTRAINT test_ex_constraints_c_excl;
+ALTER TABLE test_ex_constraints DROP CONSTRAINT test_ex_constraints_dkey_c_excl;
 \d+ test_ex_constraints
                  Table "public.test_ex_constraints"
  Column |  Type  | Modifiers | Storage | Stats target | Description 
 --------+--------+-----------+---------+--------------+-------------
  c      | circle |           | plain   |              | 
+ dkey   | inet   |           | main    |              | 
 Child tables: test_ex_constraints_inh
-Distributed randomly
+Distributed by: (dkey)
 
 \d+ test_ex_constraints_inh
                Table "public.test_ex_constraints_inh"
  Column |  Type  | Modifiers | Storage | Stats target | Description 
 --------+--------+-----------+---------+--------------+-------------
  c      | circle |           | plain   |              | 
+ dkey   | inet   |           | main    |              | 
 Inherits: test_ex_constraints
-Distributed randomly
+Distributed by: (dkey)
 
 DROP TABLE test_ex_constraints_inh;
 DROP TABLE test_ex_constraints;
--- end_ignore
 -- Test non-inheritable foreign key constraints
 CREATE TABLE test_primary_constraints(id int PRIMARY KEY);
 CREATE TABLE test_foreign_constraints(id1 int REFERENCES test_primary_constraints(id));

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -82,7 +82,8 @@ SELECT * FROM mvtest_tvm;
 CREATE MATERIALIZED VIEW mvtest_tmm AS SELECT sum(totamt) AS grandtot FROM mvtest_tm;
 CREATE MATERIALIZED VIEW mvtest_tvmm AS SELECT sum(totamt) AS grandtot FROM mvtest_tvm distributed by(grandtot);
 CREATE UNIQUE INDEX mvtest_tvmm_expr ON mvtest_tvmm ((grandtot > 0));
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mvtest_tvmm"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "grandtot" is not included in the constraint.
 CREATE UNIQUE INDEX mvtest_tvmm_pred ON mvtest_tvmm (grandtot) WHERE grandtot < 0;
 CREATE VIEW mvtest_tvv AS SELECT sum(totamt) AS grandtot FROM mvtest_tv;
 EXPLAIN (costs off)

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -91,7 +91,8 @@ CREATE MATERIALIZED VIEW mvtest_tmm AS SELECT sum(totamt) AS grandtot FROM mvtes
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE MATERIALIZED VIEW mvtest_tvmm AS SELECT sum(totamt) AS grandtot FROM mvtest_tvm distributed by(grandtot);
 CREATE UNIQUE INDEX mvtest_tvmm_expr ON mvtest_tvmm ((grandtot > 0));
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mvtest_tvmm"
+DETAIL:  Distribution key column "grandtot" is not included in the constraint.
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
 CREATE UNIQUE INDEX mvtest_tvmm_pred ON mvtest_tvmm (grandtot) WHERE grandtot < 0;
 CREATE VIEW mvtest_tvv AS SELECT sum(totamt) AS grandtot FROM mvtest_tv;
 EXPLAIN (costs off)

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -4286,6 +4286,30 @@ select schemaname, tablename, indexname from pg_indexes where schemaname = 'publ
 (3 rows)
 
 drop table it;
+--
+-- Exclusion constraints are currently not supported on partitioned tables.
+--
+create table parttab_with_excl_constraint (
+  i int,
+  j int,
+  CONSTRAINT part_excl EXCLUDE (i WITH =) )
+distributed by (i) partition by list (i) (
+  partition a values (1),
+  partition b values (2),
+  partition c values (3)
+);
+ERROR:  exclusion constraints are not supported on partitioned tables
+create table parttab_with_excl_constraint (
+  i int,
+  j int)
+distributed by (i) partition by list (i) (
+  partition a values (1),
+  partition b values (2),
+  partition c values (3)
+);
+alter table parttab_with_excl_constraint ADD CONSTRAINT part_excl EXCLUDE (i WITH =);
+ERROR:  cannot create exclusion constraint on partitioned table "parttab_with_excl_constraint"
+drop table parttab_with_excl_constraint;
 -- MPP-6297: test special WITH(tablename=...) syntax for dump/restore
 -- original table was:
 -- PARTITION BY RANGE(l_commitdate) 

--- a/src/test/regress/expected/partition_indexing.out
+++ b/src/test/regress/expected/partition_indexing.out
@@ -238,17 +238,20 @@ CREATE UNIQUE INDEX mpp3033a_unique2 ON mpp3033a (unique2);
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
 CREATE UNIQUE INDEX mpp3033a_hundred ON mpp3033a (hundred);
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
 CREATE UNIQUE INDEX mpp3033a_stringu1 ON mpp3033a (stringu1);
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
 CREATE UNIQUE INDEX mpp3033b_unique1 ON mpp3033b (unique1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
@@ -263,7 +266,8 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
 CREATE UNIQUE INDEX mpp3033b_hundred ON mpp3033b (hundred);
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
@@ -271,7 +275,8 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
 CREATE UNIQUE INDEX mpp3033b_stringu1 ON mpp3033b (stringu1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
@@ -279,7 +284,8 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
 select count(*) from mpp3033a;
  count 
 -------
@@ -845,7 +851,8 @@ NOTICE:  building index for child partition "mpp3033a_1_prt_aa_7"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
 CREATE UNIQUE INDEX mpp3033a_hundred ON mpp3033a (hundred);
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_1"
@@ -858,7 +865,8 @@ NOTICE:  building index for child partition "mpp3033a_1_prt_aa_7"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
 CREATE UNIQUE INDEX mpp3033a_stringu1 ON mpp3033a (stringu1);
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_1"
@@ -871,7 +879,8 @@ NOTICE:  building index for child partition "mpp3033a_1_prt_aa_7"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
 CREATE UNIQUE INDEX mpp3033b_unique1 ON mpp3033b (unique1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_4"
@@ -910,7 +919,8 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
 CREATE UNIQUE INDEX mpp3033b_hundred ON mpp3033b (hundred);
 NOTICE:  building index for child partition "mpp3033b_1_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_4"
@@ -930,7 +940,8 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
 CREATE UNIQUE INDEX mpp3033b_stringu1 ON mpp3033b (stringu1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_4"
@@ -950,7 +961,8 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
 select count(*) from mpp3033a;
  count 
 -------

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -4299,6 +4299,30 @@ select schemaname, tablename, indexname from pg_indexes where schemaname = 'publ
 (3 rows)
 
 drop table it;
+--
+-- Exclusion constraints are currently not supported on partitioned tables.
+--
+create table parttab_with_excl_constraint (
+  i int,
+  j int,
+  CONSTRAINT part_excl EXCLUDE (i WITH =) )
+distributed by (i) partition by list (i) (
+  partition a values (1),
+  partition b values (2),
+  partition c values (3)
+);
+ERROR:  exclusion constraints are not supported on partitioned tables
+create table parttab_with_excl_constraint (
+  i int,
+  j int)
+distributed by (i) partition by list (i) (
+  partition a values (1),
+  partition b values (2),
+  partition c values (3)
+);
+alter table parttab_with_excl_constraint ADD CONSTRAINT part_excl EXCLUDE (i WITH =);
+ERROR:  cannot create exclusion constraint on partitioned table "parttab_with_excl_constraint"
+drop table parttab_with_excl_constraint;
 -- MPP-6297: test special WITH(tablename=...) syntax for dump/restore
 -- original table was:
 -- PARTITION BY RANGE(l_commitdate) 

--- a/src/test/regress/expected/rangetypes.out
+++ b/src/test/regress/expected/rangetypes.out
@@ -1137,8 +1137,6 @@ drop table test_range_elem;
 -- constraints with range types, use singleton int ranges for the "="
 -- portion of the constraint.
 --
--- start_ignore
--- GPDB does not support exclusion constraints, so no need to run this test
 create table test_range_excl(
   id int4,
   room int4range,
@@ -1146,7 +1144,7 @@ create table test_range_excl(
   during tsrange,
   exclude using gist (room with =, during with &&),
   exclude using gist (speaker with =, during with &&)
-) DISTRIBUTED BY (id);
+) DISTRIBUTED REPLICATED;
 insert into test_range_excl
   values(1, int4range(123, 123, '[]'), int4range(1, 1, '[]'), '[2010-01-02 10:00, 2010-01-02 11:00)');
 insert into test_range_excl
@@ -1161,7 +1159,6 @@ insert into test_range_excl
   values(1, int4range(125, 125, '[]'), int4range(1, 1, '[]'), '[2010-01-02 10:10, 2010-01-02 11:00)');
 ERROR:  conflicting key value violates exclusion constraint "test_range_excl_speaker_during_excl"  (seg0 127.0.0.1:25432 pid=8632)
 DETAIL:  Key (speaker, during)=([1,2), ["Sat Jan 02 10:10:00 2010","Sat Jan 02 11:00:00 2010")) conflicts with existing key (speaker, during)=([1,2), ["Sat Jan 02 10:00:00 2010","Sat Jan 02 11:00:00 2010")).
--- end_ignore
 -- test bigint ranges
 select int8range(10000000000::int8, 20000000000::int8,'(]');
          int8range         

--- a/src/test/regress/expected/rangetypes_optimizer.out
+++ b/src/test/regress/expected/rangetypes_optimizer.out
@@ -1137,8 +1137,6 @@ drop table test_range_elem;
 -- constraints with range types, use singleton int ranges for the "="
 -- portion of the constraint.
 --
--- start_ignore
--- GPDB does not support exclusion constraints, so no need to run this test
 create table test_range_excl(
   id int4,
   room int4range,
@@ -1146,7 +1144,7 @@ create table test_range_excl(
   during tsrange,
   exclude using gist (room with =, during with &&),
   exclude using gist (speaker with =, during with &&)
-) DISTRIBUTED BY (id);
+) DISTRIBUTED REPLICATED;
 insert into test_range_excl
   values(1, int4range(123, 123, '[]'), int4range(1, 1, '[]'), '[2010-01-02 10:00, 2010-01-02 11:00)');
 insert into test_range_excl
@@ -1161,7 +1159,6 @@ insert into test_range_excl
   values(1, int4range(125, 125, '[]'), int4range(1, 1, '[]'), '[2010-01-02 10:10, 2010-01-02 11:00)');
 ERROR:  conflicting key value violates exclusion constraint "test_range_excl_speaker_during_excl"  (seg0 127.0.0.1:25432 pid=8632)
 DETAIL:  Key (speaker, during)=([1,2), ["Sat Jan 02 10:10:00 2010","Sat Jan 02 11:00:00 2010")) conflicts with existing key (speaker, during)=([1,2), ["Sat Jan 02 10:00:00 2010","Sat Jan 02 11:00:00 2010")).
--- end_ignore
 -- test bigint ranges
 select int8range(10000000000::int8, 20000000000::int8,'(]');
          int8range         

--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -460,15 +460,13 @@ DROP TABLE unique_tbl;
 -- EXCLUDE constraints
 --
 
--- start_ignore
--- GPDB does not support exclusion constraints, so no need to run these tests
 CREATE TABLE circles (
   c1 CIRCLE,
   c2 TEXT,
   EXCLUDE USING gist
     (c1 WITH &&, (c2::circle) WITH &&)
     WHERE (circle_center(c1) <> '(0,0)')
-);
+) DISTRIBUTED REPLICATED;
 
 -- these should succeed because they don't match the index predicate
 INSERT INTO circles VALUES('<(0,0), 5>', '<(0,0), 5>');
@@ -535,7 +533,6 @@ UPDATE deferred_excl SET f1 = 3;
 ALTER TABLE deferred_excl ADD EXCLUDE (f1 WITH =);
 
 DROP TABLE deferred_excl;
--- end_ignore
 
 -- Comments
 CREATE TABLE constraint_comments_tbl (a int CONSTRAINT the_constraint CHECK (a > 0));

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -630,15 +630,13 @@ DROP TABLE unique_tbl;
 --
 -- EXCLUDE constraints
 --
--- start_ignore
--- GPDB does not support exclusion constraints, so no need to run these tests
 CREATE TABLE circles (
   c1 CIRCLE,
   c2 TEXT,
   EXCLUDE USING gist
     (c1 WITH &&, (c2::circle) WITH &&)
     WHERE (circle_center(c1) <> '(0,0)')
-);
+) DISTRIBUTED REPLICATED;
 -- these should succeed because they don't match the index predicate
 INSERT INTO circles VALUES('<(0,0), 5>', '<(0,0), 5>');
 INSERT INTO circles VALUES('<(0,0), 5>', '<(0,0), 4>');
@@ -711,7 +709,6 @@ ALTER TABLE deferred_excl ADD EXCLUDE (f1 WITH =);
 ERROR:  could not create exclusion constraint "deferred_excl_f1_excl"
 DETAIL:  Key (f1)=(3) conflicts with key (f1)=(3).
 DROP TABLE deferred_excl;
--- end_ignore
 -- Comments
 CREATE TABLE constraint_comments_tbl (a int CONSTRAINT the_constraint CHECK (a > 0));
 CREATE DOMAIN constraint_comments_dom AS int CONSTRAINT the_constraint CHECK (value > 0);

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -820,7 +820,7 @@ SELECT COUNT(*) from gp_read_error_log('exttab_constraints_1');
 
 CREATE TABLE exttab_constraints_insert_1 (LIKE exttab_constraints_1) distributed by (i);
 ALTER TABLE exttab_constraints_insert_1 ADD CONSTRAINT exttab_uniq_constraint_1 UNIQUE (j);
-NOTICE:  updating distribution policy to match new unique index
+NOTICE:  updating distribution policy to match new UNIQUE constraint
 -- This should fail
 select gp_truncate_error_log('exttab_constraints_1');
  gp_truncate_error_log 

--- a/src/test/regress/output/partindex_test.source
+++ b/src/test/regress/output/partindex_test.source
@@ -829,7 +829,7 @@ NOTICE:  building index for child partition "part_table4_1_prt_girls_2_prt_5"
 NOTICE:  building index for child partition "part_table4_1_prt_girls_2_prt_1"
 -- create 2 indexes on part_table4_1_prt_girls_2_prt_1
 create unique index id_index_unique on part_table4_1_prt_girls_2_prt_1(id);
-NOTICE:  updating distribution policy to match new unique index
+NOTICE:  updating distribution policy to match new UNIQUE index
 -- create another index on column id
 create index id_rank_index on part_table4_1_prt_girls_2_prt_1(id, rank); 
 -- given index on part_table4_1_prt_boys_2_prt_3_id_idx, return similar index on part_table4_1_prt_girls_2_prt_1

--- a/src/test/regress/sql/gpdist_opclasses.sql
+++ b/src/test/regress/sql/gpdist_opclasses.sql
@@ -121,6 +121,20 @@ INSERT INTO abs_opclass_test VALUES
 \d abs_opclass_test
 
 
+--
+-- Test interaction between unique and primary key indexes and distribution keys.
+--
+-- should fail, because the default index opclass is not compatible with the |=| operator
+CREATE UNIQUE INDEX ON abs_opclass_test (i, j, t);
+ALTER TABLE abs_opclass_test ADD PRIMARY KEY (i, j, t);
+
+-- but this is allowed. (There is no syntax to specify the opclasses with ADD PRIMARY KEY)
+CREATE UNIQUE INDEX ON abs_opclass_test (i abs_int_btree_ops, j abs_int_btree_ops, t);
+
+-- ALTER TABLE should perform the same tests
+ALTER TABLE abs_opclass_test SET DISTRIBUTED BY (i, j); -- not allowed
+ALTER TABLE abs_opclass_test SET DISTRIBUTED BY (i abs_int_hash_ops, j abs_int_hash_ops);
+
 
 --
 -- Test scenario, where a type has a hash operator class, but not a default

--- a/src/test/regress/sql/index_constraint_naming.sql
+++ b/src/test/regress/sql/index_constraint_naming.sql
@@ -106,10 +106,7 @@ ALTER TABLE st_pk2 RENAME CONSTRAINT st_pk2_pkey_r_i  TO st_pk_pkey;
 ALTER INDEX st_pk2_pkey_r_i RENAME TO st_pk_pkey;
 
 -- EXCLUSION CONSTRAINT
-
--- EXCLUSION CONSTRAINT: GPDB does not support exclusion constraints
 CREATE TABLE st_x (a int, b int, EXCLUDE (a with =, b with =));
--- Should fail
 SELECT table_name,constraint_name,index_name,constraint_type FROM constraints_and_indices() WHERE (constraint_name::text=index_name::text AND constraint_type='x');
 
 -- U_P

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -339,20 +339,19 @@ ALTER TABLE ONLY test_constraints DROP CONSTRAINT test_constraints_val1_val2_key
 DROP TABLE test_constraints_inh;
 DROP TABLE test_constraints;
 
--- start_ignore
--- GPDB does not support exclusion constraints, so no need to run this test
 CREATE TABLE test_ex_constraints (
     c circle,
-    EXCLUDE USING gist (c WITH &&)
+    dkey inet,
+    EXCLUDE USING gist (dkey inet_ops WITH =, c WITH &&)
 );
+
 CREATE TABLE test_ex_constraints_inh () INHERITS (test_ex_constraints);
 \d+ test_ex_constraints
-ALTER TABLE test_ex_constraints DROP CONSTRAINT test_ex_constraints_c_excl;
+ALTER TABLE test_ex_constraints DROP CONSTRAINT test_ex_constraints_dkey_c_excl;
 \d+ test_ex_constraints
 \d+ test_ex_constraints_inh
 DROP TABLE test_ex_constraints_inh;
 DROP TABLE test_ex_constraints;
--- end_ignore
 
 -- Test non-inheritable foreign key constraints
 CREATE TABLE test_primary_constraints(id int PRIMARY KEY);

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -2179,6 +2179,31 @@ alter table it add primary key(i);
 select schemaname, tablename, indexname from pg_indexes where schemaname = 'public' and tablename like 'it%';
 drop table it;
 
+--
+-- Exclusion constraints are currently not supported on partitioned tables.
+--
+create table parttab_with_excl_constraint (
+  i int,
+  j int,
+  CONSTRAINT part_excl EXCLUDE (i WITH =) )
+distributed by (i) partition by list (i) (
+  partition a values (1),
+  partition b values (2),
+  partition c values (3)
+);
+
+create table parttab_with_excl_constraint (
+  i int,
+  j int)
+distributed by (i) partition by list (i) (
+  partition a values (1),
+  partition b values (2),
+  partition c values (3)
+);
+alter table parttab_with_excl_constraint ADD CONSTRAINT part_excl EXCLUDE (i WITH =);
+
+drop table parttab_with_excl_constraint;
+
 
 -- MPP-6297: test special WITH(tablename=...) syntax for dump/restore
 

--- a/src/test/regress/sql/rangetypes.sql
+++ b/src/test/regress/sql/rangetypes.sql
@@ -320,8 +320,6 @@ drop table test_range_elem;
 -- portion of the constraint.
 --
 
--- start_ignore
--- GPDB does not support exclusion constraints, so no need to run this test
 create table test_range_excl(
   id int4,
   room int4range,
@@ -329,7 +327,7 @@ create table test_range_excl(
   during tsrange,
   exclude using gist (room with =, during with &&),
   exclude using gist (speaker with =, during with &&)
-) DISTRIBUTED BY (id);
+) DISTRIBUTED REPLICATED;
 
 insert into test_range_excl
   values(1, int4range(123, 123, '[]'), int4range(1, 1, '[]'), '[2010-01-02 10:00, 2010-01-02 11:00)');
@@ -341,7 +339,6 @@ insert into test_range_excl
   values(1, int4range(124, 124, '[]'), int4range(3, 3, '[]'), '[2010-01-02 10:10, 2010-01-02 11:10)');
 insert into test_range_excl
   values(1, int4range(125, 125, '[]'), int4range(1, 1, '[]'), '[2010-01-02 10:10, 2010-01-02 11:00)');
--- end_ignore
 
 -- test bigint ranges
 select int8range(10000000000::int8, 20000000000::int8,'(]');


### PR DESCRIPTION
The first commit tightens up the cross-checks between unique/primary keys and distribution keys, to fix issue #6971. The second commit builds on that, to allow exclusion constraints, with some restrictions. See commit messages for details.