### PR TITLE
Remove useless FIXME in InitPlan

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1747,7 +1747,6 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 				containRoot = true;
 			}
 
-			/* FIXME: does relid here have to be the root's OID? */
 			estate->es_result_partitions = BuildPartitionNodeFromRoot(relid);
 
 			/*


### PR DESCRIPTION
`BuildPartitionNodeFromRoot` will always use root relid no matter
what parameter is passed to it.

There is an optimization we might do: for some cases, like if user directly insert into
a child partition, then set `estate->es_result_partitions` to NULL to avoid dispatch it
since a huge partition table's partition info may cost much memory. We can spike this
later.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
