### PR TITLE
Improve correlated subquery handling in ORCA

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.43.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.44.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.43.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.44.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13982,7 +13982,7 @@ int
 main ()
 {
 
-return strncmp("3.43.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.44.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13992,7 +13992,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.43.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.44.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.43.1@gpdb/stable
+orca/v3.44.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -88,9 +88,9 @@ sync_tools: opt_write_test
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
 ifeq "$(findstring sles,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/archive/v3.43.1.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/archive/v3.44.0.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 else
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.43.1/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.44.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 endif
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1361,8 +1361,21 @@ CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry
 	func_expr->inputcollid = gpdb::ExprCollation((Node *) func_expr->args);
 	func_expr->funccollid = gpdb::TypeCollation(func_expr->funcresulttype);
 
+	// Populate RangeTblFunction::funcparams, by walking down the entire
+	// func_expr to capture ids of all the PARAMs
+	ListCell *lc = NULL;
+	List *param_exprs = gpdb::ExtractNodesExpression(
+			(Node *) func_expr, T_Param, false /*descend_into_subqueries */);
+	Bitmapset  *funcparams = NULL;
+	ForEach (lc, param_exprs)
+	{
+		Param *param = (Param*) lfirst(lc);
+		funcparams = gpdb::BmsAddMember(funcparams, param->paramid);
+	}
+
 	RangeTblFunction *rtfunc = MakeNode(RangeTblFunction);
 	rtfunc->funcexpr = (Node *) func_expr;
+	rtfunc->funcparams = funcparams;
 	// GPDB_91_MERGE_FIXME: collation
 	// set rtfunc->funccoltypemods & rtfunc->funccolcollations?
 	rte->functions = ListMake1(rtfunc);

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -775,7 +775,9 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar
 	{
 		// test expression is expected to be a comparison between an outer expression 
 		// and a scalar identifier from subplan child
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,  GPOS_WSZ_LIT("Unexpected subplan test expression"));
+		// ORCA currently only supports PARAMs on the inner side of the form id or cast(id)
+		// The outer side may be any non-param thing.
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,  GPOS_WSZ_LIT("Unsupported subplan test expression"));
 	}
 
 	// extract type of inner column

--- a/src/test/regress/expected/pg_lsn_optimizer.out
+++ b/src/test/regress/expected/pg_lsn_optimizer.out
@@ -90,10 +90,8 @@ SELECT DISTINCT (i || '/' || j)::pg_lsn f
                                        ->  Function Scan on generate_series generate_series_2
                                  ->  Result
                                        Filter: (generate_series_1.generate_series <= 10)
-                                       ->  Materialize
-                                             ->  Function Scan on generate_series generate_series_1
-                           ->  Materialize
-                                 ->  Function Scan on generate_series
+                                       ->  Function Scan on generate_series generate_series_1
+                           ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA) version 3.8.0
 (21 rows)
 

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -473,6 +473,35 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
  -1
 (10 rows)
 
+explain select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..33.51 rows=1 width=4)
+   ->  Seq Scan on a  (cost=0.00..33.51 rows=1 width=4)
+         Filter: (j = (SubPlan 1))
+         SubPlan 1  (slice3; segments: 3)
+           ->  Hash Semi Join  (cost=3.14..6.29 rows=2 width=4)
+                 Hash Cond: (c.i = b.i)
+                 ->  Result  (cost=0.00..3.12 rows=1 width=8)
+                       Filter: (c.j = a.j)
+                       ->  Materialize  (cost=0.00..3.12 rows=1 width=8)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.11 rows=1 width=8)
+                                   ->  Seq Scan on c  (cost=0.00..3.11 rows=1 width=8)
+                 ->  Hash  (cost=3.08..3.08 rows=2 width=4)
+                       ->  Result  (cost=0.00..3.10 rows=2 width=4)
+                             ->  Materialize  (cost=0.00..3.10 rows=2 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.08 rows=2 width=4)
+                                         ->  Seq Scan on b  (cost=0.00..3.08 rows=2 width=4)
+                                               Filter: (i <> 10)
+ Optimizer: legacy query optimizer
+(18 rows)
+
+select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
+ i  
+----
+ 99
+(1 row)
+
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_any.sql - Correlated Subquery: CSQ using ANY clause (Heap)
 -- ----------------------------------------------------------------------
