### PR TITLE
Fixed pip/python report error after `source greenplum_path.sh`

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -44,6 +44,7 @@ cat <<EOF
 #setup PYTHONHOME
 if [ -x \$GPHOME/ext/python/bin/python ]; then
     PYTHONHOME="\$GPHOME/ext/python"
+    export PYTHONHOME
 fi
 EOF
 
@@ -100,6 +101,5 @@ EOF
 
 cat <<EOF
 export PYTHONPATH
-export PYTHONHOME
 EOF
 


### PR DESCRIPTION
If no python in $GPHOME/ext/python/bin/python, $PYTHONHOME will be set
to empty string, which make python env wrong.

```
➜  [/Users/gpadmin/workspace/install/gpdb] source greenplum_path.sh
➜  [/Users/gpadmin/workspace/install/gpdb] env | grep PYTHON
PYTHONPATH=/Users/gpadmin/workspace/gpdb/../install/gpdb/lib/python
PYTHONHOME=
➜  [/Users/gpadmin/workspace/install/gpdb] pip
ImportError: No module named site
```

Signed-off-by: Tingfang Bao <bbao@pivotal.io>