### PR TITLE
Correcting limitation re: updating distribution keys

### DIFF
--- a/gpdb-doc/dita/admin_guide/dml.xml
+++ b/gpdb-doc/dita/admin_guide/dml.xml
@@ -182,7 +182,8 @@
       </p>
       <p>Using <codeph>UPDATE</codeph> in Greenplum Database has the following restrictions:</p>
       <ul>
-        <li id="ix155050">The Greenplum distribution key columns may not be updated.</li>
+        <li id="ix155050">While GPORCA supports updates to Greenplum distribution key columns, the
+          Postgres planner does not.</li>
         <li id="ix142137">If mirrors are enabled, you cannot use <codeph>STABLE</codeph> or
             <codeph>VOLATILE</codeph> functions in an <codeph>UPDATE</codeph> statement.</li>
         <li id="ix155339">Greenplum Database partitioning columns cannot be updated.</li>


### PR DESCRIPTION
This small change is to address https://github.com/greenplum-db/gpdb/issues/7060

Other areas of the doc seem to correctly indicate gporca support for updating dist key columns.

Will be backported to 5X_STABLE.