### PR TITLE
Allow PXF to talk to custom host and port

### DIFF
--- a/gpcontrib/pxf/src/libchurl.c
+++ b/gpcontrib/pxf/src/libchurl.c
@@ -638,7 +638,10 @@ get_dest_address(CURL *curl_handle)
 	/* add dest url, if any, and curl was nice to tell us */
 	if (CURLE_OK == curl_easy_getinfo(curl_handle, CURLINFO_PRIMARY_IP, &dest_url) && dest_url)
 	{
-		return psprintf("'%s:%d'", dest_url, PXF_DEFAULT_PORT);
+		char *pStr = getenv(ENV_PXF_PORT);
+		int  port  = pStr ? (int) strtol(pStr, &pStr, 10) : PXF_DEFAULT_PORT;
+
+		return psprintf("'%s:%d'", dest_url, port);
 	}
 	return dest_url;
 }

--- a/gpcontrib/pxf/src/libchurl.c
+++ b/gpcontrib/pxf/src/libchurl.c
@@ -638,10 +638,7 @@ get_dest_address(CURL *curl_handle)
 	/* add dest url, if any, and curl was nice to tell us */
 	if (CURLE_OK == curl_easy_getinfo(curl_handle, CURLINFO_PRIMARY_IP, &dest_url) && dest_url)
 	{
-		char *pStr = getenv(ENV_PXF_PORT);
-		int  port  = pStr ? (int) strtol(pStr, &pStr, 10) : PXF_DEFAULT_PORT;
-
-		return psprintf("'%s:%d'", dest_url, port);
+		return psprintf("'%s:%d'", dest_url, get_pxf_port());
 	}
 	return dest_url;
 }

--- a/gpcontrib/pxf/src/libchurl.c
+++ b/gpcontrib/pxf/src/libchurl.c
@@ -638,7 +638,7 @@ get_dest_address(CURL *curl_handle)
 	/* add dest url, if any, and curl was nice to tell us */
 	if (CURLE_OK == curl_easy_getinfo(curl_handle, CURLINFO_PRIMARY_IP, &dest_url) && dest_url)
 	{
-		return psprintf("'%s:%d'", dest_url, PxfDefaultPort);
+		return psprintf("'%s:%d'", dest_url, PXF_DEFAULT_PORT);
 	}
 	return dest_url;
 }

--- a/gpcontrib/pxf/src/pxfuriparser.c
+++ b/gpcontrib/pxf/src/pxfuriparser.c
@@ -56,11 +56,7 @@ static void GPHDUri_free_fragments(GPHDUri *uri);
 GPHDUri *
 parseGPHDUri(const char *uri_str)
 {
-	char *host = getenv(ENV_PXF_HOST) ? getenv(ENV_PXF_HOST) : PXF_DEFAULT_HOST;
-	char *pStr = getenv("PXF_PORT");
-	int  port  = pStr ? (int) strtol(pStr, &pStr, 10) : PXF_DEFAULT_PORT;
-
-	return parseGPHDUriHostPort(uri_str, host, port);
+	return parseGPHDUriHostPort(uri_str, get_pxf_host(), get_pxf_port());
 }
 
 GPHDUri *

--- a/gpcontrib/pxf/src/pxfuriparser.c
+++ b/gpcontrib/pxf/src/pxfuriparser.c
@@ -56,7 +56,11 @@ static void GPHDUri_free_fragments(GPHDUri *uri);
 GPHDUri *
 parseGPHDUri(const char *uri_str)
 {
-	return parseGPHDUriHostPort(uri_str, PXF_DEFAULT_HOST, PXF_DEFAULT_PORT);
+	char *host = getenv(ENV_PXF_HOST) ? getenv(ENV_PXF_HOST) : PXF_DEFAULT_HOST;
+	char *pStr = getenv("PXF_PORT");
+	int  port  = pStr ? (int) strtol(pStr, &pStr, 10) : PXF_DEFAULT_PORT;
+
+	return parseGPHDUriHostPort(uri_str, host, port);
 }
 
 GPHDUri *
