### PR TITLE
Correctly expand writable external table

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -276,6 +276,7 @@ status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
                           table_oid oid,
                           root_partition_name text,
                           rank int,
+                          external_writable bool,
                           status text,
                           expansion_started timestamp,
                           expansion_finished timestamp,
@@ -1420,24 +1421,24 @@ class gpexpand:
     c.oid as tableoid,
     NULL as root_partition_name,
     2 as rank,
+    pe.writable is not null as external_writable,
     '%s' as undone_status,
     NULL as expansion_started,
     NULL as expansion_finished,
     %s as source_bytes
 FROM
-            pg_class c
+    pg_class c
     JOIN pg_namespace n ON (c.relnamespace=n.oid)
     JOIN pg_catalog.gp_distribution_policy p on (c.oid = p.localoid)
     LEFT JOIN pg_partition pp on (c.oid=pp.parrelid)
     LEFT JOIN pg_partition_rule pr on (c.oid=pr.parchildrelid)
+    LEFT JOIN pg_exttable pe on (c.oid=pe.reloid and pe.writable)
 WHERE
     pp.parrelid is NULL
     AND pr.parchildrelid is NULL
     AND n.nspname != 'gpexpand'
     AND n.nspname != 'pg_bitmapindex'
     AND c.relpersistence != 't'
