### PR TITLE
gprecoverseg: Show progress of pg_basebackup on each segment

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -856,7 +856,9 @@ class ConfigureNewSegment(Command):
     def __init__(self, name, confinfo, logdir, newSegments=False, tarFile=None,
                  batchSize=None, verbose=False,ctxt=LOCAL, remoteHost=None, validationOnly=False, writeGpIdFileOnly=False,
                  forceoverwrite=False):
+
         cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\" -l %s' % (confinfo, pipes.quote(logdir))
+
         if newSegments:
             cmdStr += ' -n'
         if tarFile:
@@ -899,7 +901,6 @@ class ConfigureNewSegment(Command):
                         : <segment dbid>
         """
         result = {}
-
         for segIndex, seg in enumerate(segments):
             if primaryMirror == 'primary' and seg.isSegmentPrimary() == False:
                continue
@@ -923,13 +924,16 @@ class ConfigureNewSegment(Command):
                 isPrimarySegment = "false"
                 isTargetReusedLocationString = "false"
 
-            result[hostname] += '%s:%d:%s:%s:%d:%d:%s:%s' % (seg.getSegmentDataDirectory(), seg.getSegmentPort(),
+            progressFile = getattr(seg, 'progressFile', "")
+
+            result[hostname] += '%s:%d:%s:%s:%d:%d:%s:%s:%s' % (seg.getSegmentDataDirectory(), seg.getSegmentPort(),
                                                           isPrimarySegment,
                                                           isTargetReusedLocationString,
                                                           seg.getSegmentDbId(),
                                                           seg.getSegmentContentId(),
                                                           primaryHostname,
-                                                          primarySegmentPort
+                                                          primarySegmentPort,
+                                                          progressFile
             )
         return result
 

--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -307,7 +307,8 @@ def simple_main_locked(createOptionParserFn, createCommandFn, mainOptions):
 def addStandardLoggingAndHelpOptions(parser, includeNonInteractiveOption, includeUsageOption=False):
     """
     Add the standard options for help and logging
-    to the specified parser object.
+    to the specified parser object. Returns the logging OptionGroup so that
+    callers may modify as needed.
     """
     parser.set_usage('%prog [--help] [options] ')
     parser.remove_option('-h')
@@ -330,6 +331,7 @@ def addStandardLoggingAndHelpOptions(parser, includeNonInteractiveOption, includ
     if includeNonInteractiveOption:
         addTo.add_option('-a', dest="interactive", action='store_false', default=True,
                          help="quiet mode, do not require user input for confirmations")
+    return addTo
 
 
 def addMasterDirectoryOptionForSingleClusterProgram(addTo):

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -1,4 +1,6 @@
+import datetime
 import os
+import pipes
 import signal
 import time
 
@@ -158,6 +160,17 @@ class GpMirrorListToBuild:
             raise Exception('logger argument cannot be None')
 
         self.__logger = logger
+
+    class ProgressCommand(gp.Command):
+        """
+        A Command, but with an associated DBID and log file path for use by
+        _join_and_show_segment_progress(). This class is tightly coupled to that
+        implementation.
+        """
+        def __init__(self, name, cmdStr, dbid, filePath, ctxt, remoteHost):
+            super(GpMirrorListToBuild.ProgressCommand, self).__init__(name, cmdStr, ctxt, remoteHost)
+            self.dbid = dbid
+            self.filePath = filePath
 
     def getMirrorsToBuild(self):
         """
@@ -391,14 +404,56 @@ class GpMirrorListToBuild:
                         (hostName, dbid, usedDataDirectories.get(path), path))
                 usedDataDirectories[path] = dbid
 
