### PR TITLE
Silence unused-but-set-variable warning while building _pg extension

### DIFF
--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
@@ -3514,7 +3514,6 @@ static PyObject *
 pgsetdefpasswd(PyObject * self, PyObject * args)
 {
 	char	   *temp = NULL;
-	PyObject   *old;
 
 	/* gets arguments */
 	if (!PyArg_ParseTuple(args, "z", &temp))
@@ -3523,9 +3522,6 @@ pgsetdefpasswd(PyObject * self, PyObject * args)
 			"set_defpasswd(password), with password (string/None).");
 		return NULL;
 	}
-
-	/* adjusts value */
-	old = pg_default_passwd;
 
 	if (temp)
 		pg_default_passwd = PyString_FromString(temp);


### PR DESCRIPTION
The function `pgsetdefpasswd` seems to be following the format of similar static
set functions in the file. The main difference is that this function returns
none instead of the old value.

Remove the unused variable.

Tested with gcc >= 4.8
