### PR TITLE
Bump ORCA version to 3.29.0, updating ICG expected files

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.28.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.29.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.28.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.29.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.28.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.29.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.28.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.29.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.28.0@gpdb/stable
+orca/v3.29.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.28.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.29.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -86,34 +86,34 @@ NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_4" for table "csq_t2"
 insert into csq_t1 select * from csq_t1_base;
 insert into csq_t2 select * from csq_t2_base;
 explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                 QUERY PLAN                                                                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1293.00 rows=1 width=8)
    Filter: (subplan)
    ->  Sort  (cost=0.00..431.00 rows=1 width=8)
          Sort Key: csq_t1.x
-         ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Partition Selector for csq_t1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
-                           Partitions selected:  4 (out of 4)
+                     ->  Partition Selector for csq_t1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                           Partitions selected: 4 (out of 4)
                      ->  Dynamic Table Scan on csq_t1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
    SubPlan 1
      ->  Result  (cost=0.00..431.00 rows=1 width=1)
            ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                 Filter: "ColRef_0022" = true
+                 Filter: (CASE WHEN (sum((CASE WHEN $0 <= csq_t2.x THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN csq_t2.x IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <= csq_t2.x THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
                        ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
                              ->  Result  (cost=0.00..431.00 rows=1 width=8)
                                    ->  Result  (cost=0.00..431.00 rows=1 width=4)
                                          Filter: csq_t2.y = $1
                                          ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                               ->  Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..431.00 rows=1 width=8)
+                                               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                                      ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
-                                                           ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=50 width=4)
-                                                                 Partitions selected:  4 (out of 4)
+                                                           ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                                                 Partitions selected: 4 (out of 4)
                                                            ->  Dynamic Table Scan on csq_t2 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
+ Settings:  optimizer_nestloop_factor=1; optimizer_segments=3
+ Optimizer status: PQO version 3.28.0
 (26 rows)
 
 select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
@@ -198,32 +198,32 @@ select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
 (20 rows)
 
 explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
-                                                                                                         QUERY PLAN                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..1293.04 rows=20 width=4)
-   ->  Result  (cost=0.00..1293.04 rows=10 width=4)
-         Filter: CASE WHEN NOT public.mrs_t1.x IS NULL THEN CASE WHEN "ColRef_0019" = "ColRef_0018" THEN NULL::boolean WHEN NOT "ColRef_0019" IS NULL THEN true ELSE false END ELSE NULL::boolean END OR public.mrs_t1.x < 5
-         ->  GroupAggregate  (cost=0.00..1293.03 rows=10 width=20)
-               Group By: public.mrs_t1.x, public.mrs_t1.ctid, public.mrs_t1.gp_segment_id
-               ->  Sort  (cost=0.00..1293.03 rows=10 width=30)
-                     Sort Key: public.mrs_t1.ctid, public.mrs_t1.gp_segment_id
-                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..1293.03 rows=10 width=30)
-                           Hash Key: public.mrs_t1.gp_segment_id
-                           ->  Result  (cost=0.00..1293.03 rows=10 width=30)
-                                 ->  GroupAggregate  (cost=0.00..1293.03 rows=10 width=30)
-                                       Group By: public.mrs_t1.x, public.mrs_t1.ctid, public.mrs_t1.gp_segment_id
-                                       ->  Nested Loop Left Join  (cost=0.00..1293.03 rows=210 width=18)
-                                             Join Filter: public.mrs_t1.x = "inner"."?column?" OR "inner"."?column?" IS NULL
-                                             ->  Sort  (cost=0.00..431.00 rows=10 width=14)
-                                                   Sort Key: public.mrs_t1.ctid, public.mrs_t1.gp_segment_id
-                                                   ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=10 width=14)
-                                             ->  Result  (cost=0.00..431.00 rows=30 width=8)
-                                                   ->  Materialize  (cost=0.00..431.00 rows=30 width=4)
-                                                         ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=30 width=4)
-                                                               ->  Result  (cost=0.00..431.00 rows=10 width=4)
-                                                                     ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=10 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
+                                                                                                                                                              QUERY PLAN                                                                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.03 rows=20 width=4)
+   ->  Result  (cost=0.00..1293.03 rows=7 width=4)
+         Filter: CASE WHEN (count((count("inner".ColRef_0017)))) > 0::bigint THEN CASE WHEN (pg_catalog.sum((sum((CASE WHEN (subselect_gp.mrs_t1.x = (subselect_gp.mrs_t1.x - 95)) IS NULL THEN 1 ELSE 0 END))))) = (count((count("inner".ColRef_0017)))) THEN NULL::boolean ELSE true END ELSE false END OR subselect_gp.mrs_t1.x < 5
+         ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=20)
+               Group By: subselect_gp.mrs_t1.x, subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
+               ->  Sort  (cost=0.00..1293.02 rows=7 width=30)
+                     Sort Key: subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.02 rows=7 width=30)
+                           Hash Key: subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
+                           ->  Result  (cost=0.00..1293.02 rows=7 width=30)
+                                 ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=30)
+                                       Group By: subselect_gp.mrs_t1.x, subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
+                                       ->  Result  (cost=0.00..1293.02 rows=56 width=19)
+                                             ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
+                                                   Join Filter: (subselect_gp.mrs_t1.x = (subselect_gp.mrs_t1.x - 95)) IS NOT FALSE
+                                                   ->  Sort  (cost=0.00..431.00 rows=7 width=14)
+                                                         Sort Key: subselect_gp.mrs_t1.ctid, subselect_gp.mrs_t1.gp_segment_id
+                                                         ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=14)
+                                                   ->  Result  (cost=0.00..431.00 rows=20 width=5)
+                                                         ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
+                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
+                                                                     ->  Table Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
+ Settings:  optimizer_nestloop_factor=1; optimizer_segments=3
+ Optimizer status: PQO version 3.28.0
 (24 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
@@ -379,24 +379,25 @@ select * from csq_d1;
 -- outer plan node is master-only and CSQ has distributed relation
 --
 explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- gather motion
-                                                                                                                                        QUERY PLAN                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1293.00 rows=1 width=4)
-   Filter: CASE WHEN NOT csq_m1.x IS NULL THEN CASE WHEN (sum((CASE WHEN csq_d1.x IS NULL THEN 1 ELSE 0 END))) = (count()) THEN NULL::boolean WHEN NOT (sum((CASE WHEN csq_d1.x IS NULL THEN 1 ELSE 0 END))) IS NULL THEN false ELSE true END ELSE NULL::boolean END OR csq_m1.x < (-100)
+   Filter: CASE WHEN (count("inner".ColRef_0016)) > 0::bigint THEN CASE WHEN (sum((CASE WHEN (csq_m1.x = csq_d1.x) IS NULL THEN 1 ELSE 0 END))) = (count("inner".ColRef_0016)) THEN NULL::boolean ELSE false END ELSE true END OR csq_m1.x < (-100)
    ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
          Group By: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-         ->  Sort  (cost=0.00..1293.00 rows=1 width=18)
