### PR TITLE
docs - add new host/seg resource group usage views

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -876,6 +876,34 @@ gpstart
 </codeblock>
         </p>
       </body>
+      <topic id="topic23a" xml:lang="en">
+        <title id="iz152239">Viewing Resource Group CPU/Memory Usage Per Host</title>
+        <body>
+          <p>The <codeph><xref href="../ref_guide/gp_toolkit.xml#perhost" type="topic" format="dita"
+            /></codeph>
+          <codeph>gp_toolkit</codeph> system view enables you to view the real-time CPU
+            and memory usage of a resource group on a per-host basis. To view this
+            information:</p>
+        <p>
+          <codeblock>=# SELECT * FROM gp_toolkit.gp_resgroup_status_per_host;
+</codeblock>
+        </p>
+        </body>
+      </topic>
+      <topic id="topic23b" xml:lang="en">
+        <title id="iz152239">Viewing Resource Group CPU/Memory Usage Per Segment</title>
+        <body>
+          <p>The <codeph><xref href="../ref_guide/gp_toolkit.xml#perseg" type="topic" format="dita"
+            /></codeph>
+          <codeph>gp_toolkit</codeph> system view enables you to view the real-time CPU
+            and memory usage of a resource group on a per-segment, per-host basis. To
+            view this information:</p>
+        <p>
+          <codeblock>=# SELECT * FROM gp_toolkit.gp_resgroup_status_per_segment;
+</codeblock>
+        </p>
+        </body>
+      </topic>
     </topic>
     <topic id="topic25" xml:lang="en">
       <title id="iz152239">Viewing the Resource Group Assigned to a Role</title>

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1544,7 +1544,7 @@
         transaction submitted by a user against the limits configured for the user's resource group
         before running the transaction.</p>
       <p>You can use the <codeph>gp_resgroup_config</codeph> view to check the configuration of each
-        resource group. You can use the <codeph>gp_resgroup_status</codeph> view to display the
+        resource group. You can use the <codeph>gp_resgroup_status*</codeph> views to display the
         current transaction status and resource usage of each resource group.</p>
       <ul class="- topic/ul ">
         <li id="ie193806" class="- topic/li ">
@@ -1552,6 +1552,12 @@
         </li>
         <li id="ie193833" class="- topic/li ">
           <xref href="#topic31x" type="topic" format="dita"/>
+        </li>
+        <li id="tperhost" class="- topic/li ">
+          <xref href="#perhost" type="topic" format="dita"/>
+        </li>
+        <li id="tperseg" class="- topic/li ">
+          <xref href="#perseg" type="topic" format="dita"/>
         </li>
       </ul>
     </body>
@@ -1750,6 +1756,216 @@
           memory limit on each segment. The following example shows <codeph>memory_usage</codeph>
           column output for an external component resource group for a single segment:
           <codeblock>"1":{"used":11, "limit_granted":15}</codeblock></p>
