### PR TITLE
WIP: introduce abstract storage layer for AO/CO tables

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -164,7 +164,8 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
 										RelationGetRelationName(rel),
 										/* title */ titleBuf.data,
 										RelationNeedsWAL(rel));
-
+		/* Set Relation ptr */
+		set_relation(ds[i], rel);
 	}
 }
 
@@ -825,6 +826,9 @@ aocs_insert_init(Relation rel, int segno, bool update_mode)
 	AOCSInsertDesc desc;
 	TupleDesc	tupleDesc;
 	int64		firstSequence = 0;
+
+	/* Open SMgrRelation_ao */
+	RelationOpenSmgr(rel);
 
 	desc = (AOCSInsertDesc) palloc0(sizeof(AOCSInsertDescData));
 	desc->aoi_rel = rel;
@@ -1802,6 +1806,9 @@ aocs_addcol_init(Relation rel,
 	desc->rel = rel;
 	desc->cur_segno = -1;
 
+	/* Open it at the smgr level if not already done */
+	RelationOpenSmgr(rel);
+
 	/*
 	 * Rewrite catalog phase of alter table has updated catalog with info for
 	 * new columns, which is available through rel.
@@ -1826,6 +1833,8 @@ aocs_addcol_init(Relation rel,
 											   attr, RelationGetRelationName(rel),
 											   titleBuf.data,
 											   RelationNeedsWAL(rel));
+		/* Set Relation Ptr */
+		set_relation(desc->dsw[i], rel);
 	}
 	return desc;
 }

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -818,7 +818,8 @@ datumstreamwrite_open_file(DatumStreamWrite *ds, char *fn, int64 eof, int64 eofU
 									eof,
 									eofUncompressed,
 									relFileNode,
-									segmentFileNum);
+									segmentFileNum,
+									ds->aoi_rel);
 
 	ds->need_close_file = true;
 }
@@ -1619,3 +1620,14 @@ datumstreamread_get_upgrade_space(DatumStreamRead *ds, size_t len)
 
 	return ds->datum_upgrade_buffer;
 }
+
+/*
+ * Set relation pointer for DatumStreamWrite and its sub struct.
+ */
+void set_relation(DatumStreamWrite *dsw, Relation rel)
+{
+	dsw->aoi_rel = rel;
+	dsw->ao_write.aoi_rel = rel;
+	dsw->ao_write.bufferedAppend.aoi_rel = rel;
+}
+

--- a/src/include/cdb/cdbappendonlystoragewrite.h
+++ b/src/include/cdb/cdbappendonlystoragewrite.h
@@ -174,6 +174,9 @@ typedef struct AppendOnlyStorageWrite
 
 	bool needsWAL;
 
+	/* AO Relation pointer */
+	Relation		aoi_rel;
+
 } AppendOnlyStorageWrite;
 
 extern void AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
@@ -194,7 +197,8 @@ extern void AppendOnlyStorageWrite_OpenFile(AppendOnlyStorageWrite *storageWrite
 								int64 logicalEof,
 								int64 fileLen_uncompressed,
 								RelFileNodeBackend *relFileNode,
-								int32 segmentFileNum);
+								int32 segmentFileNum,
+								Relation rel);
 extern void AppendOnlyStorageWrite_FlushAndCloseFile(AppendOnlyStorageWrite *storageWrite,
 											 int64 *newLogicalEof,
 											 int64 *fileLen_uncompressed);

--- a/src/include/cdb/cdbbufferedappend.h
+++ b/src/include/cdb/cdbbufferedappend.h
@@ -76,6 +76,9 @@ typedef struct BufferedAppend
     int64                fileLen;
     int64				 fileLen_uncompressed; /* for calculating compress ratio */
 
