### PR TITLE
Docs: reword from 'experimental' to 'beta'

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/backup-plugin-api.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-plugin-api.xml
@@ -2,14 +2,12 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="backup-plugin-api" xml:lang="en">
-  <title id="kk1598353">Backup/Restore Storage Plugin API</title>
+  <title id="kk1598353">Backup/Restore Storage Plugin API (Beta)</title>
   <body>
     <p>This topic describes how to develop a custom storage plugin with the Greenplum Database
       Backup/Restore Storage Plugin API.</p>
-    <note type="warning">The Greenplum Database Backup/Restore Storage Plugin API is an experimental
-      feature and is not intended for use in a production environment. Experimental features are
-      subject to change without notice in future releases.<p>Only the Backup/Restore Storage Plugin
-        API is experimental. The storage plugins are not experimental.</p></note>
+    <note type="note">Only the Backup/Restore Storage Plugin API is Beta feature. The storage
+      plugins are supported features.</note>
     <p>The Backup/Restore Storage Plugin API provides a framework that you can use to develop and
       integrate a custom backup storage system with the Greenplum Database <xref
         href="../../utility_guide/admin_utilities/gpbackup.xml"><codeph>gpbackup</codeph></xref> and

--- a/gpdb-doc/dita/admin_guide/managing/backup-plugins.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-plugins.xml
@@ -11,8 +11,8 @@
       the backup files to a remote location. During a restore operation, the plugin retrieves the
       files from the remote location. </p>
     <p>You can also develop a custom storage plugin with the Greenplum Database Backup/Restore
-      Storage Plugin API (Experimental). See <xref href="backup-plugin-api.xml"/>.</p>
-    <note>Only the Backup/Restore Storage Plugin API is experimental. The storage plugins are not
-      experimental.</note>
+      Storage Plugin API (Beta). See <xref href="backup-plugin-api.xml"/>.</p>
+    <note>Only the Backup/Restore Storage Plugin API is a Beta feature. The storage plugins are
+      supported features.</note>
   </body>
 </topic>

--- a/gpdb-doc/dita/admin_guide/query/topics/CTE-query.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/CTE-query.xml
@@ -32,9 +32,7 @@ GROUP BY region, product;
         <codeph>WITH</codeph> clause.</p>
     <p>The <codeph>RECURSIVE</codeph> keyword can be enabled by setting the server configuration
       parameter <codeph>gp_recursive_cte_prototype</codeph> to <codeph>on</codeph>.<note
-        type="warning">The <codeph>RECURSIVE</codeph> keyword is an experimental feature and is not
-        intended for use in a production environment. Experimental features are subject to change
-        without notice in future releases.</note></p>
+        type="warning">The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</note></p>
     <p>The optional <codeph>RECURSIVE</codeph> keyword changes <codeph>WITH</codeph> accomplishes
       things not otherwise possible in standard SQL. Using <codeph>RECURSIVE</codeph>, a query in
       the <codeph>WITH</codeph> clause can refer to its own output. This is a simple example that

--- a/gpdb-doc/dita/admin_guide/wlmgmt.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt.xml
@@ -18,9 +18,8 @@
       4.4.73-5.1 or newer. <p>If you use RedHat 6 and the performance with resource groups is
         acceptable for your use case, upgrade your kernel to version 2.6.32-696 or higher to benefit
         from other fixes to the cgroups implementation. </p><p>SuSE 11 does not have a kernel
-        version that resolves this issue; resource groups are still considered to be an experimental
-        feature on this platform. <ph otherprops="pivotal">Resource groups are not supported on SuSE
-          11 for production use.</ph></p></note>
+        version that resolves this issue; resource groups are a Beta feature on this
+      platform.</p></note>
     <p>Either the resource queue or the resource group management scheme can be active in Greenplum
       Database; both schemes cannot be active at the same time.</p>
     <p>Resource queues are enabled by default when you install your Greenplum Database cluster.

--- a/gpdb-doc/dita/admin_guide/wlmgmt.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt.xml
@@ -12,14 +12,11 @@
       a query. Greenplum Database provides two schemes to manage resources - Resource Queues and
       Resource Groups.</p>
     <note type="important">Significant Greenplum Database performance degradation has been observed
