### PR TITLE
Docs - removes replication port references

### DIFF
--- a/gpdb-doc/dita/best_practices/sysconfig.xml
+++ b/gpdb-doc/dita/best_practices/sysconfig.xml
@@ -47,9 +47,7 @@
         <codeblock>net.ipv4.ip_local_port_range = 10000  65535</codeblock></p>
       <p>you could set the Greenplum Database base port numbers to these
         values.<codeblock>PORT_BASE = 6000
-MIRROR_PORT_BASE = 7000
-REPLICATION_PORT_BASE = 8000
-MIRROR_REPLICATION_PORT_BASE = 9000</codeblock></p>
+MIRROR_PORT_BASE = 7000</codeblock></p>
     </section>
     <section id="io_config">
       <title>I/O Configuration</title>

--- a/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
+++ b/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
@@ -14,23 +14,32 @@
       to coordinate database operations with the segments. The <codeph>gpstate -p</codeph> command,
       executed on the Greenplum master, lists the port assignments for the Greenplum master and the
       primary segments and mirrors. For example:
-      <codeblock>[gpadmin@mdw ~]$ gpstate -p
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-Starting gpstate with args: -p
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.6.0 build 62994'
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 8.2.15 (Greenplum Database 4.3.6.0 build 62994) on x86_64-unknown-linux-gnu, compiled by GCC gcc (GCC) 4.4.2 compiled on Jul 24 2015 11:35:08'
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-Obtaining Segment details from master...
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:--Master segment instance  /data/master/gpseg-1  port = 5432
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:--Segment instance port assignments
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-----------------------------------
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   Host   Datadir                Port
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/primary/gpseg0   40000
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/mirror/gpseg0    50000
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/primary/gpseg1   40000
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/mirror/gpseg1    50001
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/primary/gpseg2   40000
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw4   /data/mirror/gpseg2    50000
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw4   /data/primary/gpseg3   40000
-20160126:15:40:22:028389 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/mirror/gpseg3    50001
+      <codeblock>[gpadmin@mdw ~]$ gpstate -p 20190403:02:57:04:011030 gpstate:mdw:gpadmin-[INFO]:-Starting gpstate with args: -p
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 5.17.0 build commit:fc9a9d4cad8dd4037b9bc07bf837c0b958726103'
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 8.3.23 (Greenplum Database 5.17.0 build commit:fc9a9d4cad8dd4037b9bc07bf837c0b958726103) on x86_64-pc-linux-gnu, compiled by GCC gcc (GCC) 6.2.0, 64-bit compiled on Feb 13 2019 15:26:34'
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-Obtaining Segment details from master...
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:--Master segment instance  /data/master/gpseg-1  port = 5432
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:--Segment instance port assignments
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-----------------------------------
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   Host   Datadir                Port
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/primary/gpseg0   20000
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/mirror/gpseg0    21000
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/primary/gpseg1   20001
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/mirror/gpseg1    21001
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/primary/gpseg2   20002
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/mirror/gpseg2    21002
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/primary/gpseg3   20000
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/mirror/gpseg3    21000
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/primary/gpseg4   20001
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/mirror/gpseg4    21001
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw2   /data/primary/gpseg5   20002
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/mirror/gpseg5    21002
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/primary/gpseg6   20000
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/mirror/gpseg6    21000
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/primary/gpseg7   20001
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/mirror/gpseg7    21001
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw3   /data/primary/gpseg8   20002
+20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-   sdw1   /data/mirror/gpseg8    21002
 </codeblock></p>
     <p>Additional Greenplum Database network connections are created for features such as standby
       replication, segment mirroring, statistics collection, and data exchange between segments.

--- a/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
+++ b/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
@@ -14,7 +14,8 @@
       to coordinate database operations with the segments. The <codeph>gpstate -p</codeph> command,
       executed on the Greenplum master, lists the port assignments for the Greenplum master and the
       primary segments and mirrors. For example:
-      <codeblock>[gpadmin@mdw ~]$ gpstate -p 20190403:02:57:04:011030 gpstate:mdw:gpadmin-[INFO]:-Starting gpstate with args: -p
+      <codeblock>[gpadmin@mdw ~]$ gpstate -p 
+20190403:02:57:04:011030 gpstate:mdw:gpadmin-[INFO]:-Starting gpstate with args: -p
 20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 5.17.0 build commit:fc9a9d4cad8dd4037b9bc07bf837c0b958726103'
 20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 8.3.23 (Greenplum Database 5.17.0 build commit:fc9a9d4cad8dd4037b9bc07bf837c0b958726103) on x86_64-pc-linux-gnu, compiled by GCC gcc (GCC) 6.2.0, 64-bit compiled on Feb 13 2019 15:26:34'
 20190403:02:57:05:011030 gpstate:mdw:gpadmin-[INFO]:-Obtaining Segment details from master...

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpinitsystem.xml
@@ -299,9 +299,7 @@
                 set Greenplum Database base port numbers to these values.</p>
             <p>
                 <codeblock>PORT_BASE = 6000
