### PR TITLE
163440165 gprecoverseg progress

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -856,7 +856,9 @@ class ConfigureNewSegment(Command):
     def __init__(self, name, confinfo, logdir, newSegments=False, tarFile=None,
                  batchSize=None, verbose=False,ctxt=LOCAL, remoteHost=None, validationOnly=False, writeGpIdFileOnly=False,
                  forceoverwrite=False):
+
         cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\" -l %s' % (confinfo, pipes.quote(logdir))
+
         if newSegments:
             cmdStr += ' -n'
         if tarFile:
@@ -899,7 +901,6 @@ class ConfigureNewSegment(Command):
                         : <segment dbid>
         """
         result = {}
-
         for segIndex, seg in enumerate(segments):
             if primaryMirror == 'primary' and seg.isSegmentPrimary() == False:
                continue
@@ -923,13 +924,16 @@ class ConfigureNewSegment(Command):
                 isPrimarySegment = "false"
                 isTargetReusedLocationString = "false"
 
-            result[hostname] += '%s:%d:%s:%s:%d:%d:%s:%s' % (seg.getSegmentDataDirectory(), seg.getSegmentPort(),
+            progressFile = getattr(seg, 'progressFile', "")
+
+            result[hostname] += '%s:%d:%s:%s:%d:%d:%s:%s:%s' % (seg.getSegmentDataDirectory(), seg.getSegmentPort(),
                                                           isPrimarySegment,
                                                           isTargetReusedLocationString,
                                                           seg.getSegmentDbId(),
                                                           seg.getSegmentContentId(),
                                                           primaryHostname,
-                                                          primarySegmentPort
+                                                          primarySegmentPort,
+                                                          progressFile
             )
         return result
 

--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -307,7 +307,8 @@ def simple_main_locked(createOptionParserFn, createCommandFn, mainOptions):
 def addStandardLoggingAndHelpOptions(parser, includeNonInteractiveOption, includeUsageOption=False):
     """
     Add the standard options for help and logging
