### PR TITLE
Remove non-existent gptest.py and test_fsync from NON_PRODUCTION_FILES

### DIFF
--- a/gpAux/releng/NON_PRODUCTION_FILES.txt
+++ b/gpAux/releng/NON_PRODUCTION_FILES.txt
@@ -1,7 +1,5 @@
 bin/explain.pl
 bin/explain.pm
 bin/gptorment.pl
-bin/lib/gptest.py
 bin/pgbench
 bin/postgresql_conf_gp_additions
-bin/test_fsync


### PR DESCRIPTION
These files don't exist in the gpdb repo, nor the bin_gpdb tar.gz
resources in Concourse for 6 or 5 as far as we can tell.

Co-authored-by: Amil Khanzada <akhanzada@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>