### PR TITLE
Fix comparison with FirstNormalObjectId

### DIFF
--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -1516,7 +1516,7 @@ AcquireExecutorLocks(List *stmt_list, bool acquire)
 				 * Since we have introduced Global Deadlock Detector, only for ao
 				 * table should we upgrade the lock.
 				 */
-				if (rte->relid > FirstNormalObjectId &&
+				if (rte->relid >= FirstNormalObjectId &&
 					(plannedstmt->commandType == CMD_UPDATE ||
 					 plannedstmt->commandType == CMD_DELETE) &&
 					CondUpgradeRelLock(rte->relid))
@@ -1606,7 +1606,7 @@ ScanQueryForLocks(Query *parsetree, bool acquire)
 					 * Catalog tables are replicated across cluster and don't
 					 * suffer from the deadlock.
 					 */
-					if (rte->relid > FirstNormalObjectId &&
+					if (rte->relid >= FirstNormalObjectId &&
 						(parsetree->commandType == CMD_UPDATE ||
 						 parsetree->commandType == CMD_DELETE) &&
 						CondUpgradeRelLock(rte->relid))

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1818,7 +1818,7 @@ selectDumpableCast(CastInfo *cast)
 	if (checkExtensionMembership(&cast->dobj))
 		return;					/* extension membership overrides all else */
 
-	if (cast->dobj.catId.oid <= (Oid) FirstNormalObjectId)
+	if (cast->dobj.catId.oid < (Oid) FirstNormalObjectId)
 		cast->dobj.dump = false;
 	else
 		cast->dobj.dump = include_everything;
@@ -1838,7 +1838,7 @@ selectDumpableProcLang(ProcLangInfo *plang)
 	if (checkExtensionMembership(&plang->dobj))
 		return;					/* extension membership overrides all else */
 
-	if (plang->dobj.catId.oid <= (Oid) FirstNormalObjectId)
+	if (plang->dobj.catId.oid < (Oid) FirstNormalObjectId)
 		plang->dobj.dump = false;
 	else
 		plang->dobj.dump = include_everything;
@@ -1857,7 +1857,7 @@ selectDumpableProcLang(ProcLangInfo *plang)
 static void
 selectDumpableExtension(ExtensionInfo *extinfo)
 {
-	if (binary_upgrade && extinfo->dobj.catId.oid <= (Oid) FirstNormalObjectId)
+	if (binary_upgrade && extinfo->dobj.catId.oid < (Oid) FirstNormalObjectId)
 		extinfo->dobj.dump = false;
 	else
 		extinfo->dobj.dump = include_everything;


### PR DESCRIPTION
FirstNormalObjectId indicates the first OID for user objects, when a
relation's oid >= FirstNormalObjectId then it's an user object,
otherwise it's a catalog object.

Fixed some incorrect uses of it, they treat oid == FirstNormalObjectId
as catalog objects.

Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/ZHy-x1DaoXE/ceyzZ4TuCgAJ

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
