### PR TITLE
Converting FTS, GDD, DTX Recovery to background workers

### DIFF
--- a/contrib/worker_spi/worker_spi.c
+++ b/contrib/worker_spi/worker_spi.c
@@ -350,6 +350,7 @@ _PG_init(void)
 	worker.bgw_restart_time = BGW_NEVER_RESTART;
 	worker.bgw_main = worker_spi_main;
 	worker.bgw_notify_pid = 0;
+	worker.bgw_start_rule = NULL;
 
 	/*
 	 * Now fill in worker-specific data, and do the actual registrations.

--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -202,18 +202,6 @@ static void SIGHUP_handler(int sig)
 	ax.reload = 1;
 }
 
-static void SIGTERM_handler(int sig)
-{
-	ax.exit = 1;
-}
-
-static void SIGQUIT_handler(int sig)
-{
-	/* Quick exit here */
-	sigprocmask(SIG_SETMASK, &blocksig, NULL);
-	exit(0);
-}
-
 static void SIGUSR2_handler(int sig)
 {
 	ax.exit = 1;
@@ -1467,9 +1455,7 @@ int main(int argc, const char* const argv[])
 	sigfillset(&blocksig);
 
 	/* Set up signal handlers */
-	if ((signal(SIGQUIT, SIGQUIT_handler) == SIG_ERR) ||
-		(signal(SIGTERM, SIGTERM_handler) == SIG_ERR) ||
-		(signal(SIGHUP, SIGHUP_handler) == SIG_ERR) ||
+	if ((signal(SIGHUP, SIGHUP_handler) == SIG_ERR) ||
 		(signal(SIGUSR2, SIGUSR2_handler) == SIG_ERR))
 	{
 		interuptable_sleep(30); // sleep to prevent loop of forking process and failing

--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -637,7 +637,7 @@ DtxRecoveryMain(Datum main_arg)
 	BackgroundWorkerUnblockSignals();
 
 	/* Connect to postgres */
-	BackgroundWorkerInitializeConnection("postgres", NULL);
+	BackgroundWorkerInitializeConnection(DB_FOR_COMMON_ACCESS, NULL);
 
 	/* do the real job of dtx recovery process */
 	StartTransactionCommand();

--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -13,27 +13,23 @@
 #include "postgres.h"
 #include <unistd.h>
 
+/* These are always necessary for a bgworker */
+#include "miscadmin.h"
+#include "postmaster/bgworker.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "storage/lwlock.h"
+#include "storage/proc.h"
+#include "storage/shmem.h"
+#include "storage/procarray.h"
+
 #include "access/xact.h"
-#include "cdb/cdbtm.h"
 #include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbdisp_query.h"
-#include "postmaster/fork_process.h"
 #include "postmaster/postmaster.h"
-#include "storage/ipc.h"
-#include "storage/procsignal.h"
-#include "storage/proc.h"
-#include "storage/sinvaladt.h"
 #include "tcop/tcopprot.h"
-#include "utils/faultinjector.h"
-#include "utils/guc.h"
-#include "utils/ps_status.h"
-#include "utils/syscache.h"
-#include "utils/snapmgr.h"
-
-#include "libpq/pqsignal.h"
-#include "libpq-fe.h"
 #include "libpq-int.h"
 
 volatile bool *shmDtmStarted;
@@ -44,8 +40,6 @@ volatile int *shmNumCommittedGxacts;
 
 static int	redoFileFD = -1;
 static int	redoFileOffset;
-
-bool		am_dtx_recovery;
 
 typedef struct InDoubtDtx
 {
@@ -72,8 +66,6 @@ static void UtilityModeSaveRedo(bool committed, TMGXACT_LOG *gxact_log);
 static void ReplayRedoFromUtilityMode(void);
 static void RemoveRedoUtilityModeFile(void);
 static void dumpRMOnlyDtx(HTAB *htab, StringInfoData *buff);
-
-NON_EXEC_STATIC void DtxRecoveryMain(int argc, char *argv[]);
 
 static bool
 doNotifyCommittedInDoubt(char *gid)
@@ -625,213 +617,31 @@ redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log)
 		 gxact_log->gid);
 }
 
-/*
- * Main entry point for dtx recovery process.
- *
- * This code is heavily based on pgarch.c, q.v.
- */
-int
-dtx_recovery_start(void)
+bool
+DtxRecoveryStartRule(Datum main_arg)
 {
-	pid_t		pid;
+	/* only start dtx recovery in dispatch mode */
+	if (IsUnderMasterDispatchMode())
+		return true;
 
-	switch ((pid = fork_process()))
-	{
-		case -1:
-			ereport(LOG,
-					(errmsg("could not fork dtx recovery process: %m")));
-			return 0;
-
-		case 0:
-			/* in postmaster child ... */
-			/* Close the postmaster's sockets */
-			ClosePostmasterPorts(false);
-			DtxRecoveryMain(0, NULL);
-			break;
-
-		default:
-			return (int) pid;
-	}
-
-	/* shouldn't get here */
-	return 0;
+	return false;
 }
 
 /*
  * DtxRecoveryMain
  */
-NON_EXEC_STATIC void
-DtxRecoveryMain(int argc, char *argv[])
+void
+DtxRecoveryMain(Datum main_arg)
 {
-	sigjmp_buf	local_sigjmp_buf;
-	char	   *fullpath;
+	/* We're now ready to receive signals */
+	BackgroundWorkerUnblockSignals();
 
-	IsUnderPostmaster = true;
-
-	am_dtx_recovery = true;
-
-	/* Stay away from PMChildSlot */
-	MyPMChildSlot = -1;
-
-	/* Reset MyProcPid */
-	MyProcPid = getpid();
-
-	/* Record Start Time for logging */
-	MyStartTime = time(NULL);
-
-	/* Lose the postmaster's on-exit routines */
-	on_exit_reset();
-
-	/*
-	 * If possible, make this process a group leader, so that the postmaster
-	 * can signal any child processes too
-	 */
-#ifdef HAVE_SETSID
-	if (setsid() < 0)
-		elog(FATAL, "setsid() failed: %m");
-#endif
-
-	/* Identify myself via ps */
-	init_ps_display("dtx recovery process", "", "", "");
-
-	SetProcessingMode(InitProcessing);
-
-	pqsignal(SIGHUP, SIG_IGN);
-	pqsignal(SIGINT, StatementCancelHandler);
-	pqsignal(SIGTERM, die);
-	pqsignal(SIGQUIT, quickdie);
-	pqsignal(SIGALRM, SIG_IGN);
-
-	pqsignal(SIGPIPE, SIG_IGN);
-	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
-	/* We don't listen for async notifies */
-	pqsignal(SIGUSR2, SIG_IGN);
-	pqsignal(SIGFPE, FloatExceptionHandler);
-	pqsignal(SIGCHLD, SIG_DFL);
-
-	/*
-	 * Create a resource owner to keep track of our resources (currently only
-	 * buffer pins).
-	 */
-	CurrentResourceOwner = ResourceOwnerCreate(NULL, "DtxRecovery");
-
-	/* Early initialization */
-	BaseInit();
-
-	/*
-	 * Create a per-backend PGPROC struct in shared memory. We must do this
-	 * before we can use LWLocks (and in the EXEC_BACKEND case we already had
-	 * to do some stuff with LWLocks).
-	 */
-	InitProcess();
-	InitBufferPoolBackend();
-	InitXLOGAccess();
-
-	SetProcessingMode(NormalProcessing);
-
-	/*
-	 * If an exception is encountered, processing resumes here.
-	 *
-	 * See notes in postgres.c about the design of this coding.
-	 */
-	if (sigsetjmp(local_sigjmp_buf, 1) != 0)
-	{
-		/* Prevents interrupts while cleaning up */
-		HOLD_INTERRUPTS();
-
-		/* Report the error to the server log */
-		EmitErrorReport();
-
-		/*
-		 * We can now go away.	Note that because we'll call InitProcess, a
-		 * callback will be registered to do ProcKill, which will clean up
-		 * necessary state.
-		 */
-		proc_exit(1);
-	}
-
-	/* We can now handle ereport(ERROR) */
-	PG_exception_stack = &local_sigjmp_buf;
-
-	PG_SETMASK(&UnBlockSig);
-
-	/*
-	 * The following additional initialization allows us to call the
-	 * persistent meta-data modules.
-	 */
-
-	/*
-	 * Add my PGPROC struct to the ProcArray.
-	 *
-	 * Once I have done this, I am visible to other backends!
-	 */
-	InitProcessPhase2();
-
-	/*
-	 * Initialize my entry in the shared-invalidation manager's array of
-	 * per-backend data.
-	 *
-	 * Sets up MyBackendId, a unique backend identifier.
-	 */
-	MyBackendId = InvalidBackendId;
-
-	SharedInvalBackendInit(false);
-
-	if (MyBackendId > MaxBackends || MyBackendId <= 0)
-		elog(FATAL, "bad backend id: %d", MyBackendId);
-
-	/*
-	 * Bufmgr needs another initialization call too
-	 */
-	InitBufferPoolBackend();
-
-	/* Heap access requires the rel-cache */
-	RelationCacheInitialize();
-	InitCatalogCache();
-
-	/*
-	 * It's now possible to do real access to the system catalogs.
-	 *
-	 * Load relcache entries for the system catalogs.  This must create at
-	 * least the minimum set of "nailed-in" cache entries.
-	 */
-	RelationCacheInitializePhase2();
-
-	/*
-	 * Start a new transaction here before first access to db, and get a
-	 * snapshot.  We don't have a use for the snapshot itself, but we're
-	 * interested in the secondary effect that it sets RecentGlobalXmin.
-	 */
-	StartTransactionCommand();
-	(void) GetTransactionSnapshot();
-
-	/*
-	 * In order to access the catalog, we need a database, and a tablespace;
-	 * our access to the heap is going to be slightly limited, so we'll just
-	 * use some defaults.
-	 */
-	if (!FindMyDatabase(DB_FOR_COMMON_ACCESS, &MyDatabaseId, &MyDatabaseTableSpace))
-		ereport(FATAL,
-				(errcode(ERRCODE_UNDEFINED_DATABASE),
-				 errmsg("database \"%s\" does not exit", DB_FOR_COMMON_ACCESS)));
-
-	/*
-	 * Now we can mark our PGPROC entry with the database ID
-	 * (We assume this is an atomic store so no lock is needed)
-	 */
-	MyProc->databaseId = MyDatabaseId;
-
-	fullpath = GetDatabasePath(MyDatabaseId, MyDatabaseTableSpace);
-
-	SetDatabasePath(fullpath);
-
-	RelationCacheInitializePhase3();
-
-	InitializeSessionUserIdStandalone();
+	/* Connect to postgres */
+	BackgroundWorkerInitializeConnection("postgres", NULL);
 
 	/* do the real job of dtx recovery process */
+	StartTransactionCommand();
 	recoverTM();
-
 	CommitTransactionCommand();
 
 	/* One iteration done, go away */

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -987,8 +987,13 @@ cdb_setup(void)
 	/*
 	 * Backend process requires consistent state, it cannot proceed until
 	 * dtx recovery process finish up the recovery of distributed transactions.
+	 *
+	 * Ignore background worker because bgworker_should_start_mpp() already did
+	 * the check.
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH && !*shmDtmStarted)
+	if (!IsBackgroundWorker &&
+		Gp_role == GP_ROLE_DISPATCH &&
+		!*shmDtmStarted)
 	{
 		while (true)
 		{

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -135,7 +135,7 @@ FtsProbeMain(Datum main_arg)
 	BackgroundWorkerUnblockSignals();
 
 	/* Connect to our database */
-	BackgroundWorkerInitializeConnection("postgres", NULL);
+	BackgroundWorkerInitializeConnection(DB_FOR_COMMON_ACCESS, NULL);
 
 	/* main loop */
 	FtsLoop();

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -20,158 +20,64 @@
 
 #include <unistd.h>
 
-#include "access/genam.h"
-#include "access/heapam.h"
-#include "access/xact.h"
-#include "catalog/gp_segment_config.h"
-#include "catalog/indexing.h"
-#include "catalog/pg_authid.h"
-#include "libpq/pqsignal.h"
+/* These are always necessary for a bgworker */
 #include "miscadmin.h"
+#include "postmaster/bgworker.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "storage/lwlock.h"
+#include "storage/proc.h"
+#include "storage/shmem.h"
+
+#include "access/xact.h"
+#include "catalog/indexing.h"
+#include "libpq/pqsignal.h"
 #include "cdb/cdbvars.h"
-#include "libpq-fe.h"
 #include "libpq-int.h"
 #include "cdb/cdbfts.h"
-#include "postmaster/fork_process.h"
-#include "postmaster/postmaster.h"
 #include "postmaster/fts.h"
 #include "postmaster/ftsprobe.h"
-#include "storage/ipc.h"
-#include "storage/proc.h"
-#include "storage/procsignal.h"
-#include "storage/pmsignal.h"			/* PostmasterIsAlive */
-#include "storage/sinvaladt.h"
+#include "postmaster/postmaster.h"
 #include "utils/builtins.h"
 #include "utils/faultinjector.h"
 #include "utils/fmgroids.h"
 #include "utils/memutils.h"
-#include "utils/ps_status.h"
-#include "utils/relcache.h"
-#include "utils/snapmgr.h"
-#include "utils/syscache.h"
-#include "utils/tqual.h"
-#include "utils/timeout.h"
-
-#include "catalog/pg_authid.h"
-#include "catalog/pg_database.h"
-#include "catalog/pg_tablespace.h"
-#include "catalog/catalog.h"
 
 #include "catalog/gp_configuration_history.h"
 #include "catalog/gp_segment_config.h"
-
-#include "storage/backendid.h"
-#include "storage/bufmgr.h"
-#include "executor/spi.h"
 
 #include "tcop/tcopprot.h" /* quickdie() */
 
 bool am_ftsprobe = false;
 bool am_ftshandler = false;
 
-
 /*
  * STATIC VARIABLES
  */
-
+static volatile pid_t *shmFtsProbePID;
 static bool skip_fts_probe = false;
 
-static volatile bool shutdown_requested = false;
 static volatile bool probe_requested = false;
 static volatile sig_atomic_t got_SIGHUP = false;
 
 /*
  * FUNCTION PROTOTYPES
  */
-
-#ifdef EXEC_BACKEND
-static pid_t ftsprobe_forkexec(void);
-#endif
-NON_EXEC_STATIC void ftsMain(int argc, char *argv[]);
 static void FtsLoop(void);
-static void TimeoutHandler(void);
 
 static CdbComponentDatabases *readCdbComponentInfoAndUpdateStatus(MemoryContext);
-
-/*
- * Main entry point for ftsprobe process.
- *
- * This code is heavily based on pgarch.c, q.v.
- */
-int
-ftsprobe_start(void)
-{
-	pid_t		FtsProbePID;
-
-#ifdef EXEC_BACKEND
-	switch ((FtsProbePID = ftsprobe_forkexec()))
-#else
-	switch ((FtsProbePID = fork_process()))
-#endif
-	{
-		case -1:
-			ereport(LOG,
-					(errmsg("could not fork ftsprobe process: %m")));
-			return 0;
-
-#ifndef EXEC_BACKEND
-		case 0:
-			/* in postmaster child ... */
-			/* Close the postmaster's sockets */
-			ClosePostmasterPorts(false);
-
-			ftsMain(0, NULL);
-			break;
-#endif
-		default:
-			return (int)FtsProbePID;
-	}
-
-	
-	/* shouldn't get here */
-	return 0;
-}
-
 
 /*=========================================================================
  * HELPER FUNCTIONS
  */
-
-
-#ifdef EXEC_BACKEND
-/*
- * ftsprobe_forkexec()
- *
- * Format up the arglist for the ftsprobe process, then fork and exec.
- */
-static pid_t
-ftsprobe_forkexec(void)
-{
-	char	   *av[10];
-	int			ac = 0;
-
-	av[ac++] = "postgres";
-	av[ac++] = "--forkftsprobe";
-	av[ac++] = NULL;			/* filled in by postmaster_forkexec */
-	av[ac] = NULL;
-
-	Assert(ac < lengthof(av));
-
-	return postmaster_forkexec(ac, av);
-}
-#endif   /* EXEC_BACKEND */
-
-static void
-RequestShutdown(SIGNAL_ARGS)
-{
-	shutdown_requested = true;
-}
-
 /* SIGHUP: set flag to reload config file */
 static void
 sigHupHandler(SIGNAL_ARGS)
 {
 	got_SIGHUP = true;
+
+	if (MyProc)
+		SetLatch(&MyProc->procLatch);
 }
 
 /* SIGINT: set flag to indicate a FTS scan is requested */
@@ -179,165 +85,57 @@ static void
 sigIntHandler(SIGNAL_ARGS)
 {
 	probe_requested = true;
+
+	if (MyProc)
+		SetLatch(&MyProc->procLatch);
+}
+
+void
+FtsProbeShmemInit(void)
+{
+	if (IsUnderPostmaster)
+		return;
+
+	shmFtsProbePID = (volatile pid_t*)ShmemAlloc(sizeof(*shmFtsProbePID));
+	*shmFtsProbePID = 0;
+}
+
+pid_t
+FtsProbePID(void)
+{
+	return *shmFtsProbePID;
+}
+
+bool
+FtsProbeStartRule(Datum main_arg)
+{
+	/* we only start fts probe on master when -E is specified */
+	if (IsUnderMasterDispatchMode())
+		return true;
+
+	return false;
 }
 
 /*
  * FtsProbeMain
  */
-NON_EXEC_STATIC void
-ftsMain(int argc, char *argv[])
+void
+FtsProbeMain(Datum main_arg)
 {
-	sigjmp_buf	local_sigjmp_buf;
-	char	   *fullpath;
-
-	IsUnderPostmaster = true;
+	*shmFtsProbePID = MyProcPid;
 	am_ftsprobe = true;
-
-	/* Stay away from PMChildSlot */
-	MyPMChildSlot = -1;
-
-	/* reset MyProcPid */
-	MyProcPid = getpid();
-	
-	/* Lose the postmaster's on-exit routines */
-	on_exit_reset();
-
-	/* Identify myself via ps */
-	init_ps_display("ftsprobe process", "", "", "");
-
-	SetProcessingMode(InitProcessing);
 
 	/*
 	 * reread postgresql.conf if requested
 	 */
 	pqsignal(SIGHUP, sigHupHandler);
 	pqsignal(SIGINT, sigIntHandler);
-	pqsignal(SIGTERM, die);
-	pqsignal(SIGQUIT, quickdie); /* we don't do any ftsprobe specific cleanup, just use the standard. */
-	InitializeTimeouts();		/* establishes SIGALRM handler */
 
-	pqsignal(SIGPIPE, SIG_IGN);
-	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
-	/* We don't listen for async notifies */
-	pqsignal(SIGUSR2, RequestShutdown);
-	pqsignal(SIGFPE, FloatExceptionHandler);
-	pqsignal(SIGCHLD, SIG_DFL);
+	/* We're now ready to receive signals */
+	BackgroundWorkerUnblockSignals();
 
-	RegisterTimeout(DEADLOCK_TIMEOUT, TimeoutHandler);
-	RegisterTimeout(STATEMENT_TIMEOUT, TimeoutHandler);
-	RegisterTimeout(LOCK_TIMEOUT, TimeoutHandler);
-	RegisterTimeout(GANG_TIMEOUT, TimeoutHandler);
-
-	/*
-	 * Copied from bgwriter
-	 */
-	CurrentResourceOwner = ResourceOwnerCreate(NULL, "FTS Probe");
-
-	/* Early initialization */
-	BaseInit();
-
-	/* See InitPostgres()... */
-	InitProcess();
-	InitBufferPoolBackend();
-	InitXLOGAccess();
-
-	SetProcessingMode(NormalProcessing);
-
-	/*
-	 * If an exception is encountered, processing resumes here.
-	 *
-	 * See notes in postgres.c about the design of this coding.
-	 */
-	if (sigsetjmp(local_sigjmp_buf, 1) != 0)
-	{
-		/* Prevents interrupts while cleaning up */
-		HOLD_INTERRUPTS();
-
-		/* Report the error to the server log */
-		EmitErrorReport();
-
-		AbortCurrentTransaction();
-
-		/*
-		 * We can now go away.	Note that because we'll call InitProcess, a
-		 * callback will be registered to do ProcKill, which will clean up
-		 * necessary state.
-		 */
-		proc_exit(0);
-	}
-
-	/* We can now handle ereport(ERROR) */
-	PG_exception_stack = &local_sigjmp_buf;
-
-	PG_SETMASK(&UnBlockSig);
-
-	/*
-	 * Add my PGPROC struct to the ProcArray.
-	 *
-	 * Once I have done this, I am visible to other backends!
-	 */
-	InitProcessPhase2();
-
-	/*
-	 * Initialize my entry in the shared-invalidation manager's array of
-	 * per-backend data.
-	 *
-	 * Sets up MyBackendId, a unique backend identifier.
-	 */
-	MyBackendId = InvalidBackendId;
-
-	SharedInvalBackendInit(false);
-
-	if (MyBackendId > MaxBackends || MyBackendId <= 0)
-		elog(FATAL, "bad backend id: %d", MyBackendId);
-
-	/*
-	 * bufmgr needs another initialization call too
-	 */
-	InitBufferPoolBackend();
-
-	/* heap access requires the rel-cache */
-	RelationCacheInitialize();
-	InitCatalogCache();
-
-	/*
-	 * It's now possible to do real access to the system catalogs.
-	 *
-	 * Load relcache entries for the system catalogs.  This must create at
-	 * least the minimum set of "nailed-in" cache entries.
-	 */
-	RelationCacheInitializePhase2();
-
-	/*
-	 * Start a new transaction here before first access to db, and get a
-	 * snapshot.  We don't have a use for the snapshot itself, but we're
-	 * interested in the secondary effect that it sets RecentGlobalXmin.
-	 */
-	StartTransactionCommand();
-	(void) GetTransactionSnapshot();
-
-	/*
-	 * In order to access the catalog, we need a database, and a
-	 * tablespace; our access to the heap is going to be slightly
-	 * limited, so we'll just use some defaults.
-	 */
-	if (!FindMyDatabase(DB_FOR_COMMON_ACCESS, &MyDatabaseId, &MyDatabaseTableSpace))
-		ereport(FATAL,
-				(errcode(ERRCODE_UNDEFINED_DATABASE),
-				 errmsg("database \"%s\" does not exit", DB_FOR_COMMON_ACCESS)));
-
-	/* Now we can mark our PGPROC entry with the database ID */
-	/* (We assume this is an atomic store so no lock is needed) */
-	MyProc->databaseId = MyDatabaseId;
-
-	fullpath = GetDatabasePath(MyDatabaseId, MyDatabaseTableSpace);
-
-	SetDatabasePath(fullpath);
-
-	RelationCacheInitializePhase3();
-
-	/* close the transaction we started above */
-	CommitTransactionCommand();
+	/* Connect to our database */
+	BackgroundWorkerInitializeConnection("postgres", NULL);
 
 	/* main loop */
 	FtsLoop();
@@ -487,7 +285,7 @@ void FtsLoop()
 {
 	bool	updated_probe_state;
 	MemoryContext probeContext = NULL, oldContext = NULL;
-	time_t elapsed,	probe_start_time;
+	time_t elapsed,	probe_start_time, timeout;
 	CdbComponentDatabases *cdbs = NULL;
 
 	probeContext = AllocSetContextCreate(TopMemoryContext,
@@ -495,19 +293,19 @@ void FtsLoop()
 										 ALLOCSET_DEFAULT_INITSIZE,	/* always have some memory */
 										 ALLOCSET_DEFAULT_INITSIZE,
 										 ALLOCSET_DEFAULT_MAXSIZE);
-	while (!shutdown_requested)
+
+	while (true)
 	{
 		bool		has_mirrors;
-
-		/* no need to live on if postmaster has died */
-		if (!PostmasterIsAlive())
-			exit(1);
+		int			rc;
 
 		if (got_SIGHUP)
 		{
 			got_SIGHUP = false;
 			ProcessConfigFile(PGC_SIGHUP);
 		}
+
+		CHECK_FOR_INTERRUPTS();
 
 		probe_start_time = time(NULL);
 
@@ -583,13 +381,18 @@ void FtsLoop()
 
 		/* check if we need to sleep before starting next iteration */
 		elapsed = time(NULL) - probe_start_time;
-		if (elapsed < gp_fts_probe_interval && !shutdown_requested)
-		{
-			if (!probe_requested)
-				pg_usleep((gp_fts_probe_interval - elapsed) * USECS_PER_SEC);
+		timeout = elapsed >= gp_fts_probe_interval ? 0 : 
+							gp_fts_probe_interval - elapsed;
 
-			CHECK_FOR_INTERRUPTS();
-		}
+		rc = WaitLatch(&MyProc->procLatch,
+					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+					   timeout * 1000L);
+
+		ResetLatch(&MyProc->procLatch);
+
+		/* emergency bailout if postmaster has died */
+		if (rc & WL_POSTMASTER_DEATH)
+			proc_exit(1);
 	} /* end server loop */
 
 	return;
@@ -601,11 +404,5 @@ void FtsLoop()
 bool
 FtsIsActive(void)
 {
-	return (!skip_fts_probe && !shutdown_requested);
-}
-
-static void
-TimeoutHandler(void)
-{
-	kill(MyProcPid, SIGINT);
+	return !skip_fts_probe;
 }

--- a/src/backend/postmaster/backoff.c
+++ b/src/backend/postmaster/backoff.c
@@ -28,8 +28,6 @@
 #include "postgres.h"
 
 #include "postmaster/backoff.h"
-#include "postmaster/fork_process.h"
-#include "postmaster/postmaster.h"
 #ifndef HAVE_GETRUSAGE
 #include "rusagestub.h"
 #else
@@ -37,36 +35,21 @@
 #include <sys/resource.h>
 #endif
 #include "storage/ipc.h"
-#include "storage/smgr.h"
-#include "storage/shmem.h"
-#include "utils/resowner.h"
 #include "cdb/cdbvars.h"
-#include "storage/backendid.h"
-#include "pgstat.h"
-#include "miscadmin.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
 #include "libpq-fe.h"
-#include <unistd.h>
 
 #include <signal.h>
 #include "libpq/pqsignal.h"
-#include "utils/ps_status.h"
 #include "tcop/tcopprot.h"
+#include "postmaster/bgworker.h"
 #include "storage/pmsignal.h"	/* PostmasterIsAlive */
-#include "catalog/pg_database.h"
-#include "catalog/pg_resourcetype.h"
-#include "catalog/pg_resqueue.h"
-#include "catalog/pg_tablespace.h"
-#include "catalog/catalog.h"
 #include "storage/proc.h"
-#include "storage/sinval.h"
+#include "catalog/pg_resourcetype.h"
 #include "utils/builtins.h"
 #include "utils/resource_manager.h"
-#include "utils/syscache.h"
 #include "funcapi.h"
-#include "catalog/pg_type.h"
-#include "access/tuptoaster.h"
 #include "access/xact.h"
 #include "port/atomics.h"
 #include "pg_trace.h"
@@ -210,9 +193,6 @@ static inline double numProcsPerSegment(void);
 /* Sweeper related routines */
 static void BackoffSweeper(void);
 static void BackoffSweeperLoop(void);
-NON_EXEC_STATIC void BackoffSweeperMain(int argc, char *argv[]);
-static void BackoffRequestShutdown(SIGNAL_ARGS);
-static volatile bool sweeperShutdownRequested = false;
 static volatile bool isSweeperProcess = false;
 
 /* Resource queue related routines */
@@ -1181,125 +1161,26 @@ gp_adjust_priority_int(PG_FUNCTION_ARGS)
 	PG_RETURN_INT32(numfound);
 }
 
-/*
- * Main entry point for backoff process. This forks off a sweeper process
- * and calls BackoffSweeperMain(), which does all the setup.
- *
- * This code is heavily based on pgarch.c, q.v.
- */
-int
-backoff_start(void)
+bool
+BackoffSweeperStartRule(Datum main_arg)
 {
-	pid_t		backoffId = -1;
+	if (IsResQueueEnabled())
+		return true;
 
-	switch ((backoffId = fork_process()))
-	{
-		case -1:
-			ereport(LOG,
-					(errmsg("could not fork sweeper process: %m")));
-			return 0;
-
-		case 0:
-			/* in postmaster child ... */
-			/* Close the postmaster's sockets */
-			ClosePostmasterPorts(false);
-
-			BackoffSweeperMain(0, NULL);
-			break;
-		default:
-			return (int) backoffId;
-	}
-
-	/* shouldn't get here */
-	Assert(false);
-	return 0;
+	return false;
 }
-
 
 /**
  * This method is called after fork of the sweeper process. It sets up signal
  * handlers and does initialization that is required by a postgres backend.
  */
-NON_EXEC_STATIC void
-BackoffSweeperMain(int argc, char *argv[])
+void
+BackoffSweeperMain(Datum main_arg)
 {
-	sigjmp_buf	local_sigjmp_buf;
-
-	IsUnderPostmaster = true;
 	isSweeperProcess = true;
 
-	/* Stay away from PMChildSlot */
-	MyPMChildSlot = -1;
-
-	/* reset MyProcPid */
-	MyProcPid = getpid();
-
-	/* Lose the postmaster's on-exit routines */
-	on_exit_reset();
-
-	/* Identify myself via ps */
-	init_ps_display("sweeper process", "", "", "");
-
-	SetProcessingMode(InitProcessing);
-
-	/*
-	 * Set up signal handlers.  We operate on databases much like a regular
-	 * backend, so we use the same signal handling.  See equivalent code in
-	 * tcop/postgres.c.
-	 */
-	pqsignal(SIGHUP, SIG_IGN);
-	pqsignal(SIGINT, SIG_IGN);
-	pqsignal(SIGALRM, SIG_IGN);
-	pqsignal(SIGPIPE, SIG_IGN);
-	pqsignal(SIGUSR1, SIG_IGN);
-
-	pqsignal(SIGTERM, die);
-	pqsignal(SIGQUIT, quickdie);
-	pqsignal(SIGUSR2, BackoffRequestShutdown);
-
-	pqsignal(SIGFPE, FloatExceptionHandler);
-	pqsignal(SIGCHLD, SIG_DFL);
-
-	/*
-	 * Copied from bgwriter
-	 */
-	CurrentResourceOwner = ResourceOwnerCreate(NULL, "Sweeper process");
-
-	/* Early initialization */
-	BaseInit();
-
-	/* See InitPostgres()... */
-	InitProcess();
-
-	SetProcessingMode(NormalProcessing);
-
-	/*
-	 * If an exception is encountered, processing resumes here.
-	 *
-	 * See notes in postgres.c about the design of this coding.
-	 */
-	if (sigsetjmp(local_sigjmp_buf, 1) != 0)
-	{
-		/* Prevents interrupts while cleaning up */
-		HOLD_INTERRUPTS();
-
-		/* Report the error to the server log */
-		EmitErrorReport();
-
-		/*
-		 * We can now go away.  Note that because we'll call InitProcess, a
-		 * callback will be registered to do ProcKill, which will clean up
-		 * necessary state.
-		 */
-		proc_exit(0);
-	}
-
-	/* We can now handle ereport(ERROR) */
-	PG_exception_stack = &local_sigjmp_buf;
-
-	PG_SETMASK(&UnBlockSig);
-
-	MyBackendId = InvalidBackendId;
+	/* We're now ready to receive signals */
+	BackgroundWorkerUnblockSignals();
 
 	/* main loop */
 	BackoffSweeperLoop();
@@ -1317,33 +1198,25 @@ BackoffSweeperLoop(void)
 {
 	for (;;)
 	{
-		CHECK_FOR_INTERRUPTS();
-
-		if (sweeperShutdownRequested)
-			break;
-
-		/* no need to live on if postmaster has died */
-		if (!PostmasterIsAlive())
-			exit(1);
+		int		rc;
 
 		if (gp_enable_resqueue_priority)
 			BackoffSweeper();
 
 		Assert(gp_resqueue_priority_sweeper_interval > 0.0);
+
 		/* Sleep a while. */
-		pg_usleep(gp_resqueue_priority_sweeper_interval * 1000.0);
+		rc = WaitLatch(&MyProc->procLatch,
+					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+					   gp_resqueue_priority_sweeper_interval * 1000L);
+		ResetLatch(&MyProc->procLatch);
+
+		/* emergency bailout if postmaster has died */
+		if (rc & WL_POSTMASTER_DEATH)
+			proc_exit(1);
 	}							/* end server loop */
 
 	return;
-}
-
-/**
- * Note the request to shut down.
- */
-static void
-BackoffRequestShutdown(SIGNAL_ARGS)
-{
-	sweeperShutdownRequested = true;
 }
 
 /**

--- a/src/backend/postmaster/perfmon_segmentinfo.c
+++ b/src/backend/postmaster/perfmon_segmentinfo.c
@@ -25,21 +25,15 @@
 #include <signal.h>
 
 #include "postmaster/perfmon_segmentinfo.h"
-#include "postmaster/fork_process.h"
-#include "postmaster/postmaster.h"
+#include "postmaster/bgworker.h"
 
 #include "storage/ipc.h"
 #include "storage/proc.h"
-#include "storage/backendid.h"
 #include "storage/pmsignal.h"			/* PostmasterIsAlive */
 
 #include "utils/metrics_utils.h"
-#include "utils/resowner.h"
-#include "utils/ps_status.h"
 
 #include "gpmon/gpmon.h"
-#include "miscadmin.h"
-#include "libpq/pqsignal.h"
 #include "tcop/tcopprot.h"
 #include "cdb/cdbvars.h"
 #include "utils/vmem_tracker.h"
@@ -47,11 +41,6 @@
 /* Sender-related routines */
 static void SegmentInfoSender(void);
 static void SegmentInfoSenderLoop(void);
-NON_EXEC_STATIC void SegmentInfoSenderMain(int argc, char *argv[]);
-static void SegmentInfoRequestShutdown(SIGNAL_ARGS);
-
-static volatile bool senderShutdownRequested = false;
-static volatile bool isSenderProcess = false;
 
 /* Static gpmon_seginfo_t item, (re)used for sending UDP packets. */
 static gpmon_packet_t seginfopkt;
@@ -72,133 +61,39 @@ cluster_state_collect_hook_type cluster_state_collect_hook = NULL;
  */
 query_info_collect_hook_type query_info_collect_hook = NULL;
 
-/**
- * Main entry point for segment info process. This forks off a sender process
- * and calls SegmentInfoSenderMain(), which does all the setup.
- *
- * This code is heavily based on pgarch.c, q.v.
- */
-int
-perfmon_segmentinfo_start(void)
-{
-	pid_t		segmentInfoId = -1;
-
-	switch ((segmentInfoId = fork_process()))
-	{
-		case -1:
-			ereport(LOG,
-				(errmsg("could not fork stats sender process: %m")));
-		return 0;
-
-		case 0:
-			/* in postmaster child ... */
-			/* Close the postmaster's sockets */
-			ClosePostmasterPorts(false);
-
-			SegmentInfoSenderMain(0, NULL);
-			break;
-		default:
-			return (int)segmentInfoId;
-	}
-
-	/* shouldn't get here */
-	Assert(false);
-	return 0;
-}
-
 
 /**
  * This method is called after fork of the stats sender process. It sets up signal
  * handlers and does initialization that is required by a postgres backend.
  */
-NON_EXEC_STATIC void SegmentInfoSenderMain(int argc, char *argv[])
+void SegmentInfoSenderMain(Datum main_arg)
 {
-	sigjmp_buf	local_sigjmp_buf;
+	/* We're now ready to receive signals */
+	BackgroundWorkerUnblockSignals();
 
-	IsUnderPostmaster = true;
-	isSenderProcess = true;
+	/* Init gpmon connection */
+	gpmon_init();
 
-	/* Stay away from PMChildSlot */
-	MyPMChildSlot = -1;
-
-	/* reset MyProcPid */
-	MyProcPid = getpid();
-
-	/* Lose the postmaster's on-exit routines */
-	on_exit_reset();
-
-	/* Identify myself via ps */
-	init_ps_display("stats sender process", "", "", "");
-
-	SetProcessingMode(InitProcessing);
-
-	/* Set up signal handlers, see equivalent code in tcop/postgres.c. */
-	pqsignal(SIGHUP, SIG_IGN);
-	pqsignal(SIGINT, SIG_IGN);
-	pqsignal(SIGALRM, SIG_IGN);
-	pqsignal(SIGPIPE, SIG_IGN);
-	pqsignal(SIGUSR1, SIG_IGN);
-
-	pqsignal(SIGTERM, die);
-	pqsignal(SIGQUIT, die);
-	pqsignal(SIGUSR2, SegmentInfoRequestShutdown);
-
-	pqsignal(SIGFPE, FloatExceptionHandler);
-	pqsignal(SIGCHLD, SIG_DFL);
-
-	/* Copied from bgwriter */
-	CurrentResourceOwner = ResourceOwnerCreate(NULL, "Segment info sender process");
-
-	/* Early initialization */
-	BaseInit();
-
-	/* See InitPostgres()... */
-	InitProcess();
-
-	SetProcessingMode(NormalProcessing);
-
-	/*
-	 * If an exception is encountered, processing resumes here.
-	 *
-	 * See notes in postgres.c about the design of this coding.
-	 */
-	if (sigsetjmp(local_sigjmp_buf, 1) != 0)
-	{
-		/* Prevents interrupts while cleaning up */
-		HOLD_INTERRUPTS();
-
-		/* Report the error to the server log */
-		EmitErrorReport();
-
-		/*
-		 * We can now go away.	Note that because we'll call InitProcess, a
-		 * callback will be registered to do ProcKill, which will clean up
-		 * necessary state.
-		 */
-		proc_exit(0);
-	}
-
-	/* We can now handle ereport(ERROR) */
-	PG_exception_stack = &local_sigjmp_buf;
-
-	PG_SETMASK(&UnBlockSig);
-
-	MyBackendId = InvalidBackendId;
-
-	if (gp_enable_gpperfmon)
-	{
-		/* Init gpmon connection */
-		gpmon_init();
-
-		/* Create and initialize gpmon_pkt */
-		InitSegmentInfoGpmonPkt(&seginfopkt);
-	}
+	/* Create and initialize gpmon_pkt */
+	InitSegmentInfoGpmonPkt(&seginfopkt);
 
 	/* main loop */
 	SegmentInfoSenderLoop();
 
 	/* One iteration done, go away */
 	proc_exit(0);
+}
+
+bool
+SegmentInfoSenderStartRule(Datum main_arg)
+{
+	/*
+	 * TODO: is this correct? either GUC is on will turn on this auxiliary process ? */
+	if (!gp_enable_gpperfmon && !gp_enable_query_metrics)
+		return false;
+
+	/* FIXME: even for the utility mode? */
+	return true;
 }
 
 /**
@@ -214,17 +109,6 @@ SegmentInfoSenderLoop(void)
 
 	for (counter = 0;; counter += SEGMENT_INFO_LOOP_SLEEP_MS)
 	{
-		CHECK_FOR_INTERRUPTS();
-
-		if (senderShutdownRequested)
-		{
-			break;
-		}
-
-		/* no need to live on if postmaster has died */
-		if (!PostmasterIsAlive())
-			exit(1);
-
 		if (cluster_state_collect_hook)
 			cluster_state_collect_hook();
 
@@ -246,15 +130,6 @@ SegmentInfoSenderLoop(void)
 	} /* end server loop */
 
 	return;
-}
-
-/**
- * Note the request to shut down.
- */
-static void
-SegmentInfoRequestShutdown(SIGNAL_ARGS)
-{
-	senderShutdownRequested = true;
 }
 
 /**

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -653,7 +653,6 @@ static void ShmemBackendArrayRemove(Backend *bn);
 #define EXIT_STATUS_1(st)  (WIFEXITED(st) && WEXITSTATUS(st) == 1)
 
 /* if we are a QD postmaster or not */
-extern bool Gp_entry_postmaster;
 bool Gp_entry_postmaster = false;
 
 #ifndef WIN32
@@ -7196,6 +7195,21 @@ setProcAffinity(int id)
 	elog(LOG, "gp_set_proc_affinity setting ignored; feature not configured");
 }
 #endif
+
+/*
+ * Master is started once in utility mode by gpstart to fetch segment info,
+ * then it is restarted again to production/dispatch mode with "-E" specified.
+ *
+ * This function checks 1) is master, 2) is under dispatch mode
+ */
+bool
+IsUnderMasterDispatchMode(void)
+{
+	if (Gp_entry_postmaster && Gp_role == GP_ROLE_DISPATCH)
+		return true;
+
+	return false;
+}
 
 void
 load_auxiliary_libraries(void)

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -205,8 +205,7 @@ static dlist_head BackendList = DLIST_STATIC_INIT(BackendList);
 /* CDB */
 typedef enum pmsub_type
 {
-	PerfmonProc = 0,
-	MaxPMSubType
+	MaxPMSubType = 0,
 } PMSubType;
 
 #ifdef EXEC_BACKEND
@@ -402,9 +401,6 @@ typedef struct pmsubproc
 
 static PMSubProc PMSubProcList[MaxPMSubType] =
 {
-	{0, PerfmonProc,
-	(PMSubStartCallback*)&perfmon_start,
-	"perfmon process", PMSUBPROC_FLAG_QD, false},
 };
 
 static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
@@ -447,9 +443,9 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 	{"perfmon process",
 	 BGWORKER_SHMEM_ACCESS,
 	 BgWorkerStart_RecoveryFinished,
-	 0, /* restart immediately if ftsprobe exits with non-zero code */
+	 0, /* restart immediately if perfmon process exits with non-zero code */
 	 PerfmonMain, {0}, {0}, 0, 0,
-	 PerfmonStartRule, false},
+	 PerfmonStartRule},
 };
 
 static bool ReachedNormalRunning = false;		/* T if we've reached PM_RUN */
