### PR TITLE
Bring back pg_basebackup test for walsender configuration.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2185,7 +2185,7 @@ static struct config_int ConfigureNamesInt[] =
 		 * request and 1 WalSnd to serve the log streamer process started by
 		 * pg_basebackup.
 		 */
-		10, 2, MAX_BACKENDS,
+		10, 0, MAX_BACKENDS,
 		NULL, NULL, NULL
 	},
 

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Cwd;
 use TestLib;
-use Test::More tests => 33;
+use Test::More tests => 34;
 
 program_help_ok('pg_basebackup');
 program_version_ok('pg_basebackup');
@@ -31,23 +31,18 @@ system_or_bail 'pg_ctl', '-D', "$tempdir/pgdata", 'reload';
 command_fails(['pg_basebackup', '-D', "$tempdir/backup"],
 	'pg_basebackup fails without specifiying the target greenplum db id');
 
-
 #
-# GPDB: The minimum value of max_wal_senders is 2 in GPDB
+# GPDB: The default value of max_wal_senders is 10 in GPDB
 # instead of 0 in Postgres.
 #
-# This test is disabled because it is difficult to
-# set up an environment that consumes all of the slots
-# without setting up mirrors.
-#
-# open CONF, ">>$tempdir/pgdata/postgresql.conf";
-# print CONF "max_wal_senders = 0\n";
-# close CONF;
-# restart_test_server;
+open CONF, ">>$tempdir/pgdata/postgresql.conf";
+print CONF "max_wal_senders = 0\n";
+close CONF;
+restart_test_server;
 
-# command_fails(
-# 	[ 'pg_basebackup', '-D', "$tempdir/backup", '--target-gp-dbid', '123' ],
-# 	'pg_basebackup fails because of WAL configuration');
+command_fails(
+	[ 'pg_basebackup', '-D', "$tempdir/backup", '--target-gp-dbid', '123' ],
+	'pg_basebackup fails because of WAL configuration');
 
 open CONF, ">>$tempdir/pgdata/postgresql.conf";
 print CONF "max_wal_senders = 2\n";


### PR DESCRIPTION
Reset the max_wal_senders to match upstream, which allows us to reenable a TAP test for pg_basebackup. The GUC is still set to a reasonable default value for GPDB of ten.

