### PR TITLE
Dispatch GUCs to QE along with query.

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3245,6 +3245,12 @@ AbortTransaction(void)
 	ProcArrayEndTransaction(MyProc, latestXid, false);
 
 	/*
+	 * Need to rollback dtx before GUC reset
+	 * Since dtm_debug GUCs will be dispatched to QEs.
+	 */
+	rollbackDtxTransaction();
+
+	/*
 	 * Post-abort cleanup.  See notes in CommitTransaction() concerning
 	 * ordering.  We can skip all of it if the transaction failed before
 	 * creating a resource owner.
@@ -3294,8 +3300,6 @@ AbortTransaction(void)
 	 * CleanupTransaction().
 	 */
 	TopTransactionStateData.transactionId = InvalidTransactionId;
-
-	rollbackDtxTransaction();
 
 	MyProc->localDistribXactData.state = LOCALDISTRIBXACT_STATE_NONE;
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3414,6 +3414,11 @@ StartTransactionCommand(void)
 				 */
 				s->blockState = TBLOCK_STARTED;
 			}
+
+			/* QE needs to apply the GUCs passed from QD when StartTransaction()*/
+			if (Gp_role == GP_ROLE_EXECUTE)
+				apply_guc_from_qd(NULL, 0);
+
 			break;
 
 			/*

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1557,3 +1557,46 @@ getgpsegmentCount(void)
 
 	return numsegments;
 }
+
+/*
+ * Set guc_need_sync for QEs
+ * If global guc_need_sync flag is true, we need to set
+ * connection level guc_need_sync flag for all the existing QEs
+ */
+void setSyncFlagForIdleQEs(void)
+{
+	CdbComponentDatabases *cdbs;
+	ListCell   *le;
+	int i;
+
+	cdbs = cdbcomponent_getCdbComponents(true);
+
+	if (cdbs->entry_db_info != NULL)
+	{
+		for (i = 0; i < cdbs->total_entry_dbs; i++)
+		{
+			CdbComponentDatabaseInfo *cdi = &cdbs->entry_db_info[i];
+			foreach (le, cdi->freelist)
+			{
+				SegmentDatabaseDescriptor *segdbDesc =
+						(SegmentDatabaseDescriptor *)lfirst(le);
+				segdbDesc->guc_need_sync = true;
+			}
+		}
+	}
+
+	if (cdbs->segment_db_info != NULL)
+	{
+		for (i = 0; i < cdbs->total_segment_dbs; i++)
+		{
+			CdbComponentDatabaseInfo *cdi = &cdbs->segment_db_info[i];
+			foreach (le, cdi->freelist)
+			{
+				SegmentDatabaseDescriptor *segdbDesc =
+						(SegmentDatabaseDescriptor *)lfirst(le);
+				segdbDesc->guc_need_sync = true;
+			}
+		}
+	}
+	return ;
+}

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -91,6 +91,9 @@ cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, int id
 	segdbDesc->identifier = identifier;
 	segdbDesc->isWriter = isWriter;
 
+	/* New created gang always need to sync GUCs. */
+	segdbDesc->guc_need_sync = true;
+
 	MemoryContextSwitchTo(oldContext);
 	return segdbDesc;
 }

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -301,6 +301,7 @@ cdbdisp_makeDispatcherState(bool isExtendedQuery)
 	handle->dispatcherState->isExtendedQuery = isExtendedQuery;
 	handle->dispatcherState->allocatedGangs = NIL;
 	handle->dispatcherState->largestGangSize = 0;
+	handle->dispatcherState->isNonSyncGUCCommand = false;
 
 	return handle->dispatcherState;
 }
@@ -493,6 +494,12 @@ AtAbort_DispatcherState(void)
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
 
+	/*
+	 * No 2PC guaranteed, thus reset guc_need_sync_session
+	 * to true when xact abort
+	 */
+	guc_need_sync_session = true;
+
 	if (CurrentGangCreating != NULL)
 	{
 		RecycleGang(CurrentGangCreating, true);
@@ -523,6 +530,12 @@ AtSubAbort_DispatcherState(void)
 {
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
+
+	/*
+	 * No 2PC guaranteed, thus reset guc_need_sync_session
+	 * to true when xact abort
+	 */
+	guc_need_sync_session = true;
 
 	if (CurrentGangCreating != NULL)
 	{

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -301,7 +301,6 @@ cdbdisp_makeDispatcherState(bool isExtendedQuery)
 	handle->dispatcherState->isExtendedQuery = isExtendedQuery;
 	handle->dispatcherState->allocatedGangs = NIL;
 	handle->dispatcherState->largestGangSize = 0;
-	handle->dispatcherState->isNonSyncGUCCommand = false;
 
 	return handle->dispatcherState;
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -38,6 +38,8 @@
 #include "miscadmin.h"
 #include "commands/sequence.h"
 #include "access/xact.h"
+#include "utils/guc_tables.h"
+#include "utils/memutils.h"
 #include "utils/timestamp.h"
 #define DISPATCH_WAIT_TIMEOUT_MSEC 2000
 

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -107,8 +107,6 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	 * Dispatch the command.
 	 */
 	ds = cdbdisp_makeDispatcherState(false);
-	/* dxt commands do not sync all of GUCs */
-	ds->isNonSyncGUCCommand = true;
 
 	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, twophaseSegments);
 
@@ -254,7 +252,7 @@ buildGpDtxProtocolCommand(DispatchCommandDtxProtocolParms *pDtxProtocolParms,
 	int			gidLen = strlen(gid) + 1;
 
 	if (guc_need_sync)
-		guc = serializeGUC(&guc_len, true);
+		guc = serializeGUC(&guc_len);
 
 	int			total_query_len = 1 /* 'T' */ +
 	sizeof(len) +

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -53,7 +53,7 @@ typedef struct DispatchCommandDtxProtocolParms
 static DtxContextInfo TempQDDtxContextInfo = DtxContextInfo_StaticInit;
 
 static char *buildGpDtxProtocolCommand(DispatchCommandDtxProtocolParms *pDtxProtocolParms,
-						  int *finalLen);
+						  int *finalLen, bool guc_need_sync);
 
 /*
  * CdbDispatchDtxProtocolCommand:
@@ -107,10 +107,12 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	 * Dispatch the command.
 	 */
 	ds = cdbdisp_makeDispatcherState(false);
-
-	queryText = buildGpDtxProtocolCommand(&dtxProtocolParms, &queryTextLen);
+	/* dxt commands do not sync all of GUCs */
+	ds->isNonSyncGUCCommand = true;
 
 	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, twophaseSegments);
+
+	queryText = buildGpDtxProtocolCommand(&dtxProtocolParms, &queryTextLen, ds->guc_need_sync);
 
 	Assert(primaryGang);
 
@@ -234,7 +236,7 @@ qdSerializeDtxContextInfo(int *size, bool wantSnapshot, bool inCursor,
  */
 static char *
 buildGpDtxProtocolCommand(DispatchCommandDtxProtocolParms *pDtxProtocolParms,
-						 int *finalLen)
+						 int *finalLen, bool guc_need_sync)
 {
 	int			dtxProtocolCommand = (int) pDtxProtocolParms->dtxProtocolCommand;
 	int			flags = pDtxProtocolParms->flags;
@@ -243,11 +245,17 @@ buildGpDtxProtocolCommand(DispatchCommandDtxProtocolParms *pDtxProtocolParms,
 	int			gxid = pDtxProtocolParms->gxid;
 	char	   *serializedDtxContextInfo = pDtxProtocolParms->serializedDtxContextInfo;
 	int			serializedDtxContextInfoLen = pDtxProtocolParms->serializedDtxContextInfoLen;
+	char		   *guc = NULL;
+	int			guc_len = 0;
 	int			tmp = 0;
 	int			len = 0;
 
 	int			loggingStrLen = strlen(dtxProtocolCommandLoggingStr) + 1;
 	int			gidLen = strlen(gid) + 1;
+
+	if (guc_need_sync)
+		guc = serializeGUC(&guc_len, true);
+
 	int			total_query_len = 1 /* 'T' */ +
 	sizeof(len) +
 	sizeof(dtxProtocolCommand) +
@@ -258,7 +266,9 @@ buildGpDtxProtocolCommand(DispatchCommandDtxProtocolParms *pDtxProtocolParms,
 	gidLen +
 	sizeof(gxid) +
 	sizeof(serializedDtxContextInfoLen) +
-	serializedDtxContextInfoLen;
+	serializedDtxContextInfoLen +
+	sizeof(guc_len) +
+	guc_len;
 
 	char	   *shared_query = NULL;
 	char	   *pos = NULL;
@@ -307,6 +317,16 @@ buildGpDtxProtocolCommand(DispatchCommandDtxProtocolParms *pDtxProtocolParms,
 	{
 		memcpy(pos, serializedDtxContextInfo, serializedDtxContextInfoLen);
 		pos += serializedDtxContextInfoLen;
+	}
+
+	tmp = htonl(guc_len);
+	memcpy(pos, &tmp, sizeof(tmp));
+	pos += sizeof(tmp);
+
+	if (guc_len > 0)
+	{
+		memcpy(pos, guc, guc_len);
+		pos += guc_len;
 	}
 
 	len = pos - shared_query - 1;

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1379,7 +1379,7 @@ fillGucNode(GUCNode *guc_node, struct config_generic *guc)
 			{
 				struct config_string *sguc = (struct config_string *) guc;
 
-				appendStringInfo(&string, "%s", *sguc->variable);
+				appendStringInfoString(&string, *sguc->variable);
 				break;
 			}
 		case PGC_ENUM:
@@ -1388,13 +1388,13 @@ fillGucNode(GUCNode *guc_node, struct config_generic *guc)
 				int			value = *eguc->variable;
 				const char *str = config_enum_lookup_by_value(eguc, value);
 
-				appendStringInfo(&string, "%s", str);
+				appendStringInfoString(&string, str);
 				break;
 			}
 		default:
 			Insist(false);
 	}
-	guc_node->value = pstrdup(string.data);
+	guc_node->value = string.data;
 	guc_node->name = pstrdup(guc->name);
 	guc_node->source = guc->source;
 	guc_node->context = guc->scontext;

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1558,6 +1558,10 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, cdbCopy->seglist);
 	Assert(primaryGang);
 
+	/*
+	 * Place buildGpQueryString after AllocateGang() since it needs the state
+	 * from allocated gangs to determine whether to include GUC info
+	 */
 	queryText = buildGpQueryString(pQueryParms, &queryTextLength, ds->guc_need_sync);
 
 	cdbdisp_makeDispatchResults(ds, 1, flags & DF_CANCEL_ON_ERROR);

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -30,6 +30,7 @@
 #include "tcop/tcopprot.h"
 #include "utils/datum.h"
 #include "utils/guc.h"
+#include "utils/guc_tables.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/faultinjector.h"
@@ -91,6 +92,10 @@ typedef struct DispatchCommandQueryParms
 	 */
 	char	   *serializedDtxContextInfo;
 	int			serializedDtxContextInfolen;
+
+	/* serialized GUC values */
+	char	   *serializedGUC;
+	int		serializedGUClen;
 } DispatchCommandQueryParms;
 
 static int fillSliceVector(SliceTable *sliceTable,
@@ -99,7 +104,7 @@ static int fillSliceVector(SliceTable *sliceTable,
 				int len);
 
 static char *buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
-				   int *finalLen);
+				   int *finalLen, bool guc_need_sync);
 
 static DispatchCommandQueryParms *cdbdisp_buildPlanQueryParms(struct QueryDesc *queryDesc, bool planRequiresTxn);
 static DispatchCommandQueryParms *cdbdisp_buildUtilityQueryParms(struct Node *stmt, int flags, List *oid_assignments);
@@ -264,13 +269,13 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 
 	ds = cdbdisp_makeDispatcherState(false);
 
-	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
-
 	AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, cdbcomponent_getCdbComponentsList());
 
 	/* put all idle segment to a gang so QD can send SET command to them */
 	AllocateGang(ds, GANGTYPE_PRIMARY_READER, formIdleSegmentIdList());
 	
+	queryText = buildGpQueryString(pQueryParms, &queryTextLength, ds->guc_need_sync);
+
 	cdbdisp_makeDispatchResults(ds, list_length(ds->allocatedGangs), cancelOnError);
 	cdbdisp_makeDispatchParams (ds, list_length(ds->allocatedGangs), queryText, queryTextLength);
 
@@ -416,13 +421,17 @@ cdbdisp_dispatchCommandInternal(DispatchCommandQueryParms *pQueryParms,
 	 */
 	ds = cdbdisp_makeDispatcherState(false);
 
-	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
+	/* BEGIN commands do not sync GUCs */
+	if (pQueryParms->strCommand && strncmp(pQueryParms->strCommand, "BEGIN", 5) == 0)
+		ds->isNonSyncGUCCommand = true;
 
 	/*
 	 * Allocate a primary QE for every available segDB in the system.
 	 */
 	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, segments);
 	Assert(primaryGang);
+
+	queryText = buildGpQueryString(pQueryParms, &queryTextLength, ds->guc_need_sync);
 
 	cdbdisp_makeDispatchResults(ds, 1, flags & DF_CANCEL_ON_ERROR);
 	cdbdisp_makeDispatchParams (ds, 1, queryText, queryTextLength);
