### PR TITLE
tap tests: re-enable pg_isready test

### DIFF
--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -398,12 +398,12 @@ endef
 ifeq ($(enable_tap_tests),yes)
 define prove_installcheck
 rm -rf $(CURDIR)/tmp_check/log
-cd $(srcdir) && TESTDIR='$(CURDIR)' PATH="$(bindir):$$PATH" top_builddir='$(CURDIR)/$(top_builddir)' PG_REGRESS='$(CURDIR)/$(top_builddir)/src/test/regress/pg_regress' $(PROVE) $(PG_PROVE_FLAGS) $(PROVE_FLAGS) $(if $(PROVE_TESTS),$(PROVE_TESTS),t/*.pl)
+cd $(srcdir) && TESTDIR='$(CURDIR)' PATH="$(bindir):$$PATH" PGPORT='6$(DEF_PGPORT)' top_builddir='$(CURDIR)/$(top_builddir)' PG_REGRESS='$(CURDIR)/$(top_builddir)/src/test/regress/pg_regress' $(PROVE) $(PG_PROVE_FLAGS) $(PROVE_FLAGS) $(if $(PROVE_TESTS),$(PROVE_TESTS),t/*.pl)
 endef
 
 define prove_check
 rm -rf $(CURDIR)/tmp_check/log
-cd $(srcdir) && TESTDIR='$(CURDIR)' $(with_temp_install) top_builddir='$(CURDIR)/$(top_builddir)' PG_REGRESS='$(CURDIR)/$(top_builddir)/src/test/regress/pg_regress' $(PROVE) $(PG_PROVE_FLAGS) $(PROVE_FLAGS) $(if $(PROVE_TESTS),$(PROVE_TESTS),t/*.pl)
+cd $(srcdir) && TESTDIR='$(CURDIR)' $(with_temp_install) PGPORT='6$(DEF_PGPORT)' top_builddir='$(CURDIR)/$(top_builddir)' PG_REGRESS='$(CURDIR)/$(top_builddir)/src/test/regress/pg_regress' $(PROVE) $(PG_PROVE_FLAGS) $(PROVE_FLAGS) $(if $(PROVE_TESTS),$(PROVE_TESTS),t/*.pl)
 endef
 
 else

--- a/src/bin/scripts/t/080_pg_isready.pl
+++ b/src/bin/scripts/t/080_pg_isready.pl
@@ -1,17 +1,13 @@
 use strict;
 use warnings;
 use TestLib;
-use Test::More tests => 9;
+use Test::More tests => 10;
 
 program_help_ok('pg_isready');
 program_version_ok('pg_isready');
 program_options_handling_ok('pg_isready');
 
-#
-# Disable temporarily. This test expects the server to not currently
-# be running which is not the case on Concourse.
-#
-#command_fails(['pg_isready'], 'fails with no server running');
+command_fails(['pg_isready'], 'fails with no server running');
 
 my $tempdir = tempdir;
 start_test_server $tempdir;


### PR DESCRIPTION
In order for the pg_isready tap test to run successfully, we need to set the PGPORT in the same way that upstream does when running tap tests.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