-    def __runWaitAndCheckWorkerPoolForErrorsAndClear(self, cmds, actionVerb, suppressErrorCheck=False):
+    def _join_and_show_segment_progress(self, cmds, inplace=False, outfile=sys.stdout, interval=0.1):
+        written = False
+
+        def print_progress():
+            if written and inplace:
+                outfile.write("\x1B[%dA" % len(cmds))
+
+            output = []
+            for cmd in cmds:
+                try:
+                    # since print_progress is called multiple times,
+                    # cache cmdStr to reset it after being mutated by cmd.run()
+                    cmd_str = cmd.cmdStr
+                    cmd.run(validateAfter=True)
+                    cmd.cmdStr = cmd_str
+                    results = cmd.get_results().stdout.rstrip()
+                except ExecutionError:
+                    lines = cmd.get_results().stderr.splitlines()
+                    if lines:
+                        results = lines[0]
+                    else:
+                        results = ''
+
+                output.append("%s (dbid %d): %s" % (cmd.remoteHost, cmd.dbid, results))
+                if inplace:
+                    output.append("\x1B[K")
+                output.append("\n")
+
+            outfile.write("".join(output))
+            outfile.flush()
+
+        while not self.__pool.join(interval):
+            print_progress()
+            written = True
+
+        # Make sure every line is updated with the final status.
+        print_progress()
+
+    def __runWaitAndCheckWorkerPoolForErrorsAndClear(self, cmds, actionVerb, suppressErrorCheck=False,
+                                                     progressCmds=[]):
         for cmd in cmds:
             self.__pool.addCommand(cmd)
 
         if self.__quiet:
             self.__pool.join()
         else:
-            base.join_and_indicate_progress(self.__pool)
+            if progressCmds:
+                self._join_and_show_segment_progress(progressCmds, inplace=True)
+            else:
+                base.join_and_indicate_progress(self.__pool)
 
         if not suppressErrorCheck:
             self.__pool.check_results()
@@ -425,12 +480,15 @@ class GpMirrorListToBuild:
         srcSegments = []
         destSegments = []
         isTargetReusedLocation = []
+        timeStamp = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
         for directive in directives:
             srcSegment = directive.getSrcSegment()
             destSegment = directive.getDestSegment()
             destSegment.primaryHostname = srcSegment.getSegmentHostName()
             destSegment.primarySegmentPort = srcSegment.getSegmentPort()
-
+            destSegment.progressFile = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
+                                                                               timeStamp,
+                                                                               destSegment.getSegmentDbId())
             srcSegments.append(srcSegment)
             destSegments.append(destSegment)
             isTargetReusedLocation.append(directive.isTargetReusedLocation())
@@ -452,7 +510,6 @@ class GpMirrorListToBuild:
                                           remoteHost=hostName,
                                           validationOnly=validationOnly,
                                           forceoverwrite=self.__forceoverwrite)
-
         #
         # validate directories for target segments
         #
@@ -484,14 +541,47 @@ class GpMirrorListToBuild:
         if validationErrors:
             raise ExceptionNoStackTraceNeeded("\n" + ("\n".join(validationErrors)))
 
+        # Configure a new segment
         #
-        # unpack and configure new segments
+        # Recover segments using gpconfigurenewsegment, which
+        # uses pg_basebackup. gprecoverseg generates a log filename which is
+        # passed to gpconfigurenewsegment as a confinfo parameter. gprecoverseg
+        # tails this file to show recovery progress to the user, and removes the
+        # file when one done. A new file is generated for each run of
+        # gprecoverseg based on a timestamp.
         #
+        # There is race between when the pg_basbackup log file is created and
+        # when the progress command is run. Thus, the progress command touches
+        # the file to ensure its present before tailing.
         self.__logger.info('Configuring new segments')
         cmds = []
+        progressCmds = []
+        removeCmds= []
         for hostName in destSegmentByHost.keys():
