### PR TITLE
Do not transform ShareInputScan in correlated subplan.

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -449,8 +449,11 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		}
 	}
 
+	/*
+	 * We do not do this tranformation for ShareInputScan, instead we do it for
+	 * the SeqScan beneath the ShareInputScan.
+	 */
 	if (IsA(node, SeqScan)
-		||IsA(node, ShareInputScan)
 		||IsA(node, ExternalScan))
 	{
 		Plan	   *scanPlan = (Plan *) node;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10943,52 +10943,48 @@ INSERT INTO onetimefilter2 SELECT i, i FROM generate_series(1,10)i;
 ANALYZE onetimefilter1;
 ANALYZE onetimefilter2;
 EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=3.43..12.31 rows=10 width=12)
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=3.43..12.31 rows=10 width=12)
    ->  Hash Join  (cost=3.43..12.31 rows=4 width=12)
          Hash Cond: (f1.b = f2.b)
-         ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.30 rows=4 width=8)
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..3.30 rows=4 width=8)
                Hash Key: f1.b
                ->  Seq Scan on onetimefilter1 f1  (cost=0.00..3.10 rows=4 width=8)
          ->  Hash  (cost=3.30..3.30 rows=4 width=4)
-               ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..3.30 rows=4 width=4)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.30 rows=4 width=4)
                      Hash Key: f2.b
                      ->  Seq Scan on onetimefilter2 f2  (cost=0.00..3.10 rows=4 width=4)
-         SubPlan 1  (slice6; segments: 3)
+         SubPlan 1  (slice5; segments: 3)
            ->  Limit  (cost=0.00..0.04 rows=1 width=0)
                  ->  Limit  (cost=0.00..0.02 rows=1 width=0)
                        ->  Result  (cost=0.00..0.20 rows=4 width=0)
                              One-Time Filter: (f1.b = f2.b)
-                             ->  Result  (cost=6.51..6.77 rows=4 width=8)
-                                   ->  Materialize  (cost=6.51..6.77 rows=4 width=8)
-                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=6.51..6.72 rows=4 width=8)
-                                               ->  Shared Scan (share slice:id 1:0)  (cost=6.51..6.72 rows=4 width=8)
-                                                     ->  Materialize  (cost=3.23..6.51 rows=4 width=8)
-                                                           ->  Hash Join  (cost=3.23..6.46 rows=4 width=8)
-                                                                 Hash Cond: (onetimefilter1.a = onetimefilter2.a)
+                             ->  Shared Scan (share slice:id 5:0)  (cost=6.51..6.72 rows=4 width=8)
+                                   ->  Materialize  (cost=3.23..6.51 rows=4 width=8)
+                                         ->  Hash Join  (cost=3.23..6.46 rows=4 width=8)
+                                               Hash Cond: (onetimefilter1.a = onetimefilter2.a)
+                                               ->  Result  (cost=0.00..3.15 rows=4 width=8)
+                                                     ->  Materialize  (cost=0.00..3.15 rows=4 width=8)
+                                                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.10 rows=4 width=8)
                                                                  ->  Seq Scan on onetimefilter1  (cost=0.00..3.10 rows=4 width=8)
-                                                                 ->  Hash  (cost=3.10..3.10 rows=4 width=4)
+                                               ->  Hash  (cost=3.10..3.10 rows=4 width=4)
+                                                     ->  Result  (cost=0.00..3.15 rows=4 width=4)
+                                                           ->  Materialize  (cost=0.00..3.15 rows=4 width=4)
+                                                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.10 rows=4 width=4)
                                                                        ->  Seq Scan on onetimefilter2  (cost=0.00..3.10 rows=4 width=4)
-         SubPlan 2  (slice6; segments: 3)
+         SubPlan 2  (slice5; segments: 3)
            ->  Result  (cost=0.00..0.28 rows=1 width=0)
                  One-Time Filter: (f1.a = 2)
                  ->  Subquery Scan on abc  (cost=0.00..0.28 rows=1 width=0)
                        Filter: ((f1.a)::double precision = random())