@@ -3640,9 +3669,86 @@ explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
 select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
  a | count 
 ---+-------
- 1 |     1
  2 |     2
  3 |     3
+ 1 |     1
+(3 rows)
+
+-- with limit
+explain select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.99 rows=3 width=4)
+   ->  Seq Scan on t1  (cost=0.00..3.99 rows=1 width=4)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.64..0.65 rows=1 width=8)
+                 ->  Limit  (cost=0.00..0.63 rows=1 width=2)
+                       ->  Limit  (cost=0.00..0.61 rows=1 width=2)
+                             ->  Result  (cost=0.00..3.07 rows=2 width=2)
+                                   ->  Materialize  (cost=0.00..3.07 rows=2 width=2)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.05 rows=2 width=2)
+                                               ->  Seq Scan on supplier  (cost=0.00..3.05 rows=2 width=2)
+ Optimizer: legacy query optimizer
+(11 rows)
+
+select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+ a | c 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+(3 rows)
+
+-- with nested join
+explain select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..30000000533.18 rows=3 width=8)
+   ->  Seq Scan on t1  (cost=0.00..30000000533.18 rows=1 width=8)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=10000000177.04..10000000177.05 rows=1 width=8)
+                 ->  Nested Loop  (cost=10000000000.00..10000000049.54 rows=1000 width=0)
+                       ->  Function Scan on generate_series  (cost=0.00..10.00 rows=334 width=0)
+                       ->  Materialize  (cost=0.00..2.04 rows=1 width=0)
+                             ->  Result  (cost=0.00..2.04 rows=1 width=0)
+                                   ->  Materialize  (cost=0.00..2.04 rows=1 width=0)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.03 rows=1 width=0)
+                                               ->  Seq Scan on t1 t1_1  (cost=0.00..2.03 rows=1 width=0)
+ Optimizer: legacy query optimizer
+(12 rows)
+
+select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+ a | b | ct 
+---+---+----
+ 1 | 1 |  3
+ 2 | 2 |  6
+ 3 | 3 |  9
+(3 rows)
+
+explain select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..30000000533.19 rows=1 width=8)
+   ->  Seq Scan on t1  (cost=0.00..30000000533.19 rows=1 width=8)
+         Filter: (0 < (SubPlan 1))
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=10000000177.04..10000000177.05 rows=1 width=8)
+                 ->  Nested Loop  (cost=10000000000.00..10000000049.54 rows=1000 width=0)
+                       ->  Function Scan on generate_series  (cost=0.00..10.00 rows=334 width=0)
+                       ->  Materialize  (cost=0.00..2.04 rows=1 width=0)
+                             ->  Result  (cost=0.00..2.04 rows=1 width=0)
+                                   ->  Materialize  (cost=0.00..2.04 rows=1 width=0)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.03 rows=1 width=0)
+                                               ->  Seq Scan on t1 t1_1  (cost=0.00..2.03 rows=1 width=0)
+ Optimizer: legacy query optimizer
+(13 rows)
+
+select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
 (3 rows)
 
 reset optimizer_enforce_subplans;

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3609,6 +3609,46 @@ SELECT * FROM qp_nl_tab1 t1 WHERE t1.c1 + 5 > ANY(SELECT t2.c2 FROM qp_nl_tab2 t
 (1 row)
 
 -- ----------------------------------------------------------------------
+-- Test: Various single & skip-level correlated subqueries
+-- ----------------------------------------------------------------------
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
+NOTICE:  table "supplier" does not exist, skipping
+create table t1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table supplier(city text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'city' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1 values (1, 1), (2, 2), (3, 3);
+insert into supplier values ('a'),('b'),('c'),('d'),('e');
+analyze t1;
+analyze supplier;
+set optimizer_enforce_subplans = 1;
+-- with TVF
+explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..39.57 rows=3 width=4)
+   ->  Seq Scan on t1 x1  (cost=0.00..39.57 rows=1 width=4)
+         SubPlan 1  (slice1; segments: 1)
+           ->  Aggregate  (cost=12.50..12.51 rows=1 width=8)
+                 ->  Function Scan on generate_series  (cost=0.00..10.00 rows=334 width=0)
+ Optimizer: legacy query optimizer
+(6 rows)
+
+select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+ a | count 
+---+-------
+ 1 |     1
+ 2 |     2
+ 3 |     3
+(3 rows)
+
+reset optimizer_enforce_subplans;
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 set client_min_messages='warning';

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3788,6 +3788,47 @@ SELECT * FROM qp_nl_tab1 t1 WHERE t1.c1 + 5 > ANY(SELECT t2.c2 FROM qp_nl_tab2 t
 (1 row)
 
 -- ----------------------------------------------------------------------
+-- Test: Various single & skip-level correlated subqueries
+-- ----------------------------------------------------------------------
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
+NOTICE:  table "supplier" does not exist, skipping
+create table t1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table supplier(city text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'city' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1 values (1, 1), (2, 2), (3, 3);
+insert into supplier values ('a'),('b'),('c'),('d'),('e');
+analyze t1;
+analyze supplier;
+set optimizer_enforce_subplans = 1;
+-- with TVF
+explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882708.48 rows=3 width=12)
+   ->  Result  (cost=0.00..882708.48 rows=1 width=12)
+         ->  Seq Scan on t1  (cost=0.00..882708.48 rows=334 width=12)
+         SubPlan 1  (slice1; segments: 3)
+           ->  Aggregate  (cost=0.00..0.00 rows=1 width=8)
+                 ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=1)
+ Optimizer: PQO version 3.27.0
+(7 rows)
+
+select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+ a | count 
+---+-------
+ 1 |     1
+ 2 |     2
+ 3 |     3
+(3 rows)
+
+reset optimizer_enforce_subplans;
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 set client_min_messages='warning';

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -197,33 +197,32 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
 -- Test for ALL_SUBLINK pull-up based on both left-hand and right-hand input
 explain (costs off)
 select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
-                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                              QUERY PLAN                                                                                                                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    ->  Nested Loop
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice3; segments: 3)
                ->  Seq Scan on a
