### PR TITLE
Change usages of gpdb_master-ci-secrets.yml to use .prod suffix

### DIFF
--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -89,7 +89,7 @@ fly -t gpdb-prod \
     -p gpdb_master \
     -c gpdb_master-generated.yml \
     -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.yml
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.prod.yml
 
 fly -t gpdb-prod \
     set-pipeline \

--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -185,7 +185,7 @@ def how_to_use_generated_pipeline_message():
         msg += '    -p gpdb_master \\\n'
         msg += '    -c %s \\\n' % ARGS.output_filepath
         msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
-        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.yml \\\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.prod.yml \\\n'
         msg += '    -v pipeline-name=gpdb_master\n\n'
 
         msg += 'fly -t gpdb-prod \\\n'


### PR DESCRIPTION
We are in the process of renaming the secrets files in
gp-continuous-integration to use the .prod suffix consistently.

Co-authored-by: Ben Christel <bchristel@pivotal.io>
Co-authored-by: Sambitesh Dash <sdash@pivotal.io>