### PR TITLE
docs - gpdb5 - deprecate skip_root_stats analyzedb option.

### DIFF
--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -311,10 +311,8 @@
           The legacy optimizer does not use these statistics. </p><p>The time to analyze a
           partitioned table is similar to the time to analyze a non-partitioned table with the same
           data since <codeph>ANALYZE ROOTPARTITION</codeph> does not collect statistics on the leaf
-          partitions (the data is only sampled). The <codeph>analyzedb</codeph> utility updates root
-          partition statistics by default but you can add the <codeph>--skip_root_stats</codeph>
-          option to leave root partition statistics empty if you do not use GPORCA. </p>The
-        Greenplum Database server configuration parameter <codeph><xref
+          partitions (the data is only sampled). </p><p>The Greenplum Database server configuration
+        parameter <codeph><xref
             href="../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
             >optimizer_analyze_root_partition</xref></codeph> affects when statistics are collected
         on the root partition of a partitioned table. If the parameter is <codeph>on</codeph> (the
@@ -323,14 +321,13 @@
         collected when you run <codeph>ANALYZE</codeph> on the root partition, or when you run
           <codeph>ANALYZE</codeph> on a child leaf partition of the partitioned table and the other
         child leaf partitions have statistics. If the parameter is <codeph>off</codeph>, you must
-        run <codeph>ANALZYE ROOTPARTITION</codeph> to collect root partition statistics.<p>If you do
+        run <codeph>ANALYZE ROOTPARTITION</codeph> to collect root partition statistics.</p><p>If you do
           not intend to execute queries on partitioned tables with GPORCA (setting the server
           configuration parameter <codeph><xref
-              href="../../ref_guide/config_params/guc-list.xml#optimizer"
-              >optimizer</xref></codeph> to <codeph>off</codeph>), you can also set the server
-          configuration parameter <codeph>optimizer_analyze_root_partition</codeph> to
-            <codeph>off</codeph> to limit when <codeph>ANALYZE</codeph> updates the root partition
-          statistics. </p></section>
+              href="../../ref_guide/config_params/guc-list.xml#optimizer">optimizer</xref></codeph>
+          to <codeph>off</codeph>), you can also set the server configuration parameter
+            <codeph>optimizer_analyze_root_partition</codeph> to <codeph>off</codeph> to limit when
+            <codeph>ANALYZE</codeph> updates the root partition statistics. </p></section>
       <section> </section>
     </body>
   </topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/analyzedb.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/analyzedb.xml
@@ -56,14 +56,12 @@
         <b>Partitioned Append-Optimized Tables</b>
         <p>For a partitioned, append-optimized table, <cmdname>analyzedb</cmdname> checks the
           partitioned table root partition and leaf partitions. If needed, the utility updates
-          statistics for non-current partitions and the root partition. </p>
-        <p dir="ltr">The root partition statistics is required by GPORCA. By default, the
-            <cmdname>analyzedb</cmdname> utility collects statistics on the root partition of a
-          partitioned table if the statistics do not exist. If any of the leaf partitions have stale
-          statistics, <cmdname>analyzedb</cmdname> also refreshes the root partition statistics. The
-          cost of refreshing the root level statistics is comparable to analyzing one leaf
-          partition. You can specify the option <codeph>--skip_root_stats</codeph> to disable
-          collection of statistics on the root partition of a partitioned table.</p>
+          statistics for non-current partitions and the root partition. </p><p dir="ltr">The root
+          partition statistics is required by GPORCA. By default, the <cmdname>analyzedb</cmdname>
+          utility collects statistics on the root partition of a partitioned table if the statistics
+          do not exist. If any of the leaf partitions have stale statistics,
+            <cmdname>analyzedb</cmdname> also refreshes the root partition statistics. The cost of
+          refreshing the root level statistics is comparable to analyzing one leaf partition. </p>
       </sectiondiv>
     </section>
     <section><title>Notes</title><p>The <cmdname>analyzedb</cmdname> utility updates append
@@ -171,10 +169,9 @@ public.lineitem -i l_shipdate, l_receiptdate </codeblock></pd>
         <plentry>
           <pt>--skip_root_stats</pt>
           <pd>For a partitioned table, skip refreshing root partition statistics if only some of the
-            leaf partitions statistics require updating. </pd>
-          <pd>When updating statistics for a partitioned table and you know which leaf partition
-            statistics require updating, you can specify those partitions and this option to improve
-            performance.</pd>
+            leaf partitions statistics require updating. This is the default behavior. This option
+            is deprecated<ph otherprops="pivotal"> and is removed in Greenplum Database
+            6.0</ph>.</pd>
           <pd>For information about how statistics are collected for partitioned tables, see
                 <codeph><xref href="../../ref_guide/sql_commands/ANALYZE.xml"
               >ANALYZE</xref></codeph>.</pd>


### PR DESCRIPTION
Deprecate the --skip_root_stats analyzedb option in 5X. It is the default behavior. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
