### PR TITLE
Set default value of guc log_rotation_size so that log file would be …

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2344,7 +2344,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_UNIT_KB
 		},
 		&Log_RotationSize,
-		0, 0, INT_MAX / 1024,
+		1 * 1024 * 1024, 0, INT_MAX / 1024,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
…rotated each 1GB.

Previously the default value is 0, then normally log rotation happens each
day by default. That often makes a single log file rather large in real users'
environment.  Limiting the log file size so that people could be easier to open
and search the log files.