### PR TITLE
Rename recursive CTE guc to remove _prototype

### DIFF
--- a/contrib/citext/citext--unpackaged--1.0.sql
+++ b/contrib/citext/citext--unpackaged--1.0.sql
@@ -89,7 +89,7 @@ ALTER EXTENSION citext ADD function translate(citext,citext,text);
 -- default collation is pinned.
 --
 
-SET gp_recursive_cte_prototype TO ON;
+SET gp_recursive_cte TO ON;
 
 WITH RECURSIVE typeoids(typoid) AS
   ( SELECT 'citext'::pg_catalog.regtype UNION
@@ -199,5 +199,5 @@ WHERE indclass[7] IN (
   WHERE opcintype = typeoids.typoid
 );
 
-SET gp_recursive_cte_prototype TO OFF;
+SET gp_recursive_cte TO OFF;
 -- somewhat arbitrarily, we assume no citext indexes have more than 8 columns

--- a/gpdb-doc/dita/admin_guide/query/topics/CTE-query.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/CTE-query.xml
@@ -26,7 +26,7 @@
     <p>By default, the <codeph>RECURSIVE</codeph> keyword for the <codeph>WITH</codeph> clause is
       disabled. <codeph>RECURSIVE</codeph> can be enabled by setting the server configuration
       parameter <codeph><xref
-          href="../../../ref_guide/config_params/guc-list.xml#gp_recursive_cte_prototype"/></codeph>
+          href="../../../ref_guide/config_params/guc-list.xml#gp_recursive_cte"/></codeph>
       to <codeph>true</codeph>.
       <note type="warning">The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</note></p>
   </body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -342,7 +342,7 @@
             <li>
               <xref href="#gp_motion_cost_per_row"/>
             </li>
-            <li><xref href="#gp_recursive_cte_prototype"/></li>
+            <li><xref href="#gp_recursive_cte"/></li>
             <li>
               <xref href="#gp_reject_percent_threshold"/>
             </li>
@@ -4416,8 +4416,8 @@
       </table>
     </body>
   </topic>
-  <topic id="gp_recursive_cte_prototype">
-    <title>gp_recursive_cte_prototype</title>
+  <topic id="gp_recursive_cte">
+    <title>gp_recursive_cte</title>
     <body>
       <p>Controls the availability of the <codeph>RECURSIVE</codeph> keyword (Beta) in the
           <codeph>WITH</codeph> clause of a <codeph>SELECT [INTO]</codeph> command, or a
@@ -4432,7 +4432,9 @@
       <p>The parameter can be set for a database system, an individual database, or a session or
         query.</p>
       <note>This parameter will be removed if the <codeph>RECURSIVE</codeph> keyword is promoted
-        from Beta, or if the keyword is removed from Greenplum Database.</note>
+        from Beta, or if the keyword is removed from Greenplum Database.
+        This parameter was previously named <codeph>gp_recursive_cte_prototype</codeph>, but
+        has been renamed to reflect the current status of the implementation.</note>
       <table id="table_j4s_yyx_1bb">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -138,7 +138,7 @@
             <topicref href="guc-list.xml#gp_max_slices"/>
             <topicref href="guc-list.xml#memory_spill_ratio"/>
             <topicref href="guc-list.xml#gp_motion_cost_per_row"/>
-            <topicref href="guc-list.xml#gp_recursive_cte_prototype"/>
+            <topicref href="guc-list.xml#gp_recursive_cte"/>
             <topicref href="guc-list.xml#gp_reject_percent_threshold"/>
             <topicref href="guc-list.xml#gp_reraise_signal"/>
             <topicref href="guc-list.xml#gp_resqueue_memory_policy"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
@@ -71,7 +71,7 @@ DELETE FROM [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
                     <pd>The <codeph>RECURSIVE</codeph> keyword is a Beta feature. By default, The
                             <codeph>RECURSIVE</codeph> keyword is not available. The keyword can be
                         enabled by setting the server configuration parameter <codeph><xref
-                                href="../config_params/guc-list.xml#gp_recursive_cte_prototype"
+                                href="../config_params/guc-list.xml#gp_recursive_cte"
                             /></codeph> to <codeph>true</codeph>. </pd>
                     <pd>See <xref
                             href="../../admin_guide/query/topics/CTE-query.xml#topic_zhs_r1s_w1b"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
@@ -66,7 +66,7 @@ INSERT INTO <varname>table</varname> [( <varname>column</varname> [, ...] )]
           <pd>The <codeph>RECURSIVE</codeph> keyword is a Beta feature. By default, The
               <codeph>RECURSIVE</codeph> keyword is not available. The keyword can be enabled by
             setting the server configuration parameter <codeph><xref
-                href="../config_params/guc-list.xml#gp_recursive_cte_prototype"/></codeph> to
+                href="../config_params/guc-list.xml#gp_recursive_cte"/></codeph> to
               <codeph>true</codeph>. </pd>
           <pd>See <xref href="../../admin_guide/query/topics/CTE-query.xml#topic_zhs_r1s_w1b"/> and
                 <codeph><xref href="SELECT.xml#topic1"/></codeph> for details. </pd>

--- a/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
@@ -142,7 +142,7 @@ ROWS FROM( function_name ( [ argument [, ...] ] ) [ AS ( column_definition [, ..
           specified; if the list of column names is omitted, the names are inferred from the
           subquery. The primary query and the <codeph>WITH</codeph> queries are all (notionally)
           executed at the same time. </p><p>The <codeph>RECURSIVE</codeph> keyword can be enabled by setting the server configuration
-          parameter <codeph>gp_recursive_cte_prototype</codeph> to <codeph>true</codeph>. For
+          parameter <codeph>gp_recursive_cte</codeph> to <codeph>true</codeph>. For
           information about the parameter, see <xref href="../config_params/guc_config.xml#topic1"
             />.<note type="note">The <codeph>RECURSIVE</codeph> keyword is a Beta
           feature.</note></p><p>If <codeph>RECURSIVE</codeph> is specified, it

--- a/gpdb-doc/dita/ref_guide/sql_commands/SELECT_INTO.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SELECT_INTO.xml
@@ -32,7 +32,7 @@ SELECT [ALL | DISTINCT [ON ( <varname>expression</varname> [, ...] )]]
                     <codeph>SELECT</codeph>. The new table's columns have the names and data types
                 associated with the output columns of the <codeph>SELECT</codeph>. </p>
             <p>The <codeph>RECURSIVE</codeph> keyword can be enabled by setting the server
-                configuration parameter <codeph>gp_recursive_cte_prototype</codeph> to
+                configuration parameter <codeph>gp_recursive_cte</codeph> to
                     <codeph>true</codeph>.<note type="note">The <codeph>RECURSIVE</codeph> keyword
                     is a Beta feature.</note></p>
         </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
@@ -67,7 +67,7 @@ UPDATE [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
           <pd>The <codeph>RECURSIVE</codeph> keyword is a Beta feature. By default, The
               <codeph>RECURSIVE</codeph> keyword is not available. The keyword can be enabled by
             setting the server configuration parameter <codeph><xref
-                href="../config_params/guc-list.xml#gp_recursive_cte_prototype"/></codeph> to
+                href="../config_params/guc-list.xml#gp_recursive_cte"/></codeph> to
               <codeph>true</codeph>. </pd>
           <pd>See <xref href="../../admin_guide/query/topics/CTE-query.xml#topic_zhs_r1s_w1b"/> and
                 <codeph><xref href="SELECT.xml#topic1"/></codeph> for details. </pd>

--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -114,14 +114,14 @@ transformWithClause(ParseState *pstate, WithClause *withClause)
 	Assert(pstate->p_future_ctes == NIL);
 
 	/*
-	 * WITH RECURSIVE is disabled if gp_recursive_cte_prototype is not set
+	 * WITH RECURSIVE is disabled if gp_recursive_cte is not set
 	 * to allow recursive CTEs.
 	 */
-	if (withClause->recursive && !gp_recursive_cte_prototype)
+	if (withClause->recursive && !gp_recursive_cte)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("RECURSIVE clauses in WITH queries are currently disabled"),
-				 errhint("In order to use recursive CTEs, \"gp_recursive_cte_prototype\" must be turned on.")));
+				 errhint("In order to use recursive CTEs, \"gp_recursive_cte\" must be turned on.")));
 
 	/*
 	 * For either type of WITH, there must not be duplicate CTE names in the

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -309,7 +309,7 @@ bool		gp_dynamic_partition_pruning = true;
 bool		gp_log_dynamic_partition_pruning = false;
 bool		gp_cte_sharing = false;
 bool		gp_enable_relsize_collection = false;
-bool		gp_recursive_cte_prototype = false;
+bool		gp_recursive_cte = false;
 
 /* Optimizer related gucs */
 bool		optimizer;
@@ -2075,12 +2075,22 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_recursive_cte_prototype", PGC_USERSET, QUERY_TUNING_METHOD,
+		{"gp_recursive_cte_prototype", PGC_USERSET, DEPRECATED_OPTIONS,
+			gettext_noop("Enable RECURSIVE clauses in CTE queries (deprecated option, use \"gp_recursive_cte\" instead)."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_recursive_cte,
+		false, NULL, NULL
+	},
+
+	{
+		{"gp_recursive_cte", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable RECURSIVE clauses in CTE queries."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
-		&gp_recursive_cte_prototype,
+		&gp_recursive_cte,
 		false, NULL, NULL
 	},
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -2418,7 +2418,7 @@ buildMatViewRefreshDependencies(Archive *fout)
 
 	query = createPQExpBuffer();
 
-	ExecuteSqlStatement(fout, "SET gp_recursive_cte_prototype TO ON;");
+	ExecuteSqlStatement(fout, "SET gp_recursive_cte TO ON;");
 
 	appendPQExpBufferStr(query, "WITH RECURSIVE w AS "
 						 "( "

--- a/src/bin/pg_rewind/libpq_fetch.c
+++ b/src/bin/pg_rewind/libpq_fetch.c
@@ -176,7 +176,7 @@ libpqProcessFileList(void)
 	 * directory, they won't be copied correctly.
 	 */
 	sql =
-		"SET gp_recursive_cte_prototype TO ON;\n"
+		"SET gp_recursive_cte TO ON;\n"
 		"WITH RECURSIVE files (path, filename, size, isdir) AS (\n"
 		"  SELECT '' AS path, filename, size, isdir FROM\n"
 		"  (SELECT pg_ls_dir('.', true, false) AS filename) AS fn,\n"

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -744,7 +744,7 @@ extern bool gp_dynamic_partition_pruning;
 /* Sharing of plan fragments for common table expressions */
 extern bool gp_cte_sharing;
 /* Enable RECURSIVE clauses in common table expressions */
-extern bool gp_recursive_cte_prototype;
+extern bool gp_recursive_cte;
 
 /* Priority for the segworkers relative to the postmaster's priority */
 extern int gp_segworker_relative_priority;

--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -6,7 +6,7 @@ set search_path=recursive_cte;
 create table recursive_table_1(id int);
 insert into recursive_table_1 values (1), (2), (100);
 -- Test the featureblocking GUC for recursive CTE
-set gp_recursive_cte_prototype to off;
+set gp_recursive_cte to off;
 with recursive r(i) as (
    select 1
    union all
@@ -14,8 +14,8 @@ with recursive r(i) as (
 )
 select * from recursive_table_1 where recursive_table_1.id IN (select * from r limit 10);
 ERROR:  RECURSIVE clauses in WITH queries are currently disabled
-HINT:  In order to use recursive CTEs, "gp_recursive_cte_prototype" must be turned on.
-set gp_recursive_cte_prototype to on;
+HINT:  In order to use recursive CTEs, "gp_recursive_cte" must be turned on.
+set gp_recursive_cte to on;
 -- WITH RECURSIVE ref used with IN without correlation
 with recursive r(i) as (
    select 1

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -8,7 +8,7 @@
 --
 -- test numeric hash join
 --
-set gp_recursive_cte_prototype to on;
+set gp_recursive_cte to on;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -8,7 +8,7 @@
 --
 -- test numeric hash join
 --
-set gp_recursive_cte_prototype to on;
+set gp_recursive_cte to on;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;

--- a/src/test/regress/sql/collate.linux.utf8.sql
+++ b/src/test/regress/sql/collate.linux.utf8.sql
@@ -1,5 +1,5 @@
 -- start_ignore
-SET gp_recursive_cte_prototype TO ON;
+SET gp_recursive_cte TO ON;
 -- end_ignore
 /*
  * This test is for Linux/glibc systems and assumes that a full set of

--- a/src/test/regress/sql/collate.sql
+++ b/src/test/regress/sql/collate.sql
@@ -1,5 +1,5 @@
 -- start_ignore
-SET gp_recursive_cte_prototype TO ON;
+SET gp_recursive_cte TO ON;
 -- end_ignore
 /*
  * This test is intended to pass on all platforms supported by Postgres.

--- a/src/test/regress/sql/gp_recursive_cte.sql
+++ b/src/test/regress/sql/gp_recursive_cte.sql
@@ -9,14 +9,14 @@ create table recursive_table_1(id int);
 insert into recursive_table_1 values (1), (2), (100);
 
 -- Test the featureblocking GUC for recursive CTE
-set gp_recursive_cte_prototype to off;
+set gp_recursive_cte to off;
 with recursive r(i) as (
    select 1
    union all
    select i + 1 from r
 )
 select * from recursive_table_1 where recursive_table_1.id IN (select * from r limit 10);
-set gp_recursive_cte_prototype to on;
+set gp_recursive_cte to on;
 
 -- WITH RECURSIVE ref used with IN without correlation
 with recursive r(i) as (

--- a/src/test/regress/sql/ic.sql
+++ b/src/test/regress/sql/ic.sql
@@ -1,5 +1,5 @@
 -- start_ignore
-SET gp_recursive_cte_prototype TO ON;
+SET gp_recursive_cte TO ON;
 -- end_ignore
 /*
  * 

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -1,5 +1,5 @@
 -- start_ignore
-SET gp_recursive_cte_prototype TO ON;
+SET gp_recursive_cte TO ON;
 -- end_ignore
 --
 -- Test inheritance features

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -11,7 +11,7 @@
 -- test numeric hash join
 --
 
-set gp_recursive_cte_prototype to on;
+set gp_recursive_cte to on;
 
 set enable_hashjoin to on;
 set enable_mergejoin to off;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -4,7 +4,7 @@
 
 --start_ignore
 set gp_cte_sharing to on;
-set gp_recursive_cte_prototype to on;
+set gp_recursive_cte to on;
 --end_ignore
 
 -- Basic WITH


### PR DESCRIPTION
The GUC which enables recursive CTEs is in the currently released version called gp_recursive_cte_prototype, but in order to reflect the current state of the code it's now renamed to gp_recursive_cte. The documentation still contains warning notices that the feature is considered experimental, and that should probably be reworded, but thats for another stream of work than the renaming.

The previous GUC name is still supported, but marked as deprecated, in order to make upgrades easier.