### PR TITLE
Warn not to run gpbackup/gprestore during expand.

### DIFF
--- a/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
@@ -64,8 +64,8 @@
             <li>New segments are immediately available and participate in new queries and data
               loads. The existing data, however, is skewed. It is concentrated on the original
               segments and must be redistributed across the new total number of primary segments. </li>
-            <li>Because some the table data is skewed, some queries might be less efficient because
-              more data motion operations might be needed. </li>
+            <li>Because some of the table data is skewed, some queries might be less efficient
+              because more data motion operations might be needed. </li>
           </ul></li>
         <li>The last step of the software phase is redistributing table data. Using the expansion
           control tables in the <i>gpexpand</i> schema as a guide, tables are redistributed. For

--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -234,9 +234,9 @@
           <li><codeph>gpcheck</codeph></li>
           <li><codeph>gpcheckat</codeph></li>
         </ul></p>
-      <note type="warning">Running <codeph>gpbackup</codeph> or <codeph>gprestore</codeph> is not
-        supported during system expansion. Locks obtained for backups can interfere with the
-        expansion process and invalid backup sets could be created. </note>
+      <note type="warning">Do not run <codeph>gpbackup</codeph> or <codeph>gprestore</codeph> during
+        system expansion. Locks obtained for backups can interfere with the expansion process and
+        invalid backup sets could be created. </note>
       <note type="important">After you begin initializing new segments, you can no longer restore
         the system using backup files created for the pre-expansion system. When initialization
         successfully completes, the expansion is committed and cannot be rolled back. </note>

--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -234,6 +234,9 @@
           <li><codeph>gpcheck</codeph></li>
           <li><codeph>gpcheckat</codeph></li>
         </ul></p>
+      <note type="warning">Running <codeph>gpbackup</codeph> or <codeph>gprestore</codeph> is not
+        supported during system expansion. Locks obtained for backups can interfere with the
+        expansion process and invalid backup sets could be created. </note>
       <note type="important">After you begin initializing new segments, you can no longer restore
         the system using backup files created for the pre-expansion system. When initialization
         successfully completes, the expansion is committed and cannot be rolled back. </note>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
@@ -73,6 +73,9 @@
         configuration file. See <xref
           href="../../admin_guide/managing/backup-gpbackup.xml#topic_qwd_d5d_tbb" format="dita"
         />.</p>
+      <note type="warning">Do not run the <codeph>gpbackup</codeph> utility during a Greenplum
+        Database system expansion. See <xref href="gpexpand.xml#topic1"/> for more information about
+        expanding a Greenplum Database system.</note>
       <note>This utility uses secure shell (SSH) connections between systems to perform its tasks.
         In large Greenplum Database deployments, cloud deployments, or deployments with a large
         number of segments per host, this utility may exceed the host's maximum threshold for

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
@@ -37,10 +37,13 @@
         <li id="kt137052">Enough disk space on your segment hosts to temporarily hold a copy of your
           largest table. </li>
         <li>When redistributing data, Greenplum Database must be running in production mode.
-          Greenplum Database cannot be restricted mode or in master mode. The
+          Greenplum Database cannot be running in restricted mode or in master mode. The
             <codeph>gpstart</codeph> options <codeph>-R</codeph> or <codeph>-m</codeph> cannot be
-          specified to start Greenplum Database. </li>
+          specified to start Greenplum Database. </li>      
       </ul>
+      <note type="warning">Do not run the
+          <codeph>gpbackup</codeph> or <codeph>gprestore</codeph> utilities while system expansion is
+        in process.</note>
       <p>For information about preparing a system for expansion, see <xref
           href="../../admin_guide/expand/expand-main.xml" scope="peer">Expanding a Greenplum
           System</xref><ph otherprops="op-print"> in the <cite>Greenplum Database Administrator
@@ -64,9 +67,9 @@
         <li id="kt138259">Creates an expansion schema to store the status of the expansion
           operation, including detailed status for tables.</li>
       </ul>
-      <p>In the table data redistribution phase, <codeph>gpexapand</codeph> redistributes table data
+      <p>In the table data redistribution phase, <codeph>gpexpand</codeph> redistributes table data
         to rebalance the data across the old and new segment instances.</p>
-      <note>Data redistribution should be performed during low-use hours. Redistribution can divided
+      <note>Data redistribution should be performed during low-use hours. Redistribution can be divided
         into batches over an extended period.</note>
       <p>To begin the redistribution phase, run <codeph>gpexpand</codeph> with either the
           <codeph>-d</codeph> (duration) or <codeph>-e</codeph> (end time) options, or with no

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
@@ -79,8 +79,8 @@
         />.</p>
     </section>
     <note type="warning">Do not run the <codeph>gprestore</codeph> utility during a Greenplum
-      Database system expansion. Note that a backup set you created before the expansion may not be
-      compatible with the new cluster configuration. See <xref href="gpexpand.xml#topic1"/> for more
+      Database system expansion. Also note that backup sets you created before the expansion may not
+      be compatible with the expanded cluster. See <xref href="gpexpand.xml#topic1"/> for more
       information about expanding a Greenplum Database system.</note>
     <note>This utility uses secure shell (SSH) connections between systems to perform its tasks. In
       large Greenplum Database deployments, cloud deployments, or deployments with a large number of

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
@@ -78,6 +78,10 @@
           href="../../admin_guide/managing/backup-gpbackup.xml#topic_qwd_d5d_tbb" format="dita"
         />.</p>
     </section>
+    <note type="warning">Do not run the <codeph>gprestore</codeph> utility during a Greenplum
+      Database system expansion. Note that a backup set you created before the expansion may not be
+      compatible with the new cluster configuration. See <xref href="gpexpand.xml#topic1"/> for more
+      information about expanding a Greenplum Database system.</note>
     <note>This utility uses secure shell (SSH) connections between systems to perform its tasks. In
       large Greenplum Database deployments, cloud deployments, or deployments with a large number of
       segments per host, this utility may exceed the host's maximum threshold for unauthenticated


### PR DESCRIPTION
Warn not to run gpbackup or gprestore during expansion. These utilities don't yet check if gpexpand is running. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
