### PR TITLE
make: Print CONFIGFLAGS passed to configure

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -266,6 +266,7 @@ $(GPPGDIR)/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	if [ "$(BLD_ARCH)" = "win32" ]; then \
 		$(MAKE) -C $(GPPGDIR)/src/bin/gpfdist/ext BLD_TOP=$(BLD_TOP); \
 	fi
+	echo "Running ./configure with CONFIGFLAGS=$(CONFIGFLAGS)\n"
 	cd $(GPPGDIR) && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"    \
                      CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL) \
                      ./configure $(CONFIGFLAGS)               \
@@ -275,6 +276,7 @@ $(GPPGDIR)/GNUmakefile : $(GPPGDIR)/configure  env.sh
 Debug/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	rm -rf $(INSTLOC)
 	mkdir -p Debug
+	echo "Running ./configure with CONFIGFLAGS=$(CONFIGFLAGS)\n"
 	cd Debug && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"        \
                 CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL)     \
                 ./configure $(CONFIGFLAGS)                   \
@@ -284,6 +286,7 @@ Debug/GNUmakefile : $(GPPGDIR)/configure  env.sh
 Release/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	rm -rf $(INSTLOC)
 	mkdir -p Release
+	echo "Running ./configure with CONFIGFLAGS=$(CONFIGFLAGS)\n"
 	cd Release && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"     \
                   CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL)  \
                   ./configure $(CONFIGFLAGS)                \


### PR DESCRIPTION
We should print all the flags passed to ./configure when we build GPDB in CI, otherwise it's annoying to manually repro bad builds

Dev pipeline with example output: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-gpreleng-configflags/jobs/compile_gpdb_centos7/builds/2

```
Running ./configure with CONFIGFLAGS=--with-quicklz --enable-tap-tests --enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-orca --with-libxml --with-pgport=5432 --with-libedit-preferred --enable-cassert --with-perl --with-python --with-includes=/tmp/build/f8c7ee08/gpdb_src/gpAux/ext/rhel7_x86_64/include /tmp/build/f8c7ee08/gpdb_src/gpAux/ext/rhel7_x86_64/include/libxml2 /tmp/build/f8c7ee08/gpdb_src/gpAux/addon/src/include --with-libraries=/tmp/build/f8c7ee08/gpdb_src/gpAux/ext/rhel7_x86_64/lib --with-openssl --with-pam --with-ldap    ADDON_DIR=addon\n
```

Co-authored-by: David Sharp <dsharp@pivotal.io>
Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>
Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
Co-authored-by: Sambitesh Dash <sdash@pivotal.io>