@@ -816,7 +825,7 @@ fillSliceVector(SliceTable *sliceTbl, int rootIdx,
  */
 static char *
 buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
-				   int *finalLen)
+				   int *finalLen, bool guc_need_sync)
 {
 	const char *command = pQueryParms->strCommand;
 	int			command_len;
@@ -830,6 +839,8 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 	int			sddesc_len = pQueryParms->serializedQueryDispatchDesclen;
 	const char *dtxContextInfo = pQueryParms->serializedDtxContextInfo;
 	int			dtxContextInfo_len = pQueryParms->serializedDtxContextInfolen;
+	const char *guc = NULL;
+	int			guc_len = 0;
 	int64		currentStatementStartTimestamp = GetCurrentStatementStartTimestamp();
 	Oid			sessionUserId = GetSessionUserId();
 	Oid			outerUserId = GetOuterUserId();
@@ -863,6 +874,9 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 	else
 		command_len = strlen(command) + 1;
 
+	if (guc_need_sync)
+		guc = serializeGUC(&guc_len, false);
+
 	initStringInfo(&resgroupInfo);
 	if (IsResGroupActivated())
 		SerializeResGroupInfo(&resgroupInfo);
@@ -880,12 +894,14 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 		sizeof(params_len) +
 		sizeof(sddesc_len) +
 		sizeof(dtxContextInfo_len) +
+		sizeof(guc_len) +
 		dtxContextInfo_len +
 		command_len +
 		querytree_len +
 		plantree_len +
 		params_len +
 		sddesc_len +
+		guc_len +
 		sizeof(numsegments) +
 		sizeof(resgroupInfo.len) +
 		resgroupInfo.len;
@@ -954,6 +970,10 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 	memcpy(pos, &tmp, sizeof(tmp));
 	pos += sizeof(tmp);
 
+	tmp = htonl(guc_len);
+	memcpy(pos, &tmp, sizeof(tmp));
+	pos += sizeof(tmp);
+
 	if (dtxContextInfo_len > 0)
 	{
 		memcpy(pos, dtxContextInfo, dtxContextInfo_len);
@@ -987,6 +1007,12 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 	{
 		memcpy(pos, sddesc, sddesc_len);
 		pos += sddesc_len;
+	}
+
+	if (guc_len > 0)
+	{
+		memcpy(pos, guc, guc_len);
+		pos += guc_len;
 	}
 
 	tmp = htonl(numsegments);
@@ -1078,7 +1104,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 	nSlices = fillSliceVector(sliceTbl, rootIdx, sliceVector, nTotalSlices);
 
 	pQueryParms = cdbdisp_buildPlanQueryParms(queryDesc, planRequiresTxn);
-	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
+	queryText = buildGpQueryString(pQueryParms, &queryTextLength, ds->guc_need_sync);
 
 	/*
 	 * Allocate result array with enough slots for QEs of primary gangs.
@@ -1318,6 +1344,104 @@ serializeParamListInfo(ParamListInfo paramLI, int *len_p)
 	return nodeToBinaryStringFast(sparams, len_p);
 }
 
+
+/*
+ * Add GUC value to the GUCNode.
+ */
+static void
+fillGucNode(GUCNode *guc_node, struct config_generic *guc)
+{
+	StringInfoData string;
+	initStringInfo(&string);
+	switch (guc->vartype)
+	{
+		case PGC_BOOL:
+			{
+				struct config_bool *bguc = (struct config_bool *) guc;
+				appendStringInfo(&string, "%s", *(bguc->variable) ? "true" : "false");
+				break;
+			}
+		case PGC_INT:
+			{
+				struct config_int *iguc = (struct config_int *) guc;
+
+				appendStringInfo(&string, "%d", *iguc->variable);
+				break;
+			}
+		case PGC_REAL:
+			{
+				struct config_real *rguc = (struct config_real *) guc;
+
+				appendStringInfo(&string, "%f", *rguc->variable);
+				break;
+			}
+		case PGC_STRING:
+			{
+				struct config_string *sguc = (struct config_string *) guc;
+
+				appendStringInfo(&string, "%s", *sguc->variable);
+				break;
+			}
+		case PGC_ENUM:
+			{
+				struct config_enum *eguc = (struct config_enum *) guc;
+				int			value = *eguc->variable;
+				const char *str = config_enum_lookup_by_value(eguc, value);
+
+				appendStringInfo(&string, "%s", str);
+				break;
+			}
+		default:
+			Insist(false);
+	}
+	guc_node->value = pstrdup(string.data);
+	guc_node->name = pstrdup(guc->name);
+	guc_node->source = guc->source;
+	guc_node->context = guc->scontext;
+}
+
+
+/*
+ * Serialization of GUC
+ *
+ * When a query is dispatched from QD to QE, we also need to dispatch any
+ * unsynchronized GUCs.
+ *
+ */
+char *
+serializeGUC(int *len_p, bool isDtx)
+{
+	List		   *guc_node_list  = NIL;
+	ListCell *lc;
+
+	/*
+	 * Since we don't need 2PC to ensure the GUC consistent
+	 * among QEs, we need to synchronize all the potential
+	 * changed GUCs to QEs.
+	 */
+	foreach(lc, guc_list_need_sync_global)
+	{
+		GUCNode *guc_node;
+		struct config_generic *guc = find_option((char *) lfirst(lc), false, 0);
+
+		/*
+		 * Since we could not startxact in exec_mpp_dtx_protocol_command()
+		 * to set GUC, but some assign functions of GUC need transaction started.
+		 * So if it is dtx comamnd, then we only sync GUC with GUC_GPDB_DTX flags
+		 *
+		 */
+		if (guc != NULL &&
+			(!isDtx || (guc->flags & GUC_GPDB_DTX)))
+		{
+			guc_node = makeNode(GUCNode);
+			fillGucNode(guc_node, guc);
+			guc_node_list = lappend(guc_node_list, guc_node);
+		}
+	}
+
+	return nodeToBinaryStringFast(guc_node_list, len_p);
+}
+
 ParamListInfo
 deserializeParamListInfo(const char *str, int slen)
 {
@@ -1428,13 +1552,13 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	 */
 	ds = cdbdisp_makeDispatcherState(false);
 
-	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
-
 	/*
 	 * Allocate a primary QE for every available segDB in the system.
 	 */
 	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, cdbCopy->seglist);
 	Assert(primaryGang);
+
+	queryText = buildGpQueryString(pQueryParms, &queryTextLength, ds->guc_need_sync);
 
 	cdbdisp_makeDispatchResults(ds, 1, flags & DF_CANCEL_ON_ERROR);
 	cdbdisp_makeDispatchParams (ds, 1, queryText, queryTextLength);

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -119,8 +119,6 @@ AllocateGang(CdbDispatcherState *ds, GangType type, List *segments)
 	if (guc_need_sync_session)
 	{
 		setSyncFlagForIdleQEs();
-		if (!ds->isNonSyncGUCCommand)
-			guc_need_sync_session = false;
 	}
 
 	if (type == GANGTYPE_PRIMARY_WRITER)
@@ -144,8 +142,6 @@ AllocateGang(CdbDispatcherState *ds, GangType type, List *segments)
 		if(newGang->db_descriptors[i]->guc_need_sync)
 		{
 			ds->guc_need_sync = true;
-			if (!ds->isNonSyncGUCCommand)
-				newGang->db_descriptors[i]->guc_need_sync = false;
 		}
 	}
 

--- a/src/backend/commands/variable.c
+++ b/src/backend/commands/variable.c
@@ -855,7 +855,7 @@ assign_session_authorization(const char *newval, void *extra)
 	role_auth_extra *myextra = (role_auth_extra *) extra;
 
 	/* Do nothing for the boot_val default of NULL */
-	if (!myextra)
+	if (!myextra || Gp_role != GP_ROLE_DISPATCH)
 		return;
 
 	SetSessionAuthorization(myextra->roleid, myextra->is_superuser);
@@ -938,6 +938,8 @@ assign_role(const char *newval, void *extra)
 {
 	role_auth_extra *myextra = (role_auth_extra *) extra;
 
+	if (Gp_role != GP_ROLE_DISPATCH)
+		return;
 	SetCurrentRoleId(myextra->roleid, myextra->is_superuser);
 }
 

--- a/src/backend/commands/variable.c
+++ b/src/backend/commands/variable.c
@@ -854,7 +854,12 @@ assign_session_authorization(const char *newval, void *extra)
 {
 	role_auth_extra *myextra = (role_auth_extra *) extra;
 
-	/* Do nothing for the boot_val default of NULL */
+	/*
+	 * Do nothing for the boot_val default of NULL
+	 * Also session/role info will be dispatched to QE from
+	 * QD explicitly, so we should not override them based on GUC.
+	 *
+	 */
 	if (!myextra || Gp_role != GP_ROLE_DISPATCH)
 		return;
 
@@ -938,6 +943,10 @@ assign_role(const char *newval, void *extra)
 {
 	role_auth_extra *myextra = (role_auth_extra *) extra;
 
+	/*
+	 * role info will be dispatched to QE from QD explicitly
+	 * so we should not override them based on GUC.
+	 */
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
 	SetCurrentRoleId(myextra->roleid, myextra->is_superuser);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -30,6 +30,7 @@
 #include "nodes/plannodes.h"
 #include "nodes/relation.h"
 #include "utils/datum.h"
+#include "utils/guc.h"
 #include "cdb/cdbgang.h"
 
 
@@ -5007,6 +5008,19 @@ _copyDistributedBy(const DistributedBy *from)
 	return newnode;
 }
 
+static GUCNode *
+_copyGUCNode(const GUCNode *from)
+{
+	GUCNode *newnode = makeNode(GUCNode);
+
+	COPY_STRING_FIELD(name);
+	COPY_STRING_FIELD(value);
+	COPY_SCALAR_FIELD(context);
+	COPY_SCALAR_FIELD(source);
+
+	return newnode;
+}
+
 /* ****************************************************************
  *					pg_list.h copy functions
  * ****************************************************************
@@ -6028,6 +6042,9 @@ copyObject(const void *from)
 
 		case T_DistributedBy:
 			retval = _copyDistributedBy(from);
+			break;
+		case T_GUCNode:
+			retval = _copyGUCNode(from);
 			break;
 
 		default:

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -33,6 +33,7 @@
 
 #include "nodes/relation.h"
 #include "utils/datum.h"
+#include "utils/guc.h"
 #include "catalog/gp_policy.h"
 
 
@@ -2724,6 +2725,18 @@ _equalXmlSerialize(const XmlSerialize *a, const XmlSerialize *b)
 	return true;
 }
 
+static bool
+_equalGUCNode(const GUCNode *a, const GUCNode *b)
+{
+	COMPARE_STRING_FIELD(name);
+	COMPARE_STRING_FIELD(value);
+
+	COMPARE_SCALAR_FIELD(context);
+	COMPARE_SCALAR_FIELD(source);
+
+	return true;
+}
+
 /*
  * Stuff from pg_list.h
  */
@@ -3499,6 +3512,9 @@ equal(const void *a, const void *b)
 			break;
 		case T_DistributedBy:
 			retval = _equalDistributedBy(a, b);
+			break;
+		case T_GUCNode:
+			retval = _equalGUCNode(a, b);
 			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d",

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -40,6 +40,7 @@
 #include "utils/datum.h"
 #include "catalog/heap.h"
 #include "cdb/cdbgang.h"
+#include "utils/guc.h"
 #include "utils/workfile_mgr.h"
 #include "parser/parsetree.h"
 
@@ -1275,6 +1276,17 @@ _outAlterTableSpaceOptionsStmt(StringInfo str, AlterTableSpaceOptionsStmt *node)
 	WRITE_BOOL_FIELD(isReset);
 }
 
+static void
+_outGUCNode(StringInfo str, GUCNode *node)
+{
+	WRITE_NODE_TYPE("GUCNODE");
+
+	WRITE_STRING_FIELD(name);
+	WRITE_STRING_FIELD(value);
+	WRITE_ENUM_FIELD(context, GucContext);
+	WRITE_ENUM_FIELD(source, GucSource);
+}
+
 /*
  * _outNode -
  *	  converts a Node into binary string and append it to 'str'
@@ -2221,6 +2233,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_AlterTableSpaceOptionsStmt:
 				_outAlterTableSpaceOptionsStmt(str, obj);
+				break;
+			case T_GUCNode:
+				_outGUCNode(str, obj);
 				break;
 			default:
 				elog(ERROR, "could not serialize unrecognized node type: %d",

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -38,6 +38,7 @@
 #include "catalog/pg_class.h"
 #include "catalog/heap.h"
 #include "cdb/cdbgang.h"
+#include "utils/guc.h"
 
 static Bitmapset *bitmapsetRead(void);
 
@@ -2978,6 +2979,22 @@ _readGpPolicy(void)
 	READ_DONE();
 }
 
+/*
+ * _readGUCNode
+ */
+static GUCNode *
+_readGUCNode(void)
+{
+	READ_LOCALS(GUCNode);
+
+	READ_STRING_FIELD(name);
+	READ_STRING_FIELD(value);
+	READ_ENUM_FIELD(context, GucContext);
+	READ_ENUM_FIELD(source, GucSource);
+
+	READ_DONE();
+}
+
 
 static void *
 readNodeBinary(void)
@@ -3844,6 +3861,9 @@ readNodeBinary(void)
 				break;
 			case T_AlterTableMoveAllStmt:
 				return_value = _readAlterTableMoveAllStmt();
+				break;
+			case T_GUCNode:
+				return_value = _readGUCNode();
 				break;
 			default:
 				return_value = NULL; /* keep the compiler silent */

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5944,7 +5944,7 @@ apply_guc_from_qd(const char * serializedGUC, int serializedGUClen)
 		{
 			guc = (GUCNode *) lfirst(lc);
 			if (!guc || !IsA(guc, GUCNode))
-				elog(ERROR, "MPPEXEC: receive invalid guc");
+				elog(ERROR, "MPPEXEC: receive invalid guc with node tag: %d", guc->type);
 			set_config_option(guc->name, guc->value,
 							guc->context, guc->source,
 							0, true, 0);

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1049,8 +1049,7 @@ exec_mpp_query(const char *query_string,
 			   const char * serializedQuerytree, int serializedQuerytreelen,
 			   const char * serializedPlantree, int serializedPlantreelen,
 			   const char * serializedParams, int serializedParamslen,
-			   const char * serializedQueryDispatchDesc, int serializedQueryDispatchDesclen,
-			   const char * serializedGUC, int serializedGUClen)
+			   const char * serializedQueryDispatchDesc, int serializedQueryDispatchDesclen)
 {
 	CommandDest dest = whereToSendOutput;
 	MemoryContext oldcontext;
@@ -1471,8 +1470,7 @@ static void
 exec_mpp_dtx_protocol_command(DtxProtocolCommand dtxProtocolCommand,
 							  int flags, const char *loggingStr,
 							  const char *gid, DistributedTransactionId gxid,
-							  DtxContextInfo *contextInfo,
-							  const char * serializedGUC, int serializedGUClen)
+							  DtxContextInfo *contextInfo)
 {
 	CommandDest dest = whereToSendOutput;
 	const char *commandTag = loggingStr;
@@ -1559,9 +1557,7 @@ CheckDebugDtmActionSqlCommandTag(const char *sqlCommandTag)
  * Execute a "simple Query" protocol message.
  */
 static void
-exec_simple_query(const char *query_string,
-				const char * serializedGUC,
-				int serializedGUClen)
+exec_simple_query(const char *query_string)
 {
 	CommandDest dest = whereToSendOutput;
 	MemoryContext oldcontext;
@@ -5255,7 +5251,7 @@ PostgresMain(int argc, char *argv[],
 					else if (am_ftshandler)
 						HandleFtsMessage(query_string);
 					else
-						exec_simple_query(query_string, NULL, 0);
+						exec_simple_query(query_string);
 
 					send_ready_for_query = true;
 				}
@@ -5407,7 +5403,7 @@ PostgresMain(int argc, char *argv[],
 						}
 						else
 						{
-							exec_simple_query(query_string, serializedGUC, serializedGUClen);
+							exec_simple_query(query_string);
 						}
 					}
 					else
@@ -5415,8 +5411,7 @@ PostgresMain(int argc, char *argv[],
 									   serializedQuerytree, serializedQuerytreelen,
 									   serializedPlantree, serializedPlantreelen,
 									   serializedParams, serializedParamslen,
-									   serializedQueryDispatchDesc, serializedQueryDispatchDesclen,
-									   serializedGUC, serializedGUClen);
+									   serializedQueryDispatchDesc, serializedQueryDispatchDesclen);
 
 					SetUserIdAndContext(GetOuterUserId(), false);
 
@@ -5493,8 +5488,7 @@ PostgresMain(int argc, char *argv[],
 
 					pq_getmsgend(&input_message);
 
-					exec_mpp_dtx_protocol_command(dtxProtocolCommand, flags, loggingStr, gid, gxid, &TempDtxContextInfo,
-											serializedGUC, serializedGUClen);
+					exec_mpp_dtx_protocol_command(dtxProtocolCommand, flags, loggingStr, gid, gxid, &TempDtxContextInfo);
 
 					send_ready_for_query = true;
             	}

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5945,6 +5945,11 @@ apply_guc_from_qd(const char * serializedGUC, int serializedGUClen)
 			guc = (GUCNode *) lfirst(lc);
 			if (!guc || !IsA(guc, GUCNode))
 				elog(ERROR, "MPPEXEC: receive invalid guc with node tag: %d", guc->type);
+			/*
+			 * Whether to change GUC value is determined at QD side.
+			 * As a result, we just set GucSource to highest value PGC_S_SESSION,
+			 * and set changeVal to True.
+			 */
 			set_config_option(guc->name, guc->value,
 							guc->context, guc->source,
 							0, true, 0);

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1096,9 +1096,6 @@ exec_mpp_query(const char *query_string,
 	 */
 	start_xact_command();
 
-	/* apply GUC from QD */
-	//apply_guc_from_qd(serializedGUC, serializedGUClen);
-
 	/*
 	 * Zap any pre-existing unnamed statement.	(While not strictly necessary,
 	 * it seems best to define simple-Query mode as if it used the unnamed
@@ -1480,9 +1477,6 @@ exec_mpp_dtx_protocol_command(DtxProtocolCommand dtxProtocolCommand,
 	CommandDest dest = whereToSendOutput;
 	const char *commandTag = loggingStr;
 
-	/* apply DTM specific GUC from QD */
-	//apply_guc_from_qd(serializedGUC, serializedGUClen);
-
 	if (log_statement == LOGSTMT_ALL)
 	{
 		elog(LOG,"DTM protocol command '%s' for gid = %s",
@@ -1605,9 +1599,6 @@ exec_simple_query(const char *query_string,
 	 * will normally change current memory context.)
 	 */
 	start_xact_command();
-
-	/* apply GUC from QD */
-	//apply_guc_from_qd(serializedGUC, serializedGUClen);
 
 	/*
 	 * Zap any pre-existing unnamed statement.  (While not strictly necessary,

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5776,37 +5776,6 @@ parse_and_validate_value(struct config_generic * record,
 }
 
 /*
- * Add need sync GUCs into guc_list_need_sync_global
- */
-static void
-add_guc_to_sync_list(struct config_generic *record, const char *name)
-{
-	ListCell *lc;
-	char *cur_guc_name;
-	bool isexists;
-
-	/* Sync GUC with flag GUC_GPDB_ADDOPT */
-	if ((record->flags & GUC_GPDB_ADDOPT))
-	{
-		MemoryContext oldContext = MemoryContextSwitchTo(TopMemoryContext);
-		foreach (lc, guc_list_need_sync_global)
-		{
-			cur_guc_name = (char*)(lc);
-			if (strlen(name) != strlen(cur_guc_name))
-				continue;
-			if (strncmp(cur_guc_name, name, strlen(name)) == 0)
-			{
-				isexists = true;
-				break;
-			}
-		}
-		if (!isexists)
-			guc_list_need_sync_global = lappend(guc_list_need_sync_global, pstrdup(name));
-		MemoryContextSwitchTo(oldContext);
-	}
-}
-
-/*
  * Sets option `name' to given value.
  *
  * The value should be a string, which will be parsed and converted to

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3417,17 +3417,6 @@ static struct config_enum ConfigureNamesEnum[] =
 		{"IntervalStyle", PGC_USERSET, CLIENT_CONN_LOCALE,
 			gettext_noop("Sets the display format for interval values."),
 			NULL,
-			GUC_REPORT
-		},
-		&IntervalStyle,
-		INTSTYLE_POSTGRES, intervalstyle_options,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"IntervalStyle", PGC_USERSET, CLIENT_CONN_LOCALE,
-			gettext_noop("Sets the display format for interval values."),
-			NULL,
 			GUC_REPORT | GUC_GPDB_ADDOPT
 		},
 		&IntervalStyle,

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5191,6 +5191,8 @@ AtEOXact_GUC(bool isCommit, int nestLevel)
 			/* Report new value if we changed it */
 			if (changed && (gconf->flags & GUC_REPORT))
 				ReportGUCOption(gconf);
+			if (changed)
+				guc_need_sync_session = true;
 		}						/* end of stack-popping loop */
 
 		if (stack != NULL)

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5858,7 +5858,7 @@ set_config_option(const char *name, const char *value,
 		 * If GUC value changed, turn on flag guc_need_sync_session.
 		 */
 		guc_need_sync_session = true;
-		add_guc_to_sync_list(record, name);
+		add_guc_to_sync_list(record, name, source, context);
 	}
 	/*
 	 * Check if option can be set by the user.

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -996,7 +996,7 @@ static struct config_bool ConfigureNamesBool[] =
 		{"log_duration", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Logs the duration of each completed SQL statement."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&log_duration,
 		false,
@@ -1060,7 +1060,7 @@ static struct config_bool ConfigureNamesBool[] =
 		{"log_executor_stats", PGC_SUSET, STATS_MONITORING,
 			gettext_noop("Writes executor performance statistics to the server log."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&log_executor_stats,
 		false,
@@ -1070,7 +1070,7 @@ static struct config_bool ConfigureNamesBool[] =
 		{"log_statement_stats", PGC_SUSET, STATS_MONITORING,
 			gettext_noop("Writes cumulative performance statistics to the server log."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&log_statement_stats,
 		false,
@@ -1325,7 +1325,7 @@ static struct config_bool ConfigureNamesBool[] =
 	{
 		{"check_function_bodies", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Check function bodies during CREATE FUNCTION."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&check_function_bodies,
 		true,
@@ -1337,7 +1337,7 @@ static struct config_bool ConfigureNamesBool[] =
 			gettext_noop("When turned on, unquoted NULL in an array input "
 						 "value means a null value; "
 						 "otherwise it is taken literally."),
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Array_nulls,
 		true,
@@ -1515,7 +1515,7 @@ static struct config_bool ConfigureNamesBool[] =
 		{"allow_system_table_mods", PGC_USERSET, CUSTOM_OPTIONS,
 			gettext_noop("Allows modifications of the structure of system tables."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_NEED_SYNC
 		},
 		&allowSystemTableMods,
 		false,
@@ -1768,7 +1768,7 @@ static struct config_int ConfigureNamesInt[] =
 		{"temp_buffers", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the maximum number of temporary buffers used by each session."),
 			NULL,
-			GUC_UNIT_BLOCKS | GUC_GPDB_ADDOPT
+			GUC_UNIT_BLOCKS | GUC_GPDB_NEED_SYNC
 		},
 		&num_temp_buffers,
 		1024, 100, INT_MAX / 2,
@@ -1820,7 +1820,7 @@ static struct config_int ConfigureNamesInt[] =
 			gettext_noop("This much memory can be used by each internal "
 						 "sort operation and hash table before switching to "
 						 "temporary disk files."),
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT
+			GUC_UNIT_KB | GUC_GPDB_NEED_SYNC
 		},
 		&work_mem,
         32768, 64, MAX_KILOBYTES,
@@ -1831,7 +1831,7 @@ static struct config_int ConfigureNamesInt[] =
 		{"maintenance_work_mem", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the maximum memory to be used for maintenance operations."),
 			gettext_noop("This includes operations such as VACUUM and CREATE INDEX."),
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT
+			GUC_UNIT_KB | GUC_GPDB_NEED_SYNC
 		},
 		&maintenance_work_mem,
 		65536, 1024, MAX_KILOBYTES,
@@ -1988,7 +1988,7 @@ static struct config_int ConfigureNamesInt[] =
 		{"statement_timeout", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Sets the maximum allowed duration of any statement."),
 			gettext_noop("A value of 0 turns off the timeout."),
-			GUC_UNIT_MS | GUC_GPDB_ADDOPT
+			GUC_UNIT_MS | GUC_GPDB_NEED_SYNC
 		},
 		&StatementTimeout,
 		0, 0, INT_MAX,
@@ -1999,7 +1999,7 @@ static struct config_int ConfigureNamesInt[] =
 		{"lock_timeout", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Sets the maximum allowed duration of any wait for a lock."),
 			gettext_noop("A value of 0 turns off the timeout."),
-			GUC_UNIT_MS | GUC_GPDB_ADDOPT
+			GUC_UNIT_MS | GUC_GPDB_NEED_SYNC
 		},
 		&LockTimeout,
 		0, 0, INT_MAX,
@@ -2009,7 +2009,7 @@ static struct config_int ConfigureNamesInt[] =
 	{
 		{"vacuum_freeze_min_age", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Minimum age at which VACUUM should freeze a table row."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&vacuum_freeze_min_age,
 		50000000, 0, 1000000000,
@@ -2019,7 +2019,7 @@ static struct config_int ConfigureNamesInt[] =
 	{
 		{"vacuum_freeze_table_age", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Age at which VACUUM should scan whole table to freeze tuples."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&vacuum_freeze_table_age,
 		150000000, 0, 2000000000,
@@ -2039,7 +2039,7 @@ static struct config_int ConfigureNamesInt[] =
 	{
 		{"vacuum_multixact_freeze_table_age", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Multixact age at which VACUUM should scan whole table to freeze tuples."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&vacuum_multixact_freeze_table_age,
 		150000000, 0, 2000000000,
@@ -2049,7 +2049,7 @@ static struct config_int ConfigureNamesInt[] =
 	{
 		{"vacuum_defer_cleanup_age", PGC_SIGHUP, REPLICATION_MASTER,
 			gettext_noop("Number of transactions by which VACUUM and HOT cleanup should be deferred, if any."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&vacuum_defer_cleanup_age,
 		0, 0, 1000000,
@@ -2218,7 +2218,7 @@ static struct config_int ConfigureNamesInt[] =
 			gettext_noop("Sets the delay in microseconds between transaction commit and "
 						 "flushing WAL to disk."),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_DISALLOW_USER_SET
+			GUC_GPDB_NEED_SYNC | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_DISALLOW_USER_SET
 			/* we have no microseconds designation, so can't supply units here */
 		},
 		&CommitDelay,
@@ -2231,7 +2231,7 @@ static struct config_int ConfigureNamesInt[] =
 			gettext_noop("Sets the minimum concurrent open transactions before performing "
 						 "commit_delay."),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_DISALLOW_USER_SET
+			GUC_GPDB_NEED_SYNC | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_DISALLOW_USER_SET
 		},
 		&CommitSiblings,
 		5, 0, 1000,
@@ -2255,7 +2255,7 @@ static struct config_int ConfigureNamesInt[] =
 			gettext_noop("Sets the minimum execution time above which "
 						 "statements will be logged."),
 			gettext_noop("Zero prints all queries. -1 turns this feature off."),
-			GUC_UNIT_MS | GUC_GPDB_ADDOPT
+			GUC_UNIT_MS | GUC_GPDB_NEED_SYNC
 		},
 		&log_min_duration_statement,
 		-1, -1, INT_MAX,