-         ->  Materialize
-               ->  Result
-                     Filter: ((SubPlan 1) > 0::bigint)
-                     ->  Seq Scan on b
-                     SubPlan 1  (slice4; segments: 3)
-                       ->  Aggregate
-                             ->  Nested Loop
-                                   Join Filter: true
+         ->  Result
+               Filter: ((SubPlan 1) > 0::bigint)
+               ->  Seq Scan on b
+               SubPlan 1  (slice4; segments: 3)
+                 ->  Aggregate
+                       ->  Nested Loop
+                             Join Filter: true
+                             ->  Result
+                                   Filter: ((CASE WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (c_1.i IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (b.i IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
                                    ->  Result
-                                         Filter: ((CASE WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (c_1.i IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (b.i IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
-                                         ->  Result
-                                               ->  Aggregate
-                                                     ->  Result
-                                                           ->  Materialize
-                                                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                                                       ->  Seq Scan on c c_1
-                                                                             Filter: (i <> 10)
-                                   ->  Materialize
-                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                               ->  Seq Scan on c
+                                         ->  Aggregate
+                                               ->  Result
+                                                     ->  Materialize
+                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                                 ->  Seq Scan on c c_1
+                                                                       Filter: (i <> 10)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         ->  Seq Scan on c
  Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (26 rows)
 
@@ -504,6 +503,33 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
  -1
  -1
 (10 rows)
+
+explain select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1765379.74 rows=5 width=4)
+   ->  Result  (cost=0.00..1765379.74 rows=2 width=4)
+         ->  Seq Scan on a  (cost=0.00..1765379.74 rows=2 width=4)
+               Filter: (j = (SubPlan 1))
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Result  (cost=0.00..862.00 rows=1 width=4)
+                       Filter: (c.j = a.j)
+                       ->  Materialize  (cost=0.00..862.00 rows=6 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=6 width=4)
+                                   ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
+                                         Hash Cond: ((c.i = b.i) AND (c.i = b.i))
+                                         ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=8)
+                                         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                                               ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                     Filter: (i <> 10)
+ Optimizer: PQO version 3.27.0
+(16 rows)
+
+select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
+ i  
+----
+ 99
+(1 row)
 
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_any.sql - Correlated Subquery: CSQ using ANY clause (Heap)
@@ -3823,6 +3849,82 @@ select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
  1 |     1
  2 |     2
  3 |     3
+(3 rows)
+
+-- with limit
+explain select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324051.59 rows=3 width=12)
+   ->  Result  (cost=0.00..1324051.59 rows=1 width=12)
+         ->  Seq Scan on t1  (cost=0.00..1324051.59 rows=334 width=12)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Limit  (cost=0.00..431.00 rows=5 width=1)
+                       ->  Materialize  (cost=0.00..431.00 rows=5 width=1)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=1)
+                                   ->  Seq Scan on supplier  (cost=0.00..431.00 rows=2 width=1)
+ Optimizer: PQO version 3.27.0
+(10 rows)
+
+select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+ a | c 
+---+---
+ 2 | 2
+ 3 | 3
+ 1 | 1
+(3 rows)
+
+-- with nested join
+explain select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1808684647.64 rows=3 width=16)
+   ->  Result  (cost=0.00..1808684647.64 rows=1 width=16)
+         ->  Seq Scan on t1  (cost=0.00..1808684647.64 rows=334 width=16)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..1765431.58 rows=1 width=8)
+                 ->  Nested Loop  (cost=0.00..1765431.58 rows=1000 width=1)
+                       Join Filter: true
+                       ->  Materialize  (cost=0.00..431.00 rows=3 width=1)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=1)
+                                   ->  Seq Scan on t1 t1_1  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=1)
+ Optimizer: PQO version 3.27.0
+(12 rows)
+
+select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+ a | b | ct 
+---+---+----
+ 1 | 1 |  3
+ 2 | 2 |  6
+ 3 | 3 |  9
+(3 rows)
+
+explain select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1808684647.65 rows=3 width=8)
+   ->  Result  (cost=0.00..1808684647.65 rows=1 width=8)
+         Filter: (0 < (SubPlan 1))
+         ->  Seq Scan on t1  (cost=0.00..1808684647.64 rows=334 width=16)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..1765431.58 rows=1 width=8)
+                 ->  Nested Loop  (cost=0.00..1765431.58 rows=1000 width=1)
+                       Join Filter: true
+                       ->  Materialize  (cost=0.00..431.00 rows=3 width=1)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=1)
+                                   ->  Seq Scan on t1 t1_1  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=1)
+ Optimizer: PQO version 3.27.0
+(13 rows)
+
+select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
 (3 rows)
 
 reset optimizer_enforce_subplans;

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -706,6 +706,29 @@ SELECT * FROM qp_nl_tab1 t1 WHERE t1.c1 + 5 > ANY(SELECT t2.c2 FROM qp_nl_tab2 t
 
 
 -- ----------------------------------------------------------------------
+-- Test: Various single & skip-level correlated subqueries
+-- ----------------------------------------------------------------------
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
+create table t1(a int, b int);
+create table supplier(city text);
+insert into t1 values (1, 1), (2, 2), (3, 3);
+insert into supplier values ('a'),('b'),('c'),('d'),('e');
+analyze t1;
+analyze supplier;
+
+set optimizer_enforce_subplans = 1;
+
+-- with TVF
+explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+
+reset optimizer_enforce_subplans;
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 set client_min_messages='warning';

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -139,6 +139,8 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
 select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
 
+explain select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
+select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
 
 
 -- ----------------------------------------------------------------------
@@ -722,6 +724,17 @@ set optimizer_enforce_subplans = 1;
 -- with TVF
 explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
 select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+
+-- with limit
+explain select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+
+-- with nested join
+explain select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+
+explain select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
+select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
 
 reset optimizer_enforce_subplans;
 


### PR DESCRIPTION
This PR also fixes a wrong results bug stemming from changes in
nodeFunctionScan after the 9.4 merge.

Matching ORCA PR: https://github.com/greenplum-db/gporca/pull/451