### PR TITLE
Re-add constraint tests for updates on distribution columns

### DIFF
--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -540,6 +540,7 @@ INSERT INTO fkc_foreign_table1 VALUES (2, 'bar');
 UPDATE fkc_foreign_table1 SET b = 'foo';
 DELETE FROM fkc_primary_table1 WHERE a = 1;
 COMMIT;
+UPDATE fkc_primary_table1 SET a = 3 where a = 2;
 
 BEGIN;
 -- Test with an ao table and heap table
@@ -554,3 +555,4 @@ INSERT INTO fkc_foreign_table2 VALUES (2, 'bar');
 UPDATE fkc_foreign_table2 SET b = 'foo';
 DELETE FROM fkc_primary_table2 WHERE a = 1;
 COMMIT;
+UPDATE fkc_primary_table2 SET a = 3 where a = 2;

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -711,6 +711,8 @@ INSERT INTO fkc_foreign_table1 VALUES (2, 'bar');
 UPDATE fkc_foreign_table1 SET b = 'foo';
 DELETE FROM fkc_primary_table1 WHERE a = 1;
 COMMIT;
+UPDATE fkc_primary_table1 SET a = 3 where a = 2;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
 BEGIN;
 -- Test with an ao table and heap table
 CREATE TABLE fkc_primary_table2(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
@@ -724,3 +726,5 @@ INSERT INTO fkc_foreign_table2 VALUES (2, 'bar');
 UPDATE fkc_foreign_table2 SET b = 'foo';
 DELETE FROM fkc_primary_table2 WHERE a = 1;
 COMMIT;
+UPDATE fkc_primary_table2 SET a = 3 where a = 2;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers


### PR DESCRIPTION
This reverts, and amends, commit 46e5a84da7f6af3b230d6fe6f61e3665498ae561 which was committed with the below commitmessage.
```
  Temporarily remove test that exposes inconsistent behavior

  When a DML `UPDATE`s the distribution column, the postgres planner will
  bail. ORCA can theoretically do this, and indeed it does on some
  platforms, e.g. Darwin (OS X 10.11). It's unclear to us why it fails to
  do so on some Linux builds. We are working hard to resolve that which is
  tracked by #1139.

  Before #1139 is resolved we want to remove these two SQL statements to
  expedite getting all of `installcheck` to green.
```
Since SplitUpdate support has been committed, it's time to bring these tests back and end the temporary period.

It's not entirely clear whether these tests meaningfully increase coverage, but here is at least what it would look like such that we can make an informed decision given that #1139 has been reopened.