@@ -2551,7 +2551,7 @@ static struct config_int ConfigureNamesInt[] =
 		{"gin_fuzzy_search_limit", PGC_USERSET, CLIENT_CONN_OTHER,
 			gettext_noop("Sets the maximum allowed result for exact search by GIN."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&GinFuzzySearchLimit,
 		0, 0, INT_MAX,
@@ -2809,7 +2809,7 @@ static struct config_string ConfigureNamesString[] =
 			gettext_noop("Sets the display format for date and time values."),
 			gettext_noop("Also controls interpretation of ambiguous "
 						 "date inputs."),
-			GUC_LIST_INPUT | GUC_REPORT | GUC_GPDB_ADDOPT
+			GUC_LIST_INPUT | GUC_REPORT | GUC_GPDB_NEED_SYNC
 		},
 		&datestyle_string,
 		"ISO, MDY",
@@ -2922,7 +2922,7 @@ static struct config_string ConfigureNamesString[] =
 			gettext_noop("Sets the locale for formatting numbers."),
 			NULL,
 			/* Please don't remove GUC_GPDB_ADDOPT or lc_numeric won't work correctly */
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&locale_numeric,
 		"C",
@@ -2976,7 +2976,7 @@ static struct config_string ConfigureNamesString[] =
 		{"search_path", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Sets the schema search order for names that are not schema-qualified."),
 			NULL,
-			GUC_LIST_INPUT | GUC_LIST_QUOTE | GUC_GPDB_ADDOPT
+			GUC_LIST_INPUT | GUC_LIST_QUOTE | GUC_GPDB_NEED_SYNC
 		},
 		&namespace_search_path,
 		"\"$user\",public",
@@ -3092,7 +3092,7 @@ static struct config_string ConfigureNamesString[] =
 		{"TimeZone", PGC_USERSET, CLIENT_CONN_LOCALE,
 			gettext_noop("Sets the time zone for displaying and interpreting time stamps."),
 			NULL,
-			GUC_REPORT | GUC_GPDB_ADDOPT
+			GUC_REPORT | GUC_GPDB_NEED_SYNC
 		},
 		&timezone_string,
 		"GMT",
@@ -3373,7 +3373,7 @@ static struct config_enum ConfigureNamesEnum[] =
 			gettext_noop("Sets the message levels that are sent to the client."),
 			gettext_noop("Each level includes all the levels that follow it. The later"
 						 " the level, the fewer messages are sent."),
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&client_min_messages,
 		NOTICE, client_message_level_options,
@@ -3417,7 +3417,7 @@ static struct config_enum ConfigureNamesEnum[] =
 		{"IntervalStyle", PGC_USERSET, CLIENT_CONN_LOCALE,
 			gettext_noop("Sets the display format for interval values."),
 			NULL,
-			GUC_REPORT | GUC_GPDB_ADDOPT
+			GUC_REPORT | GUC_GPDB_NEED_SYNC
 		},
 		&IntervalStyle,
 		INTSTYLE_POSTGRES, intervalstyle_options, NULL, NULL
@@ -3427,7 +3427,7 @@ static struct config_enum ConfigureNamesEnum[] =
 		{"log_error_verbosity", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Sets the verbosity of logged messages."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Log_error_verbosity,
 		PGERROR_DEFAULT, log_error_verbosity_options,
@@ -3439,7 +3439,7 @@ static struct config_enum ConfigureNamesEnum[] =
 			gettext_noop("Sets the message levels that are logged."),
 			gettext_noop("Each level includes all the levels that follow it. The later"
 						 " the level, the fewer messages are sent."),
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&log_min_messages,
 		WARNING, server_message_level_options,
@@ -3451,7 +3451,7 @@ static struct config_enum ConfigureNamesEnum[] =
 			gettext_noop("Causes all statements generating error at or above this level to be logged."),
 			gettext_noop("Each level includes all the levels that follow it. The later"
 						 " the level, the fewer messages are sent."),
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&log_min_error_statement,
 		ERROR, server_message_level_options,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -609,7 +609,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_use_legacy_hashops", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
 			gettext_noop("If set, new tables will use legacy distribution hashops by default"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_use_legacy_hashops,
 		false,
@@ -702,7 +702,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"log_dispatch_stats", PGC_SUSET, STATS_MONITORING,
 			gettext_noop("Writes dispatcher performance statistics to the server log."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&log_dispatch_stats,
 		false,
@@ -875,7 +875,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_enable_mk_sort", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable multi-key sort."),
 			gettext_noop("A faster sort."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 
 		},
 		&gp_enable_mk_sort,
@@ -887,7 +887,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_enable_motion_mk_sort", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable multi-key sort in sorted motion recv."),
 			gettext_noop("A faster sort for recv motion"),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 
 		},
 		&gp_enable_motion_mk_sort,
@@ -901,7 +901,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_mk_sort_check", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Extensive check mk_sort"),
 			gettext_noop("Expensive debug checking"),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_mk_sort_check,
 		false,
