### PR TITLE
WIP: Rearchitect tablespace directory structure

### DIFF
--- a/contrib/pg_xlogdump/compat.c
+++ b/contrib/pg_xlogdump/compat.c
@@ -106,17 +106,3 @@ appendStringInfoChar(StringInfo str, char ch)
 	appendStringInfo(str, "%c", ch);
 }
 
-
-const char *
-tablespace_version_directory(void)
-{
-	static char path[MAXPGPATH] = "";
-
-	// GPDB_93_MERGE_FIXME: I hardcoded dbid 0 here, just to make this compile.
-	// Where do we get the actual value?
-	if (!path[0])
-		snprintf(path, MAXPGPATH, "%s_db%d", GP_TABLESPACE_VERSION_DIRECTORY,
-				 0 /* GpIdentity.dbid */);
-
-	return path;
-}

--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -69,22 +69,6 @@
 static bool IsAoSegmentClass(Form_pg_class reltuple);
 
 /*
- * Return directory name within tablespace location to use, for this server.
- * This is the GPDB replacement for PostgreSQL's TABLESPACE_VERSION_DIRECTORY
- * constant.
- */
-const char *
-tablespace_version_directory(void)
-{
-	static char path[MAXPGPATH] = "";
-
-	if (!path[0])
-		snprintf(path, MAXPGPATH, "%s_db%d", GP_TABLESPACE_VERSION_DIRECTORY, GpIdentity.dbid);
-
-	return path;
-}
-
-/*
  * Like relpath(), but gets the directory containing the data file
  * and the filename separately.
  */

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -1026,7 +1026,7 @@ sendTablespace(char *path, bool sizeonly)
 	 * the version directory in it that belongs to us.
 	 */
 	snprintf(pathbuf, sizeof(pathbuf), "%s/%s", path,
-			 tablespace_version_directory());
+			 GP_TABLESPACE_VERSION_DIRECTORY);
 
 	/*
 	 * Store a directory entry in the tar file so we get the permissions
@@ -1044,7 +1044,7 @@ sendTablespace(char *path, bool sizeonly)
 		return 0;
 	}
 	if (!sizeonly)
-		_tarWriteHeader(tablespace_version_directory(), NULL, &statbuf);
+		_tarWriteHeader(GP_TABLESPACE_VERSION_DIRECTORY, NULL, &statbuf);
 	size = 512;					/* Size of the header just added */
 
 	/* Send all the files in the tablespace version directory */

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1394,7 +1394,7 @@ GetTempFilePath(const char *filename, bool createdir)
 	{
 		/* All other tablespaces are accessed via symlinks */
 		snprintf(tempdirpath, sizeof(tempdirpath), "pg_tblspc/%u/%s/%s",
-				 tblspcOid, tablespace_version_directory(), PG_TEMP_FILES_DIR);
+				 tblspcOid, GP_TABLESPACE_VERSION_DIRECTORY, PG_TEMP_FILES_DIR);
 	}
 
 	/*
@@ -1442,7 +1442,7 @@ OpenTemporaryFileInTablespace(Oid tblspcOid, bool rejectError,
 	{
 		/* All other tablespaces are accessed via symlinks */
 		snprintf(tempdirpath, sizeof(tempdirpath), "pg_tblspc/%u/%s/%s",
-				 tblspcOid, tablespace_version_directory(), PG_TEMP_FILES_DIR);
+				 tblspcOid, GP_TABLESPACE_VERSION_DIRECTORY, PG_TEMP_FILES_DIR);
 	}
 
 	/*
@@ -2754,7 +2754,7 @@ CleanupTempFiles(bool isProcExit)
 void
 RemovePgTempFiles(void)
 {
-	char		temp_path[MAXPGPATH + 10 + strlen(tablespace_version_directory()) + 1 + sizeof(PG_TEMP_FILES_DIR)];
+	char		temp_path[MAXPGPATH + 10 + sizeof(GP_TABLESPACE_VERSION_DIRECTORY) + sizeof(PG_TEMP_FILES_DIR)];
 	DIR		   *spc_dir;
 	struct dirent *spc_de;
 
@@ -2777,11 +2777,11 @@ RemovePgTempFiles(void)
 			continue;
 
 		snprintf(temp_path, sizeof(temp_path), "pg_tblspc/%s/%s/%s",
-				 spc_de->d_name, tablespace_version_directory(), PG_TEMP_FILES_DIR);
+				 spc_de->d_name, GP_TABLESPACE_VERSION_DIRECTORY, PG_TEMP_FILES_DIR);
 		RemovePgTempFilesInDir(temp_path, true, false);
 
 		snprintf(temp_path, sizeof(temp_path), "pg_tblspc/%s/%s",
-				 spc_de->d_name, tablespace_version_directory());
+				 spc_de->d_name, GP_TABLESPACE_VERSION_DIRECTORY);
 		RemovePgTempRelationFiles(temp_path);
 	}
 

--- a/src/backend/storage/file/reinit.c
+++ b/src/backend/storage/file/reinit.c
@@ -49,7 +49,7 @@ typedef struct
 void
 ResetUnloggedRelations(int op)
 {
-	char		temp_path[MAXPGPATH + 10 + strlen(tablespace_version_directory()) + 1];
+	char		temp_path[MAXPGPATH + 10 + sizeof(GP_TABLESPACE_VERSION_DIRECTORY)];
 	DIR		   *spc_dir;
 	struct dirent *spc_de;
 	MemoryContext tmpctx,
@@ -88,7 +88,7 @@ ResetUnloggedRelations(int op)
 			continue;
 
 		snprintf(temp_path, sizeof(temp_path), "pg_tblspc/%s/%s",
-				 spc_de->d_name, tablespace_version_directory());
+				 spc_de->d_name, GP_TABLESPACE_VERSION_DIRECTORY);
 		ResetUnloggedRelationsInTablespaceDir(temp_path, op);
 	}
 

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -152,7 +152,7 @@ calculate_database_size(Oid dbOid)
 	DIR		   *dirdesc;
 	struct dirent *direntry;
 	char		dirpath[MAXPGPATH];
-	char		pathname[MAXPGPATH + 12 + strlen(tablespace_version_directory()) + 1];
+	char		pathname[MAXPGPATH + 12 + sizeof(GP_TABLESPACE_VERSION_DIRECTORY)];
 	AclResult	aclresult;
 
 	/* User must have connect privilege for target database */
