### PR TITLE
Bump ORCA version to 3.30.0 (6X_STABLE)

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.29.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.30.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.29.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.30.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -14026,7 +14026,7 @@ int
 main ()
 {
 
-return strncmp("3.29.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.30.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -14036,7 +14036,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.29.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.30.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.29.0@gpdb/stable
+orca/v3.30.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -87,7 +87,7 @@ sync_tools: opt_write_test
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.29.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.30.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test


### PR DESCRIPTION
Corresponding ORCA commit: "Fix crash during expression to DXL
translation in correlated NLJ" (PR: https://github.com/greenplum-db/gporca/pull/452)