+        <note>See the <codeph>gp_resgroup_status_per_host</codeph> and
+          <codeph>gp_resgroup_status_per_segment</codeph> views, described below, for
+          more user-friendly display of CPU and memory usage.</note>
+      </body>
+    </topic>
+    <topic id="perhost">
+      <title id="ie193152x">gp_resgroup_status_per_host</title>
+      <body>
+        <p>The <codeph><xref href="system_catalogs/gp_resgroup_status_per_host.xml"
+          type="topic" format="dita">gp_resgroup_status_per_host</xref></codeph>
+          view displays the real-time CPU and memory usage (MBs) for each resource
+          group on a per-host basis. The view also displays available and granted
+          group fixed and shared memory for each resource group on a host.</p>
+        
+        <table id="fp141982">
+          <title class="- topic/title ">gp_resgroup_status_per_host view</title>
+          <tgroup cols="2" class="- topic/tgroup ">
+            <colspec colnum="1" colname="col1" colwidth="130pt" class="- topic/colspec "/>
+            <colspec colnum="2" colname="col2" colwidth="238pt" class="- topic/colspec "/>
+            <thead class="- topic/thead ">
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">Column</entry>
+                <entry colname="col2" class="- topic/entry ">Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry colname="col1"><codeph>rsgname</codeph></entry>
+                <entry colname="col2">The name of the resource group.</entry>
+              </row>
+              <row>
+                <entry colname="col1"><codeph>groupid</codeph></entry>
+                <entry colname="col2">The ID of the resource group.</entry>
+              </row>
+              <row>
+                <entry colname="col1"><codeph>hostname</codeph></entry>
+                <entry colname="col2">The hostname of the segment host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"><codeph>cpu</codeph></entry>
+                <entry colname="col2">The real-time CPU usage of the resource group on the
+                  host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_used</codeph> </entry>
+                <entry colname="col2">The real-time memory usage of the resource group on
+                  the host. This total includes resource group fixed and shared memory.
+                  It does not include resource group global shared memory.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_available</codeph> </entry>
+                <entry colname="col2">The unused fixed and shared memory for the resource
+                  group that is available on the host. This total does not include available
+                  resource group global shared memory.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_quota_used</codeph> </entry>
+                <entry colname="col2">The real-time fixed memory usage for the resource
+                  group on the host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_quota_available</codeph> </entry>
+                <entry colname="col2">The fixed memory available to the resource group
+                  on the host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_quota_proposed</codeph> </entry>
+                <entry colname="col2">The total amount of fixed memory that Greenplum
+                  Database has allotted to the resource group on the host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_shared_used</codeph> </entry>
+                <entry colname="col2">The group shared memory used by the resource
+                  group on the host. If Greenplum Database has allotted any global shared
+                  memory to the resource group, this amount is included in the total as
+                  well.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_shared_available</codeph> </entry>
+                <entry colname="col2">The amount of group shared memory available to the
+                  resource group on the host. Resource group global shared memory is not
+                  included in this total.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_shared_granted</codeph> </entry>
+                <entry colname="col2">The portion of group shared memory that Greenplum
+                  Database has granted to the resource group on the host. Resource group
+                  global shared memory is not included in this value.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_shared_proposed</codeph> </entry>
+                <entry colname="col2">The total amount of group shared memory that
+                  Greenplum Database has allotted to the resource group on the host.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+        <p>Sample output for the <codeph>gp_resgroup_status_per_host</codeph> view:</p>
+        <codeblock> rsgname       | groupid | hostname   | cpu  | memory_used | memory_available | memory_quota_used | memory_quota_available | memory_quota_proposed | memory_shared_used | memory_shared_available | memory_shared_granted | memory_shared_proposed 
+---------------+---------+------------+------+-------------+------------------+-------------------+------------------------+-----------------------+--------------------+-------------------------+-----------------------+------------------------
+ admin_group   | 6438    | my-desktop | 0.84 | 1           | 271              | 68                | 68                     | 136                   | 0                  | 136                     | 136                   | 136                    
+ default_group | 6437    | my-desktop | 0.00 | 0           | 816              | 0                 | 400                    | 400                   | 0                  | 416                     | 416                   | 416                    
+(2 rows)</codeblock>
+      </body>
+    </topic>
+    <topic id="perseg">
+      <title id="ie193152x">gp_resgroup_status_per_segment</title>
+      <body>
+        <p>The <codeph><xref href="system_catalogs/gp_resgroup_status_per_segment.xml"
+          type="topic" format="dita">gp_resgroup_status_per_segment</xref></codeph>
+          view displays the real-time CPU and memory usage (MBs) for each resource
+          group on a per-segment-instance and per-host basis. The view also
+          displays available and granted group fixed and shared memory for each
+          resource group and segment instance combination on the host.</p>
+        
+        
+        <table id="fp141982">
+          <title class="- topic/title ">gp_resgroup_status_per_segment view</title>
+          <tgroup cols="2" class="- topic/tgroup ">
+            <colspec colnum="1" colname="col1" colwidth="130pt" class="- topic/colspec "/>
+            <colspec colnum="2" colname="col2" colwidth="238pt" class="- topic/colspec "/>
+            <thead class="- topic/thead ">
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">Column</entry>
+                <entry colname="col2" class="- topic/entry ">Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry colname="col1"> <codeph>rsgname</codeph> </entry>
+                <entry colname="col4">The name of the resource group.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>groupid</codeph> </entry>
+                <entry colname="col4">The ID of the resource group.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>hostname</codeph> </entry>
+                <entry colname="col4">The hostname of the segment host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>segment_id</codeph> </entry>
+                <entry colname="col4">The content ID for a segment instance on the
+                  segment host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>cpu</codeph> </entry>
+                <entry colname="col4">The real-time CPU usage of the resource group for the
+                  segment instance on the host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_used</codeph> </entry>
+                <entry colname="col4">The real-time memory usage of the resource group for
+                  the segment instance on the host. This total includes resource group
+                  fixed and shared memory. It does not include resource group global shared
+                  memory.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_available</codeph> </entry>
+                <entry colname="col4">The unused fixed and shared memory for the resource
+                  group for the segment instance on the host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_quota_used</codeph> </entry>
+                <entry colname="col4">The real-time fixed memory usage for the resource group
+                  for the segment instance on the host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_quota_available</codeph> </entry>
+                <entry colname="col4">The fixed memory available to the resource group for
+                  the segment instance on the host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_quota_proposed</codeph> </entry>
+                <entry colname="col4">The total amount of fixed memory that Greenplum Database
+                  has allotted to the resource group for the segment on the host. This value
+                  will be the same for all resource group and segment instance combinations
+                  on a host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_shared_used</codeph> </entry>
+                <entry colname="col4">The group shared memory used by the resource
+                  group for the segment instance on the host.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_shared_available</codeph> </entry>
+                <entry colname="col4">The amount of group shared memory available
+                  for the segment instance on the host. Resource group global shared memory
+                  is not included in this total.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_shared_granted</codeph> </entry>
+                <entry colname="col4">The portion of group shared memory that
+                  Greenplum Database has granted to the resource group for the segment instance
+                  on the host. Resource group global shared memory is not included in this
+                  value.</entry>
+              </row>
+              <row>
+                <entry colname="col1"> <codeph>memory_shared_proposed</codeph> </entry>
+                <entry colname="col4">The total amount of group shared memory that
+                  Greenplum Database has allotted to the resource group for the segment
+                  instance on the host. This value will be the same for all resource group
+                  and segment instance combinations on a host.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+        <p>Query output for this view is similar to that of the 
+          <codeph>gp_resgroup_status_per_host</codeph> view, and breaks out the CPU and
+          memory (used and available) for each segment instance on each host.</p>
       </body>
     </topic>
   </topic>

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1803,7 +1803,7 @@
                 <entry colname="col1"> <codeph>memory_used</codeph> </entry>
                 <entry colname="col2">The real-time memory usage of the resource group on
                   the host. This total includes resource group fixed and shared memory.
