### PR TITLE
update relpages and reltuples when vacuum full

### DIFF
--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -839,6 +839,9 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 	Relation	NewHeap,
 				OldHeap,
 				OldIndex;
+    Relation	relRelation;
+    HeapTuple	reltup;
+    Form_pg_class relform;
 	TupleDesc	oldTupDesc;
 	TupleDesc	newTupDesc;
 	int			natts;
@@ -857,6 +860,7 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 	double		num_tuples = 0,
 				tups_vacuumed = 0,
 				tups_recently_dead = 0;
+    BlockNumber num_pages;
 	int			elevel = verbose ? INFO : DEBUG2;
 	PGRUsage	ru0;
 
@@ -1184,6 +1188,8 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 	/* Reset rd_toastoid just to be tidy --- it shouldn't be looked at again */
 	NewHeap->rd_toastoid = InvalidOid;
 
+    num_pages = RelationGetNumberOfBlocks(NewHeap);
+
 	/* Log what we did */
 	ereport(elevel,
 			(errmsg("\"%s\": found %.0f removable, %.0f nonremovable row versions in %u pages",
@@ -1203,6 +1209,35 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 		index_close(OldIndex, NoLock);
 	heap_close(OldHeap, NoLock);
 	heap_close(NewHeap, NoLock);
+
+	/* Update pg_class to reflect the correct values of pages and tuples. */
+	relRelation = heap_open(RelationRelationId, RowExclusiveLock);
+
+	reltup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(OIDNewHeap));
+	if (!HeapTupleIsValid(reltup))
+		elog(ERROR, "cache lookup failed for relation %u", OIDNewHeap);
+	relform = (Form_pg_class) GETSTRUCT(reltup);
+
+	relform->relpages = num_pages;
+	relform->reltuples = num_tuples;
+
+	/* Don't update the stats for pg_class.  See swap_relation_files. */
+	if (OIDOldHeap != RelationRelationId)
+	{
+		simple_heap_update(relRelation, &reltup->t_self, reltup);
+
+		/* keep the catalog indexes up to date */
+		CatalogUpdateIndexes(relRelation, reltup);
+	}
+	else
+		CacheInvalidateRelcacheByTuple(reltup);
+
+	/* Clean up. */
+	heap_freetuple(reltup);
+	heap_close(relRelation, RowExclusiveLock);
+
+	/* Make the update visible */
+	CommandCounterIncrement();
 }
 
 /*

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2423,6 +2423,8 @@ vacuum_rel(Relation onerel, Oid relid, VacuumStmt *vacstmt, LOCKMODE lmode,
 								   save_userid,
 								   save_sec_context | SECURITY_RESTRICTED_OPERATION);
 			dispatchVacuum(vacstmt, &stats_context);
+
+			vac_update_relstats_from_list(stats_context.updated_stats);
 		}
 	}
 	else

--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -41,19 +41,19 @@ and usename='xxx' and datname='xxx';
                         QUERY PLAN                         
 -----------------------------------------------------------
  Hash Join
-   Hash Cond: (s.datid = d.oid)
+   Hash Cond: (s.usesysid = u.oid)
    InitPlan 1 (returns $0)
      ->  Result
    ->  Hash Join
-         Hash Cond: (u.oid = s.usesysid)
+         Hash Cond: (s.datid = d.oid)
+         ->  Function Scan on pg_stat_get_activity s
+               Filter: (query = $0)
+         ->  Hash
+               ->  Seq Scan on pg_database d
+                     Filter: (datname = 'xxx'::name)
+   ->  Hash
          ->  Seq Scan on pg_authid u
                Filter: (rolname = 'xxx'::name)
-         ->  Hash
-               ->  Function Scan on pg_stat_get_activity s
-                     Filter: (query = $0)
-   ->  Hash
-         ->  Seq Scan on pg_database d
-               Filter: (datname = 'xxx'::name)
  Optimizer: legacy query optimizer
 (15 rows)
 

--- a/src/test/regress/expected/vacuum_full_heap.out
+++ b/src/test/regress/expected/vacuum_full_heap.out
@@ -17,7 +17,24 @@ select pg_relation_size('ivfheap') from gp_dist_random('gp_id') where gp_segment
 (1 row)
 
 -- show pages are truncated
+-- GPDB-specific: VACUUM FULL on heap gives proper relpages and reltuples
+select relname, relpages, reltuples, gp_segment_id from gp_dist_random('pg_class') where oid = 'vfheap'::regclass;
+ relname | relpages | reltuples | gp_segment_id 
+---------+----------+-----------+---------------
+ vfheap  |        0 |         0 |             0
+ vfheap  |        4 |       100 |             1
+ vfheap  |        0 |         0 |             2
+(3 rows)
+
 vacuum full vfheap;
+select relname, relpages, reltuples, gp_segment_id from gp_dist_random('pg_class') where oid = 'vfheap'::regclass;
+ relname | relpages | reltuples | gp_segment_id 
+---------+----------+-----------+---------------
+ vfheap  |        2 |        50 |             1
+ vfheap  |        0 |         0 |             2
+ vfheap  |        0 |         0 |             0
+(3 rows)
+
 select pg_relation_size('vfheap') from gp_dist_random('gp_id') where gp_segment_id = 1;
  pg_relation_size 
 ------------------

--- a/src/test/regress/sql/vacuum_full_heap.sql
+++ b/src/test/regress/sql/vacuum_full_heap.sql
@@ -9,7 +9,10 @@ select pg_relation_size('vfheap') from gp_dist_random('gp_id') where gp_segment_
 select pg_relation_size('ivfheap') from gp_dist_random('gp_id') where gp_segment_id = 1;
 
 -- show pages are truncated
+-- GPDB-specific: VACUUM FULL on heap gives proper relpages and reltuples
+select relname, relpages, reltuples, gp_segment_id from gp_dist_random('pg_class') where oid = 'vfheap'::regclass;
 vacuum full vfheap;
+select relname, relpages, reltuples, gp_segment_id from gp_dist_random('pg_class') where oid = 'vfheap'::regclass;
 select pg_relation_size('vfheap') from gp_dist_random('gp_id') where gp_segment_id = 1;
 select pg_relation_size('ivfheap') from gp_dist_random('gp_id') where gp_segment_id = 1;
 


### PR DESCRIPTION
During the postgres merge, vacuum full was changed to use cluster. Cluster would swap the relfilenodes as well as the pg_class tuple. The temporary pg_class tuple does not contain proper statistics which will cause relpages and reltuples to be 0 after vacuum full finishes. We expect it to have the proper relpages and reltuples reported back to the master or else query planning performance will be hit quite a bit for large partition tables.

@jimmyyih has written the initial patch, I read through his patch and modify it,  also add more logic.

The PR is seperated by two parts

1. Apply upstream commit https://github.com/postgres/postgres/commit/ad337c76b6f454157982309089c3302fe77c9cbc?diff=unified
the diff in copy_heap_data() is all from the upstream commit.

2. And logic in swap_relation_files() collect QE's rel_pages and rel_tuples to QD when doing vacuum full.


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
