### PR TITLE
Only get necessary relids for partition table in InitPlan

### DIFF
--- a/src/test/isolation2/expected/ao_partition_lock.out
+++ b/src/test/isolation2/expected/ao_partition_lock.out
@@ -1,0 +1,29 @@
+-- Previously, even directly insert into a partition ao
+-- table's child partition, the transaction will lock
+-- all the tables' aoseg table in this partition on
+-- each segment. This test case is to test that extra
+-- lock is not acquired.
+
+create table test_ao_partition_lock ( field_dk integer ,field_part integer) with (appendonly=true) DISTRIBUTED BY (field_dk) PARTITION BY LIST(field_part) ( partition val1 values(1), partition val2 values(2), partition val3 values(3) );
+CREATE
+
+1: begin;
+BEGIN
+1: insert into test_ao_partition_lock_1_prt_val1 values(1,1);
+INSERT 1
+
+2: begin;
+BEGIN
+2: alter table test_ao_partition_lock truncate partition for (2);
+ALTER
+2: end;
+END
+
+1: end;
+END
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+drop table test_ao_partition_lock;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,3 +1,5 @@
+test: ao_partition_lock
+
 test: select_dropped_table
 # test update hash col under utility mode
 test: update_hash_col_utilitymode

--- a/src/test/isolation2/sql/ao_partition_lock.sql
+++ b/src/test/isolation2/sql/ao_partition_lock.sql
@@ -1,0 +1,30 @@
+-- Previously, even directly insert into a partition ao
+-- table's child partition, the transaction will lock
+-- all the tables' aoseg table in this partition on
+-- each segment. This test case is to test that extra
+-- lock is not acquired.
+
+create table test_ao_partition_lock
+( field_dk integer ,field_part integer)
+with (appendonly=true)
+DISTRIBUTED BY (field_dk)
+PARTITION BY LIST(field_part)
+(
+  partition val1 values(1),
+  partition val2 values(2),
+  partition val3 values(3)
+);
+
+1: begin;
+1: insert into test_ao_partition_lock_1_prt_val1 values(1,1);
+
+2: begin;
+2: alter table test_ao_partition_lock truncate partition for (2);
+2: end;
+
+1: end;
+
+1q:
+2q:
+
+drop table test_ao_partition_lock;


### PR DESCRIPTION
Previously, during initializing ResultRelations in InitPlan on
QD, it always builds the relids as all the relation oids in a
partition table (including root and all its inheritors).
Sometimes we does not need all the relids.

A typical case is for ao partition table. When we directly
insert into a specific child partition, the plan's ResultRelation
only contains the child partition. And if we still make relids
as root and all its inheritors, during `assignPerRelSegno`,
it might lock each aoseg file on AccessShare mode on QEs. It
causes confusion that the insert statement is only for a child
partition but holding other partition's lock.

This commit changes the relids building logic as:
  - if the ResultRelation contains the root partition, then
    relids is root and all its inheritors
  - otherwise, relids is a map of ResultRelations to get the
    element's relation oid

Co-authored-by: Shujie Zhang <shzhang@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