-                  It does not include resource group global shared memory.</entry>
+                  It also includes global shared memory used by the resource group.</entry>
               </row>
               <row>
                 <entry colname="col1"> <codeph>memory_available</codeph> </entry>
@@ -1829,9 +1829,8 @@
               <row>
                 <entry colname="col1"> <codeph>memory_shared_used</codeph> </entry>
                 <entry colname="col2">The group shared memory used by the resource
-                  group on the host. If Greenplum Database has allotted any global shared
-                  memory to the resource group, this amount is included in the total as
-                  well.</entry>
+                  group on the host. If any global shared memory is used by the resource
+                  group, this amount is included in the total as well.</entry>
               </row>
               <row>
                 <entry colname="col1"> <codeph>memory_shared_available</codeph> </entry>
@@ -1842,17 +1841,23 @@
               <row>
                 <entry colname="col1"> <codeph>memory_shared_granted</codeph> </entry>
                 <entry colname="col2">The portion of group shared memory that Greenplum
-                  Database has granted to the resource group on the host. Resource group
+                  Database has allotted to the resource group on the host. Resource group
                   global shared memory is not included in this value.</entry>
               </row>
               <row>
                 <entry colname="col1"> <codeph>memory_shared_proposed</codeph> </entry>
-                <entry colname="col2">The total amount of group shared memory that
-                  Greenplum Database has allotted to the resource group on the host.</entry>
+                <entry colname="col2">The total amount of group shared memory requested
+                  by the resource group on the host.</entry>
               </row>
             </tbody>
           </tgroup>
         </table>