-    to the specified parser object.
+    to the specified parser object. Returns the logging OptionGroup so that
+    callers may modify as needed.
     """
     parser.set_usage('%prog [--help] [options] ')
     parser.remove_option('-h')
@@ -330,6 +331,7 @@ def addStandardLoggingAndHelpOptions(parser, includeNonInteractiveOption, includ
     if includeNonInteractiveOption:
         addTo.add_option('-a', dest="interactive", action='store_false', default=True,
                          help="quiet mode, do not require user input for confirmations")
+    return addTo
 
 
 def addMasterDirectoryOptionForSingleClusterProgram(addTo):

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -150,10 +150,11 @@ class GpMirrorToBuild:
 
 
 class GpMirrorListToBuild:
-    def __init__(self, toBuild, pool, quiet, parallelDegree, additionalWarnings=None, logger=logger, forceoverwrite=False):
+    def __init__(self, toBuild, pool, quiet, parallelDegree, additionalWarnings=None, logger=logger, forceoverwrite=False, showProgressInplace=True):
         self.__mirrorsToBuild = toBuild
         self.__pool = pool
         self.__quiet = quiet
+        self.__showProgressInplace = showProgressInplace
         self.__parallelDegree = parallelDegree
         self.__forceoverwrite = forceoverwrite
         self.__additionalWarnings = additionalWarnings or []
@@ -456,7 +457,7 @@ class GpMirrorListToBuild:
             self.__pool.join()
         else:
             if progressCmds:
-                self._join_and_show_segment_progress(progressCmds, inplace=True)
+                self._join_and_show_segment_progress(progressCmds, inplace=self.__showProgressInplace)
             else:
                 base.join_and_indicate_progress(self.__pool)
 
@@ -492,8 +493,8 @@ class GpMirrorListToBuild:
             destSegment.primaryHostname = srcSegment.getSegmentHostName()
             destSegment.primarySegmentPort = srcSegment.getSegmentPort()
             destSegment.progressFile = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
-                                                                               timeStamp,
-                                                                               destSegment.getSegmentDbId())
+                                                                           timeStamp,
+                                                                           destSegment.getSegmentDbId())
             srcSegments.append(srcSegment)
             destSegments.append(destSegment)
             isTargetReusedLocation.append(directive.isTargetReusedLocation())

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 #
-# Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
+# Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
 from gppylib.gparray import Segment, GpArray
 from gppylib.test.unit.gp_unittest import *
-import tempfile, os, shutil
-from gppylib.commands.base import CommandResult
+import logging
+import os
+import shutil
+import StringIO
+import tempfile
+from gppylib.commands import base
 from mock import patch, MagicMock, Mock
 from gppylib.operations.buildMirrorSegments import GpMirrorListToBuild
 from gppylib.operations.startSegments import StartSegmentsResult
@@ -27,8 +31,8 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         self.buildMirrorSegs = GpMirrorListToBuild(
             toBuild = [],
-            pool = None, 
-            quiet = True, 
+            pool = None,
+            quiet = True,
             parallelDegree = 0,
             logger=self.logger
             )
@@ -41,7 +45,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
         expected_output = []
         segs = self.buildMirrorSegs._get_running_postgres_segments(toBuild)
         self.assertEquals(segs, expected_output)
-        
+
     @patch('gppylib.operations.buildMirrorSegments.get_pid_from_remotehost')
     @patch('gppylib.operations.buildMirrorSegments.is_pid_postmaster', return_value=True)
     @patch('gppylib.operations.buildMirrorSegments.check_pid_on_remotehost', return_value=True)
@@ -89,14 +93,14 @@ class buildMirrorSegmentsTestCase(GpTestCase):
         self.assertEquals(segs, expected_output)
 
     @patch('gppylib.commands.base.Command.run')
-    @patch('gppylib.commands.base.Command.get_results', return_value=CommandResult(rc=0, stdout='/tmp/seg0', stderr='', completed=True, halt=False))
+    @patch('gppylib.commands.base.Command.get_results', return_value=base.CommandResult(rc=0, stdout='/tmp/seg0', stderr='', completed=True, halt=False))
     def test_dereference_remote_symlink_valid_symlink(self, mock1, mock2):
         datadir = '/tmp/link/seg0'
         host = 'h1'
         self.assertEqual(self.buildMirrorSegs.dereference_remote_symlink(datadir, host), '/tmp/seg0')
 
     @patch('gppylib.commands.base.Command.run')
-    @patch('gppylib.commands.base.Command.get_results', return_value=CommandResult(rc=1, stdout='', stderr='', completed=True, halt=False))
+    @patch('gppylib.commands.base.Command.get_results', return_value=base.CommandResult(rc=1, stdout='', stderr='', completed=True, halt=False))
     def test_dereference_remote_symlink_unable_to_determine_symlink(self, mock1, mock2):
         datadir = '/tmp/seg0'
         host = 'h1'
@@ -173,6 +177,105 @@ class buildMirrorSegmentsTestCase(GpTestCase):
 
         with self.assertRaisesRegexp(Exception, r"Segment dbid's 2 and 1 on host samehost cannot have the same data directory '/data'"):
             self.buildMirrorSegs.checkForPortAndDirectoryConflicts(gpArray)
+
+class SegmentProgressTestCase(GpTestCase):
+    """
+    Test case for GpMirrorListToBuild._join_and_show_segment_progress().
+    """
+    def setUp(self):
+        self.pool = Mock(spec=base.WorkerPool)
+        self.buildMirrorSegs = GpMirrorListToBuild(
+            toBuild=[],
+            pool=self.pool,
+            quiet=True,
+            parallelDegree=0,
+            logger=Mock(spec=logging.Logger)
+        )
+
+    def test_command_output_is_displayed_once_after_worker_pool_completes(self):
+        cmd = Mock(spec=base.Command)
+        cmd.remoteHost = 'localhost'
+        cmd.dbid = 2
+        cmd.get_results.return_value.stdout = "string 1\n"
+
+        cmd2 = Mock(spec=base.Command)
+        cmd2.remoteHost = 'host2'
+        cmd2.dbid = 4
+        cmd2.get_results.return_value.stdout = "string 2\n"
+
+        outfile = StringIO.StringIO()
+        self.pool.join.return_value = True
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], outfile=outfile)
+
+        results = outfile.getvalue()
+        self.assertEqual(results, (
+            'localhost (dbid 2): string 1\n'
+            'host2 (dbid 4): string 2\n'
+        ))
+
+    def test_command_output_is_displayed_once_for_every_blocked_join(self):
+        cmd = Mock(spec=base.Command)
+        cmd.remoteHost = 'localhost'
+        cmd.dbid = 2
+
+        cmd.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
+
+        outfile = StringIO.StringIO()
+        self.pool.join.side_effect = [False, True]
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd], outfile=outfile)
+
+        results = outfile.getvalue()
+        self.assertEqual(results, (
+            'localhost (dbid 2): string 1\n'
+            'localhost (dbid 2): string 2\n'
+        ))
+
+    def test_inplace_display_uses_ansi_escapes_to_overwrite_previous_output(self):
+        cmd = Mock(spec=base.Command)
+        cmd.remoteHost = 'localhost'
+        cmd.dbid = 2
+        cmd.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
+
+        cmd2 = Mock(spec=base.Command)
+        cmd2.remoteHost = 'host2'
+        cmd2.dbid = 4
+        cmd2.get_results.side_effect = [Mock(stdout="string 3"), Mock(stdout="string 4")]
+
+        outfile = StringIO.StringIO()
+        self.pool.join.side_effect = [False, True]
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], inplace=True, outfile=outfile)
+
+        results = outfile.getvalue()
+        self.assertEqual(results, (
+            'localhost (dbid 2): string 1\x1b[K\n'
+            'host2 (dbid 4): string 3\x1b[K\n'
+            '\x1b[2A'
+            'localhost (dbid 2): string 2\x1b[K\n'
+            'host2 (dbid 4): string 4\x1b[K\n'
+        ))
+
+    def test_errors_during_command_execution_are_displayed(self):
+        cmd = Mock(spec=base.Command)
+        cmd.remoteHost = 'localhost'
+        cmd.dbid = 2
+        cmd.get_results.return_value.stderr = "some error\n"
+        cmd.run.side_effect = base.ExecutionError("Some exception", cmd)
+
+        cmd2 = Mock(spec=base.Command)
+        cmd2.remoteHost = 'host2'
+        cmd2.dbid = 4
+        cmd2.get_results.return_value.stderr = ''
+        cmd2.run.side_effect = base.ExecutionError("Some exception", cmd2)
+
+        outfile = StringIO.StringIO()
+        self.pool.join.return_value = True
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], outfile=outfile)
+
+        results = outfile.getvalue()
+        self.assertEqual(results, (
+            'localhost (dbid 2): some error\n'
+            'host2 (dbid 4): \n'
+        ))
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -127,6 +127,12 @@ class GpRecoverSegmentProgram:
         self.__pool = None
         self.logger = logger
 
+        # If user did not specify a value for showProgressInplace and
+        # stdout is a tty then send escape sequences to gprecoverseg
+        # output. Otherwise do not show progress inplace.
+        if self.__options.showProgressInplace is None:
+            self.__options.showProgressInplace = sys.stdout.isatty()
+
     def outputToFile(self, mirrorBuilder, gpArray, fileName):
         lines = []
 
@@ -251,7 +257,8 @@ class GpRecoverSegmentProgram:
         self._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
 
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
-                                   self.__options.parallelDegree, forceoverwrite=True)
+                                   self.__options.parallelDegree, forceoverwrite=True,
+                                   showProgressInplace=self.__options.showProgressInplace)
 
     def findAndValidatePeersForFailedSegments(self, gpArray, failedSegments):
         dbIdToPeerMap = gpArray.getDbIdToPeerMap()
@@ -387,7 +394,8 @@ class GpRecoverSegmentProgram:
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
                                    self.__options.parallelDegree,
                                    interfaceHostnameWarnings,
-                                   forceoverwrite=True)
+                                   forceoverwrite=True,
+                                   showProgressInplace=self.__options.showProgressInplace)
 
     def _output_segments_with_persistent_mirroring_disabled(self, segs_persistent_mirroring_disabled=None):
         if segs_persistent_mirroring_disabled:
@@ -685,7 +693,10 @@ class GpRecoverSegmentProgram:
                            version='%prog version $Revision$')
         parser.setHelp(help)
 
-        addStandardLoggingAndHelpOptions(parser, True)
+        loggingGroup = addStandardLoggingAndHelpOptions(parser, True)
+        loggingGroup.add_option("-s", None, default=None, action='store_false',
+                                dest='showProgressInplace',
+                                help='Show pg_basebackup progress sequentially instead of inplace')
 
         addTo = OptionGroup(parser, "Connection Options")
         parser.add_option_group(addTo)

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -133,6 +133,19 @@ class GpRecoverSegmentProgram:
         if self.__options.showProgressInplace is None:
             self.__options.showProgressInplace = sys.stdout.isatty()
 
+
+    def getProgressMode(self):
+        if self.__options.showProgress:
+            if self.__options.showProgressInplace:
+                progressMode = GpMirrorListToBuild.Progress.INPLACE
+            else:
+                progressMode = GpMirrorListToBuild.Progress.SEQUENTIAL
+        else:
+            progressMode = GpMirrorListToBuild.Progress.NONE
+
+        return progressMode
+
+
     def outputToFile(self, mirrorBuilder, gpArray, fileName):
         lines = []
 
@@ -258,7 +271,7 @@ class GpRecoverSegmentProgram:
 
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
                                    self.__options.parallelDegree, forceoverwrite=True,
-                                   showProgressInplace=self.__options.showProgressInplace)
+                                   progressMode=self.getProgressMode())
 
     def findAndValidatePeersForFailedSegments(self, gpArray, failedSegments):
         dbIdToPeerMap = gpArray.getDbIdToPeerMap()
@@ -395,7 +408,7 @@ class GpRecoverSegmentProgram:
                                    self.__options.parallelDegree,
                                    interfaceHostnameWarnings,
                                    forceoverwrite=True,
-                                   showProgressInplace=self.__options.showProgressInplace)
+                                   progressMode=self.getProgressMode())
 
     def _output_segments_with_persistent_mirroring_disabled(self, segs_persistent_mirroring_disabled=None):
         if segs_persistent_mirroring_disabled:
@@ -697,6 +710,9 @@ class GpRecoverSegmentProgram:
         loggingGroup.add_option("-s", None, default=None, action='store_false',
                                 dest='showProgressInplace',
                                 help='Show pg_basebackup progress sequentially instead of inplace')
+        loggingGroup.add_option("--no-progress",
+                                dest="showProgress", default=True, action="store_false",
+                                help="Suppress pg_basebackup progress output")
 
         addTo = OptionGroup(parser, "Connection Options")
         parser.add_option_group(addTo)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -104,6 +104,7 @@ class GpRecoversegTestCase(GpTestCase):
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = self.config_file_path
+        options.showProgress = True
         options.showProgressInplace = True
 
         # import HERE so that patches are already in place!
@@ -177,6 +178,7 @@ class GpRecoversegTestCase(GpTestCase):
         options.masterDataDirectory = self.temp_dir
         options.rebalanceSegments = True
         options.spareDataDirectoryFile = None
+        options.showProgress = True
         options.showProgressInplace = True
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
@@ -197,6 +199,7 @@ class GpRecoversegTestCase(GpTestCase):
         options.masterDataDirectory = self.temp_dir
         options.rebalanceSegments = True
         options.spareDataDirectoryFile = None
+        options.showProgress = True
         options.showProgressInplace = True
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
@@ -216,6 +219,7 @@ class GpRecoversegTestCase(GpTestCase):
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = None
+        options.showProgress = True
         options.showProgressInplace = True
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
@@ -239,6 +243,7 @@ class GpRecoversegTestCase(GpTestCase):
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = None
+        options.showProgress = True
         options.showProgressInplace = True
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -104,9 +104,10 @@ class GpRecoversegTestCase(GpTestCase):
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = self.config_file_path
+        options.showProgressInplace = True
 
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
 
@@ -176,8 +177,9 @@ class GpRecoversegTestCase(GpTestCase):
         options.masterDataDirectory = self.temp_dir
         options.rebalanceSegments = True
         options.spareDataDirectoryFile = None
+        options.showProgressInplace = True
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
 
@@ -195,8 +197,9 @@ class GpRecoversegTestCase(GpTestCase):
         options.masterDataDirectory = self.temp_dir
         options.rebalanceSegments = True
         options.spareDataDirectoryFile = None
+        options.showProgressInplace = True
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
 
@@ -213,8 +216,9 @@ class GpRecoversegTestCase(GpTestCase):
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = None
+        options.showProgressInplace = True
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
         self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors
@@ -235,8 +239,9 @@ class GpRecoversegTestCase(GpTestCase):
         options = Options()
         options.masterDataDirectory = self.temp_dir
         options.spareDataDirectoryFile = None
+        options.showProgressInplace = True
         # import HERE so that patches are already in place!
-        from programs.clsRecoverSegment import GpRecoverSegmentProgram
+        from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
         self.mock_get_mirrors_to_build.side_effect = self._get_test_mirrors

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -40,7 +40,7 @@ class ValidationException(Exception):
 
 class ConfExpSegCmd(Command):
     def __init__(self, name, cmdstr, datadir, port, dbid, contentid, newseg, tarfile, useLighterDirectoryValidation, isPrimary,
-                    syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName):
+                 syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile):
         """
         @param useLighterDirectoryValidation if True then we don't require an empty directory; we just require that
                                              database stuff is not there.
