### PR TITLE
pg_upgrade changes to upgrade from GPDB5 to GPDB6

### DIFF
--- a/contrib/pg_upgrade/version_gp.c
+++ b/contrib/pg_upgrade/version_gp.c
@@ -404,7 +404,7 @@ old_GPDB5_check_for_unsupported_distribution_key_data_types(void)
 								"                      'pg_catalog.tinterval'::regtype, "
 								"                      'pg_catalog.money'::regtype, "
 								"                      'pg_catalog.anyarray'::regtype) AND "
-								"       attnum = any (p.distkey::int2[]) AND "
+								"       attnum = any (p.attrnums) AND "
 								"       c.relnamespace = n.oid AND "
 		/* exclude possible orphaned temp tables */
 								"  		n.nspname !~ '^pg_temp_'");

--- a/contrib/pg_upgrade/version_old_8_3.c
+++ b/contrib/pg_upgrade/version_old_8_3.c
@@ -63,7 +63,7 @@ old_8_3_check_for_name_data_type_usage(ClusterInfo *cluster)
 		/* exclude possible orphaned temp tables */
 								"		n.nspname !~ '^pg_temp_' AND "
 						 "		n.nspname !~ '^pg_toast_temp_' AND "
-								"		n.nspname NOT IN ('pg_catalog', 'information_schema')");
+								"		n.nspname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')");
 
 		ntups = PQntuples(res);
 		i_nspname = PQfnumber(res, "nspname");
@@ -580,8 +580,8 @@ old_8_3_invalidate_bpchar_pattern_ops_indexes(ClusterInfo *cluster,
 		/* find bpchar_pattern_ops indexes */
 
 		/*
-		 * Do only non-hash, non-gin indexees;	we already invalidated them
-		 * above; no need to reindex twice
+		 * Do only non-hash, non-gin and non-bitmap indexes; we already 
+		 * invalidated them above; no need to reindex twice
 		 */
 		res = executeQueryOrDie(conn,
 								"SELECT n.nspname, c.relname "
@@ -594,7 +594,7 @@ old_8_3_invalidate_bpchar_pattern_ops_indexes(ClusterInfo *cluster,
 								"			SELECT	o.oid "
 				   "			FROM	pg_catalog.pg_opclass o, "
 				  "					pg_catalog.pg_am a"
-		"			WHERE	a.amname NOT IN ('hash', 'gin') AND "
+		"			WHERE	a.amname NOT IN ('hash', 'gin', 'bitmap') AND "
 			"					a.oid = o.opcmethod AND "
 								"					o.opcname = 'bpchar_pattern_ops') "
 								"		= ANY (i.indclass) AND "

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7249,6 +7249,17 @@ getTableAttrs(Archive *fout, TableInfo *tblinfo, int numTables)
 								  "ORDER BY conname",
 								  tbinfo->dobj.catId.oid);
 			}
+			else if (fout->remoteVersion >= 70400)
+			{
+				appendPQExpBuffer(q, "SELECT tableoid, oid, conname, "
+						   "pg_catalog.pg_get_constraintdef(oid) AS consrc, "
+								  "true AS conislocal, true AS convalidated "
+								  "FROM pg_catalog.pg_constraint "
+								  "WHERE conrelid = '%u'::pg_catalog.oid "
+								  "   AND contype = 'c' "
+								  "ORDER BY conname",
+								  tbinfo->dobj.catId.oid);
+			}
 			else
 			{
 				error_unsupported_server_version(fout);
@@ -10310,7 +10321,7 @@ dumpFunc(Archive *fout, FuncInfo *finfo)
 					"pg_catalog.pg_get_function_arguments(oid) AS funcargs, "
 		  "pg_catalog.pg_get_function_identity_arguments(oid) AS funciargs, "
 					 "pg_catalog.pg_get_function_result(oid) AS funcresult, "
-						  "proiswindow, provolatile, proisstrict, prosecdef, "
+						  "proiswin as proiswindow, provolatile, proisstrict, prosecdef, "
 						  "false AS proleakproof, "
 						  "proconfig, procost, prorows, prodataaccess, "
 						  "'a' as proexeclocation, "


### PR DESCRIPTION
    Minor changes are made to pg_upgrade to allow GPDB5 to be upgraded
    to GPDB6:

    1). pg_ctl arguments need to explicitly contain the dbid, contentid and
    numcontents in order to start the GPDB5 cluster

    2). the type of the attnum field of the gp_distribution_policy had
    changed

    3). gp_toolkit is a view, and hence datatypes it contains that have been
    modified in GPDB6(such as name), need not be flagged as errors during
    pg_upgrade's check of the old cluster.

    4). index access method type 'bitmap' needs to be added to the exclusion
    list to select only bpchar_pattern_ops index access methods

    Co-authored-by: Jesse Zhang <jzhang@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
