### PR TITLE
Set the backoff weight avoiding catalog lookups when not in transaction

### DIFF
--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -649,6 +649,8 @@ GetResqueueCapabilityEntry(Oid  queueid)
 	Relation	 rel;
 	TupleDesc	 tupdesc;
 
+	Assert(IsTransactionState());
+
 	/* SELECT * FROM pg_resqueuecapability WHERE resqueueid = :1 */
 	rel = heap_open(ResQueueCapabilityRelationId, AccessShareLock);
 

--- a/src/include/postmaster/backoff.h
+++ b/src/include/postmaster/backoff.h
@@ -19,7 +19,7 @@ extern int gp_resqueue_priority_grouping_timeout;
 extern double gp_resqueue_priority_cpucores_per_segment;
 extern char* gp_resqueue_priority_default_value;
 
-extern void BackoffBackendEntryInit(int sessionid, int commandcount, int weight);
+extern void BackoffBackendEntryInit(int sessionid, int commandcount, Oid queueId);
 extern void BackoffBackendEntryExit(void);
 extern void BackoffStateInit(void);
 extern Datum gp_adjust_priority_int(PG_FUNCTION_ARGS);
@@ -28,8 +28,5 @@ extern Datum gp_list_backend_priorities(PG_FUNCTION_ARGS);
 
 extern int backoff_start(void);
 
-extern int BackoffSuperuserStatementWeight(void);
-extern int ResourceQueueGetPriorityWeight(Oid queueId);
-extern int BackoffDefaultWeight(void);
 
 #endif /* BACKOFF_H_ */


### PR DESCRIPTION
Upstream commit <568d4138c64> introduced a proper MVCC model for catalog
lookups. This change means that catalog lookups must be avoided if not in a
proper transaction state. In PortalSetBackoffWeight(), a check was validating if
the call was in a transaction and in case of failure no catalog look ups were
perfomed nor a backend entry was initialized.

This commit initializes a backend entry in all cases with a proper weight. No
catalogue lookups are performed outside of a transaction state.

Removes 94_MERGE_FIXME.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>