-                       ->  Result  (cost=6.51..6.77 rows=4 width=8)
-                             ->  Materialize  (cost=6.51..6.77 rows=4 width=8)
-                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=6.51..6.72 rows=4 width=8)
-                                         ->  Shared Scan (share slice:id 2:0)  (cost=6.51..6.72 rows=4 width=8)
-         SubPlan 3  (slice6; segments: 3)
+                       ->  Shared Scan (share slice:id 5:0)  (cost=6.51..6.72 rows=4 width=8)
+         SubPlan 3  (slice5; segments: 3)
            ->  Subquery Scan on abc_1  (cost=0.00..0.22 rows=1 width=4)
                  Filter: (abc_1.b = f1.b)
-                 ->  Result  (cost=6.51..6.77 rows=4 width=8)
-                       ->  Materialize  (cost=6.51..6.77 rows=4 width=8)
-                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=6.51..6.72 rows=4 width=8)
-                                   ->  Shared Scan (share slice:id 3:0)  (cost=6.51..6.72 rows=4 width=8)
- Planning time: 0.276 ms
+                 ->  Shared Scan (share slice:id 5:0)  (cost=6.51..6.72 rows=4 width=8)
  Optimizer: Postgres query optimizer
-(43 rows)
+(39 rows)
 
 WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
  ?column? | coalesce | b  

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -30,3 +30,40 @@ SELECT * FROM
 ---+---+---+---+---+---
 (0 rows)
 
+EXPLAIN (COSTS OFF)
+SELECT *,
+	   (WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
+		SELECT 1 FROM cte c1, cte c2
+		)
+	FROM bar;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on bar
+         SubPlan 1  (slice2; segments: 3)
+           ->  Nested Loop
+                 ->  Shared Scan (share slice:id 2:0)
+                 ->  Materialize
+                       ->  Subquery Scan on c2
+                             ->  Shared Scan (share slice:id 2:0)
+                                   ->  Materialize
+                                         ->  Result
+                                               Filter: (jazz.e = bar.c)
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                           ->  Seq Scan on jazz
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+SELECT *,
+	   (WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
+		SELECT 1 FROM cte c1, cte c2
+		)
+	FROM bar;
+ c | d | ?column? 
+---+---+----------
+ 1 | 1 |         
+ 2 | 2 |        1
+ 3 | 3 |        1
+(3 rows)
+

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -27,3 +27,16 @@ SELECT * FROM
         JOIN bar ON b = c
         ) AS XY
         JOIN jazz on c = e AND b = f;
+
+EXPLAIN (COSTS OFF)
+SELECT *,
+	   (WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
+		SELECT 1 FROM cte c1, cte c2
+		)
+	FROM bar;
+
+SELECT *,
+	   (WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
+		SELECT 1 FROM cte c1, cte c2
+		)
+	FROM bar;


### PR DESCRIPTION
GPDB will transform the scan node in a correlated subplan to a tree looks
like:

```
Result (with quals)
       \
        \_Material
           \
            \_Broadcast (or Gather)
               \
                \_Scan (no quals)
```

Then the transformed plan can be executed in a parallel setting since the
correlation is now part of the result node which executes in the same slice
as the outer plan node. This works well for SeqScan.

For ShareInputScan, there would be one producer that have a SeqScan beneath
it, and the correlation originally exists with that SeqScan. If we do this
kind of transformation for ShareInputScan, the correlation is still with
that SeqScan.  And above this SeqScan, now there is a Broadcast motion
added. As we cannot pass param through motion, the plan would give wrong
results.

This patch avoid doing this transformation for ShareInputScan. Thus the
SeqScan beneath it would be transformed as above, and the correlation would
be pulled up to above the Broadcast motion.

This patch fixes github issue #7071.

Discussion: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/cCSV38aTn-8

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
