### PR TITLE
refactor NUMSEGMENTS related macro

### DIFF
--- a/gpcontrib/gp_debug_numsegments/README.md
+++ b/gpcontrib/gp_debug_numsegments/README.md
@@ -4,9 +4,9 @@ could check or change the default behavior.
 How does it work?  Each table has a property numsegments to record how many
 segments its data is distributed one, the value is decided on `CREATE TABLE`
 according to an internal variable `gp_create_table_default_numsegments`, its
-value can be an integer number between `GP_POLICY_MINIMAL_NUMSEGMENTS` (always
-be 1 in current implementation) and `GP_POLICY_ALL_NUMSEGMENTS` (all the
-primary segments in the cluster), or one of below magic numbsers (policies):
+value can be an integer number between 1 (the minimal segment count) and
+`getgpsegmentCount()` (all the primary segments in the cluster), or one of
+below magic numbsers (policies):
 
 - `GP_DEFAULT_NUMSEGMENTS_FULL`: all the segments;
 - `GP_DEFAULT_NUMSEGMENTS_MINIMAL`: the minimal set of segments;

--- a/gpcontrib/gp_debug_numsegments/gp_debug_numsegments.c
+++ b/gpcontrib/gp_debug_numsegments/gp_debug_numsegments.c
@@ -71,14 +71,13 @@ gp_debug_set_create_table_default_numsegments(PG_FUNCTION_ARGS)
 
 	if (str == NULL)
 	{
-		if (numsegments < GP_POLICY_MINIMAL_NUMSEGMENTS ||
-			numsegments > GP_POLICY_ALL_NUMSEGMENTS)
+		if (numsegments < 1 || numsegments > getgpsegmentCount())
 			ereport(ERROR,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("invalid integer value for default numsegments: %d",
 							numsegments),
 					 errhint("Valid range: [1, %d (gp_num_contents_in_cluster)]",
-							 GP_POLICY_ALL_NUMSEGMENTS)));
+							 getgpsegmentCount())));
 
 		gp_create_table_default_numsegments = numsegments;
 	}

--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -41,14 +41,13 @@
 
 /*
  * The default numsegments when creating tables.  The value can be an integer
- * between GP_POLICY_MINIMAL_NUMSEGMENTS and GP_POLICY_ALL_NUMSEGMENTS or one
- * of below magic numbers:
+ * between 1 and getgpsegmentCount() or one of below magic numbers:
  *
  * - GP_DEFAULT_NUMSEGMENTS_FULL: all the segments;
  * - GP_DEFAULT_NUMSEGMENTS_RANDOM: pick a random set of segments each time;
  * - GP_DEFAULT_NUMSEGMENTS_MINIMAL: the minimal set of segments;
  *
- * A wrapper macro GP_POLICY_DEFAULT_NUMSEGMENTS is defined to get the default
+ * A wrapper macro GP_POLICY_DEFAULT_NUMSEGMENTS() is defined to get the default
  * numsegments according to the setting of this variable, always use that macro
  * instead of this variable.
  */
@@ -87,7 +86,7 @@ makeGpPolicy(GpPolicyType ptype, int nattrs, int numsegments)
 	policy->nattrs = nattrs; 
 
 	Assert(numsegments > 0);
-	if (numsegments == __GP_POLICY_EVIL_NUMSEGMENTS)
+	if (numsegments == GP_POLICY_INVALID_NUMSEGMENTS())
 	{
 		Assert(!"what's the proper value of numsegments?");
 	}
@@ -304,10 +303,10 @@ GpPolicyFetch(Oid tbloid)
 			if (strcmp(on_clause, "MASTER_ONLY") == 0)
 			{
 				return makeGpPolicy(POLICYTYPE_ENTRY,
-									0, GP_POLICY_ENTRY_NUMSEGMENTS);
+									0, getgpsegmentCount());
 			}
 
-			return createRandomPartitionedPolicy(GP_POLICY_ALL_NUMSEGMENTS);
+			return createRandomPartitionedPolicy(getgpsegmentCount());
 		}
 	}
 
