### PR TITLE
gpexpand can adjust expansion order by rank column in status_detail

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -285,6 +285,7 @@ status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
                           fq_name text,
                           table_oid oid,
                           root_partition_name text,
+                          rank int,
                           status text,
                           expansion_started timestamp,
                           expansion_finished timestamp,
@@ -1437,6 +1438,7 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
     c.oid as tableoid,
     NULL as root_partition_name,
+    2 as rank,
     '%s' as undone_status,
     NULL as expansion_started,
     NULL as expansion_finished,
@@ -1509,6 +1511,7 @@ SELECT
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
     c.oid as tableoid,
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as root_partition_name,
+    2 as rank,
     '%s' as undone_status,
     NULL as expansion_started,
     NULL as expansion_finished,
@@ -1569,7 +1572,7 @@ ORDER BY fq_name, tableoid desc
         self.conn.commit()
 
         # read schema and queue up commands
-        sql = "SELECT * FROM gpexpand.status_detail WHERE status = 'NOT STARTED'"
+        sql = "SELECT * FROM gpexpand.status_detail WHERE status = 'NOT STARTED' ORDER BY rank"
         cursor = dbconn.execSQL(self.conn, sql)
 
         for row in cursor:
@@ -1681,7 +1684,7 @@ ORDER BY fq_name, tableoid desc
             c = dbconn.connect(self.dburl, encoding='UTF8')
             self.logger.warn('Expansion has not yet completed.  Removing the expansion')
             self.logger.warn('schema now will leave the following tables unexpanded:')
-            unexpanded_tables_sql = "SELECT fq_name FROM gpexpand.status_detail WHERE status = 'NOT STARTED'"
+            unexpanded_tables_sql = "SELECT fq_name FROM gpexpand.status_detail WHERE status = 'NOT STARTED' ORDER BY rank"
 
             cursor = dbconn.execSQL(c, unexpanded_tables_sql)
             unexpanded_tables_text = ''.join("\t%s\n" % row[0] for row in cursor)
@@ -1773,7 +1776,7 @@ class ExpandTable():
         if row is not None:
             (self.dbname, self.fq_name, self.table_oid,
              self.root_partition_name,
-             self.status,
+             self.rank, self.status,
              self.expansion_started, self.expansion_finished,
              self.source_bytes) = row
         if self.fq_name == self.root_partition_name:

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_expansion_tables.xml
@@ -63,6 +63,16 @@
           </row>
           <row>
             <entry colname="col1">
+              <codeph>rank</codeph>
+            </entry>
+            <entry colname="col2">int</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Rank determines the order in which tables are expanded. The
+              expansion utility will sort on rank and expand the lowest-ranking tables
+              first.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
               <codeph>status</codeph>
             </entry>
             <entry colname="col2">text</entry>


### PR DESCRIPTION
rank column has been deleted in e2c8b17863eba0ba7ea2eb1b6babcefafca16e00
As this column is very useful for user to adjust the expansion table
order, so we get it back.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