-      when enabling resource group-based workload management on RedHat 6.x, CentOS 6.x, and SuSE 11
-      systems. This issue is caused by a Linux cgroup kernel bug. This kernel bug has been fixed in
-      CentOS 7.x and Red Hat 7.x systems, and on SuSE 12 SP2/SP3 systems with kernel version
-      4.4.73-5.1 or newer. <p>If you use RedHat 6 and the performance with resource groups is
+      when enabling resource group-based workload management on RedHat 6.x and CentOS 6.x. This
+      issue is caused by a Linux cgroup kernel bug. This kernel bug has been fixed in CentOS 7.x and
+      Red Hat 7.x systems. <p>If you use RedHat 6 and the performance with resource groups is
         acceptable for your use case, upgrade your kernel to version 2.6.32-696 or higher to benefit
-        from other fixes to the cgroups implementation. </p><p>SuSE 11 does not have a kernel
-        version that resolves this issue; resource groups are a Beta feature on this
-      platform.</p></note>
+        from other fixes to the cgroups implementation. </p></note>
     <p>Either the resource queue or the resource group management scheme can be active in Greenplum
       Database; both schemes cannot be active at the same time.</p>
     <p>Resource queues are enabled by default when you install your Greenplum Database cluster.

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -524,9 +524,8 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
         version 4.4.73-5.1 or newer. <p>If you use RedHat 6 and the performance with resource groups
           is acceptable for your use case, upgrade your kernel to version 2.6.32-696 or higher to
           benefit from other fixes to the cgroups implementation. </p><p>SuSE 11 does not have a
-          kernel version that resolves this issue; resource groups are still considered to be an
-          experimental feature on this platform. <ph otherprops="pivotal">Resource groups are not
-            supported on SuSE 11 for production use.</ph></p></note>
+          kernel version that resolves this issue; resource groups are a Beta feature on this
+          platform.</p></note>
       <section id="topic833" xml:lang="en">
         <title>Prerequisite</title>
         <p>Greenplum Database resource groups use Linux Control Groups (cgroups) to manage CPU

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -518,14 +518,11 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
     <title>Using Resource Groups</title>
     <body>
       <note type="important">Significant Greenplum Database performance degradation has been
-        observed when enabling resource group-based workload management on RedHat 6.x, CentOS 6.x,
-        and SuSE 11 systems. This issue is caused by a Linux cgroup kernel bug. This kernel bug has
-        been fixed in CentOS 7.x and Red Hat 7.x systems, and on SuSE 12 SP2/SP3 systems with kernel
-        version 4.4.73-5.1 or newer. <p>If you use RedHat 6 and the performance with resource groups
-          is acceptable for your use case, upgrade your kernel to version 2.6.32-696 or higher to
-          benefit from other fixes to the cgroups implementation. </p><p>SuSE 11 does not have a
-          kernel version that resolves this issue; resource groups are a Beta feature on this
-          platform.</p></note>
+        observed when enabling resource group-based workload management on RedHat 6.x and CentOS 6.x
+        systems. This issue is caused by a Linux cgroup kernel bug. This kernel bug has been fixed
+        in CentOS 7.x and Red Hat 7.x systems. <p>If you use RedHat 6 and the performance with
+          resource groups is acceptable for your use case, upgrade your kernel to version 2.6.32-696
+          or higher to benefit from other fixes to the cgroups implementation. </p></note>
       <section id="topic833" xml:lang="en">
         <title>Prerequisite</title>
         <p>Greenplum Database resource groups use Linux Control Groups (cgroups) to manage CPU

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4419,20 +4419,18 @@
   <topic id="gp_recursive_cte_prototype">
     <title>gp_recursive_cte_prototype</title>
     <body>
-      <p>Controls the availability of the experimental keyword <codeph>RECURSIVE</codeph> in the
+      <p>Controls the availability of the <codeph>RECURSIVE</codeph> keyword (Beta) in the
           <codeph>WITH</codeph> clause of a <codeph>SELECT[ INTO]</codeph> command. The keyword
         allows a subquery in the <codeph>WITH</codeph> clause of a <codeph>SELECT[ INTO]</codeph>
         command to reference itself. The default value is <codeph>false</codeph>, the keyword is not
         allowed in the <codeph>WITH</codeph> clause a <codeph>SELECT[ INTO]</codeph> command.</p>
-      <note type="warning">The <codeph>RECURSIVE</codeph> keyword is an experimental feature and is
-        not intended for use in a production environment. Experimental features are subject to
-        change without notice in future releases.</note>
-      <p>For information about the experimental keyword <codeph>RECURSIVE</codeph>, see the
+      <note type="note">The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</note>
+      <p>For information about the <codeph>RECURSIVE</codeph> keyword, see the
           <codeph>SELECT</codeph> command.</p>
       <p>The parameter can be set for a database system, an individual database, or a session or
         query.</p>
       <note>This parameter will be removed if the <codeph>RECURSIVE</codeph> keyword is promoted
