### PR TITLE
Retire PlannerConfig::cdbpath_segments

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -1066,14 +1066,14 @@ make_one_stage_agg_plan(PlannerInfo *root,
 			result_plan = (Plan *) make_motion_gather_to_QE(root, result_plan, current_pathkeys);
 			result_plan->total_cost +=
 				incremental_motion_cost(result_plan->plan_rows,
-										result_plan->plan_rows * root->config->cdbpath_segments);
+										result_plan->plan_rows * result_plan->flow->numsegments);
 			break;
 
 		case MPP_GRP_PREP_FOCUS_QD:
 			result_plan = (Plan *) make_motion_gather_to_QD(root, result_plan, current_pathkeys);
 			result_plan->total_cost +=
 				incremental_motion_cost(result_plan->plan_rows,
-										result_plan->plan_rows * root->config->cdbpath_segments);
+										result_plan->plan_rows * result_plan->flow->numsegments);
 			break;
 
 		case MPP_GRP_PREP_HASH_DISTINCT:
@@ -1500,7 +1500,7 @@ make_two_stage_agg_plan(PlannerInfo *root,
 			result_plan = (Plan *) make_motion_gather_to_QE(root, result_plan, NULL);
 			result_plan->total_cost +=
 				incremental_motion_cost(result_plan->plan_rows,
-										result_plan->plan_rows * root->config->cdbpath_segments);
+										result_plan->plan_rows * result_plan->flow->numsegments);
 			break;
 
 		case MPP_GRP_TYPE_NONE:
