### PR TITLE
Backport to 6X: Fix two log-rotation bugs

### DIFF
--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -497,8 +497,7 @@ SysLoggerMain(int argc, char *argv[])
 		if (Log_RotationAge > 0 && !rotation_disabled)
 		{
 			/* Do a logfile rotation if it's time */
-			pg_time_t	now = (pg_time_t) time(NULL);
-
+			now = (pg_time_t) time(NULL);
 			if (now >= next_rotation_time)
 			{
 				rotation_requested = time_based_rotation = true;


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/7127 for 6X_STABLE.

Please refer to the above PR for details.