@@ -57,7 +57,8 @@ class ConfExpSegCmd(Command):
         self.syncWithSegmentHostname = syncWithSegmentHostname
         self.syncWithSegmentPort = syncWithSegmentPort
         self.replicationSlotName = replicationSlotName
-
+        self.logfileDirectory = logfileDirectory
+        self.progressFile = progressFile
         #
         # validationOnly if True then we validate directories and other simple things only; we don't
         #                actually configure the segment
@@ -122,11 +123,15 @@ class ConfExpSegCmd(Command):
                    return
 
                 if not self.isPrimary:
-                    # Log pg_basebackup output to the same directory as gpconfigurenewsegment
-                    pgbasebackup_start_time = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
-                    pgbasebackup_progress_temp_file = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
-                                                                                          pgbasebackup_start_time,
-                                                                                          self.dbid)
+                    # If the caller does not specify a pg_basebackup
+                    # progress file, then create a temporary one and handle
+                    # its deletion upon success.
+                    shouldDeleteProgressFile = False
+                    if not self.progressFile:
+                        shouldDeleteProgressFile = True
+                        self.progressFile = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
+                                                                                datetime.datetime.today().strftime('%Y%m%d_%H%M%S'),
+                                                                                self.dbid)
                     # Create a mirror based on the primary
                     cmd = PgBaseBackup(pgdata=self.datadir,
                                        host=self.syncWithSegmentHostname,
@@ -134,13 +139,13 @@ class ConfExpSegCmd(Command):
                                        replication_slot_name=self.replicationSlotName,
                                        forceoverwrite=self.forceoverwrite,
                                        target_gp_dbid=self.dbid,
-                                       logfile=pgbasebackup_progress_temp_file)
+                                       logfile=self.progressFile)
                     try:
