### PR TITLE
Various fixes to the documentation

### DIFF
--- a/gpdb-doc/dita/admin_guide/access_db/topics/g-database-application-interfaces.xml
+++ b/gpdb-doc/dita/admin_guide/access_db/topics/g-database-application-interfaces.xml
@@ -48,7 +48,7 @@
                   <entry colname="col1">Perl DBI</entry>
                   <entry colname="col2">pgperl</entry>
                   <entry colname="col3">
-                     <xref href="http://search.cpan.org/dist/DBD-Pg/" scope="external" format="html"
+                     <xref href="https://metacpan.org/release/DBD-Pg" scope="external" format="html"
                      />
                   </entry>
                </row>

--- a/gpdb-doc/dita/admin_guide/access_db/topics/g-database-application-interfaces.xml
+++ b/gpdb-doc/dita/admin_guide/access_db/topics/g-database-application-interfaces.xml
@@ -63,7 +63,7 @@
                   <entry colname="col1">libpq C Library</entry>
                   <entry colname="col2">libpq</entry>
                   <entry colname="col3">
-                     <xref href="https://www.postgresql.org/docs/8.3/libpq.html" scope="external" format="html"/>
+                     <xref href="https://www.postgresql.org/docs/9.4/libpq.html" scope="external" format="html"/>
                   </entry>
                </row>
             </tbody>

--- a/gpdb-doc/dita/admin_guide/dml.xml
+++ b/gpdb-doc/dita/admin_guide/dml.xml
@@ -325,7 +325,7 @@
           </ul>
         </section>
         <p id="ix141505">The default transaction isolation level in Greenplum Database is
-            <codeph>READ COMITTED</codeph>. To change the isolation level for a transaction, declare
+            <codeph>READ COMMITTED</codeph>. To change the isolation level for a transaction, declare
           the isolation level when you <codeph>BEGIN</codeph> the transaction or use the <codeph>SET
             TRANSACTION</codeph> command after the transaction starts.</p>
       </body>

--- a/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
@@ -233,7 +233,7 @@ sdw5:sdw5-1:60012:/gpdata/mirror/gp10:14:10:m</codeblock>
       <codeblock>$ gpstate -x</codeblock>
       <p>If the expansion schema exists in the postgres database, <codeph>gpstate
           -x</codeph> reports on the progress of the expansion. During the first expansion phase,
-          <codeph>gpstate</codeph> reports on the progress of new segment intialization.  During the
+          <codeph>gpstate</codeph> reports on the progress of new segment initialization.  During the
         second phase, <codeph>gpstate</codeph> reports on the progress of table redistribution, and
         whether redistribution is paused or active. </p>
       <p>You can also query the expansion schema to see expansion status. See <xref

--- a/gpdb-doc/dita/admin_guide/intro/arch_overview.xml
+++ b/gpdb-doc/dita/admin_guide/intro/arch_overview.xml
@@ -14,7 +14,7 @@
       resources in parallel to process a query.</p>
     <p>Greenplum Database is based on PostgreSQL open-source technology. It is essentially several
       PostgreSQL disk-oriented database instances acting together as one cohesive database
-      management system (DBMS). It is based on PostgreSQL 8.3.23, and in most cases is very similar
+      management system (DBMS). It is based on PostgreSQL 9.4, and in most cases is very similar
       to PostgreSQL with regard to SQL support, features, configuration options, and end-user
       functionality. Database users interact with Greenplum Database as they would with a regular
       PostgreSQL DBMS. </p>
@@ -55,7 +55,7 @@
       through physical operators, and delivers results in a query response.</p>
     <p>Greenplum Database stores and processes large amounts of data by distributing the data and
       processing workload across several servers or <i>hosts</i>. Greenplum Database is an
-        <i>array</i> of individual databases based upon PostgreSQL 8.3 working together to present a
+        <i>array</i> of individual databases based upon PostgreSQL 9.4 working together to present a
       single database image. The <i>master</i> is the entry point to the Greenplum Database system.
       It is the database instance to which clients connect and submit SQL statements. The master
       coordinates its work with the other database instances in the system, called <i>segments</i>,
@@ -80,7 +80,7 @@
       <p>Greenplum Database end-users interact with Greenplum Database (through the master) as they
         would with a typical PostgreSQL database. They connect to the database using client programs
         such as <codeph>psql</codeph> or application programming interfaces (APIs) such as JDBC,
