### PR TITLE
Fix gpexpand to deal with database, schema, table with special char

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1448,11 +1448,14 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
 
         src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
         sql = """SELECT
+    current_database(),
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
     c.oid as tableoid,
-    now() as last_updated,
-    %s,
-    NULL as root_partition_name
+    NULL as root_partition_name,
+    '%s' as undone_status,
+    NULL as expansion_started,
+    NULL as expansion_finished,
+    %s as source_bytes
 FROM
             pg_class c
     JOIN pg_namespace n ON (c.relnamespace=n.oid)
@@ -1465,44 +1468,33 @@ WHERE
     AND n.nspname != 'gpexpand'
     AND n.nspname != 'pg_bitmapindex'
     AND c.relpersistence != 't'
-    AND c.relstorage != 'x';
+    AND c.relstorage != 'x'
 
-                  """ % (src_bytes_str)
+                  """ % (undone_status, src_bytes_str)
         self.logger.debug(sql)
         table_conn = self.connect_database(dbname)
-        curs = dbconn.execSQL(table_conn, sql)
-        rows = curs.fetchall()
-        try:
-            sql_file = os.path.abspath('./status_detail.dat')
-            self.logger.debug('status_detail data file: %s' % sql_file)
-            fp = open(sql_file, 'w')
-            for row in rows:
-                fqname = row[0]
-                table_oid = row[1]
-                rel_bytes = int(row[3])
-                root_partition_name = row[4]
-                full_name = '%s.%s' % (dbname, fqname)
 
-                fp.write("""%s\t%s\t%s\t%s\t%s\tNULL\tNULL\t%d\n""" % (
-                    dbname, fqname, table_oid,
-                    root_partition_name, undone_status, rel_bytes))
+        try:
+            data_file = os.path.abspath('./status_detail.dat')
+            self.logger.debug('status_detail data file: %s' % data_file)
+            copySQL = """COPY (%s) TO '%s'""" % (sql, data_file)
+
+            self.logger.debug(copySQL)
+            dbconn.execSQL(table_conn, copySQL)
+            table_conn.commit()
+            table_conn.close()
         except Exception, e:
             raise ExpansionError(e)
-        finally:
-            if fp: fp.close()
 
         try:
-            copySQL = """COPY gpexpand.status_detail FROM '%s' NULL AS 'NULL'""" % (sql_file)
+            copySQL = """COPY gpexpand.status_detail FROM '%s'""" % (data_file)
 
             self.logger.debug(copySQL)
             dbconn.execSQL(self.conn, copySQL)
         except Exception, e:
             raise ExpansionError(e)
         finally:
-            os.unlink(sql_file)
-
-        table_conn.commit()
-        table_conn.close()
+            os.unlink(data_file)
 
     def _populate_partitioned_tables(self, dbname):
         """
@@ -1528,11 +1520,14 @@ WHERE
         src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
         sql = """
 SELECT
+    current_database(),
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
     c.oid as tableoid,
-    now() as last_updated,
-    %s,
-    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as root_partition_name
+    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as root_partition_name,
+    '%s' as undone_status,
+    NULL as expansion_started,
+    NULL as expansion_finished,
+    %s as source_bytes
 FROM
     pg_class c,
     pg_namespace n,
@@ -1543,45 +1538,32 @@ WHERE
     AND p.parrelid = c.oid
     AND d.localoid = c.oid
     AND parlevel = 0
-ORDER BY fq_name, tableoid desc;
-                  """ % (src_bytes_str)
+ORDER BY fq_name, tableoid desc
+                  """ % (undone_status, src_bytes_str)
         self.logger.debug(sql)
         table_conn = self.connect_database(dbname)
-        curs = dbconn.execSQL(table_conn, sql)
-        rows = curs.fetchall()
 
         try:
-            sql_file = os.path.abspath('./status_detail.dat')
-            self.logger.debug('status_detail data file: %s' % sql_file)
-            fp = open(sql_file, 'w')
+            data_file = os.path.abspath('./status_detail.dat')
+            self.logger.debug('status_detail data file: %s' % data_file)
+            copySQL = """COPY (%s) TO '%s'""" % (sql, data_file)
 
-            for row in rows:
-                fqname = row[0]
-                table_oid = row[1]
-                rel_bytes = int(row[3])
-                root_partition_name = row[4]
-                full_name = '%s.%s' % (dbname, fqname)
-
-                fp.write("""%s\t%s\t%s\t%s\t%s\tNULL\tNULL\t%d\n""" % (
-                    dbname, fqname, table_oid,
-                    root_partition_name, undone_status, rel_bytes))
-        except Exception:
-            raise
-        finally:
-            if fp: fp.close()
+            self.logger.debug(copySQL)
+            dbconn.execSQL(table_conn, copySQL)
+            table_conn.commit()
+            table_conn.close()
+        except Exception, e:
+            raise ExpansionError(e)
 
         try:
-            copySQL = """COPY gpexpand.status_detail FROM '%s' NULL AS 'NULL'""" % (sql_file)
+            copySQL = """COPY gpexpand.status_detail FROM '%s'""" % (data_file)
 
             self.logger.debug(copySQL)
             dbconn.execSQL(self.conn, copySQL)
         except Exception, e:
             raise ExpansionError(e)
         finally:
-            os.unlink(sql_file)
-
-        table_conn.commit()
-        table_conn.close()
+            os.unlink(data_file)
 
     def perform_expansion(self):
         """Performs the actual table re-organizations"""
@@ -1816,8 +1798,8 @@ class ExpandTable():
         insertSQL = """INSERT INTO gpexpand.status_detail
                             VALUES ('%s','%s',%s,
                                     '%s',%d,'%s','%s','%s',%d)