-                        logger.info("Running pg_basebackup with progress output temporarily in %s" % pgbasebackup_progress_temp_file)
+                        logger.info("Running pg_basebackup with progress output temporarily in %s" % self.progressFile)
                         cmd.run(validateAfter=True)
-
                         self.set_results(CommandResult(0, '', '', True, False))
-                        os.remove(pgbasebackup_progress_temp_file)
+                        if shouldDeleteProgressFile:
+                            os.remove(self.progressFile)
                     except Exception, e:
                         self.set_results(CommandResult(1,'',e,True,False))
                         raise
@@ -319,6 +324,7 @@ try:
         # they will be junk data passed through the config.
         primaryHostName = seg[6]
         primarySegmentPort = int(seg[7])
+        progressFile = seg[8]
 
         cmd = ConfExpSegCmd( name = 'Configure segment directory'
                            , cmdstr = ' '.join(sys.argv)
@@ -336,6 +342,8 @@ try:
                            , validationOnly = options.validationOnly
                            , forceoverwrite = options.forceoverwrite
                            , replicationSlotName = options.replicationSlotName
+                           , logfileDirectory = options.logfileDirectory
+                           , progressFile= progressFile
                            )
         pool.addCommand(cmd)
 

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -10,7 +10,7 @@ Synopsis
 gprecoverseg [-p <new_recover_host>[,...]]
              |-i <recover_config_file> 
              [-d <master_data_directory>] [-B <parallel_processes>] 
