### PR TITLE
Exit earlier in test gp_replica_check if the cluster is not healthy.

### DIFF
--- a/gpcontrib/gp_replica_check/gp_replica_check.py
+++ b/gpcontrib/gp_replica_check/gp_replica_check.py
@@ -74,15 +74,16 @@ Mirror Data Directory Location: %s' % (self.host, self.port, self.datname,
 
 def create_restartpoint_on_ckpt_record_replay(set):
     if set:
-        cmd = "gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation; gpstop -u"
+        cmd = "gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation && gpstop -u"
     else:
-        cmd = "gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation; gpstop -u"
+        cmd = "gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation && gpstop -u"
     print cmd
     try:
         res = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
         print res
     except subprocess.CalledProcessError, e:
         print 'returncode: (%s), cmd: (%s), output: (%s)' % (e.returncode, e.cmd, e.output)
+        sys.exit(2)
 
 def install_extension(databases):
     get_datname_sql = ''' SELECT datname FROM pg_database WHERE datname != 'template0' '''


### PR DESCRIPTION
It is observed that before gp_replica_check some mirrors are down according to
the 'gpstop -u' output for unknown reason. Not sure why. Probably there is bug
in previous test, or probably oom tests affects. In any case we should not
proceed if the cluster is not ok. Of course we could restart the cluster but
we'd error out instead so that people could find potential issues in previous
testing.

Co-authored-by: Haozhou Wang <hawang@pivotal.io>