@@ -185,7 +185,7 @@ calculate_database_size(Oid dbOid)
 			continue;
 
 		snprintf(pathname, sizeof(pathname), "pg_tblspc/%s/%s/%u",
-				 direntry->d_name, tablespace_version_directory(), dbOid);
+				 direntry->d_name, GP_TABLESPACE_VERSION_DIRECTORY, dbOid);
 		totalsize += db_dir_size(pathname);
 	}
 
@@ -276,7 +276,7 @@ calculate_tablespace_size(Oid tblspcOid)
 		snprintf(tblspcPath, MAXPGPATH, "global");
 	else
 		snprintf(tblspcPath, MAXPGPATH, "pg_tblspc/%u/%s", tblspcOid,
-				 tablespace_version_directory());
+				 GP_TABLESPACE_VERSION_DIRECTORY);
 
 	dirdesc = AllocateDir(tblspcPath);
 

--- a/src/backend/utils/adt/misc.c
+++ b/src/backend/utils/adt/misc.c
@@ -301,7 +301,7 @@ pg_tablespace_databases(PG_FUNCTION_ARGS)
 				fctx->location = psprintf("base");
 			else
 				fctx->location = psprintf("pg_tblspc/%u/%s", tablespaceOid,
-										  tablespace_version_directory());
+										  GP_TABLESPACE_VERSION_DIRECTORY);
 
 			fctx->dirdesc = AllocateDir(fctx->location);
 
@@ -404,6 +404,13 @@ pg_tablespace_location(PG_FUNCTION_ARGS)
 				(errmsg("symbolic link \"%s\" target is too long",
 						sourcepath)));
 	targetpath[rllen] = '\0';
+	
+	get_parent_directory(targetpath);
+	if (strcmp(targetpath, "") == 0)
+		ereport(ERROR,
+				(errmsg("Path to tablespace is not a valid path: \"%s\"",
+					sourcepath)));
+
 
 	PG_RETURN_TEXT_P(cstring_to_text(targetpath));
 #else

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -5446,7 +5446,7 @@ RelationCacheInitFileRemove(void)
 	const char *tblspcdir = "pg_tblspc";
 	DIR		   *dir;
 	struct dirent *de;
-	char		path[MAXPGPATH + 10 + strlen(tablespace_version_directory()) + 1];
+	char		path[MAXPGPATH + 10 + sizeof(GP_TABLESPACE_VERSION_DIRECTORY)];
 
 	snprintf(path, sizeof(path), "global/%s",
 			 RELCACHE_INIT_FILENAME);