+    /* AO Relation pointer */
+    	Relation		aoi_rel;
+
 } BufferedAppend;
 
 /*
@@ -99,14 +102,14 @@ extern void BufferedAppendInit(
 	int32          memoryLen,
 	int32          maxBufferLen,
 	int32          maxLargeWriteLen,
-	char           *relationName);
+	char           *relationName,
+	Relation 	   rel);
 
 /*
  * Takes an open file handle for the next file.
  */
 extern void BufferedAppendSetFile(
     BufferedAppend       *bufferedAppend,
-    File 				 file,
 	RelFileNodeBackend	 relfilenode,
 	int32				 segmentFileNum,
     char				 *filePathName,

--- a/src/include/utils/datumstream.h
+++ b/src/include/utils/datumstream.h
@@ -70,6 +70,9 @@ typedef struct DatumStreamWrite
 	 */
 	int64		eof;
 	int64		eofUncompress;
+
+	/* AO Relation pointer */
+	Relation		aoi_rel;
 }	DatumStreamWrite;
 
 typedef enum DatumStreamLargeObjectState
@@ -324,5 +327,7 @@ extern void *datumstreamread_get_upgrade_space(DatumStreamRead *datumStream,
  */
 extern void datumstreamread_block_content(DatumStreamRead * acc);
 extern bool init_datumstream_checksum(char *compName, bool checksum);
+
+extern void set_relation(DatumStreamWrite *dsw, Relation reln);
 
 #endif   /* DATUMSTREAM_H */

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -191,6 +191,7 @@ typedef struct RelationData
 	 */
 	Form_pg_appendonly rd_appendonly;
 	struct HeapTupleData *rd_aotuple;		/* all of pg_appendonly tuple */
+	struct SMgrRelationData_ao *rd_smgr_ao;	/* cached file handle, or NULL */
 
 	/* use "struct" here to avoid needing to include pgstat.h: */
 	struct PgStat_TableStatus *pgstat_info;		/* statistics collection area */
@@ -456,7 +457,9 @@ typedef struct ViewOptions
  */
 #define RelationOpenSmgr(relation) \
 	do { \
-		if ((relation)->rd_smgr == NULL) \
+		if ((relation)->rd_smgr_ao == NULL && relstorage_is_ao((relation)->rd_rel->relstorage)) \
+			smgrsetowner_ao(&((relation)->rd_smgr_ao), smgropen_ao((relation)->rd_node, (relation)->rd_backend)); \
+		if  ((relation)->rd_smgr == NULL) \
 			smgrsetowner(&((relation)->rd_smgr), smgropen((relation)->rd_node, (relation)->rd_backend)); \
 	} while (0)
 


### PR DESCRIPTION
Note that this is just a WIP PR used to illustrate the idea of abstract storage layer for AO/CO tables.

We open a thread on mail list of gpdb-dev for detailed discussion which includes the benefit and design of this abstract storage layer and its relationship with pluggable storage. Welcome to reply on mail list. 
[Mail link of Introducing abstract storage layer for AO/CO](https://groups.google.com/a/greenplum.org/forum/#!search/Introducing$20abstract$20storage$20layer$20for$20AO$2FCO/gpdb-dev/hANSFlAqdCI/7bbPzGXzAgAJ)

Here are feature summary of smgr interface for AO/CO tables:
1. Act as a file handler cache of AO/CO relation, just like Heap tables. Heap tables use a linked list of virtual file handles to store opened files. For AO/CO tables, Insert operation normally insert into only subset of (especially for CO tables) files. To locate the file handler quickly, we modify the linked list to hash table to store the file handle cache.
2. Smgrxxx_ao() passes segmentFileNum instead of blocknum.
3. Smgrxxx_ao() passes length of buffer, since its unit is no longer a page of heap table.
4. Smgrxxx_ao() ignore forknum and skipFsync. AO/CO tables doesn’t have FSM and `Visibility` file, note that there is visibility table for AO/CO table, but it’s used to implement DELETE/UPDATE of AO/CO table, which is different from Heap visibility file. skipFsync is used by buffer manager, so ignore it too.(Please point out if my understanding is wrong)
5. Add a new struct SMgrRelationData_ao and correspondingly add a new filed struct SMgrRelationData_ao *rd_smgr_ao in RelationData struct too. We consider it’s more clear to use a separate struct SMgrRelationData_ao to represent the storage manager struct for AO/CO tables, since SMgrRelationData struct and Heap table are coupled together.

Co-authored-by: Haozhou Wang <hawang@pivotal.io>
Co-authored-by: Hao Wu <hawu@pivotal.io>