### PR TITLE
Align resource group ereports with style guide

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -622,7 +622,7 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("Cannot find limit capabilities for resource group: %d",
+				 errmsg("cannot find limit capabilities for resource group: %d",
 						groupId)));
 	}
 }
@@ -682,8 +682,8 @@ GetResGroupIdForRole(Oid roleid)
 		 */
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				errmsg("Role with Oid %d was dropped", roleid),
-				errhint("Cannot execute commands anymore, please terminate this session.")));
+				errmsg("role with Oid %d was dropped", roleid),
+				errdetail("Cannot execute commands anymore, please terminate this session.")));
 	}
 
 	/* must access tuple before systable_endscan */
@@ -784,8 +784,8 @@ ResGroupCheckForRole(Oid groupId)
 	if (caps.memAuditor == RESGROUP_MEMORY_AUDITOR_CGROUP)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("You cannot assign a role to this resource group because "
-					    "the memory_auditor property for this group is not the default.")));
+				 errmsg("you cannot assign a role to this resource group"),
+				 errdetail("The memory_auditor property for this group is not the default.")));
 
 	heap_close(pg_resgroupcapability_rel, AccessShareLock);
 }
@@ -981,7 +981,7 @@ checkResgroupMemAuditor(ResGroupCaps *caps)
 				(errcode(ERRCODE_GP_FEATURE_NOT_CONFIGURED),
 				 errmsg("cgroup is not properly configured for the 'cgroup' memory auditor"),
 				 errhint("Extra cgroup configurations are required to enable this feature, "
-						 "please refer to the Greenplum Documentations for details")));
+						 "please refer to the Greenplum Documentation for details")));
 	}
 }
 
@@ -1011,8 +1011,8 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		if (mask & (1 << type))
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					errmsg("Find duplicate resource group resource type: %s",
-						   defel->defname)));
+					 errmsg("found duplicate resource group resource type: %s",
+							defel->defname)));
 		else
 			mask |= 1 << type;
 
@@ -1359,7 +1359,8 @@ validateCapabilities(Relation rel,
 
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_OBJECT),
-					errmsg("Find duplicate resource group id:%d", groupid)));
+					 errmsg("found duplicate resource group id: %d",
+							groupid)));
 		}
 
 		typeDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_reslimittype,

--- a/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_alter_concurrency.out
@@ -672,8 +672,8 @@ DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
 61<:  <... completed>
-ERROR:  Role with Oid 213301 was dropped
-HINT:  Cannot execute commands anymore, please terminate this session.
+ERROR:  role with Oid 213301 was dropped
+DETAIL:  Cannot execute commands anymore, please terminate this session.
 61q: ... <quitting>
 
 -- cleanup

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -111,15 +111,15 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 ERROR:  must specify memory_limit
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
-ERROR:  Find duplicate resource group resource type: concurrency
+ERROR:  found duplicate resource group resource type: concurrency
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, cpu_rate_limit=5);
-ERROR:  Find duplicate resource group resource type: cpu_rate_limit
+ERROR:  found duplicate resource group resource type: cpu_rate_limit
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, memory_limit=5);
-ERROR:  Find duplicate resource group resource type: memory_limit
+ERROR:  found duplicate resource group resource type: memory_limit
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, memory_shared_quota=70, memory_shared_quota=80);
-ERROR:  Find duplicate resource group resource type: memory_shared_quota
+ERROR:  found duplicate resource group resource type: memory_shared_quota
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0', cpuset='0', memory_limit=5);
-ERROR:  Find duplicate resource group resource type: cpuset
+ERROR:  found duplicate resource group resource type: cpuset
 -- can't specify both cpu_rate_limit and cpuset
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, cpuset='0', memory_limit=5);
 ERROR:  can't specify both cpu_rate_limit and cpuset
@@ -489,6 +489,7 @@ ALTER RESOURCE GROUP cgroup_audited_group SET CONCURRENCY 10;
 ERROR:  resource group concurrency must be 0 when group memory_auditor is cgroup
 -- negative: role should not be assigned to a cgroup audited resource group
 CREATE ROLE cgroup_audited_role RESOURCE GROUP cgroup_audited_group;
-ERROR:  You cannot assign a role to this resource group because the memory_auditor property for this group is not the default.
+ERROR:  you cannot assign a role to this resource group
+DETAIL:  The memory_auditor property for this group is not the default.
 DROP RESOURCE GROUP cgroup_audited_group;
 DROP

--- a/src/test/isolation2/init_file_resgroup
+++ b/src/test/isolation2/init_file_resgroup
@@ -15,6 +15,6 @@ s/group [0-9]+ was/group OID was/
 m/^ERROR:  Out of memory  (seg\d slice\d \d+.\d+.\d+.\d+:\d+ pid=\d+)$/
 s/(seg\d+ slice\d+ \d+.\d+.\d+.\d+:\d+ pid=\d+)/(SEG SLICE ADDR:PORT pid=PID)/
 
-m/^ERROR:  Role with Oid \d+ was dropped$/
+m/^ERROR:  role with Oid \d+ was dropped$/
 s/Oid \d+ was/Oid OID was/
 -- end_matchsubs


### PR DESCRIPTION
Make sure all ereports() starts with a lowercase letter, and move longer explanations to errdetail/errhints. Also fix expected error output to match.
