### PR TITLE
Add check on exchange partion

### DIFF
--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -967,3 +967,10 @@ SUBPARTITION p027 VALUES ('027'),
 SUBPARTITION p141 VALUES ('141'),
 SUBPARTITION p037 VALUES ('037'));
 -- MPP-26829
+
+-- Add check test on partition exchange
+create table parttab (a int4, b int4) distributed by (a) partition by range (a) (start (1) end (5) every (2));
+create table parttab_x (a int4, b int4) distributed by (b);
+alter table parttab exchange partition for (1) with table parttab_x;
+alter table parttab alter partition for (1) exchange partition for (1) with table parttab_x;
+

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -2952,3 +2952,10 @@ ERROR:  syntax error at or near "TEMPLATE"
 LINE 5: SUBPARTITION TEMPLATE (START (1) END (12) EVERY (1), DEFAULT...
                      ^
 -- MPP-26829
+-- Add check test on partition exchange
+create table parttab (a int4, b int4) distributed by (a) partition by range (a) (start (1) end (5) every (2));
+create table parttab_x (a int4, b int4) distributed by (b);
+alter table parttab exchange partition for (1) with table parttab_x;
+ERROR:  distribution policy for "parttab_x" must be the same as that for "parttab"
+alter table parttab alter partition for (1) exchange partition for (1) with table parttab_x;
+ERROR:  distribution policy for "parttab_x" must be the same as that for "parttab"


### PR DESCRIPTION
On sql "alter table parttab exchange partition for (1) with table y",
we checked if the table has same columns with the partion table. But
on sql "alter table parttab alter partition for (1) exchange partition
for (1) with table x", we forgot the check. Add the check back.

This pr fix the issue https://github.com/greenplum-db/gpdb/issues/6485
## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
