### PR TITLE
gpaddmirrors increase error message clarity

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -376,8 +376,8 @@ class GpMirrorListToBuild:
                 dbid = segment.getSegmentDbId()
                 if port in usedPorts:
                     raise Exception(
-                        "On host %s, port %s for segment with dbid %s conflicts with port for segment dbid %s" %
-                        (hostName, port, dbid, usedPorts.get(port)))
+                        "Segment dbid's %s and %s on host %s cannot have the same port %s." %
+                        (dbid, usedPorts.get(port), hostName, port))
 
                 usedPorts[port] = dbid
 
@@ -386,9 +386,8 @@ class GpMirrorListToBuild:
 
                 if path in usedDataDirectories:
                     raise Exception(
-                        "On host %s, data directory for segment with dbid %s conflicts with "
-                        "data directory for segment dbid %s; directory: %s" %
-                        (hostName, dbid, usedDataDirectories.get(path), path))
+                        "Segment dbid's %s and %s on host %s cannot have the same data directory '%s'." %
+                        (dbid, usedDataDirectories.get(path), hostName, path))
                 usedDataDirectories[path] = dbid
 
     def __runWaitAndCheckWorkerPoolForErrorsAndClear(self, cmds, actionVerb, suppressErrorCheck=False):

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -177,7 +177,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         gpArray = GpArray([self.master, self.primary])
 
-        with self.assertRaisesRegexp(Exception, r'On host samehost, port 1111 for segment with dbid 2 conflicts with port for segment dbid 1'):
+        with self.assertRaisesRegexp(Exception, r"Segment dbid's 2 and 1 on host samehost cannot have the same port 1111."):
             self.buildMirrorSegs.checkForPortAndDirectoryConflicts(gpArray)
 
     def test_checkForPortAndDirectoryConflicts__given_the_same_host_checks_data_directories_differ(self):
@@ -189,7 +189,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         gpArray = GpArray([self.master, self.primary])
 
-        with self.assertRaisesRegexp(Exception, r'On host samehost, data directory for segment with dbid 2 conflicts with data directory for segment dbid 1; directory: \/data'):
+        with self.assertRaisesRegexp(Exception, r"Segment dbid's 2 and 1 on host samehost cannot have the same data directory '/data'."):
             self.buildMirrorSegs.checkForPortAndDirectoryConflicts(gpArray)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR is for 6X _before_ backporting a similar fix to 5x.

Specifically, while on 5X gpaddmirrors can raise the following exception:
`Exception: On host example.com, replication port 27 for segment with dbid 9004 conflicts with a port for segment dbid 26`. Where the port and dbid values got swapped, and the exception could be better worded.

This commit adds tests while making the error messages more clear and concise before backporting to 5X (which will require a few more tests).
