### PR TITLE
Remove MERGE_FIXME in adjust_selectivity_for_nulltest.

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -3887,19 +3887,6 @@ adjust_selectivity_for_nulltest(Selectivity selec,
 				{
 					double	nullfrac = 1 - selec;
 	
-#if 0
-					/*
-					 * GPDB_92_MERGE_FIXME
-					 * Param 'left' and 'right' are not passed in.
-					 */
-					/* 
-					 * a pushed qual must be applied on the inner side only; type implies 
-					 * where to find the var in the inputs
-					 */
-					Assert(!(JOIN_RIGHT == jointype) || bms_is_member(var->varno, left->relids));
-					Assert(!(JOIN_LEFT == jointype) || bms_is_member(var->varno, right->relids));
-#endif
-
 					/* adjust selectivity according to test */
 					switch (((NullTest *) clause)->nulltesttype)
 					{


### PR DESCRIPTION
Previously we have assertions in adjust_selectivity_for_nulltest() to
ensure that the pushed qual of form "Var IS (NOT) NULL" is applied on
the nullable side of the outer join.

Now that we do not have the outer_rel and inner_rel passed in as
parameters, we cannot do that assertion any more. But we can know the
assertion is true, because otherwise the qual would be figured out as
not outerjoin_delayed by check_outerjoin_delay() and be pushed down to
the non-nullable side of the outer join.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
