### PR TITLE
5X: Introduce ABI compatibility checks 

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -179,7 +179,7 @@ def how_to_use_generated_pipeline_message():
         msg += '    -p %s \\\n' % os.path.basename(ARGS.output_filepath).rsplit('.', 1)[0]
         msg += '    -c %s \\\n' % ARGS.output_filepath
         msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
-        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_5X_STABLE-ci-secrets.yml \\\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_5X_STABLE-ci-secrets.dev.yml \\\n'
         msg += '    -l ~/workspace/gp-continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \\\n'
         msg += '    -v bucket-name=gpdb5-concourse-builds-dev \\\n'
         msg += '    -v gpdb-git-remote=%s \\\n' % suggested_git_remote()

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -49,6 +49,7 @@ groups:
   - compile_gpdb_sles11
   - compile_gpdb_ubuntu16
   - compile_gpdb_ubuntu16_oss
+  - compile_gpdb_ubuntu16_oss_abi
   - compile_gpdb_open_source_centos6
   - compile_gpdb_binary_swap_centos6
   - compile_gpdb_windows_cl
@@ -162,6 +163,7 @@ groups:
 - name: Release
   jobs:
   - gate_release_candidate_start
+  - compile_gpdb_ubuntu16_oss_abi
   - Release_Candidate
 
 {% endif %}
