### PR TITLE
Mark get_dns_cached_address fault injector to fts probe only

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1155,7 +1155,8 @@ getAddressesForDBid(CdbComponentDatabaseInfo *c, int elevel)
 	memset(c->hostaddrs, 0, COMPONENT_DBS_MAX_ADDRS * sizeof(char *));
 
 #ifdef FAULT_INJECTOR
-	if (SIMPLE_FAULT_INJECTOR(GetDnsCachedAddress) == FaultInjectorTypeSkip)
+	if (am_ftsprobe &&
+		SIMPLE_FAULT_INJECTOR(GetDnsCachedAddress) == FaultInjectorTypeSkip)
 	{
 		/* inject a dns error for primary of segment 0 */
 		if (c->segindex == 0 &&

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -243,7 +243,7 @@ FI_IDENT(CollateLocaleOsLookup, "collate_locale_os_lookup")
 FI_IDENT(CreateResourceGroupFail, "create_resource_group_fail")
 /* inject fault before auto vacuum worker calls do_autovacuum */
 FI_IDENT(AutoVacWorkerBeforeDoAutovacuum, "auto_vac_worker_before_do_autovacuum")
-/* inject fault when search DNS cache */
+/* inject fault when search DNS cache (only works for fts probe) */
 FI_IDENT(GetDnsCachedAddress, "get_dns_cached_address")
 /* inject fault before aquiring lock during AlterTableCreateAoBlkdirTable */
 FI_IDENT(BeforeAcquireLockDuringCreateAoBlkdirTable, "before_acquire_lock_during_create_ao_blkdir_table")


### PR DESCRIPTION
To test that fts probe can handle dns error, a fault named
get_dns_cached_address is added, however, this fault might
effect any connections that call getCdbComponentInfo() and
make the fts_errors flaky. To fix this, mark the dns fault
to fts probe only.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
