### PR TITLE
Sanity check update/delete to prevent potential data corruption when …

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2423,6 +2423,7 @@ InitResultRelInfo(ResultRelInfo *resultRelInfo,
 	resultRelInfo->ri_FdwState = NULL;
 	resultRelInfo->ri_ConstraintExprs = NULL;
 	resultRelInfo->ri_junkFilter = NULL;
+	resultRelInfo->ri_segid_attno = InvalidAttrNumber;
 	resultRelInfo->ri_projectReturning = NULL;
 	resultRelInfo->ri_aoInsertDesc = NULL;
 	resultRelInfo->ri_aocsInsertDesc = NULL;

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -133,6 +133,22 @@ ExecDML(DMLState *node)
 		ItemPointerData tuple_ctid = *tupleid;
 		tupleid = &tuple_ctid;
 
+		/*
+		 * Sanity check the distribution of the tuple to prevent potential
+		 * data corruption in case users manipulate data incorrectly (e.g.
+		 * insert data on incorrect segments through utility mode) or there is
+		 * bug in code, etc.
+		 */
+		if (AttributeNumberIsValid(node->segid_attno))
+		{
+			int32 segid = DatumGetInt32(slot_getattr(slot, node->segid_attno, &isnull));
+			Assert(!isnull);
+
+			if (segid != GpIdentity.segindex)
+				elog(ERROR, "distribution key of the tuple doesn't belong to "
+					 "current segment (actually from seg%d)", segid);
+		}
+
 		/* Correct tuple count by ignoring deletes when splitting tuples. */
 		ExecDelete(tupleid,
 				   NULL, /* GPDB_91_MERGE_FIXME: oldTuple? */
@@ -177,6 +193,24 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 
 	Plan *outerPlan  = outerPlan(node);
 	outerPlanState(dmlstate) = ExecInitNode(outerPlan, estate, eflags);
+
+	/*
+	 * ORCA Plan does not seem to set junk attribute for "gp_segment_id", else we
+	 * could call the simple code below.
+	 * resultRelInfo->ri_segid_attno = ExecFindJunkAttributeInTlist(outerPlanState(dmlstate)->plan->targetlist, "gp_segment_id");
+	 */
+	ListCell   *t;
+	dmlstate->segid_attno = InvalidAttrNumber;
+	foreach(t, outerPlanState(dmlstate)->plan->targetlist)
+	{
+		TargetEntry *tle = lfirst(t);
+
+		if (tle->resname && (strcmp(tle->resname, "gp_segment_id") == 0))
+		{
+			dmlstate->segid_attno = tle->resno;
+			break;
+		}
+	}
 
 	ExecAssignResultTypeFromTL(&dmlstate->ps);
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -366,6 +366,7 @@ typedef struct ResultRelInfo
 	List	   *ri_WithCheckOptionExprs;
 	List	  **ri_ConstraintExprs;
 	JunkFilter *ri_junkFilter;
+	AttrNumber  ri_segid_attno; /* gpdb: attribute number of "gp_segment_id" */
 	ProjectionInfo *ri_projectReturning;
 	int			tupdesc_match;
 	struct MemTupleBinding *mt_bind;
@@ -2785,6 +2786,7 @@ typedef struct DMLState
 	PlanState	ps;
 	JunkFilter *junkfilter;			/* filter that removes junk and dropped attributes */
 	TupleTableSlot *cleanedUpSlot;	/* holds 'final' tuple which matches the target relation schema */
+	AttrNumber	segid_attno;		/* attribute number of "gp_segment_id" */
 } DMLState;
 
 /*

--- a/src/test/isolation2/expected/modifytable_with_bad_distribution.out
+++ b/src/test/isolation2/expected/modifytable_with_bad_distribution.out
@@ -1,0 +1,106 @@
+-- start_matchsubs
+-- m/nodeDML.c:\d+/
+-- s/nodeDML.c:\d+/nodeDML.c:XXX/
+-- m/nodeModifyTable.c:\d+/
+-- s/nodeModifyTable.c:\d+/nodeModifyTable.c:XXX/
+-- end_matchsubs
+
+create table bad_distribution1 (a int, b int) distributed by (a);
+CREATE
+create table pbad_distribution1 (a int, b int) distributed by (a) PARTITION BY RANGE(a) (START(1) END(9) EVERY (4));
+CREATE
+create table help_distribution (a int, b int) distributed by (a);
+CREATE
+
+-- insert & verify test prerequisite: (2,2), (7,7) on seg0, (1,1) on seg1, (5,5) on seg2.
+insert into bad_distribution1 values(2,2), (1,1), (5, 5), (7, 7);
+INSERT 4
+insert into pbad_distribution1 values(2,2), (1,1), (5, 5), (7, 7);
+INSERT 4
+select gp_segment_id, * from bad_distribution1 order by a;
+ gp_segment_id | a | b 
+---------------+---+---
+ 1             | 1 | 1 
+ 0             | 2 | 2 
+ 2             | 5 | 5 
+ 0             | 7 | 7 
+(4 rows)
+delete from bad_distribution1 where a = 7;
+DELETE 1
+delete from pbad_distribution1 where a = 7;
+DELETE 1
+-- populate the help table.
+insert into help_distribution select s,s from generate_series(1,10) s;
+INSERT 10
+
+-- insert (7,7) on unexpected seg, i.e. seg2. Note 'insert into bad_distribution1 values(7,7)' does not work.
+2U: insert into bad_distribution1 select s,s from generate_series(7,7) s;
+INSERT 1
+2U: insert into pbad_distribution1_1_prt_2 select s,s from generate_series(7,7) s;
+INSERT 1
+2Uq: ... <quitting>
+
+analyze bad_distribution1;
+ANALYZE
+analyze pbad_distribution1;
+ANALYZE
+analyze help_distribution;
+ANALYZE
+
+-- Test update on distribution key. Expect error.
+update bad_distribution1 set a=a+1;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg2) (nodeModifyTable.c:1856)  (seg0 127.0.0.1:25432 pid=24218) (nodeModifyTable.c:1856)
+update pbad_distribution1 set a=a+1;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg2) (nodeModifyTable.c:1856)  (seg0 127.0.0.1:25432 pid=24218) (nodeModifyTable.c:1856)
+
+-- Test delete. Expect error for orca plan.
+explain verbose delete from bad_distribution1 using (select * from help_distribution where b < 20) s where s.a = bad_distribution1.b;
+ QUERY PLAN                                                                                                           
+----------------------------------------------------------------------------------------------------------------------
+ Delete on public.bad_distribution1  (cost=3.17..6.37 rows=2 width=16)                                                
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.17..6.37 rows=2 width=16)                     
+         Output: bad_distribution1.ctid, bad_distribution1.gp_segment_id, help_distribution.ctid                      
+         ->  Hash Join  (cost=3.17..6.37 rows=2 width=16)                                                             
+               Output: bad_distribution1.ctid, bad_distribution1.gp_segment_id, help_distribution.ctid                
+               Hash Cond: (help_distribution.a = bad_distribution1.b)                                                 
+               ->  Seq Scan on public.help_distribution  (cost=0.00..3.12 rows=4 width=10)                            
+                     Output: help_distribution.ctid, help_distribution.a                                              
+                     Filter: (help_distribution.b < 20)                                                               
+               ->  Hash  (cost=3.12..3.12 rows=2 width=14)                                                            
+                     Output: bad_distribution1.ctid, bad_distribution1.gp_segment_id, bad_distribution1.b             
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.12 rows=2 width=14)            
+                           Output: bad_distribution1.ctid, bad_distribution1.gp_segment_id, bad_distribution1.b       
+                           Hash Key: bad_distribution1.b                                                              
+                           ->  Seq Scan on public.bad_distribution1  (cost=0.00..3.04 rows=2 width=14)                
+                                 Output: bad_distribution1.ctid, bad_distribution1.gp_segment_id, bad_distribution1.b 
+ Optimizer: Postgres query optimizer                                                                                  
+ Settings: optimizer=off                                                                                              
+(18 rows)
+delete from bad_distribution1 using (select * from help_distribution where b < 20) s where s.a = bad_distribution1.b;
+DELETE 4
+delete from pbad_distribution1 using (select * from help_distribution where b < 20) s where s.a = pbad_distribution1.b;
+DELETE 4
+
+-- Test update on non-distribution key. Expect ok.
+update bad_distribution1 set b=b+1;
+UPDATE 0
+update pbad_distribution1 set b=b+1;
+UPDATE 0
+
+-- check the final results.
+select * from bad_distribution1 order by 1;
+ a | b 
+---+---
+(0 rows)
+select * from pbad_distribution1 order by 1;
+ a | b 
+---+---
+(0 rows)
+
+-- cleanup.
+drop table bad_distribution1;
+DROP
+drop table pbad_distribution1;
+DROP
+drop table help_distribution;
+DROP

--- a/src/test/isolation2/expected/modifytable_with_bad_distribution_optimizer.out
+++ b/src/test/isolation2/expected/modifytable_with_bad_distribution_optimizer.out
@@ -1,0 +1,117 @@
+-- start_matchsubs
+-- m/nodeDML.c:\d+/
+-- s/nodeDML.c:\d+/nodeDML.c:XXX/
+-- m/nodeModifyTable.c:\d+/
+-- s/nodeModifyTable.c:\d+/nodeModifyTable.c:XXX/
+-- end_matchsubs
+
+create table bad_distribution1 (a int, b int) distributed by (a);
+CREATE
+create table pbad_distribution1 (a int, b int) distributed by (a) PARTITION BY RANGE(a) (START(1) END(9) EVERY (4));
+CREATE
+create table help_distribution (a int, b int) distributed by (a);
+CREATE
+
+-- insert & verify test prerequisite: (2,2), (7,7) on seg0, (1,1) on seg1, (5,5) on seg2.
+insert into bad_distribution1 values(2,2), (1,1), (5, 5), (7, 7);
+INSERT 4
+insert into pbad_distribution1 values(2,2), (1,1), (5, 5), (7, 7);
+INSERT 4
+select gp_segment_id, * from bad_distribution1 order by a;
+ gp_segment_id | a | b 
+---------------+---+---
+ 1             | 1 | 1 
+ 0             | 2 | 2 
+ 2             | 5 | 5 
+ 0             | 7 | 7 
+(4 rows)
+delete from bad_distribution1 where a = 7;
+DELETE 1
+delete from pbad_distribution1 where a = 7;
+DELETE 1
+-- populate the help table.
+insert into help_distribution select s,s from generate_series(1,10) s;
+INSERT 10
+
+-- insert (7,7) on unexpected seg, i.e. seg2. Note 'insert into bad_distribution1 values(7,7)' does not work.
+2U: insert into bad_distribution1 select s,s from generate_series(7,7) s;
+INSERT 1
+2U: insert into pbad_distribution1_1_prt_2 select s,s from generate_series(7,7) s;
+INSERT 1
+2Uq: ... <quitting>
+
+analyze bad_distribution1;
+ANALYZE
+analyze pbad_distribution1;
+ANALYZE
+analyze help_distribution;
+ANALYZE
+
+-- Test update on distribution key. Expect error.
+update bad_distribution1 set a=a+1;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg2) (nodeDML.c:149)  (seg0 127.0.0.1:25432 pid=21878) (nodeDML.c:149)
+update pbad_distribution1 set a=a+1;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg2) (nodeDML.c:149)  (seg0 127.0.0.1:25432 pid=21878) (nodeDML.c:149)
+
+-- Test delete. Expect error for orca plan.
+explain verbose delete from bad_distribution1 using (select * from help_distribution where b < 20) s where s.a = bad_distribution1.b;
+ QUERY PLAN                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Delete  (cost=0.00..862.12 rows=2 width=1)                                                                                                
+   Output: bad_distribution1.a, bad_distribution1.b, "outer".ColRef_0018, bad_distribution1.ctid                                           
+   ->  Result  (cost=0.00..862.00 rows=2 width=22)                                                                                         
+         Output: bad_distribution1.a, bad_distribution1.b, bad_distribution1.ctid, bad_distribution1.gp_segment_id, 0                      
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=18)                                           
+               Output: bad_distribution1.a, bad_distribution1.b, bad_distribution1.ctid, bad_distribution1.gp_segment_id                   
+               Hash Key: bad_distribution1.a                                                                                               
+               ->  Hash Join  (cost=0.00..862.00 rows=2 width=18)                                                                          
+                     Output: bad_distribution1.a, bad_distribution1.b, bad_distribution1.ctid, bad_distribution1.gp_segment_id             
+                     Hash Cond: (bad_distribution1.b = help_distribution.a)                                                                
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=18)                               
+                           Output: bad_distribution1.a, bad_distribution1.b, bad_distribution1.ctid, bad_distribution1.gp_segment_id       
+                           Hash Key: bad_distribution1.b                                                                                   
+                           ->  Seq Scan on public.bad_distribution1  (cost=0.00..431.00 rows=2 width=18)                                   
+                                 Output: bad_distribution1.a, bad_distribution1.b, bad_distribution1.ctid, bad_distribution1.gp_segment_id 
+                     ->  Hash  (cost=431.00..431.00 rows=4 width=4)                                                                        
+                           Output: help_distribution.a                                                                                     
+                           ->  Seq Scan on public.help_distribution  (cost=0.00..431.00 rows=4 width=4)                                    
+                                 Output: help_distribution.a                                                                               
+                                 Filter: (help_distribution.b < 20)                                                                        
+ Optimizer: PQO version 3.32.2                                                                                                             
+(21 rows)
+delete from bad_distribution1 using (select * from help_distribution where b < 20) s where s.a = bad_distribution1.b;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg2) (nodeDML.c:149)  (seg0 127.0.0.1:25432 pid=21878) (nodeDML.c:149)
+delete from pbad_distribution1 using (select * from help_distribution where b < 20) s where s.a = pbad_distribution1.b;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg2) (nodeDML.c:149)  (seg0 127.0.0.1:25432 pid=21878) (nodeDML.c:149)
+
+-- Test update on non-distribution key. Expect ok.
+update bad_distribution1 set b=b+1;
+UPDATE 4
+update pbad_distribution1 set b=b+1;
+UPDATE 4
+
+-- check the final results.
+select * from bad_distribution1 order by 1;
+ a | b 
+---+---
+ 1 | 2 
+ 2 | 3 
+ 5 | 6 
+ 7 | 8 
+(4 rows)
+select * from pbad_distribution1 order by 1;
+ a | b 
+---+---
+ 1 | 2 
+ 2 | 3 
+ 5 | 6 
+ 7 | 8 
+(4 rows)
+
+-- cleanup.
+drop table bad_distribution1;
+DROP
+drop table pbad_distribution1;
+DROP
+drop table help_distribution;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -6,6 +6,9 @@ test: select_dropped_table
 # test update hash col under utility mode
 test: update_hash_col_utilitymode
 
+# test delete/update when there are tuples with wrong distribution on segments.
+test: modifytable_with_bad_distribution
+
 # Tests for crash recovery
 test: uao_crash_compaction_column
 test: uao_crash_compaction_row

--- a/src/test/isolation2/sql/modifytable_with_bad_distribution.sql
+++ b/src/test/isolation2/sql/modifytable_with_bad_distribution.sql
@@ -1,0 +1,50 @@
+-- start_matchsubs
+-- m/nodeDML.c:\d+/
+-- s/nodeDML.c:\d+/nodeDML.c:XXX/
+-- m/nodeModifyTable.c:\d+/
+-- s/nodeModifyTable.c:\d+/nodeModifyTable.c:XXX/
+-- end_matchsubs
+
+create table bad_distribution1 (a int, b int) distributed by (a);
+create table pbad_distribution1 (a int, b int) distributed by (a) PARTITION BY RANGE(a) (START(1) END(9) EVERY (4));
+create table help_distribution (a int, b int) distributed by (a);
+
+-- insert & verify test prerequisite: (2,2), (7,7) on seg0, (1,1) on seg1, (5,5) on seg2.
+insert into bad_distribution1 values(2,2), (1,1), (5, 5), (7, 7);
+insert into pbad_distribution1 values(2,2), (1,1), (5, 5), (7, 7);
+select gp_segment_id, * from bad_distribution1 order by a;
+delete from bad_distribution1 where a = 7;
+delete from pbad_distribution1 where a = 7;
+-- populate the help table.
+insert into help_distribution select s,s from generate_series(1,10) s;
+
+-- insert (7,7) on unexpected seg, i.e. seg2. Note 'insert into bad_distribution1 values(7,7)' does not work.
+2U: insert into bad_distribution1 select s,s from generate_series(7,7) s;
+2U: insert into pbad_distribution1_1_prt_2 select s,s from generate_series(7,7) s;
+2Uq:
+
+analyze bad_distribution1;
+analyze pbad_distribution1;
+analyze help_distribution;
+
+-- Test update on distribution key. Expect error.
+update bad_distribution1 set a=a+1;
+update pbad_distribution1 set a=a+1;
+
+-- Test delete. Expect error for orca plan.
+explain verbose delete from bad_distribution1 using (select * from help_distribution where b < 20) s where s.a = bad_distribution1.b;
+delete from bad_distribution1 using (select * from help_distribution where b < 20) s where s.a = bad_distribution1.b;
+delete from pbad_distribution1 using (select * from help_distribution where b < 20) s where s.a = pbad_distribution1.b;
+
+-- Test update on non-distribution key. Expect ok.
+update bad_distribution1 set b=b+1;
+update pbad_distribution1 set b=b+1;
+
+-- check the final results.
+select * from bad_distribution1 order by 1;
+select * from pbad_distribution1 order by 1;
+
+-- cleanup.
+drop table bad_distribution1;
+drop table pbad_distribution1;
+drop table help_distribution;


### PR DESCRIPTION
…there are tuples with bad distribution.

Data being stored with bad distribution is not unusal in real product
environment. There could be issues if the ctid for update/delete is distributed
to another segment. This patch will double check this and error out.