### PR TITLE
Set analyze_only in vacuum_appendonly_index

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2866,6 +2866,8 @@ vacuum_appendonly_index(Relation indexRelation,
 	pg_rusage_init(&ru0);
 
 	ivinfo.index = indexRelation;
+	ivinfo.analyze_only = false;
+	ivinfo.estimated_count = false;
 	ivinfo.message_level = elevel;
 	ivinfo.num_heap_tuples = rel_tuple_count;
 	ivinfo.strategy = vac_strategy;

--- a/src/test/regress/expected/vacuum_full_ao.out
+++ b/src/test/regress/expected/vacuum_full_ao.out
@@ -33,3 +33,12 @@ select pg_relation_size((select segrelid from pg_appendonly where relid = 'vfao'
             32768
 (1 row)
 
+-- github issue https://github.com/greenplum-db/gpdb/issues/7050
+drop table if exists ao;
+NOTICE:  table "ao" does not exist, skipping
+create table ao (a int, b box) with(appendonly=true) distributed by (a);
+create index gist_ao on ao using gist (b);
+insert into ao select i, ('(0,'||i||', 1,'||i+1||')')::box from generate_series(1,5)i;
+update ao set b = '((1,1),(4,4))' where a = 1;
+vacuum ao;
+drop table ao;

--- a/src/test/regress/sql/vacuum_full_ao.sql
+++ b/src/test/regress/sql/vacuum_full_ao.sql
@@ -22,3 +22,13 @@ select pg_relation_size((select segrelid from pg_appendonly where relid = 'vfao'
 
 vacuum full vfao;
 select pg_relation_size((select segrelid from pg_appendonly where relid = 'vfao'::regclass)) from gp_dist_random('gp_id') where gp_segment_id = 1;
+
+-- github issue https://github.com/greenplum-db/gpdb/issues/7050
+
+drop table if exists ao;
+create table ao (a int, b box) with(appendonly=true) distributed by (a);
+create index gist_ao on ao using gist (b);
+insert into ao select i, ('(0,'||i||', 1,'||i+1||')')::box from generate_series(1,5)i;
+update ao set b = '((1,1),(4,4))' where a = 1;
+vacuum ao;
+drop table ao;


### PR DESCRIPTION
If not set `IndexVacuumInfo.analyze_only`, `index_vacuum_cleanup()` will not
update relpages  when index is GIST, it can also happen on GIN index and SP-GIST index. Thus, relpages could be 0 and hit the assertion failure in `vac_update_relstats()`

Why btree does not have this issue, because in `btvacuumcleanup()`, it calls `btvacuumcleanup()`, and this function have already updated relpages.

It will fix https://github.com/greenplum-db/gpdb/issues/7050

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