@@ -383,7 +382,7 @@ GpPolicyFetch(Oid tbloid)
 	if (policy == NULL)
 	{
 		return makeGpPolicy(POLICYTYPE_ENTRY,
-							0, GP_POLICY_ENTRY_NUMSEGMENTS);
+							0, getgpsegmentCount());
 	}
 
 	return policy;

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -5369,7 +5369,7 @@ initAggPlanInfo(AggPlanInfo *info, Path *input_path, Plan *input_plan)
 	if (input_path != NULL)
 		info->input_locus = input_path->locus;
 	else
-		CdbPathLocus_MakeNull(&info->input_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
+		CdbPathLocus_MakeNull(&info->input_locus, GP_POLICY_INVALID_NUMSEGMENTS());
 
 	info->group_type = MPP_GRP_TYPE_BASEPLAN;
 	info->group_prep = MPP_GRP_PREP_NONE;

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -81,7 +81,7 @@ makeCdbHash(int numsegs, int natts, Oid *hashfuncs)
 
 	Assert(numsegs > 0);		/* verify number of segments is legal. */
 
-	if (numsegs == __GP_POLICY_EVIL_NUMSEGMENTS)
+	if (numsegs == GP_POLICY_INVALID_NUMSEGMENTS())
 	{
 		Assert(!"what's the proper value of numsegments?");
 	}

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -920,7 +920,7 @@ makeFlow(FlowType flotype, int numsegments)
 	Flow	   *flow = makeNode(Flow);
 
 	Assert(numsegments > 0);
-	if (numsegments == __GP_POLICY_EVIL_NUMSEGMENTS)
+	if (numsegments == GP_POLICY_INVALID_NUMSEGMENTS())
 	{
 		Assert(!"what's the proper value of numsegments?");
 	}
@@ -1156,7 +1156,7 @@ adjustPlanFlow(Plan *plan,
 	Assert(flow->flow_before_req_move == NULL);
 
 	Assert(numsegments > 0);
-	if (numsegments == __GP_POLICY_EVIL_NUMSEGMENTS)
+	if (numsegments == GP_POLICY_INVALID_NUMSEGMENTS())
 	{
 		Assert(!"what's the proper value of numsegments?");
 	}

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -356,7 +356,7 @@ get_partitioned_policy_from_flow(Plan *plan)
 	 */
 	return createHashPartitionedPolicy(policykeys,
 									   policyopclasses,
-									   GP_POLICY_DEFAULT_NUMSEGMENTS);
+									   GP_POLICY_DEFAULT_NUMSEGMENTS());
 }
 
 
@@ -385,7 +385,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 	ApplyMotionState state;
 	bool		needToAssignDirectDispatchContentIds = false;
 	bool		bringResultToDispatcher = false;
-	int			numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+	int			numsegments = getgpsegmentCount();
 
 	/* Initialize mutator context. */
 
@@ -432,7 +432,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 				}
 				else if (gp_create_table_random_default_distribution)
 				{
-					targetPolicy = createRandomPartitionedPolicy(GP_POLICY_DEFAULT_NUMSEGMENTS);
+					targetPolicy = createRandomPartitionedPolicy(GP_POLICY_DEFAULT_NUMSEGMENTS());
 					ereport(NOTICE,
 							(errcode(ERRCODE_SUCCESSFUL_COMPLETION),
 							 errmsg("using default RANDOM distribution since no distribution was specified"),
@@ -474,7 +474,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 						}
 						targetPolicy = createHashPartitionedPolicy(policykeys,
 																   policyopclasses,
-																   GP_POLICY_DEFAULT_NUMSEGMENTS);
+																   GP_POLICY_DEFAULT_NUMSEGMENTS());
 					}
 
 					/* If we deduced the policy from the query, give a NOTICE */
