### PR TITLE
Error out on out of memory in resource queue handling

### DIFF
--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -293,7 +293,11 @@ ResCreateQueue(Oid queueid, Cost limits[NUM_RES_LIMIT_TYPES], bool overcommit,
 	 */
 	
 	queue = ResQueueHashNew(queueid);
-	Assert(queue != NULL);
+	if (!queue)
+		ereport(ERROR,
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				 errmsg("out of shared memory"),
+				 errhint("You may need to increase max_resource_queues.")));
 	
 	/* Set queue oid and offset in the scheduler array */
 	queue->queueid = queueid;


### PR DESCRIPTION
If `ResQueueHashNew()` returns NULL it means that the processing ran out of memory and we need to error out. This is a situation which clearly can happen in production, so we need to upgrade the assert to a runtime check which properly errors out instead of fail on a subsequent NULL pointer dereference.
