### PR TITLE
Remove superfluous architecture limit

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmonlib.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmonlib.h
@@ -27,21 +27,10 @@ typedef int SOCKET;
 #define ASSERT(x)    if (x) ; else gpmon_fatal(FLINE, "Check condition:%s failed", #x)
 
 extern int verbose;
-/* TODO: REMOVE */
-//extern int very_verbose;
 #define TR0(x) gpmon_print x
 #define TR1(x) if (verbose == 1) gpmon_print x
 #define TR2(x) if (verbose == 2) gpmon_print x
 #define TR1_FILE(x) if (verbose == 1) gpmon_print_file x
-
-/* Architecture specific limits for metrics */
-#if defined(osx104_x86) || defined(osx105_x86)
-	#define GPSMON_METRIC_MAX 0xffffffffUL
-#elif defined(rhel7_x86_64) || defined(rhel6_x86_64) || defined(suse10_x86_64)
-	#define GPSMON_METRIC_MAX 0xffffffffffffffffULL
-#else
-	#define GPSMON_METRIC_MAX 0xffffffffUL
-#endif
 
 #define GPMON_DATE_BUF_SIZE 24
 


### PR DESCRIPTION
The `GPSMON_METRIC_MAX` setting was only used for platforms where we couldn't link with libsigar (namely Solaris, making these defines even more redundant), and support for that has long since been ripped out so remove the useless defines too.

Also remove a commented out variable while in there.