### PR TITLE
dbconn: stop committing transactions at the start of every connection

### DIFF
--- a/gpMgmt/bin/gppylib/db/dbconn.py
+++ b/gpMgmt/bin/gppylib/db/dbconn.py
@@ -196,6 +196,16 @@ def connect(dburl, utility=False, verbose=False,
         cstr    = "dbname='%s'" % dbbase
         retries = 1
 
+    options = []
+    #by default, libpq will print WARNINGS to stdout
+    if not verbose:
+        options.append("-c CLIENT_MIN_MESSAGES=ERROR")
+
+    # set client encoding if needed
+    if encoding:
+        options.append("-c CLIENT_ENCODING=%s" % encoding)
+    cstr += " options='%s'" % " ".join(options)
+
     # This flag helps to avoid logging the connection string in some special
     # situations as requested
     if (logConn == True):
@@ -216,20 +226,6 @@ def connect(dburl, utility=False, verbose=False,
         raise ConnectionError('Failed to connect to %s' % dbbase)
 
     conn = pgdb.pgdbCnx(cnx)
-
-    #by default, libpq will print WARNINGS to stdout
-    if not verbose:
-        cursor=conn.cursor()
-        cursor.execute("SET CLIENT_MIN_MESSAGES='ERROR'")
-        conn.commit()
-        cursor.close()
-
-    # set client encoding if needed
-    if encoding:
-        cursor=conn.cursor()
-        cursor.execute("SET CLIENT_ENCODING='%s'" % encoding)
-        conn.commit()
-        cursor.close()
 
     def __enter__(self):
         return self

--- a/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
+++ b/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
@@ -1,0 +1,63 @@
+import unittest
+
+from pygresql import pg
+
+from gppylib.db import dbconn
+
+
+class ConnectTestCase(unittest.TestCase):
+    """A test case for dbconn.connect()."""
+
+    def setUp(self):
+        # Connect to the database pointed to by PGHOST et al.
+        self.url = dbconn.DbURL()
+
+    def _raise_warning(self, db, msg):
+        """Raises a WARNING message on the given pg.DB."""
+        db.query("""
+            DO LANGUAGE plpgsql $$
+            BEGIN
+                RAISE WARNING '{msg}';
+            END
+            $$
+        """.format(msg=msg))
+
+    def test_warnings_are_normally_suppressed(self):
+        warning = "this is my warning message"
+
+        with dbconn.connect(self.url) as conn:
+            # Wrap our connection in pg.DB() so we can get at the underlying
+            # notices. (This isn't available in the standard DB-API.)
+            db = pg.DB(conn)
+            self._raise_warning(db, warning)
+            notices = db.notices()
+
+        self.assertEqual(notices, []) # we expect no notices
+
+    def test_verbose_mode_allows_warnings_to_be_sent_to_the_client(self):
+        warning = "this is my warning message"
+
+        with dbconn.connect(self.url, verbose=True) as conn:
+            db = pg.DB(conn)
+            self._raise_warning(db, warning)
+            notices = db.notices()
+
+        for notice in notices:
+            if warning in notice:
+                return # found it!
+
+        self.fail("Didn't find expected notice '{}' in {!r}".format(
+            warning, notices
+        ))
+
+    def test_client_encoding_can_be_set(self):
+        encoding = 'SQL_ASCII'
+
+        with dbconn.connect(self.url, encoding=encoding) as conn:
+            actual = dbconn.execSQLForSingleton(conn, 'SHOW client_encoding')
+
+        self.assertEqual(actual, encoding)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -58,7 +58,7 @@ Feature: gpstate tests
     Scenario: gpstate -c logs cluster info for a cluster that is unsynchronized
         Given a standard local demo cluster is running
         When user kills all mirror processes
-        And an FTS probe is triggered
+        And user can start transactions
         And the user runs "gpstate -c"
         Then gpstate output looks like
             | Status                        | Data State  | Primary | Datadir                 | Port   | Mirror | Datadir                        | Port   |
@@ -366,7 +366,7 @@ Feature: gpstate tests
     Scenario: gpstate -i warns if any mirrors are marked down
         Given a standard local demo cluster is running
           And user kills all mirror processes
-          And an FTS probe is triggered
+          And user can start transactions
         When the user runs "gpstate -i"
         Then gpstate output looks like
 		  | Host | Datadir                        | Port   | Version                                                                           |

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -910,21 +910,7 @@ def impl(context, segment_type, signal_name):
 @when('user can start transactions')
 @then('user can start transactions')
 def impl(context):
-    num_retries = 150
-    attempt = 0
-    while attempt < num_retries:
-        try:
-            with dbconn.connect(dbconn.DbURL()) as conn:
-                # Cursor.execute() will issue an implicit BEGIN for us.
-                conn.cursor().execute('COMMIT')
-                break
-        except Exception as e:
-            attempt += 1
-            pass
-        time.sleep(1)
-
-    if attempt == num_retries:
-        raise Exception('Unable to establish a connection to database !!!')
+    wait_for_unblocked_transactions(context)
 
 
 @given('the environment variable "{var}" is not set')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -915,6 +915,8 @@ def impl(context):
     while attempt < num_retries:
         try:
             with dbconn.connect(dbconn.DbURL()) as conn:
+                # Cursor.execute() will issue an implicit BEGIN for us.
+                conn.cursor().execute('COMMIT')
                 break
         except Exception as e:
             attempt += 1

--- a/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
@@ -9,6 +9,7 @@ from test.behave_utils.utils import (
     trigger_fts_probe,
     run_gprecoverseg,
     execute_sql,
+    wait_for_unblocked_transactions,
 )
 
 
@@ -88,6 +89,7 @@ def step_impl(context):
 @when(u'a mirror has crashed')
 def step_impl(context):
     run_command(context, "ps aux | grep dbfast_mirror1 | awk '{print $2}' | xargs kill -9")
+    wait_for_unblocked_transactions(context)
 
 
 @when(u'I create a cluster')
@@ -128,6 +130,7 @@ def step_impl(context):
 @given(u'a preferred primary has failed')
 def step_impl(context):
     stop_primary(context, 0)
+    wait_for_unblocked_transactions(context)
 
 
 @when('primary and mirror switch to non-preferred roles')


### PR DESCRIPTION
`dbconn.connect()` was using an odd pattern to set connection parameters like `client_encoding` -- it would `SET` these parameters after the connection was established and then issue a `COMMIT`. Even if your purpose for connecting was read-only, you'd need to wait for a transaction. This slows down everyone -- especially those utilities (like `gpstate`) which are supposed to be run while FTS is still catching up to reality after a mirror goes down.

Fixing this is too risky a change for 6X, IMO, since it's very difficult to tell what software has been relying on this implicit behavior by accident. (There are a few tests with race conditions that were flushed out by this change, and they're fixed in the second commit. Some of those tests have been flaking on the master pipeline recently, in ways that look suspiciously similar. But there's really no guarantee that I found them all.) So I'd like to get this into master, early on in the 7X cycle, and then backport the race fixes to 6X.

@dgkimura FYI

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
