### PR TITLE
Lower the log level of the fts probe while unpacking response.

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -621,7 +621,7 @@ probeRecordResponse(fts_segment_info *ftsInfo, PGresult *result)
 	Assert (retryRequested);
 	ftsInfo->result.retryRequested = *retryRequested;
 
-	elogif(gp_log_fts >= GPVARS_VERBOSITY_TERSE, LOG,
+	elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "FTS: segment (content=%d, dbid=%d, role=%c) reported "
 		   "isMirrorUp %d, isInSync %d, isSyncRepEnabled %d, "
 		   "isRoleMirror %d, and retryRequested %d to the prober.",


### PR DESCRIPTION
The level of TERSE or greater was set during development, we can lower
this to DEBUG now that this feature has stablized.

We'll need to backport this to 6X too.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
