### PR TITLE
Make `fts_errors` test deterministic

### DIFF
--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -37,6 +37,10 @@ CREATE
 include: helpers/server_helpers.sql;
 CREATE
 
+-- Helper function
+CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
 -- no segment down.
 select count(*) from gp_segment_configuration where status = 'd';
  count 
@@ -99,17 +103,26 @@ select gp_request_fts_probe_scan();
  t                         
 (1 row)
 
-select gp_inject_fault_infinite('get_dns_cached_address', 'reset', 1);
- gp_inject_fault_infinite 
---------------------------
- t                        
+-- Since both gp_request_fts_probe_scan() and gp_inject_fault() will
+-- call the cdbcomponent_updateCdbComponents(), there is a plausible
+-- race condition between the fts_probes and the reset of the fault
+-- injector; if the reset triggers the fault before the fts probe
+-- completes, the primary will be taken down without removing the fault
+-- To avoid the race condition, the test waits until both the segments
+-- go down before removing the fault.
+-- The test expect the following 2 segments to go down:
+-- 1. pg_ctl stop for dbid=3(content 1, primary)
+-- 2. get_dns_cached_address fault injected for dbid=2(content 0, primary)
+-1U: select wait_until_segments_are_down(2);
+ wait_until_segments_are_down 
+------------------------------
+ t                            
 (1 row)
 
--- verify a segment is down
-select count(*) from gp_segment_configuration where status = 'd';
- count 
--------
- 2     
+select gp_inject_fault('get_dns_cached_address', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ t               
 (1 row)
 
 -- session 1: in no transaction and no temp table created, it's safe to


### PR DESCRIPTION
Reset the fault injector on dbid 2 after re-verifying the segment is
down.

Both gp_request_fts_probe_scan() and gp_inject_fault() call
getCdbComponentInfo() in order to dispatch to QEs, which will trigger
the fault `GetDnsCachedAddress` on dbid 2, and
gp_request_fts_probe_scan() returns true even before the probe finishes.
Therefore, there is a race condition between the fts_probes and the
reset of the fault injector; when the reset triggers the fault before
the fts probe completes, the primary will be taken down without removing
the fault, which caused all the following tests failing after a
`gprecoverseg -ar` with double fault detected.

Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
