### PR TITLE
6X_STABLE Backport: Remove gpaddmirrors from NON_PRODUCTION_FILES.txt

### DIFF
--- a/gpAux/releng/NON_PRODUCTION_FILES.txt
+++ b/gpAux/releng/NON_PRODUCTION_FILES.txt
@@ -1,6 +1,5 @@
 bin/explain.pl
 bin/explain.pm
-bin/gpaddmirrors
 bin/gptorment.pl
 bin/lib/gptest.py
 bin/pgbench


### PR DESCRIPTION
gpaddmirrors is missing from the GPDB6 beta tag. This commit adds gpaddmirrors back to the distribution.
