### PR TITLE
Fix LOCK_DEBUG in LWLock acquiring

### DIFF
--- a/src/backend/storage/lmgr/lwlock.c
+++ b/src/backend/storage/lmgr/lwlock.c
@@ -417,14 +417,9 @@ LWLockAssign(void)
 #ifdef LOCK_DEBUG
 
 static void
-LWLockTryLockWaiting(
-		PGPROC	   *proc, 
-		LWLockId lockid, 
-		LWLockMode mode)
+LWLockTryLockWaiting(PGPROC *proc, volatile LWLock *l)
 {
-	volatile LWLock *lock = &(LWLockArray[lockid].lock);
-	int 			milliseconds = 0;
-	int				exclusivePid;
+	int 		milliseconds = 0;
 	
 	while(true)
 	{
@@ -432,46 +427,13 @@ LWLockTryLockWaiting(
 		if (PGSemaphoreTryLock(&proc->sem))
 		{
 			if (milliseconds >= 750)
-				elog(LOG, "Done waiting on lockid %d", lockid);
+				elog(LOG, "Done waiting on lock");
 			return;
 		}
 
 		milliseconds += 5;
 		if (milliseconds == 750)
-		{
-			int l;
-			int count = 0;
-			char buffer[200];
-
-			SpinLockAcquire(&lock->mutex);
-			
-			if (lock->exclusive > 0)
-				exclusivePid = lock->exclusivePid;
-			else
-				exclusivePid = 0;
-			
-			SpinLockRelease(&lock->mutex);
-
-			memcpy(buffer, "none", 5);
-			
-			for (l = 0; l < num_held_lwlocks; l++)
-			{
-				if (l == 0)
-					count += sprintf(&buffer[count],"(");
-				else
-					count += sprintf(&buffer[count],", ");
-				
-				count += sprintf(&buffer[count],
-							    "lockid %d",
-							    held_lwlocks[l]);
-			}
-			if (num_held_lwlocks > 0)
-				count += sprintf(&buffer[count],")");
-				
-			elog(LOG, "Waited .75 seconds on lockid %d with no success. Exclusive pid %d. Already held: %s", 
-				 lockid, exclusivePid, buffer);
-
-		}
+			elog(LOG, "Waited .75 seconds on lockid %d with no success", T_ID(l));
 	}
 }
 
@@ -719,7 +681,7 @@ LWLockAcquireCommon(LWLock *l, LWLockMode mode, uint64 *valptr, uint64 val)
 #ifndef LOCK_DEBUG
 			PGSemaphoreLock(&proc->sem, false);
 #else
-			LWLockTryLockWaiting(proc, lockid, mode);
+			LWLockTryLockWaiting(proc, lock);
 #endif
 			if (!proc->lwWaiting)
 				break;


### PR DESCRIPTION
Commit ea9df812d8502fff74e7bc37d61bdc7d66d relaxes the requirement that all LWLocks are in a single array, which broke the `LOCK_DEBUG` code for trying to acquiring an LWLock. This is a meatball surgery attempt at making it at least compile and run, without trying to reinvent the old usecase. Extending this and making the reporting better is an excercise for the reader, this is a quicker attempt at making us not ship code that doesn't compile when we cut 6.0.

Reported-by: Simon Gao in Github issue #7251