### PR TITLE
Use am_ftsprobe to determine the DNSLookupAsError

### DIFF
--- a/src/backend/cdb/cdbpgdatabase.c
+++ b/src/backend/cdb/cdbpgdatabase.c
@@ -71,7 +71,7 @@ gp_pgdatabase__(PG_FUNCTION_ARGS)
 		mystatus = (Working_State *) palloc(sizeof(Working_State));
 		funcctx->user_fctx = (void *) mystatus;
 
-		mystatus->cdb_component_dbs = cdbcomponent_getCdbComponents(true);
+		mystatus->cdb_component_dbs = cdbcomponent_getCdbComponents();
 		mystatus->currIdx = 0;
 
 		MemoryContextSwitchTo(oldcontext);

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1485,7 +1485,7 @@ formIdleSegmentIdList(void)
 	List					*segments = NIL;
 	int						i, j;
 
-	cdbs = cdbcomponent_getCdbComponents(true);
+	cdbs = cdbcomponent_getCdbComponents();
 
 	if (cdbs->segment_db_info != NULL)
 	{

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -348,7 +348,7 @@ static
 CdbComponentDatabases *readCdbComponentInfoAndUpdateStatus(MemoryContext probeContext)
 {
 	int i;
-	CdbComponentDatabases *cdbs = cdbcomponent_getCdbComponents(false);
+	CdbComponentDatabases *cdbs = cdbcomponent_getCdbComponents();
 
 	for (i=0; i < cdbs->total_segment_dbs; i++)
 	{

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2661,7 +2661,7 @@ gpdb::GetComponentDatabases(void)
 	GP_WRAP_START;
 	{
 		/* catalog tables: gp_segment_config */
-		return cdbcomponent_getCdbComponents(true);
+		return cdbcomponent_getCdbComponents();
 	}
 	GP_WRAP_END;
 	return NULL;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1499,7 +1499,7 @@ create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly)
 	}
 
 	/* get the total valid primary segdb count */
-	db_info = cdbcomponent_getCdbComponents(true);
+	db_info = cdbcomponent_getCdbComponents();
 	total_primaries = 0;
 	for (i = 0; i < db_info->total_segment_dbs; i++)
 	{

--- a/src/backend/utils/misc/gpexpand.c
+++ b/src/backend/utils/misc/gpexpand.c
@@ -154,7 +154,7 @@ gp_expand_protect_catalog_changes(Relation relation)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("gpexpand in progress, catalog changes are disallowed.")));
 
-	oldVersion = cdbcomponent_getCdbComponents(true)->expand_version;
+	oldVersion = cdbcomponent_getCdbComponents()->expand_version;
 	newVersion = GetGpExpandVersion();
 	if (oldVersion != newVersion)
 		ereport(FATAL,

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -140,7 +140,7 @@ extern void cdb_cleanup(int code, Datum arg  __attribute__((unused)) );
  * The same is true for pointer-based values in CdbComponentDatabaseInfo.  The caller is responsible
  * for setting the current storage context and releasing the storage occupied the returned values.
  */
-CdbComponentDatabases * cdbcomponent_getCdbComponents(bool DNSLookupAsError);
+CdbComponentDatabases * cdbcomponent_getCdbComponents(void);
 void cdbcomponent_destroyCdbComponents(void);
 
 void cdbcomponent_updateCdbComponents(void);


### PR DESCRIPTION
Fts probe didn't report an error if it failed to resolve the DNS, so fts probe
can mark those segments as down. Previously, DNSLookupAsError was only set to
false in readCdbComponentInfoAndUpdateStatus(), however, codes keep coming and
evolving, fts probe may set DNSLookupAsError to true in other code paths.

To avoiding fts probe report a DNS error unexpectedly, use am_ftsprobe only to
determine it and hide the DNSLookupAsError from callers.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