@@ -990,7 +990,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_select_invisible", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Use dummy snapshot for MVCC visibility calculation."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_NEED_SYNC
 		},
 		&gp_select_invisible,
 		false,
@@ -1012,7 +1012,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_debug_pgproc", PGC_POSTMASTER, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug info relevant to PGPROC."),
 			NULL /* long description */ ,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_debug_pgproc,
 		false,
@@ -1023,7 +1023,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_appendonly_verify_block_checksums", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Verify the append-only block checksum when reading."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_NEED_SYNC
 		},
 		&gp_appendonly_verify_block_checksums,
 		true,
@@ -1034,7 +1034,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_appendonly_verify_write_block", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Verify the append-only block as it is being written."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_NEED_SYNC
 		},
 		&gp_appendonly_verify_write_block,
 		false,
@@ -1045,7 +1045,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_appendonly_compaction", PGC_SUSET, APPENDONLY_TABLES,
 			gettext_noop("Perform append-only compaction instead of eof truncation on vacuum."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_NEED_SYNC
 		},
 		&gp_appendonly_compaction,
 		true,
@@ -1121,7 +1121,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_workfile_compression", PGC_USERSET, RESOURCES_DISK,
 			gettext_noop("Enables compression of temporary files."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&gp_workfile_compression,
 		false,
@@ -1163,7 +1163,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_interconnect_full_crc", PGC_USERSET, QUERY_TUNING_OTHER,
 			gettext_noop("Sanity check incoming data stream."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_interconnect_full_crc,
 		false,
@@ -1174,7 +1174,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_interconnect_log_stats", PGC_USERSET, QUERY_TUNING_OTHER,
 			gettext_noop("Emit statistics from the UDP-IC at the end of every statement."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_interconnect_log_stats,
 		false,
@@ -1184,7 +1184,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_interconnect_cache_future_packets", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Control whether future packets are cached."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&gp_interconnect_cache_future_packets,
 		true,
@@ -1235,7 +1235,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_print_full_dtm", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Prints full DTM information to server log."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_print_full_dtm,
 		false,
@@ -1246,7 +1246,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_print_snapshot_dtm", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Prints snapshot DTM information to server log."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_print_snapshot_dtm,
 		false,
@@ -1257,7 +1257,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_disable_distributed_snapshot", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Disables distributed snapshots."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_disable_distributed_snapshot,
 		false,
@@ -1268,7 +1268,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_abort_after_distributed_prepared", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Cause an abort after all segments are prepared but before the distributed commit is written."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_abort_after_distributed_prepared,
 		false,
@@ -1279,7 +1279,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_blockdirectory", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only block directory."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_blockdirectory,
 		false,
@@ -1290,7 +1290,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"Debug_appendonly_print_read_block", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only reads."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_read_block,
 		false,
@@ -1301,7 +1301,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"Debug_appendonly_print_append_block", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only writes."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_append_block,
 		false,
@@ -1312,7 +1312,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_visimap", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only visibility bitmap information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_visimap,
 		false,
@@ -1323,7 +1323,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_compaction", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages about append-only visibility compactions."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_compaction,
 		false,
@@ -1334,7 +1334,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_insert", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only insert."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_insert,
 		false,
@@ -1345,7 +1345,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_insert_tuple", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only insert tuples (caution -- generates a lot of log!)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_insert_tuple,
 		false,
@@ -1356,7 +1356,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_scan", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only scan."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_scan,
 		false,
@@ -1367,7 +1367,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_scan_tuple", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only scan tuples (caution -- generates a lot of log!)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_scan_tuple,
 		false,
@@ -1378,7 +1378,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_delete", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only delete."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_delete,
 		false,
@@ -1389,7 +1389,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_storage_headers", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only storage headers."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_storage_headers,
 		false,
@@ -1400,7 +1400,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_verify_write_block", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only verify block during write."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_verify_write_block,
 		false,
@@ -1411,7 +1411,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_use_no_toast", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Use no toast for an append-only table.  Store the large row inline."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_use_no_toast,
 		false,
@@ -1422,7 +1422,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_segfile_choice", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only writers about their choice for AO segment file."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_segfile_choice,
 		false,
@@ -1433,7 +1433,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"test_AppendOnlyHash_eviction_vs_just_marking_not_inuse", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Helps to test evicting the entry for AppendOnlyHash as soon as its usage is done instead of just marking it not inuse."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&test_AppendOnlyHash_eviction_vs_just_marking_not_inuse,
 		false,
@@ -1444,7 +1444,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_datumstream", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only datum stream content."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_appendonly_print_datumstream,
 		false,
@@ -1455,7 +1455,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_xlog_record_read", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug information for xlog record read."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&debug_xlog_record_read,
 		false,
@@ -1466,7 +1466,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_cancel_print", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print cancel detail information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_cancel_print,
 		false,
@@ -1477,7 +1477,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_write_print_small_varlena_info", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print datum stream write small varlena information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_datumstream_write_print_small_varlena_info,
 		false,
@@ -1488,7 +1488,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_write_print_large_varlena_info", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print datum stream write large varlena information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_datumstream_write_print_large_varlena_info,
 		false,
@@ -1499,7 +1499,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_read_check_large_varlena_integrity", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Check datum stream large object integrity."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_datumstream_read_check_large_varlena_integrity,
 		false,
@@ -1510,7 +1510,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_block_read_check_integrity", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Check datum stream block read integrity."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_datumstream_block_read_check_integrity,
 		false,
@@ -1521,7 +1521,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_block_write_check_integrity", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Check datum stream block write integrity."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_datumstream_block_write_check_integrity,
 		false,
@@ -1532,7 +1532,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_read_print_varlena_info", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print datum stream read varlena information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_datumstream_read_print_varlena_info,
 		false,
@@ -1543,7 +1543,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_write_use_small_initial_buffers", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Use small datum stream write buffers to stress growing logic."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_datumstream_write_use_small_initial_buffers,
 		false,
@@ -1554,7 +1554,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"test_print_direct_dispatch_info", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("For testing purposes, print information about direct dispatch decisions."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Test_print_direct_dispatch_info,
 		false,
@@ -1565,7 +1565,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_bitmap_print_insert", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for bitmap index insert routines (caution-- generate a lot of logs!)"),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_bitmap_print_insert,
 		false,
@@ -1576,7 +1576,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_dtm_action_primary", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Specify if the primary or mirror segment is the target of the debug DTM action."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_dtm_action_primary,
 		DEBUG_DTM_ACTION_PRIMARY_DEFAULT, NULL, NULL, NULL
@@ -1586,7 +1586,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_disable_tuple_hints", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Specify if reader should set hint bits on tuples."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_disable_tuple_hints,
 		true,
@@ -1597,7 +1597,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_local_distributed_cache_stats", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prints local-distributed cache statistics at end of commit / prepare."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_local_distributed_cache_stats,
 		false,
@@ -1608,7 +1608,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"enable_partition_rules", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable creation of RULEs to implement partitioning"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&enable_partition_rules,
 		false,
@@ -1639,7 +1639,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"coredump_on_memerror", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Generate core dump on memory error."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&coredump_on_memerror,
 		false,
@@ -1648,7 +1648,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"log_autostats", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Logs details of auto-stats issued ANALYZEs."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&log_autostats,
 		true,
@@ -1657,7 +1657,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_statistics_pullup_from_child_partition", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("This guc enables the planner to utilize statistics from partitions in planning queries on the parent."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&gp_statistics_pullup_from_child_partition,
 		true,
@@ -1666,7 +1666,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_statistics_use_fkeys", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("This guc enables the planner to utilize statistics derived from foreign key relationships."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&gp_statistics_use_fkeys,
 		true,
@@ -1686,7 +1686,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_resource_group", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prints resource groups debug logs."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_resource_group,
 		false,
@@ -1697,7 +1697,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_walrepl_snd", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for WAL sender in WAL based replication (Master Mirroring)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&debug_walrepl_snd,
 		false,
@@ -1708,7 +1708,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_walrepl_syncrep", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for synchronous behavior in WAL based replication (Master Mirroring)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&debug_walrepl_syncrep,
 		false,
@@ -1719,7 +1719,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_walrepl_rcv", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for WAL receiver in WAL based replication (Master Mirroring)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&debug_walrepl_rcv,
 		false,
@@ -1730,7 +1730,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_basebackup", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for basebackup mechanism (Master Mirroring)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&debug_basebackup,
 		false,
@@ -1741,7 +1741,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_latch", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for latch mechanism."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&debug_latch,
 		false,
@@ -1764,7 +1764,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"pljava_release_lingering_savepoints", PGC_SUSET, CUSTOM_OPTIONS,
 			gettext_noop("If true, lingering savepoints will be released on function exit; if false, they will be rolled back"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
+			GUC_GPDB_NEED_SYNC | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
 		},
 		&pljava_release_lingering_savepoints,
 		false,
@@ -1774,7 +1774,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"pljava_debug", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Stop the backend to attach a debugger"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY | GUC_GPDB_NEED_SYNC
 		},
 		&pljava_debug,
 		false,
@@ -1785,7 +1785,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_keep_all_xlog", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Do not remove old xlog files."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_keep_all_xlog,
 		false,
@@ -1796,7 +1796,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_test_time_slice", PGC_USERSET, GP_ERROR_HANDLING,
 			gettext_noop("Check for time slice violation between checks for interrupts"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_test_time_slice,
 		false,
@@ -1807,7 +1807,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_test_deadlock_hazard", PGC_USERSET, GP_ERROR_HANDLING,
 			gettext_noop("Check if a lightweight lock is already held when requesting a database lock"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_test_deadlock_hazard,
 		false,
@@ -1818,7 +1818,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_partitioning_dynamic_selection_log", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print out debugging info for GPDB dynamic partition selection"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_partitioning_dynamic_selection_log,
 		false,
@@ -1829,7 +1829,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_perfmon_print_packet_info", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print out debugging info for a Perfmon packet"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_perfmon_print_packet_info,
 		false,
@@ -1840,7 +1840,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_log_stack_trace_lines", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Control if file/line information is included in stack traces"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_log_stack_trace_lines,
 		true,
@@ -1852,7 +1852,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_log_resqueue_memory", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Prints out messages related to resource queue's memory management."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_log_resqueue_memory,
 		false,
@@ -1864,7 +1864,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_log_resgroup_memory", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Prints out messages related to resource group's memory management."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_log_resgroup_memory,
 		false,
@@ -1876,7 +1876,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			gettext_noop("Prints out the memory limit for operators (in explain) assigned by resource queue's "
 						 "memory management."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_resqueue_print_operator_memory_limits,
 		false,
@@ -1888,7 +1888,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			gettext_noop("Prints out the memory limit for operators (in explain) assigned by resource group's "
 						 "memory management."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_resgroup_print_operator_memory_limits,
 		false,
@@ -1964,7 +1964,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_allow_non_uniform_partitioning_ddl", PGC_USERSET, COMPAT_OPTIONS,
 			gettext_noop("Allow DDL that will create multi-level partition table with non-uniform hierarchy."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_allow_non_uniform_partitioning_ddl,
 		true,
@@ -1974,7 +1974,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_enable_exchange_default_partition", PGC_USERSET, COMPAT_OPTIONS,
 			gettext_noop("Allow DDL that will exchange default partitions."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&gp_enable_exchange_default_partition,
 		false,
@@ -1995,7 +1995,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_recursive_cte", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable RECURSIVE clauses in CTE queries."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_recursive_cte,
 		false, NULL, NULL
@@ -2041,7 +2041,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_partition_selection_log", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Log optimizer partition selection."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&optimizer_partition_selection_log,
 		false,
@@ -2765,7 +2765,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"dml_ignore_target_partition_check", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Ignores checking whether the user provided correct partition during a direct insert to a leaf partition"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&dml_ignore_target_partition_check,
 		false,
@@ -2820,7 +2820,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"vmem_process_interrupt", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Checks for interrupts before reserving VMEM"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&vmem_process_interrupt,
 		false,
@@ -2831,7 +2831,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"execute_pruned_plan", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prune plan to discard unwanted plan nodes for each slice before execution"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&execute_pruned_plan,
 		true,
@@ -2853,7 +2853,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_enable_segment_copy_checking", PGC_USERSET, CUSTOM_OPTIONS,
 			gettext_noop("Enable check the distribution key restriction on segment for command \"COPY FROM ON SEGMENT\"."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_enable_segment_copy_checking,
 		true,
@@ -2864,7 +2864,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_ignore_error_table", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
 			gettext_noop("Ignore INTO error-table in external table and COPY (Deprecated)."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_ignore_error_table,
 		false,
@@ -2894,7 +2894,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"verify_gpfdists_cert", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Verifies the authenticity of the gpfdist's certificate"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&verify_gpfdists_cert,
 		true, check_verify_gpfdists_cert, NULL
@@ -2904,7 +2904,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_external_enable_filter_pushdown", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Enable passing of query constraints to external table providers"),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&gp_external_enable_filter_pushdown,
 		true, NULL, NULL
@@ -3002,7 +3002,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"debug_dtm_action_segment", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action segment."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_dtm_action_segment,
 		DEBUG_DTM_ACTION_SEGMENT_DEFAULT, -2, 1000,
@@ -3013,7 +3013,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"debug_dtm_action_nestinglevel", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action transaction nesting level."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_dtm_action_nestinglevel,
 		DEBUG_DTM_ACTION_NESTINGLEVEL_DEFAULT, 0, 1000,
@@ -3037,7 +3037,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			gettext_noop("The planner considers this much memory may be used by each internal "
 						 "sort operation and hash table before switching to "
 						 "temporary disk files."),
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
+			GUC_UNIT_KB | GUC_GPDB_NEED_SYNC | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
 		},
 		&planner_work_mem,
 		32768, 2 * BLCKSZ / 1024, MAX_KILOBYTES,
@@ -3048,7 +3048,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"statement_mem", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the memory to be reserved for a statement."),
 			NULL,
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT
+			GUC_UNIT_KB | GUC_GPDB_NEED_SYNC
 		},
 		&statement_mem,
 #ifdef USE_ASSERT_CHECKING
@@ -3084,7 +3084,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"max_statement_mem", PGC_SUSET, RESOURCES_MEM,
 			gettext_noop("Sets the maximum value for statement_mem setting."),
 			NULL,
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT
+			GUC_UNIT_KB | GUC_GPDB_NEED_SYNC
 		},
 		&max_statement_mem,
 		2048000, 32768, INT_MAX,
@@ -3117,7 +3117,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_max_partition_level", PGC_SUSET, PRESET_OPTIONS,
 			gettext_noop("Sets the maximum number of levels allowed when creating a partitioned table."),
 			gettext_noop("Use 0 for no limit."),
-			GUC_GPDB_ADDOPT | GUC_SUPERUSER_ONLY | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_SUPERUSER_ONLY | GUC_NOT_IN_SAMPLE
 		},
 		&gp_max_partition_level,
 		0, 0, INT_MAX,
@@ -3128,7 +3128,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_appendonly_compaction_threshold", PGC_USERSET, APPENDONLY_TABLES,
 			gettext_noop("Threshold of the ratio of dirty data in a segment file over which the file"
 						 " will be compacted during lazy vacuum."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&gp_appendonly_compaction_threshold,
 		10, 0, 100,
@@ -3150,7 +3150,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_workfile_limit_files_per_query", PGC_USERSET, RESOURCES,
 			gettext_noop("Maximum number of workfiles allowed per query per segment."),
 			gettext_noop("0 for no limit. Current query is terminated when limit is exceeded."),
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&gp_workfile_limit_files_per_query,
 		100000, 0, INT_MAX,
@@ -3172,7 +3172,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_workfile_limit_per_query", PGC_USERSET, RESOURCES,
 			gettext_noop("Maximum disk space (in KB) used for workfiles per query per segment."),
 			gettext_noop("0 for no limit. Current query is terminated when limit is exceeded."),
-			GUC_GPDB_ADDOPT | GUC_UNIT_KB
+			GUC_GPDB_NEED_SYNC | GUC_UNIT_KB
 		},
 		&gp_workfile_limit_per_query,
 		0, 0, INT_MAX,
@@ -3183,7 +3183,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_vmem_idle_resource_timeout", PGC_USERSET, CLIENT_CONN_OTHER,
 			gettext_noop("Sets the time a session can be idle (in milliseconds) before we release gangs on the segment DBs to free resources."),
 			gettext_noop("A value of 0 turns off the timeout."),
-			GUC_UNIT_MS | GUC_GPDB_ADDOPT
+			GUC_UNIT_MS | GUC_GPDB_NEED_SYNC
 		},
 		&IdleSessionGangTimeout,
 #ifdef USE_ASSERT_CHECKING
@@ -3295,7 +3295,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_max_packet_size", PGC_BACKEND, GP_ARRAY_TUNING,
 			gettext_noop("Sets the max packet size for the Interconnect."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Gp_max_packet_size,
 		DEFAULT_PACKET_SIZE, MIN_PACKET_SIZE, MAX_PACKET_SIZE,
@@ -3306,7 +3306,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_queue_depth", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the maximum size of the receive queue for each connection in the UDP interconnect"),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_queue_depth,
 		4, 1, 4096,
@@ -3317,7 +3317,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_snd_queue_depth", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the maximum size of the send queue for each connection in the UDP interconnect"),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_snd_queue_depth,
 		2, 1, 4096,
@@ -3328,7 +3328,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_timer_period", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the timer period (in ms) for UDP interconnect"),
 			NULL,
-			GUC_UNIT_MS | GUC_GPDB_ADDOPT
+			GUC_UNIT_MS | GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_timer_period,
 		5, 1, 100,
@@ -3339,7 +3339,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_timer_checking_period", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the timer checking period (in ms) for UDP interconnect"),
 			NULL,
-			GUC_UNIT_MS | GUC_GPDB_ADDOPT
+			GUC_UNIT_MS | GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_timer_checking_period,
 		20, 1, 100,
@@ -3350,7 +3350,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_default_rtt", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the default rtt (in ms) for UDP interconnect"),
 			NULL,