-            cmds.append(createConfigureNewSegmentCommand(hostName, 'configure blank segments', False))
-        self.__runWaitAndCheckWorkerPoolForErrorsAndClear(cmds, "unpacking basic segment directory")
+            for segment in destSegmentByHost[hostName]:
+                progressCmds.append(
+                    GpMirrorListToBuild.ProgressCommand("tail the last line of the file",
+                                       "set -o pipefail; touch -a {0}; tail -1 {0} | tr '\\r' '\\n' | tail -1".format(
+                                           pipes.quote(segment.progressFile)),
+                                       segment.getSegmentDbId(),
+                                       segment.progressFile,
+                                       ctxt=base.REMOTE,
+                                       remoteHost=hostName))
+                removeCmds.append(
+                    base.Command("remove file",
+                                 "rm -f %s" % pipes.quote(segment.progressFile),
+                                 ctxt=base.REMOTE,
+                                 remoteHost=hostName))
+
+            cmds.append(
+                createConfigureNewSegmentCommand(hostName, 'configure blank segments', False))
+
+        self.__runWaitAndCheckWorkerPoolForErrorsAndClear(cmds, "unpacking basic segment directory",
+                                                          suppressErrorCheck=False,
+                                                          progressCmds=progressCmds)
+
+        self.__runWaitAndCheckWorkerPoolForErrorsAndClear(removeCmds, "removing pg_basebackup progres logfiles",
+                                                          suppressErrorCheck=False)
 
         #
         # copy dump files from old segment to new segment

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -149,10 +149,11 @@ class GpMirrorToBuild:
 
 
 class GpMirrorListToBuild:
-    def __init__(self, toBuild, pool, quiet, parallelDegree, additionalWarnings=None, logger=logger, forceoverwrite=False):
+    def __init__(self, toBuild, pool, quiet, parallelDegree, additionalWarnings=None, logger=logger, forceoverwrite=False, showProgressInplace=True):
         self.__mirrorsToBuild = toBuild
         self.__pool = pool
         self.__quiet = quiet
+        self.__showProgressInplace = showProgressInplace
         self.__parallelDegree = parallelDegree
         self.__forceoverwrite = forceoverwrite
         self.__additionalWarnings = additionalWarnings or []
@@ -451,7 +452,7 @@ class GpMirrorListToBuild:
             self.__pool.join()
         else:
             if progressCmds:
-                self._join_and_show_segment_progress(progressCmds, inplace=True)
+                self._join_and_show_segment_progress(progressCmds, inplace=self.__showProgressInplace)
             else:
                 base.join_and_indicate_progress(self.__pool)
 
@@ -487,8 +488,8 @@ class GpMirrorListToBuild:
             destSegment.primaryHostname = srcSegment.getSegmentHostName()
             destSegment.primarySegmentPort = srcSegment.getSegmentPort()
             destSegment.progressFile = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
-                                                                               timeStamp,
-                                                                               destSegment.getSegmentDbId())
+                                                                           timeStamp,
+                                                                           destSegment.getSegmentDbId())
             srcSegments.append(srcSegment)
             destSegments.append(destSegment)
             isTargetReusedLocation.append(directive.isTargetReusedLocation())

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 #
-# Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
+# Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
 from gppylib.gparray import Segment, GpArray
 from gppylib.test.unit.gp_unittest import *
-import tempfile, os, shutil
-from gppylib.commands.base import CommandResult
+import logging
+import os
+import shutil
+import StringIO
+import tempfile
+from gppylib.commands import base
 from mock import patch, MagicMock, Mock
 from gppylib.operations.buildMirrorSegments import GpMirrorListToBuild
 from gppylib.operations.startSegments import StartSegmentsResult
@@ -19,8 +23,8 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         self.buildMirrorSegs = GpMirrorListToBuild(
             toBuild = [],
-            pool = None, 
-            quiet = True, 
+            pool = None,
+            quiet = True,
             parallelDegree = 0,
             logger=self.logger
             )
@@ -33,7 +37,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
         expected_output = []
         segs = self.buildMirrorSegs._get_running_postgres_segments(toBuild)
         self.assertEquals(segs, expected_output)
