### PR TITLE
Improve monitability of query_info_collect_hook to SPI queries

### DIFF
--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -590,6 +590,9 @@ init_execution_state(List *queryTree_list,
 			else
 				stmt = (Node *) pg_plan_query(queryTree, 0, NULL);
 
+	 		if (IsA(stmt, PlannedStmt))
+				((PlannedStmt*)stmt)->metricsQueryType = FUNCTION_INNER_QUERY;
+
 			/*
 			 * Precheck all commands for validity in a function.  This should
 			 * generally match the restrictions spi.c applies.
@@ -918,7 +921,7 @@ postquel_start(execution_state *es, SQLFunctionCachePtr fcache)
 								 InvalidSnapshot,
 								 dest,
 								 fcache->paramLI,
-								 GP_INSTRUMENT_OPTS);
+								 INSTRUMENT_NONE);
 
 		/* GPDB hook for collecting query info */
 		if (query_info_collect_hook)

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1256,6 +1256,7 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	CachedPlan *cplan;
 	List	   *stmt_list;
 	char	   *query_string;
+	ListCell   *lc;
 	Snapshot	snapshot;
 	MemoryContext oldcontext;
 	Portal		portal;
@@ -1327,6 +1328,14 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	/* Replan if needed, and increment plan refcount for portal */
 	cplan = GetCachedPlan(plansource, paramLI, false, NULL);
 	stmt_list = cplan->stmt_list;
+
+	/* GPDB: Mark all queries as SPI inner queries for extension usage */
+	foreach(lc, stmt_list)
+	{
+		Node *stmt = (Node *) lfirst(lc);
+		if (IsA(stmt, PlannedStmt))
+			((PlannedStmt*)stmt)->metricsQueryType = SPI_INNER_QUERY;
+	}
 
 	/* Pop the error context stack */
 	error_context_stack = spierrcontext.previous;
@@ -2213,7 +2222,10 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 
 			if (IsA(stmt, PlannedStmt))
 			{
-				canSetTag = ((PlannedStmt *) stmt)->canSetTag;
+				PlannedStmt* pstmt = (PlannedStmt *) stmt;
+				canSetTag = pstmt->canSetTag;
+				/* GPDB: Mark all queries as SPI inner query for extension usage */
+				((PlannedStmt*)pstmt)->metricsQueryType = SPI_INNER_QUERY;
 			}
 			else
 			{

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -132,6 +132,7 @@ _copyPlannedStmt(const PlannedStmt *from)
 
 	COPY_NODE_FIELD(intoClause);
 	COPY_NODE_FIELD(copyIntoClause);
+	COPY_SCALAR_FIELD(metricsQueryType);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -375,6 +375,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
+	WRITE_UINT_FIELD(metricsQueryType);
 }
 
 static void

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -323,6 +323,7 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
+	WRITE_UINT_FIELD(metricsQueryType);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1427,6 +1427,7 @@ _readPlannedStmt(void)
 	READ_UINT64_FIELD(query_mem);
 	READ_NODE_FIELD(intoClause);
 	READ_NODE_FIELD(copyIntoClause);
+	READ_UINT_FIELD(metricsQueryType);
 	READ_DONE();
 }
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -144,6 +144,11 @@ typedef struct PlannedStmt
 	 */
 	IntoClause *intoClause;
 	CopyIntoClause *copyIntoClause;
+
+	/* 
+ 	 * GPDB: whether a query is a SPI inner query for extension usage 
+ 	 */
+	uint		metricsQueryType;
 } PlannedStmt;
 
 /*

--- a/src/include/utils/metrics_utils.h
+++ b/src/include/utils/metrics_utils.h
@@ -15,6 +15,11 @@
 #ifndef METRICS_UTILS_H
 #define METRICS_UTILS_H 
 
+/* whether the query is a spi/function inner/top-level query or for extension usage */
+#define	TOP_LEVEL_QUERY 	 (0U)
+#define	SPI_INNER_QUERY 	 (1U)
+#define	FUNCTION_INNER_QUERY 	 (2U)
+
 typedef enum
 {	
 	METRICS_PLAN_NODE_INITIALIZE = 100,
@@ -26,7 +31,9 @@ typedef enum
 	METRICS_QUERY_DONE,
 	METRICS_QUERY_ERROR,
 	METRICS_QUERY_CANCELING,
-	METRICS_QUERY_CANCELED
+	METRICS_QUERY_CANCELED,
+
+	METRICS_INNER_QUERY_DONE = 300
 } QueryMetricsStatus;
 
 typedef void (*query_info_collect_hook_type)(QueryMetricsStatus, void *);