-			GUC_UNIT_MS | GUC_GPDB_ADDOPT
+			GUC_UNIT_MS | GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_default_rtt,
 		20, 1, 1000,
@@ -3361,7 +3361,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_min_rto", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the min rto (in ms) for UDP interconnect"),
 			NULL,
-			GUC_UNIT_MS | GUC_GPDB_ADDOPT
+			GUC_UNIT_MS | GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_min_rto,
 		20, 1, 1000,
@@ -3372,7 +3372,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_transmit_timeout", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Timeout (in seconds) on interconnect to transmit a packet"),
 			gettext_noop("Used by Interconnect to timeout packet transmission."),
-			GUC_UNIT_S | GUC_GPDB_ADDOPT
+			GUC_UNIT_S | GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_transmit_timeout,
 		3600, 1, 7200,
@@ -3383,7 +3383,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_min_retries_before_timeout", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the min retries before reporting a transmit timeout in the interconnect."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_min_retries_before_timeout,
 		100, 1, 4096,
@@ -3394,7 +3394,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_debug_retry_interval", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the interval by retry times to record a debug message for retry."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_debug_retry_interval,
 		10, 1, 4096,
@@ -3405,7 +3405,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_udp_bufsize_k", PGC_BACKEND, GP_ARRAY_TUNING,
 			gettext_noop("Sets recv buf size of UDP interconnect, for testing."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Gp_udp_bufsize_k,
 		0, 0, 32768,
@@ -3417,7 +3417,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_udpic_dropseg", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Specifies a segment to which the dropacks, and dropxmit settings will be applied, for testing. (The default is to apply the dropacks and dropxmit settings to all segments)"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_udpic_dropseg,
 		UNDEF_SEGMENT, UNDEF_SEGMENT, INT_MAX,
@@ -3428,7 +3428,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_udpic_dropacks_percent", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the percentage of correctly-received acknowledgment packets to synthetically drop, for testing. (affected by gp_udpic_dropseg)"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_udpic_dropacks_percent,
 		0, 0, 100,
@@ -3439,7 +3439,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_udpic_dropxmit_percent", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the percentage of correctly-received data packets to synthetically drop, for testing. (affected by gp_udpic_dropseg)"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_udpic_dropxmit_percent,
 		0, 0, 100,
@@ -3450,7 +3450,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_udpic_fault_inject_percent", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the percentage of fault injected into system calls, for testing. (affected by gp_udpic_dropseg)"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_udpic_fault_inject_percent,
 		0, 0, 100,
@@ -3461,7 +3461,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_udpic_fault_inject_bitmap", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the bitmap for faults injection, for testing. (affected by gp_udpic_dropseg)"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_udpic_fault_inject_bitmap,
 		0, 0, INT_MAX,
@@ -3472,7 +3472,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_udpic_network_disable_ipv6", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the address info hint to disable the ipv6, for testing. (affected by gp_udpic_dropseg)"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_udpic_network_disable_ipv6,
 		0, 0, 1,
@@ -3515,7 +3515,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_cached_segworkers_threshold", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the maximum number of segment workers to cache between statements."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_cached_gang_threshold,
 		5, 1, INT_MAX,
@@ -3528,7 +3528,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_debug_linger", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Number of seconds for QD/QE process to linger upon fatal internal error."),
 			gettext_noop("Allows an opportunity to debug the backend process before it terminates."),
-			GUC_NOT_IN_SAMPLE | GUC_NO_RESET_ALL | GUC_UNIT_S | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_NO_RESET_ALL | GUC_UNIT_S | GUC_GPDB_NEED_SYNC
 		},
 		&gp_debug_linger,
 		120, 0, 3600,
