### PR TITLE
Make sure array type is not missed after partition exchange.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16646,11 +16646,11 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 		List			*newcons;
 		bool			 ok;
 		bool			 validate	= intVal(pc2->arg1) ? true : false;
-		Oid				 oldnspid	= InvalidOid;
-		Oid				 newnspid	= InvalidOid;
 		Oid				 parentrelid = InvalidOid;
-		char			*newNspName = NULL;
-		char			*oldNspName = NULL;
+		Oid				 oldnspid;
+		Oid				 newnspid;
+		Oid				 newrel_owner;
+		Oid				 newrel_type;
 
 		newrel = heap_open(newrelid, AccessExclusiveLock);
 		if (RelationIsExternal(newrel) && validate)
@@ -16661,14 +16661,11 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 
 		oldrel = heap_open(oldrelid, AccessExclusiveLock);
 
+		newrel_owner = oldrel->rd_rel->relowner;
+		newrel_type = oldrel->rd_rel->reltype;
+
 		oldnspid = RelationGetNamespace(oldrel);
 		newnspid = RelationGetNamespace(newrel);
-
-		if (oldnspid != newnspid)
-		{
-			newNspName = pstrdup(get_namespace_name(newnspid));
-			oldNspName = pstrdup(get_namespace_name(oldnspid));
-		}
 
 		newname = pstrdup(RelationGetRelationName(newrel));
 		oldname = pstrdup(RelationGetRelationName(oldrel));
@@ -16710,7 +16707,7 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 		RelationForgetRelation(oldrelid);
 
 		/* MPP-6979: if the namespaces are different, switch them */
-		if (newNspName)
+		if (oldnspid != newnspid)
 		{
 			ObjectAddresses *objsMoved = new_object_addresses();
 
@@ -16750,6 +16747,83 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 		RelationForgetRelation(oldrelid);
 
 		CommandCounterIncrement();
+
+		/*
+		 * Add array type for newname if it does not exist. Need to create
+		 * the array type and modify the corresponding composite type to
+		 * associate with the array type oid.
+		 */
+		Oid	         array_oid;
+		char        *relarrayname;
+		Relation     typrel;
+		HeapTuple    typtup;
+		Form_pg_type typform;
+		bool         create_array;
+
+		/* Has array type already existed? */
+		typrel = heap_open(TypeRelationId, AccessShareLock);
+
+		typtup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(newrel_type));
+		if (!HeapTupleIsValid(typtup))
+			elog(ERROR, "cache lookup failed for type %u", newrel_type);
+		typform = (Form_pg_type) GETSTRUCT(typtup);
+
+		create_array = (typform->typarray == 0);
+		ReleaseSysCache(typtup);
+
+		if (!create_array)
+			heap_close(typrel, AccessShareLock);
+		else
+		{
+			/* Create the array type for newname */
+			relarrayname = makeArrayTypeName(newname, newnspid);
+
+			if (Gp_role == GP_ROLE_EXECUTE)
+				array_oid = GetPreassignedOidForType(newnspid, relarrayname, true);
+			else
+				array_oid = GetNewOid(typrel);
+
+			heap_close(typrel, AccessShareLock);
+
+			TypeCreate(array_oid,		/* force the type's OID to this */
+					   relarrayname,	/* Array type name */
+					   newnspid,	/* namespace */
+					   InvalidOid,	/* Not composite, no relationOid */
+					   0,			/* relkind, also N/A here */
+					   newrel_owner,		/* owner's ID */
+					   -1,			/* Internal size (varlena) */
+					   TYPTYPE_BASE,	/* Not composite - typelem is */
+					   TYPCATEGORY_ARRAY,	/* type-category (array) */
+					   false,		/* array types are never preferred */
+					   DEFAULT_TYPDELIM,	/* default array delimiter */
+					   F_ARRAY_IN,	/* array input proc */
+					   F_ARRAY_OUT, /* array output proc */
+					   F_ARRAY_RECV,	/* array recv (bin) proc */
+					   F_ARRAY_SEND,	/* array send (bin) proc */
+					   InvalidOid,	/* typmodin procedure - none */
+					   InvalidOid,	/* typmodout procedure - none */
+					   F_ARRAY_TYPANALYZE,	/* array analyze procedure */
+					   newrel_type,	/* array element type - the rowtype */
+					   true,		/* yes, this is an array type */
+					   InvalidOid,	/* this has no array type */
+					   InvalidOid,	/* domain base type - irrelevant */
+					   NULL,		/* default value - none */
+					   NULL,		/* default binary representation */
+					   false,		/* passed by reference */
+					   'd',			/* alignment - must be the largest! */
+					   'x',			/* fully TOASTable */
+					   -1,			/* typmod */
+					   0,			/* array dimensions for typBaseType */
+					   false,		/* Type NOT NULL */
+					   InvalidOid); /* rowtypes never have a collation */
+			pfree(relarrayname);
+
+			CommandCounterIncrement();
+
+			/* Modify composite type to associate with the new array oid. */
+			AlterTypeArray(newrel_type, array_oid);
+			CommandCounterIncrement();
+		}
 
 		/* fix up partitioning rule if we're on the QD*/
 		if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/include/commands/typecmds.h
