### PR TITLE
resgroup: allow memory overuse for hashagg spill meta data

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -758,14 +758,9 @@ calcHashAggTableSizes(double memquota,	/* Memory quota in bytes. */
 
 		if (IsResGroupEnabled() && out_hats->memquota > orig_memquota)
 		{
-			ereport(WARNING,
-					(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
-					 errmsg("No enough memory quota reserved for AggHash operator."),
-					 errdetail("The operator needs a minimal of %.0f bytes memory, "
-							   "but only %.0f bytes are reserved.  "
-							   "Temporarily increased the memory quota to execute the operator.",
-							   out_hats->memquota, orig_memquota),
-					 errhint("Consider increase memory_spill_ratio for better performance.")));
+			elog(HHA_MSG_LVL,
+				 "HashAgg: auto enlarge operator memory from %.0f to %.0f in resource group mode",
+				 out_hats->memquota, orig_memquota);
 		}
 	}
 	

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -89,8 +89,24 @@ typedef enum InputRecordType
 		Assert((hashtable)->mem_for_metadata > 0); \
 		Assert((hashtable)->mem_for_metadata > (hashtable)->nbuckets * OVERHEAD_PER_BUCKET); \
 		if ((hashtable)->mem_for_metadata >= (hashtable)->max_mem) \
-			ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), \
-				errmsg(ERRMSG_GP_INSUFFICIENT_STATEMENT_MEMORY)));\
+		{ \
+			if (IsResGroupEnabled()) \
+			{ \
+				elog(HHA_MSG_LVL, \
+					 "HashAgg: no enough operator memory for spilling: " \
+					 "operator memory is %.0f bytes, " \
+					 "current meta data is %.0f bytes; " \
+					 "the overuse is allowed in resource group mode", \
+					 (hashtable)->max_mem, \
+					 (hashtable)->mem_for_metadata); \
+			} \
+			else \
+			{ \
+				ereport(ERROR, \
+						(errcode(ERRCODE_INTERNAL_ERROR), \
+						 errmsg(ERRMSG_GP_INSUFFICIENT_STATEMENT_MEMORY))); \
+			} \
+		} \
 	} while (0)
 
 #define GET_TOTAL_USED_SIZE(hashtable) \
@@ -296,7 +312,24 @@ makeHashAggEntryForInput(AggState *aggstate, TupleTableSlot *inputslot, uint32 h
 
 	if (GET_TOTAL_USED_SIZE(hashtable) + MAXALIGN(MAXALIGN(tup_len) + aggs_len) >=
 		hashtable->max_mem)
-		return NULL;
+	{
+		if (IsResGroupEnabled())
+		{
+			elog(HHA_MSG_LVL,
+				 "HashAgg: no enough operator memory to store new tuple: "
+				 "operator memory is %.0f bytes, "
+				 "current used size is %.0f bytes, "
+				 "need %lu bytes to store the new tuple; "
+				 "the overuse is allowed in resource group mode",
+				 hashtable->max_mem,
+				 GET_TOTAL_USED_SIZE(hashtable),
+				 MAXALIGN(MAXALIGN(tup_len) + aggs_len));
+		}
+		else
+		{
+			return NULL;
+		}
+	}
 
 	entry->tuple_and_aggs = mpool_alloc(hashtable->group_buf,
 										MAXALIGN(MAXALIGN(tup_len) + aggs_len));
@@ -339,7 +372,24 @@ makeHashAggEntryForGroup(AggState *aggstate, void *tuple_and_aggs,
 	MemoryContext oldcxt;
 
 	if (GET_TOTAL_USED_SIZE(hashtable) + input_size >= hashtable->max_mem)
-		return NULL;
+	{
+		if (IsResGroupEnabled())
+		{
+			elog(HHA_MSG_LVL,
+				 "HashAgg: no enough operator memory to store new group keys and aggregate values: "
+				 "operator memory is %.0f bytes, "
+				 "current used size is %.0f bytes, "
+				 "need %d bytes to store the new data; "
+				 "the overuse is allowed in resource group mode",
+				 hashtable->max_mem,
+				 GET_TOTAL_USED_SIZE(hashtable),
+				 input_size);
+		}
+		else
+		{
+			return NULL;
+		}
+	}
 
 	copy_tuple_and_aggs = mpool_alloc(hashtable->group_buf, input_size);
 	memcpy(copy_tuple_and_aggs, tuple_and_aggs, input_size);
@@ -1984,8 +2034,26 @@ reCalcNumberBatches(HashAggTable *hashtable, SpillFile *spill_file)
 	
 	if (hashtable->mem_for_metadata +
 		nbatches * BATCHFILE_METADATA > hashtable->max_mem)
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-				 ERRMSG_GP_INSUFFICIENT_STATEMENT_MEMORY));
+	{
+		if (IsResGroupEnabled())
+		{
+			elog(HHA_MSG_LVL,
+				 "HashAgg: no enough operator memory for spilling: "
+				 "operator memory is %.0f bytes, "
+				 "current meta data is %.0f bytes, "
+				 "need %lu bytes for %u more batches; "
+				 "the overuse is allowed in resource group mode",
+				 hashtable->max_mem,
+				 hashtable->mem_for_metadata,
+				 nbatches * BATCHFILE_METADATA,
+				 nbatches);
+		}
+		else
+		{
+			ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+							ERRMSG_GP_INSUFFICIENT_STATEMENT_MEMORY));
+		}
+	}
 	
 	hashtable->hats.nbatches = nbatches;
 }

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1238,7 +1238,6 @@ ResourceGroupGetQueryMemoryLimit(void)
 		 * RESGROUP_BYPASS_MODE_MEMORY_LIMIT_ON_QE chunk,
 		 * we should make sure query_mem + misc mem <= chunk.
 		 */
