### PR TITLE
Re-enable SRF-in-targetlist support for WindowAgg nodes.

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1945,9 +1945,7 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 	ExecAssignResultTypeFromTL(&aggstate->ss.ps);
 	ExecAssignProjectionInfo(&aggstate->ss.ps, NULL);
 
-#if 0
-	aggstate->ss.ps.ps_TupFromTlist = false;
-#endif
+	aggstate->ps_TupFromTlist = false;
 
 	/*
 	 * get the count of aggregates in targetlist and quals

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -1980,8 +1980,7 @@ ExecWindowAgg(WindowAggState *winstate)
 	 * output tuple (because there is a function-returning-set in the
 	 * projection expressions).  If so, try to project another one.
 	 */
-#if 0
-	if (winstate->ss.ps.ps_TupFromTlist)
+	if (winstate->ps_TupFromTlist)
 	{
 		TupleTableSlot *result;
 		ExprDoneCond isDone;
@@ -1990,9 +1989,8 @@ ExecWindowAgg(WindowAggState *winstate)
 		if (isDone == ExprMultipleResult)
 			return result;
 		/* Done with that source tuple... */
-		winstate->ss.ps.ps_TupFromTlist = false;
+		winstate->ps_TupFromTlist = false;
 	}
-#endif
 
 restart:
 	if (winstate->buffer == NULL)
@@ -2107,10 +2105,8 @@ restart:
 		goto restart;
 	}
 
-#if 0
-	winstate->ss.ps.ps_TupFromTlist =
+	winstate->ps_TupFromTlist =
 		(isDone == ExprMultipleResult);
-#endif
 
 	return result;
 }
@@ -2226,9 +2222,7 @@ ExecInitWindowAgg(WindowAgg *node, EState *estate, int eflags)
 	ExecAssignResultTypeFromTL(&winstate->ss.ps);
 	ExecAssignProjectionInfo(&winstate->ss.ps, NULL);
 
-#if 0
-	winstate->ss.ps.ps_TupFromTlist = false;
-#endif
+	winstate->ps_TupFromTlist = false;
 
 	/* Set up data for comparing tuples */
 	if (node->partNumCols > 0)
@@ -2609,9 +2603,7 @@ ExecReScanWindowAgg(WindowAggState *node)
 
 	node->all_done = false;
 
-#if 0
-	node->ss.ps.ps_TupFromTlist = false;
-#endif
+	node->ps_TupFromTlist = false;
 	node->all_first = true;
 
 	/* release tuplestore et al */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2643,6 +2643,15 @@ typedef struct WindowAggState
 	TupleTableSlot *agg_row_slot;
 	TupleTableSlot *temp_slot_1;
 	TupleTableSlot *temp_slot_2;
+
+	/*
+	 * Most executor nodes in GPDB don't support SRFs in target lists, the
+	 * planner tries to insulate them from SRFs by adding Result nodes. But
+	 * WindowAgg needs to handle them, because a Result can't evaluate
+	 * WindowFunc, which an WindowAgg's target list usually has.
+	 * This is the same logic as for AggState.
+	 */
+	bool		ps_TupFromTlist;
 } WindowAggState;
 
 /* ----------------

--- a/src/test/regress/expected/olap_window.out
+++ b/src/test/regress/expected/olap_window.out
@@ -8338,3 +8338,25 @@ FROM
      2
 (1 row)
 
+-- check SRF in WindowAgg's targetlist can be handled correctly
+explain (costs off)
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+                   QUERY PLAN                   
+------------------------------------------------
+ WindowAgg
+   Order By: a
+   ->  Sort
+         Sort Key: a
+         ->  Function Scan on generate_series a
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+ unnest | rank 
+--------+------
+      2 |    1
+      2 |    1
+      3 |    2
+      3 |    2
+(4 rows)
+

--- a/src/test/regress/expected/olap_window_optimizer.out
+++ b/src/test/regress/expected/olap_window_optimizer.out
@@ -8343,3 +8343,26 @@ FROM
      2
 (1 row)
 
+-- check SRF in WindowAgg's targetlist can be handled correctly
+explain (costs off)
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Result
+   ->  WindowAgg
+         Order By: generate_series
+         ->  Sort
+               Sort Key: generate_series
+               ->  Function Scan on generate_series
+ Optimizer: PQO version 3.30.0
+(7 rows)
+
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+ unnest | rank 
+--------+------
+      2 |    1
+      2 |    1
+      3 |    2
+      3 |    2
+(4 rows)
+

--- a/src/test/regress/sql/olap_window.sql
+++ b/src/test/regress/sql/olap_window.sql
@@ -1629,3 +1629,10 @@ FROM
   GROUP BY name,device_model
   HAVING COUNT(DISTINCT CASE WHEN ppp > 0 THEN device_id ELSE NULL END)>0
 ) b;
+
+-- check SRF in WindowAgg's targetlist can be handled correctly
+
+explain (costs off)
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;


### PR DESCRIPTION
We've removed SRF-in-targetlist support for most node types in GPDB.
Instead, we insert Result nodes to evaluate the set-returning-functions.
This can be benefit to performance.

However, Result node cannot evaluate WindowFunc, which an WindowAgg's
target list usually has. So we need to support SRF-in-targetlist for
WindowAgg nodes.

This is the same logic as for AggState.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
