### PR TITLE
Reuse the identifier when a QE is destroyed

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -99,7 +99,14 @@ cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, int id
 void
 cdbconn_termSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc)
 {
+	CdbComponentDatabases *cdbs;
+
 	Assert(CdbComponentsContext);
+
+	cdbs = segdbDesc->segment_database_info->cdbs;
+
+	/* put qe identifier to free list for reuse */
+	cdbs->freeCounterList = lappend_int(cdbs->freeCounterList, segdbDesc->identifier);
 
 	cdbconn_disconnect(segdbDesc);
 

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -102,6 +102,7 @@ struct CdbComponentDatabases
 	int			numActiveQEs;
 	int			numIdleQEs;
 	int			qeCounter;
+	List		*freeCounterList;
 };
 
 //


### PR DESCRIPTION
Now each QE in a session is assigned with a unique identifier, meanwhile, QD
dispatches a slice table to all QEs and each slice in the slice table has a
bitmapset of QE identifiers. QE go through all slices and decide the slice it
belongs to by checking its identifier in the bitmapset.

A problem is, the QE identifier was never resued when a QE was destroyed, so the
identifier was incrementally increased until the bitmapset is inefficient and
insufficient to hold it.
This commit fixes it by reusing the QE identifiers to limit it in a reasonable
range.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
