### PR TITLE
Don't compile python file in compile_gpdb.bash

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -140,7 +140,6 @@ function export_gpdb() {
   TARBALL="${GPDB_ARTIFACTS_DIR}/${GPDB_BIN_FILENAME}"
   pushd ${GREENPLUM_INSTALL_DIR}
     source greenplum_path.sh
-    python -m compileall -q -x test .
     chmod -R 755 .
     tar -czf "${TARBALL}" ./*
   popd
@@ -170,7 +169,6 @@ function export_gpdb_clients() {
   TARBALL="${GPDB_ARTIFACTS_DIR}/${GPDB_CL_FILENAME}"
   pushd ${GREENPLUM_CL_INSTALL_DIR}
     source ./greenplum_clients_path.sh
-    python -m compileall -q -x test .
     chmod -R 755 .
     tar -czf "${TARBALL}" ./*
   popd


### PR DESCRIPTION
There are some pyc files in bin and sbin folders of gpdb5/6 release
package and gpdb6 clients package. These files are not necessary for
release.
Root cause: compile_gpdb.bash runs "python -m compileall" when it compiles
gpdb.

We think there is no need to compile python when compiling gpdb,
so we just remove it.