### PR TITLE
5x gpaddmirrors fix error message wording

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -480,23 +480,22 @@ class GpMirrorListToBuild:
                 dbid = segment.getSegmentDbId()
                 if port in usedPorts:
                     raise Exception(
-                        "On host %s, port %s for segment with dbid %s conflicts with port for segment dbid %s" %
-                        (hostName, port, dbid, usedPorts.get(port)))
+                        "Segment dbid's %s and %s on host %s cannot have the same port %s." %
+                        (usedPorts.get(port), dbid, hostName, port))
 
                 if segment.isSegmentQE():
                     if replicationPort is None:
-                        raise Exception("On host %s, the replication port is not set for segment with dbid %s" %
-                                        (hostName, dbid))
+                        raise Exception("Replication port is not set for segment dbid %s on host %s." %
+                                        (dbid, hostName))
 
                     if replicationPort in usedPorts:
                         raise Exception(
-                            "On host %s, replication port %s for segment with dbid %s conflicts "
-                            "with a port for segment dbid %s" %
-                            (hostName, dbid, replicationPort, usedPorts.get(replicationPort)))
+                            "Segment dbid's %s and %s on host %s cannot have the same replication port %s." %
+                            (usedPorts.get(replicationPort), dbid, hostName, replicationPort))
 
                     if port == replicationPort:
-                        raise Exception("On host %s, segment with dbid %s has equal port and replication port" %
-                                        (hostName, dbid))
+                        raise Exception("Segment dbid %s on host %s cannot have the same value %s for port and replication port." %
+                                        (dbid, hostName, port))
 
                 usedPorts[port] = dbid
                 usedPorts[replicationPort] = dbid
@@ -509,9 +508,8 @@ class GpMirrorListToBuild:
                 for path in paths:
                     if path in usedDataDirectories:
                         raise Exception(
-                            "On host %s, directory (base or filespace) for segment with dbid %s conflicts with a "
-                            "directory (base or filespace) for segment dbid %s; directory: %s" %
-                            (hostName, dbid, usedDataDirectories.get(path), path))
+                            "Segment dbid's %s and %s on host %s cannot have the same data directory '%s'." %
+                            (usedDataDirectories.get(path), dbid, hostName, path))
                     usedDataDirectories[path] = dbid
 
     def __runWaitAndCheckWorkerPoolForErrorsAndClear(self, cmds, actionVerb, suppressErrorCheck=False):

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -145,7 +145,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         gpArray = GpArray([self.master, self.primary])
 
-        with self.assertRaisesRegexp(Exception, r"On host samehost, port 1111 for segment with dbid 2 conflicts with port for segment dbid 1"):
+        with self.assertRaisesRegexp(Exception, r"Segment dbid's 1 and 2 on host samehost cannot have the same port 1111"):
             self.buildMirrorSegs.checkForPortAndDirectoryConflicts(gpArray)
 
     def test_checkForPortAndDirectoryConflicts__given_the_same_host_checks_QE_replication_ports_differ(self):
@@ -157,7 +157,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         gpArray = GpArray([self.master, self.primary])
 
-        with self.assertRaisesRegexp(Exception, r"On host samehost, replication port 2 for segment with dbid 2222 conflicts with a port for segment dbid 1"):
+        with self.assertRaisesRegexp(Exception, r"Segment dbid's 1 and 2 on host samehost cannot have the same replication port 2222"):
             self.buildMirrorSegs.checkForPortAndDirectoryConflicts(gpArray)
 
     def test_checkForPortAndDirectoryConflicts__checks_QE_replication_port_is_set(self):
@@ -165,7 +165,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         gpArray = GpArray([self.master, self.primary])
 
-        with self.assertRaisesRegexp(Exception, r"On host primaryhost, the replication port is not set for segment with dbid 2"):
+        with self.assertRaisesRegexp(Exception, r"Replication port is not set for segment dbid 2 on host primaryhost"):
             self.buildMirrorSegs.checkForPortAndDirectoryConflicts(gpArray)
 
     def test_checkForPortAndDirectoryConflicts__given_the_same_host_checks_both_QE_replication_port_and_port_differ(self):
@@ -177,7 +177,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         gpArray = GpArray([self.master, self.primary])
 
-        with self.assertRaisesRegexp(Exception, r"On host samehost, segment with dbid 2 has equal port and replication port"):
+        with self.assertRaisesRegexp(Exception, r"Segment dbid 2 on host samehost cannot have the same value 3333 for port and replication port"):
             self.buildMirrorSegs.checkForPortAndDirectoryConflicts(gpArray)
 
     def test_checkForPortAndDirectoryConflicts__given_the_same_host_checks_data_directories_differ(self):
@@ -189,7 +189,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         gpArray = GpArray([self.master, self.primary])
 
-        with self.assertRaisesRegexp(Exception, r"On host samehost, directory \(base or filespace\) for segment with dbid 2 conflicts with a directory \(base or filespace\) for segment dbid 1; directory: /data"):
+        with self.assertRaisesRegexp(Exception, r"Segment dbid's 1 and 2 on host samehost cannot have the same data directory '/data'"):
             self.buildMirrorSegs.checkForPortAndDirectoryConflicts(gpArray)
 
 if __name__ == '__main__':


### PR DESCRIPTION
PR https://github.com/greenplum-db/gpdb/pull/7156 is for 6X while this is the 5X backport.

On 5X gpaddmirrors can raise the following exception:
`Exception: On host example.com, replication port 27 for segment with dbid 9004 conflicts with a port for segment dbid 26`. Where the port and dbid values got swapped.

This commit adds tests while making the error messages more clear and concise.