### PR TITLE
gppkg: do not check gpexpand status in build mode

### DIFF
--- a/gpMgmt/bin/gppylib/programs/gppkg.py
+++ b/gpMgmt/bin/gppylib/programs/gppkg.py
@@ -75,12 +75,17 @@ class GpPkgProgram:
                 raise ExceptionNoStackTraceNeeded('Invalid syntax, expecting "gppkg --migrate <from_gphome> <to_gphome>".')
             self.migrate = (args[0], args[1])
 
-        # gppkg should check gpexpand status
-        check_result, msg = gp.conflict_with_gpexpand("gppkg",
-                                                      refuse_phase1=True,
-                                                      refuse_phase2=False)
-        if not check_result:
-            raise ExceptionNoStackTraceNeeded(msg)
+        # gppkg should check gpexpand status unless in build mode.
+        #
+        # Build mode does not use any information from the cluster and does not
+        # affect its running status, in fact it does not require a cluster
+        # exists at all.
+        if not self.build:
+            check_result, msg = gp.conflict_with_gpexpand("gppkg",
+                                                          refuse_phase1=True,
+                                                          refuse_phase2=False)
+            if not check_result:
+                raise ExceptionNoStackTraceNeeded(msg)
 
     @staticmethod
     def create_parser():

--- a/src/test/regress/expected/run_utility_gpexpand_phase1.out
+++ b/src/test/regress/expected/run_utility_gpexpand_phase1.out
@@ -7,7 +7,14 @@
 ERROR: Usage of gpcheckcat is not supported while the cluster is in a reconfiguration state, exit gpcheckcat
 \! gpconfig -r gp_debug_linger
 20190116:16:55:31:057863 gpconfig:zlv:gpadmin-[ERROR]:-ERROR: Usage of gpconfig is not supported while the cluster is in a reconfiguration state, exit gpconfig
+-- most gppkg actions should be disallowed while gpexpand is in progress
 \! gppkg --query no-such-package
 20190220:10:23:39:016760 gppkg:nyu-vm-desktop:u-[INFO]:-Starting gppkg with args: --query no-such-package
 20190220:10:23:39:016760 gppkg:nyu-vm-desktop:u-[ERROR]:-gppkg error: ERROR: Usage of gppkg is not supported while the cluster is in a reconfiguration state, exit gppkg
+-- the only exception is 'build' which has no interaction with the cluster
+\! gppkg --build no-such-package
+20190307:15:08:14:017703 gppkg:nyu-vm-desktop:u-[INFO]:-Starting gppkg with args: --build no-such-package
+20190307:15:08:14:017703 gppkg:nyu-vm-desktop:u-[INFO]:-Building gppkg
+20190307:15:08:14:017703 gppkg:nyu-vm-desktop:u-[ERROR]:-no-such-package is an Invalid directory
+20190307:15:08:14:017703 gppkg:nyu-vm-desktop:u-[CRITICAL]:-gppkg failed. (Reason='') exiting...
 \! rm $MASTER_DATA_DIRECTORY/gpexpand.status

--- a/src/test/regress/sql/run_utility_gpexpand_phase1.sql
+++ b/src/test/regress/sql/run_utility_gpexpand_phase1.sql
@@ -6,5 +6,8 @@
 \! echo 'EXPANSION_PREPARE_STARTED:<path> to inputfile' > $MASTER_DATA_DIRECTORY/gpexpand.status
 \! gpcheckcat
 \! gpconfig -r gp_debug_linger
+-- most gppkg actions should be disallowed while gpexpand is in progress
 \! gppkg --query no-such-package
+-- the only exception is 'build' which has no interaction with the cluster
+\! gppkg --build no-such-package
 \! rm $MASTER_DATA_DIRECTORY/gpexpand.status


### PR DESCRIPTION
Build mode does not use any information from the cluster and does not
affect its running status, in fact it does not require a cluster exists
at all.

Co-authored-by: Hubert Zhang <hzhang@pivotal.io>
Co-authored-by: Ning Yu <nyu@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Pass `make installcheck`
- [x] Review a PR in return to support the community