+        <p>The <codeph>memory_shared_granted</codeph> value may be less than
+          <codeph>memory_shared_proposed</codeph> if the cluster does not have enough
+          memory to allot. It may be greater than <codeph>memory_shared_proposed</codeph>
+          when global shared memory is in use by the resource group.
+          <codeph>memory_shared_granted</codeph> and <codeph>memory_shared_proposed</codeph>
+          should reach the same value over time.</p>
         <p>Sample output for the <codeph>gp_resgroup_status_per_host</codeph> view:</p>
         <codeblock> rsgname       | groupid | hostname   | cpu  | memory_used | memory_available | memory_quota_used | memory_quota_available | memory_quota_proposed | memory_shared_used | memory_shared_available | memory_shared_granted | memory_shared_proposed 
 ---------------+---------+------------+------+-------------+------------------+-------------------+------------------------+-----------------------+--------------------+-------------------------+-----------------------+------------------------
@@ -1910,8 +1915,8 @@
                 <entry colname="col1"> <codeph>memory_used</codeph> </entry>
                 <entry colname="col4">The real-time memory usage of the resource group for
                   the segment instance on the host. This total includes resource group
-                  fixed and shared memory. It does not include resource group global shared
-                  memory.</entry>
+                  fixed and shared memory. It also includes global shared memory used by
+                  the resource group.</entry>
               </row>
               <row>
                 <entry colname="col1"> <codeph>memory_available</codeph> </entry>
@@ -1949,16 +1954,15 @@
               <row>
                 <entry colname="col1"> <codeph>memory_shared_granted</codeph> </entry>
                 <entry colname="col4">The portion of group shared memory that
-                  Greenplum Database has granted to the resource group for the segment instance
-                  on the host. Resource group global shared memory is not included in this
-                  value.</entry>
+                  Greenplum Database has allotted to the resource group for the segment
+                  instance on the host. Resource group global shared memory is not
+                  included in this value.</entry>
               </row>
               <row>
                 <entry colname="col1"> <codeph>memory_shared_proposed</codeph> </entry>
-                <entry colname="col4">The total amount of group shared memory that
-                  Greenplum Database has allotted to the resource group for the segment
-                  instance on the host. This value will be the same for all resource group
-                  and segment instance combinations on a host.</entry>
+                <entry colname="col4">The total amount of group shared memory requested
+                  by the resource group on the host. This value will be the same for all
+                  resource group and segment instance combinations on a host.</entry>
               </row>
             </tbody>
           </tgroup>

--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -182,6 +182,8 @@
 				<topicref href="system_catalogs/gp_pgdatabase.xml"/>
 				<topicref href="system_catalogs/gp_resgroup_config.xml"/>
 				<topicref href="system_catalogs/gp_resgroup_status.xml"/>
+				<topicref href="system_catalogs/gp_resgroup_status_per_host.xml"/>
+				<topicref href="system_catalogs/gp_resgroup_status_per_segment.xml"/>
 				<topicref href="system_catalogs/gp_resqueue_status.xml"/>
 				<topicref href="system_catalogs/gp_stat_replication.xml"/>
 				<topicref href="system_catalogs/gp_segment_configuration.xml"/>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
@@ -23,6 +23,12 @@
         <xref href="./gp_resgroup_status.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>
+        <xref href="./gp_resgroup_status_per_host.xml#topic1" type="topic" format="dita"/>
+      </li>
+      <li>
+        <xref href="./gp_resgroup_status_per_segment.xml#topic1" type="topic" format="dita"/>
+      </li>
+      <li>
         <xref href="./gp_resqueue_status.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_host.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_host.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fp141670">gp_resgroup_status_per_host</title>
