### PR TITLE
Remove "-oss" as default greenplum version suffix

### DIFF
--- a/concourse/scripts/compile_gpdb_open_source_centos.bash
+++ b/concourse/scripts/compile_gpdb_open_source_centos.bash
@@ -45,8 +45,15 @@ function install_system_deps() {
 function build_gpdb() {
   pushd gpdb_src
     source /opt/gcc_env.sh
-    CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --with-perl --with-libxml --with-extra-version="-oss" \
-        --disable-orca --with-python --disable-gpfdist --with-zstd --prefix=${GREENPLUM_INSTALL_DIR}
+    CC=$(which gcc) CXX=$(which g++) ./configure --with-extra-version="-oss" \
+      --with-perl \
+      --with-python \
+      --with-libxml \
+      --with-zstd \
+      --enable-mapreduce \
+      --disable-orca \
+      --disable-gpfdist \
+      --prefix=${GREENPLUM_INSTALL_DIR}
     # Use -j4 to speed up the build. (Doesn't seem worth trying to guess a better
     # value based on number of CPUs or anything like that. Going above -j4 wouldn't
     # make it much faster, and -j4 is small enough to not hurt too badly even on

--- a/concourse/scripts/compile_gpdb_open_source_centos.bash
+++ b/concourse/scripts/compile_gpdb_open_source_centos.bash
@@ -45,7 +45,7 @@ function install_system_deps() {
 function build_gpdb() {
   pushd gpdb_src
     source /opt/gcc_env.sh
-    CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --with-perl --with-libxml \
+    CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --with-perl --with-libxml --with-extra-version="-oss" \
         --disable-orca --with-python --disable-gpfdist --with-zstd --prefix=${GREENPLUM_INSTALL_DIR}
     # Use -j4 to speed up the build. (Doesn't seem worth trying to guess a better
     # value based on number of CPUs or anything like that. Going above -j4 wouldn't

--- a/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+++ b/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
@@ -37,6 +37,7 @@ function build_gpdb() {
           --with-libraries=${CWD}/depends/build/lib \
           --with-includes=${CWD}/depends/build/include \
           --prefix=${GREENPLUM_INSTALL_DIR} \
+          --with-extra-version="-oss" \
           ${CONFIGURE_FLAGS}
         make -j4 -s
         LD_LIBRARY_PATH=${CWD}/depends/build/lib make install

--- a/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+++ b/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
@@ -31,13 +31,17 @@ function build_gpdb() {
         # TODO: remove this flag after adding zstd to the ubuntu build images
         CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --without-zstd"
         CWD=$(pwd)
-        LD_LIBRARY_PATH=${CWD}/depends/build/lib CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --enable-orafce --with-gssapi --with-perl --with-libxml \
+        LD_LIBRARY_PATH=${CWD}/depends/build/lib CC=$(which gcc) CXX=$(which g++) ./configure --with-extra-version="-oss" \
+          --enable-mapreduce \
+          --enable-orafce \
+          --with-gssapi \
+          --with-perl \
+          --with-libxml \
           --with-python \
           --enable-debug-extensions \
           --with-libraries=${CWD}/depends/build/lib \
           --with-includes=${CWD}/depends/build/include \
           --prefix=${GREENPLUM_INSTALL_DIR} \
-          --with-extra-version="-oss" \
           ${CONFIGURE_FLAGS}
         make -j4 -s
         LD_LIBRARY_PATH=${CWD}/depends/build/lib make install

--- a/configure
+++ b/configure
@@ -20090,10 +20090,6 @@ BLD_ARCH=`echo $BLD_ARCH`
 
 GP_VERSION_LONG=`bash ./getversion`
 
-if test "$with_extra_version" = "" ; then
-  with_extra_version="-oss"
-fi
-
 GP_VERSION_LONG="$GP_VERSION_LONG$with_extra_version"
 
 echo $GP_VERSION_LONG > VERSION

--- a/configure.in
+++ b/configure.in
@@ -2587,10 +2587,6 @@ AC_SUBST(BLD_ARCH)
 
 GP_VERSION_LONG=`bash ./getversion`
 
-if test "$with_extra_version" = "" ; then
-  with_extra_version="-oss"
-fi
-
 GP_VERSION_LONG="$GP_VERSION_LONG$with_extra_version"
 
 echo $GP_VERSION_LONG > VERSION

--- a/configure.in
+++ b/configure.in
@@ -39,7 +39,6 @@ AC_SUBST(PG_MAJORVERSION)
 AC_DEFINE_UNQUOTED(PG_MAJORVERSION, "$PG_MAJORVERSION", [PostgreSQL major version as a string])
 
 [PG_VERSION="$PG_PACKAGE_VERSION"]
-dnl Greenplum co-opts the --with-extra-version value to append to Only the Greenplum version
 PGAC_ARG_REQ(with, extra-version, [STRING], [append STRING to version], [], [])
 AC_DEFINE_UNQUOTED(PG_VERSION, "$PG_PACKAGE_VERSION", [Postgres version Greenplum Database is based on])
 


### PR DESCRIPTION
`--with-extra-version` should not default to include an extra version suffix. The default should be no suffix unless explicitly added via `--with-extra-version`.

The default is a non OSS build across CI. Explicit CI jobs that do build OSS can use `--with-extra-version` to append `-oss`.
