### PR TITLE
 Use correct equality test for Boolean query result

### DIFF
--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -288,7 +288,7 @@ class GPCatalog():
         Some catalogs have columns that, for one reason or another, we
         need to mark as being different between the segments and the master.
         
-        These fall into two catagories:
+        These fall into two categories:
            - Bugs (marked with the appropriate jiras)
            - A small number of "special" columns
         """
@@ -505,7 +505,7 @@ class GPCatalogTable():
             self._coltypes[attname] = typname
 
         # If a primary key was not specified try to locate a unique index
-        # If a table has mutiple matching indexes, we'll pick the first index 
+        # If a table has multiple matching indexes, we'll pick the first index
         # order by indkey to avoid the issue of MPP-16663. 
         if self._pkey == []:
             qry = """

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -158,7 +158,7 @@ class GPCatalog():
         for [relname, relisshared] in curs.getresult():
             self._tables[relname] = GPCatalogTable(self, relname)
             # Note: stupid API returns t/f for boolean value
-            self._tables[relname]._setShared(relisshared is 't')
+            self._tables[relname]._setShared(relisshared == 't')
         
         # The tidycat.pl utility has been used to generate a json file 
         # describing aspects of the catalog that we can not currently


### PR DESCRIPTION
Testing for equality in Python with 'is' tests for the variables point to the same object, '==' tests for them containing the same value. In this case we want '==' as we are comparing values.

Also fixes a few typos in the same file while in there.