@@ -2303,7 +2303,7 @@ make_plan_for_one_dqa(PlannerInfo *root, MppGroupContext *ctx, int dqa_index,
 		result_plan = (Plan *) make_motion_gather_to_QE(root, result_plan, NULL);
 		result_plan->total_cost +=
 			incremental_motion_cost(result_plan->plan_rows,
-									result_plan->plan_rows * root->config->cdbpath_segments);
+									result_plan->plan_rows * result_plan->flow->numsegments);
 	}
 
 	result_plan = add_second_stage_agg(root,
@@ -4852,8 +4852,8 @@ cost_1phase_aggregation(PlannerInfo *root, MppGroupContext *ctx, AggPlanInfo *in
 		case MPP_GRP_PREP_FOCUS_QD:
 			input_dummy.total_cost +=
 				incremental_motion_cost(input_dummy.plan_rows,
-										input_dummy.plan_rows * root->config->cdbpath_segments);
-			input_dummy.plan_rows = input_dummy.plan_rows * root->config->cdbpath_segments;
+										input_dummy.plan_rows * CdbPathLocus_NumSegments(info->input_path->locus));
+			input_dummy.plan_rows = input_dummy.plan_rows * CdbPathLocus_NumSegments(info->input_path->locus);
 			break;
 		default:
 			break;
@@ -5058,7 +5058,7 @@ cost_2phase_aggregation(PlannerInfo *root, MppGroupContext *ctx, AggPlanInfo *in
 		case MPP_GRP_TYPE_PLAIN_2STAGE: /* Gather */
 			input_dummy.total_cost +=
 				incremental_motion_cost(input_dummy.plan_rows,
-										input_dummy.plan_rows * root->config->cdbpath_segments);
+										input_dummy.plan_rows * CdbPathLocus_NumSegments(info->input_path->locus));
 			break;
 		default:
 			ereport(ERROR,

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -52,8 +52,7 @@ cdbpath_cost_motion(PlannerInfo *root, CdbMotionPath *motionpath)
 	double		sendrows;
 
 	if (CdbPathLocus_IsReplicated(motionpath->path.locus))
-		/* FIXME: should use other.numsegments instead of cdbpath_segments */
-		motionpath->path.rows = subpath->rows * root->config->cdbpath_segments;
+		motionpath->path.rows = subpath->rows * CdbPathLocus_NumSegments(motionpath->path.locus);
 	else
 		motionpath->path.rows = subpath->rows;
 

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1177,6 +1177,19 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			 */
 			scaleFactor = 1.0;
 		}
+		else if (plan->flow != NULL && CdbPathLocus_IsSegmentGeneral(*(plan->flow)))
+		{
+			/* Replicated table has full data on every segment */
+			scaleFactor = 1.0;
+		}
+		else if (plan->flow != NULL && es->pstmt->planGen == PLANGEN_PLANNER)
+		{
+			/*
+			 * The plan node is executed on multiple nodes, so scale down the
+			 * number of rows seen by each segment
+			 */
+			scaleFactor = CdbPathLocus_NumSegments(*(plan->flow));
+		}
 		else
 		{
 			/*

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -4644,14 +4644,7 @@ int planner_segment_count(GpPolicy *policy)
  */
 double global_work_mem(PlannerInfo *root)
 {
-	int segment_count;
-	if (root)
-	{
-		Assert(root->config->cdbpath_segments > 0);
-		segment_count = root->config->cdbpath_segments;
-	}
-	else
-		segment_count = planner_segment_count(NULL);
+	int			segment_count = planner_segment_count(NULL);
 
 	return (double) planner_work_mem * 1024L * segment_count;	
 }

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -345,7 +345,6 @@ num_distcols_in_grouplist(List *gc)
 PlannerConfig *DefaultPlannerConfig(void)
 {
 	PlannerConfig *c1 = (PlannerConfig *) palloc(sizeof(PlannerConfig));
-	c1->cdbpath_segments = planner_segment_count(NULL);
 	c1->enable_sort = enable_sort;
 	c1->enable_hashagg = enable_hashagg;
 	c1->enable_groupagg = enable_groupagg;

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -21,7 +21,6 @@ typedef struct PlannerConfig
 	bool		enable_hashjoin;
 	bool        gp_enable_hashjoin_size_heuristic;
 	bool        gp_enable_predicate_propagation;
-	int			cdbpath_segments;
 	int			constraint_exclusion;
 
 	bool		gp_enable_minmax_optimization;

--- a/src/test/regress/expected/gangsize.out
+++ b/src/test/regress/expected/gangsize.out
@@ -25,11 +25,11 @@ set Test_print_direct_dispatch_info = true;
 -- join and aggregation so they have many slices. We are not interested in their
 -- results, so we redirect the output to /dev/null.
 select replicate_2_1.c, hash_2_3_4.c, avg(hash_3_3_2.d), max(replicate_3_3.c) from ((random_2_0 right join replicate_2_1 on random_2_0.b = replicate_2_1.c) left join (hash_3_3_2 inner join replicate_3_3 on hash_3_3_2.c >= replicate_3_3.b) on replicate_2_1.d >= hash_3_3_2.a) inner join (hash_2_3_4 inner join replicate_2_5 on hash_2_3_4.c = replicate_2_5.d) on hash_3_3_2.a <> hash_2_3_4.a group by replicate_2_1.c, hash_2_3_4.c order by 1,2;
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 5) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 2) Dispatch command to SINGLE content
+INFO:  (slice 3) Dispatch command to SINGLE content
 select hash_3_3_2.b, replicate_2_5.d, sum(replicate_2_1.d), sum(replicate_3_3.a) from (((random_2_0 left join replicate_2_1 on random_2_0.b <> replicate_2_1.d) left join hash_3_3_2 on random_2_0.c = hash_3_3_2.b) inner join (replicate_3_3 inner join hash_2_3_4 on replicate_3_3.d = hash_2_3_4.d) on hash_3_3_2.a <> hash_2_3_4.a) right join replicate_2_5 on random_2_0.d <> replicate_2_5.c group by hash_3_3_2.b, replicate_2_5.d order by 1,2;
 INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
@@ -93,11 +93,11 @@ INFO:  (slice 6) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 3) Dispatch command to SINGLE content
 select replicate_2_1.d, random_2_0.c, sum(hash_3_3_2.d), max(replicate_3_3.d) from (random_2_0 right join (replicate_2_1 inner join hash_3_3_2 on replicate_2_1.d >= hash_3_3_2.c) on random_2_0.c <= hash_3_3_2.c) inner join ((replicate_3_3 full join hash_2_3_4 on replicate_3_3.d <= hash_2_3_4.b) left join replicate_2_5 on replicate_3_3.d <= replicate_2_5.b) on random_2_0.b > replicate_2_5.b group by replicate_2_1.d, random_2_0.c order by 1,2;
 INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 5) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 4) Dispatch command to SINGLE content
-INFO:  (slice 6) Dispatch command to SINGLE content
+INFO:  (slice 6) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 3) Dispatch command to SINGLE content
 INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  (slice 5) Dispatch command to SINGLE content
 select replicate_3_3.d, hash_3_3_2.a, avg(replicate_2_5.d), max(replicate_2_1.d) from random_2_0 right join ((replicate_2_1 right join hash_3_3_2 on replicate_2_1.b <= hash_3_3_2.a) inner join (replicate_3_3 right join (hash_2_3_4 right join replicate_2_5 on hash_2_3_4.c = replicate_2_5.d) on replicate_3_3.b >= hash_2_3_4.c) on hash_3_3_2.b <> hash_2_3_4.c) on random_2_0.c >= hash_2_3_4.b group by replicate_3_3.d, hash_3_3_2.a order by 1,2;
 INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1

