### PR TITLE
Expose WorkFileUsagePerQuery definition to match API

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -61,37 +61,6 @@
  */
 int			gp_workfile_max_entries = 8192;
 
-/*
- * Shared memory data structures.
- *
- * One workfile_set per workfile. Each workfile_set entry is owned by a backend.
- *
- * Per-query summary. These could be computed by scanning the workfile_set array,
- * but we keep a summary in a separate hash table so that we can quickly detect
- * if the per-query limit is exceeded. This is needed to enforce
- * gp_workfile_limit_files_per_query
- *
- * Local:
- *
- * In addition to the bookkeeping in shared memory, we keep an array in backend
- * private memory. The array is indexed by the virtual file descriptor, File.
- */
-
-typedef struct WorkFileUsagePerQuery
-{
-	/* hash key */
-	int32		session_id;
-	int32		command_count;
-
-	int32		refcount;		/* number of working sets */
-
-	int32		num_files;
-	uint64		total_bytes;
-
-	bool		active;
-
-} WorkFileUsagePerQuery;
-
 #define SizeOfWorkFileUsagePerQueryKey (2 * sizeof(int32));
 
 typedef struct workfile_set WorkFileSetSharedEntry;

--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -22,7 +22,36 @@
 
 #define WORKFILE_PREFIX_LEN		64
 
-typedef struct WorkFileUsagePerQuery WorkFileUsagePerQuery;
+/*
+ * Shared memory data structures.
+ *
+ * One workfile_set per workfile. Each workfile_set entry is owned by a backend.
+ *
+ * Per-query summary. These could be computed by scanning the workfile_set array,
+ * but we keep a summary in a separate hash table so that we can quickly detect
+ * if the per-query limit is exceeded. This is needed to enforce
+ * gp_workfile_limit_files_per_query
+ *
+ * Local:
+ *
+ * In addition to the bookkeeping in shared memory, we keep an array in backend
+ * private memory. The array is indexed by the virtual file descriptor, File.
+ */
+
+typedef struct WorkFileUsagePerQuery
+{
+	/* hash key */
+	int32		session_id;
+	int32		command_count;
+
+	int32		refcount;		/* number of working sets */
+
+	int32		num_files;
+	uint64		total_bytes;
+
+	bool		active;
+
+} WorkFileUsagePerQuery;
 
 typedef struct workfile_set
 {


### PR DESCRIPTION
Commit dfee2ff794dc2a exposed `workfile_mgr_cache_entries_get_copy()` which returns a structure containing `WorkFileUsagePerQuery` entries, but the definition of `WorkFileUsagePerQuery` was not make public. A forward declaration was placed in the workfile_mgr.h file but it suffered from a redefinition warning (in clang at least):
```
workfile_mgr.c:93:3: warning: redefinition of typedef 'WorkFileUsagePerQuery' is a C11 feature [-Wtypedef-redefinition]
} WorkFileUsagePerQuery;
  ^
../../../../src/include/utils/workfile_mgr.h:25:38: note: previous definition is here
typedef struct WorkFileUsagePerQuery WorkFileUsagePerQuery;
                                     ^
```
Fix by moving the `WorkFileUsagePerQuery` definition to the header from which is moved in f1ef3668a8f01a3. If we expose an API which returns data in the struct we need to also make the definition available to callers.

Also copy the documentation of the structs which after dfee2ff794dc2a wasn't making much sense as the definition of one documented member had moved to the header.

Ping @hlinnaka @zhangteng5513 : I'm not entirely sure what we want to do, but the warning is clearly correct and needs to be addressed, and exposing an opaque struct isn't nice. Thoughts?