### PR TITLE
gpinitstandby: rename -F to -S, and help users on single-host systems

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -590,6 +590,12 @@ def validate_standby_init(options, array, standby_datadir):
         logger.error('Data directory already exists on host %s' % options.standby_host)
         if array.standbyMaster:
             logger.error('If you want to just start the stopped standby, use the -n option')
+        if options.standby_host == array.master.hostname:
+            logger.error(
+                'If you want to initialize a new standby on the same host as '
+                'the master (not recommended), use -F and -P to specify a new '
+                'data directory and port'
+            )
         raise GpInitStandbyException('master data directory exists')
 
     # disallow to create the same host/port

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -116,7 +116,7 @@ def parseargs():
                       help='hostname of system to create standby master on')
     optgrp.add_option('-P', '--standby-port', type='int', dest='standby_port',
                       help='port of system to create standby master on')
-    optgrp.add_option('-F', '--standby-datadir', type='string', dest='standby_datadir',
+    optgrp.add_option('-S', '--standby-datadir', type='string', dest='standby_datadir',
                       help='datadir of standby master')
     optgrp.add_option('-n', '--no-update', action='store_true', dest='no_update',
                       help='do not update system catalog tables')
@@ -155,9 +155,9 @@ def parseargs():
         logger.error('Options -s and -n cannot be specified together.')
         parser.exit(2, None)
 
-    # -F and -n are exclusive
+    # -S and -n are exclusive
     if options.standby_datadir and options.no_update:
-        logger.error('Options -F and -n cannot be specified together.')
+        logger.error('Options -S and -n cannot be specified together.')
         parser.exit(2, None)
 
     # -s and -r are exclusive
@@ -593,7 +593,7 @@ def validate_standby_init(options, array, standby_datadir):
         if options.standby_host == array.master.hostname:
             logger.error(
                 'If you want to initialize a new standby on the same host as '
-                'the master (not recommended), use -F and -P to specify a new '
+                'the master (not recommended), use -S and -P to specify a new '
                 'data directory and port'
             )
         raise GpInitStandbyException('master data directory exists')

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1544,7 +1544,7 @@ CREATE_STANDBY_QD () {
 			INIT_STANDBY_ARGS+=" -P $STANDBY_PORT"
 		fi
 		if [ x"" != x"$STANDBY_DATADIR" ]; then
-			INIT_STANDBY_ARGS+=" -F $STANDBY_DATADIR"
+			INIT_STANDBY_ARGS+=" -S $STANDBY_DATADIR"
 		fi
 		if [ $HBA_HOSTNAMES -eq 1 ]; then
 		    INIT_STANDBY_ARGS+=" --hba-hostnames"

--- a/gpMgmt/doc/gpinitstandby_help
+++ b/gpMgmt/doc/gpinitstandby_help
@@ -9,7 +9,7 @@ SYNOPSIS
 
 gpinitstandby { -s <standby_hostname> [-P <port>] | -r | -n } 
 
-[-a] [-q] [-D] [-l <logfile_directory>]
+[-a] [-q] [-D] [-S <standby data directory>] [-l <logfile_directory>]
 
 gpinitstandby -? | -v
 
@@ -99,7 +99,16 @@ OPTIONS
  If the Greenplum Database standby master is on the same host as the 
  active master, the ports must be different. If the ports are the same 
  for the active and standby master and the host is the same, the utility 
- returns an error. 
+ returns an error. (See also -S.)
+
+
+-S <standby data directory>
+
+ The data directory to use for a new standby master. The default is the same
+ directory used by the active master.
+
+ If the standby master is on the same host as the active master, a different
+ directory must be provided using this option. (See also -P.)
 
 
 -q

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -8,6 +8,14 @@ Feature: Tests for gpinitstandby feature
         Then gpinitstandby should return a return code of 2
         And gpinitstandby should print "cannot create standby on the same host and port" to stdout
 
+    Scenario: gpinitstandby fails if given same host and datadir as master segment
+        Given the database is running
+          And the standby is not initialized
+         When the user initializes a standby on the same host as master and the same data directory
+         Then gpinitstandby should return a return code of 2
+          And gpinitstandby should print "master data directory exists" to stdout
+          And gpinitstandby should print "use -F and -P to specify a new data directory and port" to stdout
+
     Scenario: gpinitstandby exclude dirs
         Given the database is running
         And the standby is not initialized

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -14,7 +14,7 @@ Feature: Tests for gpinitstandby feature
          When the user initializes a standby on the same host as master and the same data directory
          Then gpinitstandby should return a return code of 2
           And gpinitstandby should print "master data directory exists" to stdout
-          And gpinitstandby should print "use -F and -P to specify a new data directory and port" to stdout
+          And gpinitstandby should print "use -S and -P to specify a new data directory and port" to stdout
 
     Scenario: gpinitstandby exclude dirs
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -637,7 +637,7 @@ def run_gpinitstandby(context, hostname, port, standby_data_dir, options='', rem
         # We do not set port nor data dir here to test gpinitstandby's ability to autogather that info
         cmd = "gpinitstandby -a -s %s" % hostname
     else:
-        cmd = "gpinitstandby -a -s %s -P %s -F %s" % (hostname, port, standby_data_dir)
+        cmd = "gpinitstandby -a -s %s -P %s -S %s" % (hostname, port, standby_data_dir)
 
     run_gpcommand(context, cmd + ' ' + options)
 
@@ -729,7 +729,7 @@ def impl(context):
         # We do not set port nor data dir here to test gpinitstandby's ability to autogather that info
         cmd = "gpinitstandby -a -s %s" % context.master_hostname
     else:
-        cmd = "gpinitstandby -a -s %s -P %s -F %s" % (context.master_hostname, context.master_port, master_data_dir)
+        cmd = "gpinitstandby -a -s %s -P %s -S %s" % (context.master_hostname, context.master_port, master_data_dir)
 
     context.execute_steps(u'''Then the user runs command "%s" from standby master''' % cmd)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -647,6 +647,14 @@ def impl(context):
     temp_data_dir = tempfile.mkdtemp() + "/standby_datadir"
     run_gpinitstandby(context, hostname, os.environ.get("PGPORT"), temp_data_dir)
 
+@when('the user initializes a standby on the same host as master and the same data directory')
+def impl(context):
+    hostname = get_master_hostname('postgres')[0][0]
+    master_port = int(os.environ.get("PGPORT"))
+
+    cmd = "gpinitstandby -a -s %s -P %d" % (hostname, master_port + 1)
+    run_gpcommand(context, cmd)
+
 @when('the user runs gpinitstandby with options "{options}"')
 @then('the user runs gpinitstandby with options "{options}"')
 @given('the user runs gpinitstandby with options "{options}"')


### PR DESCRIPTION
gpinitstandby's `-F` option (to override the new standby's data directory) came from the old filespace system. Since the option no longer has anything to do with filespaces, `-F` doesn't make much sense anymore. I've renamed it to `-S`; `-D` would have been better, but that's already in use.

Prompt the user to use this option, as well as `-P` to specify a new port, if a standby is being set up on the same host as the original master. This fixes #6617.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
