### PR TITLE
Print backtrace on AO format version error and check for same sooner.

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -173,7 +173,7 @@ SetNextFileSegForRead(AppendOnlyScanDesc scan)
 	Relation	reln = scan->aos_rd;
 	int			segno = -1;
 	int64		eof = 0;
-	int			formatversion = -1;
+	int			formatversion = -2; /* some invalid value */
 	bool		finished_all_files = true;	/* assume */
 	int32		fileSegNo;
 

--- a/src/include/catalog/pg_appendonly.h
+++ b/src/include/catalog/pg_appendonly.h
@@ -93,13 +93,16 @@ typedef enum AORelationVersion
 #define AORelationVersion_IsValid(version) \
 	(version > AORelationVersion_None && version < MaxAORelationVersion)
 
+extern bool Debug_appendonly_print_verify_write_block;
+
 static inline void AORelationVersion_CheckValid(int version)
 {
 	if (!AORelationVersion_IsValid(version))
 	{
-		ereport(ERROR,
-	 		    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-	 		     errmsg("append-only table version %d is invalid", version)));
+		ereport(Debug_appendonly_print_verify_write_block?PANIC:ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("append-only table version %d is invalid", version),
+				 errprintstack(true)));
 	}
 }
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -244,7 +244,6 @@ extern bool Debug_appendonly_print_scan;
 extern bool Debug_appendonly_print_scan_tuple;
 extern bool Debug_appendonly_print_delete;
 extern bool Debug_appendonly_print_storage_headers;
-extern bool Debug_appendonly_print_verify_write_block;
 extern bool Debug_appendonly_use_no_toast;
 extern bool Debug_appendonly_print_blockdirectory;
 extern bool Debug_appendonly_print_read_block;


### PR DESCRIPTION
In some scenarios ERROR "append-only table version -1 is invalid" is
being hit. Code inspection doens't reveal any clues why it can
happen. So, for now we thought of adding more info to figure out the
cause. Backtrace would definitely be helpful when the error hits.

Also, check the format version as soon as entry is read from
catalog. Plus also would be greatly helpful if can have corefile when
the problem happens so under the controlled environment with guc
evelate ERROR to PANIC. GUC
`debug_appendonly_print_verify_write_block` usage for same is not
ideal but wish to avoid adding special guc just for this case, hence
piggyback on this existing uinteresting debug guc for now.

Co-authored-by: Daniel Gustafsson <dgustafsson@pivotal.io>

Note:
The problem was seen on 5.X, hence this will be back-ported to 5.X.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
