### PR TITLE
docs - revisit dblink module doc contents

### DIFF
--- a/gpdb-doc/dita/ref_guide/modules/dblink.xml
+++ b/gpdb-doc/dita/ref_guide/modules/dblink.xml
@@ -2,28 +2,35 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_lv4_czp_fz">
   <title>dblink</title>
-  <shortdesc>The <codeph>dblink</codeph> module supports connections to other Greenplum Database
-    databases from within a database session. These databases can reside in the same Greenplum
-    Database system, or in a remote system. </shortdesc>
   <body>
-    <p>Greenplum Database supports <codeph>dblink</codeph> connections between databases in
-      Greenplum Database installations with the same major version number. <codeph>dblink</codeph>
-      may also connect to other Greenplum Database installations that use compatible
-        <codeph>libpq</codeph> libraries.</p>
-    <p>You create a <codeph>dblink</codeph> connection to a database and execute an SQL command in
-      the database as a Greenplum Database user. The user must have the appropriate access
-      privileges to the database tables referenced in the SQL command. If the database is in a
-      remote system, the user must be defined as a Greenplum Database user in the remote system with
-      the appropriate access privileges. </p>
-    <p><codeph>dblink</codeph> is intended for database users to perform short ad hoc queries in
-      other databases. <codeph>dblink</codeph> is not intended for use as a replacement for external
-      tables or for administrative tools such as <codeph>gpcopy</codeph>.</p>
-    <p>Refer to <xref href="https://www.postgresql.org/docs/9.4/dblink.html" format="html"
-        scope="external">dblink</xref> in the PostgreSQL documentation for more information about
-      individual <codeph>dblink</codeph> functions. </p>
+    <p>The <codeph>dblink</codeph> module supports connections to other Greenplum Database
+      databases from within a database session. These databases can reside in the same Greenplum
+      Database system, or in a remote system.</p>
+      <p>Greenplum Database supports <codeph>dblink</codeph> connections between databases
+        in Greenplum Database installations with the same major version number. You can also
+        use <codeph>dblink</codeph> to connect to other Greenplum Database installations that
+        use compatible <codeph>libpq</codeph> libraries.</p>
+      <note><codeph>dblink</codeph> is intended for database users to perform short ad hoc queries in
+        other databases. <codeph>dblink</codeph> is not intended for use as a replacement for external
+        tables or for administrative tools such as <codeph>gpcopy</codeph>.</note>
+    <p>The Greenplum Database <codeph>dblink</codeph> module is a modified version of the
+       PostgreSQL <codeph>dblink</codeph> module. There are some restrictions and
+       limitations when you use the module in Greenplum Database.</p>
   </body>
-  <topic id="topic_ikh_dsm_bdb">
-    <title>Limitations</title>
+  <topic id="topic_reg">
+    <title>Installing and Registering the Module</title>
+    <body>
+      <p>The <codeph>dblink</codeph> module is installed when you install
+        Greenplum Database. Before you can use any of the functions defined in the
+        module, you must register the <codeph>dblink</codeph> extension in
+        each database in which you want to use the functions.
+        <ph otherprops="pivotal">Refer to <xref href="../../install_guide/install_modules.xml"
+          format="dita" scope="peer">Installing Additional Supplied Modules</xref>
+        for more information.</ph></p>
+    </body>
+  </topic>
+  <topic id="topic_mpp">
+    <title>Greenplum Database Considerations</title>
     <body>
       <p>In this release of Greenplum Database, statements that modify table data cannot use named
         or implicit <codeph>dblink</codeph> connections. Instead, you must provide the connection
@@ -40,17 +47,13 @@ INSERT 0 2</codeblock></p>
         </ul></p>
     </body>
   </topic>
-  <topic id="topic_tvb_csm_bdb">
+  <topic id="topic_using">
     <title>Using dblink</title>
     <body>
       <p>The following procedure identifies the basic steps for configuring and using
           <codeph>dblink</codeph> in Greenplum Database. The examples use
           <codeph>dblink_connect()</codeph> to create a connection to a database and
           <codeph>dblink()</codeph> to execute an SQL query. </p>
-      <p>Only superusers can use <codeph>dblink_connect()</codeph> to create connections that do not
-        require a password. If non-superusers need this capability, use
-          <codeph>dblink_connect_u()</codeph> instead. See <xref href="#topic_tvb_csm_bdb/dblink_u"
-          format="dita"/>.</p>
       <ol id="ol_axw_csm_bdb">
         <li>Begin by creating a sample table to query using the <codeph>dblink</codeph> functions.
           These commands create a small table in the <codeph>postgres</codeph> database, which you