-        ODBC or <xref href="https://www.postgresql.org/docs/8.3/libpq.html" format="html"
+        ODBC or <xref href="https://www.postgresql.org/docs/9.4/libpq.html" format="html"
           scope="external">libpq</xref> (the PostgreSQL C API).</p>
       <p>The master is where the <i>global system catalog</i> resides. The global system catalog is
         the set of system tables that contain metadata about the Greenplum Database system itself.

--- a/gpdb-doc/dita/admin_guide/kerberos-win-client.xml
+++ b/gpdb-doc/dita/admin_guide/kerberos-win-client.xml
@@ -93,7 +93,7 @@ kinit
           you can run the Windows utility <codeph>chcp</codeph> to change the code page. This is an
           example of the warning and fix.</p>
         <codeblock>psql -h prod1.example.local warehouse
-psql (8.3.23)
+psql (9.4.20)
 WARNING: Console code page (850) differs from Windows code page (1252)
  8-bit characters might not work correctly. See psql reference
  page "Notes for Windows users" for details.
@@ -105,7 +105,7 @@ chcp 1252
 Active code page: 1252
 
 psql -h prod1.example.local warehouse
-psql (8.3.23)
+psql (9.4.20)
 Type "help" for help.</codeblock>
       </section>
       <section id="win_keytab">

--- a/gpdb-doc/dita/admin_guide/kerberos.xml
+++ b/gpdb-doc/dita/admin_guide/kerberos.xml
@@ -165,7 +165,7 @@ $ chmod 400 /home/gpadmin/gpdb-kerberos.keytab</codeblock>
             information about the <codeph>pg_hba.conf</codeph> file, see <xref
               href="https://www.postgresql.org/docs/8.4/auth-pg-hba-conf.html"
               scope="external" format="html">The pg_hba.conf file</xref> in the
-            Postgres documentation.</p>
+            PostgreSQL documentation.</p>
         </li>
         <li>Restart Greenplum Database after updating the
               <codeph>krb_server_keyfile</codeph> parameter and the

--- a/gpdb-doc/dita/admin_guide/kerberos.xml
+++ b/gpdb-doc/dita/admin_guide/kerberos.xml
@@ -163,7 +163,7 @@ $ chmod 400 /home/gpadmin/gpdb-kerberos.keytab</codeblock>
               <codeph>include_realm</codeph> option to <codeph>0</codeph>
             excludes the realm name from the authenticated user name. For
             information about the <codeph>pg_hba.conf</codeph> file, see <xref
-              href="https://www.postgresql.org/docs/8.4/auth-pg-hba-conf.html"
+              href="https://www.postgresql.org/docs/9.4/auth-pg-hba-conf.html"
               scope="external" format="html">The pg_hba.conf file</xref> in the
             PostgreSQL documentation.</p>
         </li>
@@ -201,7 +201,7 @@ Valid starting       Expires              Service principal
         </li>
         <li id="nr166158">As a test, log in to the postgres database with the
             <codeph>gpadmin/admin</codeph> role: <codeblock>$ psql -U "gpadmin/admin" -h mdw postgres
-psql (8.3.23)
+psql (9.4.20)
 Type "help" for help.
 
 postgres=# select current_user;
@@ -277,7 +277,7 @@ mymap       /^(.*)_gp)@GPDB.KRB$   \1</codeblock>
           <codeph>pg_ident.conf</codeph> file, so the order of entries is
         significant.</p>
       <p>For more information about using username maps see <xref
-          href="https://www.postgresql.org/docs/8.4/auth-username-maps.html"
+          href="https://www.postgresql.org/docs/9.4/auth-username-maps.html"
           scope="external" format="html">Username maps</xref> in the PostgreSQL
         documentation.</p>
     </body>

--- a/gpdb-doc/dita/admin_guide/load/topics/g-installing-the-external-table-protocol.xml
+++ b/gpdb-doc/dita/admin_guide/load/topics/g-installing-the-external-table-protocol.xml
@@ -25,7 +25,7 @@
         </p>
         <p>For more information on compiling and linking dynamically-loaded functions and examples
             of compiling C source code to create a shared library on other operating systems, see
-            the Postgres documentation at <xref
+            the PostgreSQL documentation at <xref
                 href="https://www.postgresql.org/docs/8.4/xfunc-c.html#DFUNC" scope="external"
                 format="html">
                 <ph>https://www.postgresql.org/docs/8.4/xfunc-c.html#DFUNC</ph>

