### PR TITLE
Remove dead code from `copylibs` make target

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -810,11 +810,6 @@ copylibs : thirdparty-dist
 	mkdir -p $(INSTLOC)/etc
 	mkdir -p $(INSTLOC)/include
 
-ifeq "$(BLD_ARCH)" "win32"
-	# Copy kfw dlls
-	cp -rp $(BLD_TOP)/ext/win32/kfw-3-2-2/lib/*dll $(INSTLOC)/lib/
-endif
-
 greenplum_path:
 	mkdir -p $(INSTLOC)
 	unset LIBPATH; \

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -798,42 +798,6 @@ endif
 libcopy=(cd $(1) && $(TAR) cf - $(2)) | (cd $(3) && $(TAR) xvf -)$(check_pipe_for_errors)
 
 copylibs : thirdparty-dist
-	if [ `uname -s` = 'SunOS' ]; then cp `ldd $(INSTLOC)/bin/psql | grep gcc | head -1 | awk '{print $$3}'` $(INSTLOC)/lib; fi
-	if [ `uname -s` = 'Darwin' ] ; then \
-	    for lib in `otool -L $(INSTLOC)/bin/psql | egrep 'libssl|libcrypto|libcom_err|libkrb5|curl|readline|numa' | awk '{print $$1}'`; do \
-	        if [ x"`dirname $$lib`" = x"$(INSTLOC)/lib" ]; then continue; fi; \
-	        if [ -f $(INSTLOC)/lib/`basename $$lib` -a ! -w $(INSTLOC)/lib/`basename $$lib` ]; then chmod u+w $(INSTLOC)/lib/`basename $$lib`; fi; \
-	        if [ -f $(BLD_THIRDPARTY_LIB_DIR)/`basename $$lib` ]; then \
-	            echo "cp -p $(BLD_THIRDPARTY_LIB_DIR)/`basename $$lib` $(INSTLOC)/lib/" ; \
-	            cp -p $(BLD_THIRDPARTY_LIB_DIR)/`basename $$lib` $(INSTLOC)/lib/ ; \
-	        else \
-	            echo "cp -p $$lib $(INSTLOC)/lib/" ; \
-	            cp -p $$lib $(INSTLOC)/lib/ ; \
-	        fi ; \
-	    done ; \
-	fi
-	if [ `uname -s` != 'Darwin' -a `uname -s` != 'AIX' ] ; then \
-	    for lib in `ldd $(INSTLOC)/bin/psql | egrep 'readline|numa' | awk '{print $$3}' | sort -u`; do \
-	        if [ x"`dirname $$lib`" = x"$(INSTLOC)/lib" ]; then continue; fi; \
-	        if [ -f $(INSTLOC)/lib/`basename $$lib` -a ! -w $(INSTLOC)/lib/`basename $$lib` ]; then chmod u+w $(INSTLOC)/lib/`basename $$lib`; fi; \
-	        echo "cp -p $$lib $(INSTLOC)/lib" ; \
-	        cp -p $$lib $(INSTLOC)/lib ; \
-	    done ; \
-	fi
-	if [ `uname -s` = 'AIX' ] ; then \
-	    for lib in `ldd $(INSTLOC)/bin/psql | egrep 'libssl|libcrypto|libcom_err|curl|readline|numa' | awk -F\( '{print $$1}' | sort -u`; do \
-	        if [ x"`dirname $$lib`" = x"$(INSTLOC)/lib" ]; then continue; fi; \
-	        if [ -f $(INSTLOC)/lib/`basename $$lib` -a ! -w $(INSTLOC)/lib/`basename $$lib` ]; then chmod u+w $(INSTLOC)/lib/`basename $$lib`; fi; \
-	        echo "cp -p $$lib $(INSTLOC)/lib" ; \
-	        cp -p $$lib $(INSTLOC)/lib ; \
-	    done ; \
-	    for lib in `ldd $(INSTLOC)/bin/gpfdist | egrep 'libbz2|libz' | awk -F\( '{print $$1}' | sort -u`; do \
-	        if [ x"`dirname $$lib`" = x"$(INSTLOC)/lib" ]; then continue; fi; \
-	        if [ -f $(INSTLOC)/lib/`basename $$lib` -a ! -w $(INSTLOC)/lib/`basename $$lib` ]; then chmod u+w $(INSTLOC)/lib/`basename $$lib`; fi; \
-	        echo "cp -p $$lib $(INSTLOC)/lib" ; \
-	        cp -p $$lib $(INSTLOC)/lib ; \
-	    done ; \
-	fi
 	# Create the python directory to flag to build scripts that python has been handled
 	mkdir -p $(INSTLOC)/ext/python
 	@if [ ! -z "$(PYTHONHOME)" ]; then \
@@ -845,21 +809,6 @@ copylibs : thirdparty-dist
 	fi
 	mkdir -p $(INSTLOC)/etc
 	mkdir -p $(INSTLOC)/include
-ifeq "$(findstring $(BLD_ARCH),rhel7_x86_64 rhel6_x86_64 aix5_ppc_32 aix5_ppc_64 aix7_ppc_64 win32 win64)" ""
-	# Copy curl header file
-	cp -rp $(BLD_THIRDPARTY_INCLUDE_DIR)/curl $(INSTLOC)/include/
-endif
-ifeq "$(findstring $(BLD_ARCH),rhel7_x86_64 rhel6_x86_64 aix5_ppc_32 win32 win64)" ""
-ifneq "$(BLD_ARCH)" "osx104_x86"
-	cp -rp $(BLD_THIRDPARTY_BIN_DIR)/openssl $(INSTLOC)/bin/
-	cp -rp $(BLD_THIRDPARTY_INCLUDE_DIR)/openssl $(INSTLOC)/include/
-	cp -rp $(BLD_THIRDPARTY_DIR)/ssl/openssl.cnf $(INSTLOC)/etc/
-else
-	cp -rp /usr/bin/openssl $(INSTLOC)/bin/
-	cp -rp /usr/include/openssl $(INSTLOC)/include/
-	cp -rp /System/Library/OpenSSL/openssl.cnf $(INSTLOC)/etc/
-endif
-endif
 
 ifeq "$(BLD_ARCH)" "win32"
 	# Copy kfw dlls

--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -4,8 +4,6 @@ default: all
 
 BLD_TOP=..
 
-GPAUX_DIR=$(BLD_TOP)/gpAux/
-
 ext_dir=$(BLD_TOP)/gpAux/ext
 
 top_builddir = ..

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -17,8 +17,6 @@ subdir = src/backend
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 
-BLD_TOP = $(top_builddir)/gpAux
-
 SUBDIRS = access bootstrap catalog parser commands executor foreign \
 	fts lib libpq main nodes optimizer port postmaster regex \
 	replication rewrite storage tcop tsearch utils $(top_builddir)/src/timezone cdb


### PR DESCRIPTION
Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-drop-copylibs-releng. The AIX failure is also present on master; the job is just paused in the master pipeline.

Since we have removed the Ivy dependency manager entirely from GPDB 6+,
we do not need this code anymore. It used to copy Ivy-managed libraries
into the Greenplum installation for packaging.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>