### PR TITLE
docs - add pxf config info for s3 server-side encryption

### DIFF
--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -135,7 +135,7 @@ To encrypt data that you write to S3 via a writable external table created speci
 
 ##### <a id="s3-sse-bucket"></a>Configuring SSE via an S3 Bucket Policy (Recommended)
 
-You can create S3 <i>Bucket Policy</i>(s) that identify the objects that you want to encrypt, the encryption key management scheme, and the write actions permitted on those objects. Refer to [Protecting Data Using Server-Side Encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html) in the AWS S3 documentation for more information about the SSE encryption key management schemes, and how to set bucket policies for each.
+You can create S3 <i>Bucket Policy</i>(s) that identify the objects that you want to encrypt, the encryption key management scheme, and the write actions permitted on those objects. Refer to [Protecting Data Using Server-Side Encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html) in the AWS S3 documentation for more information about the SSE encryption key management schemes. [How Do I Enable Default Encryption for an S3 Bucket?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/default-bucket-encryption.html) describes how to set default encryption bucket policies.
 
 
 ##### <a id="s3-sse-pxfs3cfg"></a>Specifying SSE Options in a PXF S3 Server Configuration

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -142,7 +142,7 @@ You can create S3 <i>Bucket Policy</i>(s) that identify the objects that you wan
 
 You must include certain properties in `s3-site.xml` to configure server-side encryption in a PXF S3 server configuration. The properties and values that you add to the file are SSE encryption key management scheme-specific.
 
-###### <a id="sse-s3"></a>SSE-S3
+**SSE-S3**
 
 To enable SSE-S3 on any file that you write to any S3 bucket, set the following encryption algorithm property and value in the `s3-site.xml` file:
 
@@ -164,7 +164,7 @@ To enable SSE-S3 for a specific S3 bucket, use the property name variant that in
 
 Replace `YOUR_BUCKET1_NAME` with the name of the S3 bucket.
 
-###### <a id="sse-kms"></a>SSE-KMS
+**SSE-KMS**
 
 To enable SSE-KMS on any file that you write to any S3 bucket, you must set both the encryption algorithm and encryption key ID. Set these properties in the `s3-site.xml` file:
 
@@ -181,6 +181,8 @@ To enable SSE-KMS on any file that you write to any S3 bucket, you must set both
 
 Substitute `YOUR_AWS_SSE_KMS_KEY_ARN` with your key resource name. If you do not specify an encryption key, the default key defined in the Amazon KMS is used. Example KMS key: `arn:aws:kms:us-west-2:123456789012:key/1a23b456-7890-12cc-d345-6ef7890g12f3`.
 
