### PR TITLE
ALTER TABLE SET DISTRIBUTED RANDOMLY should check for primary key or unique index

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15380,7 +15380,17 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 
 		if (ldistro && ldistro->ptype == POLICYTYPE_PARTITIONED && ldistro->keyCols == NIL)
 		{
+			bool hasPrimaryKey = relationHasPrimaryKey(rel);
+			bool hasUniqueIndex = relationHasUniqueIndex(rel);
 			rand_pol = true;
+
+			if (hasPrimaryKey || hasUniqueIndex)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+						 errmsg("cannot set to DISTRIBUTED RANDOMLY because relation has %s", hasPrimaryKey ? "primary Key" : "unique index"),
+						 errhint("Drop the %s first.", hasPrimaryKey ? "primary key" : "unique index")));
+			}
 
 			if (!force_reorg)
 			{

--- a/src/include/catalog/index.h
+++ b/src/include/catalog/index.h
@@ -42,6 +42,7 @@ typedef enum
 
 
 extern bool relationHasPrimaryKey(Relation rel);
+extern bool relationHasUniqueIndex(Relation rel);
 extern void index_check_primary_key(Relation heapRel,
 						IndexInfo *indexInfo,
 						bool is_alter_table);

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1400,3 +1400,13 @@ CREATE TABLE tstab (i int4, t tsvector) distributed by (i);
 CREATE UNIQUE INDEX tstab_idx ON tstab(t);
 ERROR:  UNIQUE index must contain all columns in the distribution key of relation "tstab"
 INSERT INTO tstab VALUES (1, 'foo');
+-- ALTER TABLE SET DISTRIBUTED RANDOMLY should not work on a table
+-- that has a primary key or unique index.
+CREATE TABLE alter_table_with_primary_key (a int primary key);
+ALTER TABLE alter_table_with_primary_key SET DISTRIBUTED RANDOMLY;
+ERROR:  cannot set to DISTRIBUTED RANDOMLY because relation has primary Key
+HINT:  Drop the primary key first
+CREATE TABLE alter_table_with_unique_index (a int unique);
+ALTER TABLE alter_table_with_unique_index SET DISTRIBUTED RANDOMLY;
+ERROR:  cannot set to DISTRIBUTED RANDOMLY because relation has unique index
+HINT:  Drop the unique index first

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -421,3 +421,10 @@ select policytype, distkey, distclass from gp_distribution_policy where localoid
 CREATE TABLE tstab (i int4, t tsvector) distributed by (i);
 CREATE UNIQUE INDEX tstab_idx ON tstab(t);
 INSERT INTO tstab VALUES (1, 'foo');
+
+-- ALTER TABLE SET DISTRIBUTED RANDOMLY should not work on a table
+-- that has a primary key or unique index.
+CREATE TABLE alter_table_with_primary_key (a int primary key);
+ALTER TABLE alter_table_with_primary_key SET DISTRIBUTED RANDOMLY;
+CREATE TABLE alter_table_with_unique_index (a int unique);
+ALTER TABLE alter_table_with_unique_index SET DISTRIBUTED RANDOMLY;


### PR DESCRIPTION
Currently, a randomly distributed table cannot be created with a
primary key or unique index. We should put this restriction for ALTER
TABLE SET DISTRIBUTED RANDOMLY as well. This was caught by gpcheckcat
distribution_policy check.

Also, added a commit to make relationHasUniqueIndex() an extern
function. The Greenplum-specific relationHasUniqueIndex() function is
similar to the already existing relationHasPrimaryKey() function. We
should make it available for extern use, and put them closer since
they could be used together sometimes (like in this PR).