-        from experimental or if the keyword is removed from Greenplum Database.</note>
+        from Beta, or if the keyword is removed from Greenplum Database.</note>
       <table id="table_j4s_yyx_1bb">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
@@ -68,10 +68,9 @@ DELETE FROM [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
                             <codeph>WITH</codeph> clause cannot contain a data-modifying command
                             (<codeph>INSERT</codeph>, <codeph>UPDATE</codeph>, or
                             <codeph>DELETE</codeph>). </pd>
-                    <pd>The <codeph>RECURSIVE</codeph> keyword is an experimental feature. By
-                        default, The <codeph>RECURSIVE</codeph> keyword is not available. The
-                        keyword can be enabled by setting the server configuration parameter
-                                <codeph><xref
+                    <pd>The <codeph>RECURSIVE</codeph> keyword is a Beta feature. By default, The
+                            <codeph>RECURSIVE</codeph> keyword is not available. The keyword can be
+                        enabled by setting the server configuration parameter <codeph><xref
                                 href="../config_params/guc-list.xml#gp_recursive_cte_prototype"
                             /></codeph> to <codeph>true</codeph>. </pd>
                     <pd>See <xref

--- a/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
@@ -13,8 +13,7 @@ INSERT INTO <varname>table</varname> [( <varname>column</varname> [, ...] )]
    [RETURNING * | <varname>output_expression</varname> [[AS] <varname>output_name</varname>] [, ...]]</codeblock>
     </section>
     <p><b>Note:</b>
-      <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is an experimental feature and is not
-      recommended for production use.</p>
+      <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</p>
     <section id="section3">
       <title>Description</title>
       <p><codeph>INSERT</codeph> inserts new rows into a table. One can insert one or more rows
@@ -64,7 +63,7 @@ INSERT INTO <varname>table</varname> [( <varname>column</varname> [, ...] )]
               <codeph>WITH</codeph> clause. In such a case both sets of
               <varname>with_query</varname> can be referenced within the <codeph>INSERT</codeph>
             query, but the second one takes precedence since it is more closely nested.</pd>
-          <pd>The <codeph>RECURSIVE</codeph> keyword is an experimental feature. By default, The
+          <pd>The <codeph>RECURSIVE</codeph> keyword is a Beta feature. By default, The
               <codeph>RECURSIVE</codeph> keyword is not available. The keyword can be enabled by
             setting the server configuration parameter <codeph><xref
                 href="../config_params/guc-list.xml#gp_recursive_cte_prototype"/></codeph> to

--- a/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
@@ -59,8 +59,7 @@ with_query_name</varname> [ [AS] <varname>alias</varname> [( <varname>column_ali
   UNBOUNDED FOLLOWING
 </codeblock></p>
       <p><b>Note:</b>
-        <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is an experimental feature and is not
-        recommended for production use.</p>
+        <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is A Beta feature.</p>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -138,13 +137,11 @@ with_query_name</varname> [ [AS] <varname>alias</varname> [( <varname>column_ali
           each query in the <codeph>WITH</codeph> clause. Optionally, a list of column names can be
           specified; if the list of column names is omitted, the names are inferred from the
           subquery. The primary query and the <codeph>WITH</codeph> queries are all (notionally)
-          executed at the same time. </p><p>The <codeph>RECURSIVE</codeph> keyword can be enabled by
-          setting the server configuration parameter <codeph>gp_recursive_cte_prototype</codeph> to
-            <codeph>true</codeph>. For information about the parameter, see <xref
-            href="../config_params/guc_config.xml#topic1"/>.<note type="warning">The
-              <codeph>RECURSIVE</codeph> keyword is an experimental feature and is not intended for
-            use in a production environment. Experimental features are subject to change without
-            notice in future releases.</note></p><p>If <codeph>RECURSIVE</codeph> is specified, it
+          executed at the same time. </p><p>The <codeph>RECURSIVE</codeph> keyword can be enabled by setting the server configuration
+          parameter <codeph>gp_recursive_cte_prototype</codeph> to <codeph>true</codeph>. For
+          information about the parameter, see <xref href="../config_params/guc_config.xml#topic1"
+            />.<note type="note">The <codeph>RECURSIVE</codeph> keyword is a Beta
+          feature.</note></p><p>If <codeph>RECURSIVE</codeph> is specified, it
           allows a <codeph>SELECT</codeph> subquery to reference itself by name. Such a subquery has
           the general
           form</p><codeblock><varname>non_recursive_term</varname> UNION [ALL | DISTINCT] <varname>recursive_term</varname></codeblock><p>where

--- a/gpdb-doc/dita/ref_guide/sql_commands/SELECT_INTO.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SELECT_INTO.xml
@@ -25,8 +25,7 @@ SELECT [ALL | DISTINCT [ON ( <varname>expression</varname> [, ...] )]]
         </section>
         <section id="section3">
             <p><b>Note:</b>
-                <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is an experimental feature and is
-                not recommended for production use.</p>
+                <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</p>
             <title>Description</title>
             <p><codeph>SELECT INTO</codeph> creates a new table and fills it with data computed by a
                 query. The data is not returned to the client, as it is with a normal
@@ -34,10 +33,8 @@ SELECT [ALL | DISTINCT [ON ( <varname>expression</varname> [, ...] )]]
                 associated with the output columns of the <codeph>SELECT</codeph>. </p>
             <p>The <codeph>RECURSIVE</codeph> keyword can be enabled by setting the server
                 configuration parameter <codeph>gp_recursive_cte_prototype</codeph> to
-                    <codeph>true</codeph>.<note type="warning">The <codeph>RECURSIVE</codeph>
-                    keyword is an experimental feature and is not intended for use in a production
-                    environment. Experimental features are subject to change without notice in
-                    future releases.</note></p>
+                    <codeph>true</codeph>.<note type="note">The <codeph>RECURSIVE</codeph> keyword
+                    is a Beta feature.</note></p>
         </section>
         <section id="section4">
             <title>Parameters</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
@@ -14,8 +14,7 @@ UPDATE [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
    [FROM <varname>fromlist</varname>]
    [WHERE <varname>condition </varname>| WHERE CURRENT OF <varname>cursor_name</varname> ]</codeblock>
       <p><b>Note:</b>
-        <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is an experimental feature and is not
-        recommended for production use.</p>
+        <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</p>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -65,7 +64,7 @@ UPDATE [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
               <codeph>WITH</codeph> clause. In such a case both sets of
               <varname>with_query</varname> can be referenced within the <codeph>UPDATE</codeph>
             query, but the second one takes precedence since it is more closely nested.</pd>
-          <pd>The <codeph>RECURSIVE</codeph> keyword is an experimental feature. By default, The
+          <pd>The <codeph>RECURSIVE</codeph> keyword is a Beta feature. By default, The
               <codeph>RECURSIVE</codeph> keyword is not available. The keyword can be enabled by
             setting the server configuration parameter <codeph><xref
                 href="../config_params/guc-list.xml#gp_recursive_cte_prototype"/></codeph> to

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -25,7 +25,7 @@ Use the PXF HDFS connector to read and write Parquet-format data. This section d
 
 PXF currently supports reading and writing primitive Parquet data types only.
 
-<div class="note">PXF Parquet write support is an Beta feature.</div>
+<div class="note">PXF Parquet write support is a Beta feature.</div>
 
 
 ## <a id="prereq"></a>Prerequisites

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -25,7 +25,7 @@ Use the PXF HDFS connector to read and write Parquet-format data. This section d
 
 PXF currently supports reading and writing primitive Parquet data types only.
 
-<div class="note warning">PXF Parquet write support is an experimental feature and is not intended for use in a production environment. Experimental features are subject to change without notice in future releases.</div>
+<div class="note">PXF Parquet write support is an Beta feature.</div>
 
 
 ## <a id="prereq"></a>Prerequisites

--- a/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
@@ -23,7 +23,7 @@ under the License.
 
 The PXF object store connectors support reading and writing Parquet-format data. This section decribes how to use PXF to access Parquet-format data in an object store, including how to create and query an external table that references a Parquet file in the store.
 
-<div class="note warning">PXF Parquet write support is an experimental feature and is not intended for use in a production environment. Experimental features are subject to change without notice in future releases.</div>
+<div class="note">PXF Parquet write support is a Beta feature.</div>
 
 **Note**: Accessing Parquet-format data from an object store is very similar to accessing Parquet-format data in HDFS. This topic identifies object store-specific information required to read and write Parquet data, and links to the [PXF HDFS Parquet documentation](hdfs_parquet.html) where appropriate for common information.
 


### PR DESCRIPTION
No longer using "experimental" in favor of the more generally-understood "Beta" for features still in development.