@@ -77,7 +80,7 @@ testdb=# <b>CREATE EXTENSION dblink</b>;
 CREATE EXTENSION</codeblock></li>
         <li>Use the <codeph>dblink_connect()</codeph> function to create either an implicit or a
           named connection to another database. The connection string that you provide should be a
-          libpq-style keyword/value string. This example creates a connection named
+          <codeph>libpq</codeph>-style keyword/value string. This example creates a connection named
             <codeph>mylocalconn</codeph> to the <codeph>postgres</codeph> database on the local
           Greenplum Database system:<codeblock>testdb=# <b>SELECT dblink_connect('mylocalconn', 'dbname=postgres user=gpadmin');</b>
  dblink_connect
@@ -121,8 +124,10 @@ CREATE EXTENSION</codeblock></li>
             <codeph>dblink_connect_u()</codeph> function is identical to
             <codeph>dblink_connect()</codeph>, except that it allows non-superusers to create
           connections that do not require a password. </p>
-        <p>In some situations, it may be appropriate to grant <codeph>EXECUTE</codeph> permission on
-            <codeph>dblink_connect_u()</codeph> to specific users who are considered trustworthy,
+        <p><codeph>dblink_connect_u()</codeph> is initially installed with all privileges
+          revoked from <codeph>PUBLIC</codeph>, making it un-callable except by superusers.
+          In some situations, it may be appropriate to grant <codeph>EXECUTE</codeph> permission on
+          <codeph>dblink_connect_u()</codeph> to specific users who are considered trustworthy,
           but this should be done with care.</p>
         <note type="warning">If a Greenplum Database system has configured users with an
           authentication method that does not involve a password, then impersonation and subsequent
@@ -133,7 +138,8 @@ CREATE EXTENSION</codeblock></li>
             <codeph>trust</codeph> authentication. <p>Also, even if the <codeph>dblink</codeph>
             connection requires a password, it is possible for the password to be supplied from the
             server environment, such as a <codeph>~/.pgpass</codeph> file belonging to the server's
-            user.</p></note>
+            user. It is recommended that any <codeph>~/.pgpass</codeph> file belonging to the
+            server's user not contain any records specifying a wildcard host name.</p></note>
         <ol id="ol_dpt_ll3_5fb">
           <li>As a superuser, grant the <codeph>EXECUTE</codeph> privilege on the
               <codeph>dblink_connect_u()</codeph> functions in the user database. This example
@@ -156,6 +162,14 @@ testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_u(text, text) TO test_user;
             table.<codeblock>testdb=> <b>SELECT * FROM dblink('testconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b></codeblock></li>
         </ol>
       </section>
+    </body>
+  </topic>
+  <topic id="topic_info">
+    <title>Additional Module Documentation</title>
+    <body>
+      <p>Refer to <xref href="https://www.postgresql.org/docs/9.4/dblink.html" format="html"
+        scope="external">dblink</xref> in the PostgreSQL documentation for detailed
+        information about the individual functions in this module.</p>
     </body>
   </topic>
 </topic>

--- a/gpdb-doc/dita/ref_guide/modules/intro.xml
+++ b/gpdb-doc/dita/ref_guide/modules/intro.xml
@@ -17,8 +17,7 @@
               >citext</xref></codeph> - Provides a case-insensitive, multibyte-aware text
           data type.</li>
        <li><codeph><xref href="dblink.xml" scope="peer" format="dita"
-              >dblink</xref></codeph> - Provides connections to other Greenplum and PostgreSQL
-         databases.</li>
+              >dblink</xref></codeph> - Provides connections to other Greenplum databases.</li>
        <li><codeph><xref href="fuzzystrmatch.xml" scope="peer"
              format="dita">fuzzystrmatch</xref></codeph> - Determines similarities and differences
          between strings.</li>


### PR DESCRIPTION
unify the organization and content of the docs for additional supplied modules. for dblink:
- identify that the module has greenplum considerations
- xref to module install/registration page
- keep the current "using" content, enhance with some info from postgres 9.4 dblink docs
- xref to dblink module docs

doc review site link:  http://docs-lisa-dblink.cfapps.io/6-0/ref_guide/modules/dblink.html