### PR TITLE
Add a hook point in MultiExecProcNode

### DIFF
--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -1189,6 +1189,14 @@ MultiExecProcNode(PlanState *node)
 	START_MEMORY_ACCOUNT(node->memoryAccountId);
 {
 	TRACE_POSTGRESQL_EXECPROCNODE_ENTER(GpIdentity.segindex, currentSliceId, nodeTag(node), node->plan->plan_node_id);
+	
+	if (!node->fHadSentNodeStart)
+	{
+		/* GPDB hook for collecting query info */
+		if (query_info_collect_hook)
+			(*query_info_collect_hook)(METRICS_PLAN_NODE_EXECUTING, node);
+		node->fHadSentNodeStart = true;
+	}
 
 	if (node->chgParam != NULL) /* something changed */
 		ExecReScan(node);		/* let ReScan handle this */

--- a/src/test/regress/input/query_info_hook_test.source
+++ b/src/test/regress/input/query_info_hook_test.source
@@ -1,5 +1,6 @@
 LOAD '@abs_builddir@/query_info_hook_test/query_info_hook_test@DLSUFFIX@';
 SET client_min_messages='warning';
+SET optimizer=off;
 
 -- Test Normal case
 SELECT * FROM generate_series(1, 3);
@@ -17,7 +18,9 @@ SELECT * FROM generate_series(1, 3/0);
 
 -- Test query abort
 select pg_cancel_backend(pg_backend_pid());
-
 -- Test alter table set distributed by
 CREATE TABLE queryInfoHookTable1 (id int, name text) DISTRIBUTED BY(id);
 ALTER TABLE queryInfoHookTable1 SET DISTRIBUTED BY (name);
+-- Test Hash node
+CREATE TABLE tb_a(a int);
+SELECT a FROM tb_a WHERE a IN (SELECT max(a) FROM tb_a);

--- a/src/test/regress/output/query_info_hook_test.source
+++ b/src/test/regress/output/query_info_hook_test.source
@@ -1,11 +1,12 @@
 LOAD '@abs_builddir@/query_info_hook_test/query_info_hook_test@DLSUFFIX@';
 SET client_min_messages='warning';
+SET optimizer=off;
 -- Test Normal case
 SELECT * FROM generate_series(1, 3);
 WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
-WARNING:  Plan node executing
+WARNING:  Plan node executing node_type: FUNCTIONSCAN
 WARNING:  Plan node finished
 WARNING:  Query Done
  generate_series 
@@ -25,7 +26,7 @@ SELECT * FROM error_in_execution();
 WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
-WARNING:  Plan node executing
+WARNING:  Plan node executing node_type: FUNCTIONSCAN
 WARNING:  Query Error
 ERROR:  error in function execution
 -- Test Error case: Error out in planner.
@@ -36,7 +37,7 @@ select pg_cancel_backend(pg_backend_pid());
 WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
-WARNING:  Plan node executing
+WARNING:  Plan node executing node_type: RESULT
 WARNING:  Query Canceling
 WARNING:  Query Canceled
 ERROR:  canceling statement due to user request
@@ -46,12 +47,38 @@ ALTER TABLE queryInfoHookTable1 SET DISTRIBUTED BY (name);
 WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
-WARNING:  Plan node executing
+WARNING:  Plan node executing node_type: RESULT
 WARNING:  Plan node finished
 WARNING:  Query Done
 WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
+WARNING:  Plan node executing node_type: MOTION
 WARNING:  Plan node finished
 WARNING:  Plan node finished
 WARNING:  Query Done
+-- Test Hash node
+CREATE TABLE tb_a(a int);
+SELECT a FROM tb_a WHERE a IN (SELECT max(a) FROM tb_a);
+WARNING:  Query submit
+WARNING:  Query start
+WARNING:  Plan node initializing
+WARNING:  Plan node executing node_type: MOTION
+WARNING:  Plan node executing node_type: HASHJOIN
+WARNING:  Plan node executing node_type: HASH
+WARNING:  Plan node finished
+WARNING:  Query Done
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Query Done
+ a 
+---
+(0 rows)
+

--- a/src/test/regress/query_info_hook_test/query_info_hook_test.c
+++ b/src/test/regress/query_info_hook_test/query_info_hook_test.c
@@ -2,6 +2,8 @@
 
 #include "fmgr.h"
 #include "utils/metrics_utils.h"
+#include "nodes/execnodes.h"
+#include "nodes/print.h"
 
 PG_MODULE_MAGIC;
 
@@ -35,7 +37,7 @@ test_hook(QueryMetricsStatus status, void* args)
 			ereport(WARNING, (errmsg("Plan node initializing")));
 			break;
 		case METRICS_PLAN_NODE_EXECUTING:
-			ereport(WARNING, (errmsg("Plan node executing")));
+			ereport(WARNING, (errmsg("Plan node executing node_type: %s", plannode_type(((PlanState *)args)->plan))));
 			break;
 		case METRICS_PLAN_NODE_FINISHED:
 			ereport(WARNING, (errmsg("Plan node finished")));


### PR DESCRIPTION
Previously we put a hook point in `ExecProcNode` so that we can detect most nodes process information. But for some nodes like Hash/BitmapIndex/DynamicBitmapIndex/BitmapAnd/BitmapOr, 
whose process will go through `MultiExecProcNode` instead of `ExecProcNode`, so in this commit, we add a hook point in `MultiExecProcNode` so that we can detect the executing status of nodes above, and add a test to make sure the hook function is invoked on segments, when the `Hash` node is running. 