### PR TITLE
Disallow joins between nested RECURSIVE clauses

### DIFF
--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2163,3 +2163,21 @@ SELECT * FROM y;
  1100 |  
 (15 rows)
 
+-- Nested RECURSIVE queries with double self-referential joins are planned by
+-- joining two WorkTableScans, which GPDB cannot do yet. Ensure that we error
+-- out with a descriptive message.
+SET gp_recursive_cte TO ON;
+WITH RECURSIVE r1 AS (
+	SELECT 1 AS a
+	UNION ALL
+	(
+		WITH RECURSIVE r2 AS (
+			SELECT 2 AS b
+			UNION ALL
+			SELECT b FROM r1, r2
+		)
+		SELECT b FROM r2
+	)
+)
+SELECT * FROM r1 LIMIT 1;
+ERROR:  joining nested RECURSIVE clauses is not supported

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2162,3 +2162,21 @@ SELECT * FROM y;
  1100 |  
 (15 rows)
 
+-- Nested RECURSIVE queries with double self-referential joins are planned by
+-- joining two WorkTableScans, which GPDB cannot do yet. Ensure that we error
+-- out with a descriptive message.
+SET gp_recursive_cte TO ON;
+WITH RECURSIVE r1 AS (
+	SELECT 1 AS a
+	UNION ALL
+	(
+		WITH RECURSIVE r2 AS (
+			SELECT 2 AS b
+			UNION ALL
+			SELECT b FROM r1, r2
+		)
+		SELECT b FROM r2
+	)
+)
+SELECT * FROM r1 LIMIT 1;
+ERROR:  joining nested RECURSIVE clauses is not supported

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -341,3 +341,21 @@ WITH t AS (
 SELECT m BETWEEN 100 AND 1500 FROM t LIMIT 1;
 
 SELECT * FROM y;
+
+-- Nested RECURSIVE queries with double self-referential joins are planned by
+-- joining two WorkTableScans, which GPDB cannot do yet. Ensure that we error
+-- out with a descriptive message.
+SET gp_recursive_cte TO ON;
+WITH RECURSIVE r1 AS (
+	SELECT 1 AS a
+	UNION ALL
+	(
+		WITH RECURSIVE r2 AS (
+			SELECT 2 AS b
+			UNION ALL
+			SELECT b FROM r1, r2
+		)
+		SELECT b FROM r2
+	)
+)
+SELECT * FROM r1 LIMIT 1;


### PR DESCRIPTION
Joining nested `REURSIVE` clauses is planned as a join between two `WorkTableScan` nodes, which we currently cannot do. Detect and disallow for now until we have the required infrastructure to handle this class of queries. The below query is an example of this:
```
  WITH RECURSIVE r1 AS (
      SELECT 1 AS a
      UNION ALL
       (
          WITH RECURSIVE r2 AS (
              SELECT 2 as b
              UNION ALL
              SELECT b FROM r1, r2
          )
          SELECT b FROM r2
      )
  )
  SELECT * FROM r1 LIMIT 1;
```
In upstream PostgreSQL, the resulting plan exhibits the same behavior as in GPDB, but there is no restiction on `WorkTableScan` on the inner side of joins in PostgreSQL:
```
                           QUERY PLAN
  -------------------------------------------------------------
   Limit
     CTE r1
       ->  Recursive Union
             ->  Result
             ->  CTE Scan on r2 r2_1
                   CTE r2
                     ->  Recursive Union
                           ->  Result
                           ->  Nested Loop
                                 ->  WorkTable Scan on r1 r1_1
                                 ->  WorkTable Scan on r2
     ->  CTE Scan on r1
  (12 rows)
```
Backport to 6X_STABLE as it's a live bug there. This can be revisited during the 7.X devcycle when we get rescannable motions, but for 6.X it's too late to do anything other than erroring out.

I spent some time trying to fit this check into the wellformed recursionwalker in `parse_cte.c` but it turned a lot messier and had the potential to miss cases as opposed to this much simpler test.

@d this is essentially just covering another case based on the work that you and Haisheng did, does it make sense to you?