### PR TITLE
docs - correct the parquet version property name

### DIFF
--- a/gpdb-doc/dita/admin_guide/external/g-hdfs-parquet-format.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-hdfs-parquet-format.xml
@@ -444,7 +444,7 @@ done</codeblock></p>
                   <entry colname="col3"> 8 MB</entry>
                 </row>
                 <row>
-                  <entry colname="col1">version</entry>
+                  <entry colname="col1">parquetversion <i>or</i> pqversion</entry>
                   <entry colname="col2">
                     <codeph>v1</codeph>, <codeph>v2</codeph></entry>
                   <entry>Write only</entry>


### PR DESCRIPTION
the property name for the gphdfs parquet version is incorrect.  correct it, even though we have deprecated these docs.
