### PR TITLE
Move gp_segment_connect_timeout upper in dispatch test to make ICW test stable

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -244,10 +244,10 @@ select cleanupAllGangs();
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 
+set gp_segment_connect_timeout to 0;
+
 select gp_inject_fault('process_startup_packet', 'resume', 2);
 select gp_inject_fault('process_startup_packet', 'reset', 2);
-
-set gp_segment_connect_timeout to 0;
 
 select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 1, 2, 2::smallint);
 

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -421,6 +421,7 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 ERROR:  failed to acquire resources on one or more segments
 DETAIL:  timeout expired
  (seg0 127.0.0.1:40000)
+set gp_segment_connect_timeout to 0;
 select gp_inject_fault('process_startup_packet', 'resume', 2);
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
  gp_inject_fault 
@@ -435,7 +436,6 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
  t
 (1 row)
 
-set gp_segment_connect_timeout to 0;
 select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 1, 2, 2::smallint);
 NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11337)
  gp_inject_fault 


### PR DESCRIPTION
Move `gp_segment_connect_timeout` before `gp_inject_fault` in dispatch test to make the
ICW stable in a slow system. The previous `gp_segment_connect_timeout` is
set to 1 second, which my cause `gp_inject_fault` timeout if the system is slow.

Co-authored-by: Tang Pengzhou <ptang@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
