### PR TITLE
gpcheckcat: correctly display 'None' oids in summary

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -4558,7 +4558,7 @@ class RelationObject(GPObject):
         self.paroid = None
 
     def reportAllIssues(self):
-        oid = 'N/A' if self.oid is None else self.oid
+        oid = 'N/A' if self.oid is None else str(self.oid)
         nspname = 'N/A' if self.nspname is None else self.nspname
         relname = 'N/A' if self.relname is None else self.relname
 
@@ -4567,14 +4567,14 @@ class RelationObject(GPObject):
             myprint('----------------------------------------------------')
 
             objname = 'Type' if self.relkind == 'c' else 'Relation'
-            myprint('%s oid: %d' % (objname, oid))
+            myprint('%s oid: %s' % (objname, oid))
             myprint('%s schema: %s' % (objname, nspname))
             myprint('%s name: %s' % (objname, relname))
 
         else:
             myprint('    Sub-object: ')
             myprint('    ----------------------------------------------------')
-            myprint('    Relation oid: %d' % oid)
+            myprint('    Relation oid: %s' % oid)
             myprint('    Relation schema: %s' % nspname)
             myprint('    Relation name: %s' % relname)
         myprint('')

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -325,6 +325,17 @@ class GpCheckCatTestCase(GpTestCase):
         report_cfg = self.subject.getReportConfiguration()
         self.assertEqual("content -1", report_cfg[-1]['segname'])
 
+    def test_RelationObject_reportAllIssues_handles_None_fields(self):
+        uut = self.subject.RelationObject(None, 'pg_class')
+        uut.setRelInfo(relname=None, nspname=None, relkind='t', paroid=0)
+
+        uut.reportAllIssues()
+        log_messages = [args[0][1].strip() for args in self.subject.logger.log.call_args_list]
+
+        self.assertIn('Relation oid: N/A', log_messages)
+        self.assertIn('Relation schema: N/A', log_messages)
+        self.assertIn('Relation name: N/A', log_messages)
+
     ####################### PRIVATE METHODS #######################
 
     def _run_batch_size_experiment(self, num_primaries):


### PR DESCRIPTION
This is a backport of the bugfix from #6722 to 5X_STABLE.

The summary pane handled an oid of None by turning it into an 'N/A' string...
but then attempted to print that string as an integer. Always handle it as a
string.

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>
(cherry picked from commit 11685a93c2be506138105db077dcea28060171f8)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Communicate to Doc team for mentioning the bug fix in release notes
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