--- a/src/test/regress/expected/gangsize_optimizer.out
+++ b/src/test/regress/expected/gangsize_optimizer.out
@@ -25,11 +25,11 @@ set Test_print_direct_dispatch_info = true;
 -- join and aggregation so they have many slices. We are not interested in their
 -- results, so we redirect the output to /dev/null.
 select replicate_2_1.c, hash_2_3_4.c, avg(hash_3_3_2.d), max(replicate_3_3.c) from ((random_2_0 right join replicate_2_1 on random_2_0.b = replicate_2_1.c) left join (hash_3_3_2 inner join replicate_3_3 on hash_3_3_2.c >= replicate_3_3.b) on replicate_2_1.d >= hash_3_3_2.a) inner join (hash_2_3_4 inner join replicate_2_5 on hash_2_3_4.c = replicate_2_5.d) on hash_3_3_2.a <> hash_2_3_4.a group by replicate_2_1.c, hash_2_3_4.c order by 1,2;
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 5) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 2) Dispatch command to SINGLE content
+INFO:  (slice 3) Dispatch command to SINGLE content
 select hash_3_3_2.b, replicate_2_5.d, sum(replicate_2_1.d), sum(replicate_3_3.a) from (((random_2_0 left join replicate_2_1 on random_2_0.b <> replicate_2_1.d) left join hash_3_3_2 on random_2_0.c = hash_3_3_2.b) inner join (replicate_3_3 inner join hash_2_3_4 on replicate_3_3.d = hash_2_3_4.d) on hash_3_3_2.a <> hash_2_3_4.a) right join replicate_2_5 on random_2_0.d <> replicate_2_5.c group by hash_3_3_2.b, replicate_2_5.d order by 1,2;
 INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
@@ -93,11 +93,11 @@ INFO:  (slice 6) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 3) Dispatch command to SINGLE content
 select replicate_2_1.d, random_2_0.c, sum(hash_3_3_2.d), max(replicate_3_3.d) from (random_2_0 right join (replicate_2_1 inner join hash_3_3_2 on replicate_2_1.d >= hash_3_3_2.c) on random_2_0.c <= hash_3_3_2.c) inner join ((replicate_3_3 full join hash_2_3_4 on replicate_3_3.d <= hash_2_3_4.b) left join replicate_2_5 on replicate_3_3.d <= replicate_2_5.b) on random_2_0.b > replicate_2_5.b group by replicate_2_1.d, random_2_0.c order by 1,2;
 INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 5) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 4) Dispatch command to SINGLE content
-INFO:  (slice 6) Dispatch command to SINGLE content
+INFO:  (slice 6) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 3) Dispatch command to SINGLE content
 INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  (slice 5) Dispatch command to SINGLE content
 select replicate_3_3.d, hash_3_3_2.a, avg(replicate_2_5.d), max(replicate_2_1.d) from random_2_0 right join ((replicate_2_1 right join hash_3_3_2 on replicate_2_1.b <= hash_3_3_2.a) inner join (replicate_3_3 right join (hash_2_3_4 right join replicate_2_5 on hash_2_3_4.c = replicate_2_5.d) on replicate_3_3.b >= hash_2_3_4.c) on hash_3_3_2.b <> hash_2_3_4.c) on random_2_0.c >= hash_2_3_4.b group by replicate_3_3.d, hash_3_3_2.a order by 1,2;
 INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1


### PR DESCRIPTION
We used to make cost calculation with this property, it is equal to the
segments count of the cluster, however this is wrong when the table is a
partial one (this happens during gpexpand).  We should always get
numsegments from the motion.

The gangsize.sql test is updated as in some of its queries the slices
order is different than before due to change of the costs.

Also fixed the `rows` information in `EXPLAIN` output.

A replicated table has a full replica of the data on each segment, so
the 'rows' in the EXPLAIN output should not be scaled.

A partial table's 'rows' in the EXPLAIN output should be scaled with the
numsegments of itself.

We used to scale both of above cases with the cluster size in the
EXPLAIN output, so the 'rows' were incorrectly displayed.  It's only a
bug in EXPLAIN output, the cost calculation of the plan is not affected.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