@@ -1785,10 +1781,7 @@ ServiceStartable(PMSubProc *subProc)
 	 * GUC gp_enable_gpperfmon controls the start
 	 * of both the 'perfmon' and 'stats sender' processes
 	 */
-	if (subProc->procType == PerfmonProc && !gp_enable_gpperfmon)
-		result = 0;
-	else
-		result = ((subProc->flags & flagNeeded) != 0);
+	result = ((subProc->flags & flagNeeded) != 0);
 
 	return result;
 }

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -206,7 +206,6 @@ static dlist_head BackendList = DLIST_STATIC_INIT(BackendList);
 typedef enum pmsub_type
 {
 	PerfmonProc = 0,
-	BackoffProc,
 	MaxPMSubType
 } PMSubType;
 
@@ -406,9 +405,6 @@ static PMSubProc PMSubProcList[MaxPMSubType] =
 	{0, PerfmonProc,
 	(PMSubStartCallback*)&perfmon_start,
 	"perfmon process", PMSUBPROC_FLAG_QD, false},
-	{0, BackoffProc,
-	(PMSubStartCallback*)&backoff_start,
-	"sweeper process", PMSUBPROC_FLAG_QD_AND_QE, true},
 };
 
 static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
@@ -440,6 +436,20 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 	 0, /* restart immediately if stats sender exits with non-zero code */
 	 SegmentInfoSenderMain, {0}, {0}, 0, 0,
 	 SegmentInfoSenderStartRule},