+**Note**: Be sure to create the bucket and the key in the same Amazon Availability Zone.
+
 To enable SSE-KMS for a specific S3 bucket, use property name variants that include the bucket name. For example:
 
 ``` xml
@@ -196,7 +198,7 @@ To enable SSE-KMS for a specific S3 bucket, use property name variants that incl
 
 Replace `YOUR_BUCKET2_NAME` with the name of the S3 bucket.
 
-###### <a id="sse-sc"></a>SSE-C
+**SSE-C**
 
 To enable SSE-C on any file that you write to any S3 bucket, you must set both the encryption algorithm and the encryption key (base-64 encoded). All clients must share the same key.
 

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -113,6 +113,109 @@ The template configuration file for S3 is `$PXF_CONF/templates/s3-site.xml`. Whe
 
 You can override an S3 server configuration by directly specifying the S3 access ID and secret key via custom options in the CREATE EXTERNAL TABLE command LOCATION clause. Refer to [Overriding the S3 Server Configuration](access_objstore.html#s3_override) for additional information.
 
+
+#### <a id="s3-sse"></a>Configuring S3 Server-Side Encryption
+
+PXF supports Amazon Web Service S3 Server-Side Encryption (SSE) for S3 files that you access with readable and writable Greenplum Database external tables that specify the `pxf` protocol and an `s3:*` profile. AWS S3 server-side encryption protects your data at rest; it encrypts your object data as it writes to disk, and transparently decrypts the data for you when you access it.
+
+PXF supports the following AWS SSE encryption key management schemes:
+
+- SSE with S3-Managed Keys (SSE-S3) - Amazon manages the data and master encryption keys.
+- SSE with Key Management Service Managed Keys (SSE-KMS) - Amazon manages the data key, you manage the encryption key in AWS KMS.
+- SSE with Customer-Provided Keys (SSE-C) - You set and manage the encryption key.
+
+Your S3 access key and secret key govern your access to all S3 bucket objects, whether the data is encrypted or not.
+
+S3 transparently decrypts data during a read operation of an encrypted file that you access via a readable external table created specifying the `pxf` protocol and an `s3:*` profile. No additional configuration is required.
+
+To encrypt data that you write to S3 via a writable external table created specifying the `pxf` protocol and an `s3:*` profile, you have two options, discussed below:
+
+- Configure the default SSE encryption key management scheme on a per-S3-bucket basis via the AWS console or command line tools (recommended).
+- Configure SSE encryption options in your PXF S3 server `s3-site.xml` configuration file.
+
+##### <a id="s3-sse-bucket"></a>Configuring SSE via an S3 Bucket Policy (Recommended)
+
+You can create S3 <i>Bucket Policy</i>(s) that identify the objects that you want to encrypt, the encryption key management scheme, and the write actions permitted on those objects. Refer to [Protecting Data Using Server-Side Encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html) in the AWS S3 documentation for more information about the SSE encryption key management schemes, and how to set bucket policies for each.
+
+
+##### <a id="s3-sse-pxfs3cfg"></a>Specifying SSE Options in a PXF S3 Server Configuration
+
+You must include certain properties in `s3-site.xml` to configure server-side encryption in a PXF S3 server configuration. The properties and values that you add to the file are SSE encryption key management scheme-specific.
+
+###### <a id="sse-s3"></a>SSE-S3
+
+To enable SSE-S3 on any file that you write to any S3 bucket, set the following encryption algorithm property and value in the `s3-site.xml` file:
+
+``` xml
+<property>
+  <name>fs.s3a.server-side-encryption-algorithm</name>
+  <value>AES256</value>
+</property>
+```
+
+To enable SSE-S3 for a specific S3 bucket, use the property name variant that includes the bucket name. For example:
+
+``` xml
+<property>
+  <name>fs.s3a.bucket.YOUR_BUCKET1_NAME.server-side-encryption-algorithm</name>
+  <value>AES256</value>
+</property>
+```
+
+Replace `YOUR_BUCKET1_NAME` with the name of the S3 bucket.
+
+###### <a id="sse-kms"></a>SSE-KMS
+
+To enable SSE-KMS on any file that you write to any S3 bucket, you must set both the encryption algorithm and encryption key ID. Set these properties in the `s3-site.xml` file:
+
+``` xml
+<property>
+  <name>fs.s3a.server-side-encryption-algorithm</name>
+  <value>SSE-KMS</value>
+</property>
+<property>
+  <name>fs.s3a.server-side-encryption.key</name>
+  <value>YOUR_AWS_SSE_KMS_KEY_ARN</value>
+</property>
+```
+
+Substitute `YOUR_AWS_SSE_KMS_KEY_ARN` with your key resource name. If you do not specify an encryption key, the default key defined in the Amazon KMS is used. Example KMS key: `arn:aws:kms:us-west-2:123456789012:key/1a23b456-7890-12cc-d345-6ef7890g12f3`.
+
+To enable SSE-KMS for a specific S3 bucket, use property name variants that include the bucket name. For example:
+
+``` xml
+<property>
+  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption-algorithm</name>
+  <value>SSE-KMS</value>
+</property>
+<property>
+  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption.key</name>
+  <value>YOUR_AWS_SSE_KMS_KEY_ARN</value>
+</property>
+```
+
+Replace `YOUR_BUCKET2_NAME` with the name of the S3 bucket.
+
+###### <a id="sse-sc"></a>SSE-C
+
+To enable SSE-C on any file that you write to any S3 bucket, you must set both the encryption algorithm and the encryption key (base-64 encoded). All clients must share the same key.
+
+Set these properties in the `s3-site.xml` file:
+
+``` xml
+<property>
+  <name>fs.s3a.server-side-encryption-algorithm</name>
+  <value>SSE-C</value>
+</property>
+<property>
+  <name>fs.s3a.server-side-encryption.key</name>
+  <value>YOUR_BASE64-ENCODED_ENCRYPTION_KEY</value>
+</property>
+```
+
+To enable SSE-C for a specific S3 bucket, use the property name variants that include the bucket name as described in the SSE-KMS example.
+
+
 ## <a id="cfg_proc"></a>Example Configuration Procedure
 
 Ensure that you have initialized PXF before you configure an object store connector.

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -157,12 +157,12 @@ To enable SSE-S3 for a specific S3 bucket, use the property name variant that in
 
 ``` xml
 <property>