--- a/gpdb-doc/dita/admin_guide/managing/maintain.xml
+++ b/gpdb-doc/dita/admin_guide/managing/maintain.xml
@@ -99,7 +99,7 @@ wraparound data loss in database "database_name"
           <p>For information about the configuration parameters, see the <i>Greenplum Database
               Reference Guide</i>. </p>
           <p>For information about transaction ID wraparound see the <xref
-              href="https://www.postgresql.org/docs/8.3/index.html" scope="external"
+              href="https://www.postgresql.org/docs/9.4/index.html" scope="external"
               format="html"><ph>PostgreSQL documentation</ph></xref>.</p>
         </section>
       </body>

--- a/gpdb-doc/dita/best_practices/ha.xml
+++ b/gpdb-doc/dita/best_practices/ha.xml
@@ -130,7 +130,7 @@
         work, so performance can be degraded until the balance is restored by recovering the
         original primary. </p>
       <p>Administrators perform the recovery while Greenplum Database is up and running by running
-        the <codeph>gprecoverseg</codeph> utility.This utility locates the failed segments, verifies
+        the <codeph>gprecoverseg</codeph> utility. This utility locates the failed segments, verifies
         they are valid, and compares the transactional state with the currently active segment to
         determine changes made while the segment was offline. <codeph>gprecoverseg</codeph>
         synchronizes the changed database files with the active segment and brings the segment back

--- a/gpdb-doc/dita/best_practices/maintenance.xml
+++ b/gpdb-doc/dita/best_practices/maintenance.xml
@@ -41,7 +41,7 @@
               benchmark program (optionally <codeph>netperf)</codeph> to test network performance.
               The test is run in one of three modes: parallel pair test (<codeph>-r N</codeph>),
               serial pair test (<codeph>-r n</codeph>), or full-matrix test (<codeph>-r
-              M)</codeph>.The minimum, maximum, average, and median transfer rates are reported in
+              M)</codeph>. The minimum, maximum, average, and median transfer rates are reported in
               megabytes per second. </li>
           </ul>To obtain valid numbers from <codeph>gpcheckperf</codeph>, the database system must
           be stopped. The numbers from <codeph>gpcheckperf</codeph> can be inaccurate even if the

--- a/gpdb-doc/dita/best_practices/schema.xml
+++ b/gpdb-doc/dita/best_practices/schema.xml
@@ -388,7 +388,7 @@ root     29622 29566  0 12:50 pts/16   00:00:00 grep 15673</codeblock>
           the node, the size of the cluster, SQL access, concurrency, workload, and skew. There are
           generally six to eight segments per host, but large clusters should have fewer segments
           per host. When using partitioning and columnar storage it is important to balance the
-          total number of files in the cluster ,but it is <i>more</i> important to consider the
+          total number of files in the cluster, but it is <i>more</i> important to consider the
           number of files per segment and the total number of files on a node. </p>
         <p>Example DCA V2 64GB Memory per Node</p>
         <ul id="ul_nyy_tgb_3r">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -8321,7 +8321,7 @@
           <tbody>
             <row>
               <entry colname="col1">string</entry>
-              <entry colname="col2">8.3.23</entry>
+              <entry colname="col2">9.4.20</entry>
               <entry colname="col3">read only</entry>
             </row>
           </tbody>
@@ -8349,7 +8349,7 @@
           <tbody>
             <row>
               <entry colname="col1">integer</entry>
-              <entry colname="col2">80323</entry>
+              <entry colname="col2">90420</entry>
               <entry colname="col3">read only</entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -6541,7 +6541,7 @@
         well. For more information about limiting concurrent connections, see "Configuring Client
         Authentication" in the <i>Greenplum Database Administrator Guide</i>.</p>
       <p>Increasing this parameter may cause Greenplum Database to request more shared
-        memory.Increasing this parameter might cause Greenplum Database to request more shared
+        memory. Increasing this parameter might cause Greenplum Database to request more shared
         memory. See <xref href="#shared_buffers" format="dita"/> for information about Greenplum
         server instance shared memory buffers.</p>
       <table id="max_connections_table">
@@ -7635,7 +7635,7 @@
         </ul></p>
       <p>The information is logged during query execution, or with the <codeph>EXPLAIN</codeph> or
           <codeph>EXPLAIN ANALYZE</codeph> commands.</p>
-      <p>This parameter can be set for a database system, an individual database,or a session or
+      <p>This parameter can be set for a database system, an individual database, or a session or
         query.</p>
       <table id="table_pdm_kx2_5z">
         <tgroup cols="3">

