### PR TITLE
Lint separate_qautils_files_for_rc.bash / Support globs for INPUT_TARBALL

### DIFF
--- a/concourse/scripts/separate_qautils_files_for_rc.bash
+++ b/concourse/scripts/separate_qautils_files_for_rc.bash
@@ -15,21 +15,21 @@ main() {
 
   pushd "$INTERMEDIATE_PLACE"
     echo "Move files listed in $ABS_QAUTILS_FILES"
-    while read file; do
+    while read -r file; do
       if [ -f "$file" ]; then
-	TARGET_QAUTILS_DIR="$QAUTILS_DIR"/`dirname $file`
-	echo "Moving $file to directory $TARGET_QAUTILS_DIR"
-	mkdir -p "$TARGET_QAUTILS_DIR"
-	mv "$file" "$TARGET_QAUTILS_DIR"
+        TARGET_QAUTILS_DIR="$QAUTILS_DIR/$(dirname "$file")"
+        echo "Moving $file to directory $TARGET_QAUTILS_DIR"
+        mkdir -p "$TARGET_QAUTILS_DIR"
+        mv "$file" "$TARGET_QAUTILS_DIR"
       else
-	echo "File $file does not exists, skipping moving it"
+        echo "File $file does not exist, skipping moving it"
       fi
     done < "$ABS_QAUTILS_FILES"
-    tar czf "$ABS_PATH_OUTPUT_TARBALL" *
+    tar czf "$ABS_PATH_OUTPUT_TARBALL" -- *
   popd
 
   pushd "$QAUTILS_DIR"
-    tar czf "$ABS_PATH_QAUTILS_TARBALL" *
+    tar czf "$ABS_PATH_QAUTILS_TARBALL" -- *
   popd
 }
 

--- a/concourse/scripts/separate_qautils_files_for_rc.bash
+++ b/concourse/scripts/separate_qautils_files_for_rc.bash
@@ -9,7 +9,9 @@ main() {
   QAUTILS_DIR="$(mktemp -d)"
 
   INTERMEDIATE_PLACE="$(mktemp -d)"
-  tar zxf $INPUT_TARBALL -C "$INTERMEDIATE_PLACE"
+
+  # use eval/ls to expand any globs in the input param
+  tar zxf "$(eval ls "${INPUT_TARBALL}")" -C "$INTERMEDIATE_PLACE"
 
   pushd "$INTERMEDIATE_PLACE"
     echo "Move files listed in $ABS_QAUTILS_FILES"


### PR DESCRIPTION
    Lint separate_qautils_files_for_rc.bash

    - use read -r to avoid mangling backslashes
    - use consistent indentation
    - use '-- *' instead of '*' to avoid files w/ dashes being interpreted as
      options to `tar`

    Support globs for INPUT_TARBALL

    Bash does not expand glob patterns inside of double quotes. Rather than
    remove the quoting and risk unintentional word splitting, we use `eval`
    and `ls` to expand globs passed in via a Concourse task param.

    Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>
    Co-authored-by: Amil Khanzada <akhanzada@pivotal.io>