### PR TITLE
Fix gpexpand flaky case

### DIFF
--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -181,8 +181,13 @@ def start_database(context):
 
 
 def stop_database_if_started(context):
-    if check_database_is_running(context):
+    try:
         stop_database(context)
+    except Exception, err:
+        if check_database_is_running(context):
+            raise Exception(err)
+        else:
+            context.exception = None
 
 
 def stop_database(context):


### PR DESCRIPTION
As a kill may be not taken effect at "the database is killed on hosts "
immediately, so we double check the cluster and stop database if it is
still running. But if kill takes effect after checking, stop_database
will raise an exception for gpstop will fail to stop an unstarted cluster.
To fix this flaky case, we stop database first and check the database
status later. It will raise an exception only when gpstop failed and
the cluster is still running.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

Fixes #7229