### PR TITLE
gprecoverseg: attempt a workaround for FTS probe races

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -20,6 +20,9 @@ from gppylib.mainUtils import *
 
 from optparse import OptionGroup
 import os, sys, signal, time
+
+from pygresql import pg
+
 from gppylib import gparray, gplog, userinput, utils
 from gppylib.util import gp_utils
 from gppylib.commands import gp, pg, unix
@@ -660,8 +663,13 @@ class GpRecoverSegmentProgram:
     def trigger_fts_probe(self, port=0):
         self.logger.info('Triggering FTS probe')
         with dbconn.connect(dbconn.DbURL(port=port)) as conn:
-            res = dbconn.execSQL(conn, "SELECT gp_request_fts_probe_scan()")
-        return res.fetchall()
+            db = pg.DB(conn)
+
+            # XXX Perform two probe scans in a row, to work around a known
+            # race where gp_request_fts_probe_scan() can return early during the
+            # first call. Remove this duplication once that race is fixed.
+            for _ in range(2):
+                db.query("SELECT gp_request_fts_probe_scan()")
 
     def validate_heap_checksum_consistency(self, gpArray, mirrorBuilder):
         live_segments = [target.getLiveSegment() for target in mirrorBuilder.getMirrorsToBuild()]


### PR DESCRIPTION
replication_slots tests are hitting frequent intermittent failures during gprecoverseg operation. Some failures are because mirrors aren't being marked 'up' after gprecoverseg exits cleanly, and we already know that FTS probes have a known race that occasionally causes them to do nothing on the first call.

As a stop-gap before the probe race is fixed, try a double-call to `gp_request_fts_probe_scan()` to see if that helps the situation any.

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
