### PR TITLE
Vagrant: Source greenplum_path.sh in ~/.bashrc

### DIFF
--- a/src/tools/vagrant/common/vagrant-build-gpdb.sh
+++ b/src/tools/vagrant/common/vagrant-build-gpdb.sh
@@ -65,11 +65,16 @@ chmod 600 ~/.ssh/authorized_keys
 echo export LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH \
   >>/usr/local/gpdb/greenplum_path.sh
 
-pushd "${GPDB_DIR}/gpAux/gpdemo"
+# source greenplum_path in ~/.bashrc
+GPDEMO_ENV=${GPDB_DIR}/gpAux/gpdemo/gpdemo-env.sh
+cat <<EOF >>~/.bashrc
 source /usr/local/gpdb/greenplum_path.sh
+if [[ -r $GPDEMO_ENV ]]; then
+  source "$GPDEMO_ENV"
+fi
+EOF
+
+pushd "${GPDB_DIR}/gpAux/gpdemo"
+source ~/.bashrc
 make
 popd
-
-#cd /vagrant/src/pl/plspython/tests
-#make containers
-#sudo -u postgres make


### PR DESCRIPTION
* this way when you ssh onto the VM, you have e.g. psql available to you
* also conditionally checks if `gpdemo-env.sh` is available and sources it

Authored-by: Oliver Albertini <oalbertini@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