-                    """ % (self.dbname, self.fq_name.replace("\'", "\'\'"), self.table_oid,
-                           self.root_partition_name,
+                    """ % (self.dbname.replace("'", "''"), self.fq_name.replace("'", "''"), self.table_oid,
+                           self.root_partition_name.replace("'", "''"),
                            self.rank, self.status,
                            self.expansion_started, self.expansion_finished,
                            self.source_bytes)
@@ -1839,7 +1821,7 @@ class ExpandTable():
                       source_bytes = %d
                   WHERE dbname = '%s'
                         AND table_oid = %s """ % (start_status, start_time,
-                                                  src_bytes, self.dbname,
+                                                  src_bytes, self.dbname.replace("'", "''"),
                                                   self.table_oid)
 
         logger.debug("Mark Started: " + sql.decode('utf-8'))
@@ -1851,7 +1833,7 @@ class ExpandTable():
                  SET status = '%s', expansion_started=NULL, expansion_finished=NULL
                  WHERE dbname = '%s'
                  AND table_oid = %s """ % (undone_status,
-                                           self.dbname, self.table_oid)
+                                           self.dbname.replace("'", "''"), self.table_oid)
 
         logger.debug('Resetting detailed_status: %s' % sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
@@ -1890,7 +1872,7 @@ class ExpandTable():
                   SET status = '%s', expansion_started='%s', expansion_finished='%s'
                   WHERE dbname = '%s'
                   AND table_oid = %s """ % (done_status, start_time, finish_time,
-                                            self.dbname, self.table_oid)
+                                            self.dbname.replace("'", "''"), self.table_oid)
         logger.debug(sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
         status_conn.commit()
@@ -1900,7 +1882,7 @@ class ExpandTable():
                   SET status = '%s', expansion_finished='%s'
                   WHERE dbname = '%s'
                   AND table_oid = %s """ % (does_not_exist_status, finish_time,
-                                            self.dbname, self.table_oid)
+                                            self.dbname.replace("'", "''"), self.table_oid)
         logger.debug(sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
         status_conn.commit()

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -356,3 +356,24 @@ Feature: expand the cluster by adding more segments
         And run rollback with database "gptest"
         And verify the gp_segment_configuration has been restored
         And unset fault inject
+
+    @gpexpand_no_mirrors
+    @gpexpand_with_special_character
+    Scenario: create database,schema,table with special character
+        Given a working directory of the test as '/tmp/gpexpand_behave'
+        And the database is killed on hosts "mdw,sdw1"
+        And the user runs command "rm -rf /tmp/gpexpand_behave/*"
+        And a temporary directory under "/tmp/gpexpand_behave/expandedData" to expand into
+        And the database is not running
+        And a cluster is created with no mirrors on "mdw" and "sdw1"
+        And database "gptest" exists
+        And create database schema table with special character
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "mdw,sdw1"
+        And the number of segments have been saved
+        And the user runs gpexpand interview to add 1 new segment and 0 new host "ignored.host"
+        When the user runs gpexpand with the latest gpexpand_inputfile without ret code check
+        Then gpexpand should return a return code of 0
+        And verify that the cluster has 1 new segments
+        When the user runs gpexpand against database "gptest" to redistribute
+        Then the tables have finished expanding


### PR DESCRIPTION
Now gpexpand will fail if database,schema or table contains special
character. Because it creates pending tables data file by python and
load it to working queue table gpexpand.status_detail by "COPY",
but didn't do escape according to COPY rule.
So we generate data file by COPY instead of generating by native
python write, the escape rule will be same.
Meanwhile, we have added other gpexpand.status_detail related escape
operation.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
