### PR TITLE
Stop tests as soon as one fails

### DIFF
--- a/concourse/pipelines/gpdb_master-generated.yml
+++ b/concourse/pipelines/gpdb_master-generated.yml
@@ -1000,7 +1000,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       TEST_OS: centos
       TEST_BINARY_SWAP: false
       CONFIGURE_FLAGS: {{configure_flags}}
@@ -1019,7 +1019,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
       DUMP_DB: "true"
@@ -1041,7 +1041,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: optimizer_use_gpdb_allocators=on
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
@@ -1060,7 +1060,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c gp_interconnect_type=tcp -c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c gp_interconnect_type=tcp -c optimizer=off' installcheck-world
       TEST_OS: centos
 
 - name: icw_gporca_centos7
@@ -1077,7 +1077,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos7-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
 
@@ -1095,7 +1095,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos7-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       TEST_OS: centos
       TEST_BINARY_SWAP: false
       CONFIGURE_FLAGS: {{configure_flags}}
@@ -1114,7 +1114,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos7-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       TEST_OS: centos
       TEST_BINARY_SWAP: false
       CONFIGURE_FLAGS: {{configure_flags}}
@@ -1133,7 +1133,7 @@ jobs:
   - task: ic_gpdb
     file: gpdb_src/concourse/tasks/ic_gpdb_sles11.yml
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       TEST_OS: sles
       CONFIGURE_FLAGS: {{configure_flags}}
 
@@ -1170,7 +1170,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb_sles12.yml
     image: ccp-image
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       TEST_OS: sles12
     on_success:
       <<: *ccp_destroy
@@ -1210,7 +1210,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb_sles12.yml
     image: ccp-image
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       TEST_OS: sles12
     on_success:
       <<: *ccp_destroy
@@ -1230,7 +1230,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb_ubuntu.yml
     image: ubuntu-gpdb-dev-16
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       CONFIGURE_FLAGS: {{configure_flags}}
 
 - name: icw_gporca_conan_ubuntu16
@@ -1321,7 +1321,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off'
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off'
         BUILD_TYPE=((rc-build-type)) -C src/test/regress installcheck-icudp
       TEST_OS: centos
 

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -1147,7 +1147,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       TEST_OS: centos
       TEST_BINARY_SWAP: false
       CONFIGURE_FLAGS: {{configure_flags}}
@@ -1166,7 +1166,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
       DUMP_DB: "true"
@@ -1188,7 +1188,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: optimizer_use_gpdb_allocators=on
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
@@ -1207,7 +1207,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c gp_interconnect_type=tcp -c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c gp_interconnect_type=tcp -c optimizer=off' installcheck-world
       TEST_OS: centos
 
 {% endif %}
@@ -1226,7 +1226,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos7-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
 
@@ -1244,7 +1244,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos7-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       TEST_OS: centos
       TEST_BINARY_SWAP: false
       CONFIGURE_FLAGS: {{configure_flags}}
@@ -1263,7 +1263,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos7-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       TEST_OS: centos
       TEST_BINARY_SWAP: false
       CONFIGURE_FLAGS: {{configure_flags}}
@@ -1284,7 +1284,7 @@ jobs:
   - task: ic_gpdb
     file: gpdb_src/concourse/tasks/ic_gpdb_sles11.yml
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       TEST_OS: sles
       CONFIGURE_FLAGS: {{configure_flags}}
 
@@ -1321,7 +1321,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb_sles12.yml
     image: ccp-image
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
       TEST_OS: sles12
     on_success:
       <<: *ccp_destroy
@@ -1361,7 +1361,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb_sles12.yml
     image: ccp-image
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       TEST_OS: sles12
     on_success:
       <<: *ccp_destroy
@@ -1383,7 +1383,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb_ubuntu.yml
     image: ubuntu-gpdb-dev-16
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
       CONFIGURE_FLAGS: {{configure_flags}}
 
 - name: icw_gporca_conan_ubuntu16
@@ -1500,7 +1500,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off'
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off'
         BUILD_TYPE=((rc-build-type)) -C src/test/regress installcheck-icudp
       TEST_OS: centos
 {% endif %}


### PR DESCRIPTION
We started an experiment of using `make --keep-going` in 86c302152fd.
IIRC the rationale was that during the merge work with upstream, we
didn't want the early stages of installcheck-world to gate the more
interesting tests. Nine months later, we've learned a lot about what
we'd like from an ICW experience. This experiment has proven to be
mostly a failure: the output from a test is far noisier than we'd like
it to be, and it makes diagnosing test failure all the more difficult.
And the original argument was also a bit bogus: we could've disabled the
early stages of the ICW if we believe we won't get to it in a while,
instead of blindly slap on the hammer of `-k`.

This commit undoes that.

Co-authored-by: Melanie Plageman <mplageman@pivotal.io>