### PR TITLE
gpcheckcat: fix up length calculation for distkey

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1062,7 +1062,7 @@ partitionRegularityChecks = {
                                 select
                                     localoid::regclass,
                                     distkey,
-                                    coalesce(1+array_length(distkey,1),0)
+                                    array_length(distkey, 1)
                                 from
                                     gp_distribution_policy
                             ) as d(relid, distkey, attrcnt)


### PR DESCRIPTION
This line was updated during the recent changes to gp_distribution_policy -- it used to be
```
coalesce(1+array_upper(attrnums,1)-array_lower(attrnums,1),0)
```
which should just be replaced with `array_length()` directly at this point. The current implementation is off by one due to the retention of the old `+ 1`, and we no longer need a `COALESCE` because `distkey` can't be `NULL`.