### PR TITLE
Backport5x fix snapshot shared memory allocation setup

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -41,6 +41,7 @@
 #include "utils/syscache.h"
 #include "utils/fmgroids.h"
 #include "utils/numeric.h"
+#include "utils/sharedsnapshot.h"
 
 static Datum ao_compression_ratio_internal(Oid relid);
 static void UpdateFileSegInfo_internal(Relation parentrel,
@@ -2164,6 +2165,23 @@ PrintPgaosegAndGprelationNodeEntries(FileSegInfo **allseginfo, int totalsegs, bo
 
 		for (i = 0; i < snapshot->xcnt; i++)
 			appendStringInfo(msg, "%d ", snapshot->xip[i]);
+
+		appendStringInfoString(msg, "])");
+
+		/*
+		 * while we're at it, inspect the shared snapshot to see if the private
+		 * snapshot is corrupt
+		 */
+		appendStringInfo(msg, "\nshared snapshot (xmin %d, xmax %d, xcnt %d,"
+						 " curcid %d, haveDistributed %d\n in progress array [",
+						 SharedLocalSnapshotSlot->snapshot.xmin,
+						 SharedLocalSnapshotSlot->snapshot.xmax,
+						 SharedLocalSnapshotSlot->snapshot.xcnt,
+						 SharedLocalSnapshotSlot->snapshot.curcid,
+						 SharedLocalSnapshotSlot->snapshot.haveDistribSnapshot);
+
+		for (i = 0; i < SharedLocalSnapshotSlot->snapshot.xcnt; i++)
+			appendStringInfo(msg, "%d ", SharedLocalSnapshotSlot->snapshot.xip[i]);
 
 		appendStringInfoString(msg, "])");
 

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -275,6 +275,11 @@ CreateSharedSnapshotArray(void)
 		sharedSnapshotArray->maxSlots = slotCount;
 		sharedSnapshotArray->nextSlot = 0;
 
+		/*
+		 * Set slots to point to the next byte beyond what was allocated for
+		 * SharedSnapshotStruct. xips is the last element in the struct but is
+		 * not included in SharedSnapshotShmemSize allocation.
+		 */
 		sharedSnapshotArray->slots = (SharedSnapshotSlot *)&sharedSnapshotArray->xips;
 
 		/* xips start just after the last slot structure */
@@ -294,7 +299,7 @@ CreateSharedSnapshotArray(void)
 			 * Note: xipEntryCount is initialized in SharedSnapshotShmemSize().
 			 * So each slot gets (MaxBackends + max_prepared_xacts) transaction-ids.
 			 */
-			tmpSlot->snapshot.xip = &xip_base[xipEntryCount];
+			tmpSlot->snapshot.xip = &xip_base[0];
 			xip_base += xipEntryCount;
 		}
 	}

--- a/src/backend/utils/time/test/Makefile
+++ b/src/backend/utils/time/test/Makefile
@@ -1,0 +1,11 @@
+subdir=src/backend/utils/time
+top_builddir=../../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=sharedsnapshot
+
+include $(top_builddir)/src/backend/mock.mk
+
+sharedsnapshot.t: \
+	$(MOCK_DIR)/backend/storage/ipc/shmem_mock.o \
+	$(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -1,0 +1,63 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "postgres.h"
+#include "utils/memutils.h"
+
+#include "../sharedsnapshot.c"
+
+void
+test_boundaries_of_CreateSharedSnapshotArray(void **state)
+{
+	/*
+	 * max_prepared_xacts is used to calculate NUM_SHARED_SNAPSHOT_SLOTS. Make
+	 * it non-zero so that we actually allocate some local snapshot slots.
+	 */
+	max_prepared_xacts = 2;
+
+	SharedSnapshotStruct *fakeSharedSnapshotArray = NULL;
+
+	Size sharedSnapshotShmemSize = SharedSnapshotShmemSize();
+	fakeSharedSnapshotArray = malloc(sharedSnapshotShmemSize);
+
+	will_return(ShmemInitStruct, fakeSharedSnapshotArray);
+	will_assign_value(ShmemInitStruct, foundPtr, false);
+	expect_any_count(ShmemInitStruct, name, 1);
+	expect_any_count(ShmemInitStruct, size, 1);
+	expect_any_count(ShmemInitStruct, foundPtr, 1);
+
+	/*
+	 * Each slot in SharedSnapshotStrut has an associated dynamically allocated
+	 * LWLock, so LWLockAssign should be called for each slot.
+	 */
+	will_be_called_count(LWLockAssign, NUM_SHARED_SNAPSHOT_SLOTS);
+
+	CreateSharedSnapshotArray();
+
+	for (int i=0; i<sharedSnapshotArray->maxSlots; i++)
+	{
+		SharedSnapshotSlot *s = &sharedSnapshotArray->slots[i];
+
+		/*
+		 * Assert that every slot xip array falls inside the boundaries of the
+		 * allocated shared snapshot.
+		 */
+		assert_true(s->snapshot.xip > fakeSharedSnapshotArray);
+		assert_true(s->snapshot.xip < (((void *)fakeSharedSnapshotArray) +
+												sharedSnapshotShmemSize));
+	}
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_boundaries_of_CreateSharedSnapshotArray)
+	};
+	MemoryContextInit();
+	return run_tests(tests);
+}


### PR DESCRIPTION
Print out the shared snapshot in addition to the private copy

We suspect at least one of the following two memory regions are corrupt
during execution:

- The snapshot's (backend-private) in-progress xid array
- The shared snapshot slot corresponding to the current process (where
we copied "snapshot" from)

Printing out the shared snapshot will help us validate this hypothesis.
Where this will _not_ help us is if the shared snapshot's in-progress
XID array is already corrupt before we `memcpy` it.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>
Co-authored-by: Jesse Zhang <sbjesse@gmail.com>