@@ -977,7 +977,7 @@ add_slice_to_motion(Motion *motion,
 	int			i;
 
 	Assert(numsegments > 0);
-	if (numsegments == __GP_POLICY_EVIL_NUMSEGMENTS)
+	if (numsegments == GP_POLICY_INVALID_NUMSEGMENTS())
 	{
 		Assert(!"what's the proper value of numsegments?");
 	}

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -112,7 +112,7 @@ cdbpath_create_motion_path(PlannerInfo *root,
 			CdbPathLocus_IsEntry(locus))
 		{
 			/* FIXME: how to reach here? what's the proper value for numsegments? */
-			subpath->locus.numsegments = GP_POLICY_ENTRY_NUMSEGMENTS;
+			subpath->locus.numsegments = getgpsegmentCount();
 			return subpath;
 		}
 		/* singleQE-->singleQE?  No motion needed. */
@@ -846,9 +846,9 @@ cdbpath_distkeys_from_preds(PlannerInfo *root,
 	 * Callers of this functions must correct numsegments themselves
 	 */
 
-	CdbPathLocus_MakeHashed(a_locus, a_distkeys, __GP_POLICY_EVIL_NUMSEGMENTS);
+	CdbPathLocus_MakeHashed(a_locus, a_distkeys, GP_POLICY_INVALID_NUMSEGMENTS());
 	if (b_distkeys)
-		CdbPathLocus_MakeHashed(b_locus, b_distkeys, __GP_POLICY_EVIL_NUMSEGMENTS);
+		CdbPathLocus_MakeHashed(b_locus, b_distkeys, GP_POLICY_INVALID_NUMSEGMENTS());
 	else
 		*b_locus = *a_locus;
 	return true;
@@ -1518,7 +1518,7 @@ cdbpath_motion_for_join(PlannerInfo *root,
 	return cdbpathlocus_join(jointype, outer.path->locus, inner.path->locus);
 
 fail:							/* can't do this join */
-	CdbPathLocus_MakeNull(&outer.move_to, __GP_POLICY_EVIL_NUMSEGMENTS);
+	CdbPathLocus_MakeNull(&outer.move_to, GP_POLICY_INVALID_NUMSEGMENTS());
 	return outer.move_to;
 }								/* cdbpath_motion_for_join */
 

--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -345,7 +345,7 @@ cdbpathlocus_from_subquery(struct PlannerInfo *root,
 				break;
 			}
 		default:
-			CdbPathLocus_MakeNull(&locus, __GP_POLICY_EVIL_NUMSEGMENTS);
+			CdbPathLocus_MakeNull(&locus, GP_POLICY_INVALID_NUMSEGMENTS());
 			Insist(0);
 	}
 	return locus;

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -418,7 +418,7 @@ make_motion_hash_all_targets(PlannerInfo *root, Plan *subplan)
 								  hashexprs,
 								  hashopfamilies,
 								  false /* useExecutorVarFormat */,
-								  GP_POLICY_ALL_NUMSEGMENTS);
+								  getgpsegmentCount());
 	}
 	else
 	{
@@ -499,7 +499,7 @@ mark_append_locus(Plan *plan, GpSetOpType optype)
 	/*
 	 * FIXME: for append we forcely collect data on all segments
 	 */
-	int			numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+	int			numsegments = getgpsegmentCount();
 
 	switch (optype)
 	{
@@ -605,7 +605,7 @@ void
 mark_plan_entry(Plan *plan)
 {
 	Assert(is_plan_node((Node *) plan) && plan->flow == NULL);
-	plan->flow = makeFlow(FLOW_SINGLETON, GP_POLICY_ENTRY_NUMSEGMENTS);
+	plan->flow = makeFlow(FLOW_SINGLETON, getgpsegmentCount());
 	plan->flow->segindex = -1;
 	plan->flow->locustype = CdbLocusType_Entry;
 }

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1510,7 +1510,8 @@ cdbcomponent_getCdbComponentsList(void)
 int
 getgpsegmentCount(void)
 {
-	int32 numsegments = -1;
+	/* 1 represents a singleton postgresql in utility mode */
+	int32 numsegments = 1;
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 		numsegments = cdbcomponent_getCdbComponents(true)->total_segments;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4899,7 +4899,7 @@ FillSliceTable(EState *estate, PlannedStmt *stmt)
 			 * segments, the catalog changes must be dispatched to all the
 			 * segments, so a full gang is required.
 			 */
-			numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+			numsegments = getgpsegmentCount();
 		else
 			/* FIXME: ->lefttree or planTree? */
 			numsegments = stmt->planTree->flow->numsegments;

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -408,7 +408,7 @@ ExecInitResult(Result *node, EState *estate, int eflags)
 			 * For ORCA generated plan we could distribute to ALL as partially
 			 * distributed tables are not supported by ORCA yet.
 			 */
-			numSegments = GP_POLICY_ALL_NUMSEGMENTS;
+			numSegments = getgpsegmentCount();
 		}
 
 		resstate->hashFilter = makeCdbHash(numSegments, node->numHashFilterCols, node->hashFilterFuncs);

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -104,7 +104,7 @@ query_planner(PlannerInfo *root, List *tlist,
 				CdbPathLocus_MakeEntry(&result_path->locus);
 			else if (exec_location == PROEXECLOCATION_ALL_SEGMENTS)
 				CdbPathLocus_MakeStrewn(&result_path->locus,
-										GP_POLICY_ALL_NUMSEGMENTS);
+										getgpsegmentCount());
 		}
 
 		return final_rel;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1705,7 +1705,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	gp_motion_cost_per_row :
 	2.0 * cpu_tuple_cost;
 
-	CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
+	CdbPathLocus_MakeNull(&current_locus, GP_POLICY_INVALID_NUMSEGMENTS());
 
 	/* Tweak caller-supplied tuple_fraction if have LIMIT/OFFSET */
 	if (parse->limitCount || parse->limitOffset)
@@ -2342,7 +2342,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 
 				/* Hashed aggregation produces randomly-ordered results */
 				current_pathkeys = NIL;
-				CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
+				CdbPathLocus_MakeNull(&current_locus, GP_POLICY_INVALID_NUMSEGMENTS());
 			}
 			else if (!grpext && (parse->hasAggs || parse->groupClause))
 			{
@@ -2407,7 +2407,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 												  0);
 				}
 
