### PR TITLE
Properly account for size of boolean when doing memset

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6699,10 +6699,10 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 			if (oldTupDesc)
 			{
 				Assert(oldTupDesc->natts <= nvp);
-				memset(proj, true, oldTupDesc->natts);
+				memset(proj, true, oldTupDesc->natts * sizeof(bool));
 			}
 			else
-				memset(proj, true, nvp);
+				memset(proj, true, nvp * sizeof(bool));
 
 			if(newrel)
 				idesc = aocs_insert_init(newrel, segno, false);


### PR DESCRIPTION
sizeof(bool) is implementation specific in C, and while relying on it being 1 is generally safe it's also not guaranteed to be safe. Fix by multiplying the counter by the actual size as it's done across the
codebase. Given our current supported architectures, this is mostly an exercise in code hygiene.

This leaves one callsite in nodeWindowAgg.c, which will be fixed as we merge a9c35cf85ca from upstream.