@@ -5470,7 +5470,7 @@ RelationCacheInitFileRemove(void)
 		{
 			/* Scan the tablespace dir for per-database dirs */
 			snprintf(path, sizeof(path), "%s/%s/%s",
-					 tblspcdir, de->d_name, tablespace_version_directory());
+					 tblspcdir, de->d_name, GP_TABLESPACE_VERSION_DIRECTORY);
 			RelationCacheInitFileRemoveInDir(path);
 		}
 	}

--- a/src/common/relpath.c
+++ b/src/common/relpath.c
@@ -122,7 +122,7 @@ GetDatabasePath(Oid dbNode, Oid spcNode)
 	{
 		/* All other tablespaces are accessed via symlinks */
 		return psprintf("pg_tblspc/%u/%s/%u",
-						spcNode, tablespace_version_directory(), dbNode);
+						spcNode, GP_TABLESPACE_VERSION_DIRECTORY, dbNode);
 	}
 }
 
@@ -191,24 +191,24 @@ GetRelationPath(Oid dbNode, Oid spcNode, Oid relNode,
 		{
 			if (forkNumber != MAIN_FORKNUM)
 				path = psprintf("pg_tblspc/%u/%s/%u/%u_%s",
-								spcNode, tablespace_version_directory(),
+								spcNode, GP_TABLESPACE_VERSION_DIRECTORY,
 								dbNode, relNode,
 								forkNames[forkNumber]);
 			else
 				path = psprintf("pg_tblspc/%u/%s/%u/%u",
-								spcNode, tablespace_version_directory(),
+								spcNode, GP_TABLESPACE_VERSION_DIRECTORY,
 								dbNode, relNode);
 		}
 		else
 		{
 			if (forkNumber != MAIN_FORKNUM)
 				path = psprintf("pg_tblspc/%u/%s/%u/t_%u_%s",
-								spcNode, tablespace_version_directory(),
+								spcNode, GP_TABLESPACE_VERSION_DIRECTORY,
 								dbNode, relNode,
 								forkNames[forkNumber]);
 			else
 				path = psprintf("pg_tblspc/%u/%s/%u/t_%u",
-								spcNode, tablespace_version_directory(),
+								spcNode, GP_TABLESPACE_VERSION_DIRECTORY,
 								dbNode, relNode);
 		}
 	}


### PR DESCRIPTION
This is a draft PR with the intention of soliciting comment on a pending change to the tablespace directory structure, with the intention of backporting this necessary, but breaking change into `6X_STABLE` before it goes GA. If this committed, this will break any database that contains data in user defined tablespaces, and will need manual migration to the new directory structure.

This commit links pg_tblspc to a <dbid> subdirectory of the tablespace, rather than to the path of the tablespace directly, and removes the <dbid> from the `tablespace_version_directory()`

Before this commit, the full path to an arbitrary file would look like:
```bash
  # Link to TS directory:  
  $PG_DATA/pg_tblspc/spcoid/ -> /<tablespace_location>/
  # Path to a relfile:
  /<tablespace_location>/GPDB_MAJORVER_CATVER_db<dbid>/dboid/relfilenode
```
e.g.
```bash
  # Link to TS directory: 
  /pg_data/pg_tblspc/20981/ -> /data1/tsp1
  # Path to a relfile:
  /data1/tsp1/GPDB_6_201902061_db1/19849/192814
```
After this commit, the full path to an abitrary file will look like this:
```bash
  # Link to TS directory: 
  $PG_DATA/pg_tblspc/spcoid/ -> /<tablespace_location>/<dbid>/
  # Path to a relfile:
  /<tablespace_location>/GPDB_MAJORVER_CATVER/dboid/relfilenode
```
e.g.
```bash
  # Link to TS directory: 
  /pg_data/pg_tblspc/20981/ -> /data1/tsp1/1/
  # Path to a relfile:
  /data1/tsp1/GPDB_6_201902061/19849/192814
```

Motivation:

When tablespaces were aligned to upstream postgres, while removing filespaces, we added the `tablespace_version_directory()` function to supply each segment with a unique tablespace directory name. This was accomplished by appending the 'magic' `GpIdentity.dbid` global variable
to the `GP_TABLESPACE_VERSION_DIRECTORY` in `tablespace_version_directory()`.

This is problematic for several reasons- but perhaps most severely is the fact that in order to use any code in libpgcommon.so that references this value, you need to first set the `GpIdentity.dbid` global,
otherwise any functions that deal with tablespaces will be broken in unpredictable ways.

An example is pg_rewind- where `GetRelationPath()` will not return a valid relation unless you repeatedly toggle the `GpIdentity.dbid` between the value of the source or target segment dependant on the context of which relfiles are being examined.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [x] Review a PR in return to support the community
