### PR TITLE
Re-enable SRF-in-targetlist support for Window nodes.

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2461,6 +2461,14 @@ typedef struct WindowState
 
 	/* Indicate if child is done returning tuples */
 	bool	    is_input_done;
+
+	/*
+	 * Most executor nodes in GPDB don't support SRFs in target lists, the
+	 * planner tries to insulate them from SRFs by adding Result nodes. But
+	 * WindowAgg needs to handle them, because a Result can't evaluate
+	 * WindowFunc, which an WindowAgg's target list usually has.
+	 */
+	bool        ps_TupFromTlist;
 } WindowState;
 
 /* ----------------

--- a/src/test/regress/expected/olap_window.out
+++ b/src/test/regress/expected/olap_window.out
@@ -8343,3 +8343,26 @@ FROM
      2
 (1 row)
 
+-- check SRF in Window's targetlist can be handled correctly
+explain
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Window  (cost=62.33..69.83 rows=1000 width=4)
+   Order By: a
+   ->  Sort  (cost=62.33..64.83 rows=1000 width=4)
+         Sort Key: a
+         ->  Function Scan on generate_series a  (cost=0.00..12.50 rows=1000 width=4)
+ Settings:  gp_enable_sequential_window_plans=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+ unnest | rank 
+--------+------
+      2 |    1
+      2 |    1
+      3 |    2
+      3 |    2
+(4 rows)
+

--- a/src/test/regress/expected/olap_window_optimizer.out
+++ b/src/test/regress/expected/olap_window_optimizer.out
@@ -8346,3 +8346,27 @@ FROM
      2
 (1 row)
 
+-- check SRF in Window's targetlist can be handled correctly
+explain
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Result  (cost=0.00..0.25 rows=334 width=12)
+   ->  Window  (cost=0.00..0.23 rows=334 width=12)
+         Order By: generate_series
+         ->  Sort  (cost=0.00..0.23 rows=334 width=4)
+               Sort Key: generate_series
+               ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
+ Settings:  gp_enable_sequential_window_plans=off
+ Optimizer status: PQO version 3.32.0
+(8 rows)
+
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+ unnest | rank 
+--------+------
+      2 |    1
+      2 |    1
+      3 |    2
+      3 |    2
+(4 rows)
+

--- a/src/test/regress/sql/olap_window.sql
+++ b/src/test/regress/sql/olap_window.sql
@@ -1634,3 +1634,9 @@ FROM
   GROUP BY name,device_model
   HAVING COUNT(DISTINCT CASE WHEN ppp > 0 THEN device_id ELSE NULL END)>0
 ) b;
+
+-- check SRF in Window's targetlist can be handled correctly
+explain
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
+
+select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;


### PR DESCRIPTION
We've removed SRF-in-targetlist support for most node types in GPDB.
Instead, we insert Result nodes to evaluate the set-returning-functions.
This can be benefit to performance.

However, Result node cannot evaluate WindowRef, which an Window's target
list usually has. So we need to support SRF-in-targetlist for Window
nodes.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