--- a/gpdb-doc/dita/ref_guide/datatype-pseudo.xml
+++ b/gpdb-doc/dita/ref_guide/datatype-pseudo.xml
@@ -26,7 +26,7 @@
         expression—an expression that computes a table. Greenplum Database allows this type only as
         an argument to a user-defined function. See <xref href="#topic_ig2_1pc_qfb" format="dita"/>
         for more about the <i>anytable</i> pseudo-type.</p>
-      <p>For more information about pseudo-types, see the Postgres documentation about <xref
+      <p>For more information about pseudo-types, see the PostgreSQL documentation about <xref
           href="https://www.postgresql.org/docs/8.3/datatype-pseudo.html" format="html"
           scope="external">Pseudo-Types</xref>.</p>
     </body>
@@ -74,7 +74,7 @@
           last parameter is declared as <codeph>VARIADIC <i>anyarray</i></codeph>. For purposes of
           argument matching and determining the actual result type, such a function behaves the same
           as if you had declared the appropriate number of <i>anynonarray</i> parameters.</p>
-        <p>For more information about polymorphic types, see the Postgres documentation about <xref
+        <p>For more information about polymorphic types, see the PostgreSQL documentation about <xref
             href="https://www.postgresql.org/docs/8.3/xfunc-c.html#AEN41553" format="html"
             scope="external">Polymorphic Arguments and Return Types</xref>.</p>
       </body>

--- a/gpdb-doc/dita/ref_guide/extensions/gppc.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/gppc.xml
@@ -61,7 +61,7 @@
     <title id="py21716799">Using the GPPC API</title>
     <body>
       <p>The GPPC API shares some concepts with C language functions as defined
-        by PostgreSQL. Refer to <xref href="https://www.postgresql.org/docs/8.3/xfunc-c.html" format="html" scope="external">C-Language Functions</xref>
+        by PostgreSQL. Refer to <xref href="https://www.postgresql.org/docs/9.4/xfunc-c.html" format="html" scope="external">C-Language Functions</xref>
         in the PostgreSQL documentation for detailed information about developing
         C language functions.</p>
       <p>The GPPC API is a wrapper that makes a C/C++ function SQL-invokable
@@ -611,7 +611,7 @@ GppcReport(GPPC_ERROR, "Unknown user name: %s", GppcTextGetCString(uname));</cod
         <p>The Greenplum Database Server Programming Interface (SPI) provides
           writers of C/C++ functions the ability to run SQL commands within a
           GPPC function. For additional information on SPI functions, refer to
-           <xref href="https://www.postgresql.org/docs/8.3/spi.html"
+           <xref href="https://www.postgresql.org/docs/9.4/spi.html"
              scope="external"
              format="html">Server Programming Interface</xref>
             in the PostgreSQL documentation.</p>
@@ -1060,7 +1060,7 @@ ntuple = GppcAnyTableGetNextTuple(intbl);</codeblock></p>
         <p>To use the PGXS infrastructure to generate a shared library for
           functions that you create with the GPPC API, create a simple
           <codeph>Makefile</codeph> that sets PGXS-specific variables.</p>
-        <note>Refer to <xref href="https://www.postgresql.org/docs/8.3/xfunc-c.html#XFUNC-C-PGXS" format="html" scope="external">Extension Building Infrastructure</xref>
+        <note>Refer to <xref href="https://www.postgresql.org/docs/9.4/extend-pgxs.html" format="html" scope="external">Extension Building Infrastructure</xref>
           in the PostgreSQL documentation for information about the
           <codeph>Makefile</codeph> variables supported by PGXS.</note>
         <p>For example, the following <codeph>Makefile</codeph> generates

--- a/gpdb-doc/dita/ref_guide/extensions/pl_perl.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_perl.xml
@@ -127,7 +127,7 @@
                     PL/Perl language from the database named <codeph>testdb</codeph>: </p>
                 <codeblock>
 $ psql -d testdb
-psql (8.3.23)
+psql (9.4.20)
 Type "help" for help.
 
 testdb=# DROP LANGUAGE plperl;

--- a/gpdb-doc/dita/ref_guide/feature_summary.xml
+++ b/gpdb-doc/dita/ref_guide/feature_summary.xml
@@ -440,7 +440,7 @@ NEXT 10 ROWS ONLY; </codeblock><p>Greenplum
               <entry colname="col1"><codeph>CREATE EXTERNAL TABLE</codeph></entry>
               <entry colname="col2">YES</entry>
               <entry colname="col3">Greenplum Database parallel ETL feature - not in PostgreSQL
