### PR TITLE
Reduce chances of master PANIC due to failure of phase 2 of 2PC.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4262,7 +4262,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&dtx_phase2_retry_count,
-		2, 0, 15,
+		10, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -194,7 +194,7 @@ CHECKPOINT
 -- Set to maximum number of 2PC retries to avoid any failures. Alter
 -- system is required to set the GUC and can't be set on session level
 -- as session reset happens for every abort retry.
-11: alter system set dtx_phase2_retry_count to 15;
+11: alter system set dtx_phase2_retry_count to 1500;
 ALTER
 11: select pg_reload_conf();
  pg_reload_conf 

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -106,7 +106,7 @@ $$ LANGUAGE plpgsql;
 -- Set to maximum number of 2PC retries to avoid any failures. Alter
 -- system is required to set the GUC and can't be set on session level
 -- as session reset happens for every abort retry.
-11: alter system set dtx_phase2_retry_count to 15;
+11: alter system set dtx_phase2_retry_count to 1500;
 11: select pg_reload_conf();
 -- skip FTS probes always
 11: SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);


### PR DESCRIPTION
This PR increases retry count and adds small delay between retries for 2PC. Looking for feedback on all the value additions/changes.

Commit-Prepared or Abort-Prepared (phase 2) of 2PC perform retries if
first attempt fails to complete the transaction. Default only 2
retries were performed and also were with zero delay. Once retries are
exhausted master PANIC's and has to continue retrying. Most of the
times the phase 2 fails on first attempt if segment is undergoing
recovery or failover happens on mirror. In such instances, just 2
retries are attempted in msecs and seems to defeat the purpose of the
retries.

Hence, modifying default number to retries to 10. Also, adding 100msec
delay between each retry to provide resonable opportunity to succeed
on retries. This should help avoid master PANICs for not able to
complete phase 2. I gave lot of thought but couldn't think of any
downsides from incresing the number of retries.

Also, maximum number allowed to be configured was only 15, which seems
too restrictive. Mainly for the tests where sometime to avoid
flakiness and avoiding master panics having higher number of retries
is helpful. So, changing the guc `dtx_phase2_retry_count` maximum
allowed to INT_MAX. Don't practically expect it to be set to any value
higher than some thousands. But think we don't have to be so
restrictive for the maximum.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [X] Pass `make installcheck`
