### PR TITLE
Restore previous logic for PXF HAS-FILTER header

### DIFF
--- a/gpcontrib/pxf/src/pxfheaders.c
+++ b/gpcontrib/pxf/src/pxfheaders.c
@@ -107,10 +107,10 @@ build_http_headers(PxfInputData *input)
 
 	/* filters */
 	if (filterstr != NULL)
+	{
 		churl_headers_append(headers, "X-GP-FILTER", filterstr);
-
-	if (list_length(input->quals) > 0)
 		churl_headers_append(headers, "X-GP-HAS-FILTER", "1");
+	}
 	else
 		churl_headers_append(headers, "X-GP-HAS-FILTER", "0");
 }

--- a/gpcontrib/pxf/test/pxfheaders_test.c
+++ b/gpcontrib/pxf/test/pxfheaders_test.c
@@ -258,7 +258,7 @@ void test__build_http_header__where_is_not_supported(void **state)
 	expect_headers_append(input_data->headers, "X-GP-URL-PORT", gphd_uri->port);
 	expect_headers_append(input_data->headers, "X-GP-DATA-DIR", gphd_uri->data);
 	expect_headers_append(input_data->headers, "X-GP-URI", gphd_uri->uri);
-	expect_headers_append(input_data->headers, "X-GP-HAS-FILTER", "1");
+	expect_headers_append(input_data->headers, "X-GP-HAS-FILTER", "0");
 
 	build_http_headers(input_data);
 


### PR DESCRIPTION
- This will allow existing PXF Release (java) continue working with the
  gpdb 6

Reviewed-by: Lav Jain <ljain@pivotal.io>