-                8.3.</entry>
+                9.4.</entry>
             </row>
             <row>
               <entry colname="col1"><codeph>CREATE FUNCTION</codeph></entry>
@@ -505,7 +505,7 @@ NEXT 10 ROWS ONLY; </codeblock><p>Greenplum
               <entry colname="col1"><codeph>CREATE RESOURCE QUEUE</codeph></entry>
               <entry colname="col2">YES</entry>
               <entry colname="col3">Greenplum Database resource management feature - not in
-                PostgreSQL 8.3.</entry>
+                PostgreSQL 9.4.</entry>
             </row>
             <row>
               <entry colname="col1"><codeph>CREATE ROLE</codeph></entry>
@@ -650,7 +650,7 @@ NEXT 10 ROWS ONLY; </codeblock><p>Greenplum
               <entry colname="col1"><codeph>DROP EXTERNAL TABLE</codeph></entry>
               <entry colname="col2">YES</entry>
               <entry colname="col3">Greenplum Database parallel ETL feature - not in PostgreSQL
-                8.3.</entry>
+                9.4.</entry>
             </row>
             <row>
               <entry colname="col1"><codeph>DROP FUNCTION</codeph></entry>
@@ -702,7 +702,7 @@ NEXT 10 ROWS ONLY; </codeblock><p>Greenplum
               <entry colname="col1"><codeph>DROP RESOURCE QUEUE</codeph></entry>
               <entry colname="col2">YES</entry>
               <entry colname="col3">Greenplum Database resource management feature - not in
-                PostgreSQL 8.3.</entry>
+                PostgreSQL 9.4.</entry>
             </row>
             <row>
               <entry colname="col1"><codeph>DROP ROLE</codeph></entry>

--- a/gpdb-doc/dita/ref_guide/modules/dblink.xml
+++ b/gpdb-doc/dita/ref_guide/modules/dblink.xml
@@ -56,7 +56,7 @@ INSERT 0 2</codeblock></p>
           These commands create a small table in the <codeph>postgres</codeph> database, which you
           will later query from the <codeph>testdb</codeph> database using
           <codeph>dblink</codeph>:<codeblock>$ <b>psql -d postgres</b>
-psql (8.3.23)
+psql (9.4.20)
 Type "help" for help.
 
 postgres=# <b>CREATE TABLE testdblink (a int, b text) DISTRIBUTED BY (a);</b>

--- a/gpdb-doc/dita/ref_guide/modules/passwordcheck.xml
+++ b/gpdb-doc/dita/ref_guide/modules/passwordcheck.xml
@@ -15,7 +15,7 @@
         class="- topic/note " type="caution">To prevent unencrypted passwords from being sent across
         the network, written to the server log, or otherwise stolen by a database administrator,
         Greenplum Database enables you to supply pre-encrypted passwords. Many client programs make
-        use of this functionality and encrypt the password before sending it to the server.This
+        use of this functionality and encrypt the password before sending it to the server. This
         limits the usefulness of the <codeph>passwordcheck</codeph> module, because in that case it
         can only try to guess the password. For this reason, <codeph>passwordcheck</codeph> is not
         recommended if your security requirements are high. It is more secure to use an external

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_INDEX.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_INDEX.xml
@@ -33,7 +33,7 @@ on the stored data.</li>
           The fillfactor for an index is a percentage that determines how full the index method will
           try to pack index pages. Index contents will not be modified immediately by this command.
           Use <codeph>REINDEX</codeph> to rebuild the index to get the desired effects. </li><li id="ap136527"><b>RESET</b> — Resets storage parameters for the index to their defaults. The
-          build-in index methods all accept a single parameter: <varname>fillfactor</varname>. As
+          built-in index methods all accept a single parameter: <varname>fillfactor</varname>. As
           with <codeph>SET</codeph>, a <codeph>REINDEX</codeph> may be needed to update the index
           entirely.</li></ul></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of an existing index to alter.
 </pd></plentry><plentry><pt><varname>new_name</varname></pt><pd>New name for the index. </pd></plentry><plentry><pt><varname>tablespace_name</varname></pt><pd>The tablespace to which the index will be moved. </pd></plentry><plentry><pt><varname>storage_parameter</varname></pt>