--- a/src/test/regress/input/query_info_hook_test.source
+++ b/src/test/regress/input/query_info_hook_test.source
@@ -24,3 +24,28 @@ ALTER TABLE queryInfoHookTable1 SET DISTRIBUTED BY (name);
 -- Test Hash node
 CREATE TABLE tb_a(a int);
 SELECT a FROM tb_a WHERE a IN (SELECT max(a) FROM tb_a);
+DROP TABLE tb_a;
+-- Test SPI
+-- start_ignore
+CREATE TABLE tb_b(b int);
+INSERT INTO tb_b SELECT generate_series(1, 10);
+-- end_ignore
+CREATE OR REPLACE FUNCTION spi_func() RETURNS setof record
+LANGUAGE plpgsql AS $$
+DECLARE
+    obj1 record;
+BEGIN
+    FOR obj1 IN SELECT * FROM tb_b
+    LOOP
+        RETURN next obj1;
+    END LOOP;
+    RETURN;
+END
+$$;
+SELECT * FROM spi_func() AS (a int) order by 1; 
+-- Test function
+SELECT CASE WHEN information_schema._pg_truetypmod(a.*, b.*) > 0 THEN 0 ELSE 0 END
+FROM
+  (SELECT * FROM pg_catalog.pg_attribute LIMIT 1) a,
+  (SELECT * FROM pg_catalog.pg_type LIMIT 1) b
+;

--- a/src/test/regress/output/query_info_hook_test.source
+++ b/src/test/regress/output/query_info_hook_test.source
@@ -8,7 +8,7 @@ WARNING:  Query start
 WARNING:  Plan node initializing
 WARNING:  Plan node executing node_type: FUNCTIONSCAN
 WARNING:  Plan node finished
-WARNING:  Query Done
+WARNING:  Query done
  generate_series 
 -----------------
                1
@@ -49,14 +49,14 @@ WARNING:  Query start
 WARNING:  Plan node initializing
 WARNING:  Plan node executing node_type: RESULT
 WARNING:  Plan node finished
-WARNING:  Query Done
+WARNING:  Query done
 WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
 WARNING:  Plan node executing node_type: MOTION
 WARNING:  Plan node finished
 WARNING:  Plan node finished
-WARNING:  Query Done
+WARNING:  Query done
 -- Test Hash node
 CREATE TABLE tb_a(a int);
 SELECT a FROM tb_a WHERE a IN (SELECT max(a) FROM tb_a);
@@ -67,7 +67,7 @@ WARNING:  Plan node executing node_type: MOTION
 WARNING:  Plan node executing node_type: HASHJOIN
 WARNING:  Plan node executing node_type: HASH
 WARNING:  Plan node finished
-WARNING:  Query Done
+WARNING:  Query done
 WARNING:  Plan node finished
 WARNING:  Plan node finished
 WARNING:  Plan node finished
@@ -77,8 +77,98 @@ WARNING:  Plan node finished
 WARNING:  Plan node finished
 WARNING:  Plan node finished
 WARNING:  Plan node finished
-WARNING:  Query Done
+WARNING:  Query done
  a 
 ---
 (0 rows)
