### PR TITLE
Fix typo in gpconfig variable name

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -32,8 +32,8 @@ def singleton_side_effect(unused1, unused2):
 class GpConfig(GpTestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
-        self.postgressql_conf = self.temp_dir + "/postgresql.conf"
-        with open(self.postgressql_conf, "w") as postgresql:
+        postgresql_conf = self.temp_dir + "/postgresql.conf"
+        with open(postgresql_conf, "w") as postgresql:
             postgresql.close()
 
         # because gpconfig does not have a .py extension,


### PR DESCRIPTION
While harmless, knowing it's there I can't unsee it.

Trivial change but since I don't know Python I prefer to see a pipeline run with it to ensure there is no magic being broken.. 