### PR TITLE
Use offsetof to calculate SVECHDRSIZE 

### DIFF
--- a/gpcontrib/gp_sparse_vector/sparse_vector.h
+++ b/gpcontrib/gp_sparse_vector/sparse_vector.h
@@ -41,11 +41,7 @@ typedef struct {
  *
  * All macros take an (SvecType *) as argument
  */
-/*
- * GPDB_93_MERGE_FIXME: Shouldn't this just be sizeof(int32) + sizeof(int32). OR
- * use similar to other header routines use offset of data.
- */
-#define SVECHDRSIZE	(VARHDRSZ + sizeof(int32))
+#define SVECHDRSIZE	(offsetof(SvecType, data))
 /* Beginning of the serialized SparseData */
 #define SVEC_SDATAPTR(x)	((char *)(x)+SVECHDRSIZE)
 #define SVEC_SIZEOFSERIAL(x)	(SVECHDRSIZE+SIZEOF_SPARSEDATASERIAL((SparseData)SVEC_SDATAPTR(x)))


### PR DESCRIPTION
Style in accordance with the majority of HDRSIZE definitions

Removes a merge fixme