+
+DROP TABLE tb_a;
+-- Test SPI
+CREATE OR REPLACE FUNCTION spi_func() RETURNS setof record
+LANGUAGE plpgsql AS $$
+DECLARE
+    obj1 record;
+BEGIN
+    FOR obj1 IN SELECT * FROM tb_b
+    LOOP
+        RETURN next obj1;
+    END LOOP;
+    RETURN;
+END
+$$;
+SELECT * FROM spi_func() AS (a int) order by 1; 
+WARNING:  Query submit
+WARNING:  Query start
+WARNING:  Plan node initializing
+WARNING:  Plan node executing node_type: SORT
+WARNING:  Plan node executing node_type: FUNCTIONSCAN
+WARNING:  SPI inner query submit
+CONTEXT:  PL/pgSQL function spi_func() line 5 at FOR over SELECT rows
+WARNING:  SPI inner query start
+CONTEXT:  PL/pgSQL function spi_func() line 5 at FOR over SELECT rows
+WARNING:  Plan node of SPI inner query initializing
+CONTEXT:  PL/pgSQL function spi_func() line 5 at FOR over SELECT rows
+WARNING:  Plan node of SPI inner query executing node_type: MOTION
+CONTEXT:  PL/pgSQL function spi_func() line 5 at FOR over SELECT rows
+WARNING:  Plan node of SPI inner query finished
+CONTEXT:  PL/pgSQL function spi_func() line 5 at FOR over SELECT rows
+WARNING:  Plan node of SPI inner query finished
+CONTEXT:  PL/pgSQL function spi_func() line 5 at FOR over SELECT rows
+WARNING:  Inner query done
+CONTEXT:  PL/pgSQL function spi_func() line 5 at FOR over SELECT rows
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Query done
+ a  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(10 rows)
+
+-- Test function
+SELECT CASE WHEN information_schema._pg_truetypmod(a.*, b.*) > 0 THEN 0 ELSE 0 END
+FROM
+  (SELECT * FROM pg_catalog.pg_attribute LIMIT 1) a,
+  (SELECT * FROM pg_catalog.pg_type LIMIT 1) b
+;
+WARNING:  Query submit
+WARNING:  Query start
+WARNING:  Plan node initializing
+WARNING:  Plan node executing node_type: NESTLOOP
+WARNING:  Plan node executing node_type: LIMIT
+WARNING:  Plan node executing node_type: SEQSCAN
+WARNING:  Plan node executing node_type: MATERIAL
+WARNING:  Plan node executing node_type: LIMIT
+WARNING:  Plan node executing node_type: SEQSCAN
+WARNING:  function inner query submit
+CONTEXT:  SQL function "_pg_truetypmod" statement 1
+WARNING:  function inner query start
+CONTEXT:  SQL function "_pg_truetypmod" statement 1
+WARNING:  Plan node of function inner query initializing
+CONTEXT:  SQL function "_pg_truetypmod" statement 1
+WARNING:  Plan node of function inner query executing node_type: RESULT
+CONTEXT:  SQL function "_pg_truetypmod" statement 1
+WARNING:  Plan node of function inner query finished
+CONTEXT:  SQL function "_pg_truetypmod" statement 1
+WARNING:  Inner query done
+CONTEXT:  SQL function "_pg_truetypmod" statement 1
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Plan node finished
+WARNING:  Query done
+ case 
+------
+    0
+(1 row)
 

--- a/src/test/regress/query_info_hook_test/query_info_hook_test.c
+++ b/src/test/regress/query_info_hook_test/query_info_hook_test.c
@@ -4,6 +4,7 @@
 #include "utils/metrics_utils.h"
 #include "nodes/execnodes.h"
 #include "nodes/print.h"
+#include "executor/execdesc.h"
 
 PG_MODULE_MAGIC;
 
