### PR TITLE
6X: Do not install gpMgmt/bin/README files

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -128,6 +128,7 @@ install: generate_greenplum_path_file
 	rm -rf $(DESTDIR)$(prefix)/bin/src
 	rm -rf $(DESTDIR)$(prefix)/bin/gppylib
 	rm -rf $(DESTDIR)$(prefix)/bin/gpload_test
+	rm -rf $(DESTDIR)$(prefix)/bin/README*
 	find $(DESTDIR)$(prefix)/lib/python/gppylib -name test -type d | xargs rm -rf
 
 clean distclean:


### PR DESCRIPTION
These files used to be installed to ${prefix}/bin/ directory, but as
they are not user documents we should not install them.

Reviewed-by: Bradford D. Boyle <bboyle@pivotal.io>
Reviewed-by: Bob Bao <bbao@pivotal.io>
(cherry picked from commit b176c4e66e854fba0632d7bb722f6d5c63f2099c)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
- [x] Got green light from production team