@@ -64,7 +68,7 @@ parseGPHDUriHostPort(const char *uri_str, const char *host, const int port)
 {
 	GPHDUri    *uri = (GPHDUri *) palloc0(sizeof(GPHDUri));
 	uri->host = pstrdup(host);
-	uri->port = psprintf("%d", PXF_DEFAULT_PORT);
+	uri->port = psprintf("%d", port);
 	uri->uri = pstrdup(uri_str);
 
 	char	   *cursor = uri->uri;

--- a/gpcontrib/pxf/src/pxfuriparser.c
+++ b/gpcontrib/pxf/src/pxfuriparser.c
@@ -56,23 +56,18 @@ static void GPHDUri_free_fragments(GPHDUri *uri);
 GPHDUri *
 parseGPHDUri(const char *uri_str)
 {
-	return parseGPHDUriHostPort(uri_str, PxfDefaultHost, PxfDefaultPort);
+	return parseGPHDUriHostPort(uri_str, PXF_DEFAULT_HOST, PXF_DEFAULT_PORT);
 }
 
 GPHDUri *
 parseGPHDUriHostPort(const char *uri_str, const char *host, const int port)
 {
 	GPHDUri    *uri = (GPHDUri *) palloc0(sizeof(GPHDUri));
-
 	uri->host = pstrdup(host);
-	StringInfoData portstr;
-
-	initStringInfo(&portstr);
-	appendStringInfo(&portstr, "%d", port);
-	uri->port = portstr.data;
+	uri->port = psprintf("%d", PXF_DEFAULT_PORT);
 	uri->uri = pstrdup(uri_str);
-	char	   *cursor = uri->uri;
 
+	char	   *cursor = uri->uri;
 	GPHDUri_parse_protocol(uri, &cursor);
 	GPHDUri_parse_data(uri, &cursor);
 	GPHDUri_parse_options(uri, &cursor);

--- a/gpcontrib/pxf/src/pxfutils.c
+++ b/gpcontrib/pxf/src/pxfutils.c
@@ -65,9 +65,24 @@ concat(int num_args,...)
 char *
 get_authority(void)
 {
-	char *host = getenv(ENV_PXF_HOST) ? getenv(ENV_PXF_HOST) : PXF_DEFAULT_HOST;
-	char *pStr = getenv(ENV_PXF_PORT);
-	int  port  = pStr ? (int) strtol(pStr, &pStr, 10) : PXF_DEFAULT_PORT;
+	return psprintf("%s:%d", get_pxf_host(), get_pxf_port());
+}
 
-	return psprintf("%s:%d", host, port);
+/* Returns the PXF Host defined in the PXF_HOST
+ * environment variable or the default when undefined
+ */
+const char *
+get_pxf_host(void)
+{
+	return getenv(ENV_PXF_HOST) ? getenv(ENV_PXF_HOST) : PXF_DEFAULT_HOST;
+}
+
+/* Returns the PXF Port defined in the PXF_PORT
+ * environment variable or the default when undefined
+ */
+const int
+get_pxf_port(void)
+{
+	char *pStr = getenv(ENV_PXF_PORT);
+	return pStr ? (int) strtol(pStr, &pStr, 10) : PXF_DEFAULT_PORT;
 }

--- a/gpcontrib/pxf/src/pxfutils.c
+++ b/gpcontrib/pxf/src/pxfutils.c
@@ -65,5 +65,9 @@ concat(int num_args,...)
 char *
 get_authority(void)
 {
-	return psprintf("%s:%d", PXF_DEFAULT_HOST, PXF_DEFAULT_PORT);
+	char *host = getenv(ENV_PXF_HOST) ? getenv(ENV_PXF_HOST) : PXF_DEFAULT_HOST;
+	char *pStr = getenv(ENV_PXF_PORT);
+	int  port  = pStr ? (int) strtol(pStr, &pStr, 10) : PXF_DEFAULT_PORT;
+
+	return psprintf("%s:%d", host, port);
 }

--- a/gpcontrib/pxf/src/pxfutils.c
+++ b/gpcontrib/pxf/src/pxfutils.c
@@ -88,10 +88,22 @@ get_pxf_host(void)
 const int
 get_pxf_port(void)
 {
+	char *endptr = NULL;
 	char *pStr = getenv(ENV_PXF_PORT);
-	if (pStr)
-		elog(DEBUG3, "read environment variable %s=%s", ENV_PXF_PORT, pStr);
+	int port = PXF_DEFAULT_PORT;
+
+	if (pStr) {
+		port = (int) strtol(pStr, &endptr, 10);
+
+		if (pStr == endptr)
+			elog(ERROR, "unable to parse PXF port number %s=%s", ENV_PXF_PORT, pStr);
+		else
+			elog(DEBUG3, "read environment variable %s=%s", ENV_PXF_PORT, pStr);
+	}
 	else
+	{
 		elog(DEBUG3, "environment variable %s was not supplied", ENV_PXF_PORT);
-	return pStr ? (int) strtol(pStr, &pStr, 10) : PXF_DEFAULT_PORT;
+	}
+
+	return port;
 }

--- a/gpcontrib/pxf/src/pxfutils.c
+++ b/gpcontrib/pxf/src/pxfutils.c
@@ -74,7 +74,12 @@ get_authority(void)
 const char *
 get_pxf_host(void)
 {
-	return getenv(ENV_PXF_HOST) ? getenv(ENV_PXF_HOST) : PXF_DEFAULT_HOST;
+	const char *hStr = getenv(ENV_PXF_HOST);
+	if (hStr)
+		elog(DEBUG3, "read environment variable %s=%s", ENV_PXF_HOST, hStr);
+	else
+		elog(DEBUG3, "environment variable %s was not supplied", ENV_PXF_HOST);
+	return hStr ? hStr : PXF_DEFAULT_HOST;
 }
 
 /* Returns the PXF Port defined in the PXF_PORT
@@ -84,5 +89,9 @@ const int
 get_pxf_port(void)
 {
 	char *pStr = getenv(ENV_PXF_PORT);
+	if (pStr)
+		elog(DEBUG3, "read environment variable %s=%s", ENV_PXF_PORT, pStr);
+	else
+		elog(DEBUG3, "environment variable %s was not supplied", ENV_PXF_PORT);
 	return pStr ? (int) strtol(pStr, &pStr, 10) : PXF_DEFAULT_PORT;
 }

--- a/gpcontrib/pxf/src/pxfutils.c
+++ b/gpcontrib/pxf/src/pxfutils.c
@@ -65,5 +65,5 @@ concat(int num_args,...)
 char *
 get_authority(void)
 {
-	return psprintf("%s:%d", PxfDefaultHost, PxfDefaultPort);
+	return psprintf("%s:%d", PXF_DEFAULT_HOST, PXF_DEFAULT_PORT);
 }

--- a/gpcontrib/pxf/src/pxfutils.h
+++ b/gpcontrib/pxf/src/pxfutils.h
@@ -15,6 +15,16 @@ char	   *concat(int num_args,...);
 /* Get authority (host:port) for the PXF server URL */
 char	   *get_authority(void);
 
+/* Returns the PXF Host defined in the PXF_HOST
+ * environment variable or the default when undefined
+ */
+const char *get_pxf_host(void);
+
+/* Returns the PXF Port defined in the PXF_PORT
+ * environment variable or the default when undefined
+ */
+const int  get_pxf_port(void);
+
 #define PXF_PROFILE       "PROFILE"
 #define FRAGMENTER        "FRAGMENTER"
 #define ACCESSOR          "ACCESSOR"

--- a/gpcontrib/pxf/src/pxfutils.h
+++ b/gpcontrib/pxf/src/pxfutils.h
@@ -20,7 +20,9 @@ char	   *get_authority(void);
 #define ACCESSOR          "ACCESSOR"
 #define RESOLVER          "RESOLVER"
 #define ANALYZER          "ANALYZER"
-#define PxfDefaultHost    "localhost"
-#define PxfDefaultPort    5888
+#define ENV_PXF_HOST      "PXF_HOST"
+#define ENV_PXF_PORT      "PXF_PORT"
+#define PXF_DEFAULT_HOST  "localhost"
+#define PXF_DEFAULT_PORT  5888
 
 #endif							/* _PXFUTILS_H_ */

--- a/gpcontrib/pxf/test/libchurl_test.c
+++ b/gpcontrib/pxf/test/libchurl_test.c
@@ -10,6 +10,7 @@
 #define UNIT_TESTING
 
 /* include unit under test */
+#include "../src/pxfutils.c"
 #include "../src/libchurl.c"
 
 /* include mock files */

--- a/gpcontrib/pxf/test/pxfuriparser_test.c
+++ b/gpcontrib/pxf/test/pxfuriparser_test.c
@@ -45,17 +45,13 @@ void
 test_parseGPHDUri_ValidURI(void **state)
 {
 	GPHDUri    *parsed = parseGPHDUri(uri);
-	StringInfoData port;
-
-	initStringInfo(&port);
-	appendStringInfo(&port, "%d", PxfDefaultPort);
 
 	assert_true(parsed != NULL);
 	assert_string_equal(parsed->uri, uri);
 
 	assert_string_equal(parsed->protocol, "pxf");
-	assert_string_equal(parsed->host, PxfDefaultHost);
-	assert_string_equal(parsed->port, pstrdup(port.data));
+	assert_string_equal(parsed->host, PXF_DEFAULT_HOST);
+	assert_string_equal(parsed->port, psprintf("%d", PXF_DEFAULT_PORT));
 	assert_string_equal(parsed->data, "some/path/and/table.tbl");
 
 	List	   *options = parsed->options;

--- a/gpcontrib/pxf/test/pxfutils_test.c
+++ b/gpcontrib/pxf/test/pxfutils_test.c
@@ -12,6 +12,9 @@
 /* include unit under test */
 #include "../src/pxfutils.c"
 
+/* helper functions */
+static void restore_env(const char *name, const char *value);
+
 void
 test_normalize_key_name(void **state)
 {
@@ -74,6 +77,60 @@ test_get_authority(void **state)
 	pfree(authority);
 }
 
+void
+test_get_authority_from_env(void **state)
+{
+	const char *pStore = getenv(ENV_PXF_PORT);
+	const char *hStore = getenv(ENV_PXF_HOST);
+
+	setenv(ENV_PXF_HOST, "bar.com", 1);
+	setenv(ENV_PXF_PORT, "777", 1);
+
+	char	*authority = get_authority();
+	assert_string_equal(authority, "bar.com:777");
+	pfree(authority);
+
+	restore_env(ENV_PXF_PORT, pStore);
+	restore_env(ENV_PXF_HOST, hStore);
+}
+
+void
+test_get_pxf_port_with_env_var_set(void **state)
+{
+	// store the existing value of the environment variable
+	const char *store = getenv(ENV_PXF_PORT);
+	setenv(ENV_PXF_PORT, "6162", 1);
+
+	const int port = get_pxf_port();
+	assert_int_equal(port, 6162);
+
+	// restore environment variable
+	restore_env(ENV_PXF_PORT, store);
+}
+
+void
+test_get_pxf_host_with_env_var_set(void **state)
+{
+	// store the existing value of the environment variable
+	const char *store = getenv(ENV_PXF_HOST);
+	setenv(ENV_PXF_HOST, "foo.com", 1);
+
+	const char *host = get_pxf_host();
+	assert_string_equal(host, "foo.com");
+
+	// restore environment variable
+	restore_env(ENV_PXF_HOST, store);
+}
+
+static void
+restore_env(const char *name, const char *value)
+{
+	if (value)
+		setenv(name, value, 1);
+	else
+		unsetenv(name);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -81,7 +138,10 @@ main(int argc, char *argv[])
 
 	const		UnitTest tests[] = {
 		unit_test(test_normalize_key_name),
-		unit_test(test_get_authority)
+		unit_test(test_get_authority),
+		unit_test(test_get_authority_from_env),
+		unit_test(test_get_pxf_port_with_env_var_set),
+		unit_test(test_get_pxf_host_with_env_var_set),
 	};
 
 	MemoryContextInit();

--- a/gpcontrib/pxf/test/pxfutils_test.c
+++ b/gpcontrib/pxf/test/pxfutils_test.c
@@ -95,6 +95,20 @@ test_get_authority_from_env(void **state)
 }
 
 void
+test_get_pxf_port_fails_with_invalid_value(void **state)
+{
+	// store the existing value of the environment variable
+	const char *store = getenv(ENV_PXF_PORT);
+	setenv(ENV_PXF_PORT, "bad_value", 1);
+
+	const int port = get_pxf_port();
+	assert_int_equal(port, 0);
+
+	// restore environment variable
+	restore_env(ENV_PXF_PORT, store);
+}
+
+void
 test_get_pxf_port_with_env_var_set(void **state)
 {
 	// store the existing value of the environment variable
@@ -142,6 +156,7 @@ main(int argc, char *argv[])
 		unit_test(test_get_authority_from_env),
 		unit_test(test_get_pxf_port_with_env_var_set),
 		unit_test(test_get_pxf_host_with_env_var_set),
+		unit_test(test_get_pxf_port_fails_with_invalid_value)
 	};
 
 	MemoryContextInit();


### PR DESCRIPTION
PXF host and port were hardcoded to localhost:5888. In this PR,
we read two environment variables `PXF_HOST` and `PXF_PORT`
to determine the host and port of the PXF service. If the environment
variables are not provided, we default to the current hardcoded
values.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
