### PR TITLE
Unused gucs again

### DIFF
--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -336,17 +336,6 @@
         <p>When calculating statistics for large tables, Greenplum Database creates a smaller table
           by sampling the base table. If the table is partitioned, samples are taken from all
           partitions. </p>
-        <p>If the number of rows in the base table is estimated to be less than the value of the
-            <codeph>gp_statistics_sampling_threshold</codeph> configuration parameter, the entire
-          base table is used to calculate the statistics. </p>
-        <p>If a sample table is created, the number of rows in the sample is calculated to provide a
-          maximum acceptable relative error. The amount of acceptable error is specified with the
-            <codeph>gp_analyze_relative_error</codeph> system configuration parameter, which is set
-          to .25 (25%) by default. This is usually sufficiently accurate to generate correct query
-          plans. If <codeph>ANALYZE</codeph> is not producing good estimates for a table column, you
-          can increase the sample size by setting the <codeph>gp_analyze_relative_error</codeph>
-          configuration parameter to a lower value. Beware that setting this parameter to a low
-          value can lead to a very large sample size and dramatically increase analyze time. </p>
       </section>
       <section id="section_u5p_brv_mt">
         <title>Updating Statistics</title>

--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -551,9 +551,6 @@
             <li id="kh158362">
               <codeph>default_statistics_target </codeph>
             </li>
-            <li id="kh158369">
-              <codeph>gp_analyze_relative_error</codeph>
-            </li>
           </ul>
         </body>
       </topic>

--- a/gpdb-doc/dita/admin_guide/perf_issues.xml
+++ b/gpdb-doc/dita/admin_guide/perf_issues.xml
@@ -120,9 +120,6 @@
           <li id="jb158767">
             <codeph>default_statistics_target</codeph>
           </li>
-          <li id="jb158800">
-            <codeph>gp_analyze_relative_error</codeph>
-          </li>
         </ul>
         <p>These parameters control statistics sampling at the system level. It is better to sample
           only increased statistics for columns used most frequently in query predicates. You can

--- a/gpdb-doc/dita/best_practices/analyze.xml
+++ b/gpdb-doc/dita/best_practices/analyze.xml
@@ -44,15 +44,6 @@
         may improve the quality of the query planner’s estimates, especially for columns with
         irregular data patterns. <codeph>default_statistics_target</codeph> can be set at the
         master/session level and requires a reload. </p>
-      <p>The <codeph>gp_analyze_relative_error</codeph> configuration parameter affects the sampling
-        rate during statistics collection to determine cardinality in a column. For example, a value
-        of .5 is equivalent to an acceptable error of 50%. The default is .25. Use the
-          <codeph>gp_analyze_relative_error</codeph> parameter to set the acceptable estimated
-        relative error in the cardinality of a table. If statistics do not produce good estimates of
-        cardinality for a particular table attribute, decreasing the relative error fraction
-        (accepting less errors) tells the system to sample more rows. However, it is not recommended
-        to reduce this below 0.1 as it will increase <codeph>ANALYZE</codeph> time
-        substantially.</p>
     </section>
     <section>
       <title>When to Run ANALYZE</title>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -153,9 +153,6 @@
               <xref href="#gp_adjust_selectivity_for_outerjoins"/>
             </li>
             <li>
-              <xref href="#gp_analyze_relative_error"/>
-            </li>
-            <li>
               <xref href="#gp_appendonly_compaction"/>
             </li>
             <li>
@@ -2251,37 +2248,6 @@
             <row>
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">on</entry>
-              <entry colname="col3">master<p>session</p><p>reload</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="gp_analyze_relative_error">
-    <title>gp_analyze_relative_error</title>
-    <body>
-      <p>Sets the estimated acceptable error in the cardinality of the table " a value of 0.5 is
-        supposed to be equivalent to an acceptable error of 50% (this is the default value used in
-        PostgreSQL). If the statistics collected during <codeph>ANALYZE</codeph> are not producing
-        good estimates of cardinality for a particular table attribute, decreasing the relative
-        error fraction (accepting less error) tells the system to sample more rows.</p>
-      <table id="gp_analyze_relative_error_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">floating point &lt; 1.0</entry>
-              <entry colname="col2">0.25</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -532,10 +532,6 @@
                 <xref href="guc-list.xml#default_statistics_target" type="section"
                   >default_statistics_target </xref>
               </p>
-              <p>
-                <xref href="guc-list.xml#gp_analyze_relative_error" type="section"
-                  >gp_analyze_relative_error</xref>
-              </p>
             </stentry>
           </strow>
         </simpletable>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -74,7 +74,6 @@
             <topicref href="guc-list.xml#extra_float_digits"/>
             <topicref href="guc-list.xml#from_collapse_limit"/>
             <topicref href="guc-list.xml#gp_adjust_selectivity_for_outerjoins"/>
