### PR TITLE
docs - misc pxf updates

### DIFF
--- a/gpdb-doc/markdown/pxf/access_hdfs.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_hdfs.html.md.erb
@@ -49,6 +49,7 @@ Before working with Hadoop data using PXF, ensure that:
 - You have configured and initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring PXF](instcfg_pxf.html) for additional information.
 - You have configured the PXF Hadoop Connectors that you plan to use on each Greenplum Database segment host. Refer to [Configuring PXF Hadoop Connectors](client_instcfg.html) for instructions. If you plan to access JSON-formatted data stored in a Cloudera Hadoop cluster, PXF requires a Cloudera version 5.8 or later Hadoop distribution.
 - If user impersonation is enabled (the default), ensure that you have granted read (and write as appropriate) permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database to each Greenplum Database user/role name that will access the HDFS files and directories. If user impersonation is not enabled, you must grant this permission to the `gpadmin` user.
+- Time is synchronized between the Greenplum Database segment hosts and the external Hadoop systems.
 
 
 ## <a id="hdfs_cmdline"></a>HDFS Shell Command Primer

--- a/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
@@ -29,6 +29,7 @@ Before working with object store data using PXF, ensure that:
 
 - You have configured and initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring PXF](instcfg_pxf.html) for additional information.
 - You have configured the PXF Object Store Connectors that you plan to use on each Greenplum Database segment host. Refer to [Configuring Connectors to Azure, Google Cloud Storage, Minio, and S3 Object Stores](objstore_cfg.html) for instructions.
+- Time is synchronized between the Greenplum Database segment hosts and the external object store systems.
 
 
 ## <a id="objstore_connectors"></a>Connectors, Data Formats, and Profiles

--- a/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
@@ -214,13 +214,13 @@ public class PxfExample_CustomWritable implements Writable {
     $ ssh gpadmin@<gpmaster>
     ````
 
-5. Copy the `pxfex-customwritable.jar` JAR file to the user runtime library directory, and note the location. For example, if `PXF_CONF=/etc/pxf/usercfg`:
+5. Copy the `pxfex-customwritable.jar` JAR file to the user runtime library directory, and note the location. For example, if `PXF_CONF=/usr/local/greenplum-pxf`:
 
     ``` shell
-    gpadmin@gpmaster$ cp /home/gpadmin/pxfex-customwritable.jar /etc/pxf/usercfg/lib/pxfex-customwritable.jar
+    gpadmin@gpmaster$ cp /home/gpadmin/pxfex-customwritable.jar /usr/local/greenplum-pxf/lib/pxfex-customwritable.jar
     ```
 
-5. Sync the PXF configuration to each Greenplum Database segment host. For example, if `PXF_CONF=/etc/pxf/usercfg`:
+5. Synchronize the PXF configuration to each Greenplum Database segment host. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
@@ -29,6 +29,8 @@ The PXF Hive connector reads data stored in a Hive table. This section describes
 
 Before working with Hive table data using PXF, ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq).
 
+If you plan to use PXF filter pushdown with Hive, ensure that the `hive-site.xml` configuration parameter `hive.metastore.integral.jdo.pushdown` exists and is set to `true`.
+
 
 ## <a id="hive_fileformats"></a>Hive Data Formats
 
