### PR TITLE
Doc updates for removal of filespaces.

### DIFF
--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
@@ -148,7 +148,7 @@
           <pd>Specifies the name of the expansion configuration file, which contains one line for
             each segment to be added in the format of:</pd>
           <pd>
-            <varname>hostname:address:port:fselocation:dbid:content:preferred_role:replication_port</varname>
+            <varname>hostname:address:port:datadir:dbid:content:preferred_role</varname>
           </pd>
         </plentry>
         <plentry>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitstandby.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitstandby.xml
@@ -8,8 +8,8 @@
         <p>Adds and/or initializes a standby master host for a Greenplum Database system.</p>
         <section id="section2">
             <title>Synopsis</title>
-            <codeblock><b>gpinitstandby</b> { <b>-s</b> <varname>standby_hostname</varname> [<b>-P</b> port] | <b>-r</b> | <b>-n</b> } 
-      [<b>-a</b>] [<b>-q</b>] [<b>-D</b>] [<b>-l</b> <varname>logfile_directory</varname>]
+            <codeblock><b>gpinitstandby</b> { <b>-s</b> <varname>standby_hostname</varname> [<b>-P</b> port] | <b>-r</b> | <b>-n</b> } [<b>-a</b>] [<b>-q</b>] 
+    [<b>-D</b>] [<b>-S</b> <varname>standby_data_directory</varname>] [<b>-l</b> <varname>logfile_directory</varname>]
 
 <b>gpinitstandby</b> <b>-v</b> 
 
@@ -17,39 +17,39 @@
         </section>
         <section id="section3">
             <title>Description</title>
-            <p>The <codeph>gpinitstandby</codeph> utility adds a backup, standby master host to your
-                Greenplum Database system. If your system has an existing standby master host
-                configured, use the <codeph>-r</codeph> option to remove it before adding the new
-                standby master host. </p>
+            <p>The <codeph>gpinitstandby</codeph> utility adds a backup, standby master instance to
+                your Greenplum Database system. If your system has an existing standby master
+                instance configured, use the <codeph>-r</codeph> option to remove it before adding
+                the new standby master instance. </p>
             <p>Before running this utility, make sure that the Greenplum Database software is
                 installed on the standby master host and that you have exchanged SSH keys between
                 the hosts. It is recommended that the master port is set to the same port number on
-                the master host and the backup master host. </p>
+                the master host and the standby master host. </p>
             <p>This utility should be run on the currently active <i>primary</i> master host.<ph>
                     See the <i>Greenplum Database Installation Guide</i> for instructions.</ph></p>
             <p>The utility performs the following steps:</p>
             <ul>
                 <li id="js138559">Updates the Greenplum Database system catalog to remove the
