### PR TITLE
Docs remove skip root option from analyzedb

### DIFF
--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -371,9 +371,8 @@
           partitioned table is similar to the time to analyze a non-partitioned table with the same
           data since <codeph>ANALYZE ROOTPARTITION</codeph> does not collect statistics on the leaf
           partitions (the data is only sampled). The <codeph>analyzedb</codeph> utility updates root
-          partition statistics by default but you can add the <codeph>--skip_root_stats</codeph>
-          option to leave root partition statistics empty if you do not use GPORCA. </p>The
-        Greenplum Database server configuration parameter <codeph><xref
+          partition statistics by default. </p>The Greenplum Database server configuration parameter
+            <codeph><xref
             href="../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
             >optimizer_analyze_root_partition</xref></codeph> affects when statistics are collected
         on the root partition of a partitioned table. If the parameter is <codeph>on</codeph> (the
@@ -382,14 +381,13 @@
         collected when you run <codeph>ANALYZE</codeph> on the root partition, or when you run
           <codeph>ANALYZE</codeph> on a child leaf partition of the partitioned table and the other
         child leaf partitions have statistics. If the parameter is <codeph>off</codeph>, you must
-        run <codeph>ANALZYE ROOTPARTITION</codeph> to collect root partition statistics.<p>If you do
+        run <codeph>ANALYZE ROOTPARTITION</codeph> to collect root partition statistics.<p>If you do
           not intend to execute queries on partitioned tables with GPORCA (setting the server
           configuration parameter <codeph><xref
-              href="../../ref_guide/config_params/guc-list.xml#optimizer"
-              >optimizer</xref></codeph> to <codeph>off</codeph>), you can also set the server
-          configuration parameter <codeph>optimizer_analyze_root_partition</codeph> to
-            <codeph>off</codeph> to limit when <codeph>ANALYZE</codeph> updates the root partition
-          statistics. </p></section>
+              href="../../ref_guide/config_params/guc-list.xml#optimizer">optimizer</xref></codeph>
+          to <codeph>off</codeph>), you can also set the server configuration parameter
+            <codeph>optimizer_analyze_root_partition</codeph> to <codeph>off</codeph> to limit when
+            <codeph>ANALYZE</codeph> updates the root partition statistics. </p></section>
       <section> </section>
     </body>
   </topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/analyzedb.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/analyzedb.xml
@@ -19,7 +19,6 @@
    [ <b>--gen_profile_only</b> ]   
    [ <b>-p</b> <varname>parallel-level</varname> ]
    [ <b>--full</b> ]
-   [ <b>--skip_root_stats</b> ]
    [ <b>-v</b> | <b>--verbose</b> ]
    [ <b>--debug</b> ]
    [ <b>-a</b> ]
@@ -167,17 +166,6 @@ public.lineitem -i l_shipdate, l_receiptdate </codeblock></pd>
           <pt>-p <varname>parallel-level</varname></pt>
           <pd>The number of tables that are analyzed in parallel. <varname>parallel level</varname>
             can be an integer between 1 and 10, inclusive. Default value is 5. </pd>
-        </plentry>
-        <plentry>
-          <pt>--skip_root_stats</pt>
-          <pd>For a partitioned table, skip refreshing root partition statistics if only some of the
-            leaf partitions statistics require updating. </pd>
-          <pd>When updating statistics for a partitioned table and you know which leaf partition
-            statistics require updating, you can specify those partitions and this option to improve
-            performance.</pd>
-          <pd>For information about how statistics are collected for partitioned tables, see
-                <codeph><xref href="../../ref_guide/sql_commands/ANALYZE.xml"
-              >ANALYZE</xref></codeph>.</pd>
         </plentry>
         <plentry>
           <pt>-s <varname>schema</varname></pt>


### PR DESCRIPTION
For GPDB 6, remove the --skip_root_stats option from the analyzedb utility.

(separate PR for 5X to deprecate)


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