+
+	{"sweeper process",
+	 BGWORKER_SHMEM_ACCESS,
+	 BgWorkerStart_RecoveryFinished,
+	 0, /* restart immediately if sweeper process exits with non-zero code */
+	 BackoffSweeperMain, {0}, {0}, 0, 0,
+	 BackoffSweeperStartRule},
+
+	{"perfmon process",
+	 BGWORKER_SHMEM_ACCESS,
+	 BgWorkerStart_RecoveryFinished,
+	 0, /* restart immediately if ftsprobe exits with non-zero code */
+	 PerfmonMain, {0}, {0}, 0, 0,
+	 PerfmonStartRule, false},
 };
 
 static bool ReachedNormalRunning = false;		/* T if we've reached PM_RUN */

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -55,8 +55,6 @@
 /* The maximum bytes for error message */
 #define ERROR_MESSAGE_MAX_SIZE 200
 
-extern bool Gp_entry_postmaster;
-
 /*
  * We read() into a temp buffer twice as big as a chunk, so that any fragment
  * left after processing can be moved down to the front and we'll still have
@@ -278,7 +276,7 @@ SysLoggerMain(int argc, char *argv[])
 
 	am_syslogger = true;
 
-	if (Gp_entry_postmaster && Gp_role == GP_ROLE_DISPATCH)
+	if (IsUnderMasterDispatchMode())
 		init_ps_display("master logger process", "", "", "");
 	else
 		init_ps_display("logger process", "", "", "");
@@ -819,8 +817,7 @@ SysLoggerMain(int argc, char *argv[])
 static void
 open_alert_log_file()
 {
-    if (Gp_entry_postmaster &&
-        Gp_role == GP_ROLE_DISPATCH &&
+	if (IsUnderMasterDispatchMode() &&
         gpperfmon_log_alert_level != GPPERFMON_LOG_ALERT_LEVEL_NONE)
     {
         alert_log_level_opened = true;
@@ -1464,7 +1461,7 @@ fillinErrorDataFromSegvChunk(GpErrorData *errorData, PipeProtoChunk *chunk)
 	Assert(signalName != NULL);
 	snprintf(errorData->error_message, ERROR_MESSAGE_MAX_SIZE,
 			 "Unexpected internal error: %s received signal %s",
-			 (Gp_entry_postmaster && Gp_role == GP_ROLE_DISPATCH) ? "Master process" : "Segment process",
+			 IsUnderMasterDispatchMode() ? "Master process" : "Segment process",
 			 signalName);
 	
 	errorData->error_detail = NULL;

--- a/src/backend/postmaster/test/syslogger_test.c
+++ b/src/backend/postmaster/test/syslogger_test.c
@@ -26,7 +26,6 @@ test__open_alert_log_file__NonGucOpen(void **state)
 void 
 test__open_alert_log_file__NonMaster(void **state)
 {
-    Gp_entry_postmaster = false;
     gpperfmon_log_alert_level = GPPERFMON_LOG_ALERT_LEVEL_WARNING;
     open_alert_log_file();
     assert_false(alert_log_level_opened);

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -33,6 +33,7 @@
 #include "postmaster/bgworker_internals.h"
 #include "postmaster/bgwriter.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/fts.h"
 #include "replication/slot.h"
 #include "replication/walreceiver.h"
 #include "replication/walsender.h"
@@ -348,6 +349,9 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		InstrShmemInit();
 
 	GpExpandVersionShmemInit();
+
+	FtsProbeShmemInit();
+
 #ifdef EXEC_BACKEND
 
 	/*

--- a/src/backend/storage/ipc/procsignal.c
+++ b/src/backend/storage/ipc/procsignal.c
@@ -59,7 +59,7 @@ typedef struct
  * possible auxiliary process type.  (This scheme assumes there is not
  * more than one of any auxiliary process type at a time.)
  */
