### PR TITLE
Eliminate the gp difference of StrNCpy() against pg version.

### DIFF
--- a/src/include/c.h
+++ b/src/include/c.h
@@ -912,12 +912,6 @@ typedef NameData *Name;
 			strncpy(_dst, (src), _len); \
 			_dst[_len-1] = '\0'; \
 		} \
-		else \
-			/* upstream does not have the branch code. Without this, coverity \
-			 * warns potential len as 0 (e.g. potential overflow though with \
-			 * low probability, etc) in some code. \
-			 */ \
-			_dst[0] = '\0'; \
 	} while (0)
 
 


### PR DESCRIPTION
Previously we added the code due to Coverity report,
however, we conclude that we should better align with upstream
after some further discussion. See below.

https://github.com/greenplum-db/gpdb/pull/7120

In the long run, we hope StrNCpy() is gone, by the way.
