### PR TITLE
Fix assert failure for copy to partition table (#7132)

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4893,18 +4893,21 @@ PROCESS_SEGMENT_DATA:
 				 */
 				if (resultRelInfo->ri_partSlot != NULL)
 				{
+					int relnatts;
 					AttrMap *map = resultRelInfo->ri_partInsertMap;
 					Assert(map != NULL);
 
 					slot = resultRelInfo->ri_partSlot;
 					ExecClearTuple(slot);
+					relnatts = resultRelInfo->ri_RelationDesc->rd_att->natts;
+
 					partValues = slot_get_values(resultRelInfo->ri_partSlot);
 					partNulls = slot_get_isnull(resultRelInfo->ri_partSlot);
-					MemSet(partValues, 0, attr_count * sizeof(Datum));
-					MemSet(partNulls, true, attr_count * sizeof(bool));
+					MemSet(partValues, 0, relnatts * sizeof(Datum));
+					MemSet(partNulls, true, relnatts * sizeof(bool));
 
 					reconstructTupleValues(map, baseValues, baseNulls, (int) num_phys_attrs,
-										   partValues, partNulls, (int) attr_count);
+										   partValues, partNulls, (int) relnatts);
 					ExecStoreVirtualTuple(slot);
 				}
 				else

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -7923,3 +7923,42 @@ ERROR:  SUBPARTITION TEMPLATE need to be nested under a SUBPARTITION BY at or ne
 LINE 7: SUBPARTITION TEMPLATE ( 
         ^
 -- MPP-26829
+-- Exchage partiton table with a table having dropped column
+create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (5));
+create table exchange1(a int, c int, b int);
+alter table exchange1 drop column c;
+alter table exchange_part exchange partition for (1) with table exchange1;
+copy exchange_part from STDIN DELIMITER as '|';
+select * from exchange_part;
+  a   | b 
+------+---
+ 9797 | 3
+ 9799 | 4
+ 9801 | 5
+ 9836 | 5
+ 9802 | 6
+ 9840 | 6
+ 9803 | 7
+ 9822 | 7
+ 9806 | 8
+ 9824 | 8
+ 9807 | 9
+ 9794 | 1
+ 9808 | 1
+ 9810 | 2
+ 9828 | 2
+ 9831 | 3
+ 9817 | 5
+ 9818 | 6
+ 9843 | 7
+ 9844 | 8
+ 9825 | 9
+ 9827 | 1
+ 9795 | 2
+ 9814 | 3
+ 9815 | 4
+ 9832 | 4
+(26 rows)
+
+drop table exchange_part;
+drop table exchange1;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -7917,3 +7917,42 @@ ERROR:  SUBPARTITION TEMPLATE need to be nested under a SUBPARTITION BY at or ne
 LINE 7: SUBPARTITION TEMPLATE ( 
         ^
 -- MPP-26829
+-- Exchage partiton table with a table having dropped column
+create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (5));
+create table exchange1(a int, c int, b int);
+alter table exchange1 drop column c;
+alter table exchange_part exchange partition for (1) with table exchange1;
+copy exchange_part from STDIN DELIMITER as '|';
+select * from exchange_part;
+  a   | b 
+------+---
+ 9797 | 3
+ 9799 | 4
+ 9801 | 5
+ 9836 | 5
+ 9802 | 6
+ 9840 | 6
+ 9803 | 7
+ 9822 | 7
+ 9806 | 8
+ 9824 | 8
+ 9807 | 9
+ 9794 | 1
+ 9808 | 1
+ 9810 | 2
+ 9828 | 2
+ 9831 | 3
+ 9817 | 5
+ 9818 | 6
+ 9843 | 7
+ 9844 | 8
+ 9825 | 9
+ 9827 | 1
+ 9795 | 2
+ 9814 | 3
+ 9815 | 4
+ 9832 | 4
+(26 rows)
+
+drop table exchange_part;
+drop table exchange1;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3805,3 +3805,40 @@ SUBPARTITION p027 VALUES ('027'),
 SUBPARTITION p141 VALUES ('141'),
 SUBPARTITION p037 VALUES ('037'));
 -- MPP-26829
+
+-- Exchage partiton table with a table having dropped column
+create table exchange_part(a int, b int) partition by range(b) (start (0) end (10) every (5));
+create table exchange1(a int, c int, b int);
+alter table exchange1 drop column c;
+alter table exchange_part exchange partition for (1) with table exchange1;
+copy exchange_part from STDIN DELIMITER as '|';
+9794 | 1
+9795 | 2
+9797 | 3
+9799 | 4
+9801 | 5
+9802 | 6
+9803 | 7
+9806 | 8
+9807 | 9
+9808 | 1
+9810 | 2
+9814 | 3
+9815 | 4
+9817 | 5
+9818 | 6
+9822 | 7
+9824 | 8
+9825 | 9
+9827 | 1
+9828 | 2
+9831 | 3
+9832 | 4
+9836 | 5
+9840 | 6
+9843 | 7
+9844 | 8
+\.
+select * from exchange_part;
+drop table exchange_part;
+drop table exchange1;


### PR DESCRIPTION
We have an assert failure for copy to partition table if root and child relation
have different attno. The root cause is that 'reconstructTupleValues'
has a wrong value of newNumAttrs lenth.

cherry pick from master commit 5425da14f571bda1ee1e955c5c1e43677ed5d447
Fix the issue https://github.com/greenplum-db/gpdb/issues/7110

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