-             [-F] [-a] [-q] [-s] [-l <logfile_directory>]
+             [-F] [-a] [-q] [-s] [--no-progress] [-l <logfile_directory>]
 
 
 gprecoverseg -r
@@ -224,6 +224,12 @@ be cancelled and rolled back.
 Show pg_basebackup progress sequentially instead of inplace. Useful when
 writing to a file, or if a tty does not support escape sequences. Defaults to
 showing the progress inplace.
+
+
+--no-progress
+
+Do no show pg_basebackup progress. Useful when writing to a
+file. Defaults to showing the progress.
 
 
 -v

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -10,7 +10,7 @@ Synopsis
 gprecoverseg [-p <new_recover_host>[,...]]
              |-i <recover_config_file> 
              [-d <master_data_directory>] [-B <parallel_processes>] 
-             [-F] [-a] [-q] [-l <logfile_directory>]
+             [-F] [-a] [-q] [-s] [-l <logfile_directory>]
 
 
 gprecoverseg -r
@@ -218,6 +218,12 @@ This option rebalances primary and mirror segments by returning them to
 their preferred roles. All segments must be valid and synchronized before 
 running gprecoverseg -r. If there are any in progress queries, they will 
 be cancelled and rolled back.
+
+-s
+
+Show pg_basebackup progress sequentially instead of inplace. Useful when
+writing to a file, or if a tty does not support escape sequences. Defaults to
+showing the progress inplace.
 
 
 -v

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -34,6 +34,19 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
 