-#define NumProcSignalSlots	(MaxBackends + NUM_AUXILIARY_PROCS)
+#define NumProcSignalSlots	(MaxBackends + NUM_AUXPROCTYPES)
 
 /*
  * If this flag is set, the process latch will be set whenever SIGUSR1

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -319,7 +319,7 @@ InitProcess(void)
 	 * such as mppSessionId being valid and mppIsWriter set to true.
 	 */
 	if (IsAutoVacuumWorkerProcess() || am_walsender || am_ftshandler ||
-		am_ftsprobe || IsFaultHandler)
+		IsFaultHandler)
 		Gp_role = GP_ROLE_UTILITY;
 
 	/*

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -115,7 +115,7 @@ GlobalDeadLockDetectorMain(Datum main_arg)
 	BackgroundWorkerUnblockSignals();
 
 	/* Connect to our database */
-	BackgroundWorkerInitializeConnection("postgres", NULL);
+	BackgroundWorkerInitializeConnection(DB_FOR_COMMON_ACCESS, NULL);
 
 	/* disable orca here */
 	extern bool optimizer;

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -14,37 +14,26 @@
 
 #include <unistd.h>
 
-#include "access/xact.h"
-#include "access/transam.h"
-#include "postmaster/fork_process.h"
-#include "postmaster/postmaster.h"
-#include "catalog/catalog.h"
-#include "catalog/pg_authid.h"
+/* These are always necessary for a bgworker */
+#include "miscadmin.h"
+#include "postmaster/bgworker.h"
 #include "storage/ipc.h"
