### PR TITLE
Fix assertion when creating unique index on tables created in utility…

### DIFF
--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -675,6 +675,13 @@ checkPolicyForUniqueIndex(Relation rel, AttrNumber *indattr, int nidxatts,
 	TupleDesc	desc = RelationGetDescr(rel);
 
 	/*
+	 * POLICYTYPE_ENTRY normally means it's a system table or a table created
+	 * in utility mode, so unique/primary key is allowed anywhere.
+	 */
+	if (GpPolicyIsEntry(rel->rd_cdbpolicy))
+		return;
+
+	/*
 	 * Firstly, unique/primary key indexes aren't supported if we're
 	 * distributing randomly.
 	 */
@@ -686,9 +693,11 @@ checkPolicyForUniqueIndex(Relation rel, AttrNumber *indattr, int nidxatts,
 						isprimary ? "PRIMARY KEY" : "UNIQUE")));
 	}
 
-	/* replicated table support unique/primary key indexes */
+	/* Replicated table support unique/primary key indexes */
 	if (GpPolicyIsReplicated(rel->rd_cdbpolicy))
 		return;
+
+	Assert(GpPolicyIsHashPartitioned(rel->rd_cdbpolicy));
 
 	/*
 	 * We use bitmaps to make intersection tests easier. As noted, order is

--- a/src/test/isolation2/expected/misc.out
+++ b/src/test/isolation2/expected/misc.out
@@ -1,0 +1,12 @@
+--
+-- Validate GPDB can create unique index on a table created in utility mode
+--
+-- NOTICE: we must connect to master in utility mode because the oid of table is
+-- preassigned in QD, if we create a table in utility mode in QE, the oid might
+-- conflict with preassigned oid.
+-1U: create table utilitymode_primary_key_tab (c1 int);
+CREATE
+-1U: create unique index idx_utilitymode_c1 on utilitymode_primary_key_tab (c1);
+CREATE
+-1U: drop table utilitymode_primary_key_tab;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -25,7 +25,7 @@ test: gdd/local-deadlock-03
 # gdd end
 test: gdd/end
 
-test: pg_terminate_backend deadlock_under_entry_db_singleton starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue
+test: pg_terminate_backend deadlock_under_entry_db_singleton starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/sql/misc.sql
+++ b/src/test/isolation2/sql/misc.sql
@@ -1,0 +1,9 @@
+--
+-- Validate GPDB can create unique index on a table created in utility mode
+--
+-- NOTICE: we must connect to master in utility mode because the oid of table is
+-- preassigned in QD, if we create a table in utility mode in QE, the oid might
+-- conflict with preassigned oid.
+-1U: create table utilitymode_primary_key_tab (c1 int);
+-1U: create unique index idx_utilitymode_c1 on utilitymode_primary_key_tab (c1);
+-1U: drop table utilitymode_primary_key_tab;


### PR DESCRIPTION
… mode

checkPolicyForUniqueIndex() checks if distribution key conflict with unique/primary
key, for example, unique index is not allowed for random-distributed table and
allowed for replicated-distributed table, for normal distributed, the set of
columns being indexed should be a superset of the table.

What about entry-distributed table? (eg, table created in utility mode, it has
no records in gp_distribution_policy and GpPolicyFetch translated it to
entry-distributed)? Such tables are localized in a single db, so adding a unique
index should also be allowed.

This is spotted by the assertion in checkPolicyForUniqueIndex() when checking
the conflict for normal distributed tables.

This fixes #5880

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
