### PR TITLE
Add pg_basebackup tests to validate works for primaries with tablespaces

### DIFF
--- a/src/test/isolation2/helpers/gp_management_utils_helpers.sql
+++ b/src/test/isolation2/helpers/gp_management_utils_helpers.sql
@@ -36,3 +36,12 @@ create or replace function count_of_items_in_directory(user_path text) returns t
        results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
        return len([result for result in results.splitlines() if result != ''])
 $$ language plpythonu;
+
+create or replace function count_of_items_in_database_directory(user_path text, database_oid oid) returns int as $$
+       import subprocess
+       import os
+       directory = os.path.join(user_path, str(database_oid))
+       cmd = 'ls ' + directory
+       results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+       return len([result for result in results.splitlines() if result != ''])
+$$ language plpythonu;

--- a/src/test/isolation2/input/pg_basebackup_with_tablespaces.source
+++ b/src/test/isolation2/input/pg_basebackup_with_tablespaces.source
@@ -10,22 +10,42 @@ create tablespace some_isolation2_pg_basebackup_tablespace location '@testtables
 drop database if exists some_database_with_tablespace;
 create database some_database_with_tablespace tablespace some_isolation2_pg_basebackup_tablespace;
 
+-- And a database without using the tablespace
+drop database if exists some_database_without_tablespace;
+create database some_database_without_tablespace;
+
+-- And a table and index, temp table and index using the tablespace
+1:@db_name some_database_without_tablespace: CREATE TABLE test(a INT, b INT) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+1:@db_name some_database_without_tablespace: CREATE INDEX test_index on test(a) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+2:@db_name some_database_without_tablespace: CREATE TEMP TABLE test_tmp(a INT, b INT) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+2:@db_name some_database_without_tablespace: CREATE INDEX test_tmp_index on test_tmp(a) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+
+1q:
+
 -- When we create a full backup
 select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
 
--- Then we should have a backup of the source segment files in the newly created target tablespace
+-- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
 select count_of_items_in_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/');
+
+-- Then we should have four files in newly created target tablespace under the some_database_without_tablespace, test, test_index, test_tmp, test_tmp_index
+select count_of_items_in_database_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/', oid) from pg_database where datname='some_database_without_tablespace';
 
 -- When we create a full backup using force overwrite
 select pg_basebackup(address, 200, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', true) from gp_segment_configuration where content = 0 and role = 'p';
 
--- Then we should have a backup of the source segment files in the newly created target tablespace
+-- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
 select count_of_items_in_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db200/');
 
+-- Then we should have four files in newly created target tablespace under the some_database_without_tablespace, test, test_index, test_tmp, test_tmp_index
+select count_of_items_in_database_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/', oid) from pg_database where datname='some_database_without_tablespace';
+
+2q:
 
 -- Cleanup things we've created
 0U: select pg_drop_replication_slot('some_replication_slot');
 drop database some_database_with_tablespace;
+drop database some_database_without_tablespace;
 drop tablespace some_isolation2_pg_basebackup_tablespace;
 !\retcode rm -rf @testtablespace@/some_isolation2_pg_basebackup;
 !\retcode rm -rf @testtablespace@/some_isolation2_pg_basebackup_tablespace/*;

--- a/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
+++ b/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
@@ -19,6 +19,24 @@ DROP
 create database some_database_with_tablespace tablespace some_isolation2_pg_basebackup_tablespace;
 CREATE
 
+-- And a database without using the tablespace
+drop database if exists some_database_without_tablespace;
+DROP
+create database some_database_without_tablespace;
+CREATE
+
+-- And a table and index, temp table and index using the tablespace
+1:@db_name some_database_without_tablespace: CREATE TABLE test(a INT, b INT) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+CREATE
+1:@db_name some_database_without_tablespace: CREATE INDEX test_index on test(a) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+CREATE
+2:@db_name some_database_without_tablespace: CREATE TEMP TABLE test_tmp(a INT, b INT) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+CREATE
+2:@db_name some_database_without_tablespace: CREATE INDEX test_tmp_index on test_tmp(a) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+CREATE
+
+1q: ... <quitting>
+
 -- When we create a full backup
 select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
  pg_basebackup 
@@ -26,11 +44,18 @@ select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespa
                
 (1 row)
 
--- Then we should have a backup of the source segment files in the newly created target tablespace
+-- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
 select count_of_items_in_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/');
  count_of_items_in_directory 
 -----------------------------
- 1                           
+ 2                           
+(1 row)
+
+-- Then we should have four files in newly created target tablespace under the some_database_without_tablespace, test, test_index, test_tmp, test_tmp_index
+select count_of_items_in_database_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/', oid) from pg_database where datname='some_database_without_tablespace';
+ count_of_items_in_database_directory 
+--------------------------------------
+ 4                                    
 (1 row)
 
 -- When we create a full backup using force overwrite
@@ -40,13 +65,21 @@ select pg_basebackup(address, 200, port, 'some_replication_slot', '@testtablespa
                
 (1 row)
 
--- Then we should have a backup of the source segment files in the newly created target tablespace
+-- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
 select count_of_items_in_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db200/');
  count_of_items_in_directory 
 -----------------------------
- 1                           
+ 2                           
 (1 row)
 
+-- Then we should have four files in newly created target tablespace under the some_database_without_tablespace, test, test_index, test_tmp, test_tmp_index
+select count_of_items_in_database_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/', oid) from pg_database where datname='some_database_without_tablespace';
+ count_of_items_in_database_directory 
+--------------------------------------
+ 4                                    
+(1 row)
+
+2q: ... <quitting>
 
 -- Cleanup things we've created
 0U: select pg_drop_replication_slot('some_replication_slot');
@@ -55,6 +88,8 @@ select count_of_items_in_directory('@testtablespace@/some_isolation2_pg_baseback
                           
 (1 row)
 drop database some_database_with_tablespace;
+DROP
+drop database some_database_without_tablespace;
 DROP
 drop tablespace some_isolation2_pg_basebackup_tablespace;
 DROP


### PR DESCRIPTION
Add a helper function `count_of_items_directory_in_one_database(user_path text, datname text)` to see how many files are there under `user_path/oid`, oid is datname' database oid.

The way to validate is to create a table and index for the table, and create a temp table and index for temp table, all in a specific tablespace, so, there there will be four files under `tablespace_location/database_oid_without_tablespace/`

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