-#include "storage/pmsignal.h"			/* PostmasterIsAlive */
+#include "storage/latch.h"
+#include "storage/lwlock.h"
 #include "storage/proc.h"
+#include "storage/shmem.h"
 #include "storage/procarray.h"
-#include "storage/procsignal.h"
-#include "storage/backendid.h"
-#include "storage/bufmgr.h"
-#include "storage/sinvaladt.h"
+
+#include "access/xact.h"
+#include "cdb/cdbvars.h"
+#include "executor/spi.h"
+#include "postmaster/postmaster.h"
 #include "tcop/tcopprot.h"
 #include "utils/gdd.h"
 #include "utils/builtins.h"
-#include "utils/fmgroids.h"
 #include "utils/snapmgr.h"
 #include "utils/memutils.h"
-#include "utils/syscache.h"
-#include "utils/ps_status.h"
 #include "utils/faultinjector.h"
-#include "cdb/cdbvars.h"
-
-#include "libpq/pqsignal.h"
-#include "libpq/libpq-be.h"
-#include "executor/spi.h"
-#include "utils/sharedsnapshot.h"
-#include "utils/timeout.h"
-
 #include "gdddetector.h"
 #include "gdddetectorpriv.h"
 
@@ -71,10 +60,7 @@ typedef struct EdgeSatelliteData
 #define GET_LOCKMODE_FROM_EDGE(edge) (((EdgeSatelliteData *) ((edge)->data))->lockmode)
 #define GET_LOCKTYPE_FROM_EDGE(edge) (((EdgeSatelliteData *) ((edge)->data))->locktype)
 
