### PR TITLE
Re-enable citext as distribution column in test

### DIFF
--- a/contrib/citext/expected/citext.out
+++ b/contrib/citext/expected/citext.out
@@ -216,12 +216,10 @@ SELECT citext_cmp('B'::citext, 'a'::citext) > 0 AS true;
 
 -- Do some tests using a table and index.
 CREATE TEMP TABLE try (
-   a text,
-   name citext,
-   UNIQUE (a, name)
-) DISTRIBUTED BY (a);
-INSERT INTO try (a, name)
-VALUES ('a', 'a'), ('a','ab'), ('â','â'), ('aba','aba'), ('b','b'), ('ba','ba'), ('bab','bab'), ('AZ','AZ');
+   name citext PRIMARY KEY
+);
+INSERT INTO try (name)
+VALUES ('a'), ('ab'), ('â'), ('aba'), ('b'), ('ba'), ('bab'), ('AZ');
 SELECT name, 'a' = name AS eq_a   FROM try WHERE name <> 'â';
  name | eq_a 
 ------+------
@@ -1057,6 +1055,8 @@ CREATE TABLE caster (
     tsquery     tsquery,
     uuid        uuid
 );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'citext' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO caster (text)          VALUES ('foo'::citext);
 INSERT INTO caster (citext)        VALUES ('foo'::text);
 INSERT INTO caster (varchar)       VALUES ('foo'::text);
@@ -2245,6 +2245,7 @@ SELECT like_escape( name::text, ''::citext ) = like_escape( name::text, '' ) AS 
  t
 (4 rows)
 
+-- start_ignore
 -- Ensure correct behavior for citext with materialized views.
 CREATE TABLE citext_table (
   id serial primary key,
@@ -2286,3 +2287,4 @@ SELECT * FROM citext_matview ORDER BY id;
   5 | 
 (5 rows)
 
+-- end_ignore

--- a/contrib/citext/expected/citext_1.out
+++ b/contrib/citext/expected/citext_1.out
@@ -2241,6 +2241,7 @@ SELECT like_escape( name::text, ''::citext ) = like_escape( name::text, '' ) AS 
  t
 (4 rows)
 
+-- start_ignore
 -- Ensure correct behavior for citext with materialized views.
 CREATE TABLE citext_table (
   id serial primary key,
@@ -2282,3 +2283,4 @@ SELECT * FROM citext_matview ORDER BY id;
   5 | 
 (5 rows)
 
+-- end_ignore

--- a/contrib/citext/sql/citext.sql
+++ b/contrib/citext/sql/citext.sql
@@ -87,13 +87,11 @@ SELECT citext_cmp('B'::citext, 'a'::citext) > 0 AS true;
 -- Do some tests using a table and index.
 
 CREATE TEMP TABLE try (
-   a text,
-   name citext,
-   UNIQUE (a, name)
-) DISTRIBUTED BY (a);
+   name citext PRIMARY KEY
+);
 
-INSERT INTO try (a, name)
-VALUES ('a', 'a'), ('a','ab'), ('â','â'), ('aba','aba'), ('b','b'), ('ba','ba'), ('bab','bab'), ('AZ','AZ');
+INSERT INTO try (name)
+VALUES ('a'), ('ab'), ('â'), ('aba'), ('b'), ('ba'), ('bab'), ('AZ');
 
 SELECT name, 'a' = name AS eq_a   FROM try WHERE name <> 'â';
 SELECT name, 'a' = name AS t      FROM try where name = 'a';
@@ -102,9 +100,9 @@ SELECT name, 'A' = name AS t      FROM try where name = 'A';
 SELECT name, 'A' = name AS t      FROM try where name = 'A';
 
 -- expected failures on duplicate key
-INSERT INTO try (a,name) VALUES ('a','a');
-INSERT INTO try (a,name) VALUES ('a','A');
-INSERT INTO try (a,name) VALUES ('a','aB');
+INSERT INTO try (name) VALUES ('a');
+INSERT INTO try (name) VALUES ('A');
+INSERT INTO try (name) VALUES ('aB');
 
 -- Make sure that citext_smaller() and citext_larger() work properly.
 SELECT citext_smaller( 'ab'::citext, 'ac'::citext ) = 'ab' AS t;
@@ -713,6 +711,7 @@ SELECT COUNT(*) = 19::bigint AS t FROM try;
 SELECT like_escape( name, '' ) = like_escape( name::text, '' ) AS t FROM srt;
 SELECT like_escape( name::text, ''::citext ) = like_escape( name::text, '' ) AS t FROM srt;
 
+-- start_ignore
 -- Ensure correct behavior for citext with materialized views.
 CREATE TABLE citext_table (
   id serial primary key,
@@ -735,3 +734,4 @@ SELECT *
   WHERE t.id IS NULL OR m.id IS NULL;
 REFRESH MATERIALIZED VIEW CONCURRENTLY citext_matview;
 SELECT * FROM citext_matview ORDER BY id;
+-- end_ignore


### PR DESCRIPTION
The citext test was altered in the past to add a distribution column other than citext. Since we now allow for extension datatypes to be distribution columns with the new hashing work, remove the workaround and re-align the test with upstream.

This also updates the testdata from upstream to work in Greenplum.