-				CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
+				CdbPathLocus_MakeNull(&current_locus, GP_POLICY_INVALID_NUMSEGMENTS());
 			}
 			else if (grpext && (parse->hasAggs || parse->groupClause))
 			{
@@ -2467,7 +2467,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 							make_pathkeys_for_sortclauses(root,
 														  parse->sortClause,
 														  result_plan->targetlist);
-					CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
+					CdbPathLocus_MakeNull(&current_locus, GP_POLICY_INVALID_NUMSEGMENTS());
 				}
 			}
 			else if (root->hasHavingQual)
@@ -2492,8 +2492,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 												   NULL);
 				/* Result will be only one row anyway; no sort order */
 				current_pathkeys = NIL;
-				mark_plan_general(result_plan, GP_POLICY_ALL_NUMSEGMENTS);
-				CdbPathLocus_MakeNull(&current_locus, __GP_POLICY_EVIL_NUMSEGMENTS);
+				mark_plan_general(result_plan, getgpsegmentCount());
+				CdbPathLocus_MakeNull(&current_locus, GP_POLICY_INVALID_NUMSEGMENTS());
 			}
 		}						/* end of non-minmax-aggregate case */
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1359,12 +1359,12 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 	{
 		/* FIXME: do not hard code to ALL */
 		CdbPathLocus_MakeGeneral(&pathnode->locus,
-								 GP_POLICY_ALL_NUMSEGMENTS);
+								 getgpsegmentCount());
 		return;
 	}
 
 	/* By default put Append node on all the segments */