-#ifdef EXEC_BACKEND
-static pid_t global_deadlock_detector_forkexec(void);
-#endif
-NON_EXEC_STATIC void GlobalDeadLockDetectorMain(int argc, char *argv[]);
+void GlobalDeadLockDetectorMain(Datum main_arg);
 
 static void GlobalDeadLockDetectorLoop(void);
 static int  doDeadLockCheck(void);
@@ -84,283 +70,52 @@ static void dumpCancelResult(StringInfo str, List *xids);
 extern void dumpGddCtx(GddCtx *ctx, StringInfo str);
 static void dumpGddGraph(GddGraph *graph, StringInfo str);
 static void dumpGddEdge(GddEdge *edge, StringInfo str);
-static void TimeoutHandler(void);
 
 static MemoryContext	gddContext;
 static MemoryContext    oldContext;
 
 static volatile sig_atomic_t got_SIGHUP = false;
-static volatile bool shutdown_requested = false;
 
 int gp_global_deadlock_detector_period;
 
-bool am_global_deadlock_detector = false;
-
-/*
- * Main entry point for global deadlock detector process.
- *
- * This code is heavily based on pgarch.c, q.v.
- */
-int
-global_deadlock_detector_start(void)
-{
-	pid_t		GlobalDeadLockDetectorPID;
-
-#ifdef EXEC_BACKEND
-	switch ((GlobalDeadLockDetectorPID = global_deadlock_detector_forkexec()))
-#else
-	switch ((GlobalDeadLockDetectorPID = fork_process()))
-#endif
-	{
-		case -1:
-			ereport(LOG,
-					(errmsg("could not fork global dead lock detector process: %m")));
-			return 0;
-
-#ifndef EXEC_BACKEND
-		case 0:
-			/* in postmaster child ... */
-			/* Close the postmaster's sockets */
-			ClosePostmasterPorts(false);
-
-			GlobalDeadLockDetectorMain(0, NULL);
-			break;
-#endif
-		default:
-			return (int) GlobalDeadLockDetectorPID;
-	}
-
-	/* shouldn't get here */
-	return 0;
-}
-
-
-#ifdef EXEC_BACKEND
-/*
- * global_deadlock_detector_forkexec()
- *
- * Format up the arglist for the serqserver process, then fork and exec.
- */
-static pid_t
-global_deadlock_detector_forkexec(void)
-{
-	char	   *av[10];
-	int			ac = 0;
-
-	av[ac++] = "postgres";
-	av[ac++] = "--globaldeadlockdetector";
-	av[ac++] = NULL;			/* filled in by postmaster_forkexec */
-	av[ac] = NULL;
-
-	Assert(ac < lengthof(av));
-
-	return postmaster_forkexec(ac, av);
-}
-#endif   /* EXEC_BACKEND */
-
-static void
-RequestShutdown(SIGNAL_ARGS)
-{
-	shutdown_requested = true;
-}
+static bool am_global_deadlock_detector = false;
 
 /* SIGHUP: set flag to reload config file */
 static void
 sigHupHandler(SIGNAL_ARGS)
 {
 	got_SIGHUP = true;
+
+	if(MyProc)
+		SetLatch(&MyProc->procLatch);
+}
+
+bool
+GlobalDeadLockDetectorStartRule(Datum main_arg)
+{
+	/* we only start gdd on master when -E is specified */
+	if (IsUnderMasterDispatchMode() &&
+		gp_enable_global_deadlock_detector)
+		return true;
+
+	return false;
 }
 
 /*
  * GlobalDeadLockDetectorMain
  */
