### PR TITLE
Adding options to generate diff files to plan comparison script

### DIFF
--- a/concourse/scripts/perfsummary.py
+++ b/concourse/scripts/perfsummary.py
@@ -222,7 +222,7 @@ class FileState:
             if int(diffLevel) <= int(planDiffs):
                 baseTime = float(base.query_exe_time_map[q])
                 testTime = float(self.query_exe_time_map[q])
-                if testTime > baseTime * (1+float(diffThreshold)/100.0):
+                if testTime > baseTime * (1+float(diffThreshold)/100.0) or testTime < 0:
                     baseFileName = diffDir + "/base/" + q + ".plan"
                     testFileName = diffDir + "/test/" + q + ".plan"
                     with open(baseFileName, 'w') as fb:

--- a/concourse/scripts/perfsummary.py
+++ b/concourse/scripts/perfsummary.py
@@ -241,7 +241,7 @@ def main():
     parser.add_argument('--baseLog',
                         help='specify a log file from a base version to compare to')
     parser.add_argument('--diffDir',
-                        help='specify a directory to place diffs into')
+                        help='request diff files to be created and specify a directory to place diffs into')
     parser.add_argument('--diffThreshold',
                         help='specify a numerical threshold to record plan diffs with a performance regression of more than n percent')
     parser.add_argument('--diffLevel',
@@ -251,14 +251,11 @@ def main():
 
     inputfile = args.log_file
     basefile = args.baseLog
-    makeDiffs = (args.diffThreshold != None or args.diffLevel != None)
+    makeDiffs = (args.diffDir != None)
     diffDir = ""
     diffThreshold = -100
     diffLevel = 4
     if makeDiffs:
-        if args.diffDir == None:
-            print "Please specify a directory for the base and test plan files with the --diffDir <dir> options"
-            exit(1)
         # remove trailing slash, if it exists
         diffDir = re.sub(r'(.*)/$','\1', args.diffDir)
         try:
@@ -271,10 +268,14 @@ def main():
         if args.diffThreshold != None:
             diffThreshold = args.diffThreshold
             if args.diffLevel == None:
-                # if only diffThreshold is specify, then default diffLevel to COST_CHANGES
+                # if only diffThreshold is specified, then default diffLevel to COST_CHANGES
                 args.diffLevel = COST_CHANGES
         if args.diffLevel != None:
             diffLevel = args.diffLevel
+    else:
+        if (args.diffThreshold != None or args.diffLevel != None):
+            print "Please specify the --diffDir option with a directory name to request diff files\n"
+            exit(1)
 
     if inputfile is None:
         print "Expected the name of a log file with test suite queries\n"

--- a/concourse/scripts/perfsummary.py
+++ b/concourse/scripts/perfsummary.py
@@ -270,6 +270,9 @@ def main():
             exit(1)
         if args.diffThreshold != None:
             diffThreshold = args.diffThreshold
+            if args.diffLevel == None:
+                # if only diffThreshold is specify, then default diffLevel to COST_CHANGES
+                args.diffLevel = COST_CHANGES
         if args.diffLevel != None:
             diffLevel = args.diffLevel
 

--- a/concourse/scripts/perfsummary.py
+++ b/concourse/scripts/perfsummary.py
@@ -92,7 +92,11 @@ class FileState:
             self.query_comment_map[query_id] = self.comment1
         else:
             self.query_comment_map[query_id] = self.comment2
-        self.query_explain_plan_map[query_id] = self.plans[seq_num]
+        if len(self.plans) > seq_num:
+            self.query_explain_plan_map[query_id] = self.plans[seq_num]
+        else:
+            self.query_explain_plan_map[query_id] = "error - no plan found"
+            self.query_comment_map[query_id] += "error - no plan found"
 
     # process a single line of a log file
     def processLogFileLine(self, line_lf):


### PR DESCRIPTION
The script used in pipelines that search for explain plan changes
lists those queries that have cost, row or plan changes. In many
cases the user will want to investigate those changes further.

A new set of options generates two directories that are easy to
compare, one contains the baseline plans, one file per plan, and
the other contains the changed plans of the test.

```
$ ~/workspace/gpdb/concourse/scripts/perfsummary.py --help
usage: perfsummary.py [-h] [--baseLog BASELOG] [--diffDir DIFFDIR]
                      [--diffThreshold DIFFTHRESHOLD] [--diffLevel DIFFLEVEL]
                      [log_file]

Summarize the test suite execute and explain log

positional arguments:
  log_file              log file with explain/execute output

optional arguments:
  -h, --help            show this help message and exit
  --baseLog BASELOG     specify a log file from a base version to compare to
  --diffDir DIFFDIR     specify a directory to place diffs into
  --diffThreshold DIFFTHRESHOLD
                        specify a numerical threshold to record plan diffs
                        with a performance regression of more than n percent
  --diffLevel DIFFLEVEL
                        specify which diff files to generate: 1 = all diffs, 2
                        = ignore cost diffs, 3 = plan diffs only
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
