### PR TITLE
COPY a replicated table on a subset of segments should work

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1433,8 +1433,7 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	/*
 	 * Allocate a primary QE for every available segDB in the system.
 	 */
-	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER,
-										cdbcomponent_getCdbComponentsList());
+	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, cdbCopy->seglist);
 	Assert(primaryGang);
 
 	cdbdisp_makeDispatchResults(ds, 1, flags & DF_CANCEL_ON_ERROR);

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -24,6 +24,7 @@
 #define COPYOUT_CHUNK_SIZE 16 * 1024
 
 struct CdbDispatcherState;
+struct CopyStateData;
 
 typedef struct CdbCopy
 {
@@ -32,17 +33,17 @@ typedef struct CdbCopy
 
 	StringInfoData	copy_out_buf;/* holds a chunk of data from the database */
 
-	List			*outseglist;    /* segs that currently take part in copy out. 
-									 * Once a segment gave away all it's data rows
-									 * it is taken out of the list */
-	HTAB		  *aotupcounts; /* hash of ao relation id to processed tuple count */
+	List		*seglist;    	/* segs that currently take part in copy.
+								 * for copy out, once a segment gave away all it's
+								 * data rows, it is taken out of the list */
+	HTAB		*aotupcounts;	/* hash of ao relation id to processed tuple count */
 	struct CdbDispatcherState *dispatcherState;
 } CdbCopy;
 
 
 
 /* global function declarations */
-extern CdbCopy *makeCdbCopy(bool copy_in);
+extern CdbCopy *makeCdbCopy(struct CopyStateData *cstate, bool copy_in);
 extern void cdbCopyStart(CdbCopy *cdbCopy, CopyStmt *stmt,
 			 PartitionNode *partitions, List *ao_segnos, int file_encoding);
 extern void cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes);

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -4223,3 +4223,71 @@ rollback;
 -- to perform distributed commit on the other segments.
 --
 insert into r1 (c4) values (pg_relation_size('r2'));
+--
+-- copy to a partial replicated table from file should work
+--
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+create table partial_rpt_from (c1 int, c2 int) distributed replicated;
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
+copy partial_rpt_from (c1, c2) from stdin with delimiter ',';
+select * from gp_dist_random('partial_rpt_from');
+ c1 | c2 
+----+----
+  1 |  2
+  1 |  2
+(2 rows)
+
+--
+-- copy from a partial replicated table to file should work
+--
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+create table partial_rpt_to (c1 int, c2 int) distributed replicated;
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
+insert into partial_rpt_to values (1,1);
+copy partial_rpt_to to stdout;
+1	1
+-- change a replica to provide data
+\c
+set search_path=test_partial_table,public;
+copy partial_rpt_to to stdout;
+1	1
+-- change to another replica to provide data
+\c
+set search_path=test_partial_table,public;
+copy partial_rpt_to to stdout;
+1	1
+-- start_ignore
+-- We need to do a cluster expansion which will check if there are partial
+-- tables, we need to drop the partial tables to keep the cluster expansion
+-- run correctly.
+reset search_path;
+drop schema test_partial_table cascade;
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to table test_partial_table.t1
+drop cascades to table test_partial_table.d1
+drop cascades to table test_partial_table.r1
+drop cascades to table test_partial_table.t2
+drop cascades to table test_partial_table.d2
+drop cascades to table test_partial_table.r2
+drop cascades to table test_partial_table.partial_rpt
+-- end_ignore


### PR DESCRIPTION
Commit 4eb65a53 bring GPDB the ability to allow tables to be distributed on
a subset of segments, that commit taken care of the replicated table well for
SELECT/UPDATE/INSERT on a subset, however, COPY FROM was not.

For COPY FROM replicated table, only one replica should be picked to provide
data and the QE whose segid match gp_session_id % segment_size will be chosen,
obviously, for table on a subset of segments, a valid QE might be chosen.

To fix it, the real numsegments of replicated table should be used instead of
current segment size, what's more, dispatcher can allocate gangs on a subset
of segments now, QD can directly allocate picked gang directly, QE doesn't need
to care about whether it should provide data anymore.

For COPY TO replicated table, we also should allocated correct QEs matching the
numsegments of replicated table.

Co-authored-by: Gang Xiong <gxiong@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