-NON_EXEC_STATIC void
-GlobalDeadLockDetectorMain(int argc, char *argv[])
+void
+GlobalDeadLockDetectorMain(Datum main_arg)
 {
-	sigjmp_buf	local_sigjmp_buf;
-	char	   *fullpath;
-
-	IsUnderPostmaster = true;
 	am_global_deadlock_detector = true;
 
-	/* Stay away from PMChildSlot */
-	MyPMChildSlot = -1;
-
-	/* reset MyProcPid */
-	MyProcPid = getpid();
-
-	/* record Start Time for logging */
-	MyStartTime = time(NULL);
-
-	/* Lose the postmaster's on-exit routines */
-	on_exit_reset();
-
-	/*
-	 * If possible, make this process a group leader, so that the postmaster
-	 * can signal any child processes too.	(gdd probably never has any
-	 * child processes, but for consistency we make all postmaster child
-	 * processes do this.)
-	 */
-#ifdef HAVE_SETSID
-	if (setsid() < 0)
-		elog(FATAL, "setsid() failed: %m");
-#endif
-
-	/* Identify myself via ps */
-	init_ps_display("global deadlock detector process", "", "", "");
-
-	SetProcessingMode(InitProcessing);
-
 	pqsignal(SIGHUP, sigHupHandler);
-	pqsignal(SIGINT, StatementCancelHandler);
-	pqsignal(SIGTERM, die);
-	pqsignal(SIGQUIT, quickdie); /* we don't do any seq-server specific cleanup, just use the standard. */
-	InitializeTimeouts();
 
-	pqsignal(SIGPIPE, SIG_IGN);
-	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
-	/* We don't listen for async notifies */
-	pqsignal(SIGUSR2, RequestShutdown);
-	pqsignal(SIGFPE, FloatExceptionHandler);
-	pqsignal(SIGCHLD, SIG_DFL);
+	/* We're now ready to receive signals */
+	BackgroundWorkerUnblockSignals();
 
-	RegisterTimeout(DEADLOCK_TIMEOUT, TimeoutHandler);
-	RegisterTimeout(STATEMENT_TIMEOUT, TimeoutHandler);
-	RegisterTimeout(LOCK_TIMEOUT, TimeoutHandler);
-	RegisterTimeout(GANG_TIMEOUT, TimeoutHandler);
-
-	/*
-	 * Create a resource owner to keep track of our resources (currently only
-	 * buffer pins).
-	 */
-	CurrentResourceOwner = ResourceOwnerCreate(NULL, "GlobalDeadLockDetector");
-
-	/* Early initialization */
-	BaseInit();
-
-	/* See InitPostgres()... */
-	/*
-	 * Create a per-backend PGPROC struct in shared memory, except in the
-	 * EXEC_BACKEND case where this was done in SubPostmasterMain. We must do
-	 * this before we can use LWLocks (and in the EXEC_BACKEND case we already
-	 * had to do some stuff with LWLocks).
-	 */
-#ifndef EXEC_BACKEND
-	InitProcess();
-#endif
-	InitBufferPoolBackend();
-	InitXLOGAccess();
-
-	SetProcessingMode(NormalProcessing);
-
-	/* Allocate MemoryContext */
-	gddContext = AllocSetContextCreate(TopMemoryContext,
-									   "GddContext",
-									   ALLOCSET_DEFAULT_MINSIZE,
-									   ALLOCSET_DEFAULT_INITSIZE,
-									   ALLOCSET_DEFAULT_MAXSIZE);
-
-	/*
-	 * If an exception is encountered, processing resumes here.
-	 *
-	 * See notes in postgres.c about the design of this coding.
-	 */
-	if (sigsetjmp(local_sigjmp_buf, 1) != 0)
-	{
-		/* Prevents interrupts while cleaning up */
-		HOLD_INTERRUPTS();
-
-		/* Report the error to the server log */
-		EmitErrorReport();
-
-		AbortCurrentTransaction();
-		/*
-		 * We can now go away.	Note that because we'll call InitProcess, a
-		 * callback will be registered to do ProcKill, which will clean up
-		 * necessary state.
-		 */
-		proc_exit(0);
-	}
-
-	/* We can now handle ereport(ERROR) */
-	PG_exception_stack = &local_sigjmp_buf;
-
-	PG_SETMASK(&UnBlockSig);
-
-
-	/*
-	 * The following additional initialization allows us to call the persistent meta-data modules.
-	 */
-
-	/*
-	 * Add my PGPROC struct to the ProcArray.
-	 *
-	 * Once I have done this, I am visible to other backends!
-	 */
-	InitProcessPhase2();
-
-	/*
-	 * Initialize my entry in the shared-invalidation manager's array of
-	 * per-backend data.
-	 *
-	 * Sets up MyBackendId, a unique backend identifier.
-	 */
-	MyBackendId = InvalidBackendId;
-
-	SharedInvalBackendInit(false);
-
-	if (MyBackendId > MaxBackends || MyBackendId <= 0)
-		elog(FATAL, "bad backend id: %d", MyBackendId);
-
-	/*
-	 * bufmgr needs another initialization call too
-	 */
-	InitBufferPoolBackend();
-
-	/* heap access requires the rel-cache */
-	RelationCacheInitialize();
-	InitCatalogCache();
-
-	/*
-	 * It's now possible to do real access to the system catalogs.
-	 *
-	 * Load relcache entries for the system catalogs.  This must create at
-	 * least the minimum set of "nailed-in" cache entries.
-	 */
-	RelationCacheInitializePhase2();
-
-	/*
-	 * Start a new transaction here before first access to db, and get a
-	 * snapshot.  We don't have a use for the snapshot itself, but we're
-	 * interested in the secondary effect that it sets RecentGlobalXmin.
-	 */
-	StartTransactionCommand();
-	(void) GetTransactionSnapshot();
-
-	/*
-	 * In order to access the catalog, we need a database, and a
-	 * tablespace; our access to the heap is going to be slightly
-	 * limited, so we'll just use some defaults.
-	 */
-	if (!FindMyDatabase(DB_FOR_COMMON_ACCESS, &MyDatabaseId, &MyDatabaseTableSpace))
-		ereport(FATAL,
-				(errcode(ERRCODE_UNDEFINED_DATABASE),
-				 errmsg("database \"%s\" does not exit", DB_FOR_COMMON_ACCESS)));
-
-	/* Now we can mark our PGPROC entry with the database ID */
-	/* (We assume this is an atomic store so no lock is needed) */
-	MyProc->databaseId = MyDatabaseId;
-
-	fullpath = GetDatabasePath(MyDatabaseId, MyDatabaseTableSpace);
-
-	SetDatabasePath(fullpath);
-
-	RelationCacheInitializePhase3();
-
-	InitializeSessionUserIdStandalone();
-
-	/* close the transaction we started above */
-	CommitTransactionCommand();
+	/* Connect to our database */
+	BackgroundWorkerInitializeConnection("postgres", NULL);
 
 	/* disable orca here */
 	extern bool optimizer;
@@ -375,18 +130,19 @@ GlobalDeadLockDetectorMain(int argc, char *argv[])
 static void
 GlobalDeadLockDetectorLoop(void)
 {
-	int status;
+	int	status;
 
-	for (;;)
+	/* Allocate MemoryContext */
+	gddContext = AllocSetContextCreate(TopMemoryContext,
+									   "GddContext",
+									   ALLOCSET_DEFAULT_MINSIZE,
+									   ALLOCSET_DEFAULT_INITSIZE,
+									   ALLOCSET_DEFAULT_MAXSIZE);
+
+	while (true)
 	{
-		CHECK_FOR_INTERRUPTS();
-
-		if (shutdown_requested)
-			break;
-
-		/* no need to live on if postmaster has died */
-		if (!PostmasterIsAlive())
-			exit(1);
+		int			rc;
+		int			timeout;
 
 		if (got_SIGHUP)
 		{
@@ -406,9 +162,17 @@ GlobalDeadLockDetectorLoop(void)
 		else
 			AbortCurrentTransaction();
 
-		/* GUC gp_global_deadlock_detector_period may be changed, skip sleep */
-		if (!got_SIGHUP)
-			pg_usleep(gp_global_deadlock_detector_period * 1000000L);
+		timeout = got_SIGHUP ? 0 : gp_global_deadlock_detector_period;
+
+		rc = WaitLatch(&MyProc->procLatch,
+					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+					   timeout * 1000L);
+
+		ResetLatch(&MyProc->procLatch);
+
+		/* emergency bailout if postmaster has died */
+		if (rc & WL_POSTMASTER_DEATH)
+			proc_exit(1);
 	}
 
 	return;
@@ -723,10 +487,4 @@ dumpGddEdge(GddEdge *edge, StringInfo str)
 					 GET_PID_FROM_VERT(edge->to),
 					 edge->to->id,
 					 GET_SESSIONID_FROM_VERT(edge->from));
-}
-
-static void
-TimeoutHandler(void)
-{
-	kill(MyProcPid, SIGINT);
 }

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -22,6 +22,7 @@
 #include "libpq/pqcomm.h"
 #include "miscadmin.h"
 #include "storage/backendid.h"
+#include "postmaster/postmaster.h"
 
 
 ProtocolVersion FrontendProtocol;
@@ -131,7 +132,7 @@ int			maintenance_work_mem = 65536;
  */
 int			NBuffers = 4096;
 int			MaxConnections = 90;
-int			max_worker_processes = 8;
+int			max_worker_processes = 8 + MaxPMAuxProc;
 int			MaxBackends = 0;
 
 int			VacuumCostPageHit = 1;		/* GUC parameters for vacuum */

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -1397,9 +1397,11 @@ void
 process_shared_preload_libraries(void)
 {
 	process_shared_preload_libraries_in_progress = true;
+
 	load_libraries(shared_preload_libraries_string,
 				   "shared_preload_libraries",
 				   false);
+
 	process_shared_preload_libraries_in_progress = false;
 }
 

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -471,7 +471,6 @@ InitializeSessionUserIdStandalone(void)
 	 */
 	AssertState(!IsUnderPostmaster || IsAutoVacuumWorkerProcess() || IsBackgroundWorker
 				|| am_startup
-				|| am_dtx_recovery
 				|| (IsFaultHandler && am_mirror)
 				|| (am_ftshandler && am_mirror));
 

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -472,9 +472,8 @@ InitializeSessionUserIdStandalone(void)
 	AssertState(!IsUnderPostmaster || IsAutoVacuumWorkerProcess() || IsBackgroundWorker
 				|| am_startup
 				|| am_dtx_recovery
-				|| (am_ftshandler && am_mirror)
 				|| (IsFaultHandler && am_mirror)
-				|| am_global_deadlock_detector);
+				|| (am_ftshandler && am_mirror));
 
 	/* call only once */
 	AssertState(!OidIsValid(AuthenticatedUserId));

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1152,8 +1152,11 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	/* initialize client encoding */
 	InitializeClientEncoding();
 
-	/* report this backend in the PgBackendStatus array */
-	if (!bootstrap)
+	/*
+	 * report this backend in the PgBackendStatus array, meanwhile, we do not
+	 * want users to see auxiliary background worker like fts in pg_stat_* views.
+	 */
+	if (!bootstrap && !amAuxiliaryBgWorker())
 		pgstat_bestart();
 		
 	/* 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2322,7 +2322,7 @@ static struct config_int ConfigureNamesInt[] =
 			NULL,
 		},
 		&max_worker_processes,
-		8, 1, MAX_BACKENDS,
+		8 + MaxPMAuxProc, 1, MAX_BACKENDS,
 		check_max_worker_processes, NULL, NULL
 	},
 
@@ -9891,6 +9891,14 @@ check_max_worker_processes(int *newval, void **extra, GucSource source)
 {
 	if (MaxConnections + autovacuum_max_workers + 1 + *newval > MAX_BACKENDS)
 		return false;
+
+	if (*newval < MaxPMAuxProc)
+	{
+		elog(ERROR, "max_worker_processes less than %d, must reserve %d "
+			 "for auxiliary processes like FTS", MaxPMAuxProc, MaxPMAuxProc);
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -282,7 +282,6 @@ typedef struct TmControlBlock
 
 extern volatile bool *shmDtmStarted;
 extern int max_tm_gxacts;
-extern bool am_dtx_recovery;
 
 extern DtxContext DistributedTransactionContext;
 
@@ -368,8 +367,10 @@ extern bool currentGxactWriterGangLost(void);
 
 extern void addToGxactTwophaseSegments(struct Gang* gp);
 
-extern int dtx_recovery_start(void);
 extern DistributedTransactionId generateGID(void);
 extern void ClearTransactionState(TransactionId latestXid);
+
+extern void DtxRecoveryMain(Datum main_arg);
+extern bool DtxRecoveryStartRule(Datum main_arg);
 
 #endif   /* CDBTM_H */