@@ -417,6 +419,13 @@ resources:
     ignore_paths:
     - gpdb-doc/*
     - README*
+
+- name: gpdb_src_latest_5X_tag
+  type: git
+  source:
+    branch: 5X_STABLE
+    uri: {{gpdb-git-remote}}
+    tag_filter: 5.*
 
 - name: gpdb_src_binary_swap
   type: git
@@ -1258,6 +1267,86 @@ jobs:
     - put: deb_package_open_source_ubuntu16
       params:
         file: {{deb_package_open_source_ubuntu16_versioned_file}}
+
+- name: compile_gpdb_ubuntu16_oss_abi
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gate_compile_start]
+      trigger: ((gpdb_src-trigger-flag))
+    - get: gpdb_src_latest_5X_tag
+    - get: ubuntu-gpdb-dev-16
+      passed: [gate_compile_start]
+  - aggregate:
+    - task: compile_gpdb_head
+      image: ubuntu-gpdb-dev-16
+      config:
+        platform: linux
+        inputs:
+          - name: gpdb_src
+        outputs:
+          - name: compiled_bits_ubuntu16_head
+        run:
+          path: gpdb_src/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+        params:
+          CFLAGS: -g -Og
+          CXXFLAGS: -g -Og
+          CONFIGURE_FLAGS: {{configure_flags}}
+          TRANSFER_DIR: compiled_bits_ubuntu16_head
+          COMPILED_BITS_FILENAME: compiled_bits_ubuntu16.tar.gz
+    - task: compile_gpdb_tag
+      image: ubuntu-gpdb-dev-16
+      input_mapping:
+        gpdb_src: gpdb_src_latest_5X_tag
+      config:
+        platform: linux
+        inputs:
+          - name: gpdb_src
+        outputs:
+          - name: compiled_bits_ubuntu16_tag
+        run:
+          path: gpdb_src/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+        params:
+          CFLAGS: -g -Og
+          CXXFLAGS: -g -Og
+          CONFIGURE_FLAGS: {{configure_flags}}
+          TRANSFER_DIR: compiled_bits_ubuntu16_tag
+          COMPILED_BITS_FILENAME: compiled_bits_ubuntu16.tar.gz
+  - task: compare_abi
+    image: ubuntu-gpdb-dev-16
+    config:
+      platform: linux
+      inputs:
+        - name: gpdb_src
+        - name: compiled_bits_ubuntu16_head
+        - name: compiled_bits_ubuntu16_tag
+      outputs:
+        - name: abi
+      run:
+        path: gpdb_src/concourse/scripts/compare_abi_ubuntu.bash
+        args: [
+          'bin/postgres',
+          'lib/libecpg.so',
+          'lib/libecpg_compat.so',
+          'lib/libgppc.so',
+          'lib/libpgtypes.so',
+          'lib/libpq.so',
+        ]
+      params:
+  - task: publish_report
+    image: ubuntu-gpdb-dev-16
+    config:
+      platform: linux
+      inputs:
+        - name: gpdb_src
+        - name: abi
+      run:
+        path: gpdb_src/concourse/scripts/s3_sync
+        args: [ "./abi/", "s3://((public-bucket-name))/" ]
+      params:
+        AWS_ACCESS_KEY_ID: {{bucket-access-key-id}}
+        AWS_SECRET_ACCESS_KEY: {{bucket-secret-access-key}}
+        AWS_DEFAULT_REGION: {{aws-region}}
 
 - name: compile_gpdb_open_source_centos6
   public: true

--- a/concourse/scripts/compare_abi_ubuntu.bash
+++ b/concourse/scripts/compare_abi_ubuntu.bash
@@ -1,0 +1,62 @@
+#! /bin/bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+set -x
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 binary [binary ...]"
+    exit 1
+fi
+
+OLD_DIR=$(pwd)/compiled_bits_ubuntu16_tag
+NEW_DIR=$(pwd)/compiled_bits_ubuntu16_head
+
+pushd ${OLD_DIR}
+    tar xzf *.tar.gz
+    old=`expr "$(source ./bin/lib/gp_bash_version.sh; print_version)" : ".*\([0-9]\+\.[0-9]\+\.[0-9]\+\)"`
+popd
+
+pushd ${NEW_DIR}
+    tar xzf *.tar.gz
+    new=HEAD
+popd
+
+# Install our ABI compliance checker. TODO: move to Concourse inputs.
+apt-get update && apt-get install -y libelf-dev elfutils
+git clone https://github.com/lvc/vtable-dumper
+make -C vtable-dumper && make -C vtable-dumper install prefix=/usr/local
+
+git clone https://github.com/lvc/abi-dumper
+make -C abi-dumper install prefix=/usr/local
+
+git clone https://github.com/lvc/abi-compliance-checker
+make -C abi-compliance-checker install prefix=/usr/local
+
+# Check compliance.
+pushd abi
+    echo "Comparing ABI between $old and $new..."
+
+    failed=
+    for binary in "$@"; do
+        echo "Checking $binary ABI..."
+        binary_name=$(basename "$binary")
+
+        abi-dumper -lver "$old" -o "$binary_name.$old.dump" "${OLD_DIR}/$binary"
+        abi-dumper -lver "$new" -o "$binary_name.$new.dump" "${NEW_DIR}/$binary"
+        if ! abi-compliance-checker -l "$binary_name" -old "$binary_name.$old.dump" -new "$binary_name.$new.dump"; then
+            failed+="$binary "
+        fi
+    done
+popd
+
+if [ -n "$failed" ]; then
+    set +x
+    echo
+    echo "The following binaries have ABI differences from $old:"
+    echo
+    echo "    $failed"
+    echo
+    echo "A report has been generated."
+fi

--- a/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+++ b/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
@@ -28,7 +28,8 @@ function build_gpdb() {
           --with-python \
           --with-libraries=${CWD}/depends/build/lib \
           --with-includes=${CWD}/depends/build/include \
-          --prefix=${GREENPLUM_INSTALL_DIR}
+          --prefix=${GREENPLUM_INSTALL_DIR} \
+          ${CONFIGURE_FLAGS}
         make -j4
         LD_LIBRARY_PATH=${CWD}/depends/build/lib make install
     popd

--- a/concourse/scripts/s3_sync
+++ b/concourse/scripts/s3_sync
@@ -1,0 +1,28 @@
+#! /bin/bash
+#
+# A helper for syncing a folder to an S3 bucket, since Concourse resources can't
+# do that for you.
+#
+# Usage: ./s3_sync SRC DST
+#
+# You need to set the AWS_* envvars for authentication and region (see below).
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 SRC DST"
+	exit 1
+fi
+
+required_envvars="AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION"
+for var in $required_envvars; do
+    if [ -z "${!var:-}" ]; then
+        echo "This script requires ($required_envvars) to be set."
+        exit 1
+    fi
+done
+
+pip install awscli
+aws s3 sync "$1" "$2"


### PR DESCRIPTION
Create a job that uses the [ABI Compliance Checker](https://github.com/lvc/abi-compliance-checker) to compare the most recent commit to `5X_STABLE` against the last tagged version. We perform ABI comparisons for each of the shared objects shipped in `$prefix/lib` as well as the postgres binary (since extensions rely on its exported interfaces).

This introduces a new pipeline variable, `compatibility-bucket-name`, to point to the bucket in which to store the generated reports. It also introduces a helper script (`s3_sync`) to more easily perform the
upload, since Concourse s3 resources can only put single files.

In passing, also update the OSS Ubuntu job to respect `CONFIGURE_FLAGS`.

At the moment, we're uploading to an S3 bucket that is set up for static hosting (hence the `s3 sync` call). We should discuss whether that's what we want long-term.

Here is some example output from the pipeline:

http://gpdb-compatibility-reports.s3-website-us-west-2.amazonaws.com/compat_reports/postgres/5.17.0_to_HEAD/compat_report.html

## Here are some reminders before you submit the pull request
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
