### PR TITLE
Fix the wildcard for separate_qautils_files_for_rc

### DIFF
--- a/concourse/scripts/separate_qautils_files_for_rc.bash
+++ b/concourse/scripts/separate_qautils_files_for_rc.bash
@@ -9,7 +9,7 @@ main() {
   QAUTILS_DIR="$(mktemp -d)"
 
   INTERMEDIATE_PLACE="$(mktemp -d)"
-  tar zxf "$INPUT_TARBALL" -C "$INTERMEDIATE_PLACE"
+  tar zxf $INPUT_TARBALL -C "$INTERMEDIATE_PLACE"
 
   pushd "$INTERMEDIATE_PLACE"
     echo "Move files listed in $ABS_QAUTILS_FILES"


### PR DESCRIPTION
  eg. tar xzf "*.tar.gz" does not work.

  Remove the double quotes, it works

Authored-by: Bob Bao <bbao@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
