### PR TITLE
Syntax fix to compile libpq on non-C99 compiler

### DIFF
--- a/src/interfaces/libpq/fe-misc.c
+++ b/src/interfaces/libpq/fe-misc.c
@@ -1047,9 +1047,10 @@ pqFlush(PGconn *conn)
 int
 pqFlushNonBlocking(PGconn *conn)
 {
+	int			ret;
 	bool old = conn->nonblocking;
 	conn->nonblocking = TRUE;
-	int ret = pqFlush(conn);
+	ret = pqFlush(conn);
 	conn->nonblocking = old;
 	return ret;
 }


### PR DESCRIPTION
fe-misc.c belongs to libpq frontend. libpq is needed by pygresql.
On windows python 2.7 is compiled with VS 2008, and so must be all
extensions including pygresql. VS 2008 is not compliant with C99.
Most part of libpq comes from upstream and is friendly with non-C99
compiler. We only need to fix pqFlushNonBlocking() which is
introduced in commit 510a20b6c2e and unique to GPDB.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