-        
+
     @patch('gppylib.operations.buildMirrorSegments.get_pid_from_remotehost')
     @patch('gppylib.operations.buildMirrorSegments.is_pid_postmaster', return_value=True)
     @patch('gppylib.operations.buildMirrorSegments.check_pid_on_remotehost', return_value=True)
@@ -81,14 +85,14 @@ class buildMirrorSegmentsTestCase(GpTestCase):
         self.assertEquals(segs, expected_output)
 
     @patch('gppylib.commands.base.Command.run')
-    @patch('gppylib.commands.base.Command.get_results', return_value=CommandResult(rc=0, stdout='/tmp/seg0', stderr='', completed=True, halt=False))
+    @patch('gppylib.commands.base.Command.get_results', return_value=base.CommandResult(rc=0, stdout='/tmp/seg0', stderr='', completed=True, halt=False))
     def test_dereference_remote_symlink_valid_symlink(self, mock1, mock2):
         datadir = '/tmp/link/seg0'
         host = 'h1'
         self.assertEqual(self.buildMirrorSegs.dereference_remote_symlink(datadir, host), '/tmp/seg0')
 
     @patch('gppylib.commands.base.Command.run')
-    @patch('gppylib.commands.base.Command.get_results', return_value=CommandResult(rc=1, stdout='', stderr='', completed=True, halt=False))
+    @patch('gppylib.commands.base.Command.get_results', return_value=base.CommandResult(rc=1, stdout='', stderr='', completed=True, halt=False))
     def test_dereference_remote_symlink_unable_to_determine_symlink(self, mock1, mock2):
         datadir = '/tmp/seg0'
         host = 'h1'
@@ -159,6 +163,105 @@ class buildMirrorSegmentsTestCase(GpTestCase):
             "5|1|m|m|s|u|sdw1|sdw1|50001|/data/mirror1")
 
         return GpArray([self.master, self.primary0, self.primary1, mirror0, mirror1])
+
+class SegmentProgressTestCase(GpTestCase):
+    """
+    Test case for GpMirrorListToBuild._join_and_show_segment_progress().
+    """
+    def setUp(self):
+        self.pool = Mock(spec=base.WorkerPool)
+        self.buildMirrorSegs = GpMirrorListToBuild(
+            toBuild=[],
+            pool=self.pool,
+            quiet=True,
+            parallelDegree=0,
+            logger=Mock(spec=logging.Logger)
+        )
+
+    def test_command_output_is_displayed_once_after_worker_pool_completes(self):
+        cmd = Mock(spec=base.Command)
+        cmd.remoteHost = 'localhost'
+        cmd.dbid = 2
+        cmd.get_results.return_value.stdout = "string 1\n"
+
+        cmd2 = Mock(spec=base.Command)
+        cmd2.remoteHost = 'host2'
+        cmd2.dbid = 4
+        cmd2.get_results.return_value.stdout = "string 2\n"
+
+        outfile = StringIO.StringIO()
+        self.pool.join.return_value = True
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], outfile=outfile)
+
+        results = outfile.getvalue()
+        self.assertEqual(results, (
+            'localhost (dbid 2): string 1\n'
+            'host2 (dbid 4): string 2\n'
+        ))
+
+    def test_command_output_is_displayed_once_for_every_blocked_join(self):
+        cmd = Mock(spec=base.Command)
+        cmd.remoteHost = 'localhost'
+        cmd.dbid = 2
+
+        cmd.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
+
+        outfile = StringIO.StringIO()
+        self.pool.join.side_effect = [False, True]
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd], outfile=outfile)
+
+        results = outfile.getvalue()
+        self.assertEqual(results, (
+            'localhost (dbid 2): string 1\n'
+            'localhost (dbid 2): string 2\n'
+        ))
+
+    def test_inplace_display_uses_ansi_escapes_to_overwrite_previous_output(self):
+        cmd = Mock(spec=base.Command)
+        cmd.remoteHost = 'localhost'
+        cmd.dbid = 2
+        cmd.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
+
+        cmd2 = Mock(spec=base.Command)
+        cmd2.remoteHost = 'host2'
+        cmd2.dbid = 4
+        cmd2.get_results.side_effect = [Mock(stdout="string 3"), Mock(stdout="string 4")]
+
+        outfile = StringIO.StringIO()
+        self.pool.join.side_effect = [False, True]
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], inplace=True, outfile=outfile)
+
+        results = outfile.getvalue()
+        self.assertEqual(results, (
+            'localhost (dbid 2): string 1\x1b[K\n'
+            'host2 (dbid 4): string 3\x1b[K\n'
+            '\x1b[2A'
+            'localhost (dbid 2): string 2\x1b[K\n'
+            'host2 (dbid 4): string 4\x1b[K\n'
+        ))
+
+    def test_errors_during_command_execution_are_displayed(self):
+        cmd = Mock(spec=base.Command)
+        cmd.remoteHost = 'localhost'
+        cmd.dbid = 2
+        cmd.get_results.return_value.stderr = "some error\n"
+        cmd.run.side_effect = base.ExecutionError("Some exception", cmd)
+
+        cmd2 = Mock(spec=base.Command)
+        cmd2.remoteHost = 'host2'
+        cmd2.dbid = 4
+        cmd2.get_results.return_value.stderr = ''
+        cmd2.run.side_effect = base.ExecutionError("Some exception", cmd2)
+
+        outfile = StringIO.StringIO()
+        self.pool.join.return_value = True
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], outfile=outfile)
+
+        results = outfile.getvalue()
+        self.assertEqual(results, (
+            'localhost (dbid 2): some error\n'
+            'host2 (dbid 4): \n'
+        ))
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -127,6 +127,12 @@ class GpRecoverSegmentProgram:
         self.__pool = None
         self.logger = logger
 