+    Scenario: gprecoverseg does not display pg_basebackup progress to the user when --no-progress option is specified
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user kills all mirror processes
+        When user can start transactions
+        And the user runs "gprecoverseg -F -a --no-progress"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should not print "pg_basebackup: base backup completed" to stdout
+        And gpAdminLogs directory has no "pg_basebackup*" files
+        And all the segments are running
+        And the segments are synchronized
+
     Scenario: When gprecoverseg full recovery is executed and an existing postmaster.pid on the killed primary segment corresponds to a non postgres process
         Given the database is running
         And all the segments are running

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -21,6 +21,19 @@ Feature: gprecoverseg tests
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
 
+    Scenario: gprecoverseg displays pg_basebackup progress to the user
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user kills all mirror processes
+        When user can start transactions
+        And the user runs "gprecoverseg -F -a -s"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for each mirror
+        And gpAdminLogs directory has no "pg_basebackup*" files
+        And all the segments are running
+        And the segments are synchronized
+
     Scenario: When gprecoverseg full recovery is executed and an existing postmaster.pid on the killed primary segment corresponds to a non postgres process
         Given the database is running
         And all the segments are running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1941,14 +1941,12 @@ def impl(context, gppkg_name):
 def impl(context, gppkg_name):
     _remove_gppkg_from_host(context, gppkg_name, is_master_host=True)
 
