### PR TITLE
Use memset for initializing projection list for aocs_beginscan.

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2854,12 +2854,8 @@ IndexBuildAppendOnlyColScan(Relation parentRelation,
 								proj,
 								parentRelation->rd_att->natts);
 	}
-	
 	else
-	{
-		for (attno = 0; attno < parentRelation->rd_att->natts; attno++)
-			proj[attno] = true;
-	}
+		memset(proj, true, parentRelation->rd_att->natts);
 	
 	aocsscan = aocs_beginscan(parentRelation, snapshot, snapshot, NULL /* relationTupleDesc */, proj);
 

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1696,11 +1696,7 @@ acquire_sample_rows_ao(Relation onerel, int elevel,
 	{
 		int			natts = RelationGetNumberOfAttributes(onerel);
 		bool	   *proj = (bool *) palloc(natts * sizeof(bool));
-		int			i;
-
-		for(i = 0; i < natts; i++)
-			proj[i] = true;
-
+		memset(proj, true, natts);
 		Assert(RelationIsAoCols(onerel));
 		aocsScanDesc = aocs_beginscan(onerel,
 									  SnapshotSelf,

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3028,7 +3028,6 @@ CopyTo(CopyState cstate)
 				bool *proj = NULL;
 
 				int nvp = tupDesc->natts;
-				int i;
 
 				if (tupDesc->tdhasoid)
 				{
@@ -3036,9 +3035,7 @@ CopyTo(CopyState cstate)
 				}
 
 				proj = palloc(sizeof(bool) * nvp);
-				for(i = 0; i < nvp; ++i)
-				    proj[i] = true;
-
+				memset(proj, true, nvp);
 				scan = aocs_beginscan(rel, GetActiveSnapshot(),
 									  GetActiveSnapshot(),
 									  NULL /* relationTupleDesc */, proj);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17498,18 +17498,12 @@ split_rows(Relation intoa, Relation intob, Relation temprel)
 	else if (RelationIsAoCols(temprel))
 	{
 		int nvp = temprel->rd_att->natts;
-		int i;
-
 		aocsproj = (bool *) palloc(sizeof(bool) * nvp);
-		for(i=0; i<nvp; ++i)
-			aocsproj[i] = true;
-
+		memset(aocsproj, true, nvp);
 		aocsscan = aocs_beginscan(temprel, snapshot, snapshot, NULL /* relationTupleDesc */, aocsproj);
 	}
 	else
-	{
 		Assert(false);
-	}
 
 	oldCxt = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -6777,12 +6777,7 @@ neededColumnContextWalker(Node *node, neededColumnContext *c)
 		 * set all entries in mask to true.
 		 */
 		else if (var->varattno == 0)
-		{
-			int i;
-
-			for (i=0; i < c->n; i++)
-				c->mask[i] = true;
-		}
+			memset(c->mask, true, c->n);
 
 		return false;
 	}


### PR DESCRIPTION
Cases where all the columns need to be scanned for aocs, which are
quite is few in code, better avoid looping on number of columns.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
