### PR TITLE
6X: Add deserialization method for lockingclause

### DIFF
--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2906,6 +2906,18 @@ _readLockRows(void)
 	READ_DONE();
 }
 
+static LockingClause *
+_readLockingClause(void)
+{
+	READ_LOCALS(LockingClause);
+
+	READ_NODE_FIELD(lockedRels);
+	READ_ENUM_FIELD(strength, LockClauseStrength);
+	READ_BOOL_FIELD(noWait);
+
+	READ_DONE();
+}
+
 static Node *
 _readValue(NodeTag nt)
 {
@@ -3844,6 +3856,9 @@ readNodeBinary(void)
 				break;
 			case T_AlterTableMoveAllStmt:
 				return_value = _readAlterTableMoveAllStmt();
+				break;
+			case T_LockingClause:
+				return_value = _readLockingClause();
 				break;
 			default:
 				return_value = NULL; /* keep the compiler silent */

--- a/src/test/regress/expected/rules.out
+++ b/src/test/regress/expected/rules.out
@@ -2727,3 +2727,7 @@ SELECT pg_get_functiondef('func_with_set_params()'::regprocedure);
  
 (1 row)
 
+-- test rule for select-for-update
+create table t_test_rules_select_for_update (c int) distributed randomly;
+create rule myrule as on insert to t_test_rules_select_for_update
+do instead select * from t_test_rules_select_for_update for update;

--- a/src/test/regress/sql/rules.sql
+++ b/src/test/regress/sql/rules.sql
@@ -1035,3 +1035,8 @@ CREATE FUNCTION func_with_set_params() RETURNS integer
     SET search_path TO PG_CATALOG, "Mixed/Case", 'c:/''a"/path', '', '0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'
     IMMUTABLE STRICT;
 SELECT pg_get_functiondef('func_with_set_params()'::regprocedure);
+
+-- test rule for select-for-update
+create table t_test_rules_select_for_update (c int) distributed randomly;
+create rule myrule as on insert to t_test_rules_select_for_update
+do instead select * from t_test_rules_select_for_update for update;


### PR DESCRIPTION
`create rule <...> do instead select * from t for update`
will dispatch a query with lockingclause node. Add
deserialization method for it to make things correct.

----------

This is a cherry-pick (of the pr: https://github.com/greenplum-db/gpdb/pull/7345 ) from the master. It has been merged in master branch (already reviewed).

This PR is waiting for PM's green light and waiting for pipeline turning green.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
