### PR TITLE
Make variable name of BufferedAppend and AppendOnlyStorageWrite consi…

### DIFF
--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -131,21 +131,21 @@ AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
 	 */
 	storageWrite->maxBufferWithCompressionOverrrunLen =
 		storageWrite->maxBufferLen + storageWrite->compressionOverrunLen;
-	storageWrite->largeWriteLen = 2 * storageWrite->maxBufferLen;
+	storageWrite->maxLargeWriteLen = 2 * storageWrite->maxBufferLen;
 	Assert(storageWrite->maxBufferWithCompressionOverrrunLen <= storageWrite->largeWriteLen);
 
 	memoryLen = BufferedAppendMemoryLen
 		(
 		 storageWrite->maxBufferWithCompressionOverrrunLen, /* maxBufferLen */
-		 storageWrite->largeWriteLen);
+		 storageWrite->maxLargeWriteLen);
 
 	memory = (uint8 *) palloc(memoryLen);
 
 	BufferedAppendInit(&storageWrite->bufferedAppend,
 					   memory,
 					   memoryLen,
-					    /* maxBufferLen */ storageWrite->maxBufferWithCompressionOverrrunLen,
-					   storageWrite->largeWriteLen,
+					   storageWrite->maxBufferWithCompressionOverrrunLen,
+					   storageWrite->maxLargeWriteLen,
 					   relationName);
 
 	elogif(Debug_appendonly_print_insert || Debug_appendonly_print_append_block, LOG,
@@ -154,7 +154,7 @@ AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
 		   (storageWrite->storageAttributes.compress ? "true" : "false"),
 		   storageWrite->storageAttributes.compressLevel,
 		   storageWrite->maxBufferWithCompressionOverrrunLen,
-		   storageWrite->largeWriteLen);
+		   storageWrite->maxLargeWriteLen);
 
 	/*
 	 * When doing VerifyBlock, allocate the extra buffers.

--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -53,7 +53,7 @@ void
 BufferedAppendInit(BufferedAppend *bufferedAppend,
 				   uint8 *memory,
 				   int32 memoryLen,
-				   int32 maxBufferLen,
+				   int32 maxBufferWithCompressionOverrrunLen,
 				   int32 maxLargeWriteLen,
 				   char *relationName)
 {
@@ -73,7 +73,7 @@ BufferedAppendInit(BufferedAppend *bufferedAppend,
 	/*
 	 * Large-read memory level members.
 	 */
-	bufferedAppend->maxBufferLen = maxBufferLen;
+	bufferedAppend->maxBufferWithCompressionOverrrunLen = maxBufferWithCompressionOverrrunLen;
 	bufferedAppend->maxLargeWriteLen = maxLargeWriteLen;
 
 	bufferedAppend->memory = memory;
@@ -257,10 +257,10 @@ BufferedAppendGetBuffer(BufferedAppend *bufferedAppend,
 
 	Assert(bufferedAppend != NULL);
 	Assert(bufferedAppend->file >= 0);
-	if (bufferLen > bufferedAppend->maxBufferLen)
+	if (bufferLen > bufferedAppend->maxBufferWithCompressionOverrrunLen)
 		elog(ERROR,
 			 "bufferLen %d greater than maxBufferLen %d at position " INT64_FORMAT " in table \"%s\" in file \"%s\"",
-			 bufferLen, bufferedAppend->maxBufferLen, bufferedAppend->largeWritePosition,
+			 bufferLen, bufferedAppend->maxBufferWithCompressionOverrrunLen, bufferedAppend->largeWritePosition,
 			 bufferedAppend->relationName,
 			 bufferedAppend->filePathName);
 
@@ -304,7 +304,7 @@ BufferedAppendGetMaxBuffer(BufferedAppend *bufferedAppend)
 
 	return BufferedAppendGetBuffer(
 								   bufferedAppend,
-								   bufferedAppend->maxBufferLen);
+								   bufferedAppend->maxBufferWithCompressionOverrrunLen);
 }
 
 void

--- a/src/include/cdb/cdbappendonlystoragewrite.h
+++ b/src/include/cdb/cdbappendonlystoragewrite.h
@@ -43,8 +43,10 @@ typedef struct AppendOnlyStorageWrite
 
 	/*
 	 * The large write length given to the BufferedAppend module.
+	 * The buffer in BufferedAppend will be flushed to disk when
+	 * maxLargeWriteLen is reached.
 	 */
-	int32		largeWriteLen;
+	int32		maxLargeWriteLen;
 
 	/*
 	 * Version number indicating the AO table format version to write in.

--- a/src/include/cdb/cdbbufferedappend.h
+++ b/src/include/cdb/cdbbufferedappend.h
@@ -31,10 +31,13 @@ typedef struct BufferedAppend
 	/*
 	 * Large-write memory level members.
 	 */
-    int32      			 maxBufferLen;
+
+    /* AO block size plus additional space cost of compression algorithm */
+    int32      			 maxBufferWithCompressionOverrrunLen;
+    /* buffer will be flushed to disk when maxLargeWriteLen is reached  */
     int32      			 maxLargeWriteLen;
 
-	uint8                *memory;
+    uint8                *memory;
     int32                memoryLen;
 
     uint8                *largeWriteMemory;
@@ -97,7 +100,7 @@ extern void BufferedAppendInit(
 	BufferedAppend *bufferedAppend,
 	uint8          *memory,
 	int32          memoryLen,
-	int32          maxBufferLen,
+	int32          maxBufferWithCompressionOverrrunLen,
 	int32          maxLargeWriteLen,
 	char           *relationName);
 


### PR DESCRIPTION
…stent

AppendOnlyStorageWrite and BufferedAppend are two helper struct to do insert
for AO tables. They share many variables, but some of them with same name but
different semantic. This PR corrects their names to be consistent.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