-            <topicref href="guc-list.xml#gp_analyze_relative_error"/>
             <topicref href="guc-list.xml#gp_appendonly_compaction"/>
             <topicref href="guc-list.xml#gp_appendonly_compaction_threshold"/>
             <topicref href="guc-list.xml#gp_autostats_mode"/>

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -22,12 +22,8 @@
  * Statistics related parameters.
  */
 
-double			analyze_relative_error = 0.25;
 bool			gp_statistics_pullup_from_child_partition = FALSE;
 bool			gp_statistics_use_fkeys = FALSE;
-int				gp_statistics_blocks_target = 25;
-double			gp_statistics_ndistinct_scaling_ratio_threshold = 0.10;
-double			gp_statistics_sampling_threshold = 10000;
 
 typedef struct
 {

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2975,7 +2975,7 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"writable_external_table_bufsize", PGC_USERSET, EXTERNAL_TABLES,
-			gettext_noop("Buffer size in kilo bytes for writable external table before writing data to gpfdist."),
+			gettext_noop("Buffer size in kilobytes for writable external table before writing data to gpfdist."),
 			gettext_noop("Valid value is between 32K and 128M: [32, 131072]."),
 			GUC_UNIT_KB | GUC_NOT_IN_SAMPLE
 		},

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -107,8 +107,6 @@ bool		Debug_print_full_dtm = false;
 bool		Debug_print_snapshot_dtm = false;
 bool		Debug_disable_distributed_snapshot = false;
 bool		Debug_abort_after_distributed_prepared = false;
-bool		Debug_print_server_processes = false;
-bool		Debug_print_control_checkpoints = false;
 bool		Debug_appendonly_print_insert = false;
 bool		Debug_appendonly_print_insert_tuple = false;
 bool		Debug_appendonly_print_scan = false;
@@ -122,20 +120,13 @@ bool		Debug_appendonly_print_read_block = false;
 bool		Debug_appendonly_print_append_block = false;
 bool		Debug_appendonly_print_segfile_choice = false;
 bool        test_AppendOnlyHash_eviction_vs_just_marking_not_inuse = false;
-int			Debug_appendonly_bad_header_print_level = ERROR;
 bool		Debug_appendonly_print_datumstream = false;
 bool		Debug_appendonly_print_visimap = false;
 bool		Debug_appendonly_print_compaction = false;
 bool		Debug_resource_group = false;
-bool		gp_crash_recovery_abort_suppress_fatal = false;
 bool		Debug_bitmap_print_insert = false;
-bool		Test_appendonly_override = false;
 bool		Test_print_direct_dispatch_info = false;
-bool		gp_test_orientation_override = false;
 bool		gp_permit_relation_node_change = false;
-int			Test_compresslevel_override = 0;
-int			Test_blocksize_override = 0;
-int			Test_safefswritesize_override = 0;
 int			gp_max_local_distributed_cache = 1024;
 bool		gp_appendonly_verify_block_checksums = true;
 bool		gp_appendonly_verify_write_block = false;
@@ -165,11 +156,6 @@ char	   *memory_profiler_dataset_id = "none";
 char	   *memory_profiler_query_id = "none";
 int			memory_profiler_dataset_size = 0;
 
-bool		rle_type_compression_stats = false;
-
-bool		Debug_database_command_print = false;
-bool		gp_startup_integrity_checks = true;
-
 /* WAL based replication debug GUCs */
 bool		debug_walrepl_snd = false;
 bool		debug_walrepl_syncrep = false;
@@ -179,17 +165,12 @@ bool		debug_basebackup = false;
 /* Latch mechanism debug GUCs */
 bool		debug_latch = false;
 
-bool		gp_crash_recovery_suppress_ao_eof = false;
 bool		gp_keep_all_xlog = false;
 
 #define DEBUG_DTM_ACTION_PRIMARY_DEFAULT true
 bool		Debug_dtm_action_primary = DEBUG_DTM_ACTION_PRIMARY_DEFAULT;
 
 bool		gp_log_optimization_time = false;
-
-int			Debug_delay_prepare_broadcast_ms = 0;
-int			Debug_delay_commit_broadcast_ms = 0;
-int			Debug_delay_abort_broadcast_ms = 0;
 
 int			Debug_dtm_action = DEBUG_DTM_ACTION_NONE;
 