--- a/gpdb-doc/dita/security-guide/topics/preface.xml
+++ b/gpdb-doc/dita/security-guide/topics/preface.xml
@@ -7,9 +7,9 @@
     <p>This guide describes how to secure a Greenplum Database system. The guide assumes knowledge
       of Linux/UNIX system administration and database management systems. Familiarity with
       structured query language (SQL) is helpful.</p>
-    <p>Because Greenplum Database is based on PostgreSQL8.3.23, this guide assumes some familiarity
+    <p>Because Greenplum Database is based on PostgreSQL 9.4, this guide assumes some familiarity
       with PostgreSQL. References to <xref
-        href="https://www.postgresql.org/docs/8.3/index.html" scope="external" format="html"
+        href="https://www.postgresql.org/docs/9.4/index.html" scope="external" format="html"
           ><ph>PostgreSQL documentation</ph></xref> are provided throughout this guide for features
       that are similar to those in Greenplum Database.</p>
     <p>This information is intended for system administrators responsible for administering a

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -21,7 +21,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Use the PXF HDFS connector to read and write Parquet-format data. This section decribes how to read and write HDFS files that are stored in Parquet format, including how to create, query, and insert into external tables that reference files in the HDFS data store.
+Use the PXF HDFS connector to read and write Parquet-format data. This section describes how to read and write HDFS files that are stored in Parquet format, including how to create, query, and insert into external tables that reference files in the HDFS data store.
 
 PXF currently supports reading and writing primitive Parquet data types only.
 

--- a/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
@@ -21,7 +21,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The PXF object store connectors support reading and writing Parquet-format data. This section decribes how to use PXF to access Parquet-format data in an object store, including how to create and query external tables that references a Parquet file in the store.
+The PXF object store connectors support reading and writing Parquet-format data. This section describes how to use PXF to access Parquet-format data in an object store, including how to create and query external tables that references a Parquet file in the store.
 
 <div class="note">PXF Parquet write support is a Beta feature.</div>
 

--- a/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/overview_pxf.html.md.erb
@@ -29,7 +29,7 @@ The Greenplum Platform Extension Framework (PXF) provides parallel, high through
 
 -   [Administering PXF](about_pxf_dir.html)
 
-    This set of topics details the adminstration of PXF including installation, configuration, initialization, upgrade, and management procedures.
+    This set of topics details the administration of PXF including installation, configuration, initialization, upgrade, and management procedures.
 
 -   [Accessing Hadoop with PXF](access_hdfs.html)
 

--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -65,7 +65,7 @@ After you upgrade to the new version of Greenplum Database, perform the followin
         gpadmin@gpmaster$ vi $PXF_CONF/conf/pxf-env.sh
            <update the file>
         ```
-    2. Simlarly, if you updated the `pxf-profiles.xml` configuration file in your *PXF.from* installation, re-apply those changes to `$PXF_CONF/conf/pxf-profiles.xml` on the master host.
+    2. Similarly, if you updated the `pxf-profiles.xml` configuration file in your *PXF.from* installation, re-apply those changes to `$PXF_CONF/conf/pxf-profiles.xml` on the master host.
 
         **Note:** Starting in Greenplum Database version 5.12, the package name for PXF classes was changed to use the prefix `org.greenplum.*`. If you are upgrading from an older *PXF.from* version and you customized the `pxf-profiles.xml` file, you must change any `org.apache.hawq.pxf.*` references to `org.greenplum.pxf.*` when you re-apply your changes.
     3. If you updated the `pxf-log4j.properties` configuration file in your *PXF.from* installation, re-apply those changes to `$PXF_CONF/conf/pxf-log4j.properties` on the master host.


### PR DESCRIPTION
This PR contains a few commits with some random fixes to the documentation:

Refer to upstream documentation consistently: In all but a few places we referred to the upstream documentation as "PostgreSQL documentation", this fixes the few places where we had a different spelling.

Update links to search.cpan.org: The search.cpan.org site has been discontinued and replaced with metacpan.org, fix by replacing all links in the documentation. There is an additional link in the testcode which will be fixed as we merge with upstream.

Update references to upstream to 9.4: Since Greenplum is now based on PostgreSQL 9.4, update links to the upstream documentation to refer to the 9.4 docset rather than older versions. Also fix a few mentions of 8.3(.23) in the text along with some spacing. There are more 8.3 links in the docs still, going through the remaining places is still a TODO but this was a start.

This also fixes a few typos and some spacing issues.