-		return bytesInChunk * RESGROUP_BYPASS_MODE_MEMORY_LIMIT_ON_QE / 2;
 		return Min(bytesInMB,
 				   bytesInChunk * RESGROUP_BYPASS_MODE_MEMORY_LIMIT_ON_QE / 2);
 	}

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -166,14 +166,7 @@ autoIncOpMemForResGroup(uint64 *opMemKB, int numOps)
 	if (*opMemKB >= minOpMemKB)
 		return;
 
-	/*
-	 * FIXME: a `SET hello<TAB>` auto completion will trigger this WARNING if
-	 * the group memory setting is low, which causes a messy command line
-	 * prompt.
-	 *
-	 * Is there any way to hide this WARNING for auto completion?
-	 */
-	ereport(WARNING,
+	ereport(DEBUG2,
 			(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
 			 errmsg("No enough operator memory for current query."),
 			 errdetail("Current query contains %d operators, "

--- a/src/test/isolation2/expected/resgroup/resgroup_agghash_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_agghash_memory.out
@@ -1,0 +1,78 @@
+-- When an agghash operator begins to spill it needs 16KB memory as meta data
+-- for each batch file, when there are many batch files there might not be
+-- enough operator memory for all of them, in resource queue mode the query
+-- will fail with an error like below:
+--
+--    ERROR:  insufficient memory reserved for statement
+--
+-- In resource group we allow this overuse as the shared memory is designed to
+-- serve this kind of overuse.
+
+--start_ignore
+DROP TABLE IF EXISTS t1_agghash_mem_test;
+DROP ROLE r1_agghash_mem_test;
+DROP RESOURCE GROUP rg1_agghash_mem_test;
+--end_ignore
+
+SET optimizer TO off;
+SET
+
+CREATE TABLE t1_agghash_mem_test (c1 int, c2 text) DISTRIBUTED BY (c2);
+CREATE
+INSERT INTO t1_agghash_mem_test SELECT i, i::text FROM generate_series(1,100000) i;
+INSERT 100000
+
+-- we must ensure spill to be small enough but still > 0.
+-- - rg1's memory quota is 682 * 1% = 6;
+-- - per-xact quota is 6/3=2;
+-- - spill memory is 2 * 60% = 1;
+CREATE RESOURCE GROUP rg1_agghash_mem_test WITH (cpu_rate_limit=10, memory_limit=1, memory_shared_quota=0, concurrency=3, memory_spill_ratio=60);
+CREATE
+
+CREATE ROLE r1_agghash_mem_test RESOURCE GROUP rg1_agghash_mem_test;
+CREATE
+GRANT ALL ON t1_agghash_mem_test TO r1_agghash_mem_test;
+GRANT
+
+SET gp_resgroup_memory_policy TO none;
+SET
+SET ROLE TO r1_agghash_mem_test;
+SET
+WITH a AS ( SELECT DISTINCT c2 FROM t1_agghash_mem_test INTERSECT SELECT DISTINCT c2 FROM t1_agghash_mem_test ) SELECT count(*) FROM a;
+ count  
+--------
+ 100000 
+(1 row)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO auto;
+SET
+SET ROLE TO r1_agghash_mem_test;
+SET
+WITH a AS ( SELECT DISTINCT c2 FROM t1_agghash_mem_test INTERSECT SELECT DISTINCT c2 FROM t1_agghash_mem_test ) SELECT count(*) FROM a;
+ count  
+--------
+ 100000 
+(1 row)
+RESET role;
+RESET
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET
+SET ROLE TO r1_agghash_mem_test;
+SET
+WITH a AS ( SELECT DISTINCT c2 FROM t1_agghash_mem_test INTERSECT SELECT DISTINCT c2 FROM t1_agghash_mem_test ) SELECT count(*) FROM a;
+ count  
+--------
+ 100000 
+(1 row)
+RESET role;
+RESET
+
+DROP TABLE IF EXISTS t1_agghash_mem_test;
+DROP
+DROP ROLE r1_agghash_mem_test;
+DROP
+DROP RESOURCE GROUP rg1_agghash_mem_test;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -34,6 +34,7 @@ test: resgroup/resgroup_cancel_terminate_concurrency
 # regression tests
 test: resgroup/resgroup_recreate
 test: resgroup/resgroup_operator_memory
+test: resgroup/resgroup_agghash_memory
 
 # parallel tests
 #test: resgroup/restore_default_resgroup

--- a/src/test/isolation2/sql/resgroup/resgroup_agghash_memory.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_agghash_memory.sql
@@ -1,0 +1,59 @@
+-- When an agghash operator begins to spill it needs 16KB memory as meta data
+-- for each batch file, when there are many batch files there might not be
+-- enough operator memory for all of them, in resource queue mode the query
+-- will fail with an error like below:
+--
+--    ERROR:  insufficient memory reserved for statement
+--
+-- In resource group we allow this overuse as the shared memory is designed to
+-- serve this kind of overuse.
+
+--start_ignore
+DROP TABLE IF EXISTS t1_agghash_mem_test;
+DROP ROLE r1_agghash_mem_test;
+DROP RESOURCE GROUP rg1_agghash_mem_test;
+--end_ignore
+
+SET optimizer TO off;
+
+CREATE TABLE t1_agghash_mem_test (c1 int, c2 text) DISTRIBUTED BY (c2);
+INSERT INTO t1_agghash_mem_test SELECT i, i::text FROM generate_series(1,100000) i;
+
+-- we must ensure spill to be small enough but still > 0.
+-- - rg1's memory quota is 682 * 1% = 6;
+-- - per-xact quota is 6/3=2;
+-- - spill memory is 2 * 60% = 1;
+CREATE RESOURCE GROUP rg1_agghash_mem_test
+  WITH (cpu_rate_limit=10, memory_limit=1, memory_shared_quota=0,
+        concurrency=3, memory_spill_ratio=60);
+
+CREATE ROLE r1_agghash_mem_test RESOURCE GROUP rg1_agghash_mem_test;
+GRANT ALL ON t1_agghash_mem_test TO r1_agghash_mem_test;
+
+SET gp_resgroup_memory_policy TO none;
+SET ROLE TO r1_agghash_mem_test;
+WITH a AS (
+	SELECT DISTINCT c2 FROM t1_agghash_mem_test INTERSECT
+	SELECT DISTINCT c2 FROM t1_agghash_mem_test
+) SELECT count(*) FROM a;
+RESET role;
+
+SET gp_resgroup_memory_policy TO auto;
+SET ROLE TO r1_agghash_mem_test;
+WITH a AS (
+	SELECT DISTINCT c2 FROM t1_agghash_mem_test INTERSECT
+	SELECT DISTINCT c2 FROM t1_agghash_mem_test
+) SELECT count(*) FROM a;
+RESET role;
+
+SET gp_resgroup_memory_policy TO eager_free;
+SET ROLE TO r1_agghash_mem_test;
+WITH a AS (
+	SELECT DISTINCT c2 FROM t1_agghash_mem_test INTERSECT
+	SELECT DISTINCT c2 FROM t1_agghash_mem_test
+) SELECT count(*) FROM a;
+RESET role;
+
+DROP TABLE IF EXISTS t1_agghash_mem_test;
+DROP ROLE r1_agghash_mem_test;
+DROP RESOURCE GROUP rg1_agghash_mem_test;


### PR DESCRIPTION
Each hashagg spill batch file needs about 16KB memory to store the meta
data, when there are many batch files the overall meta data size might
exceed the assigned operatory memory.  In resource group we could allow
this overuse as there are better memory control at transaction level,
and the resource group shared memory is designed to serve these kinds of
overuses.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