-
-@given('gpAdminLogs directory has no "{prefix}" files')
-def impl(context, prefix):
+@then('gpAdminLogs directory has no "{expected_file}" files')
+def impl(context, expected_file):
     log_dir = _get_gpAdminLogs_directory()
-    items = glob.glob('%s/%s_*.log' % (log_dir, prefix))
-    for item in items:
-        os.remove(item)
-
+    files_found = glob.glob('%s/%s' % (log_dir, expected_file))
+    if files_found:
+        raise Exception("expected no %s files in %s, but found %s" % (expected_file, log_dir, files_found))
 
 @given('"{filepath}" is copied to the install directory')
 def impl(context, filepath):

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -108,3 +108,13 @@ def runCommandOnRemoteSegment(context, cid, sql_cmd):
     host = host.strip()
     psql_cmd = "PGDATABASE=\'template1\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (host, port, sql_cmd)
     Command(name='Running Remote command: %s' % psql_cmd, cmdStr = psql_cmd).run(validateAfter=True)
+
+@then('gprecoverseg should print "{output}" to stdout for each mirror')
+def impl(context, output):
+    gparray = GpArray.initFromCatalog(dbconn.DbURL())
+    segments = gparray.getDbList()
+
+    for segment in segments:
+        if segment.isSegmentMirror():
+            expected = r'\(dbid {}\): {}'.format(segment.dbid, output)
+            check_stdout_msg(context, expected)

--- a/src/test/isolation2/expected/fts_dns_error.out
+++ b/src/test/isolation2/expected/fts_dns_error.out
@@ -80,7 +80,7 @@ select count(*) from gp_segment_configuration where status = 'd';
 (1 row)
 
 -- fully recover the failed primary as new mirror
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -aF --no-progress;
 -- start_ignore
 20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Starting gprecoverseg with args: -aF
 20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss'

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -190,7 +190,7 @@ server stopped
 (1 row)
 
 -- fully recover the failed primary as new mirror
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -aF --no-progress;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -64,7 +64,7 @@ select content, preferred_role, role, status, mode from gp_segment_configuration
 0Uq: ... <quitting>
 
 -- fully recover the failed primary as new mirror
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -aF --no-progress;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -163,7 +163,7 @@ create table mirror_promotion_tblspc_heap_table (a int) tablespace mirror_promot
 CREATE
 
 -- -- now, let's fully recover the mirror
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -aF  --no-progress;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
@@ -210,10 +210,11 @@ DROP
  p    | m              
 (2 rows)
 
-5:!\retcode gprecoverseg -aF;
+5:!\retcode gprecoverseg -aF \-\-no-progress;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
+
 5:!\retcode gprecoverseg -ar;
 -- start_ignore
 -- end_ignore

--- a/src/test/isolation2/sql/fts_dns_error.sql
+++ b/src/test/isolation2/sql/fts_dns_error.sql
@@ -29,7 +29,7 @@ select gp_inject_fault_infinite('get_dns_cached_address', 'reset', 1);
 select count(*) from gp_segment_configuration where status = 'd';
 
 -- fully recover the failed primary as new mirror
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -aF --no-progress;
 
 -- loop while segments come in sync
 do $$