-    AND c.relstorage != 'x'
-
                   """ % (undone_status, src_bytes_str)
         self.logger.debug(sql)
         table_conn = self.connect_database(dbname)
@@ -1493,6 +1494,7 @@ SELECT
     c.oid as tableoid,
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as root_partition_name,
     2 as rank,
+    false as external_writable,
     '%s' as undone_status,
     NULL as expansion_started,
     NULL as expansion_finished,
@@ -1757,7 +1759,7 @@ class ExpandTable():
         if row is not None:
             (self.dbname, self.fq_name, self.table_oid,
              self.root_partition_name,
-             self.rank, self.status,
+             self.rank, self.external_writable, self.status,
              self.expansion_started, self.expansion_finished,
              self.source_bytes) = row
         if self.fq_name == self.root_partition_name:
@@ -1766,10 +1768,10 @@ class ExpandTable():
     def add_table(self, conn):
         insertSQL = """INSERT INTO gpexpand.status_detail
                             VALUES ('%s','%s',%s,
-                                    '%s',%d,'%s','%s','%s',%d)
+                                    '%s',%d,'%s','%s','%s','%s',%d)
                     """ % (self.dbname.replace("'", "''"), self.fq_name.replace("'", "''"), self.table_oid,
                            self.root_partition_name.replace("'", "''"),
-                           self.rank, self.status,
+                           self.rank, self.external_writable, self.status,
                            self.expansion_started, self.expansion_finished,
                            self.source_bytes)
         logger.info('Added table %s.%s' % (self.dbname.decode('utf-8'), self.fq_name.decode('utf-8')))
@@ -1811,12 +1813,9 @@ class ExpandTable():
     def expand(self, table_conn, cancel_flag):
         # for root partition, we want to expand whose partition in one shot
         # TODO: expand leaf partitions seperately in parallel
-        if self.is_root_partition:
-            only_str = ""
-        else:
-            only_str = "ONLY"
-
-        sql = 'ALTER TABLE %s %s EXPAND TABLE' % (only_str, self.fq_name)
+        only_str = "" if self.is_root_partition else "ONLY"
+        external_str = "EXTERNAL" if self.external_writable else ""
+        sql = 'ALTER %s TABLE %s %s EXPAND TABLE' % (external_str, only_str, self.fq_name)
 
         logger.info('Expanding %s.%s' % (self.dbname.decode('utf-8'), self.fq_name.decode('utf-8')))
         logger.debug("Expand SQL: %s" % sql.decode('utf-8'))

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -191,6 +191,24 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand to redistribute
         Then distribution information from table "public.redistribute" with data in "gptest" is verified against saved data
 
+    @gpexpand_verify_writable_external_redistribution
+    Scenario: Verify policy of writable external table is correctly updated after redistribution 
+        Given a working directory of the test as '/data/gpdata/gpexpand'
+        And the database is killed on hosts "localhost"
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And the database is not running
+        And the cluster is generated with "1" primaries only
+        And database "gptest" exists
+        And the user create a writable external table with name "ext_test"
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "localhost"
+        When the user runs gpexpand interview to add 3 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        Then verify that the cluster has 3 new segments
+        When the user runs gpexpand against database "gptest" to redistribute
+        Then the numsegments of table "ext_test" is 4
+
     @gpexpand_icw_db_concourse
     Scenario: Use a dump of the ICW database for expansion
         Given a working directory of the test as '/data/gpdata/gpexpand'

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -44,6 +44,7 @@
 #include "catalog/pg_compression.h"
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_depend.h"
+#include "catalog/pg_exttable.h"
 #include "catalog/pg_foreign_table.h"
 #include "catalog/pg_inherits.h"
 #include "catalog/pg_inherits_fn.h"
@@ -3640,7 +3641,6 @@ ATVerifyObject(AlterTableStmt *stmt, Relation rel)
 				case AT_AddInherit:
 				case AT_DropInherit:
 				case AT_SetDistributedBy:
-				case AT_ExpandTable:
 				case AT_PartAdd:
 				case AT_PartAddForSplit:
 				case AT_PartAlter:
@@ -3652,7 +3652,7 @@ ATVerifyObject(AlterTableStmt *stmt, Relation rel)
 				case AT_PartTruncate:
 				case AT_PartAddInternal:
 					ereport(ERROR,
-							(errcode(ERRCODE_INVALID_COLUMN_DEFINITION),
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("unsupported ALTER command for external table")));
 					break;
 
@@ -14806,7 +14806,21 @@ ATExecExpandTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 			rootCmd->def = (Node*)makeNode(ExpandStmtSpec);
 	}
 
-	ATExecExpandTableCTAS(rootCmd, rel, cmd);
+	if (RelationIsExternal(rel))
+	{
+		ExtTableEntry* ext = GetExtTableEntry(relid);
+		bool           iswritable = ext->iswritable;
+
+		relation_close(rel, NoLock);
+		if (!iswritable)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("unsupported ALTER command for external table")));
+	}
+	else
+	{
+		ATExecExpandTableCTAS(rootCmd, rel, cmd, ps);
+	}
 
 	/* Update numsegments to cluster size */
 	newPolicy->numsegments = getgpsegmentCount();

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14819,7 +14819,7 @@ ATExecExpandTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 	}
 	else
 	{
-		ATExecExpandTableCTAS(rootCmd, rel, cmd, ps);
+		ATExecExpandTableCTAS(rootCmd, rel, cmd);
 	}
 
 	/* Update numsegments to cluster size */

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3551,3 +3551,23 @@ SELECT * FROM tbl_ext_gpformatter;
 -- Test information_schema views for external tables
 --
 SELECT * FROM information_schema.tables WHERE table_name IN ('wet_pos4', 'exttab_basic_1');
+
+--
+-- Test external table can be safely expanded
+--
+
+-- start_ignore
+create extension if not exists gp_debug_numsegments;
+-- end_ignore
+
+select gp_debug_set_create_table_default_numsegments(2);
+
+create writable external table ext_w_expand(a text, b text) location('gpfdist://foo:7070/ext_w_expand.out') format 'text';
+
+select numsegments from gp_distribution_policy where localoid = 'ext_w_expand'::regclass;
+
+alter external table ext_w_expand expand table;
+
+select numsegments from gp_distribution_policy where localoid = 'ext_w_expand'::regclass;
+
+drop external table ext_w_expand;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4926,3 +4926,30 @@ SELECT * FROM information_schema.tables WHERE table_name IN ('wet_pos4', 'exttab
  regression    | public       | wet_pos4       | BASE TABLE |                              |                      |                           |                          |                        | YES                | NO       | 
 (2 rows)
 
+--
+-- Test external table can be safely expanded
+--
+-- start_ignore
+create extension if not exists gp_debug_numsegments;
+-- end_ignore
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+create writable external table ext_w_expand(a text, b text) location('gpfdist://foo:7070/ext_w_expand.out') format 'text';
+select numsegments from gp_distribution_policy where localoid = 'ext_w_expand'::regclass;
+ numsegments 
+-------------
+           2
+(1 row)
+
+alter external table ext_w_expand expand table;
+select numsegments from gp_distribution_policy where localoid = 'ext_w_expand'::regclass;
+ numsegments 
+-------------
+           3
+(1 row)
+
+drop external table ext_w_expand;


### PR DESCRIPTION

 Writable external table has an entry in gp_distribution_policy
 so it has numsegments field. Previous code skip any external
 tables so that their numsegments fields are not updated. This
 commit fixes this by:
      1. add a column in status_detail table to record whether the
         table is writable external and invoke correct SQL to expand
             such tables.
      2. Support `Alter external table <tab> expand table` for writable
         external tables.

Co-authored-by: Zhenghua Lyu <zlv@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