@@ -3536,7 +3536,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_debug_linger", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Number of seconds for QD/QE process to linger upon fatal internal error."),
 			gettext_noop("Allows an opportunity to debug the backend process before it terminates."),
-			GUC_NOT_IN_SAMPLE | GUC_NO_RESET_ALL | GUC_UNIT_S | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_NO_RESET_ALL | GUC_UNIT_S | GUC_GPDB_NEED_SYNC
 		},
 		&gp_debug_linger,
 		0, 0, 3600,
@@ -3582,7 +3582,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_setup_timeout", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Timeout (in seconds) on interconnect setup that occurs at query start"),
 			gettext_noop("Used by Interconnect to timeout the setup of the communication fabric."),
-			GUC_UNIT_S | GUC_GPDB_ADDOPT
+			GUC_UNIT_S | GUC_GPDB_NEED_SYNC
 		},
 		&interconnect_setup_timeout,
 		7200, 0, 7200,
@@ -3593,7 +3593,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_interconnect_tcp_listener_backlog", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Size of the listening queue for each TCP interconnect socket"),
 			gettext_noop("Cooperate with kernel parameter net.core.somaxconn and net.ipv4.tcp_max_syn_backlog to tune network performance."),
-			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&listenerBacklog,
 		128, 0, 65535,
@@ -3604,7 +3604,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_snapshotadd_timeout", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Timeout (in seconds) on setup of new connection snapshot"),
 			gettext_noop("Used by the transaction manager."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_UNIT_S | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_UNIT_S | GUC_GPDB_NEED_SYNC
 		},
 		&gp_snapshotadd_timeout,
 		10, 0, INT_MAX,
@@ -3712,7 +3712,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_hashjoin_tuples_per_bucket", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Target density of hashtable used by Hashjoin during execution"),
 			gettext_noop("A smaller value will tend to produce larger hashtables, which increases join performance"),
-			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_hashjoin_tuples_per_bucket,
 		5, 1, 25,
@@ -3723,7 +3723,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_hashagg_groups_per_bucket", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Target density of hashtable used by Hashagg during execution"),
 			gettext_noop("A smaller value will tend to produce larger hashtables, which increases agg performance"),
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_NEED_SYNC
 		},
 		&gp_hashagg_groups_per_bucket,
 		5, 1, 25,
@@ -3734,7 +3734,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_hashagg_default_nbatches", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Default number of batches for hashagg's (re-)spilling phases."),
 			gettext_noop("Must be a power of two."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_hashagg_default_nbatches,
 		32, 4, 1048576,
@@ -3745,7 +3745,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_motion_slice_noop", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Make motion nodes in certain slices noop"),
 			gettext_noop("Make motion nodes noop, to help analyze performance"),
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_NEED_SYNC
 		},
 		&gp_motion_slice_noop,
 		0, 0, INT_MAX,
@@ -3755,7 +3755,7 @@ struct config_int ConfigureNamesInt_gp[] =
 	{
 		{"gp_reject_percent_threshold", PGC_USERSET, GP_ERROR_HANDLING,
 			gettext_noop("Reject limit in percent starts calculating after this number of rows processed"),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&gp_reject_percent_threshold,
 		300, 0, INT_MAX,
@@ -3766,7 +3766,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_gpperfmon_send_interval", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Interval in seconds between sending messages to gpperfmon."),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&gp_gpperfmon_send_interval,
 		1, 1, 3600,
@@ -3827,7 +3827,7 @@ struct config_int ConfigureNamesInt_gp[] =
 	{
 		{"gp_autostats_on_change_threshold", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Threshold for number of tuples added to table by CTAS or Insert-to to trigger autostats in on_change mode. See gp_autostats_mode."),
-			NULL, GUC_GPDB_ADDOPT
+			NULL, GUC_GPDB_NEED_SYNC
 		},
 		&gp_autostats_on_change_threshold,
 		INT_MAX, 0, INT_MAX,
@@ -3840,7 +3840,7 @@ struct config_int ConfigureNamesInt_gp[] =
 						 "aggregate computation will be rewritten based on the multi-phrase aggregation. "
 						 "The rest of grouping sets in the same query will not be rewritten."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_distinct_grouping_sets_threshold,
 		32, 0, 1024,
@@ -3902,7 +3902,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_blockdirectory_entry_min_range", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Minimal range in bytes one block directory entry covers."),
 			gettext_noop("Used to reduce the size of a block directory."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_blockdirectory_entry_min_range,
 		0, 0, INT_MAX,
@@ -3913,7 +3913,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_blockdirectory_minipage_size", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Number of entries one row in a block directory table contains."),
 			gettext_noop("Use smaller value in non-bulk load cases."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_blockdirectory_minipage_size,
 		NUM_MINIPAGE_ENTRIES, 1, NUM_MINIPAGE_ENTRIES,
@@ -3937,7 +3937,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"pljava_statement_cache_size", PGC_SUSET, CUSTOM_OPTIONS,
 			gettext_noop("Size of the prepared statement MRU cache"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
+			GUC_GPDB_NEED_SYNC | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
 		},
 		&pljava_statement_cache_size,
 		0, 0, 512,
@@ -3948,7 +3948,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_test_time_slice_interval", PGC_USERSET, GP_ERROR_HANDLING,
 			gettext_noop("Maximum interval in ms between successive checks for interrupts."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_test_time_slice_interval,
 		1000, 1, 10000,
@@ -3959,7 +3959,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_resqueue_memory_policy_auto_fixed_mem", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the fixed amount of memory reserved for non-memory intensive operators in the AUTO policy."),
 			NULL,
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_UNIT_KB | GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_resqueue_memory_policy_auto_fixed_mem,
 		100, 50, INT_MAX,
@@ -3970,7 +3970,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_resgroup_memory_policy_auto_fixed_mem", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the fixed amount of memory reserved for non-memory intensive operators in the AUTO policy."),
 			NULL,
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_UNIT_KB | GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_resgroup_memory_policy_auto_fixed_mem,
 		100, 50, INT_MAX,
@@ -3991,7 +3991,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_plan_id", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Choose a plan alternative"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_plan_id,
 		0, 0, INT_MAX,
@@ -4002,7 +4002,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_samples_number", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Set the number of plan samples"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_samples_number,
 		1000, 1, INT_MAX,
@@ -4013,7 +4013,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_cte_inlining_bound", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Set the CTE inlining cutoff"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_cte_inlining_bound,
 		0, 0, INT_MAX,
@@ -4078,7 +4078,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_mdcache_size", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the size of MDCache."),
 			NULL,
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT
+			GUC_UNIT_KB | GUC_GPDB_NEED_SYNC
 		},
 		&optimizer_mdcache_size,
 		16384, 0, INT_MAX,
@@ -4089,7 +4089,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"memory_profiler_dataset_size", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Set the size in GB"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&memory_profiler_dataset_size,
 		0, 0, INT_MAX,
@@ -4111,7 +4111,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_initial_bad_row_limit", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Stops processing when number of the first bad rows exceeding this value"),
 			NULL,
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&gp_initial_bad_row_limit,
 		1000, 0, INT_MAX,
@@ -4122,7 +4122,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_indexcheck_insert", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Validate that a unique index does not already have the new tid during insert."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		(int *) &gp_indexcheck_insert,
 		INDEX_CHECK_NONE, 0, INDEX_CHECK_ALL,
@@ -4133,7 +4133,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_indexcheck_vacuum", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Validate index after lazy vacuum."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		(int *) &gp_indexcheck_vacuum,
 		INDEX_CHECK_NONE, 0, INDEX_CHECK_ALL,
@@ -4144,7 +4144,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"dtx_phase2_retry_count", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Maximum number of retries during two phase commit after which master PANICs."),
 			NULL,
-			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&dtx_phase2_retry_count,
 		10, 0, INT_MAX,
@@ -4167,7 +4167,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_max_slices", PGC_USERSET, PRESET_OPTIONS,
 			gettext_noop("Maximum slices for a single query"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NOT_IN_SAMPLE
 		},
 		&gp_max_slices,
 		0, 0, INT_MAX, NULL, NULL
@@ -4322,7 +4322,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"memory_profiler_run_id", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Set the unique run ID for memory profiling"),
 			gettext_noop("Any string is acceptable"),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&memory_profiler_run_id,
 		"none",
@@ -4333,7 +4333,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"memory_profiler_dataset_id", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Set the dataset ID for memory profiling"),
 			gettext_noop("Any string is acceptable"),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&memory_profiler_dataset_id,
 		"none",
@@ -4344,7 +4344,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"memory_profiler_query_id", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Set the query ID for memory profiling"),
 			gettext_noop("Any string is acceptable"),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&memory_profiler_query_id,
 		"none",
@@ -4388,7 +4388,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"debug_dtm_action_sql_command_tag", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action sql command tag."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_dtm_action_sql_command_tag,
 		"",
@@ -4423,7 +4423,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"pljava_vmoptions", PGC_SUSET, CUSTOM_OPTIONS,
 			gettext_noop("Options sent to the JVM when it is created"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
+			GUC_GPDB_NEED_SYNC | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
 		},
 		&pljava_vmoptions,
 		"",
@@ -4433,7 +4433,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"pljava_classpath", PGC_SUSET, CUSTOM_OPTIONS,
 			gettext_noop("classpath used by the the JVM"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NOT_IN_SAMPLE
 		},
 		&pljava_classpath,
 		"",
@@ -4444,7 +4444,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"gp_auth_time_override", PGC_SIGHUP, DEVELOPER_OPTIONS,
 			gettext_noop("The timestamp used for enforcing time constraints."),
 			gettext_noop("For testing purposes only."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_auth_time_override_str,
 		"",
@@ -4466,7 +4466,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"gp_default_storage_options", PGC_USERSET, APPENDONLY_TABLES,
 			gettext_noop("default options for appendonly storage."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+			GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&gp_default_storage_options, "",
 		check_gp_default_storage_options, assign_gp_default_storage_options, NULL
@@ -4499,7 +4499,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 						 "DEBUG1, LOG, NOTICE, WARNING, and ERROR. Each level includes all the "
 						 "levels that follow it. The later the level, the fewer messages are "
 						 "sent."),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_workfile_caching_loglevel,
 		DEBUG1, server_message_level_options,
@@ -4513,7 +4513,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 						 "DEBUG1, LOG, NOTICE, WARNING, and ERROR. Each level includes all the "
 						 "levels that follow it. The later the level, the fewer messages are "
 						 "sent."),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_sessionstate_loglevel,
 		DEBUG1, server_message_level_options,
@@ -4524,7 +4524,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"gp_test_time_slice_report_level", PGC_USERSET, LOGGING_WHEN,
 			gettext_noop("Sets the message level for time slice violation reports."),
 			gettext_noop("Valid values are NOTICE, WARNING, ERROR, FATAL and PANIC."),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_test_time_slice_report_level,
 		ERROR, test_time_slice_report_level_options,
@@ -4535,7 +4535,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"gp_test_deadlock_hazard_report_level", PGC_USERSET, LOGGING_WHEN,
 			gettext_noop("Sets the message level for deadlock hazard reports."),
 			gettext_noop("Valid values are NOTICE, WARNING, ERROR, FATAL and PANIC."),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_test_deadlock_hazard_report_level,
 		ERROR, server_message_level_options,
@@ -4556,7 +4556,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"debug_dtm_action_protocol", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action protocol."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_dtm_action_protocol,
 		DTX_PROTOCOL_COMMAND_NONE, debug_dtm_action_protocol_options,
@@ -4610,7 +4610,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"explain_memory_verbosity", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Experimental feature: show memory account usage in EXPLAIN ANALYZE."),
 			gettext_noop("Valid values are SUPPRESS, SUMMARY, DETAIL, and DEBUG."),
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&explain_memory_verbosity,
 		EXPLAIN_MEMORY_VERBOSITY_SUPPRESS, explain_memory_verbosity_options,
@@ -4621,7 +4621,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"debug_dtm_action", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_dtm_action,
 		DEBUG_DTM_ACTION_NONE, debug_dtm_action_options,
@@ -4632,7 +4632,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"debug_dtm_action_target", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action target."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC
 		},
 		&Debug_dtm_action_target,
 		DEBUG_DTM_ACTION_TARGET_NONE, debug_dtm_action_target_options,
@@ -4663,7 +4663,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"gp_interconnect_fc_method", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the flow control method used for UDP interconnect."),
 			gettext_noop("Valid values are \"capacity\" and \"loss\"."),
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_fc_method,
 		INTERCONNECT_FC_METHOD_LOSS, gp_interconnect_fc_methods,
@@ -4674,7 +4674,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"gp_interconnect_type", PGC_BACKEND, GP_ARRAY_TUNING,
 			gettext_noop("Sets the protocol used for inter-node communication."),
 			gettext_noop("Valid values are \"tcp\" and \"udpifc\"."),
-			GUC_GPDB_ADDOPT
+			GUC_GPDB_NEED_SYNC
 		},
 		&Gp_interconnect_type,
 		INTERCONNECT_TYPE_UDPIFC, gp_interconnect_types,
@@ -4707,7 +4707,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"gp_log_interconnect", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Sets the verbosity of logged messages pertaining to connections between worker processes."),
 			gettext_noop("Valid values are \"off\", \"terse\", \"verbose\" and \"debug\"."),
-			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_GPDB_NEED_SYNC | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_log_interconnect,
 		GPVARS_VERBOSITY_TERSE, gp_log_verbosity,
