### PR TITLE
Fix two fts bugs related to promoting mirror.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5557,13 +5557,6 @@ exitArchiveRecovery(TimeLineID endTLI, XLogSegNo endLogSegNo)
 	unlink(recoveryPath);		/* ignore any error */
 
 	/*
-	 * Rename the config file out of the way, so that we don't accidentally
-	 * re-enter archive recovery mode in a subsequent crash.
-	 */
-	unlink(RECOVERY_COMMAND_DONE);
-	durable_rename(RECOVERY_COMMAND_FILE, RECOVERY_COMMAND_DONE, FATAL);
-
-	/*
 	 * Response to FTS probes after this point will not indicate that we are a
 	 * mirror because the am_mirror flag is set based on existence of
 	 * RECOVERY_COMMAND_FILE.  New libpq connections to the postmaster should
@@ -5571,6 +5564,14 @@ exitArchiveRecovery(TimeLineID endTLI, XLogSegNo endLogSegNo)
 	 * mirror.
 	 */
 	ResetMirrorReadyFlag();
+
+	/*
+	 * Rename the config file out of the way, so that we don't accidentally
+	 * re-enter archive recovery mode in a subsequent crash.
+	 */
+	unlink(RECOVERY_COMMAND_DONE);
+	durable_rename(RECOVERY_COMMAND_FILE, RECOVERY_COMMAND_DONE, FATAL);
+
 	ereport(LOG,
 			(errmsg("archive recovery complete")));
 }

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -45,6 +45,8 @@
 volatile FtsProbeInfo *ftsProbeInfo = NULL;	/* Probe process updates this structure */
 static LWLockId ftsControlLock;
 
+extern volatile bool *pm_launch_walreceiver;
+
 /*
  * get fts share memory size
  */
@@ -73,6 +75,7 @@ FtsShmemInit(void)
 	/* Initialize locks and shared memory area */
 	ftsControlLock = shared->ControlLock;
 	ftsProbeInfo = &shared->fts_probe_info;
+	pm_launch_walreceiver = &shared->pm_launch_walreceiver;
 
 	if (!IsUnderPostmaster)
 	{
@@ -80,6 +83,7 @@ FtsShmemInit(void)
 		ftsControlLock = shared->ControlLock;
 
 		shared->fts_probe_info.fts_statusVersion = 0;
+		shared->pm_launch_walreceiver = false;
 	}
 }
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -156,7 +156,7 @@ void FtsProbeMain(int argc, char *argv[]);
  */
 bool am_mirror = false;
 /* GPDB specific flag to handle deadlocks during parallel segment start. */
-bool pm_launch_walreceiver = false;
+volatile bool *pm_launch_walreceiver = NULL;
 
 /*
  * Possible types of a backend. Beyond being the possible bkend_type values in
@@ -2186,7 +2186,7 @@ initMasks(fd_set *rmask)
 void
 ResetMirrorReadyFlag(void)
 {
-	pm_launch_walreceiver = false;
+	*pm_launch_walreceiver = false;
 }
 
 
@@ -2601,7 +2601,15 @@ retry1:
 		case CAC_MIRROR_READY:
 			if (am_ftshandler)
 			{
-				Assert(am_mirror);
+				/* Even if the connection state is MIRROR_READY, the role
+				 * may change to primary during promoting. Hence, we need
+				 * to decline this connection to avoid confusion. This needs
+				 * to wait until promotion is finished and pmState changed
+				 * to PM_RUN.
+				 */
+				if (!am_mirror)
+					ereport(FATAL,
+							(errmsg("mirror is being promoted.")));
 				break;
 			}
 
@@ -2764,7 +2772,7 @@ canAcceptConnections(void)
 		 * If the wal receiver has been launched at least once, return that
 		 * the mirror is ready.
 		 */
-		else if (pm_launch_walreceiver)
+		else if (*pm_launch_walreceiver)
 			return CAC_MIRROR_READY;
 		else if (!FatalError &&
 				 (pmState == PM_STARTUP ||
@@ -6143,7 +6151,7 @@ MaybeStartWalReceiver(void)
 		WalReceiverRequested = false;
 
 		/* wal receiver has been launched */
-		pm_launch_walreceiver = true;
+		*pm_launch_walreceiver = true;
 	}
 }
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2183,12 +2183,23 @@ initMasks(fd_set *rmask)
  * This function is called right after removing RECOVERY_COMMAND_FILE upon
  * receiving a promotion request.
  */
-void
+void inline
 ResetMirrorReadyFlag(void)
 {
 	*pm_launch_walreceiver = false;
 }
 
+static inline void
+SetMirrorReadyFlag(void)
+{
+	*pm_launch_walreceiver = true;
+}
+
+static inline bool
+GetMirrorReadyFlag(void)
+{
+	return *pm_launch_walreceiver;
+}
 
 /*
  * Read a client's startup packet and do something according to it.
@@ -2772,7 +2783,7 @@ canAcceptConnections(void)
 		 * If the wal receiver has been launched at least once, return that
 		 * the mirror is ready.
 		 */
-		else if (*pm_launch_walreceiver)
+		else if (GetMirrorReadyFlag())
 			return CAC_MIRROR_READY;
 		else if (!FatalError &&
 				 (pmState == PM_STARTUP ||
@@ -6151,7 +6162,7 @@ MaybeStartWalReceiver(void)
 		WalReceiverRequested = false;
 
 		/* wal receiver has been launched */
-		*pm_launch_walreceiver = true;
+		SetMirrorReadyFlag();
 	}
 }
 

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -33,7 +33,7 @@
 typedef struct FtsProbeInfo
 {
 	volatile uint8		fts_statusVersion;
-	volatile uint8      probeTick;
+	volatile uint8		probeTick;
 	volatile uint8		fts_status[FTS_MAX_DBS];
 } FtsProbeInfo;
 
@@ -41,8 +41,9 @@ typedef struct FtsProbeInfo
 
 typedef struct FtsControlBlock
 {
-	LWLockId	ControlLock;
-	FtsProbeInfo fts_probe_info;
+	LWLockId		ControlLock;
+	FtsProbeInfo	fts_probe_info;
+	volatile bool	pm_launch_walreceiver;
 }	FtsControlBlock;
 
 extern volatile FtsProbeInfo *ftsProbeInfo;


### PR DESCRIPTION
1) pm_launch_walreceiver was introduced in b824fe8f269934987e30a4c177605b250703d20f
   to avoid a potential deadlock when cluster is down after
   updating the new roles in gp_segment_configuration but before
   sending promote signal. It is buggy now since some changes.
   We need to put pm_launch_walreceiver in shared memory since
   it's used in different processes.

2) The following assertion is not always true in a real scenario if
   the segment is being promoted. We could simply stop the connection
   for the !am_mirror case.

   ProcessStartupPacket()
     if (am_ftshandler)
     {
        Assert(am_mirror);

Ning Yu and we had some discussions for these bugs. He contributed for
issue 1 also.

Hopefully, the patch could fix some gprecoverseg/fts related test failures.

Co-authored-by: Haozhou Wang <hawang@pivotal.io>