### PR TITLE
Backport 6X - Disable sanity assertion for itempointer offsetnumber

### DIFF
--- a/src/backend/access/gin/ginpostinglist.c
+++ b/src/backend/access/gin/ginpostinglist.c
@@ -86,7 +86,14 @@ itemptr_to_uint64(const ItemPointer iptr)
 	uint64		val;
 
 	Assert(ItemPointerIsValid(iptr));
+	/*
+	 * Greenplum allow 16 bits for the offsetnumber, which turns the below
+	 * upstream assertion into an always-true comparison which generates a
+	 * compiler warning; thus we need to keep this commented out.
+	 */
+#if 0
 	Assert(iptr->ip_posid < (1 << MaxHeapTuplesPerPageBits));
+#endif
 
 	val = iptr->ip_blkid.bi_hi;
 	val <<= 16;


### PR DESCRIPTION
Backporting this along with the GIN index change.