+  <body>
+    <p>The <codeph>gp_toolkit.gp_resgroup_status_per_host</codeph> view allows administrators
+      to see current memory and CPU usage and allocation for each resource group on a
+      per-host basis.</p>
+    <p>Memory amounts are specified in MBs.</p>
+      <note>The <codeph>gp_resgroup_status_per_host</codeph> view is valid only when resource
+        group-based resource management is active.</note>
+    <table id="fp141982">
+      <title>gp_toolkit.gp_resgroup_status_per_host</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="114pt"/>
+        <colspec colnum="2" colname="col2" colwidth="66pt"/>
+        <colspec colnum="3" colname="col3" colwidth="133.5pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>rsgname</codeph>
+            </entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3">pg_resgroup.rsgname</entry>
+            <entry colname="col4">The name of the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>groupid</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_resgroup.oid</entry>
+            <entry colname="col4">The ID of the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>hostname</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">gp_segment_configuration.hostname</entry>
+            <entry colname="col4">The hostname of the segment host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>cpu</codeph>
+            </entry>
+            <entry colname="col2">numeric</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The real-time CPU usage of the resource group on the
+              host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_used</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The real-time memory usage of the resource group on
+              the host. This total includes resource group fixed and shared memory.
+              It does not include resource group global shared memory.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_available</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The unused fixed and shared memory for the resource
+              group that is available on the host. This total does not include available
+              resource group global shared memory.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_quota_used</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The real-time fixed memory usage for the resource
+              group on the host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_quota_available</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The fixed memory available to the resource group
+              on the host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_quota_proposed</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The total amount of fixed memory that Greenplum
+              Database has allotted to the resource group on the host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_shared_used</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The group shared memory used by the resource
+              group on the host. If Greenplum Database has allotted any global shared
+              memory to the resource group, this amount is included in the total as
+              well.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_shared_available</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The amount of group shared memory available to the
+              resource group on the host. Resource group global shared memory is not
+              included in this total.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_shared_granted</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The portion of group shared memory that Greenplum
+              Database has granted to the resource group on the host. Resource group
+              global shared memory is not included in this value.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_shared_proposed</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The total amount of group shared memory that
+              Greenplum Database has allotted to the resource group on the host.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_host.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_host.xml
@@ -67,7 +67,7 @@
             <entry colname="col3"></entry>
             <entry colname="col4">The real-time memory usage of the resource group on
               the host. This total includes resource group fixed and shared memory.
-              It does not include resource group global shared memory.</entry>
+              It also includes global shared memory used by the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -113,9 +113,8 @@
             <entry colname="col2">integer</entry>
             <entry colname="col3"></entry>
             <entry colname="col4">The group shared memory used by the resource
-              group on the host. If Greenplum Database has allotted any global shared
-              memory to the resource group, this amount is included in the total as
-              well.</entry>
+              group on the host. If any global shared memory is used by the resource
+              group, this amount is included in the total as well.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -134,8 +133,8 @@
             <entry colname="col2">integer</entry>
             <entry colname="col3"></entry>
             <entry colname="col4">The portion of group shared memory that Greenplum
-              Database has granted to the resource group on the host. Resource group
-              global shared memory is not included in this value.</entry>
+              Database has allotted to the resource group on the host. Resource
+              group global shared memory is not included in this value.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -143,8 +142,8 @@
             </entry>
             <entry colname="col2">integer</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">The total amount of group shared memory that