@@ -5088,7 +5088,7 @@ add_guc_to_sync_list(struct config_generic *record, const char *name,
 	bool isexists = false;
 
 	/* Sync GUC with flag GUC_GPDB_ADDOPT */
-	if ((record->flags & GUC_GPDB_ADDOPT))
+	if ((record->flags & GUC_GPDB_NEED_SYNC))
 	{
 		MemoryContext oldContext = MemoryContextSwitchTo(TopMemoryContext);
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5075,3 +5075,34 @@ check_gp_workfile_compression(bool *newval, void **extra, GucSource source)
 #endif
 	return true;
 }
+
+/*
+ * Add GUCs which need sync into guc_list_need_sync_global
+ */
+void
+add_guc_to_sync_list(struct config_generic *record, const char *name)
+{
+	ListCell *lc;
+	char *cur_guc_name;
+	bool isexists = false;
+
+	/* Sync GUC with flag GUC_GPDB_ADDOPT */
+	if ((record->flags & GUC_GPDB_ADDOPT))
+	{
+		MemoryContext oldContext = MemoryContextSwitchTo(TopMemoryContext);
+		foreach (lc, guc_list_need_sync_global)
+		{
+			cur_guc_name = (char*)(lc);
+			if (strlen(name) != strlen(cur_guc_name))
+				continue;
+			if (strncmp(cur_guc_name, name, strlen(name)) == 0)
+			{
+				isexists = true;
+				break;
+			}
+		}
+		if (!isexists)
+			guc_list_need_sync_global = lappend(guc_list_need_sync_global, pstrdup(name));
+		MemoryContextSwitchTo(oldContext);
+	}
+}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -101,6 +101,10 @@ extern int listenerBacklog;
 List	   *gp_guc_list_for_explain;
 List	   *gp_guc_list_for_no_plan;
 
+/* TRUE if any guc with GUC_GPDB_ADDOPT flag changed. */
+bool guc_need_sync_session;
+List *guc_list_need_sync_global;
+
 char	   *Debug_dtm_action_sql_command_tag;
 
 bool		Debug_print_full_dtm = false;
@@ -605,7 +609,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_use_legacy_hashops", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
 			gettext_noop("If set, new tables will use legacy distribution hashops by default"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_use_legacy_hashops,
 		false,
@@ -1008,7 +1012,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_debug_pgproc", PGC_POSTMASTER, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug info relevant to PGPROC."),
 			NULL /* long description */ ,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_debug_pgproc,
 		false,
@@ -1019,7 +1023,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_appendonly_verify_block_checksums", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Verify the append-only block checksum when reading."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
 		},
 		&gp_appendonly_verify_block_checksums,
 		true,
@@ -1030,7 +1034,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_appendonly_verify_write_block", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Verify the append-only block as it is being written."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
 		},
 		&gp_appendonly_verify_write_block,
 		false,
@@ -1041,7 +1045,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_appendonly_compaction", PGC_SUSET, APPENDONLY_TABLES,
 			gettext_noop("Perform append-only compaction instead of eof truncation on vacuum."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
+			GUC_SUPERUSER_ONLY | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
 		},
 		&gp_appendonly_compaction,
 		true,
@@ -1180,7 +1184,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_interconnect_cache_future_packets", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Control whether future packets are cached."),
-			NULL,
+			NULL, GUC_GPDB_ADDOPT
 		},
 		&gp_interconnect_cache_future_packets,
 		true,
@@ -1231,7 +1235,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_print_full_dtm", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Prints full DTM information to server log."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
 		},
 		&Debug_print_full_dtm,
 		false,
@@ -1242,7 +1246,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_print_snapshot_dtm", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Prints snapshot DTM information to server log."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
 		},
 		&Debug_print_snapshot_dtm,
 		false,
@@ -1253,7 +1257,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_disable_distributed_snapshot", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Disables distributed snapshots."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_disable_distributed_snapshot,
 		false,
@@ -1264,7 +1268,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_abort_after_distributed_prepared", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Cause an abort after all segments are prepared but before the distributed commit is written."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_abort_after_distributed_prepared,
 		false,
@@ -1275,7 +1279,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_blockdirectory", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only block directory."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_blockdirectory,
 		false,
@@ -1286,7 +1290,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"Debug_appendonly_print_read_block", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only reads."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_read_block,
 		false,
@@ -1297,7 +1301,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"Debug_appendonly_print_append_block", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only writes."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_append_block,
 		false,
@@ -1308,7 +1312,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_visimap", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only visibility bitmap information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_visimap,
 		false,
@@ -1319,7 +1323,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_compaction", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages about append-only visibility compactions."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_compaction,
 		false,
@@ -1330,7 +1334,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_insert", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only insert."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_insert,
 		false,
@@ -1341,7 +1345,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_insert_tuple", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only insert tuples (caution -- generates a lot of log!)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_insert_tuple,
 		false,
@@ -1352,7 +1356,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_scan", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only scan."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_scan,
 		false,
@@ -1363,7 +1367,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_scan_tuple", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only scan tuples (caution -- generates a lot of log!)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_scan_tuple,
 		false,
@@ -1374,7 +1378,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_delete", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only delete."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_delete,
 		false,
@@ -1385,7 +1389,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_storage_headers", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only storage headers."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_storage_headers,
 		false,
@@ -1396,7 +1400,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_verify_write_block", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only verify block during write."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_verify_write_block,
 		false,
@@ -1407,7 +1411,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_use_no_toast", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Use no toast for an append-only table.  Store the large row inline."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_use_no_toast,
 		false,
@@ -1418,7 +1422,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_segfile_choice", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only writers about their choice for AO segment file."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_segfile_choice,
 		false,
@@ -1429,7 +1433,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"test_AppendOnlyHash_eviction_vs_just_marking_not_inuse", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Helps to test evicting the entry for AppendOnlyHash as soon as its usage is done instead of just marking it not inuse."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&test_AppendOnlyHash_eviction_vs_just_marking_not_inuse,
 		false,
@@ -1440,7 +1444,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_appendonly_print_datumstream", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for append-only datum stream content."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_appendonly_print_datumstream,
 		false,
@@ -1451,7 +1455,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_xlog_record_read", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug information for xlog record read."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&debug_xlog_record_read,
 		false,
@@ -1462,7 +1466,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_cancel_print", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print cancel detail information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_cancel_print,
 		false,
@@ -1473,7 +1477,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_write_print_small_varlena_info", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print datum stream write small varlena information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_datumstream_write_print_small_varlena_info,
 		false,
@@ -1484,7 +1488,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_write_print_large_varlena_info", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print datum stream write large varlena information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_datumstream_write_print_large_varlena_info,
 		false,
@@ -1495,7 +1499,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_read_check_large_varlena_integrity", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Check datum stream large object integrity."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_datumstream_read_check_large_varlena_integrity,
 		false,
@@ -1506,7 +1510,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_block_read_check_integrity", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Check datum stream block read integrity."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_datumstream_block_read_check_integrity,
 		false,
@@ -1517,7 +1521,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_block_write_check_integrity", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Check datum stream block write integrity."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_datumstream_block_write_check_integrity,
 		false,
@@ -1528,7 +1532,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_read_print_varlena_info", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print datum stream read varlena information."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_datumstream_read_print_varlena_info,
 		false,
@@ -1539,7 +1543,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_datumstream_write_use_small_initial_buffers", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Use small datum stream write buffers to stress growing logic."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_datumstream_write_use_small_initial_buffers,
 		false,
@@ -1550,7 +1554,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"test_print_direct_dispatch_info", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("For testing purposes, print information about direct dispatch decisions."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Test_print_direct_dispatch_info,
 		false,
@@ -1561,7 +1565,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_bitmap_print_insert", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print log messages for bitmap index insert routines (caution-- generate a lot of logs!)"),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_bitmap_print_insert,
 		false,
@@ -1572,7 +1576,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_dtm_action_primary", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Specify if the primary or mirror segment is the target of the debug DTM action."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_dtm_action_primary,
 		DEBUG_DTM_ACTION_PRIMARY_DEFAULT, NULL, NULL, NULL
@@ -1593,7 +1597,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_local_distributed_cache_stats", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prints local-distributed cache statistics at end of commit / prepare."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_local_distributed_cache_stats,
 		false,
@@ -1604,7 +1608,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"enable_partition_rules", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable creation of RULEs to implement partitioning"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&enable_partition_rules,
 		false,
@@ -1614,7 +1618,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_enable_gpperfmon", PGC_POSTMASTER, UNGROUPED,
 			gettext_noop("Enable gpperfmon monitoring."),
-			NULL,
+			NULL
 		},
 		&gp_enable_gpperfmon,
 		false,
@@ -1644,7 +1648,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"log_autostats", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Logs details of auto-stats issued ANALYZEs."),
-			NULL
+			NULL, GUC_GPDB_ADDOPT
 		},
 		&log_autostats,
 		true,
@@ -1653,7 +1657,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_statistics_pullup_from_child_partition", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("This guc enables the planner to utilize statistics from partitions in planning queries on the parent."),
-			NULL
+			NULL, GUC_GPDB_ADDOPT
 		},
 		&gp_statistics_pullup_from_child_partition,
 		true,
@@ -1662,7 +1666,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_statistics_use_fkeys", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("This guc enables the planner to utilize statistics derived from foreign key relationships."),
-			NULL
+			NULL, GUC_GPDB_ADDOPT
 		},
 		&gp_statistics_use_fkeys,
 		true,
@@ -1682,7 +1686,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_resource_group", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prints resource groups debug logs."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&Debug_resource_group,
 		false,
@@ -1693,7 +1697,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_walrepl_snd", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for WAL sender in WAL based replication (Master Mirroring)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&debug_walrepl_snd,
 		false,
@@ -1704,7 +1708,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_walrepl_syncrep", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for synchronous behavior in WAL based replication (Master Mirroring)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&debug_walrepl_syncrep,
 		false,
@@ -1715,7 +1719,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_walrepl_rcv", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for WAL receiver in WAL based replication (Master Mirroring)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&debug_walrepl_rcv,
 		false,
@@ -1726,7 +1730,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_basebackup", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for basebackup mechanism (Master Mirroring)."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&debug_basebackup,
 		false,
@@ -1737,7 +1741,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"debug_latch", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Print debug messages for latch mechanism."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&debug_latch,
 		false,
@@ -1770,7 +1774,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"pljava_debug", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Stop the backend to attach a debugger"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY | GUC_GPDB_ADDOPT
 		},
 		&pljava_debug,
 		false,
@@ -1781,7 +1785,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_keep_all_xlog", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Do not remove old xlog files."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_keep_all_xlog,
 		false,
@@ -1960,7 +1964,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_allow_non_uniform_partitioning_ddl", PGC_USERSET, COMPAT_OPTIONS,
 			gettext_noop("Allow DDL that will create multi-level partition table with non-uniform hierarchy."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_allow_non_uniform_partitioning_ddl,
 		true,
@@ -1970,7 +1974,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_enable_exchange_default_partition", PGC_USERSET, COMPAT_OPTIONS,
 			gettext_noop("Allow DDL that will exchange default partitions."),
-			NULL
+			NULL, GUC_GPDB_ADDOPT
 		},
 		&gp_enable_exchange_default_partition,
 		false,
@@ -1991,7 +1995,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"gp_recursive_cte", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable RECURSIVE clauses in CTE queries."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_recursive_cte,
 		false, NULL, NULL
@@ -2998,7 +3002,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"debug_dtm_action_segment", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action segment."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
 		},
 		&Debug_dtm_action_segment,
 		DEBUG_DTM_ACTION_SEGMENT_DEFAULT, -2, 1000,
@@ -3009,7 +3013,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"debug_dtm_action_nestinglevel", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action transaction nesting level."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
 		},
 		&Debug_dtm_action_nestinglevel,
 		DEBUG_DTM_ACTION_NESTINGLEVEL_DEFAULT, 0, 1000,
@@ -3124,7 +3128,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_appendonly_compaction_threshold", PGC_USERSET, APPENDONLY_TABLES,
 			gettext_noop("Threshold of the ratio of dirty data in a segment file over which the file"
 						 " will be compacted during lazy vacuum."),
-			NULL
+			NULL, GUC_GPDB_ADDOPT
 		},
 		&gp_appendonly_compaction_threshold,
 		10, 0, 100,
@@ -3511,7 +3515,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"gp_cached_segworkers_threshold", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Sets the maximum number of segment workers to cache between statements."),
 			NULL,
-			GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_cached_gang_threshold,
 		5, 1, INT_MAX,
