### PR TITLE
WIP: Use strlcpy() instead of StrNCpy()

### DIFF
--- a/src/backend/access/transam/slru.c
+++ b/src/backend/access/transam/slru.c
@@ -231,7 +231,7 @@ SimpleLruInit(SlruCtl ctl, const char *name, int nslots, int nlsns,
 	 */
 	ctl->shared = shared;
 	ctl->do_fsync = true;		/* default behavior */
-	StrNCpy(ctl->Dir, subdir, sizeof(ctl->Dir));
+	strlcpy(ctl->Dir, subdir, sizeof(ctl->Dir));
 }
 
 /*

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1067,7 +1067,7 @@ StartPrepare(GlobalTransaction gxact)
 	hdr.nabortrels = smgrGetPendingDeletes(false, &abortrels);
 	hdr.ninvalmsgs = xactGetCommittedInvalidationMessages(&invalmsgs,
 														  &hdr.initfileinval);
-	StrNCpy(hdr.gid, gxact->gid, GIDSIZE);
+	strlcpy(hdr.gid, gxact->gid, GIDSIZE);
 
 	save_state_data(&hdr, sizeof(TwoPhaseFileHeader));
 

--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -159,20 +159,20 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 				case 'p':
 					/* %p: relative path of target file */
 					sp++;
-					StrNCpy(dp, xlogpath, endp - dp);
+					strlcpy(dp, xlogpath, endp - dp);
 					make_native_path(dp);
 					dp += strlen(dp);
 					break;
 				case 'f':
 					/* %f: filename of desired file */
 					sp++;
-					StrNCpy(dp, xlogfname, endp - dp);
+					strlcpy(dp, xlogfname, endp - dp);
 					dp += strlen(dp);
 					break;
 				case 'r':
 					/* %r: filename of last restartpoint */
 					sp++;