-  <name>fs.s3a.bucket.YOUR_BUCKET1_NAME.server-side-encryption-algorithm</name>
+  <name>fs.s3a.bucket.YOUR_BUCKET_NAME.server-side-encryption-algorithm</name>
   <value>AES256</value>
 </property>
 ```
 
-Replace `YOUR_BUCKET1_NAME` with the name of the S3 bucket.
+Replace `YOUR_BUCKET_NAME` with the name of the S3 bucket.
 
 **SSE-KMS**
 
@@ -187,16 +187,16 @@ To enable SSE-KMS for a specific S3 bucket, use property name variants that incl
 
 ``` xml
 <property>
-  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption-algorithm</name>
+  <name>fs.s3a.bucket.YOUR_BUCKET_NAME.server-side-encryption-algorithm</name>
   <value>SSE-KMS</value>
 </property>
 <property>
-  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption.key</name>
+  <name>fs.s3a.bucket.YOUR_BUCKET_NAME.server-side-encryption.key</name>
   <value>YOUR_AWS_SSE_KMS_KEY_ARN</value>
 </property>
 ```
 
-Replace `YOUR_BUCKET2_NAME` with the name of the S3 bucket.
+Replace `YOUR_BUCKET_NAME` with the name of the S3 bucket.
 
 **SSE-C**
 

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -111,6 +111,8 @@ The template configuration file for S3 is `$PXF_CONF/templates/s3-site.xml`. Whe
 | fs.s3a.access.key | The AWS account access key ID. | Your access key. |
 | fs.s3a.secret.key | The secret key associated with the AWS access key ID. | Your secret key. |
 
+If required, fine-tune PXF S3 connectivity by specifying properties identified in the [S3A](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html#S3A) section of the Hadoop-AWS module documentation in your `s3-site.xml` server configuration file.
+
 You can override an S3 server configuration by directly specifying the S3 access ID and secret key via custom options in the CREATE EXTERNAL TABLE command LOCATION clause. Refer to [Overriding the S3 Server Configuration](access_objstore.html#s3_override) for additional information.
 
 

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -123,14 +123,14 @@ PXF supports Amazon Web Service S3 Server-Side Encryption (SSE) for S3 files tha
 PXF supports the following AWS SSE encryption key management schemes:
 
 - SSE with S3-Managed Keys (SSE-S3) - Amazon manages the data and master encryption keys.
-- SSE with Key Management Service Managed Keys (SSE-KMS) - Amazon manages the data key, you manage the encryption key in AWS KMS.
+- SSE with Key Management Service Managed Keys (SSE-KMS) - Amazon manages the data key, and you manage the encryption key in AWS KMS.
 - SSE with Customer-Provided Keys (SSE-C) - You set and manage the encryption key.
 
 Your S3 access key and secret key govern your access to all S3 bucket objects, whether the data is encrypted or not.
 
-S3 transparently decrypts data during a read operation of an encrypted file that you access via a readable external table created specifying the `pxf` protocol and an `s3:*` profile. No additional configuration is required.
+S3 transparently decrypts data during a read operation of an encrypted file that you access via a readable external table that is created by specifying the `pxf` protocol and an `s3:*` profile. No additional configuration is required.
 
-To encrypt data that you write to S3 via a writable external table created specifying the `pxf` protocol and an `s3:*` profile, you have two options, discussed below:
+To encrypt data that you write to S3 via this type of external table, you have two options:
 
 - Configure the default SSE encryption key management scheme on a per-S3-bucket basis via the AWS console or command line tools (recommended).
 - Configure SSE encryption options in your PXF S3 server `s3-site.xml` configuration file.
@@ -142,7 +142,7 @@ You can create S3 <i>Bucket Policy</i>(s) that identify the objects that you wan
 
 ##### <a id="s3-sse-pxfs3cfg"></a>Specifying SSE Options in a PXF S3 Server Configuration
 
-You must include certain properties in `s3-site.xml` to configure server-side encryption in a PXF S3 server configuration. The properties and values that you add to the file are SSE encryption key management scheme-specific.
+You must include certain properties in `s3-site.xml` to configure server-side encryption in a PXF S3 server configuration. The properties and values that you add to the file are dependent upon the SSE encryption key management scheme.
 
 **SSE-S3**
 
@@ -168,7 +168,7 @@ Replace `YOUR_BUCKET_NAME` with the name of the S3 bucket.
 
 **SSE-KMS**
 
-To enable SSE-KMS on any file that you write to any S3 bucket, you must set both the encryption algorithm and encryption key ID. Set these properties in the `s3-site.xml` file:
+To enable SSE-KMS on any file that you write to any S3 bucket, set both the encryption algorithm and encryption key ID. To set these properties in the `s3-site.xml` file:
 
 ``` xml
 <property>
