### PR TITLE
Don't check for existence of directory before mkdir -p

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -14,7 +14,7 @@ function set_env() {
 ## ----------------------------------------------------------------------
 
 function install_gpdb() {
-    [ ! -d /usr/local/greenplum-db-devel ] && mkdir -p /usr/local/greenplum-db-devel
+    mkdir -p /usr/local/greenplum-db-devel
     tar -xzf bin_gpdb/bin_gpdb.tar.gz -C /usr/local/greenplum-db-devel
 }
 


### PR DESCRIPTION
mkdir -p does that for us.

Note that the install_gpdb function is referenced by many other scripts
and repositories, such as gp-release.

Co-authored-by: Amil Khanzada <akhanzada@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>