### PR TITLE
ci: remove `-oss` from pattern used to parse version output

### DIFF
--- a/concourse/scripts/verify_gpdb_versions.sh
+++ b/concourse/scripts/verify_gpdb_versions.sh
@@ -14,7 +14,7 @@ compare_bin_gpdb_version_with_gpdb_src() {
 
   # Get gpdb commit SHA
   source "${GREENPLUM_INSTALL_DIR}/greenplum_path.sh"
-  bin_gpdb_version=$(postgres --gp-version | sed 's/.*build commit:\(.*\)-oss/\1/')
+  bin_gpdb_version=$(postgres --gp-version | sed 's/.*build commit:\(.*\)/\1/')
 
   if [ "${bin_gpdb_version}" != "${GPDB_SRC_VERSION}" ]; then
     echo "bin_gpdb version: ${bin_gpdb_version} does not match gpdb_src version: ${GPDB_SRC_VERSION}, please wait for the next build. Exiting..."


### PR DESCRIPTION
Authored-by: Bradford D. Boyle <bboyle@pivotal.io>
