### PR TITLE
Fix gpexpand flaky test cases

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -171,9 +171,8 @@ Feature: expand the cluster by adding more segments
     @gpexpand_verify_redistribution
     Scenario: Verify data is correctly redistributed after expansion
         Given a working directory of the test as '/data/gpdata/gpexpand'
-        And the database is killed on hosts "localhost"
-        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the database is not running
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the cluster is generated with "1" primaries only
         And database "gptest" exists
         And the user connects to "gptest" with named connection "default"
@@ -194,9 +193,8 @@ Feature: expand the cluster by adding more segments
     @gpexpand_verify_writable_external_redistribution
     Scenario: Verify policy of writable external table is correctly updated after redistribution 
         Given a working directory of the test as '/data/gpdata/gpexpand'
-        And the database is killed on hosts "localhost"
-        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the database is not running
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the cluster is generated with "1" primaries only
         And database "gptest" exists
         And the user create a writable external table with name "ext_test"


### PR DESCRIPTION
Gpexpand test cases often need to stop the cluster.
There is race condition in previous code:

1. it invokes pkill
2. it tests if cluster is there
3. if in step 2 it founds cluster is on, it invokes gpstop

The race condition is that the cluster gets down during step 2
and step 3, which leads to exception when doing gpstop while cluster
is down.

This commit fixes flaky gpexpand test cases by checking process
does not exists after killing it.

-------

Devpipeline is green for about 40 times. https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/remove_kill_gpexpand/jobs/gpexpand/builds/42

And please check that the "deep bug" is explained correctly in the comment https://github.com/greenplum-db/gpdb/pull/7245#issuecomment-477519558

As @pivotal-ning-yu points out, there are many other places using kill to stop dbs.  If that explanation is right, we might fix like this commit and to totally refactor all the places use `pkill` to 
have a global refactor design.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