+        # If user did not specify a value for showProgressInplace and
+        # stdout is a tty then send escape sequences to gprecoverseg
+        # output. Otherwise do not show progress inplace.
+        if self.__options.showProgressInplace is None:
+            self.__options.showProgressInplace = sys.stdout.isatty()
+
     def outputToFile(self, mirrorBuilder, gpArray, fileName):
         lines = []
 
@@ -251,7 +257,8 @@ class GpRecoverSegmentProgram:
         self._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
 
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
-                                   self.__options.parallelDegree, forceoverwrite=True)
+                                   self.__options.parallelDegree, forceoverwrite=True,
+                                   showProgressInplace=self.__options.showProgressInplace)
 
     def findAndValidatePeersForFailedSegments(self, gpArray, failedSegments):
         dbIdToPeerMap = gpArray.getDbIdToPeerMap()
@@ -387,7 +394,8 @@ class GpRecoverSegmentProgram:
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
                                    self.__options.parallelDegree,
                                    interfaceHostnameWarnings,
-                                   forceoverwrite=True)
+                                   forceoverwrite=True,
+                                   showProgressInplace=self.__options.showProgressInplace)
 
     def _output_segments_with_persistent_mirroring_disabled(self, segs_persistent_mirroring_disabled=None):
         if segs_persistent_mirroring_disabled:
@@ -685,7 +693,10 @@ class GpRecoverSegmentProgram:
                            version='%prog version $Revision$')
         parser.setHelp(help)
 
-        addStandardLoggingAndHelpOptions(parser, True)
+        loggingGroup = addStandardLoggingAndHelpOptions(parser, True)
+        loggingGroup.add_option("-s", None, default=None, action='store_false',
+                                dest='showProgressInplace',
+                                help='Show pg_basebackup progress sequentially instead of inplace')
 
         addTo = OptionGroup(parser, "Connection Options")
         parser.add_option_group(addTo)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -104,9 +104,10 @@ class GpRecoversegTestCase(GpTestCase):
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = self.config_file_path
+        options.showProgressInplace = True
 
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
 
@@ -176,8 +177,9 @@ class GpRecoversegTestCase(GpTestCase):
         options.masterDataDirectory = self.temp_dir
         options.rebalanceSegments = True
         options.spareDataDirectoryFile = None
