### PR TITLE
Check MyProcPort is not NULL before reference it

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -744,7 +744,7 @@ adjustMasterRouting(Slice *recvSlice)
 	{
 		CdbProcess *cdbProc = (CdbProcess *) lfirst(lc);
 
-		if (cdbProc)
+		if (cdbProc && MyProcPort)
 		{
 			if (cdbProc->listenerAddr == NULL)
 				cdbProc->listenerAddr = pstrdup(MyProcPort->remote_host);

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -740,11 +740,13 @@ adjustMasterRouting(Slice *recvSlice)
 {
 	ListCell   *lc = NULL;
 
+	Assert(MyProcPort);
+
 	foreach(lc, recvSlice->primaryProcesses)
 	{
 		CdbProcess *cdbProc = (CdbProcess *) lfirst(lc);
 
-		if (cdbProc && MyProcPort)
+		if (cdbProc)
 		{
 			if (cdbProc->listenerAddr == NULL)
 				cdbProc->listenerAddr = pstrdup(MyProcPort->remote_host);

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -143,7 +143,7 @@ setupTCPListeningSocket(int backlog, int *listenerSocketFd, uint16 *listenerPort
 	 * QD local connections tend to be AF_UNIX, or on 127.0.0.1 -- so bind
 	 * everything)
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH ||
+	if (Gp_role == GP_ROLE_DISPATCH || MyProcPort == NULL ||
 		(MyProcPort->laddr.addr.ss_family != AF_INET &&
 		 MyProcPort->laddr.addr.ss_family != AF_INET6))
 		localname = NULL;		/* We will listen on all network adapters */

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5745,6 +5745,13 @@ dispatcherAYT(void)
 	ssize_t		ret;
 	char		buf;
 
+	/*
+	 * For background worker or auxiliary process like gdd, there is no client.
+	 * As a result, MyProcPort is NULL. We should skip dispatcherAYT check here.
+	 */
+	if (MyProcPort == NULL)
+		return true;
+
 	if (MyProcPort->sock < 0)
 		return false;
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3416,7 +3416,8 @@ die(SIGNAL_ARGS)
 				 * lock(though we can handle this using pq_send_mutex_lock() now, it
 				 * is better to avoid the unnecessary cost).
 				 */
-				close(MyProcPort->sock);
+				if (MyProcPort)
+					close(MyProcPort->sock);
 				whereToSendOutput = DestNone;
 			}
 


### PR DESCRIPTION
Normal client connection to GPDB server will be represented as
MyProcPort struct in QD. This is also true for connection from QD to QE.
But for background worker and auxiliary process such as global deadlock
detector, there is no client concept, and thus MyProcPort is set to NULL.

For example, dispatcherAYT() will be called to check QD-Client connection.
But there is no client in bgworker case.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change: Just check MyProcPort not NULL
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