+         ->  Sort  (cost=0.00..1293.00 rows=1 width=19)
                Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-               ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=1 width=18)
-                     Join Filter: csq_m1.x = csq_d1.x OR csq_d1.x IS NULL
-                     ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=1 width=14)
-                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                       ->  Table Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
-(15 rows)
+               ->  Result  (cost=0.00..1293.00 rows=1 width=19)
+                     ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=1 width=19)
+                           Join Filter: (csq_m1.x = csq_d1.x) IS NOT FALSE
+                           ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=1 width=14)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=5)
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                             ->  Table Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer_nestloop_factor=1; optimizer_segments=3
+ Optimizer status: PQO version 3.28.0
+(16 rows)
 
 select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
  x 
@@ -408,32 +409,33 @@ select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
 -- outer plan node is master-only and CSQ has distributed relation
 --
 explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- broadcast motion
-                                                                                                     QUERY PLAN                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..1293.00 rows=2 width=4)
+                                                                                                                                          QUERY PLAN                                                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
-         Filter: CASE WHEN NOT csq_d1.x IS NULL THEN CASE WHEN "ColRef_0018" = "ColRef_0017" THEN NULL::boolean WHEN NOT "ColRef_0018" IS NULL THEN false ELSE true END ELSE NULL::boolean END OR csq_d1.x < (-100)
+         Filter: CASE WHEN (count((count("inner".ColRef_0016)))) > 0::bigint THEN CASE WHEN (pg_catalog.sum((sum((CASE WHEN (csq_d1.x = csq_m1.x) IS NULL THEN 1 ELSE 0 END))))) = (count((count("inner".ColRef_0016)))) THEN NULL::boolean ELSE false END ELSE true END OR csq_d1.x < (-100)
          ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group By: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
                ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
                      Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..1293.00 rows=1 width=30)
-                           Hash Key: csq_d1.gp_segment_id
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
+                           Hash Key: csq_d1.ctid, csq_d1.gp_segment_id
                            ->  Result  (cost=0.00..1293.00 rows=1 width=30)
                                  ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
                                        Group By: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-                                       ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=3 width=18)
-                                             Join Filter: csq_d1.x = csq_m1.x OR csq_m1.x IS NULL
-                                             ->  Sort  (cost=0.00..431.00 rows=1 width=14)
-                                                   Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                                                   ->  Table Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                                             ->  Result  (cost=0.00..431.00 rows=5 width=8)
-                                                   ->  Materialize  (cost=0.00..431.00 rows=5 width=4)
-                                                         ->  Broadcast Motion 1:2  (slice1)  (cost=0.00..431.00 rows=9 width=4)
-                                                               ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
-(23 rows)
+                                       ->  Result  (cost=0.00..1293.00 rows=2 width=19)
+                                             ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
+                                                   Join Filter: (csq_d1.x = csq_m1.x) IS NOT FALSE
+                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+                                                         Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
+                                                         ->  Table Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
+                                                   ->  Result  (cost=0.00..431.00 rows=1 width=5)
+                                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                                               ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=3 width=4)
+                                                                     ->  Table Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer_nestloop_factor=1; optimizer_segments=3
+ Optimizer status: PQO version 3.28.0
+(24 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
  x 


### PR DESCRIPTION
* Bump ORCA version to 3.29.0

* ORCA: Updating subquery plans in ICG expected files

This change is needed for ORCA PR greenplum-db/gporca#449.
Some subquery plans changed in minor ways in the ICG test.

This is a backport of 258a49271d5204954c896ea578b30c684beb8c75

Co-authored-by: Chris Hajas <chajas@pivotal.io>