### PR TITLE
5X: Fix missing pipeline file of 5X_STABLE

### DIFF
--- a/concourse/tasks/test_with_planner_conan.yml
+++ b/concourse/tasks/test_with_planner_conan.yml
@@ -1,0 +1,18 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: gpdb/centos-gpdb-dev-conan
+    tag: 7-gcc6.2-llvm3.7
+inputs:
+- name: gpdb_src
+- name: bin_gpdb
+outputs:
+- name: icg_output
+run:
+  path: gpdb_src/concourse/scripts/test_gpdb.py
+  args:
+  - --mode=planner
+  - --gpdb_name=bin_gpdb
+params:
+  TEST_SUITE: "icg"


### PR DESCRIPTION
"c1ad13908d - Fix configure call in test_gpdb.py" removed
test_with_planner_conan.yml, I believe it's by accident because the
commit "e36d0b3ea5" which it "cherry picked" from has no such changes.