-	numsegments = GP_POLICY_ALL_NUMSEGMENTS;
+	numsegments = getgpsegmentCount();
 	foreach(l, subpaths)
 	{
 		Path	   *subpath = (Path *) lfirst(l);
@@ -1538,7 +1538,7 @@ create_result_path(List *quals)
 	pathnode->path.total_cost = cpu_tuple_cost;
 
 	/* Result can be on any segments */
-	CdbPathLocus_MakeGeneral(&pathnode->path.locus, GP_POLICY_ALL_NUMSEGMENTS);
+	CdbPathLocus_MakeGeneral(&pathnode->path.locus, getgpsegmentCount());
 	pathnode->path.motionHazard = false;
 	pathnode->path.rescannable = true;
 
@@ -2637,14 +2637,14 @@ create_functionscan_path(PlannerInfo *root, RelOptInfo *rel,
 				CdbPathLocus_MakeEntry(&pathnode->locus);
 			else
 				CdbPathLocus_MakeGeneral(&pathnode->locus,
-										 GP_POLICY_ALL_NUMSEGMENTS);
+										 getgpsegmentCount());
 			break;
 		case PROEXECLOCATION_MASTER:
 			CdbPathLocus_MakeEntry(&pathnode->locus);
 			break;
 		case PROEXECLOCATION_ALL_SEGMENTS:
 			CdbPathLocus_MakeStrewn(&pathnode->locus,
-									GP_POLICY_ALL_NUMSEGMENTS);
+									getgpsegmentCount());
 			break;
 		default:
 			elog(ERROR, "unrecognized proexeclocation '%c'", exec_location);
