### PR TITLE
Fix shared snapshot in-progress xids off-by-one

### DIFF
--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -278,6 +278,11 @@ CreateSharedSnapshotArray(void)
 		sharedSnapshotArray->maxSlots = slotCount;
 		sharedSnapshotArray->nextSlot = 0;
 
+		/*
+		 * Set slots to point to the next byte beyond what was allocated for
+		 * SharedSnapshotStruct. xips is the last element in the struct but is
+		 * not included in SharedSnapshotShmemSize allocation.
+		 */
 		sharedSnapshotArray->slots = (SharedSnapshotSlot *)&sharedSnapshotArray->xips;
 
 		/* xips start just after the last slot structure */
@@ -297,7 +302,7 @@ CreateSharedSnapshotArray(void)
 			 * Note: xipEntryCount is initialized in SharedSnapshotShmemSize().
 			 * So each slot gets (MaxBackends + max_prepared_xacts) transaction-ids.
 			 */
-			tmpSlot->snapshot.xip = &xip_base[xipEntryCount];
+			tmpSlot->snapshot.xip = &xip_base[0];
 			xip_base += xipEntryCount;
 		}
 	}

--- a/src/backend/utils/time/test/Makefile
+++ b/src/backend/utils/time/test/Makefile
@@ -1,0 +1,11 @@
+subdir=src/backend/utils/time
+top_builddir=../../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=sharedsnapshot
+
+include $(top_builddir)/src/backend/mock.mk
+
+sharedsnapshot.t: \
+	$(MOCK_DIR)/backend/storage/ipc/shmem_mock.o \
+	$(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -1,0 +1,63 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "postgres.h"
+#include "utils/memutils.h"
+
+#include "../sharedsnapshot.c"
+
+void
+test_boundaries_of_CreateSharedSnapshotArray(void **state)
+{
+	/*
+	 * max_prepared_xacts is used to calculate NUM_SHARED_SNAPSHOT_SLOTS. Make
+	 * it non-zero so that we actually allocate some local snapshot slots.
+	 */
+	max_prepared_xacts = 2;
+
+	SharedSnapshotStruct *fakeSharedSnapshotArray = NULL;
+
+	Size sharedSnapshotShmemSize = SharedSnapshotShmemSize();
+	fakeSharedSnapshotArray = malloc(sharedSnapshotShmemSize);
+
+	will_return(ShmemInitStruct, fakeSharedSnapshotArray);
+	will_assign_value(ShmemInitStruct, foundPtr, false);
+	expect_any_count(ShmemInitStruct, name, 1);
+	expect_any_count(ShmemInitStruct, size, 1);
+	expect_any_count(ShmemInitStruct, foundPtr, 1);
+
+	/*
+	 * Each slot in SharedSnapshotStrut has an associated dynamically allocated
+	 * LWLock, so LWLockAssign should be called for each slot.
+	 */
+	will_be_called_count(LWLockAssign, NUM_SHARED_SNAPSHOT_SLOTS);
+
+	CreateSharedSnapshotArray();
+
+	for (int i=0; i<sharedSnapshotArray->maxSlots; i++)
+	{
+		SharedSnapshotSlot *s = &sharedSnapshotArray->slots[i];
+
+		/*
+		 * Assert that every slot xip array falls inside the boundaries of the
+		 * allocated shared snapshot.
+		 */
+		assert_true(s->snapshot.xip > fakeSharedSnapshotArray);
+		assert_true(s->snapshot.xip < (((void *)fakeSharedSnapshotArray) +
+												sharedSnapshotShmemSize));
+	}
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_boundaries_of_CreateSharedSnapshotArray)
+	};
+	MemoryContextInit();
+	return run_tests(tests);
+}


### PR DESCRIPTION
Issue is that we point the first snapshot's in-progress transaction
array at the second block that we've allocated for xips. This results in
every snapshot N pointing to snapshot N+1's block of allocated xips.
This meant that the memory allocated which was intended for snapshot 0
was never used. Worse though is that the last snapshot's xip points to
an address that was not memory allocated for xips.

This bug manifests itself in interesting ways because it essentially
corrupts a local snapshot passed from a writer to a reader if we are
unfortunate enough to use the last indexed shared local snapshot
in-progress transaction array. When the snapshot is corrupt then we
cannot guarantee the correct visibility of tuples in a table.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>