### PR TITLE
Backport 6X - Enable OpenSSL on the PR pipeline.

### DIFF
--- a/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
+++ b/concourse/scripts/compile_gpdb_open_source_ubuntu.bash
@@ -38,6 +38,7 @@ function build_gpdb() {
           --with-perl \
           --with-libxml \
           --with-python \
+	  --with-openssl \
           --enable-debug-extensions \
           --with-libraries=${CWD}/depends/build/lib \
           --with-includes=${CWD}/depends/build/include \

--- a/concourse/scripts/test_gpdb.py
+++ b/concourse/scripts/test_gpdb.py
@@ -53,6 +53,7 @@ def configure():
                             "--with-perl",
                             "--with-libxml",
                             "--with-python",
+                            "--with-openssl",
                             # TODO: remove this flag after zstd is vendored in the installer for ubuntu
                             "--without-zstd",
                             "--with-libs=/usr/local/gpdb/lib",


### PR DESCRIPTION
(cherry picked from commit 5e918bf6fae53819e464548763f50a20fc9d5d5a)

Backports PR https://github.com/greenplum-db/gpdb/pull/7323 to 6X_STABLE
