### PR TITLE
Improve timeout mechanism for pg_rewind tests

### DIFF
--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -98,10 +98,12 @@ function wait_for_promotion {
    retry=150
    until [ $retry -le 0 ]
    do
-      PGOPTIONS=${PGOPTIONS_UTILITY} ${1} -c "select 1;" && break
+      PGOPTIONS=${PGOPTIONS_UTILITY} ${1} -c "select 'promotion is done';" && return 0
       retry=$[$retry-1]
-      sleep 0.2
+      sleep 0.5
    done
+   echo "error: timeout, promotion is not done."
+   exit 1
 }
 
 function wait_until_standby_is_promoted {
@@ -116,8 +118,10 @@ function wait_until_standby_streaming_state {
    retry=150
    until [ $retry -le 0 ]
    do
-      PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "SELECT state FROM pg_stat_replication;" | grep 'streaming' > /dev/null && break
+      PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "SELECT state FROM pg_stat_replication;" | grep 'streaming' > /dev/null && return 0
       retry=$[$retry-1]
       sleep 0.5
    done
+   echo "error: timeout, standby streaming is not done."
+   exit 1
 }


### PR DESCRIPTION
We've seen frequent pg_rewind test failures due to promotion timeout. We
should increase the timeout. Also add code to error out on timeout.

Co-authored-by: Ning Yu <nyu@pivotal.io>