--- a/src/include/postmaster/backoff.h
+++ b/src/include/postmaster/backoff.h
@@ -26,7 +26,8 @@ extern Datum gp_adjust_priority_int(PG_FUNCTION_ARGS);
 extern Datum gp_adjust_priority_value(PG_FUNCTION_ARGS);
 extern Datum gp_list_backend_priorities(PG_FUNCTION_ARGS);
 
-extern int backoff_start(void);
+extern void BackoffSweeperMain(Datum main_arg);
+extern bool BackoffSweeperStartRule(Datum main_arg);
 
 
 #endif /* BACKOFF_H_ */

--- a/src/include/postmaster/bgworker.h
+++ b/src/include/postmaster/bgworker.h
@@ -60,13 +60,19 @@
 
 
 typedef void (*bgworker_main_type) (Datum main_arg);
+typedef bool (*bgworker_start_rule) (Datum rule_arg);
 
 /*
  * Points in time at which a bgworker can request to be started
+ *
+ * CDB: BgWorkerStart_DtxRecovering means worker can be started
+ * after postmaster started and before distributed transactions
+ * are recovered.
  */
 typedef enum
 {
 	BgWorkerStart_PostmasterStart,
+	BgWorkerStart_DtxRecovering,
 	BgWorkerStart_ConsistentState,
 	BgWorkerStart_RecoveryFinished
 } BgWorkerStartTime;
@@ -86,6 +92,7 @@ typedef struct BackgroundWorker
 	char		bgw_function_name[BGW_MAXLEN];	/* only if bgw_main is NULL */
 	Datum		bgw_main_arg;
 	pid_t		bgw_notify_pid; /* SIGUSR1 this backend on start/stop */
+	bgworker_start_rule bgw_start_rule; /* false: never be started */
 } BackgroundWorker;
 
 typedef enum BgwHandleStatus

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -134,11 +134,6 @@ typedef struct
 } FtsSegmentPairState;
 
 /*
- * FTS process interface
- */
-extern int ftsprobe_start(void);
-
-/*
  * Interface for checking if FTS is active
  */
 extern bool FtsIsActive(void);
@@ -149,4 +144,10 @@ extern bool FtsIsActive(void);
 extern void HandleFtsMessage(const char* query_string);
 extern void probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 									bool IsSegmentAlive, bool IsInSync);
+
+extern bool FtsProbeStartRule(Datum main_arg);
+extern void FtsProbeMain (Datum main_arg);
+extern void FtsProbeShmemInit(void);
+extern pid_t FtsProbePID(void);
+
 #endif   /* FTS_H */

--- a/src/include/postmaster/perfmon.h
+++ b/src/include/postmaster/perfmon.h
@@ -14,6 +14,8 @@
 #ifndef PERFMON_H
 #define PERFMON_H
 
-extern int perfmon_start(void);
+extern bool PerfmonStartRule(Datum main_arg);
+
+extern void PerfmonMain(Datum main_arg);
 
 #endif   /* PERFMON_H */

--- a/src/include/postmaster/perfmon_segmentinfo.h
+++ b/src/include/postmaster/perfmon_segmentinfo.h
@@ -24,7 +24,8 @@
 extern int gp_perfmon_segment_interval;
 
 /* Interface */
-extern int perfmon_segmentinfo_start(void);
+void SegmentInfoSenderMain(Datum main_arg);
+bool SegmentInfoSenderStartRule(Datum main_arg);
 
 typedef void (*cluster_state_collect_hook_type)(void);
 extern PGDLLIMPORT cluster_state_collect_hook_type cluster_state_collect_hook;

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -87,6 +87,6 @@ extern bool IsUnderMasterDispatchMode(void);
  * GUC check hooks and in RegisterBackgroundWorker().
  */
 #define MAX_BACKENDS	0x7fffff
-#define MaxPMAuxProc	1
+#define MaxPMAuxProc	2
 
 #endif   /* _POSTMASTER_H */

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -87,6 +87,6 @@ extern bool IsUnderMasterDispatchMode(void);
  * GUC check hooks and in RegisterBackgroundWorker().
  */
 #define MAX_BACKENDS	0x7fffff
-#define MaxPMAuxProc	4
+#define MaxPMAuxProc	5
 
 #endif   /* _POSTMASTER_H */

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -87,6 +87,6 @@ extern bool IsUnderMasterDispatchMode(void);
  * GUC check hooks and in RegisterBackgroundWorker().
  */
 #define MAX_BACKENDS	0x7fffff
-#define MaxPMAuxProc	5
+#define MaxPMAuxProc	6
 
 #endif   /* _POSTMASTER_H */

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -72,9 +72,6 @@ extern Size ShmemBackendArraySize(void);
 extern void ShmemBackendArrayAllocation(void);
 #endif
 
-/* CDB */
-typedef int (PMSubStartCallback)(void);
-
 extern void load_auxiliary_libraries(void);
 extern bool amAuxiliaryBgWorker(void);
 extern bool IsUnderMasterDispatchMode(void);

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -75,6 +75,9 @@ extern void ShmemBackendArrayAllocation(void);
 /* CDB */
 typedef int (PMSubStartCallback)(void);
 
+extern void load_auxiliary_libraries(void);
+extern bool amAuxiliaryBgWorker(void);
+
 /*
  * Note: MAX_BACKENDS is limited to 2^23-1 because inval.c stores the
  * backend ID as a 3-byte signed integer.  Even if that limitation were
@@ -83,5 +86,6 @@ typedef int (PMSubStartCallback)(void);
  * GUC check hooks and in RegisterBackgroundWorker().
  */
 #define MAX_BACKENDS	0x7fffff
+#define MaxPMAuxProc	1
 
 #endif   /* _POSTMASTER_H */

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -87,6 +87,6 @@ extern bool IsUnderMasterDispatchMode(void);
  * GUC check hooks and in RegisterBackgroundWorker().
  */
 #define MAX_BACKENDS	0x7fffff
-#define MaxPMAuxProc	3
+#define MaxPMAuxProc	4
 
 #endif   /* _POSTMASTER_H */

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -77,6 +77,7 @@ typedef int (PMSubStartCallback)(void);
 
 extern void load_auxiliary_libraries(void);
 extern bool amAuxiliaryBgWorker(void);
+extern bool IsUnderMasterDispatchMode(void);
 
 /*
  * Note: MAX_BACKENDS is limited to 2^23-1 because inval.c stores the

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -87,6 +87,6 @@ extern bool IsUnderMasterDispatchMode(void);
  * GUC check hooks and in RegisterBackgroundWorker().
  */
 #define MAX_BACKENDS	0x7fffff
-#define MaxPMAuxProc	2
+#define MaxPMAuxProc	3
 
 #endif   /* _POSTMASTER_H */

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -283,11 +283,8 @@ extern PGPROC *PreparedXactProcs;
  * Background writer, checkpointer and WAL writer run during normal operation.
  * Startup process and WAL receiver also consume 2 slots, but WAL writer is
  * launched only after startup has exited, so we only need 4 slots.
- *
- * In GPDB, we have some extra processes.
- * GPDB_90_MERGE_FIXME: count them correctly. 10 is an exaggeration.
  */
-#define NUM_AUXILIARY_PROCS		(/* PG */ 4 + /* GPDB */ 10)
+#define NUM_AUXILIARY_PROCS		4
 
 
 /* configurable options */

--- a/src/include/utils/gdd.h
+++ b/src/include/utils/gdd.h
@@ -13,11 +13,10 @@
 #ifndef GDD_H
 #define GDD_H
 
-extern bool am_global_deadlock_detector;
-
-extern int global_deadlock_detector_start(void);
-
 extern int gp_global_deadlock_detector_period;
+
+extern bool GlobalDeadLockDetectorStartRule(Datum main_arg);
+extern void GlobalDeadLockDetectorMain(Datum main_arg);
 
 #endif   /* GDD_H */
 


### PR DESCRIPTION
GPDB used to have its own framework to manage its auxiliary processes like FTS, GDD, DtxRecovery, Perfmon, Backoff, etc.
This old framework a few defects:
    1. GPDB only, different concept and make code different from upstream in many places.
    2. Not easy enough to add a new type of auxiliary process although it has tried
       to reduce the complex, but still lots of additional code needed out of core feature.
    3. not clear for backend initialization and many duplicated code.
    4. not clear for the components/resource needed.
    5. using SIGUSR2 to shutdown which differs from upstream.
    6. special code for auxiliary in the workflow.

Actually, the old framework is very similar to the background worker framework in upstream. Now we have bgworker feature merged,
it's a good chance to covert those GPDB processes to background worker now and take advantage of the background worker feature.

To do this, I want to extend the background worker framework a little bit:
1. extend bgw_start_time
     typedef enum
     {
            /* can start if startup process is lunched*/
            BgWorkerStart_PostmasterStart,
            /* can start basicly when it's saft to read (in GPDB, after DTX recovery is done) */
            BgWorkerStart_ConsistentState,
            /* can start basicly when it's safe to read/write (in GPDB, after DTX recovery is done) */
            BgWorkerStart_RecoveryFinished
    +++     BgWorkerStart_DtxRecovering,
     } BgWorkerStartTime;

    A new type called BgWorkerStart_DtxRecovering which means a worker can be started after the startup process finished and before
    DTX recovery is done. This is important because DTX recovery process is also a bgworker now and it also need FTS prober once it hit an error.


2. adding a bgw_start_rule
    Some auxiliary processes can only be launched in QD or only be lanuched when some GUCs are set. So users can provide a custom function to specify the rule
    to wether launch a bgworker or not.

This comes to me when I trying to add a new type of auxiliary process (see 48cb340d4117), I realize that it would be better and simpler if we moving GPDB auxiliary processes to background worker framework.