### PR TITLE
Dependency inject image type for tasks in job

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -24,6 +24,7 @@ resources:
       repository: pivotaldata/ubuntu-gpdb-dev
       tag: '16.04'
 
+      
 anchors:
   - &pr_failure
     put: gpdb_pr
@@ -44,6 +45,45 @@ anchors:
       path: gpdb_pr
       status: success
 
+      
+tasks:
+  - &icw_gporca_ubuntu16
+    task: icw_gporca_ubuntu16
+    image: image
+    file: gpdb_pr/concourse/tasks/test_with_orca_conan.yml
+    input_mapping:
+      gpdb_src: gpdb_pr
+      bin_gpdb: compiled_bits_ubuntu16
+    params:
+      TEST_SUITE: "icw"
+    timeout: 3h
+    on_failure: *pr_failure
+
+  - &icw_planner_ubuntu16
+    task: icw_planner_ubuntu16
+    image: image
+    file: gpdb_pr/concourse/tasks/test_with_planner_conan.yml
+    input_mapping:
+      gpdb_src: gpdb_pr
+      bin_gpdb: compiled_bits_ubuntu16
+    params:
+      TEST_SUITE: "icw"
+    timeout: 3h
+    on_failure: *pr_failure
+
+  - &compile_gpdb_ubuntu16
+    task: compile_gpdb_ubuntu16
+    file: gpdb_pr/concourse/tasks/compile_gpdb_open_source_ubuntu.yml
+    image: image
+    input_mapping:
+      gpdb_src: gpdb_pr
+    on_failure: *pr_failure
+    timeout: 30m
+    params:
+      BINTRAY_REMOTE: {{bintray_remote}}
+      BINTRAY_REMOTE_URL: {{bintray_remote_url}}
+      
+      
 jobs:
   - name: compile_and_test_gpdb
     public: true
@@ -57,39 +97,10 @@ jobs:
         resource: ubuntu-gpdb-dev-16
 
     - *pr_pending
-
-    - task: compile_gpdb_ubuntu16
-      file: gpdb_pr/concourse/tasks/compile_gpdb_open_source_ubuntu.yml
-      image: image
-      input_mapping:
-        gpdb_src: gpdb_pr
-      on_failure: *pr_failure
-      timeout: 30m
-      params:
-        BINTRAY_REMOTE: {{bintray_remote}}
-        BINTRAY_REMOTE_URL: {{bintray_remote_url}}
+    - *compile_gpdb_ubuntu16
 
     - aggregate:
-      - task: icw_gporca_ubuntu16
-        image: image
-        file: gpdb_pr/concourse/tasks/test_with_orca_conan.yml
-        input_mapping:
-          gpdb_src: gpdb_pr
-          bin_gpdb: compiled_bits_ubuntu16
-        params:
-          TEST_SUITE: "icw"
-        timeout: 3h
-        on_failure: *pr_failure
-
-      - task: icw_planner_ubuntu16
-        image: image
-        file: gpdb_pr/concourse/tasks/test_with_planner_conan.yml
-        input_mapping:
-          gpdb_src: gpdb_pr
-          bin_gpdb: compiled_bits_ubuntu16
-        params:
-          TEST_SUITE: "icw"
-        timeout: 3h
-        on_failure: *pr_failure
+        - *icw_gporca_ubuntu16
+        - *icw_planner_ubuntu16
 
     - *pr_success

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -24,6 +24,26 @@ resources:
       repository: pivotaldata/ubuntu-gpdb-dev
       tag: '16.04'
 
+anchors:
+  - &pr_failure
+    put: gpdb_pr
+    params:
+      path: gpdb_pr
+      status: failure
+      
+  - &pr_pending
+    put: gpdb_pr
+    params:
+      path: gpdb_pr
+      status: pending
+      
+  - &pr_success
+    put: report_pr_success
+    resource: gpdb_pr
+    params:
+      path: gpdb_pr
+      status: success
+
 jobs:
   - name: compile_and_test_gpdb
     public: true
@@ -33,23 +53,17 @@ jobs:
       - get: gpdb_pr
         trigger: true
         version: every
-      - get: ubuntu-gpdb-dev-16
+      - get: image
+        resource: ubuntu-gpdb-dev-16
 
-    - put: gpdb_pr
-      params:
-        path: gpdb_pr
-        status: pending
+    - *pr_pending
 
     - task: compile_gpdb_ubuntu16
       file: gpdb_pr/concourse/tasks/compile_gpdb_open_source_ubuntu.yml
-      image: ubuntu-gpdb-dev-16
+      image: image
       input_mapping:
         gpdb_src: gpdb_pr
-      on_failure: &pr_failure
-        put: gpdb_pr
-        params:
-          path: gpdb_pr
-          status: failure
+      on_failure: *pr_failure
       timeout: 30m
       params:
         BINTRAY_REMOTE: {{bintray_remote}}
@@ -57,7 +71,7 @@ jobs:
 
     - aggregate:
       - task: icw_gporca_ubuntu16
-        image: ubuntu-gpdb-dev-16
+        image: image
         file: gpdb_pr/concourse/tasks/test_with_orca_conan.yml
         input_mapping:
           gpdb_src: gpdb_pr
@@ -68,7 +82,7 @@ jobs:
         on_failure: *pr_failure
 
       - task: icw_planner_ubuntu16
-        image: ubuntu-gpdb-dev-16
+        image: image
         file: gpdb_pr/concourse/tasks/test_with_planner_conan.yml
         input_mapping:
           gpdb_src: gpdb_pr
@@ -78,8 +92,4 @@ jobs:
         timeout: 3h
         on_failure: *pr_failure
 
-    - put: report_pr_success
-      resource: gpdb_pr
-      params:
-        path: gpdb_pr
-        status: success
+    - *pr_success


### PR DESCRIPTION
* Makes initial changes necessary to remove image specific knowledge from tasks. 
* Makes use of anchors to separate high-level description of tasks to be done from low-level configuration details.

Our goal is to simplify what the tasks are responsible for. This should simplify the declaration of tasks in the pipeline files, as well as simplify the logic within the task scripts be less concerned with the specific platform in use.

We started down this path when investigating how to fan out the PR pipeline into thinner tests instead of the current ICW jobs that take quite a long time. We decided that some simplification was due also.