@@ -3751,7 +3755,7 @@ struct config_int ConfigureNamesInt_gp[] =
 	{
 		{"gp_reject_percent_threshold", PGC_USERSET, GP_ERROR_HANDLING,
 			gettext_noop("Reject limit in percent starts calculating after this number of rows processed"),
-			NULL
+			NULL, GUC_GPDB_ADDOPT
 		},
 		&gp_reject_percent_threshold,
 		300, 0, INT_MAX,
@@ -3823,7 +3827,7 @@ struct config_int ConfigureNamesInt_gp[] =
 	{
 		{"gp_autostats_on_change_threshold", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Threshold for number of tuples added to table by CTAS or Insert-to to trigger autostats in on_change mode. See gp_autostats_mode."),
-			NULL
+			NULL, GUC_GPDB_ADDOPT
 		},
 		&gp_autostats_on_change_threshold,
 		INT_MAX, 0, INT_MAX,
@@ -3836,7 +3840,7 @@ struct config_int ConfigureNamesInt_gp[] =
 						 "aggregate computation will be rewritten based on the multi-phrase aggregation. "
 						 "The rest of grouping sets in the same query will not be rewritten."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_distinct_grouping_sets_threshold,
 		32, 0, 1024,
@@ -4384,7 +4388,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"debug_dtm_action_sql_command_tag", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action sql command tag."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
 		},
 		&Debug_dtm_action_sql_command_tag,
 		"",
@@ -4440,7 +4444,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"gp_auth_time_override", PGC_SIGHUP, DEVELOPER_OPTIONS,
 			gettext_noop("The timestamp used for enforcing time constraints."),
 			gettext_noop("For testing purposes only."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_auth_time_override_str,
 		"",
@@ -4552,7 +4556,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"debug_dtm_action_protocol", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action protocol."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
 		},
 		&Debug_dtm_action_protocol,
 		DTX_PROTOCOL_COMMAND_NONE, debug_dtm_action_protocol_options,
@@ -4617,7 +4621,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"debug_dtm_action", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
 		},
 		&Debug_dtm_action,
 		DEBUG_DTM_ACTION_NONE, debug_dtm_action_options,
@@ -4628,7 +4632,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"debug_dtm_action_target", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the debug DTM action target."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT | GUC_GPDB_DTX
 		},
 		&Debug_dtm_action_target,
 		DEBUG_DTM_ACTION_TARGET_NONE, debug_dtm_action_target_options,

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -53,6 +53,7 @@ typedef struct SegmentDatabaseDescriptor
     char                   *whoami;         /* QE identifier for msgs */
 	bool					isWriter;
 	int						identifier;		/* unique identifier in the cdbcomponent segment pool */
+	bool						guc_need_sync;	/* whether need to sync guc to this segment db */
 } SegmentDatabaseDescriptor;
 
 SegmentDatabaseDescriptor *

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -44,6 +44,8 @@ typedef struct CdbDispatcherState
 	struct CdbDispatchResults *primaryResults;
 	void *dispatchParams;
 	int	largestGangSize;
+	bool guc_need_sync;
+	bool isNonSyncGUCCommand;
 } CdbDispatcherState;
 
 typedef struct DispatcherInternalFuncs
@@ -177,5 +179,8 @@ void AtSubAbort_DispatcherState(void);
 
 char *
 segmentsToContentStr(List *segments);
+
+extern char *
+serializeGUC(int *len_p, bool isDtx);
 
 #endif   /* CDBDISP_H */

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -45,7 +45,6 @@ typedef struct CdbDispatcherState
 	void *dispatchParams;
 	int	largestGangSize;
 	bool guc_need_sync;
-	bool isNonSyncGUCCommand;
 } CdbDispatcherState;
 
 typedef struct DispatcherInternalFuncs
@@ -181,6 +180,6 @@ char *
 segmentsToContentStr(List *segments);
 
 extern char *
-serializeGUC(int *len_p, bool isDtx);
+serializeGUC(int *len_p);
 
 #endif   /* CDBDISP_H */

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -199,6 +199,7 @@ extern int numsegmentsFromQD;
  * Returns the number of segments
  */
 extern int getgpsegmentCount(void);
+extern void setSyncFlagForIdleQEs(void);
 
 #define ELOG_DISPATCHER_DEBUG(...) do { \
        if (gp_log_gang >= GPVARS_VERBOSITY_DEBUG) elog(LOG, __VA_ARGS__); \

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -487,6 +487,7 @@ typedef enum NodeTag
 	T_AlterTypeStmt,
 	T_SetDistributionCmd,
 	T_ExpandStmtSpec,
+	T_GUCNode,
 
 	/*
 	 * TAGS FOR PARSE TREE NODES (parsenodes.h)

--- a/src/include/postgres.h
+++ b/src/include/postgres.h
@@ -499,6 +499,9 @@ extern void ExceptionalCondition(const char *conditionName,
 					 const char *errorType,
 			 const char *fileName, int lineNumber) __attribute__((noreturn));
 
+extern char		globalGucs[];
+extern int		globalGucsLen;
+extern void apply_guc_from_qd(const char *, int);
 
 #ifdef __cplusplus
 }   /* extern "C" */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -190,6 +190,21 @@ typedef enum
 	GUC_ACTION_SAVE				/* function SET option, or temp assignment */
 } GucAction;
 
+
+/*
+ * Serialized form of GUC. This is used when GUC are
+ * serialized, when dispatching GUCs from QD to QEs.
+ */
+typedef struct GUCNode
+{
+	NodeTag		type;
+
+	char		   *name;
+	char		   *value;
+	GucContext	context;
+	GucSource	source;
+} GUCNode;
+
 #define GUC_QUALIFIER_SEPARATOR '.'
 
 /*
@@ -220,12 +235,26 @@ typedef enum
 #define GUC_DISALLOW_IN_AUTO_FILE	0x00010000	/* can't set in PG_AUTOCONF_FILENAME */
 
 /* GPDB speific */
+/*
+ * Fixme: flag GUC_GPDB_ADDOPT indicates which GUC need to be sync
+ * between QD and QE. Need to go through and recheck this flag for
+ * each GUCs.
+ */
 #define GUC_GPDB_ADDOPT        0x00020000  /* Send by cdbgang */
 #define GUC_DISALLOW_USER_SET  0x00040000 /* Do not allow this GUC to be set by the user */
+#define GUC_GPDB_DTX  0x00080000 /* Distributed transaction related GUCs */
 
 /* GUC lists for gp_guc_list_show().  (List of struct config_generic) */
 extern List    *gp_guc_list_for_explain;
 extern List    *gp_guc_list_for_no_plan;
+
+/*
+ * GUC value changed or transaction abort will turn on this flag
+ * to indicate GUC need to be sync between QD and QE
+ */
+extern bool guc_need_sync_session;
+/* Changed GUC list which need to be pass to QE from QD */
+extern List *guc_list_need_sync_global;
 
 /* GUC vars that are actually declared in guc.c, rather than elsewhere */
 extern bool log_duration;

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -205,6 +205,23 @@ typedef struct GUCNode
 	GucSource	source;
 } GUCNode;
 
+/*
+ * GUC entry in guc_list_need_sync_global
+ */
+typedef struct GUCEntry
+{
+	char		   *name;
+	/*
+	 * context and source history value before GUC
+	 * change happens. They will be passed to QE as
+	 * parameter of set_config_option.
+	 * GUC value is skipped here since we only need
+	 * the latest GUC value.
+	 */
+	GucContext	context;
+	GucSource	source;
+} GUCEntry;
+
 #define GUC_QUALIFIER_SEPARATOR '.'
 
 /*
@@ -796,6 +813,7 @@ extern bool gpvars_check_gp_gpperfmon_send_interval(int *newval, void **extra, G
 extern StdRdOptions *defaultStdRdOptions(char relkind);
 
 /* Add GUCs which need sync into guc_list_need_sync_global */
-extern void add_guc_to_sync_list(struct config_generic *record, const char *name);
+extern void add_guc_to_sync_list(struct config_generic *record, const char *name,
+		GucSource source, GucContext context);
 
 #endif   /* GUC_H */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -795,4 +795,7 @@ extern bool gpvars_check_gp_gpperfmon_send_interval(int *newval, void **extra, G
 
 extern StdRdOptions *defaultStdRdOptions(char relkind);
 
+/* Add GUCs which need sync into guc_list_need_sync_global */
+extern void add_guc_to_sync_list(struct config_generic *record, const char *name);
+
 #endif   /* GUC_H */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -257,9 +257,8 @@ typedef struct GUCEntry
  * between QD and QE. Need to go through and recheck this flag for
  * each GUCs.
  */
-#define GUC_GPDB_ADDOPT        0x00020000  /* Send by cdbgang */
+#define GUC_GPDB_NEED_SYNC        0x00020000  /* Send by cdbgang */
 #define GUC_DISALLOW_USER_SET  0x00040000 /* Do not allow this GUC to be set by the user */
-#define GUC_GPDB_DTX  0x00080000 /* Distributed transaction related GUCs */
 
 /* GUC lists for gp_guc_list_show().  (List of struct config_generic) */
 extern List    *gp_guc_list_for_explain;

--- a/src/test/regress/expected/alter_extension.out
+++ b/src/test/regress/expected/alter_extension.out
@@ -5,3 +5,9 @@ CREATE AGGREGATE example_agg(int4) (
 );
 ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
 ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+DROP EXTENSION gp_inject_fault;
+-- test create extension with schema
+SET search_path TO invalid_path;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault WITH SCHEMA public;
+DROP EXTENSION gp_inject_fault;
+RESET search_path;

--- a/src/test/regress/expected/not_out_of_shmem_exit_slots.out
+++ b/src/test/regress/expected/not_out_of_shmem_exit_slots.out
@@ -24,10 +24,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000582.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000072.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 142)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 59)
 -- 2
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -36,10 +40,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000588.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000082.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 143)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 60)
 -- 3
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -48,10 +56,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000594.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000092.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 144)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 61)
 -- 4
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -60,10 +72,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000600.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000102.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 145)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 62)
 -- 5
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -72,10 +88,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000606.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000112.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 146)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 63)
 -- 6
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -84,10 +104,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000612.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000122.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 147)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 64)
 -- 7
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -96,10 +120,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000618.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000132.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 148)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 65)
 -- 8
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -108,10 +136,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000624.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000142.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 149)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 66)
 -- 9
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -120,10 +152,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000630.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000152.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 150)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 67)
 -- 10
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -132,10 +168,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000636.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000162.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 151)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 68)
 -- 11
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -144,10 +184,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000642.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000172.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 152)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 69)
 -- 12
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -156,10 +200,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000648.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000182.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 153)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 70)
 -- 13
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -168,10 +216,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000654.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000192.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 154)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 71)
 -- 14
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -180,10 +232,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000660.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000202.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 155)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 72)
 -- 15
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -192,10 +248,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000666.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000212.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 156)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 73)
 -- 16
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -204,10 +264,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000672.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000222.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 157)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 74)
 -- 17
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -216,10 +280,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000678.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000232.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 158)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 75)
 -- 18
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -228,10 +296,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000684.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000242.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 159)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 76)
 -- 19
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -240,10 +312,14 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000690.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000252.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 160)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 77)
 -- 20
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -252,6 +328,6 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
-WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1518745234-0000000696.  Retrying ... try 1
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1552561439-0000000262.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 161)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 78)

--- a/src/test/regress/sql/alter_extension.sql
+++ b/src/test/regress/sql/alter_extension.sql
@@ -7,3 +7,9 @@ CREATE AGGREGATE example_agg(int4) (
 
 ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
 ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+DROP EXTENSION gp_inject_fault;
+-- test create extension with schema
+SET search_path TO invalid_path;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault WITH SCHEMA public;
+DROP EXTENSION gp_inject_fault;
+RESET search_path;

--- a/src/test/regress/sql/not_out_of_shmem_exit_slots.sql
+++ b/src/test/regress/sql/not_out_of_shmem_exit_slots.sql
@@ -24,6 +24,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 2
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -32,6 +36,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 3
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -40,6 +48,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 4
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -48,6 +60,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 5
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -56,6 +72,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 6
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -64,6 +84,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 7
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -72,6 +96,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 8
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -80,6 +108,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 9
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -88,6 +120,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 10
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -96,6 +132,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 11
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -104,6 +144,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 12
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -112,6 +156,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 13
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -120,6 +168,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 14
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -128,6 +180,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 15
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -136,6 +192,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 16
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -144,6 +204,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 17
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -152,6 +216,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 18
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -160,6 +228,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 19
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;
@@ -168,6 +240,10 @@ SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 
 -- 20
+RESET debug_dtm_action_segment;
+RESET debug_dtm_action_target;
+RESET debug_dtm_action_protocol;
+RESET debug_dtm_action;
 CREATE TEMP TABLE foo_stg AS SELECT * FROM foo;
 SET debug_dtm_action_segment=1;
 SET debug_dtm_action_target=protocol;


### PR DESCRIPTION
In past, GPDB dispatch GUCs mainly in two ways:
1. Set related command to set GUC value and dispatch
"SET COMMAND" to QEs.
2. Pass GUCs with flag GUC_GPDB_ADDOPT to QEs when creategang.

It has two problems:
1. Set command is not 2PC and may lead to inconsistent GUC state.
Issue-6610 describe the details of this problem.
2. When set GUCs without GUC_GPDB_ADDOPT using SET command, it will
apply to all the existing QEs, but when cached QE exits with timeout,
the changed GUC value will not appear on the new QE process.

Make set command 2PC is too heavy, which is discussed in [PR6596](https://github.com/greenplum-db/gpdb/pull/6596)
To fix it without 2PC, this PR follow the way to dispatch GUCs to
QEs when GUC state is not consistent. Flag guc_need_sync is used
to determine whether GUCs are not in consistent state between
QD and QE. When GUC value changed or transaction abort, this flag
will be turned on.
Instead of passing all the GUCs with flag GUC_GPDB_ADDOPT, we track
the changed GUC list and only pass this subset.

Add fixme to go through and recheck which GUC should with flag GUC_GPDB_ADDOPT and
to change the name of GUC_GPDB_ADDOPT to something like GUC_GPDB_NEED_SYNC

We also have some discussion on [gpdb-dev](https://groups.google.com/a/greenplum.org/forum/#!search/sync$20GUC$20between/gpdb-dev/vjDyMeRuqik/vyx8d7rSAQAJ)

Idea from Heikki Linnakangas <hlinnakangas@pivotal.io>
Idea from Pengzhou Tang <ptang@pivotal.io>

