### PR TITLE
Add spacing for doc xrefs

### DIFF
--- a/gpdb-doc/dita/admin_guide/textsearch/dictionaries.xml
+++ b/gpdb-doc/dita/admin_guide/textsearch/dictionaries.xml
@@ -238,7 +238,7 @@ SELECT * FROM ts_debug('english', 'Paris');
         asterisk is ignored when the entry is used in
           <codeph>to_tsvector()</codeph>, but when it is used in
           <codeph>to_tsquery()</codeph>, the result will be a query item with
-        the prefix match marker (see<xref
+        the prefix match marker (see <xref
           href="controlling.xml#controlling/parsing-queries"/>). For example,
         suppose we have these entries in
           <codeph>$SHAREDIR/tsearch_data/synonym_sample.syn</codeph>:</p>

--- a/gpdb-doc/dita/best_practices/encryption.xml
+++ b/gpdb-doc/dita/best_practices/encryption.xml
@@ -15,7 +15,7 @@
           information about enabling SSL in Greenplum Database.</li>
         <li>Greenplum Database 4.2.1 and above allow SSL encryption of data in transit between the
           Greenplum parallel file distribution server, <codeph>gpfdist</codeph>, and segment hosts.
-            See<xref href="#topic_th5_5bf_jr/section_kjt_3kr_bs" format="dita"/>  for more
+            See <xref href="#topic_th5_5bf_jr/section_kjt_3kr_bs" format="dita"/> for more
           information. </li>
         <li>Network communications between hosts in the Greenplum Database cluster can be encrypted
           using IPsec. An authenticated, encrypted VPN is established between every pair of hosts in

--- a/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_container.xml
@@ -1438,7 +1438,7 @@ $$ LANGUAGE plcontainer;</codeblock></p>
           <li>The CentOS <codeph>extras</codeph> repository is accessible.</li>
           <li>The user has sudo privileges or is root.</li>
         </ul></p>
-      <p>See also the Docker site installation instructions for CentOS<xref
+      <p>See also the Docker site installation instructions for CentOS <xref
           href="https://docs.docker.com/engine/installation/linux/centos/" format="html"
           scope="external">https://docs.docker.com/engine/installation/linux/centos/</xref>. For a
         list of Docker commands, see the Docker engine Run Reference <xref

--- a/gpdb-doc/dita/ref_guide/sql_commands/COPY.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/COPY.xml
@@ -295,7 +295,7 @@ IGNORE EXTERNAL PARTITIONS</codeblock></p>
         </plentry>
         <plentry>
           <pt>CSV</pt>
-          <pd>Selects Comma Separated Value (CSV) mode. See<xref href="#topic1/section9"
+          <pd>Selects Comma Separated Value (CSV) mode. See <xref href="#topic1/section9"
               format="dita">CSV Format</xref>.</pd>
         </plentry>
         <plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
@@ -826,7 +826,7 @@ OFFSET <varname>start</varname></codeblock><p>where
             <codeph>UPDATE</codeph> operations on heap tables is <codeph>ROW EXCLUSIVE</codeph>. The
           Global Deadlock Detector is enabled by setting the <xref
             href="../config_params/guc-list.xml#gp_enable_global_deadlock_detector"
-            >gp_enable_global_deadlock_detector</xref> configuration parameter to true. See<xref
+            >gp_enable_global_deadlock_detector</xref> configuration parameter to true. See <xref
             href="../../admin_guide/dml.xml#topic_gdd"> Global Deadlock Detector</xref> in the
             <cite>Greenplum Database Administrator Guide</cite> for information about the Global
           Deadlock Detector.</note><p><codeph>FOR UPDATE</codeph> causes the rows accessed by the


### PR DESCRIPTION
Make sure there is whitespace before xref tags when used in normal text to avoid links squashed together with text. See http://docs-gpdb-6x.cfapps.io/6-0/ref_guide/sql_commands/COPY.html for an example of this (screenshot from that page below for convenience):

<img width="593" alt="screen shot 2019-03-08 at 15 36 36" src="https://user-images.githubusercontent.com/321790/54034760-02e71f80-41b8-11e9-89cc-e222c2d6912f.png">

