### PR TITLE
WIP: Support gang size greater than the segmentCount

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -721,7 +721,7 @@ EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool flushCommLa
 	 */
 	if (pMNEntry->preserve_order && pMNEntry->ready_tuple_lists != NULL)
 	{
-		for (i = 0; i < getgpsegmentCount(); i++)
+		for (i = 0; i < pMNEntry->num_senders; i++)
 		{
 			pCSEntry = &pMNEntry->ready_tuple_lists[i];
 
@@ -874,7 +874,7 @@ getChunkSorterEntry(MotionLayerState *mlStates,
 	AssertArg(motNodeEntry != NULL);
 
 	Assert(srcRoute >= 0);
-	Assert(srcRoute < getgpsegmentCount());
+	Assert(srcRoute < motNodeEntry->num_senders);
 
 	/* Do we have a sorter initialized ? */
 	if (motNodeEntry->ready_tuple_lists != NULL)
@@ -887,7 +887,7 @@ getChunkSorterEntry(MotionLayerState *mlStates,
 	oldCtxt = MemoryContextSwitchTo(mlStates->motion_layer_mctx);
 
 	if (motNodeEntry->ready_tuple_lists == NULL)
-		motNodeEntry->ready_tuple_lists = (ChunkSorterEntry *) palloc0(getgpsegmentCount() * sizeof(ChunkSorterEntry));
+		motNodeEntry->ready_tuple_lists = (ChunkSorterEntry *) palloc0(motNodeEntry->num_senders * sizeof(ChunkSorterEntry));
 
 	chunkSorterEntry = &motNodeEntry->ready_tuple_lists[srcRoute];
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4681,7 +4681,7 @@ FillSliceGangInfo(Slice *slice, int numsegments)
 				slice->gangSize = numsegments;
 				slice->segments = NIL;
 				for (i = 0; i < numsegments; i++)
-					slice->segments = lappend_int(slice->segments, i);
+					slice->segments = lappend_int(slice->segments, i % getgpsegmentCount());
 			}
 			break;
 		case GANGTYPE_ENTRYDB_READER:


### PR DESCRIPTION
Assign segments to a gang by the modulo
Use ~motion node count~ num of senders instead of the segmentCount in the sorter

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change

This has no test cases yet, we have an incoming feature with tests using this.