+        options.showProgressInplace = True
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
 
@@ -195,8 +197,9 @@ class GpRecoversegTestCase(GpTestCase):
         options.masterDataDirectory = self.temp_dir
         options.rebalanceSegments = True
         options.spareDataDirectoryFile = None
+        options.showProgressInplace = True
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
 
@@ -213,8 +216,9 @@ class GpRecoversegTestCase(GpTestCase):
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = None
+        options.showProgressInplace = True
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
         self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors
@@ -235,8 +239,9 @@ class GpRecoversegTestCase(GpTestCase):
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = None
+        options.showProgressInplace = True
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
         self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -40,7 +40,7 @@ class ValidationException(Exception):
 
 class ConfExpSegCmd(Command):
     def __init__(self, name, cmdstr, datadir, port, dbid, contentid, newseg, tarfile, useLighterDirectoryValidation, isPrimary,
-                    syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName):
+                 syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile):
         """
         @param useLighterDirectoryValidation if True then we don't require an empty directory; we just require that
                                              database stuff is not there.
@@ -57,7 +57,8 @@ class ConfExpSegCmd(Command):
         self.syncWithSegmentHostname = syncWithSegmentHostname
         self.syncWithSegmentPort = syncWithSegmentPort
         self.replicationSlotName = replicationSlotName
-
+        self.logfileDirectory = logfileDirectory
+        self.progressFile = progressFile
         #
         # validationOnly if True then we validate directories and other simple things only; we don't
         #                actually configure the segment
@@ -122,11 +123,15 @@ class ConfExpSegCmd(Command):
                    return
 
                 if not self.isPrimary:
-                    # Log pg_basebackup output to the same directory as gpconfigurenewsegment
-                    pgbasebackup_start_time = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
-                    pgbasebackup_progress_temp_file = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
-                                                                                          pgbasebackup_start_time,
-                                                                                          self.dbid)
+                    # If the caller does not specify a pg_basebackup
+                    # progress file, then create a temporary one and handle
+                    # its deletion upon success.
+                    shouldDeleteProgressFile = False
+                    if not self.progressFile:
+                        shouldDeleteProgressFile = True
+                        self.progressFile = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
+                                                                                datetime.datetime.today().strftime('%Y%m%d_%H%M%S'),
+                                                                                self.dbid)
                     # Create a mirror based on the primary
                     cmd = PgBaseBackup(pgdata=self.datadir,
                                        host=self.syncWithSegmentHostname,
@@ -134,13 +139,13 @@ class ConfExpSegCmd(Command):
                                        replication_slot_name=self.replicationSlotName,
                                        forceoverwrite=self.forceoverwrite,
                                        target_gp_dbid=self.dbid,
-                                       logfile=pgbasebackup_progress_temp_file)
+                                       logfile=self.progressFile)
                     try:
-                        logger.info("Running pg_basebackup with progress output temporarily in %s" % pgbasebackup_progress_temp_file)
+                        logger.info("Running pg_basebackup with progress output temporarily in %s" % self.progressFile)
                         cmd.run(validateAfter=True)
-
                         self.set_results(CommandResult(0, '', '', True, False))
-                        os.remove(pgbasebackup_progress_temp_file)
+                        if shouldDeleteProgressFile:
+                            os.remove(self.progressFile)
                     except Exception, e:
                         self.set_results(CommandResult(1,'',e,True,False))
                         raise
@@ -319,6 +324,7 @@ try:
         # they will be junk data passed through the config.
         primaryHostName = seg[6]
         primarySegmentPort = int(seg[7])
+        progressFile = seg[8]
 
         cmd = ConfExpSegCmd( name = 'Configure segment directory'
                            , cmdstr = ' '.join(sys.argv)
@@ -336,6 +342,8 @@ try:
                            , validationOnly = options.validationOnly
                            , forceoverwrite = options.forceoverwrite
                            , replicationSlotName = options.replicationSlotName
+                           , logfileDirectory = options.logfileDirectory
+                           , progressFile= progressFile
                            )
         pool.addCommand(cmd)
 

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -10,7 +10,7 @@ Synopsis
 gprecoverseg [-p <new_recover_host>[,...]]
              |-i <recover_config_file> 
              [-d <master_data_directory>] [-B <parallel_processes>] 
-             [-F] [-a] [-q] [-l <logfile_directory>]
+             [-F] [-a] [-q] [-s] [-l <logfile_directory>]
 
 
 gprecoverseg -r
@@ -218,6 +218,12 @@ This option rebalances primary and mirror segments by returning them to
 their preferred roles. All segments must be valid and synchronized before 
 running gprecoverseg -r. If there are any in progress queries, they will 
 be cancelled and rolled back.
+
+-s
+
+Show pg_basebackup progress sequentially instead of inplace. Useful when
+writing to a file, or if a tty does not support escape sequences. Defaults to
+showing the progress inplace.
 
 
 -v

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -21,6 +21,19 @@ Feature: gprecoverseg tests
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
 
+    Scenario: gprecoverseg displays pg_basebackup progress to the user
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user kills all mirror processes
+        When user can start transactions
+        And the user runs "gprecoverseg -F -a -s"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for each mirror
+        And gpAdminLogs directory has no "pg_basebackup*" files
+        And all the segments are running
+        And the segments are synchronized
+
     Scenario: When gprecoverseg full recovery is executed and an existing postmaster.pid on the killed primary segment corresponds to a non postgres process
         Given the database is running
         And all the segments are running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1919,14 +1919,12 @@ def impl(context, gppkg_name):
 def impl(context, gppkg_name):
     _remove_gppkg_from_host(context, gppkg_name, is_master_host=True)
 
-
-@given('gpAdminLogs directory has no "{prefix}" files')
-def impl(context, prefix):
+@then('gpAdminLogs directory has no "{expected_file}" files')
+def impl(context, expected_file):
     log_dir = _get_gpAdminLogs_directory()
-    items = glob.glob('%s/%s_*.log' % (log_dir, prefix))
-    for item in items:
-        os.remove(item)
-
+    files_found = glob.glob('%s/%s' % (log_dir, expected_file))
+    if files_found:
+        raise Exception("expected no %s files in %s, but found %s" % (expected_file, log_dir, files_found))
 
 @given('"{filepath}" is copied to the install directory')
 def impl(context, filepath):

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -108,3 +108,13 @@ def runCommandOnRemoteSegment(context, cid, sql_cmd):
     host = host.strip()
     psql_cmd = "PGDATABASE=\'template1\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (host, port, sql_cmd)
     Command(name='Running Remote command: %s' % psql_cmd, cmdStr = psql_cmd).run(validateAfter=True)
+
+@then('gprecoverseg should print "{output}" to stdout for each mirror')
+def impl(context, output):
+    gparray = GpArray.initFromCatalog(dbconn.DbURL())
+    segments = gparray.getDbList()
+
+    for segment in segments:
+        if segment.isSegmentMirror():
+            expected = r'\(dbid {}\): {}'.format(segment.dbid, output)
+            check_stdout_msg(context, expected)


### PR DESCRIPTION
The `gprecoverseg` utility runs `pg_basebackup` in parallel on all segments that are being recovered.  In this commit, we are logging the progress of each `pg_basebackup` on its host and displaying them to the user of `gprecoverseg`.  The progress files are deleted upon successful completion of gprecoverseg.

Unit tests have also been added.

Authored-by: Shoaib Lari <slari@pivotal.io>
Co-authored-by: Mark Sliva <msliva@pivotal.io>
Co-authored-by: Jacob Champion <pchampion@pivotal.io>
Co-authored-by: Ed Espino <edespino@pivotal.io>
Co-authored-by: Kalen Krempely <kkrempely@pivotal.io>

