### PR TITLE
Remove XID and segmentID from the write path sent to PXF

### DIFF
--- a/gpcontrib/pxf/src/pxfbridge.h
+++ b/gpcontrib/pxf/src/pxfbridge.h
@@ -38,7 +38,6 @@ typedef struct
 	GPHDUri        *gphd_uri;
 	StringInfoData uri;
 	ListCell       *current_fragment;
-	StringInfoData write_file_name;
 	Relation       relation;
 	char           *filterstr;
 	ProjectionInfo *proj_info;

--- a/gpcontrib/pxf/src/pxfprotocol.c
+++ b/gpcontrib/pxf/src/pxfprotocol.c
@@ -182,7 +182,6 @@ create_context(PG_FUNCTION_ARGS, bool is_import)
 
 	context->gphd_uri = uri;
 	initStringInfo(&context->uri);
-	initStringInfo(&context->write_file_name);
 	context->relation  = relation;
 	context->filterstr = filterstr;
 	context->proj_info = proj_info;
@@ -200,7 +199,6 @@ cleanup_context(gphadoop_context *context)
 	{
 		gpbridge_cleanup(context);
 		pfree(context->uri.data);
-		pfree(context->write_file_name.data);
 		pfree(context);
 	}
 }

--- a/gpcontrib/pxf/test/pxfprotocol_test.c
+++ b/gpcontrib/pxf/test/pxfprotocol_test.c
@@ -142,7 +142,6 @@ test_pxfprotocol_import_first_call(void **state)
 	/* uri has been initialized */
 	assert_true(context->uri.data != NULL);
 	/* no write file name for import case */
-	assert_int_equal(context->write_file_name.len, 0);
 	assert_true(context->relation != NULL);
 	/* relation pointer is copied */
 	assert_int_equal(context->relation, relation);
@@ -208,7 +207,6 @@ test_pxfprotocol_import_last_call(void **state)
 
 	/* init data in context that will be cleaned up */
 	initStringInfo(&call_context->uri);
-	initStringInfo(&call_context->write_file_name);
 
 	/* set mock behavior for bridge cleanup */
 	expect_value(gpbridge_cleanup, context, call_context);
@@ -279,7 +277,6 @@ test_pxfprotocol_export_first_call(void **state)
 	/* uri has been initialized */
 	assert_true(context->uri.data != NULL);
 	/* write file name initialized, but empty, since it is filled by another component */
-	assert_int_equal(context->write_file_name.len, 0);
 	assert_true(context->relation != NULL);
 	/* relation pointer is copied */
 	assert_int_equal(context->relation, relation);
@@ -345,7 +342,6 @@ test_pxfprotocol_export_last_call(void **state)
 
 	/* init data in context that will be cleaned up */
 	initStringInfo(&call_context->uri);
-	initStringInfo(&call_context->write_file_name);
 
 	/* set mock behavior for bridge cleanup */
 	expect_value(gpbridge_cleanup, context, call_context);


### PR DESCRIPTION
- The transaction ID and segment ID are only used by a subset of
  profiles. PXF on the JAVA side should be able to append the
  transaction and segment IDs depending on the profile using the
  header information.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
