### PR TITLE
Fix two log-rotation bugs.

### DIFF
--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -497,8 +497,7 @@ SysLoggerMain(int argc, char *argv[])
 		if (Log_RotationAge > 0 && !rotation_disabled)
 		{
 			/* Do a logfile rotation if it's time */
-			pg_time_t	now = (pg_time_t) time(NULL);
-
+			now = (pg_time_t) time(NULL);
 			if (now >= next_rotation_time)
 			{
 				rotation_requested = time_based_rotation = true;


### PR DESCRIPTION
_This is a reroll of #6348, after the 9.4_STABLE merge which changed the logging implementation. We feel confident that the approach still works correctly._

One bug that we've had at least since 5X, and another bug that was introduced into master with 9.2:

During time-based rotation of the log files, we'd create at least one extra log file that looked like it was from the future (e.g. at midnight on November 2nd you might see two log files created, `gpdb-2018-11-02_000000.csv` and `gpdb-2018-11-03_000000.csv`.) This was due to multiple calls to `set_next_rotation_time()`, which our first patch fixes. We're planning to backport this to 5X.

While manually testing that patch, we found that rotations still weren't happening when we expected them to -- they'd be delayed by a seemingly random but constant time. It turns out the wait delay was broken as part of the 9.2 merge, so we only rotated when receiving the periodic FTS logging information, not as part of an actual rotation wakeup. The second patch fixes that.

We (@jmcatamney and @jchampio) tried adding a TAP test for this, but it became a rabbit hole very quickly: because the bug doesn't reproduce except during a natural time-based log rotation (not `pg_rotate_logfile()` or similar), we'd have to write a test that waited a minute for that rotation, and then try to disambiguate between the actual bug and potential false negatives due to race conditions. We've decided to push this PR without it.

## Here are some reminders before you submit the pull request
- [ ] ~Add tests for the change~
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