-MIRROR_PORT_BASE = 7000
-REPLICATION_PORT_BASE = 8000
-MIRROR_REPLICATION_PORT_BASE = 9000</codeblock>
+MIRROR_PORT_BASE = 7000</codeblock>
             </p>
             <parml>
                 <plentry>
@@ -418,27 +416,6 @@ MIRROR_REPLICATION_PORT_BASE = 9000</codeblock>
                             <codeph>PORT_BASE</codeph>.</pd>
                 </plentry>
                 <plentry>
-                    <pt id="replication_port_base">REPLICATION_PORT_BASE</pt>
-                    <pd><b>Optional.</b> This specifies the base number by which the port numbers
-                        for the primary file replication process are calculated. The first
-                        replication port on a host is set as <codeph>REPLICATION_PORT_BASE</codeph>,
-                        and then incremented by one for each additional primary segment on that
-                        host. Valid values range from 1 through 65535 and cannot conflict with the
-                        ports calculated by <codeph>PORT_BASE</codeph> or
-                            <codeph>MIRROR_PORT_BASE</codeph>.</pd>
-                </plentry>
-                <plentry>
-                    <pt>MIRROR_REPLICATION_PORT_BASE</pt>
-                    <pd><b>Optional.</b> This specifies the base number by which the port numbers
-                        for the mirror file replication process are calculated. The first mirror
-                        replication port on a host is set as
-                            <codeph>MIRROR_REPLICATION_PORT_BASE</codeph>, and then incremented by
-                        one for each additional mirror segment on that host. Valid values range from
-                        1 through 65535 and cannot conflict with the ports calculated by
-                            <codeph>PORT_BASE</codeph>, <codeph>MIRROR_PORT_BASE</codeph>, or
-                            <codeph>REPLICATION_PORT_BASE</codeph>.</pd>
-                </plentry>
-                <plentry>
                     <pt>MIRROR_DATA_DIRECTORY</pt>
                     <pd><b>Optional.</b> This specifies the data storage location(s) where the
                         utility will create the mirror segment data directories. There must be the
@@ -462,17 +439,17 @@ MIRROR_REPLICATION_PORT_BASE = 9000</codeblock>
                             <codeph>MIRROR_ARRAY</codeph> define the Greenplum Database master host
                         and the primary and mirror instances on the segment hosts, respectively,
                         using the format:
-                        <codeblock><varname>host</varname>~<varname>port</varname>~<varname>data_directory</varname>/<varname>seg_prefix&lt;segment_id></varname>~<varname>dbid</varname>~<varname>content_id</varname>~<varname>replication_port</varname></codeblock>The
+                        <codeblock><varname>host</varname>~<varname>port</varname>~<varname>data_directory</varname>/<varname>seg_prefix&lt;segment_id></varname>~<varname>dbid</varname>~<varname>content_id</varname></codeblock>The
                         Greenplum Database master always uses the value -1 for the segment ID and
                         content ID. For
                         example:<codeblock>QD_PRIMARY_ARRAY=127.0.0.1~5432~/gpmaster/gpsne-1~1~-1~0
 declare -a PRIMARY_ARRAY=(
-127.0.0.1~40000~/gpdata1/gpsne0~2~0~6000
-127.0.0.1~40001~/gpdata2/gpsne1~3~1~6001
+127.0.0.1~40000~/gpdata1/gpsne0~2~0
+127.0.0.1~40001~/gpdata2/gpsne1~3~1
 )
 declare -a MIRROR_ARRAY=(
-127.0.0.1~50000~/gpmirror1/gpsne0~4~0~51000
-127.0.0.1~50001~/gpmirror2/gpsne1~5~1~51001
+127.0.0.1~50000~/gpmirror1/gpsne0~4~0
+127.0.0.1~50001~/gpmirror2/gpsne1~5~1
 )</codeblock></pd>
                     <pd>You can use the <codeph>gpinitsystem</codeph>
                         <codeph>-O <varname>output_configuration_file</varname></codeph> to populate


### PR DESCRIPTION
- Remove lingering references to MIRROR_PORT_BASE and MIRROR_REPLICATION_PORT_BASE
- Replace sample `gpstate -p` output with current output


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