@@ -202,9 +202,9 @@ Replace `YOUR_BUCKET_NAME` with the name of the S3 bucket.
 
 **SSE-C**
 
-To enable SSE-C on any file that you write to any S3 bucket, you must set both the encryption algorithm and the encryption key (base-64 encoded). All clients must share the same key.
+To enable SSE-C on any file that you write to any S3 bucket, set both the encryption algorithm and the encryption key (base-64 encoded). All clients must share the same key.
 
-Set these properties in the `s3-site.xml` file:
+To set these properties in the `s3-site.xml` file:
 
 ``` xml
 <property>

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -159,12 +159,12 @@ To enable SSE-S3 for a specific S3 bucket, use the property name variant that in
 
 ``` xml
 <property>
-  <name>fs.s3a.bucket.YOUR_BUCKET_NAME.server-side-encryption-algorithm</name>
+  <name>fs.s3a.bucket.YOUR_BUCKET1_NAME.server-side-encryption-algorithm</name>
   <value>AES256</value>
 </property>
 ```
 
-Replace `YOUR_BUCKET_NAME` with the name of the S3 bucket.
+Replace `YOUR_BUCKET1_NAME` with the name of the S3 bucket.
 
 **SSE-KMS**
 
@@ -189,16 +189,16 @@ To enable SSE-KMS for a specific S3 bucket, use property name variants that incl
 
 ``` xml
 <property>
-  <name>fs.s3a.bucket.YOUR_BUCKET_NAME.server-side-encryption-algorithm</name>
+  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption-algorithm</name>
   <value>SSE-KMS</value>
 </property>
 <property>
-  <name>fs.s3a.bucket.YOUR_BUCKET_NAME.server-side-encryption.key</name>
+  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption.key</name>
   <value>YOUR_AWS_SSE_KMS_KEY_ARN</value>
 </property>
 ```
 
-Replace `YOUR_BUCKET_NAME` with the name of the S3 bucket.
+Replace `YOUR_BUCKET2_NAME` with the name of the S3 bucket.
 
 **SSE-C**
 


### PR DESCRIPTION
PXF s3 connector supports s3 server-side encryption.  describe how to configure SSE.  (recommend setting bucket policies, also describe how to set via pxf server s3-site.xml configuration file.)

question:  if a default bucket policy is set for bucket1, SSE is also configured in s3-site.xml, and a writable external table is used to write to bucket1 - which SSE config is used?

doc review site link:
- http://docs-lisa-pxfs3sse.cfapps.io/6-0/pxf/objstore_cfg.html#s3_cfg
