### PR TITLE
Fix assert failure for copy to partition table

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3868,7 +3868,8 @@ CopyFrom(CopyState cstate)
 				MemSet(partNulls, true, relnatts * sizeof(bool));
 
 				reconstructTupleValues(map, baseValues, baseNulls, (int) num_phys_attrs,
-									   partValues, partNulls, (int) attr_count);
+									   partValues, partNulls,
+									   resultRelInfo->ri_resultSlot->tts_tupleDescriptor->natts);
 				ExecStoreVirtualTuple(slot);
 			}
 			else

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3868,8 +3868,7 @@ CopyFrom(CopyState cstate)
 				MemSet(partNulls, true, relnatts * sizeof(bool));
 
 				reconstructTupleValues(map, baseValues, baseNulls, (int) num_phys_attrs,
-									   partValues, partNulls,
-									   resultRelInfo->ri_resultSlot->tts_tupleDescriptor->natts);
+									   partValues, partNulls, relnatts);
 				ExecStoreVirtualTuple(slot);
 			}
 			else

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -8168,7 +8168,7 @@ select * from sales order by pkid;
 drop table sales cascade;
 NOTICE:  drop cascades to default for table newpart column pkid
 -- Exchage partiton table with a table having dropped column
-create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (1));
+create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (5));
 NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_1" for table "exchange_part"
 NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_2" for table "exchange_part"
 NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_3" for table "exchange_part"

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -8167,6 +8167,55 @@ select * from sales order by pkid;
 
 drop table sales cascade;
 NOTICE:  drop cascades to default for table newpart column pkid
+-- Exchage partiton table with a table having dropped column
+create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (1));
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_1" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_2" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_3" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_4" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_5" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_6" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_7" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_8" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_9" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_10" for table "exchange_part"
+create table exchange1(a int, c int, b int);
+alter table exchange1 drop column c;
+alter table exchange_part exchange partition for (1) with table exchange1;
+copy exchange_part from STDIN DELIMITER as '|';
+select * from exchange_part;
+  a   | b 
+------+---
+ 9797 | 3
+ 9799 | 4
+ 9801 | 5
+ 9836 | 5
+ 9802 | 6
+ 9840 | 6
+ 9803 | 7
+ 9822 | 7
+ 9806 | 8
+ 9824 | 8
+ 9807 | 9
+ 9794 | 1
+ 9808 | 1
+ 9810 | 2
+ 9828 | 2
+ 9831 | 3
+ 9817 | 5
+ 9818 | 6
+ 9843 | 7
+ 9844 | 8
+ 9825 | 9
+ 9827 | 1
+ 9795 | 2
+ 9814 | 3
+ 9815 | 4
+ 9832 | 4
+(26 rows)
+
+drop table exchange_part;
+drop table exchange1;
 -- Ensure that new partitions get the correct attributes (MPP17110)
 CREATE TABLE pt_tab_encode (a int, b text)
 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -8165,6 +8165,55 @@ select * from sales order by pkid;
 
 drop table sales cascade;
 NOTICE:  drop cascades to default for table newpart column pkid
+-- Exchage partiton table with a table having dropped column
+create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (1));
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_1" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_2" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_3" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_4" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_5" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_6" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_7" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_8" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_9" for table "exchange_part"
+NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_10" for table "exchange_part"
+create table exchange1(a int, c int, b int);
+alter table exchange1 drop column c;
+alter table exchange_part exchange partition for (1) with table exchange1;
+copy exchange_part from STDIN DELIMITER as '|';
+select * from exchange_part;
+  a   | b 
+------+---
+ 9797 | 3
+ 9799 | 4
+ 9801 | 5
+ 9836 | 5
+ 9802 | 6
+ 9840 | 6
+ 9803 | 7
+ 9822 | 7
+ 9806 | 8
+ 9824 | 8
+ 9807 | 9
+ 9794 | 1
+ 9808 | 1
+ 9810 | 2
+ 9828 | 2
+ 9831 | 3
+ 9817 | 5
+ 9818 | 6
+ 9843 | 7
+ 9844 | 8
+ 9825 | 9
+ 9827 | 1
+ 9795 | 2
+ 9814 | 3
+ 9815 | 4
+ 9832 | 4
+(26 rows)
+
+drop table exchange_part;
+drop table exchange1;
 -- Ensure that new partitions get the correct attributes (MPP17110)
 CREATE TABLE pt_tab_encode (a int, b text)
 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -8166,7 +8166,7 @@ select * from sales order by pkid;
 drop table sales cascade;
 NOTICE:  drop cascades to default for table newpart column pkid
 -- Exchage partiton table with a table having dropped column
-create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (1));
+create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (5));
 NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_1" for table "exchange_part"
 NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_2" for table "exchange_part"
 NOTICE:  CREATE TABLE will create partition "exchange_part_1_prt_3" for table "exchange_part"

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3912,7 +3912,7 @@ select * from sales order by pkid;
 drop table sales cascade;
 
 -- Exchage partiton table with a table having dropped column
-create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (1));
+create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (5));
 create table exchange1(a int, c int, b int);
 alter table exchange1 drop column c;
 alter table exchange_part exchange partition for (1) with table exchange1;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3911,6 +3911,42 @@ alter table sales exchange partition for (101) with table newpart2;
 select * from sales order by pkid;
 drop table sales cascade;
 
+-- Exchage partiton table with a table having dropped column
+create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (1));
+create table exchange1(a int, c int, b int);
+alter table exchange1 drop column c;
+alter table exchange_part exchange partition for (1) with table exchange1;
+copy exchange_part from STDIN DELIMITER as '|';
+9794 | 1
+9795 | 2
+9797 | 3
+9799 | 4
+9801 | 5
+9802 | 6
+9803 | 7
+9806 | 8
+9807 | 9
+9808 | 1
+9810 | 2
+9814 | 3
+9815 | 4
+9817 | 5
+9818 | 6
+9822 | 7
+9824 | 8
+9825 | 9
+9827 | 1
+9828 | 2
+9831 | 3
+9832 | 4
+9836 | 5
+9840 | 6
+9843 | 7
+9844 | 8
+\.
+select * from exchange_part;
+drop table exchange_part;
+drop table exchange1;
 -- Ensure that new partitions get the correct attributes (MPP17110)
 CREATE TABLE pt_tab_encode (a int, b text)
 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)


### PR DESCRIPTION
We have an assert failure for copy to partition table if root and child relation
have different attno. The root cause is that 'reconstructTupleValues'
has a wrong value of newNumAttrs lenth.

The pr resolve issue https://github.com/greenplum-db/gpdb/issues/7110
## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
