### PR TITLE
Fix gpexpand writable external table case

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -206,7 +206,7 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 3 new segments
-        When the user runs gpexpand against database "gptest" to redistribute
+        When the user runs gpexpand to redistribute
         Then the numsegments of table "ext_test" is 4
 
     @gpexpand_icw_db_concourse


### PR DESCRIPTION
Now gpexpand uses database `postgres` to store
expand information instead of a user-specific
database.

Co-authored-by: Jialun Du <jdu@pivotal.io>

-------
This commit fixes one test case which is red in master now. It just modifies the case itself  so no test cases needed.

PR pipeline will not run gpexpand. I have tested it manually.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
