### PR TITLE
Backport 6X - Disable gpfdist_ssl test 

### DIFF
--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -4,23 +4,10 @@ include $(top_builddir)/src/Makefile.global
 default: installcheck
 
 REGRESS = exttab1 custom_format gpfdist2
-
-ifeq ($(enable_gpfdist),yes)
-ifeq ($(with_openssl),yes)
-	REGRESS += gpfdist_ssl
-endif
-endif
-
 PSQLDIR = $(prefix)/bin
 REGRESS_OPTS = --init-file=init_file
 
 installcheck: watchdog
-ifeq ($(enable_gpfdist),yes)
-ifeq ($(with_openssl),yes)
-	cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists data/gpfdist_ssl/certs_matching
-	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_not_matching
-endif
-endif
 	$(top_builddir)/src/test/regress/pg_regress --psqldir=$(PSQLDIR) --dbname=gpfdist_regression $(REGRESS) $(REGRESS_OPTS)
 
 watchdog:


### PR DESCRIPTION
Diable until someone looks at why it is failing.

It fails and appears to not be maintained when:

--enable-gpfdist and --with-openssl are configured.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
