### PR TITLE
gpconfig: Add support for empty-string values

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -88,19 +88,19 @@ def validate_mutual_options(options):
         log_and_raise("'--file' option and '--file-compare' option cannot be used together")
     if options.file and "MASTER_DATA_DIRECTORY" not in os.environ:
         log_and_raise("--file option requires that MASTER_DATA_DIRECTORY be set")
-    if options.remove and (options.value or options.primaryvalue or options.mirrorvalue or options.mastervalue):
+    if options.remove and (options.value is not None or options.primaryvalue is not None or options.mirrorvalue is not None or options.mastervalue is not None):
         log_and_raise("remove action does not take a value, primary value, mirror value or master value parameter")
     if options.change and options.remove:
         log_and_raise("Multiple actions specified.  See the --help info.")
-    if options.change and (not options.value and (not options.mirrorvalue and not options.primaryvalue)):
+    if options.change and (options.value is None and options.mirrorvalue is None and options.primaryvalue is None):
         log_and_raise("change requested but value not specified")
-    if options.change and options.mastervalue and options.masteronly:
+    if options.change and options.mastervalue is not None and options.masteronly:
         log_and_raise("when changing a parameter on the master only specify the --value not --mastervalue")
-    if options.change and (options.value and (options.primaryvalue or options.mirrorvalue)):
+    if options.change and (options.value is not None and (options.primaryvalue is not None or options.mirrorvalue is not None)):
         log_and_raise("cannot use both value option and primaryvalue/mirrorvalue option")
-    if (options.masteronly or options.mastervalue) and options.entry in SAMEVALUE_GUCS:
+    if (options.masteronly or options.mastervalue is not None) and options.entry in SAMEVALUE_GUCS:
         log_and_raise("%s value cannot be different on master and segments" % options.entry)
-    if options.value and (not options.mastervalue):
+    if options.value is not None and options.mastervalue is None:
         options.mastervalue = options.value
 
 
@@ -355,17 +355,27 @@ def do_change(options):
     pool.haltWork()
     pool.joinWorkers()
 
-    params = " ".join(sys.argv[1:])
+    # Replace literal empty strings with empty quotes, or it will look like the
+    # user passed in an incorrect argument, which would be misleading
+    params = [pipes.quote(arg) for arg in sys.argv[1:]]
+    params = " ".join(params)
     if failure:
         LOGGER.error("finished with errors, parameter string '%s'" % params)
     else:
         LOGGER.info("completed successfully with parameters '%s'" % params)
 
 
+# If the value is a string, escape and single-quote it as per the behavior of
+# the quote_literal() function in Postgres.
 def quote_string(guc, value):
-    if value and guc and guc.vartype == "string":
-        if not value.startswith("'") and not value.endswith("'"):
-            value = "'" + value + "'"
+    if value is not None and guc and guc.vartype == "string":
+        # Remove any existing single-quoting
+        if len(value) > 2 and value[0] == "'" and value[-1] == "'":
+            value = value[1:-1]
+        # Escape single quotes and backslashes
+        value = value.replace("'", "''").replace("\\", "\\\\")
+        # Single-quote the whole string
+        value  = "'" + value + "'"
     return value
 
 

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -14,3 +14,15 @@ Feature: gpconfig integration tests
         Then gpconfig should print "Master[\s]*value: 129MB" to stdout
         # TODO verify all segments also have this string
 
+    Scenario: gpconfig with an empty string passed as a value
+        # As above, two calls to gpconfig -c are needed to guarantee a change.
+        Given the user runs "gpconfig -c unix_socket_directories -v 'foo'"
+        Then gpconfig should return a return code of 0
+        Given the user runs "gpconfig -c unix_socket_directories -v ''"
+        Then gpconfig should return a return code of 0
+        Then verify that the last line of the master postgres configuration file contains the string "unix_socket_directories=''"
+        Given the user runs "gpconfig -s unix_socket_directories --file"
+        Then gpconfig should return a return code of 0
+        Then gpconfig should print "Master[\s]*value: ''" to stdout
+        # TODO verify all segments also have this string
+

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -8,11 +8,12 @@ Feature: gpconfig integration tests
         Then gpconfig should return a return code of 0
         Given the user runs "gpconfig -c statement_mem -v 129MB"
         Then gpconfig should return a return code of 0
-        Then verify that the last line of the master postgres configuration file contains the string "129MB"
+        Then verify that the last line of the file "postgresql.conf" in the master data directory contains the string "129MB"
+        Then verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "129MB"
         Given the user runs "gpconfig -s statement_mem --file"
         Then gpconfig should return a return code of 0
         Then gpconfig should print "Master[\s]*value: 129MB" to stdout
-        # TODO verify all segments also have this string
+        Then gpconfig should print "Segment[\s]*value: 129MB" to stdout
 
     Scenario: gpconfig with an empty string passed as a value
         # As above, two calls to gpconfig -c are needed to guarantee a change.
@@ -20,9 +21,10 @@ Feature: gpconfig integration tests
         Then gpconfig should return a return code of 0
         Given the user runs "gpconfig -c unix_socket_directories -v ''"
         Then gpconfig should return a return code of 0
-        Then verify that the last line of the master postgres configuration file contains the string "unix_socket_directories=''"
+        Then verify that the last line of the file "postgresql.conf" in the master data directory contains the string "unix_socket_directories=''"
+        Then verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "unix_socket_directories=''"
         Given the user runs "gpconfig -s unix_socket_directories --file"
         Then gpconfig should return a return code of 0
         Then gpconfig should print "Master[\s]*value: ''" to stdout
-        # TODO verify all segments also have this string
+        Then gpconfig should print "Segment[\s]*value: ''" to stdout
 


### PR DESCRIPTION
Previously, gpconfig would not allow setting a GUC to a value of empty string (that is, `gpconfig -c guc_name -v ''` or the like) because it conflated passing an empty string with not setting the flag at all, so this commit fixes that and ensures that empty-string values print nicely.