### PR TITLE
Remove sanity assertion for itempointer offsetnumber

### DIFF
--- a/src/backend/access/gin/ginpostinglist.c
+++ b/src/backend/access/gin/ginpostinglist.c
@@ -86,7 +86,6 @@ itemptr_to_uint64(const ItemPointer iptr)
 	uint64		val;
 
 	Assert(ItemPointerIsValid(iptr));
-	Assert(iptr->ip_posid < (1 << MaxHeapTuplesPerPageBits));
 
 	val = iptr->ip_blkid.bi_hi;
 	val <<= 16;


### PR DESCRIPTION
Commit 99360f544ea55201afec791a36a733c7684156 extended the offset numbers in the GIN posting list to 16 bits over upstream who use 11 bits. This however means that the assertion around `ip_posid` is no longer valid as it's always true, causing a compiler warning:
```
ginpostinglist.c:89:24: warning: result of comparison of constant 65536 with expression of type 'OffsetNumber' (aka 'unsigned short') is always true
[-Wtautological-constant-out-of-range-compare]
Assert(iptr->ip_posid < (1 << MaxHeapTuplesPerPageBits));
~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../src/include/c.h:784:10: note: expanded from macro 'Assert'
Trap(!(condition), "FailedAssertion")
~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../src/include/c.h:766:28: note: expanded from macro 'Trap'
if ((assert_enabled) && (condition))
^~~~~~~~~
1 warning generated.
```
Fix by removing the assertion, even though it will cause a merge conflict in the future (anything we do will cause a conflict and this seems like the least bad option).

Reported by  @yydzero in #7314 