### PR TITLE
Always wait until the distributed transactions are recovered

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -893,9 +893,6 @@ cdbcomponent_getComponentInfo(int contentId)
 void
 cdb_setup(void)
 {
-	int	i;
-	static const int DtxRecoveryWaitTime = 40;
-
 	elog(DEBUG1, "Initializing Greenplum components...");
 
 	/* If gp_role is UTILITY, skip this call. */
@@ -911,16 +908,12 @@ cdb_setup(void)
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH && !*shmDtmStarted)
 	{
-		for (i = 0; i < DtxRecoveryWaitTime; i++)
+		while (true)
 		{
 			pg_usleep(100 * 1000); /* 100ms */
 			if (*shmDtmStarted)
-				return;
+				break;
 		}
-
-		ereport(FATAL,
-				(errcode(ERRCODE_CANNOT_CONNECT_NOW),
-				 errmsg("the database system is recovering distributed transactions")));
 	}
 }
 


### PR DESCRIPTION
In commit 48cb340d41, we spawn a dedicated process to recovery distributed
transaction, newly requested connections will error out if dtx can't be
recovered in 4 seconds. This sounds correct to error out quickly because the
system is indeed unavailable, however, for some utilities like gpstart and
gprecoverseg, an error like this will be treated as a very scary issue and
will fail the utilities.

4 seconds is designed to notify the users as soon as possible, now it seems
better to keep the old behave before 48cb340d41 which is always waiting until
the dtx is recovered.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