@@ -666,6 +668,8 @@ To take advantage of PXF partition filtering pushdown, the Hive and PXF partitio
 **Note:** The Hive connector filters only on partition columns, not on other table attributes.
 
 PXF filter pushdown is enabled by default. You configure PXF filter pushdown as described in [Configuring Filter Pushdown](using_pxf.html#filter-pushdown).
+
+To use PXF filter pushdown with Hive, the `hive-site.xml` configuration parameter `hive.metastore.integral.jdo.pushdown` must be set to `true`.
 
 
 ### <a id="hive_homog_part"></a>Example: Using the Hive Profile to Access Partitioned Homogenous Data

--- a/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
@@ -32,9 +32,9 @@ PXF provides two management commands that you can use for initialization:
 
 PXF supports both internal and user-customizable configuration properties. Initializing PXF generates PXF internal configuration files, setting default properties specific to your configuration. Initializing PXF also generates configuration file templates for user-customizable settings such as custom profiles and PXF runtime and logging settings.
 
-PXF internal configuration files are located in `$GPHOME/pxf/conf`. You identify the PXF user configuration directory at initialization time via an environment variable named `$PXF_CONF`. If you do not set `$PXF_CONF` prior to initializing PXF, PXF may prompt you to accept or decline the default user configuration directory, `$HOME/pxf`, during the initialization process.
+PXF internal configuration files are located in your Greenplum Database installation in the `$GPHOME/pxf/conf` directory. You identify the PXF user configuration directory at PXF initialization time via an environment variable named `$PXF_CONF`. If you do not set `$PXF_CONF` prior to initializing PXF, PXF may prompt you to accept or decline the default user configuration directory, `$HOME/pxf`, during the initialization process.
 
-**Note**: The `gpadmin` user must have permission to either create, or write to, the specified `$PXF_CONF` directory.
+**Note**: Choose a `$PXF_CONF` directory location that is both outside of your Greenplum Database installation, and one that you back up.
 
 During initialization, PXF creates the `$PXF_CONF` directory if necessary, and then populates it with subdirectories and template files. Refer to [PXF User Configuration Directories](about_pxf_dir.html#usercfg) for a list of these directories and their contents.
 
@@ -44,7 +44,7 @@ During initialization, PXF creates the `$PXF_CONF` directory if necessary, and t
 Before initializing PXF in your Greenplum Database cluster, ensure that:
 
 - Your Greenplum Database cluster is up and running.
-- You have identified the PXF user configuration directory filesystem location, `$PXF_CONF`.
+- You have identified the PXF user configuration directory filesystem location, `$PXF_CONF`, and that the `gpadmin` user has the necessary permissions to create, or write to, this directory.
  
 ### <a id="init-pxf-steps" class="no-quick-link"></a>Procedure
 
@@ -56,10 +56,10 @@ Perform the following procedure to initialize PXF on each segment host in your G
     $ ssh gpadmin@<gpmaster>
     ```
 
-4. Run the `pxf cluster init` command to initialize the PXF service on the master and on each segment host. For example, the following command specifies `/etc/pxf/usercfg` as the PXF user configuration directory for initialization.)
+4. Run the `pxf cluster init` command to initialize the PXF service on the master and on each segment host. For example, the following command specifies `/usr/local/greenplum-pxf` as the PXF user configuration directory for initialization:
 
     ``` shell
-    gpadmin@gpmaster$ PXF_CONF=/etc/pxf/usercfg $GPHOME/pxf/bin/pxf cluster init
+    gpadmin@gpmaster$ PXF_CONF=/usr/local/greenplum-pxf $GPHOME/pxf/bin/pxf cluster init
     ```
 
     The `init` command creates the PXF web application and initializes the internal PXF configuration. The `init` command also creates the `$PXF_CONF` user configuration directory if it does not exist, and populates the directory with user-customizable configuration templates.

--- a/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
@@ -34,7 +34,7 @@ PXF supports both internal and user-customizable configuration properties. Initi
 
 PXF internal configuration files are located in your Greenplum Database installation in the `$GPHOME/pxf/conf` directory. You identify the PXF user configuration directory at PXF initialization time via an environment variable named `$PXF_CONF`. If you do not set `$PXF_CONF` prior to initializing PXF, PXF may prompt you to accept or decline the default user configuration directory, `$HOME/pxf`, during the initialization process.
 
-**Note**: Choose a `$PXF_CONF` directory location that is both outside of your Greenplum Database installation, and one that you back up.
+**Note**: Choose a `$PXF_CONF` directory location that you can back up, and ensure that it resides outside of your Greenplum Database installation directory.
 
 During initialization, PXF creates the `$PXF_CONF` directory if necessary, and then populates it with subdirectories and template files. Refer to [PXF User Configuration Directories](about_pxf_dir.html#usercfg) for a list of these directories and their contents.
 

--- a/gpdb-doc/markdown/pxf/pxf_kerbhdfs.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxf_kerbhdfs.html.md.erb
@@ -66,12 +66,12 @@ Perform the following steps to configure PXF for a secure HDFS. You will perform
     root@kdc-server$ kadmin.local -q "listprincs"
     ```
 
-6.  Copy the keytab file for each PXF service principal to its respective segment host. For example, the following commands copy each principal generated in step 4 to the PXF default keytab directory on the segment host when `PXF_CONF=/etc/pxf/usercfg`:
+6.  Copy the keytab file for each PXF service principal to its respective segment host. For example, the following commands copy each principal generated in step 4 to the PXF default keytab directory on the segment host when `PXF_CONF=/usr/local/greenplum-pxf`:
 
     ``` shell
-    root@kdc-server$ scp /etc/security/keytabs/pxf-host1.service.keytab host1.example.com:/etc/pxf/usercfg/keytabs/pxf.service.keytab
-    root@kdc-server$ scp /etc/security/keytabs/pxf-host2.service.keytab host2.example.com:/etc/pxf/usercfg/keytabs/pxf.service.keytab
-    root@kdc-server$ scp /etc/security/keytabs/pxf-host3.service.keytab host3.example.com:/etc/pxf/usercfg/keytabs/pxf.service.keytab
+    root@kdc-server$ scp /etc/security/keytabs/pxf-host1.service.keytab host1.example.com:/usr/local/greenplum-pxf/keytabs/pxf.service.keytab
+    root@kdc-server$ scp /etc/security/keytabs/pxf-host2.service.keytab host2.example.com:/usr/local/greenplum-pxf/keytabs/pxf.service.keytab
+    root@kdc-server$ scp /etc/security/keytabs/pxf-host3.service.keytab host3.example.com:/usr/local/greenplum-pxf/keytabs/pxf.service.keytab
     ```
 
     Note the file system location of the keytab file on each PXF host; you will need this information for a later configuration step.
@@ -79,12 +79,12 @@ Perform the following steps to configure PXF for a secure HDFS. You will perform
 7. Change the ownership and permissions on the `pxf.service.keytab` files. The files must be owned and readable by only the `gpadmin` user. For example:
 
     ``` shell 
-    root@kdc-server$ ssh host1.example.com chown gpadmin:gpadmin /etc/pxf/usercfg/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host1.example.com chmod 400 /etc/pxf/usercfg/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host2.example.com chown gpadmin:gpadmin /etc/pxf/usercfg/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host2.example.com chmod 400 /etc/pxf/usercfg/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host3.example.com chown gpadmin:gpadmin /etc/pxf/usercfg/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host3.example.com chmod 400 /etc/pxf/usercfg/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host1.example.com chown gpadmin:gpadmin /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host1.example.com chmod 400 /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host2.example.com chown gpadmin:gpadmin /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host2.example.com chmod 400 /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host3.example.com chown gpadmin:gpadmin /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host3.example.com chmod 400 /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
     ```
 
 **Perform the following steps on each Greenplum Database segment host**:
@@ -102,10 +102,10 @@ Perform the following steps to configure PXF for a secure HDFS. You will perform
     root@seghost$ yum install krb5-libs krb5-workstation
     ```
 
-4. Open the PXF `pxf-env.sh` user configuration file in the editor of your choice. For example, to open the file with `vi` when `PXF_CONF=/etc/pxf/usercfg`:
+4. Open the PXF `pxf-env.sh` user configuration file in the editor of your choice. For example, to open the file with `vi` when `PXF_CONF=/usr/local/greenplum-pxf`:
 
     ``` shell
-    gpadmin@seghost$ vi /etc/pxf/usercfg/conf/pxf-env.sh
+    gpadmin@seghost$ vi /usr/local/greenplum-pxf/conf/pxf-env.sh
     ```
     
 5. Update the `PXF_KEYTAB` and `PXF_PRINCIPAL` settings, if required. Specify the location of the keytab file and the Kerberos principal, substituting your realm. *The default values for these settings are identified below*:

--- a/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
@@ -33,8 +33,8 @@ Only the Greenplum Database administrative user can restart the PXF agent.
 For example, if `PXF_CONF=/usr/local/greenplum-pxf`, these commands deploy the connector across the cluster:
 
 ``` shell
-gpadmin@gpmaster$ scp my-connector.jar $PXF_CONF/lib/
-gpadmin@gpmaster$ scp connector-dependency.jar $PXF_CONF/lib/
+gpadmin@gpmaster$ cp my-connector.jar $PXF_CONF/lib/
+gpadmin@gpmaster$ cp connector-dependency.jar $PXF_CONF/lib/
 gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
 ```
 

--- a/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
@@ -2,7 +2,7 @@
 title: Deploying a Connector
 ---
 
-The Greenplum Database administrator deploys a connector to a Greenplum Database cluster by first registering the connector and its dependencies, and then copying relevant JAR and configuration files across the Greenplum Database cluster. After deploying the connector, the administrator must restart the PXF agent.
+The Greenplum Database administrator deploys a connector to a Greenplum Database cluster by first registering the connector and its dependencies, and then synchronizing the PXF configuration files across the Greenplum Database cluster. After deploying the connector, the administrator must restart the PXF agent.
 
 
 ## <a id="runtime_depends"></a> Identifying Connector Run-Time Dependencies
@@ -13,22 +13,29 @@ You must also identify any dependencies that your connector has on third-party c
 
 ## <a id="deploy_depends"></a>Registering Connector Run-Time Dependencies
 
-The PXF agent determines certain runtime dependencies from configuration files found in the `$GPHOME/pxf/conf` and `$PXF_CONF/conf` directories. Only the Greenplum Database administrative user can register PXF dependencies.
+The PXF agent determines certain runtime dependencies from files found in the `$GPHOME/pxf/conf`, `$PXF_CONF/conf`, and `$PXF_CONF/lib` directories. Only the Greenplum Database administrative user can register PXF dependencies.
 
 The `$GPHOME/pxf/conf/pxf-private.classpath` configuration file identifies the runtime dependencies for the PXF agent itself. This file also identifies the runtime dependencies for the PXF built-in HDFS, Hive, and HBase connectors.
 
-The Greenplum Database administrator registers a third-party connector and its runtime dependencies by copying the files to the `$PXF_CONF/lib` directory, and then restarting the PXF agent on each segment host.
+The Greenplum Database administrator registers a third-party connector and its runtime dependencies by copying the files to the `$PXF_CONF/lib` directory, synchronizing the PXF configuration across the cluster, and then restarting the PXF agent on each segment host.
 
 
 ## <a id="deploy_to_cluster"></a>Deploying to the Greenplum Database Cluster
 
-When a Greenplum Database administrator deploys a new connector, they copy the connector JAR file and the (JAR) files of any dependencies to each Greenplum Database segment host, and then must restart the PXF agent on each host. Only the Greenplum Database administrative user can restart the PXF agent. 
+When a Greenplum Database administrator deploys a new connector, they:
 
-For example, if `seghostfile` contains a list, one-host-per-line, of the segment hosts in your Greenplum Database cluster and `PXF_CONF=/etc/pxf/usercfg`, these commands deploy the connector across the cluster:
+- Copy the connector JAR file and the (JAR) files of any dependencies to the Greenplum Database master host
+- Synchronize PXF configuration to each Greenplum Database segment host
+- Restart the PXF agent on each host
+
+Only the Greenplum Database administrative user can restart the PXF agent. 
+
+For example, if `PXF_CONF=/usr/local/greenplum-pxf`, these commands deploy the connector across the cluster:
 
 ``` shell
-gpadmin@gpmaster$ gpscp my-connector.jar -v -f seghostfile =:/etc/pxf/usercfg/lib
-gpadmin@gpmaster$ gpscp connector-dependency.jar -v -seghostfile /etc/pxf/usercfg/lib
+gpadmin@gpmaster$ scp my-connector.jar $PXF_CONF/lib/
+gpadmin@gpmaster$ scp connector-dependency.jar $PXF_CONF/lib/
+gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
 ```
 
 Restart PXF on each Greenplum Database segment host as described in [Restarting PXF](../cfginitstart_pxf.html#restart_pxf).
@@ -105,16 +112,16 @@ Perform the following procedure to deploy the *Demo* connector and to verify tha
     $ ssh gpadmin@<gpmaster>
     ```
 
-2. Copy the *Demo* connector JAR file that you previously built to the Greenplum Database master host. For example, to copy the JAR file to the `/tmp` directory, replace `PXFDEV_BASE` with the absolute path to your PXF development work area:
+2. Copy the *Demo* connector JAR file that you previously built to the `$PXF_CONF/lib` directory on the Greenplum Database master host. Replace `PXFDEV_BASE` with the absolute path to your PXF development work area:
 
     ``` shell
-    gpadmin@gpmaster$ scp user@devsystem:/PXFDEV_BASE/demo_example/build/libs/my-demo-connector.jar /tmp/
+    gpadmin@gpmaster$ scp user@devsystem:/PXFDEV_BASE/demo_example/build/libs/my-demo-connector.jar $PXF_CONF/lib/my-demo-connector.jar
     ```
 
-8. Copy the *Demo* connector JAR file to the PXF user runtime library directory on all Greenplum Database segment hosts. For example:
+8. Copy the JAR file to all Greenplum Database segment hosts by synchronizing PXF configuration. For example:
 
     ``` shell
-    gpadmin@gpmaster$ gpscp -v -f seghostfile /tmp/my-demo-connector.jar =:/etc/pxf/usercfg/lib/my-demo-connector.jar
+    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
     ```
 
 9. Restart PXF on each Greenplum Database segment host as described in [Restarting PXF](../cfginitstart_pxf.html#restart_pxf).

--- a/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/deploy_conn.html.md.erb
@@ -25,7 +25,7 @@ The Greenplum Database administrator registers a third-party connector and its r
 When a Greenplum Database administrator deploys a new connector, they:
 
 - Copy the connector JAR file and the (JAR) files of any dependencies to the Greenplum Database master host
-- Synchronize PXF configuration to each Greenplum Database segment host
+- Synchronize the PXF configuration to each Greenplum Database segment host
 - Restart the PXF agent on each host
 
 Only the Greenplum Database administrative user can restart the PXF agent. 
@@ -118,7 +118,7 @@ Perform the following procedure to deploy the *Demo* connector and to verify tha
     gpadmin@gpmaster$ scp user@devsystem:/PXFDEV_BASE/demo_example/build/libs/my-demo-connector.jar $PXF_CONF/lib/my-demo-connector.jar
     ```
 
-8. Copy the JAR file to all Greenplum Database segment hosts by synchronizing PXF configuration. For example:
+8. Copy the JAR file to all Greenplum Database segment hosts by synchronizing the PXF configuration. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/sdk/deploy_profile.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/deploy_profile.html.md.erb
@@ -64,21 +64,23 @@ You can re-use a single plug-in class name in multiple profile definitions. For 
 ```
 
 
-## <a id="reg_profile"></a>Registering a New Profile
+## <a id="reg_profile"></a>Registering and Deploying a New Profile
 
 When you register a new profile with PXF, you add the profile definition to the `$PXF_CONF/conf/pxf-profiles.xml` file. Ensure that you add the profile definition between the \<profiles\> and \<\profiles\> (notice the **s**) keywords when you edit the `pxf-profiles.xml` file.
 
 **Note**: In a typical Greenplum Database deployment, the `pxf-profiles.xml` file contains multiple third-party profile definitions.
 
+When you deploy a new profile, from the Greenplum Database master host you:
 
-## <a id="deploy_to_cluster"></a>Deploying to the Greenplum Database Cluster
+- Synchronize the PXF configuration to each Greenplum Database segment host
+- Restart the PXF service on each host
 
-When you deploy a new profile, you copy the updated `pxf-profiles.xml` file to each segment host, and then you must restart the PXF service on each host. Only the Greenplum Database administrative user can register profiles and restart the PXF service.
+Only the Greenplum Database administrative user can register profiles and restart the PXF service.
 
-For example, if `seghostfile` contains a list, one-host-per-line, of the segment hosts in your Greenplum Database cluster and `PXF_CONF=/etc/pxf/usercfg`, these commands deploy the profile across the cluster:
+For example, if you added a new profile to `$PXF_CONF/conf/pxf-profiles.xml`, this command deploys the profile across the cluster:
 
 ``` shell
-gpadmin@gpmaster$ gpscp -v -f seghostfile $PXF_CONF/conf/pxf-profiles.xml =:/etc/pxf/usercfg/conf/pxf-profiles.xml
+gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
 ```
 
 Restart PXF on each Greenplum Database segment host as described in [Restarting PXF](../cfginitstart_pxf.html#restart_pxf).
@@ -143,10 +145,10 @@ Perform the following procedure to define and register a read profile and a writ
 
 5. Save the file and exit the editor.
 
-6. Copy the `pxf-profiles.xml` file to all segment hosts in your Greenplum Database cluster. For example, if `seghostfile` contains a list, one-host-per-line, of the segment hosts in your Greenplum Database cluster and `PXF_CONF=/etc/pxf/usercfg`:
+6. Copy the `pxf-profiles.xml` file to all segment hosts in your Greenplum Database cluster by synchronizing the PXF configuration. For example:
 
     ``` shell
-    gpadmin@gpmaster$ gpscp -v -f seghostfile $PXF_CONF/conf/pxf-profiles.xml =:/etc/pxf/usercfg/conf/pxf-profiles.xml
+    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
     ```
 
 7. Restart PXF on each Greenplum Database segment host as described in [Restarting PXF](../cfginitstart_pxf.html#restart_pxf).

--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -219,7 +219,3 @@ You can use the `PXF_JVM_OPTS` property to set other Java options as well.
 
 As described in previous sections, you must synchronize the updated PXF configuration to each Greenplum Database segment host and restart the PXF server on each host.
 
-## <a id="pxf-segfail"></a>Greenplum Database Segment Failure
-
-If any of the PXF instances are inaccessible (due to a failure on a Greenplum Database segment host, for example), any query against an external table created with the `pxf` protocol will fail. To ensure that PXF is running on all Greenplum Database segment hosts, request the status of PXF as described in [Monitoring PXF](monitor_pxf.html).
-

--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -219,3 +219,7 @@ You can use the `PXF_JVM_OPTS` property to set other Java options as well.
 
 As described in previous sections, you must synchronize the updated PXF configuration to each Greenplum Database segment host and restart the PXF server on each host.
 
+## <a id="pxf-segfail"></a>Greenplum Database Segment Failure
+
+If any of the PXF instances are inaccessible (due to a failure on a Greenplum Database segment host, for example), any query against an external table created with the `pxf` protocol will fail. To ensure that PXF is running on all Greenplum Database segment hosts, request the status of PXF as described in [Monitoring PXF](monitor_pxf.html).
+


### PR DESCRIPTION
misc pxf doc updates (not related to any code changes):
- note setting of hive property required for filter pushdown
- add the following prerequisite:  time synchronization between segment hosts and external systems
- use example user config directory PXF_CONF=/usr/local/greenplum-pxf (was previously /etc/pxf/usercfg)
- add info about segment failure to troubleshooting section
- update some SDK docs (note that the pxf sdk section has been temporarily removed from the doc set, plan to rework some of this content)
