### PR TITLE
Warn user replication slots will be created on current segment only.

### DIFF
--- a/src/backend/replication/slotfuncs.c
+++ b/src/backend/replication/slotfuncs.c
@@ -32,6 +32,13 @@ check_permissions(void)
 				 (errmsg("must be superuser or replication role to use replication slots"))));
 }
 
+static void
+warn_slot_only_created_on_segment(const char *name) {
+	ereport(WARNING,
+			(errmsg("replication slot \"%s\" created only on this segment", name),
+			 errhint("Creating replication slots on a single segment is not advised.  Replication slots are automatically created by management tools.")));
+}
+
 /*
  * SQL function for creating a new physical (streaming replication)
  * replication slot.
@@ -55,6 +62,8 @@ pg_create_physical_replication_slot(PG_FUNCTION_ARGS)
 	check_permissions();
 
 	CheckSlotRequirements();
+
+	warn_slot_only_created_on_segment(NameStr(*name));
 
 	/* acquire replication slot, this will check for conflicting names */
 	ReplicationSlotCreate(NameStr(*name), false, RS_PERSISTENT);

--- a/src/test/regress/expected/replication_slots.out
+++ b/src/test/regress/expected/replication_slots.out
@@ -1,0 +1,25 @@
+-- When I create a replication slot on the master
+-- Then I should expect an error warning me that
+--   my command is only run on the current segment.
+select pg_create_physical_replication_slot('some_replication_slot');
+WARNING:  replication slot "some_replication_slot" created only on this segment
+HINT:  Creating replication slots on a single segment is not advised.  Replication slots are automatically created by management tools.
+ pg_create_physical_replication_slot 
+-------------------------------------
+ (some_replication_slot,)
+(1 row)
+
+-- And I should see that my replication slot exists
+select pg_get_replication_slots();
+        pg_get_replication_slots         
+-----------------------------------------
+ (some_replication_slot,,physical,,f,,,)
+(1 row)
+
+-- Cleanup:
+select pg_drop_replication_slot('some_replication_slot');
+ pg_drop_replication_slot 
+--------------------------
+ 
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -30,7 +30,7 @@ test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parame
 test: spi_processed64bit
 test: python_processed64bit
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp replication_slots
 
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
 

--- a/src/test/regress/sql/replication_slots.sql
+++ b/src/test/regress/sql/replication_slots.sql
@@ -1,0 +1,10 @@
+-- When I create a replication slot on the master
+-- Then I should expect an error warning me that
+--   my command is only run on the current segment.
+select pg_create_physical_replication_slot('some_replication_slot');
+
+-- And I should see that my replication slot exists
+select pg_get_replication_slots();
+
+-- Cleanup:
+select pg_drop_replication_slot('some_replication_slot');


### PR DESCRIPTION
A warning message is displayed to a user that attempts to perform `pg_create_physical_replication_slot()` on any individual segment, including the master segment so that they are aware that this command is not made to be distributed to the entire cluster.