@@ -2738,7 +2738,7 @@ create_valuesscan_path(PlannerInfo *root, RelOptInfo *rel,
 		/*
 		 * ValuesScan can be on any segment.
 		 */
-		CdbPathLocus_MakeGeneral(&pathnode->locus, GP_POLICY_ALL_NUMSEGMENTS);
+		CdbPathLocus_MakeGeneral(&pathnode->locus, getgpsegmentCount());
 
 	pathnode->motionHazard = false;
 	pathnode->rescannable = true;
@@ -2798,7 +2798,7 @@ create_worktablescan_path(PlannerInfo *root, RelOptInfo *rel,
 	if (rel->cdbpolicy)
 		numsegments = rel->cdbpolicy->numsegments;
 	else
-		numsegments = GP_POLICY_ALL_NUMSEGMENTS; /* FIXME */
+		numsegments = getgpsegmentCount(); /* FIXME */
 
 	if (ctelocus == CdbLocusType_Entry)
 		CdbPathLocus_MakeEntry(&result);
@@ -2891,10 +2891,10 @@ create_foreignscan_path(PlannerInfo *root, RelOptInfo *rel,
 	switch (rel->ftEntry->exec_location)
 	{
 		case FTEXECLOCATION_ANY:
-			CdbPathLocus_MakeGeneral(&(pathnode->path.locus), GP_POLICY_ALL_NUMSEGMENTS);
+			CdbPathLocus_MakeGeneral(&(pathnode->path.locus), getgpsegmentCount());
 			break;
 		case FTEXECLOCATION_ALL_SEGMENTS:
-			CdbPathLocus_MakeStrewn(&(pathnode->path.locus), GP_POLICY_ALL_NUMSEGMENTS);
+			CdbPathLocus_MakeStrewn(&(pathnode->path.locus), getgpsegmentCount());
 			break;
 		case FTEXECLOCATION_MASTER:
 			CdbPathLocus_MakeEntry(&(pathnode->path.locus));

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3710,7 +3710,7 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 	dist = (DistributedBy *)into->distributedBy;
 
 	if (dist->numsegments < 0)
-		dist->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
+		dist->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS();
 
 	/*
 	 * We have a DISTRIBUTED BY column list specified by the user

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1703,7 +1703,7 @@ transformCreateExternalStmt(CreateExternalStmt *stmt, const char *queryString)
 			stmt->distributedBy = makeNode(DistributedBy);
 			stmt->distributedBy->ptype = POLICYTYPE_PARTITIONED;
 			stmt->distributedBy->keyCols = NIL;
-			stmt->distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
+			stmt->distributedBy->numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS();
 		}
 		else
 		{
@@ -1769,7 +1769,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 		numsegments = distributedBy->numsegments;
 	else
 		/* Otherwise use DEFAULT as numsegments */
-		numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS;
+		numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS();
 
 	/* Explictly specified distributed randomly, no futher check needed */
 	if (distributedBy &&

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -65,35 +65,16 @@ typedef FormData_gp_policy *Form_gp_policy;
  * A magic number, setting GpPolicy.numsegments to this value will cause a
  * failed assertion at runtime, which allows developers to debug with gdb.
  */
-#define __GP_POLICY_EVIL_NUMSEGMENTS		(666)
-
-/*
- * All the segments.  getgpsegmentCount() should not be used directly as it
- * will return 0 in utility mode, but a valid numsegments should always be
- * greater than 0.
- */
-#define GP_POLICY_ALL_NUMSEGMENTS			Max(1, getgpsegmentCount())
-
-/*
- * Minimal set of segments.
- */
-#define GP_POLICY_MINIMAL_NUMSEGMENTS		1
-
-/*
- * A random set of segments, the value is different on each call.
- */
-#define GP_POLICY_RANDOM_NUMSEGMENTS		\
-	(GP_POLICY_MINIMAL_NUMSEGMENTS + \
-	 random() % (GP_POLICY_ALL_NUMSEGMENTS - GP_POLICY_MINIMAL_NUMSEGMENTS + 1))
+#define GP_POLICY_INVALID_NUMSEGMENTS()		(-1)
 
 /*
  * Default set of segments, the value is controlled by the variable
  * gp_create_table_default_numsegments.
  */
-#define GP_POLICY_DEFAULT_NUMSEGMENTS		\
-( gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_FULL    ? GP_POLICY_ALL_NUMSEGMENTS \
-: gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_RANDOM  ? GP_POLICY_RANDOM_NUMSEGMENTS \
-: gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_MINIMAL ? GP_POLICY_MINIMAL_NUMSEGMENTS \
+#define GP_POLICY_DEFAULT_NUMSEGMENTS()		\
+( gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_FULL    ? getgpsegmentCount() \
+: gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_RANDOM  ? (1 + random() % getgpsegmentCount()) \
+: gp_create_table_default_numsegments == GP_DEFAULT_NUMSEGMENTS_MINIMAL ? 1 \
 : gp_create_table_default_numsegments )
 
 /*
@@ -109,16 +90,6 @@ enum
 	GP_DEFAULT_NUMSEGMENTS_RANDOM  = -2,
 	GP_DEFAULT_NUMSEGMENTS_MINIMAL = -3,
 };
-
-/*
- * The segments suitable for Entry locus, which include both master and all
- * the segments.
- *
- * FIXME: in fact numsegments only describe a range of segments from 0 to
- * `numsegments-1`, master is not described by it at all.  So far this does
- * not matter.
- */
-#define GP_POLICY_ENTRY_NUMSEGMENTS			GP_POLICY_ALL_NUMSEGMENTS
 
 /*
  * GpPolicyType represents a type of policy under which a relation's

--- a/src/include/cdb/cdbpathlocus.h
+++ b/src/include/cdb/cdbpathlocus.h
@@ -208,7 +208,7 @@ typedef struct CdbPathLocus
 #define CdbPathLocus_MakeNull(plocus, numsegments_)                   \
             CdbPathLocus_MakeSimple((plocus), CdbLocusType_Null, (numsegments_))
 #define CdbPathLocus_MakeEntry(plocus)                  \
-            CdbPathLocus_MakeSimple((plocus), CdbLocusType_Entry, GP_POLICY_ENTRY_NUMSEGMENTS)
+            CdbPathLocus_MakeSimple((plocus), CdbLocusType_Entry, getgpsegmentCount())
 #define CdbPathLocus_MakeSingleQE(plocus, numsegments_)               \
             CdbPathLocus_MakeSimple((plocus), CdbLocusType_SingleQE, (numsegments_))
 #define CdbPathLocus_MakeGeneral(plocus, numsegments_)                \


### PR DESCRIPTION
- Retire GP_POLICY_ALL_NUMSEGMENTS and GP_POLICY_ENTRY_NUMSEGMENTS,
  unify to getgpsegmentCount
- Change NUMSEGMENTS related macro from variable macro to function
  macro
- Change default return value of getgpsegmentCount to 1, which
  represents a singleton postgresql in utility mode

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