@@ -34,32 +35,127 @@ test_hook(QueryMetricsStatus status, void* args)
 	switch (status)
 	{
 		case METRICS_PLAN_NODE_INITIALIZE:
-			ereport(WARNING, (errmsg("Plan node initializing")));
+			switch (((QueryDesc *)args)->plannedstmt->metricsQueryType)
+			{
+				case TOP_LEVEL_QUERY: 
+					ereport(WARNING, (errmsg("Plan node initializing")));
+					break;
+				case SPI_INNER_QUERY:
+					ereport(WARNING, (errmsg("Plan node of SPI inner query initializing")));
+					break;
+				case FUNCTION_INNER_QUERY:
+					ereport(WARNING, (errmsg("Plan node of function inner query initializing")));
+					break;
+			}
 			break;
 		case METRICS_PLAN_NODE_EXECUTING:
-			ereport(WARNING, (errmsg("Plan node executing node_type: %s", plannode_type(((PlanState *)args)->plan))));
+			switch (((PlanState *)args)->state->es_plannedstmt->metricsQueryType)
+			{
+				case TOP_LEVEL_QUERY: 
+					ereport(WARNING, (errmsg("Plan node executing node_type: %s", 
+												plannode_type(((PlanState *)args)->plan))));
+					break;
+				case SPI_INNER_QUERY:
+					ereport(WARNING, (errmsg("Plan node of SPI inner query executing node_type: %s", 
+												plannode_type(((PlanState *)args)->plan))));
+					break;
+				case FUNCTION_INNER_QUERY:
+					ereport(WARNING, (errmsg("Plan node of function inner query executing node_type: %s", 
+											plannode_type(((PlanState *)args)->plan))));
+					break;
+			}
 			break;
 		case METRICS_PLAN_NODE_FINISHED:
-			ereport(WARNING, (errmsg("Plan node finished")));
+			switch (((PlanState *)args)->state->es_plannedstmt->metricsQueryType)
+			{
+				case TOP_LEVEL_QUERY: 
+					ereport(WARNING, (errmsg("Plan node finished")));
+					break;
+				case SPI_INNER_QUERY:
+					ereport(WARNING, (errmsg("Plan node of SPI inner query finished")));
+					break;
+				case FUNCTION_INNER_QUERY:
+					ereport(WARNING, (errmsg("Plan node of function inner query finished")));
+					break;
+			}
 			break;
 		case METRICS_QUERY_SUBMIT:
-			ereport(WARNING, (errmsg("Query submit")));
+			switch (((QueryDesc *)args)->plannedstmt->metricsQueryType)
+			{
+				case TOP_LEVEL_QUERY: 
+					ereport(WARNING, (errmsg("Query submit")));
+					break;
+				case SPI_INNER_QUERY:
+					ereport(WARNING, (errmsg("SPI inner query submit")));
+					break;
+				case FUNCTION_INNER_QUERY:
+					ereport(WARNING, (errmsg("function inner query submit")));
+					break;
+			}
 			break;
 		case METRICS_QUERY_START:
-			ereport(WARNING, (errmsg("Query start")));
+			switch (((QueryDesc *)args)->plannedstmt->metricsQueryType)
+			{
+				case TOP_LEVEL_QUERY: 
+					ereport(WARNING, (errmsg("Query start")));
+					break;
+				case SPI_INNER_QUERY:
+					ereport(WARNING, (errmsg("SPI inner query start")));
+					break;
+				case FUNCTION_INNER_QUERY:
+					ereport(WARNING, (errmsg("function inner query start")));
+					break;
+			}
 			break;
 		case METRICS_QUERY_DONE:
-			ereport(WARNING, (errmsg("Query Done")));
+			ereport(WARNING, (errmsg("Query done")));
+			break;
+		case METRICS_INNER_QUERY_DONE:
+			ereport(WARNING, (errmsg("Inner query done")));
 			break;
 		case METRICS_QUERY_ERROR:
-			ereport(WARNING, (errmsg("Query Error")));
+			switch (((QueryDesc *)args)->plannedstmt->metricsQueryType)
+			{
+				case TOP_LEVEL_QUERY: 
+					ereport(WARNING, (errmsg("Query Error")));
+					break;
+				case SPI_INNER_QUERY:
+					ereport(WARNING, (errmsg("SPI inner query Error")));
+					break;
+				case FUNCTION_INNER_QUERY:
+					ereport(WARNING, (errmsg("function inner query Error")));
+					break;
+			}
 			break;
 		case METRICS_QUERY_CANCELING:
-			ereport(WARNING, (errmsg("Query Canceling")));
+			switch (((QueryDesc *)args)->plannedstmt->metricsQueryType)
+			{
+				case TOP_LEVEL_QUERY: 
+					ereport(WARNING, (errmsg("Query Canceling")));
+					break;
+				case SPI_INNER_QUERY:
+					ereport(WARNING, (errmsg("SPI inner query Canceling")));
+					break;
+				case FUNCTION_INNER_QUERY:
+					ereport(WARNING, (errmsg("function inner query Canceling")));
+					break;
+			}
 			break;
 		case METRICS_QUERY_CANCELED:
-			ereport(WARNING, (errmsg("Query Canceled")));
+			switch (((QueryDesc *)args)->plannedstmt->metricsQueryType)
+			{
+				case TOP_LEVEL_QUERY: 
+					ereport(WARNING, (errmsg("Query Canceled")));
+					break;
+				case SPI_INNER_QUERY:
+					ereport(WARNING, (errmsg("SPI inner query Canceled")));
+					break;
+				case FUNCTION_INNER_QUERY:
+					ereport(WARNING, (errmsg("function inner query Canceled")));
+					break;
+			}
 			break;
 	}
 }
+
 


### PR DESCRIPTION
To improve monitability with SPI queries, `query_info_collect_hook` needs to know whether it is a innner query or a top-level query. For example, for queries like
```
CREATE OR REPLACE FUNCTION func_spi() RETURNS setof record
LANGUAGE plpgsql AS $$
DECLARE
    obj1 record;
BEGIN
    FOR obj1 IN SELECT * FROM tb_b
    LOOP
        RETURN next obj1;
    END LOOP;
    RETURN;
END
$$;
SELECT * FROM func_spi() AS (a int) limit 1;
```
query_info_collect_hook needs to know the query `SELECT * FROM tb_b` is a inner query, and when  the hook function is ready to collect the plannode data on QEs, it also needs to know the plannode is a innner query`s node. 

So in this commit, we put a flag in `PlannedStmt` indicating whether it is a SPI innner query or not, and dispath this flag to QEs, so that collect_hook can know whether the node belongs to a SPI inner query. And in `ExecutorEnd`, since the memory context of `PlannedStmt` may be deleted before hook function is invoked, we add a local variable to save this flag first. 