--- a/src/test/isolation2/sql/fts_errors.sql
+++ b/src/test/isolation2/sql/fts_errors.sql
@@ -122,7 +122,7 @@ select pg_ctl((select datadir from gp_segment_configuration c
 where c.role='m' and c.content=0), 'stop');
 
 -- fully recover the failed primary as new mirror
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -aF --no-progress;
 
 -- loop while segments come in sync
 do $$

--- a/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
@@ -35,7 +35,7 @@ where content = 0;
 0Uq:
 
 -- fully recover the failed primary as new mirror
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -aF --no-progress;
 
 -- loop while segments come in sync
 do $$
@@ -94,7 +94,7 @@ create tablespace mirror_promotion_tablespace location '/tmp/mirror_promotion_ta
 create table mirror_promotion_tblspc_heap_table (a int) tablespace mirror_promotion_tablespace;
 
 -- -- now, let's fully recover the mirror
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -aF  --no-progress;
 
 drop table mirror_promotion_tblspc_heap_table;
 drop tablespace mirror_promotion_tablespace;

--- a/src/test/isolation2/sql/segwalrep/twophase_tolerance_with_mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/twophase_tolerance_with_mirror_promotion.sql
@@ -97,7 +97,8 @@ CREATE extension IF NOT EXISTS gp_inject_fault;
 -- are exhausted and PANICs the master.
 5:SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 2;
 
-5:!\retcode gprecoverseg -aF;
+5:!\retcode gprecoverseg -aF \-\-no-progress;
+
 5:!\retcode gprecoverseg -ar;
 
 !\retcode gpconfig -r gp_fts_probe_retries --masteronly;

--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -44,7 +44,7 @@ select gp_request_fts_probe_scan();
 select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
 -- The remaining steps are to bring back the cluster to original state.
 -- start_ignore
-\! gprecoverseg -av
+\! gprecoverseg -av --no-progress
 -- end_ignore
 
 -- loop while segments come in sync

--- a/src/test/regress/sql/mirror_replay.sql
+++ b/src/test/regress/sql/mirror_replay.sql
@@ -74,7 +74,7 @@ SELECT role, preferred_role, mode, status FROM gp_segment_configuration WHERE co
 
 -- post test cleanup
 -- start_ignore
-\! gprecoverseg -aF;
+\! gprecoverseg -aF --no-progress;
 -- end_ignore
 
 -- loop while segments come in sync


### PR DESCRIPTION
The gprecoverseg utility runs pg_basebackup in parallel on all segments that are being recovered. In this commit, we are logging the progress of each pg_basebackup on its host and displaying them to the user of gprecoverseg. The progress files are deleted upon successful completion of gprecoverseg.

A `--no-progress` flag has also been added to avoid generating progress files.

Unit tests have also been added.

This is a follow-on to https://github.com/greenplum-db/gpdb/pull/7069 which had to be reverted due to progress files slowing down some of the tests.  The main difference from the previous PR is the third commit https://github.com/greenplum-db/gpdb/pull/7207/commits/6b9980a2b83fcc4f20379e0fced35bf848bd0801 described below.

gprecoverseg: Add --no-progress flag.

We have have added a --no-progress flag that suppresses the output of
pg_basbackup.  We have also changed the pg_basebackup progress update
rate to once per second to minimize I/O.

Regression tests utilizing gprecoverseg have also been modified to use
the --no-progress flag.

Authored-by: Shoaib Lari slari@pivotal.io
Co-authored-by: Mark Sliva msliva@pivotal.io
Co-authored-by: Jacob Champion pchampion@pivotal.io
Co-authored-by: Jamie McAtamney jmcatamney@pivotal.io
Co-authored-by: Ed Espino edespino@pivotal.io
Co-authored-by: Kalen Krempely kkrempely@pivotal.io