@@ -211,8 +192,6 @@ int			Debug_dtm_action_nestinglevel = DEBUG_DTM_ACTION_NESTINGLEVEL_DEFAULT;
 bool		gp_encoding_check_locale_compatibility;
 
 int			gp_connection_send_timeout;
-
-int			WalSendClientTimeout = 30000;		/* 30 seconds. */
 
 bool create_restartpoint_on_ckpt_record_replay = false;
 
@@ -1004,17 +983,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_crash_recovery_abort_suppress_fatal", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Warning about crash recovery abort transaction issue"),
-			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&gp_crash_recovery_abort_suppress_fatal,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"gp_select_invisible", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Use dummy snapshot for MVCC visibility calculation."),
 			NULL,
@@ -1579,28 +1547,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"debug_database_command_print", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Print database command debugging information."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_database_command_print,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"test_appendonly_override", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("For testing purposes, change the default of the appendonly create table option."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Test_appendonly_override,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"test_print_direct_dispatch_info", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("For testing purposes, print information about direct dispatch decisions."),
 			NULL,
@@ -1640,27 +1586,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_disable_tuple_hints,
 		true,
-		NULL, NULL, NULL
-	},
-	{
-		{"debug_print_server_processes", PGC_SUSET, LOGGING_WHAT,
-			gettext_noop("Prints server process management to server log."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_print_server_processes,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"debug_print_control_checkpoints", PGC_SUSET, LOGGING_WHAT,
-			gettext_noop("Prints pg_control file checkpoint changes to server log."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_print_control_checkpoints,
-		false,
 		NULL, NULL, NULL
 	},
 
@@ -1754,17 +1679,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"rle_type_compression_stats", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("show compression ratio stats for rle_type compression"),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&rle_type_compression_stats,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"debug_resource_group", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prints resource groups debug logs."),
 			NULL,
@@ -1826,17 +1740,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&debug_latch,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"gp_crash_recovery_suppress_ao_eof", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Warning about crash recovery append only eof issue"),
-			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&gp_crash_recovery_suppress_ao_eof,
 		false,
 		NULL, NULL, NULL
 	},
@@ -3114,17 +3017,6 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"test_compresslevel_override", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("For testing purposes, the override value for compresslevel when non-default."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Test_compresslevel_override,
-		DEFAULT_COMPRESS_LEVEL, 0, 9, NULL,
-		NULL, NULL
-	},
-
-	{
 		{"gp_safefswritesize", PGC_BACKEND, RESOURCES,
 			gettext_noop("Minimum FS safe write size."),
 			NULL
@@ -3878,17 +3770,6 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"wal_send_client_timeout", PGC_SIGHUP, GP_ARRAY_TUNING,
-			gettext_noop("The time in milliseconds for a backend process to wait on the WAL Send server to finish a request to the QD mirroring standby."),
-			NULL,
-			GUC_UNIT_MS | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&WalSendClientTimeout,
-		30000, 100, INT_MAX / 1000,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"gpperfmon_port", PGC_POSTMASTER, UNGROUPED,
 			gettext_noop("Sets the port number of gpperfmon."),
 			NULL,
@@ -3962,16 +3843,6 @@ struct config_int ConfigureNamesInt_gp[] =
 		NULL, NULL, NULL
 	},
 
-	{
-		{"gp_statistics_blocks_target", PGC_USERSET, STATS_ANALYZE,
-			gettext_noop("The number of blocks to be sampled to estimate reltuples/relpages for heap tables."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_statistics_blocks_target,
-		25, 1, 1000,
-		NULL, NULL, NULL
-	},
 	{
 		{"gp_resqueue_priority_local_interval", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("A measure of how often a backend process must consider backing off."),
@@ -4330,16 +4201,6 @@ struct config_real ConfigureNamesReal_gp[] =
 	},
 
 	{
-		{"gp_analyze_relative_error", PGC_USERSET, STATS_ANALYZE,
-			gettext_noop("target relative error fraction for row sampling during analyze"),
-			NULL
-		},
-		&analyze_relative_error,
-		0.25, 0, 1.0,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"gp_selectivity_damping_factor", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Factor used in selectivity damping."),
 			gettext_noop("Values 1..N, 1 = basic damping, greater values emphasize damping"),
@@ -4347,28 +4208,6 @@ struct config_real ConfigureNamesReal_gp[] =
 		},
 		&gp_selectivity_damping_factor,
 		1.0, 1.0, DBL_MAX,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"gp_statistics_ndistinct_scaling_ratio_threshold", PGC_USERSET, STATS_ANALYZE,
-			gettext_noop("If the ratio of number of distinct values of an attribute to the number of rows is greater than this value, it is assumed that ndistinct will scale with table size."),
-			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&gp_statistics_ndistinct_scaling_ratio_threshold,
-		0.10, 0.001, 1.0,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"gp_statistics_sampling_threshold", PGC_USERSET, STATS_ANALYZE,
-			gettext_noop("Only tables larger than this size will be sampled."),
-			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&gp_statistics_sampling_threshold,
-		20000.0, 0.0, DBL_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -433,8 +433,6 @@ optimizer_analyze_root_partition = on # stats collection on root partitions
 
 #default_statistics_target = 100	# range 1 - 10000 (target # of
 					# histogram bins)
-#gp_analyze_relative_error = 0.25	# range 0.0 - 1.0 (target relative
-					# error fraction)
 					
 # - Query/Index Statistics Collector -
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -766,11 +766,6 @@ extern bool 	gp_statistics_pullup_from_child_partition;
 /* Extract numdistinct from foreign key relationship */
 extern bool		gp_statistics_use_fkeys;
 
-/* Analyze related gucs */
-extern int 		gp_statistics_blocks_target;
-extern double	gp_statistics_ndistinct_scaling_ratio_threshold;
-extern double	gp_statistics_sampling_threshold;
-
 /* Analyze tools */
 extern int gp_motion_slice_noop;
 

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -165,7 +165,6 @@ typedef struct VPgClassStats
 /* GUC parameters */
 extern PGDLLIMPORT int default_statistics_target;		/* PGDLLIMPORT for
 														 * PostGIS */
-extern PGDLLIMPORT double analyze_relative_error;
 extern int	vacuum_freeze_min_age;
 extern int	vacuum_freeze_table_age;
 extern int	vacuum_multixact_freeze_min_age;

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -238,7 +238,6 @@ extern bool	Debug_print_full_dtm;
 extern bool	Debug_print_snapshot_dtm;
 extern bool Debug_disable_distributed_snapshot;
 extern bool Debug_abort_after_distributed_prepared;
-extern bool Debug_abort_after_segment_prepared;
 extern bool Debug_appendonly_print_insert;
 extern bool Debug_appendonly_print_insert_tuple;
 extern bool Debug_appendonly_print_scan;
@@ -252,15 +251,11 @@ extern bool Debug_appendonly_print_read_block;
 extern bool Debug_appendonly_print_append_block;
 extern bool Debug_appendonly_print_segfile_choice;
 extern bool test_AppendOnlyHash_eviction_vs_just_marking_not_inuse;
-extern int  Debug_appendonly_bad_header_print_level;
 extern bool Debug_appendonly_print_datumstream;
 extern bool Debug_appendonly_print_visimap;
 extern bool Debug_appendonly_print_compaction;
-extern bool gp_crash_recovery_abort_suppress_fatal;
 extern bool Debug_bitmap_print_insert;
-extern bool Test_appendonly_override;
 extern bool enable_checksum_on_tables;
-extern int  Test_compresslevel_override;
 extern int  gp_max_local_distributed_cache;
 extern bool gp_local_distributed_cache_stats;
 extern bool gp_appendonly_verify_block_checksums;
@@ -287,9 +282,7 @@ extern bool Debug_datumstream_block_write_check_integrity;
 extern bool Debug_datumstream_read_print_varlena_info;
 extern bool Debug_datumstream_write_use_small_initial_buffers;
 extern bool	Debug_database_command_print;
-extern bool gp_startup_integrity_checks;
 extern bool Debug_resource_group;
-extern bool gp_crash_recovery_suppress_ao_eof;
 extern bool gp_create_table_random_default_distribution;
 extern bool gp_allow_non_uniform_partitioning_ddl;
 extern bool gp_enable_exchange_default_partition;
@@ -313,10 +306,6 @@ extern bool gp_ignore_window_exclude;
 
 extern bool gp_ignore_error_table;
 
-extern bool rle_type_compression_stats;
-
-extern bool	Debug_print_server_processes;
-extern bool Debug_print_control_checkpoints;
 extern bool	Debug_dtm_action_primary;
 
 extern bool gp_log_optimization_time;
@@ -399,8 +388,6 @@ extern int	tcp_keepalives_interval;
 extern int	tcp_keepalives_count;
 
 extern int	gp_connection_send_timeout;
-
-extern int  WalSendClientTimeout;
 
 extern bool create_restartpoint_on_ckpt_record_replay;
 


### PR DESCRIPTION
This removes a set of GUCs which are no longer in use in the code, along with their documentation. Rabbitholed down into here while reading code

The second commit fixes a GUC description typo which was spotted while doing this.