-              Greenplum Database has allotted to the resource group on the host.</entry>
+            <entry colname="col4">The total amount of group shared memory requested
+              by the resource group on the host.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_segment.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_segment.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="fp141670">gp_resgroup_status_per_segment</title>
+  <body>
+    <p>The <codeph>gp_toolkit.gp_resgroup_status_per_segment</codeph> view allows administrators
+      to see current memory and CPU usage and allocation for each resource group on a
+      per-host and per-segment basis.</p>
+    <p>Memory amounts are specified in MBs.</p>
+      <note>The <codeph>gp_resgroup_status_per_segment</codeph> view is valid only when resource
+        group-based resource management is active.</note>
+    <table id="fp141982">
+      <title>gp_toolkit.gp_resgroup_status_per_segment</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="114pt"/>
+        <colspec colnum="2" colname="col2" colwidth="66pt"/>
+        <colspec colnum="3" colname="col3" colwidth="133.5pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1">
+              <codeph>rsgname</codeph>
+            </entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3">pg_resgroup.rsgname</entry>
+            <entry colname="col4">The name of the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>groupid</codeph>
+            </entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_resgroup.oid</entry>
+            <entry colname="col4">The ID of the resource group.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>hostname</codeph>
+            </entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3">gp_segment_configuration.hostname</entry>
+            <entry colname="col4">The hostname of the segment host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>segment_id</codeph>
+            </entry>
+            <entry colname="col2">smallint</entry>
+            <entry colname="col3">gp_segment_configuration.content</entry>
+            <entry colname="col4">The content ID for a segment instance on the
+              segment host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>cpu</codeph>
+            </entry>
+            <entry colname="col2">numeric</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The real-time CPU usage of the resource group for the
+              segment instance on the host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_used</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The real-time memory usage of the resource group for
+              the segment instance on the host. This total includes resource group
+              fixed and shared memory. It does not include resource group global shared
+              memory.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_available</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The unused fixed and shared memory for the resource
+              group for the segment instance on the host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_quota_used</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The real-time fixed memory usage for the resource group
+              for the segment instance on the host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_quota_available</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The fixed memory available to the resource group for
+              the segment instance on the host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_quota_proposed</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The total amount of fixed memory that Greenplum Database
+              has allotted to the resource group for the segment on the host. This value
+              will be the same for all resource group and segment instance combinations
+              on a host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_shared_used</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The group shared memory used by the resource
+              group for the segment instance on the host.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_shared_available</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The amount of group shared memory available
+              for the segment instance on the host. Resource group global shared memory
+              is not included in this total.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_shared_granted</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The portion of group shared memory that
+              Greenplum Database has granted to the resource group for the segment instance
+              on the host. Resource group global shared memory is not included in this
+              value.</entry>
+          </row>
+          <row>
+            <entry colname="col1">
+              <codeph>memory_shared_proposed</codeph>
+            </entry>
+            <entry colname="col2">integer</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">The total amount of group shared memory that
+              Greenplum Database has allotted to the resource group for the segment
+              instance on the host. This value will be the same for all resource group
+              and segment instance combinations on a host.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_segment.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_segment.xml
@@ -76,8 +76,8 @@
             <entry colname="col3"></entry>
             <entry colname="col4">The real-time memory usage of the resource group for
               the segment instance on the host. This total includes resource group
-              fixed and shared memory. It does not include resource group global shared
-              memory.</entry>
+              fixed and shared memory. It also includes global shared memory used by
+              the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -143,9 +143,9 @@
             <entry colname="col2">integer</entry>
             <entry colname="col3"></entry>
             <entry colname="col4">The portion of group shared memory that
-              Greenplum Database has granted to the resource group for the segment instance
-              on the host. Resource group global shared memory is not included in this
-              value.</entry>
+              Greenplum Database has allotted to the resource group for the segment
+              instance on the host. Resource group global shared memory is not
+              included in this value.</entry>
           </row>
           <row>
             <entry colname="col1">
@@ -153,10 +153,9 @@
             </entry>
             <entry colname="col2">integer</entry>
             <entry colname="col3"></entry>
-            <entry colname="col4">The total amount of group shared memory that
-              Greenplum Database has allotted to the resource group for the segment
-              instance on the host. This value will be the same for all resource group
-              and segment instance combinations on a host.</entry>
+            <entry colname="col4">The total amount of group shared memory requested
+              by the resource group on the host. This value will be the same for all
+              resource group and segment instance combinations on a host.</entry>
           </row>
         </tbody>
       </tgroup>


### PR DESCRIPTION
in this PR:
- added system view pages for gp_resgroup_status_per_host and gp_resgroup_status_per_segment
- added these to views to the gp_toolkit page, include sample output
  (note: the column descriptions for these views on the gp_toolkit page mirrors the description in the system view page; no need to review, i will update both tables as appropriate)
- mention these new views in the "Using Resource Groups" admin guide topic

doc review site links:
- http://docs-lisa-newrgviews.cfapps.io/6-0/ref_guide/system_catalogs/gp_resgroup_status_per_host.html#topic1
- http://docs-lisa-newrgviews.cfapps.io/6-0/ref_guide/system_catalogs/gp_resgroup_status_per_segment.html
- http://docs-lisa-newrgviews.cfapps.io/6-0/ref_guide/gp_toolkit.html#topic26x
- http://docs-lisa-newrgviews.cfapps.io/6-0/admin_guide/workload_mgmt_resgroups.html#topic23