+++ b/src/include/commands/typecmds.h
@@ -52,6 +52,7 @@ extern Oid AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 						   bool isImplicitArray,
 						   bool errorOnTableType,
 						   ObjectAddresses *objsMoved);
+extern void AlterTypeArray(Oid typeOid, Oid arrayOid);
 
 extern void AlterType(AlterTypeStmt *stmt);
 

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -8267,3 +8267,88 @@ alter table at_list add partition foo2 start(6) end (10);
 ERROR:  cannot add range partition to list partitioned table
 alter table at_range add partition test values(5);
 ERROR:  cannot add list partition to range partitioned table
+-- Ensure array type for the non-partition table is there after partition exchange.
+CREATE TABLE pt_xchg(a int) PARTITION BY RANGE(a) (START(1) END(4) EVERY (2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "pt_xchg_1_prt_1" for table "pt_xchg"
+NOTICE:  CREATE TABLE will create partition "pt_xchg_1_prt_2" for table "pt_xchg"
+create table xchg_tab1(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE SCHEMA xchg_schema;
+create table xchg_schema.xchg_tab2(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+alter table pt_xchg exchange partition for (1) with table xchg_tab1;
+alter table pt_xchg exchange partition for (3) with table xchg_schema.xchg_tab2;
+select a.typowner=b.typowner from pg_type a join pg_type b on true where a.typname = 'xchg_tab1' and b.typname = '_xchg_tab1';
+ ?column? 
+----------
+ t
+(1 row)
+
+select nspname from pg_namespace join pg_type on pg_namespace.oid = pg_type.typnamespace where pg_type.typname = 'xchg_tab1' or pg_type.typname = '_xchg_tab1';
+ nspname 
+---------
+ public
+ public
+(2 rows)
+
+select nspname from pg_namespace join pg_type on pg_namespace.oid = pg_type.typnamespace where pg_type.typname = 'xchg_tab2' or pg_type.typname = '_xchg_tab2';
+   nspname   
+-------------
+ xchg_schema
+ xchg_schema
+(2 rows)
+
+select typname from pg_type where typelem = 'xchg_tab1'::regtype;
+  typname   
+------------
+ _xchg_tab1
+(1 row)
+
+select typname from pg_type where typelem = 'xchg_schema.xchg_tab2'::regtype;
+  typname   
+------------
+ _xchg_tab2
+(1 row)
+
+select typname from pg_type where typarray = '_xchg_tab1'::regtype;
+  typname  
+-----------
+ xchg_tab1
+(1 row)
+
+select typname from pg_type where typarray = 'xchg_schema._xchg_tab2'::regtype;
+  typname  
+-----------
+ xchg_tab2
+(1 row)
+
+alter table pt_xchg exchange partition for (1) with table xchg_tab1;
+select a.typowner=b.typowner from pg_type a join pg_type b on true where a.typname = 'xchg_tab1' and b.typname = '_xchg_tab1';
+ ?column? 
+----------
+ t
+(1 row)
+
+select nspname from pg_namespace join pg_type on pg_namespace.oid = pg_type.typnamespace where pg_type.typname = 'xchg_tab1' or pg_type.typname = '_xchg_tab1';
+ nspname 
+---------
+ public
+ public
+(2 rows)
+
+select typname from pg_type where typelem = 'xchg_tab1'::regtype;
+  typname   
+------------
+ _xchg_tab1
+(1 row)
+
+select typname from pg_type where typarray = '_xchg_tab1'::regtype;
+  typname  
+-----------
+ xchg_tab1
+(1 row)
+

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -8264,3 +8264,88 @@ alter table at_list add partition foo2 start(6) end (10);
 ERROR:  cannot add range partition to list partitioned table
 alter table at_range add partition test values(5);
 ERROR:  cannot add list partition to range partitioned table
+-- Ensure array type for the non-partition table is there after partition exchange.
+CREATE TABLE pt_xchg(a int) PARTITION BY RANGE(a) (START(1) END(4) EVERY (2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "pt_xchg_1_prt_1" for table "pt_xchg"
+NOTICE:  CREATE TABLE will create partition "pt_xchg_1_prt_2" for table "pt_xchg"
+create table xchg_tab1(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE SCHEMA xchg_schema;
+create table xchg_schema.xchg_tab2(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+alter table pt_xchg exchange partition for (1) with table xchg_tab1;
+alter table pt_xchg exchange partition for (3) with table xchg_schema.xchg_tab2;
+select a.typowner=b.typowner from pg_type a join pg_type b on true where a.typname = 'xchg_tab1' and b.typname = '_xchg_tab1';
+ ?column? 
+----------
+ t
+(1 row)
+
+select nspname from pg_namespace join pg_type on pg_namespace.oid = pg_type.typnamespace where pg_type.typname = 'xchg_tab1' or pg_type.typname = '_xchg_tab1';
+ nspname 
+---------
+ public
+ public
+(2 rows)
+
+select nspname from pg_namespace join pg_type on pg_namespace.oid = pg_type.typnamespace where pg_type.typname = 'xchg_tab2' or pg_type.typname = '_xchg_tab2';
+   nspname   
+-------------
+ xchg_schema
+ xchg_schema
+(2 rows)
+
+select typname from pg_type where typelem = 'xchg_tab1'::regtype;
+  typname   
+------------
+ _xchg_tab1
+(1 row)
+
+select typname from pg_type where typelem = 'xchg_schema.xchg_tab2'::regtype;
+  typname   
+------------
+ _xchg_tab2
+(1 row)
+
+select typname from pg_type where typarray = '_xchg_tab1'::regtype;
+  typname  
+-----------
+ xchg_tab1
+(1 row)
+
+select typname from pg_type where typarray = 'xchg_schema._xchg_tab2'::regtype;
+  typname  
+-----------
+ xchg_tab2
+(1 row)
+
+alter table pt_xchg exchange partition for (1) with table xchg_tab1;
+select a.typowner=b.typowner from pg_type a join pg_type b on true where a.typname = 'xchg_tab1' and b.typname = '_xchg_tab1';
+ ?column? 
+----------
+ t
+(1 row)
+
+select nspname from pg_namespace join pg_type on pg_namespace.oid = pg_type.typnamespace where pg_type.typname = 'xchg_tab1' or pg_type.typname = '_xchg_tab1';
+ nspname 
+---------
+ public
+ public
+(2 rows)
+
+select typname from pg_type where typelem = 'xchg_tab1'::regtype;
+  typname   
+------------
+ _xchg_tab1
+(1 row)
+
+select typname from pg_type where typarray = '_xchg_tab1'::regtype;
+  typname  
+-----------
+ xchg_tab1
+(1 row)
+

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3949,3 +3949,28 @@ create table at_list (i int) partition by list(i) (partition p1 values(1));
 
 alter table at_list add partition foo2 start(6) end (10);
 alter table at_range add partition test values(5);
+
+-- Ensure array type for the non-partition table is there after partition exchange.
+CREATE TABLE pt_xchg(a int) PARTITION BY RANGE(a) (START(1) END(4) EVERY (2));
+create table xchg_tab1(a int);
+CREATE SCHEMA xchg_schema;
+create table xchg_schema.xchg_tab2(a int);
+alter table pt_xchg exchange partition for (1) with table xchg_tab1;
+alter table pt_xchg exchange partition for (3) with table xchg_schema.xchg_tab2;
+
+select a.typowner=b.typowner from pg_type a join pg_type b on true where a.typname = 'xchg_tab1' and b.typname = '_xchg_tab1';
+
+select nspname from pg_namespace join pg_type on pg_namespace.oid = pg_type.typnamespace where pg_type.typname = 'xchg_tab1' or pg_type.typname = '_xchg_tab1';
+select nspname from pg_namespace join pg_type on pg_namespace.oid = pg_type.typnamespace where pg_type.typname = 'xchg_tab2' or pg_type.typname = '_xchg_tab2';
+
+select typname from pg_type where typelem = 'xchg_tab1'::regtype;
+select typname from pg_type where typelem = 'xchg_schema.xchg_tab2'::regtype;
+
+select typname from pg_type where typarray = '_xchg_tab1'::regtype;
+select typname from pg_type where typarray = 'xchg_schema._xchg_tab2'::regtype;
+
+alter table pt_xchg exchange partition for (1) with table xchg_tab1;
+select a.typowner=b.typowner from pg_type a join pg_type b on true where a.typname = 'xchg_tab1' and b.typname = '_xchg_tab1';
+select nspname from pg_namespace join pg_type on pg_namespace.oid = pg_type.typnamespace where pg_type.typname = 'xchg_tab1' or pg_type.typname = '_xchg_tab1';
+select typname from pg_type where typelem = 'xchg_tab1'::regtype;
+select typname from pg_type where typarray = '_xchg_tab1'::regtype;


### PR DESCRIPTION
Previously if a table (e.g. t1) is "partition exchanged" with a partition
child, the array type in pg_type for t1 is missing.  That is not friendly since
that type could be used in a function or another table.