### PR TITLE
Export OPENSSL_CONF only if there is etc/openssl.conf in gpdb.

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -87,7 +87,10 @@ fi
 
 # openssl configuration file path
 cat <<EOF
+if [ -e \$GPHOME/etc/openssl.cnf ]; then
 OPENSSL_CONF=\$GPHOME/etc/openssl.cnf
+export OPENSSL_CONF
+fi
 EOF
 
 cat <<EOF
@@ -100,6 +103,3 @@ export PYTHONPATH
 export PYTHONHOME
 EOF
 
-cat <<EOF
-export OPENSSL_CONF
-EOF


### PR DESCRIPTION
- For centos and ubuntu, openssl.conf is from system default path
now. etc/openssl.conf in gpdb directory has been removed. So we
should not export OPENSSL_CONF in greenplum_path.sh if it is not 
available.
- Tests can be covered by existing cases.