-					StrNCpy(dp, lastRestartPointFname, endp - dp);
+					strlcpy(dp, lastRestartPointFname, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':
@@ -367,7 +367,7 @@ ExecuteRecoveryCommand(char *command, char *commandName, bool failOnSignal)
 				case 'r':
 					/* %r: filename of last restartpoint */
 					sp++;
-					StrNCpy(dp, lastRestartPointFname, endp - dp);
+					strlcpy(dp, lastRestartPointFname, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -479,7 +479,7 @@ ChooseConstraintName(const char *name1, const char *name2,
 	conDesc = heap_open(ConstraintRelationId, AccessShareLock);
 
 	/* try the unmodified label first */
-	StrNCpy(modlabel, label, sizeof(modlabel));
+	strlcpy(modlabel, label, sizeof(modlabel));
 
 	for (;;)
 	{

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -8299,7 +8299,7 @@ ChooseConstraintNameForPartitionCreate(const char *rname,
 		cname = NULL;
 
 	/* try the unmodified label first */
-	StrNCpy(modlabel, label, sizeof(modlabel));
+	strlcpy(modlabel, label, sizeof(modlabel));
 
 	for (;;)
 	{

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -2017,7 +2017,7 @@ ChooseRelationNameWithCache(const char *name1, const char *name2,
 		elog(ERROR, "relation names cannot be chosen on QE");
 
 	/* try the unmodified label first */
-	StrNCpy(modlabel, label, sizeof(modlabel));
+	strlcpy(modlabel, label, sizeof(modlabel));
 
 	for (;;)
 	{

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -459,7 +459,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 			caps.memAuditor = value;
 			break;
 		case RESGROUP_LIMIT_TYPE_CPUSET:
-			StrNCpy(caps.cpuset, cpuset, sizeof(caps.cpuset));
+			strlcpy(caps.cpuset, cpuset, sizeof(caps.cpuset));
 			caps.cpuRateLimit = CPU_RATE_LIMIT_DISABLED;
 			break;
 		default:
@@ -609,7 +609,7 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 												   getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_CPUSET:
-				StrNCpy(resgroupCaps->cpuset, proposed, sizeof(resgroupCaps->cpuset));
+				strlcpy(resgroupCaps->cpuset, proposed, sizeof(resgroupCaps->cpuset));
 				break;
 			default:
 				break;
@@ -1020,7 +1020,7 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		{
 			const char *cpuset = defGetString(defel);
 			checkCpusetSyntax(cpuset);
-			StrNCpy(caps->cpuset, cpuset, sizeof(caps->cpuset));
+			strlcpy(caps->cpuset, cpuset, sizeof(caps->cpuset));
 			caps->cpuRateLimit = CPU_RATE_LIMIT_DISABLED;
 		}
 		else 
@@ -1244,7 +1244,7 @@ updateResgroupCapabilityEntry(Relation rel,
 
 	if (limitType == RESGROUP_LIMIT_TYPE_CPUSET)
 	{
-		StrNCpy(stringBuffer, strValue, sizeof(stringBuffer));
+		strlcpy(stringBuffer, strValue, sizeof(stringBuffer));
 	}
 	else
 	{

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -585,7 +585,7 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId, char relstorage, boo
 	 * Truncate relname to appropriate length (probably a waste of time, as
 	 * parser should have done this already).
 	 */
-	StrNCpy(relname, stmt->relation->relname, NAMEDATALEN);
+	strlcpy(relname, stmt->relation->relname, NAMEDATALEN);
 
 	/*
 	 * Check consistency of arguments
@@ -16833,7 +16833,7 @@ ATPExecPartRename(Relation rel,
 		targetrelation = relation_open(prule->topRule->parchildrelid,
 									   AccessExclusiveLock);
 
-		StrNCpy(targetrelname, RelationGetRelationName(targetrelation),
+		strlcpy(targetrelname, RelationGetRelationName(targetrelation),
 				NAMEDATALEN);
 
 		namespaceId = RelationGetNamespace(targetrelation);
@@ -16842,8 +16842,7 @@ ATPExecPartRename(Relation rel,
 
 		if (0 == prule->topRule->parparentoid)
 		{
-			StrNCpy(parentname,
-					RelationGetRelationName(rel), NAMEDATALEN);
+			strlcpy(parentname, RelationGetRelationName(rel), NAMEDATALEN);
 		}
 		else
 		{
@@ -16853,7 +16852,7 @@ ATPExecPartRename(Relation rel,
 				/* look in the parent prule */
 				parentrelation =
 					RelationIdGetRelation(par_prule->topRule->parchildrelid);
-				StrNCpy(parentname,
+				strlcpy(parentname,
 						RelationGetRelationName(parentrelation), NAMEDATALEN);
 				RelationClose(parentrelation);
 			}

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -851,7 +851,7 @@ cdb_define_pseudo_column(PlannerInfo   *root,
     rci->attr_width = width;
 
     /* If colname isn't unique, add suffix "_2", "_3", etc. */
-    StrNCpy(rci->colname, colname, sizeof(rci->colname));
+	strlcpy(rci->colname, colname, sizeof(rci->colname));
     for (i = 1;;)
     {
         CdbRelColumnInfo   *rci2;

--- a/src/backend/replication/slot.c
+++ b/src/backend/replication/slot.c
@@ -267,7 +267,7 @@ ReplicationSlotCreate(const char *name, bool db_specific,
 
 	/* first initialize persistent data */
 	memset(&slot->data, 0, sizeof(ReplicationSlotPersistentData));
-	StrNCpy(NameStr(slot->data.name), name, NAMEDATALEN);
+	strlcpy(NameStr(slot->data.name), name, NAMEDATALEN);
 	slot->data.database = db_specific ? MyDatabaseId : InvalidOid;
 	slot->data.persistency = persistency;
 

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -3237,7 +3237,7 @@ DCH_cache_getnew(char *str)
 #ifdef DEBUG_TO_FROM_CHAR
 		elog(DEBUG_elog_output, "OLD: '%s' AGE: %d", old->str, old->age);
 #endif
-		StrNCpy(old->str, str, DCH_CACHE_SIZE + 1);
+		strlcpy(old->str, str, DCH_CACHE_SIZE + 1);
 		/* old->format fill parser */
 		old->age = (++DCHCounter);
 		return old;
@@ -3248,7 +3248,7 @@ DCH_cache_getnew(char *str)
 		elog(DEBUG_elog_output, "NEW (%d)", n_DCHCache);
 #endif
 		ent = DCHCache + n_DCHCache;
-		StrNCpy(ent->str, str, DCH_CACHE_SIZE + 1);
+		strlcpy(ent->str, str, DCH_CACHE_SIZE + 1);
 		/* ent->format fill parser */
 		ent->age = (++DCHCounter);
 		++n_DCHCache;
@@ -3883,7 +3883,7 @@ NUM_cache_getnew(char *str)
 #ifdef DEBUG_TO_FROM_CHAR
 		elog(DEBUG_elog_output, "OLD: \"%s\" AGE: %d", old->str, old->age);
 #endif
-		StrNCpy(old->str, str, NUM_CACHE_SIZE + 1);
+		strlcpy(old->str, str, NUM_CACHE_SIZE + 1);
 		/* old->format fill parser */
 		old->age = (++NUMCounter);
 		ent = old;
@@ -3894,7 +3894,7 @@ NUM_cache_getnew(char *str)
 		elog(DEBUG_elog_output, "NEW (%d)", n_NUMCache);
 #endif
 		ent = NUMCache + n_NUMCache;
-		StrNCpy(ent->str, str, NUM_CACHE_SIZE + 1);
+		strlcpy(ent->str, str, NUM_CACHE_SIZE + 1);
 		/* ent->format fill parser */
 		ent->age = (++NUMCounter);
 		++n_NUMCache;

--- a/src/backend/utils/adt/nabstime.c
+++ b/src/backend/utils/adt/nabstime.c
@@ -132,7 +132,7 @@ abstime2tm(AbsoluteTime _time, int *tzp, struct pg_tm * tm, char **tzn)
 			 * Copy no more than MAXTZLEN bytes of timezone to tzn, in case it
 			 * contains an error message, which doesn't fit in the buffer
 			 */
-			StrNCpy(*tzn, tm->tm_zone, MAXTZLEN + 1);
+			strlcpy(*tzn, tm->tm_zone, MAXTZLEN + 1);
 			if (strlen(tm->tm_zone) > MAXTZLEN)
 				ereport(WARNING,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/backend/utils/adt/name.c
+++ b/src/backend/utils/adt/name.c
@@ -218,7 +218,7 @@ namestrcpy(Name name, const char *str)
 {
 	if (!name || !str)
 		return -1;
-	StrNCpy(NameStr(*name), str, NAMEDATALEN);
+	strlcpy(NameStr(*name), str, NAMEDATALEN);
 	return 0;
 }
 

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -1847,7 +1847,7 @@ pg_get_userbyid(PG_FUNCTION_ARGS)
 	if (HeapTupleIsValid(roletup))
 	{
 		role_rec = (Form_pg_authid) GETSTRUCT(roletup);
-		StrNCpy(NameStr(*result), NameStr(role_rec->rolname), NAMEDATALEN);
+		strlcpy(NameStr(*result), NameStr(role_rec->rolname), NAMEDATALEN);
 		ReleaseSysCache(roletup);
 	}
 	else

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -261,7 +261,7 @@ init_ps_display(const char *username, const char *dbname,
 	Assert(dbname);
 	Assert(host_info);
 
-	StrNCpy(ps_username, username, sizeof(ps_username));    /*CDB*/
+	strlcpy(ps_username, username, sizeof(ps_username));    /*CDB*/
 
 #ifndef PS_USE_NONE
 	/* no ps display for stand-alone backend */

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -974,7 +974,7 @@ readStr(Oid group, BaseType base,
 
 	readData(path, data, datasize);
 
-	StrNCpy(str, data, len);
+	strlcpy(str, data, len);
 }
 
 /*
@@ -1590,7 +1590,7 @@ ResGroupOps_AssignGroup(Oid group, ResGroupCaps *caps, int pid)
 	if (caps != NULL)
 	{
 		oldCaps.cpuRateLimit = caps->cpuRateLimit;
-		StrNCpy(oldCaps.cpuset, caps->cpuset, sizeof(oldCaps.cpuset));
+		strlcpy(oldCaps.cpuset, caps->cpuset, sizeof(oldCaps.cpuset));
 	}
 }
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -4006,7 +4006,7 @@ bool CpusetIsEmpty(const char *cpuset)
  */
 void SetCpusetEmpty(char *cpuset, int cpusetSize)
 {
-	StrNCpy(cpuset, DefaultCpuset, cpusetSize);
+	strlcpy(cpuset, DefaultCpuset, cpusetSize);
 }
 
 /*

--- a/src/common/exec.c
+++ b/src/common/exec.c
@@ -135,7 +135,7 @@ find_my_exec(const char *argv0, char *retpath)
 	if (first_dir_separator(argv0) != NULL)
 	{
 		if (is_absolute_path(argv0))
-			StrNCpy(retpath, argv0, MAXPGPATH);
+			strlcpy(retpath, argv0, MAXPGPATH);
 		else
 			join_path_components(retpath, cwd, argv0);
 		canonicalize_path(retpath);
@@ -174,7 +174,7 @@ find_my_exec(const char *argv0, char *retpath)
 			if (!endp)
 				endp = startp + strlen(startp); /* point to end */
 
-			StrNCpy(test_path, startp, Min(endp - startp + 1, MAXPGPATH));
+			strlcpy(test_path, startp, Min(endp - startp + 1, MAXPGPATH));
 
 			if (is_absolute_path(test_path))
 				join_path_components(retpath, test_path, argv0);

--- a/src/interfaces/ecpg/pgtypeslib/dt_common.c
+++ b/src/interfaces/ecpg/pgtypeslib/dt_common.c
@@ -1061,7 +1061,7 @@ abstime2tm(AbsoluteTime _time, int *tzp, struct tm * tm, char **tzn)
 			 * Copy no more than MAXTZLEN bytes of timezone to tzn, in case it
 			 * contains an error message, which doesn't fit in the buffer
 			 */
-			StrNCpy(*tzn, tm->tm_zone, MAXTZLEN + 1);
+			strlcpy(*tzn, tm->tm_zone, MAXTZLEN + 1);
 			if (strlen(tm->tm_zone) > MAXTZLEN)
 				tm->tm_isdst = -1;
 		}
@@ -1079,7 +1079,7 @@ abstime2tm(AbsoluteTime _time, int *tzp, struct tm * tm, char **tzn)
 			 * Copy no more than MAXTZLEN bytes of timezone to tzn, in case it
 			 * contains an error message, which doesn't fit in the buffer
 			 */
-			StrNCpy(*tzn, TZNAME_GLOBAL[tm->tm_isdst], MAXTZLEN + 1);
+			strlcpy(*tzn, TZNAME_GLOBAL[tm->tm_isdst], MAXTZLEN + 1);
 			if (strlen(TZNAME_GLOBAL[tm->tm_isdst]) > MAXTZLEN)
 				tm->tm_isdst = -1;
 		}


### PR DESCRIPTION
The StrNCpy() macro was introduced in commit edb58721b8f7fd76b5dfa (as strNcpy()) in 1997 when no safe and portable alternative to strncpy() existed. Since then, strlcpy() has become the de-facto API for copying a string with an guaranteed NUL termination of the target buffer. Replace all callsites, keeping the definition as it is a published API in c.h.

This PR changes several upstream codepaths, and will in case it's successful and interesting be submitted upstream first.