### PR TITLE
Fdw support MPP Analyze

### DIFF
--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -199,7 +199,7 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		 */
 		rows = (HeapTuple *) palloc0(targrows * sizeof(HeapTuple));
 
-		if(RelationGetForm(onerel)->relkind == RELSTORAGE_FOREIGN && RelationIsExternal(onerel))
+		if(RelationIsForeign(onerel))
 		{
 			FdwRoutine *fdwroutine;
 			fdwroutine = GetFdwRoutineForRelation(onerel, false);

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -15,6 +15,7 @@
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/varbit.h"
+#include "foreign/fdwapi.h"
 #include "miscadmin.h"
 #include "funcapi.h"
 
@@ -197,7 +198,17 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		 * more comfortable.)
 		 */
 		rows = (HeapTuple *) palloc0(targrows * sizeof(HeapTuple));
-		if (inherited)
+
+		if(RelationGetForm(onerel)->relkind == RELSTORAGE_FOREIGN && RelationIsExternal(onerel))
+		{
+			FdwRoutine *fdwroutine;
+			fdwroutine = GetFdwRoutineForRelation(onerel, false);
+			numrows = fdwroutine->AcquireSampleRows(onerel, DEBUG1,
+													rows, targrows,
+													&totalrows, &totaldeadrows);
+
+		}
+		else if (inherited)
 		{
 			numrows = acquire_inherited_sample_rows(onerel, DEBUG1,
 													rows, targrows,

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -43,6 +43,7 @@
 #include "utils/syscache.h"
 
 #include "libpq-fe.h"
+#include "foreign/fdwapi.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbvars.h"
@@ -463,6 +464,27 @@ pg_relation_size(PG_FUNCTION_ARGS)
 	 */
 	if (rel == NULL)
 		PG_RETURN_NULL();
+
+	if(RelationGetForm(rel)->relkind == RELSTORAGE_FOREIGN && RelationIsExternal(rel))
+	{
+		FdwRoutine *fdwroutine;
+		bool        ok = false;
+
+		fdwroutine = GetFdwRoutineForRelation(rel, false);
+
+		if (fdwroutine->AnalyzeForeignTable != NULL)
+			ok = fdwroutine->AnalyzeForeignTable(rel, NULL, &size);
+
+		if (!ok)
+			ereport(WARNING,
+					(errmsg("skipping \"%s\" --- cannot analyze this foreign table",
+							RelationGetRelationName(rel))));
+
+		relation_close(rel, AccessShareLock);
+
+		PG_RETURN_INT64(size);
+
+	}
 
 	forkNumber = forkname_to_number(text_to_cstring(forkName));
 

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -472,12 +472,12 @@ pg_relation_size(PG_FUNCTION_ARGS)
 
 		fdwroutine = GetFdwRoutineForRelation(rel, false);
 
-		if (fdwroutine->AnalyzeForeignTable != NULL)
-			ok = fdwroutine->AnalyzeForeignTable(rel, NULL, &size);
+		if (fdwroutine->GetRelationSize != NULL)
+			ok = fdwroutine->GetRelationSize(rel, &size);
 
 		if (!ok)
 			ereport(WARNING,
-					(errmsg("skipping \"%s\" --- cannot analyze this foreign table",
+					(errmsg("skipping \"%s\" --- cannot calculate this foreign table size",
 							RelationGetRelationName(rel))));
 
 		relation_close(rel, AccessShareLock);

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -465,7 +465,7 @@ pg_relation_size(PG_FUNCTION_ARGS)
 	if (rel == NULL)
 		PG_RETURN_NULL();
 
-	if(RelationGetForm(rel)->relkind == RELSTORAGE_FOREIGN && RelationIsExternal(rel))
+	if(RelationIsForeign(rel))
 	{
 		FdwRoutine *fdwroutine;
 		bool        ok = false;

--- a/src/include/foreign/fdwapi.h
+++ b/src/include/foreign/fdwapi.h
@@ -98,7 +98,7 @@ typedef int (*AcquireSampleRowsFunc) (Relation relation, int elevel,
 
 typedef bool (*AnalyzeForeignTable_function) (Relation relation,
 												 AcquireSampleRowsFunc *func,
-													BlockNumber *totalpages);
+													Datum totalpagesorsize);
 
 /*
  * FdwRoutine is the struct returned by a foreign-data wrapper's handler
@@ -144,6 +144,7 @@ typedef struct FdwRoutine
 
 	/* Support functions for ANALYZE */
 	AnalyzeForeignTable_function AnalyzeForeignTable;
+	AcquireSampleRowsFunc AcquireSampleRows;
 } FdwRoutine;
 
 

--- a/src/include/foreign/fdwapi.h
+++ b/src/include/foreign/fdwapi.h
@@ -98,7 +98,7 @@ typedef int (*AcquireSampleRowsFunc) (Relation relation, int elevel,
 
 typedef bool (*AnalyzeForeignTable_function) (Relation relation,
 												 AcquireSampleRowsFunc *func,
-													Datum totalpagesorsize);
+													BlockNumber *totalpages);
 
 /*
  * FdwRoutine is the struct returned by a foreign-data wrapper's handler

--- a/src/include/foreign/fdwapi.h
+++ b/src/include/foreign/fdwapi.h
@@ -100,6 +100,7 @@ typedef bool (*AnalyzeForeignTable_function) (Relation relation,
 												 AcquireSampleRowsFunc *func,
 													BlockNumber *totalpages);
 
+typedef bool (*ForeignTableSize_function) (Relation relation, int64 *tablesize);
 /*
  * FdwRoutine is the struct returned by a foreign-data wrapper's handler
  * function.  It provides pointers to the callback functions needed by the
@@ -145,6 +146,7 @@ typedef struct FdwRoutine
 	/* Support functions for ANALYZE */
 	AnalyzeForeignTable_function AnalyzeForeignTable;
 	AcquireSampleRowsFunc AcquireSampleRows;
+	ForeignTableSize_function GetRelationSize;
 } FdwRoutine;
 
 


### PR DESCRIPTION
At present, only the master node FDW table is able to execute "analyze".

For the internal table, analyze task can be separated into two phases:
1. call "pg_relation_size" function in all segments to calculate table size.
2. call "gp_acquire_sample_rows" in all segments to sampling tuples.

FDW table using two call back function, named as AnalyzeForeignTable_function and AcquireSampleRowsFunc, executes the above steps.

In this PR, "pg_relation_size" and "gp_acquire_sample_rows" function recognize the FDW table and invoke relevant FDW call back function, so the FDW "analyze" task can be dispatched from QD to QE.