-                    existing standby master host information (if the <codeph>-r</codeph> option is
+                    existing standby master information (if the <codeph>-r</codeph> option is
                     supplied) </li>
                 <li id="js138555">Updates the Greenplum Database system catalog to add the new
-                    standby master host information </li>
+                    standby master instance information </li>
                 <li id="js138431">Edits the <codeph>pg_hba.conf</codeph> file of the Greenplum
-                    Database master to allow access from the newly added standby master.</li>
+                    Database master to allow access from the newly added standby master</li>
                 <li id="js137684">Sets up the standby master instance on the alternate master
                     host</li>
                 <li id="js137686">Starts the synchronization process</li>
             </ul>
-            <p>A backup, standby master host serves as a 'warm standby' in the event of the primary
-                master host becoming non-operational. The standby master is kept up to date by
+            <p>A backup, standby master instance serves as a 'warm standby' in the event of the
+                primary master becoming non-operational. The standby master is kept up to date by
                 transaction log replication processes (the <codeph>walsender</codeph> and
                     <codeph>walreceiver</codeph>), which run on the primary master and standby
-                master hosts and keep the data between the primary and standby master hosts
+                master hosts and keep the data between the primary and standby master instances
                 synchronized. If the primary master fails, the log replication process is shut down,
                 and the standby master can be activated in its place by using the
                     <codeph>gpactivatestandby</codeph> utility. Upon activation of the standby
-                master, the replicated logs are used to reconstruct the state of the master host at
-                the time of the last successfully committed transaction. </p>
+                master, the replicated logs are used to reconstruct the state of the master instance
+                at the time of the last successfully committed transaction.</p>
             <p>The activated standby master effectively becomes the Greenplum Database master,
                 accepting client connections on the master port and performing normal master
                 operations such as SQL command processing and resource management. </p>
@@ -60,7 +60,7 @@
                 contains log files that can help in determining the reason for the failure.<p>If an
                     initialization failure occurs, a summary report file is generated in the standby
                     host directory <codeph>/tmp</codeph>. The report file lists the directories on
-                    standby host that require clean up.</p></note>
+                    the standby host that require clean up.</p></note>
         </section>
         <section id="section4">
             <title>Options</title>
@@ -100,7 +100,7 @@
                 </plentry>
                 <plentry>
                     <pt>-r (remove standby master)</pt>
-                    <pd>Removes the currently configured standby master host from your Greenplum
+                    <pd>Removes the currently configured standby master instance from your Greenplum
                         Database system.</pd>
                 </plentry>
                 <plentry>
@@ -108,8 +108,15 @@
                     <pd>The host name of the standby master host.</pd>
                 </plentry>
                 <plentry>
+                    <pt>-S <varname>standby_data_directory</varname></pt>
+                    <pd>The data directory to use for a new standby master. The default is the same
+                        directory used by the active master.</pd>
+                    <pd>If the standby master is on the same host as the active master, a different
+                        directory must be specified using this option.</pd>
+                </plentry>
+                <plentry>
                     <pt>-v (show utility version)</pt>
-                    <pd>Displays the version, status, last updated date, and check sum of this
+                    <pd>Displays the version, status, last updated date, and checksum of this
                         utility.</pd>
                 </plentry>
                 <plentry>
@@ -120,19 +127,21 @@
         </section>
         <section id="section5">
             <title>Examples</title>
-            <p>Add a standby master host to your Greenplum Database system and start the
+            <p>Add a standby master instance to your Greenplum Database system and start the
                 synchronization process:</p>
             <codeblock>gpinitstandby -s host09</codeblock>
-            <p>Start an existing standby master host and synchronize the data with the current
-                primary master host:</p>
+            <p>Start an existing standby master instance and synchronize the data with the current
+                primary master instance:</p>
             <codeblock>gpinitstandby -n</codeblock>
             <note type="note">Do not specify the -n and -s options in the same command.</note>
-            <p>Add a standby master host to your Greenplum Database system specifying a different
-                port:</p>
+            <p>Add a standby master instance to your Greenplum Database system specifying a
+                different port:</p>
             <codeblock>gpinitstandby -s myhost -P 2222</codeblock>
             <p>If you specify the same host name as the active Greenplum Database master, the
                 installed Greenplum Database software that is used as a standby master must be in a
-                separate location from the active Greenplum Database master. </p>
+                separate location from the active Greenplum Database master. You must also specify a
+                different port number with the <codeph>-P</codeph> option and a standby data
+                directory with the <codeph>-S</codeph> option. </p>
             <p>Remove the existing standby master from your Greenplum system configuration:</p>
             <codeblock>gpinitstandby -r</codeblock>
         </section>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitstandby.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitstandby.xml
@@ -137,11 +137,9 @@
             <p>Add a standby master instance to your Greenplum Database system specifying a
                 different port:</p>
             <codeblock>gpinitstandby -s myhost -P 2222</codeblock>
-            <p>If you specify the same host name as the active Greenplum Database master, the
-                installed Greenplum Database software that is used as a standby master must be in a
-                separate location from the active Greenplum Database master. You must also specify a
-                different port number with the <codeph>-P</codeph> option and a standby data
-                directory with the <codeph>-S</codeph> option. </p>
+            <p>If you specify the same host name as the active Greenplum Database master, you must
+                also specify a different port number with the <codeph>-P</codeph> option and a
+                standby data directory with the <codeph>-S</codeph> option. </p>
             <p>Remove the existing standby master from your Greenplum system configuration:</p>
             <codeblock>gpinitstandby -r</codeblock>
         </section>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
@@ -239,17 +239,19 @@
                 </plentry>
                 <plentry>
                     <pt>-P <varname>standby_master_port</varname></pt>
-                    <pd>Optional. If you configure a standby master instance with
-                            <codeph>-s</codeph>, specify its port number using this option. The
-                        Greenplum Database software must already be installed and configured on the
+                    <pd>If you configure a standby master instance with <codeph>-s</codeph>, specify
+                        its port number using this option. The default port is the same as the
+                        master port. To run the standby and master on the same host, you must use
+                        this option to specify a different port for the standby. The Greenplum
+                        Database software must already be installed and configured on the standby
                         host.</pd>
                 </plentry>
                 <plentry>
                     <pt>-F <varname>standby_master_datadir</varname></pt>
-                    <pd>Optional. If you configure a standby master host with <codeph>-s</codeph>,
-                        use this option to specify its data directory. If you configure a standby on
-                        the same host as the master instance, the master and standby must have
-                        separate data directories.</pd>
+                    <pd>If you configure a standby master host with <codeph>-s</codeph>, use this
+                        option to specify its data directory. If you configure a standby on the same
+                        host as the master instance, the master and standby must have separate data
+                        directories.</pd>
                 </plentry>
                 <plentry>
                     <pt>--su_password=<varname>superuser_password</varname> | -e

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
@@ -13,7 +13,8 @@
             [<b>-h</b> <varname>hostfile_gpinitsystem</varname>]
             [<b>-B</b> <varname>parallel_processes</varname>] 
             [<b>-p</b> <varname>postgresql_conf_param_file</varname>]
-            [<b>-s</b> <varname>standby_master_host</varname> [<b>-P</b> <varname>standby_master_port</varname>]
+            [<b>-s</b> <varname>standby_master_host</varname> 
+                [<b>-P</b> <varname>standby_master_port</varname>] [-F <varname>standby_master_datadir</varname>]]
             [<b>-m</b> <varname>number</varname> | <b>--max_connections</b>=<varname>number</varname>]
             [<b>-b</b> <varname>size</varname> | <b>--shared_buffers</b>=<varname>size</varname>]
             [<b>-n <varname>locale</varname> | --locale</b>=<varname>locale</varname>] [<b>--lc-collate</b>=<varname>locale</varname>] 
@@ -232,15 +233,23 @@
                 </plentry>
                 <plentry>
                     <pt>-s <varname>standby_master_host</varname></pt>
-                    <pd>Optional. If you wish to configure a backup master host, specify the host
-                        name using this option. The Greenplum Database software must already be
+                    <pd>Optional. If you wish to configure a backup master instance, specify the
+                        host name using this option. The Greenplum Database software must already be
                         installed and configured on this host.</pd>
                 </plentry>
                 <plentry>
                     <pt>-P <varname>standby_master_port</varname></pt>
-                    <pd>Optional. If you configure a standby master host, specify its port number
-                        using this option. The Greenplum Database software must already be installed
-                        and configured on this host.</pd>
+                    <pd>Optional. If you configure a standby master instance with
+                            <codeph>-s</codeph>, specify its port number using this option. The
+                        Greenplum Database software must already be installed and configured on the
+                        host.</pd>
+                </plentry>
+                <plentry>
+                    <pt>-F <varname>standby_master_datadir</varname></pt>
+                    <pd>Optional. If you configure a standby master host with <codeph>-s</codeph>,
+                        use this option to specify its data directory. If you configure a standby on
+                        the same host as the master instance, the master and standby must have
+                        separate data directories.</pd>
                 </plentry>
                 <plentry>
                     <pt>--su_password=<varname>superuser_password</varname> | -e


### PR DESCRIPTION
Changes to utility refs for #4314 and #7116

- Removes references to filespaces
- Allow configuring standby and master on the same host (options to specify host, port, data directory)
- Standy master dir is specified with -F (gpinitsystem) or -S (gpinitstandby)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
