### PR TITLE
Dispatch config to segments when create extension with schema.

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -824,18 +824,12 @@ execute_extension_script(CreateExtensionStmt *stmt,
 
 	if (client_min_messages < WARNING)
 	{
-		(void) set_config_option("client_min_messages", "warning",
-								 PGC_USERSET, PGC_S_SESSION,
-								 GUC_ACTION_SAVE, true, 0);
 		/* need to dispatch to all segments*/
 		A_Const const_value = {.type = T_A_Const, .val = {.type = T_String, .val.str = pstrdup("warning")}};
 		SetPGVariable("client_min_messages", list_make1(&const_value), true);
 	}
 	if (log_min_messages < WARNING)
 	{
-		(void) set_config_option("log_min_messages", "warning",
-								 PGC_SUSET, PGC_S_SESSION,
-								 GUC_ACTION_SAVE, true, 0);
 		/* need to dispatch to all segments*/
 		A_Const const_value = {.type = T_A_Const, .val = {.type = T_String, .val.str = pstrdup("warning")}};
 		SetPGVariable("log_min_messages", list_make1(&const_value), true);
@@ -861,10 +855,6 @@ execute_extension_script(CreateExtensionStmt *stmt,
 		if (reqname)
 			appendStringInfo(&pathbuf, ", %s", quote_identifier(reqname));
 	}
-
-	(void) set_config_option("search_path", pathbuf.data,
-							 PGC_USERSET, PGC_S_SESSION,
-							 GUC_ACTION_SAVE, true, 0);
 
 	/* need to dispatch 'set search_path' to all segments*/
 	A_Const path_const = {.type = T_A_Const, .val = {.type = T_String, .val.str = pathbuf.data}};

--- a/src/test/regress/expected/alter_extension.out
+++ b/src/test/regress/expected/alter_extension.out
@@ -5,3 +5,9 @@ CREATE AGGREGATE example_agg(int4) (
 );
 ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
 ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+DROP EXTENSION gp_inject_fault;
+-- test create extension with schema
+SET search_path TO invalid_path;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault WITH SCHEMA public;
+DROP EXTENSION gp_inject_fault;
+RESET search_path;

--- a/src/test/regress/sql/alter_extension.sql
+++ b/src/test/regress/sql/alter_extension.sql
@@ -7,3 +7,9 @@ CREATE AGGREGATE example_agg(int4) (
 
 ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
 ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+DROP EXTENSION gp_inject_fault;
+-- test create extension with schema
+SET search_path TO invalid_path;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault WITH SCHEMA public;
+DROP EXTENSION gp_inject_fault;
+RESET search_path;


### PR DESCRIPTION
Create extension with schema will modify some configs like
search_path. We need to call SetPGVariable to dispatch these
configs to segments manually. Since currently gpdb only supports to sync
GUCs with 1. explicit SET command, 2. pass GUCs when QE startup.

Co-authored-by: Haozhou Wang <hawang@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
