### PR TITLE
gpexpand: retire -D option in tests

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -81,8 +81,7 @@ function make_cluster() {
     # no test case restarting the cluster
     su gpadmin -c "head -n 1 $MASTER_DATA_DIRECTORY/postmaster.pid > master.pid.bk"
     gen_gpexpand_input
-    su gpadmin -c "createdb gpstatus"
-    su gpadmin -c "gpexpand -i input -D gpstatus"
+    su gpadmin -c "gpexpand -i input"
   else
     su gpadmin -c "make create-demo-cluster"
   fi

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -18,10 +18,10 @@ Feature: expand the cluster by adding more segments
         And user has created expansiontest tables
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
-         And the user runs gpexpand against database "gptest" to redistribute with duration "00:00:02"
+         And the user runs gpexpand to redistribute with duration "00:00:02"
         Then gpexpand should print "End time reached.  Stopping expansion." to stdout
         And verify that the cluster has 2 new segments
-        When the user runs gpexpand against database "gptest" to redistribute
+        When the user runs gpexpand to redistribute
         Then the tables have finished expanding
         And verify that the master pid has not been changed
 
@@ -42,7 +42,7 @@ Feature: expand the cluster by adding more segments
         Then user has created expansiontest tables
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
-        When the user runs gpexpand against database "gptest" to redistribute with duration "00:00:02"
+        When the user runs gpexpand to redistribute with duration "00:00:02"
         Then gpexpand should print "End time reached.  Stopping expansion." to stdout
 
     @gpexpand_no_mirrors
@@ -61,10 +61,10 @@ Feature: expand the cluster by adding more segments
         And user has created expansiontest tables
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
-         And the user runs gpexpand against database "gptest" to redistribute with the --end flag
+         And the user runs gpexpand to redistribute with the --end flag
         Then gpexpand should print "End time reached.  Stopping expansion." to stdout
         And verify that the cluster has 2 new segments
-        When the user runs gpexpand against database "gptest" to redistribute
+        When the user runs gpexpand to redistribute
         Then the tables have finished expanding
 
     @gpexpand_no_mirrors
@@ -188,7 +188,7 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 3 new segments
          And the user drops the named connection "default"
-        When the user runs gpexpand against database "gptest" to redistribute
+        When the user runs gpexpand to redistribute
         Then distribution information from table "public.redistribute" with data in "gptest" is verified against saved data
 
     @gpexpand_icw_db_concourse
@@ -330,7 +330,7 @@ Feature: expand the cluster by adding more segments
         And verify that the master pid has not been changed
         And verify the dml results and commit
         And verify the dml results again in a new transaction
-        When the user runs gpexpand against database "gptest" to redistribute
+        When the user runs gpexpand to redistribute
         # Temporarily comment the verifys until redistribute is fixed. This allows us to commit a resource to get a dump of the ICW dump for other tests to use
         # Then distribution information from table "public.redistribute" with data in "gptest" is verified against saved data
 
@@ -353,7 +353,7 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand with the latest gpexpand_inputfile without ret code check
         Then gpexpand should return a return code of 3
         And verify that the cluster has 1 new segments
-        And run rollback with database "gptest"
+        And run rollback
         And verify the gp_segment_configuration has been restored
         And unset fault inject
 
@@ -375,5 +375,5 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand with the latest gpexpand_inputfile without ret code check
         Then gpexpand should return a return code of 0
         And verify that the cluster has 1 new segments
-        When the user runs gpexpand against database "gptest" to redistribute
+        When the user runs gpexpand to redistribute
         Then the tables have finished expanding

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2088,7 +2088,7 @@ def impl(context, num_of_segments, num_of_hosts, hostnames):
     for i in range(0, num_of_segments):
         directory_pairs.append((primary_dir,mirror_dir))
 
-    gpexpand = Gpexpand(context, working_directory=context.working_directory, database='gptest')
+    gpexpand = Gpexpand(context, working_directory=context.working_directory)
     output, returncode = gpexpand.do_interview(hosts=hosts,
                                                num_of_segments=num_of_segments,
                                                directory_pairs=directory_pairs,
@@ -2102,30 +2102,30 @@ def impl(context):
 
 @when('the user runs gpexpand with the latest gpexpand_inputfile with additional parameters {additional_params}')
 def impl(context, additional_params=''):
-    gpexpand = Gpexpand(context, working_directory=context.working_directory, database='gptest')
+    gpexpand = Gpexpand(context, working_directory=context.working_directory)
     ret_code, std_err, std_out = gpexpand.initialize_segments(additional_params)
     if ret_code != 0:
         raise Exception("gpexpand exited with return code: %d.\nstderr=%s\nstdout=%s" % (ret_code, std_err, std_out))
 
 @when('the user runs gpexpand with the latest gpexpand_inputfile without ret code check')
 def impl(context):
-    gpexpand = Gpexpand(context, working_directory=context.working_directory, database='gptest')
+    gpexpand = Gpexpand(context, working_directory=context.working_directory)
     gpexpand.initialize_segments()
 
-@when('the user runs gpexpand against database "{dbname}" to redistribute with duration "{duration}"')
-def impl(context, dbname, duration):
-    _gpexpand_redistribute(context, dbname, duration)
+@when('the user runs gpexpand to redistribute with duration "{duration}"')
+def impl(context, duration):
+    _gpexpand_redistribute(context, duration)
 
-@when('the user runs gpexpand against database "{dbname}" to redistribute with the --end flag')
-def impl(context, dbname):
-    _gpexpand_redistribute(context, dbname, endtime=True)
+@when('the user runs gpexpand to redistribute with the --end flag')
+def impl(context):
+    _gpexpand_redistribute(context, endtime=True)
 
-@when('the user runs gpexpand against database "{dbname}" to redistribute')
-def impl(context, dbname):
-    _gpexpand_redistribute(context, dbname)
+@when('the user runs gpexpand to redistribute')
+def impl(context):
+    _gpexpand_redistribute(context)
 
-def _gpexpand_redistribute(context, dbname, duration=False, endtime=False):
-    gpexpand = Gpexpand(context, working_directory=context.working_directory, database=dbname)
+def _gpexpand_redistribute(context, duration=False, endtime=False):
+    gpexpand = Gpexpand(context, working_directory=context.working_directory)
     context.command = gpexpand
     ret_code, std_err, std_out = gpexpand.redistribute(duration, endtime)
     if duration or endtime:
@@ -2148,7 +2148,7 @@ sdw1:sdw1:21503:/tmp/gpexpand_behave/data/mirror/gpseg3:9:3:m"""
     with open(inputfile_name, 'w') as fd:
         fd.write(inputfile_contents)
 
-    gpexpand = Gpexpand(context, working_directory=context.working_directory, database='gptest')
+    gpexpand = Gpexpand(context, working_directory=context.working_directory)
     ret_code, std_err, std_out = gpexpand.initialize_segments()
     if ret_code != 0:
         raise Exception("gpexpand exited with return code: %d.\nstderr=%s\nstdout=%s" % (ret_code, std_err, std_out))
@@ -2555,11 +2555,11 @@ def impl(context, fault):
 def impl(context):
     os.environ['GPMGMT_FAULT_POINT'] = ""
 
-@given('run rollback with database "{database}"')
-@then('run rollback with database "{database}"')
-@when('run rollback with database "{database}"')
-def impl(context, database):
-    gpexpand = Gpexpand(context, working_directory=context.working_directory, database=database)
+@given('run rollback')
+@then('run rollback')
+@when('run rollback')
+def impl(context):
+    gpexpand = Gpexpand(context, working_directory=context.working_directory)
     ret_code, std_err, std_out = gpexpand.rollback()
     if ret_code != 0:
         raise Exception("rollback exited with return code: %d.\nstderr=%s\nstdout=%s" % (ret_code, std_err, std_out))

--- a/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
@@ -56,9 +56,7 @@ def expand(context):
     ensure_temp_directory_is_empty(context, "behave_test_expansion_primary")
     ensure_temp_directory_is_empty(context, "behave_test_expansion_mirror")
 
-    run_command(context, "createdb expansion_database")
-
-    expansion_command = """gpexpand -D expansion_database --input <(echo '
+    expansion_command = """gpexpand --input <(echo '
     localhost:localhost:25438:/tmp/behave_test_expansion_primary:8:3:p
     localhost:localhost:25439:/tmp/behave_test_expansion_mirror:9:3:m
 ')

--- a/gpMgmt/test/behave_utils/cluster_expand.py
+++ b/gpMgmt/test/behave_utils/cluster_expand.py
@@ -7,8 +7,8 @@ from gppylib.commands.base import Command
 from gppylib.db import dbconn
 
 class Gpexpand:
-    def __init__(self, context, working_directory=None, database='pivotal'):
-        self.database = database
+    def __init__(self, context, working_directory=None):
+        self.database = 'postgres'
         self.working_directory = working_directory
         self.context = context
 
@@ -33,7 +33,7 @@ class Gpexpand:
 
         # If working_directory is None, then Popen will use the directory where
         # the python code is being ran.
-        p1 = Popen(["gpexpand", "-D", self.database], stdout=PIPE, stdin=PIPE,
+        p1 = Popen(["gpexpand"], stdout=PIPE, stdin=PIPE,
                    cwd=self.working_directory)
 
         # Very raw form of doing the interview part of gpexpand.
@@ -66,7 +66,7 @@ class Gpexpand:
 
     def initialize_segments(self, additional_params=''):
         input_files = sorted(glob.glob('%s/gpexpand_inputfile*' % self.working_directory))
-        return run_gpcommand(self.context, "gpexpand -D %s -i %s %s" % (self.database, input_files[-1], additional_params))
+        return run_gpcommand(self.context, "gpexpand -i %s %s" % (input_files[-1], additional_params))
 
     def get_redistribute_status(self):
         sql = 'select status from gpexpand.status order by updated desc limit 1'
@@ -90,13 +90,13 @@ class Gpexpand:
         else:
             flags = ""
 
-        rc, stderr, stdout = run_gpcommand(self.context, "gpexpand -D %s %s" % (self.database, flags))
+        rc, stderr, stdout = run_gpcommand(self.context, "gpexpand %s" % (flags))
         if rc == 0:
             rc = self.get_redistribute_status()
         return (rc, stderr, stdout)
 
     def rollback(self):
-        return run_gpcommand(self.context, "gpexpand -D %s -r" % (self.database))
+        return run_gpcommand(self.context, "gpexpand -r")
 
 if __name__ == '__main__':
     gpexpand = Gpexpand()


### PR DESCRIPTION
The -D option was retired in commit
ec708f3412c399faa6b1dc012cf7dac369261b1d, but we did not update the
tests accordingly.

Now we retire the -D option from gpexpand tests, too.

