### PR TITLE
Backport 5X - Do not modify a cached plan statement during ExecuteTruncate.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1089,6 +1089,12 @@ ExecuteTruncate(TruncateStmt *stmt)
 	ListCell   *cell;
     int partcheck = 2;
 	List *partList = NIL;
+	TruncateStmt *truncateStatement;
+
+	/*
+	 * Copy the statement to ensure we do not modify a cached plan
+	 */
+	truncateStatement = (TruncateStmt *) copyObject(stmt);
 
 	/*
 	 * Open, exclusive-lock, and check all the explicitly-specified relations
@@ -1097,7 +1103,7 @@ ExecuteTruncate(TruncateStmt *stmt)
 	 */
 	while (partcheck)
 	{
-		foreach(cell, stmt->relations)
+		foreach(cell, truncateStatement->relations)
 		{
 			RangeVar   *rv = lfirst(cell);
 			Relation	rel;
@@ -1134,9 +1140,9 @@ ExecuteTruncate(TruncateStmt *stmt)
 			/* add the partitions to the relation list and try again */
 			if (partcheck == 1)
 			{
-				stmt->relations = list_concat(partList, stmt->relations);
+				truncateStatement->relations = list_concat(partList, truncateStatement->relations);
 
-				cell = list_head(stmt->relations);
+				cell = list_head(truncateStatement->relations);
 				while (cell != NULL)
 				{
 					RangeVar   *rv = lfirst(cell);
@@ -1162,7 +1168,7 @@ ExecuteTruncate(TruncateStmt *stmt)
 	/*
 	 * Open, exclusive-lock, and check all the explicitly-specified relations
 	 */
-	foreach(cell, stmt->relations)
+	foreach(cell, truncateStatement->relations)
 	{
 		RangeVar   *rv = lfirst(cell);
 		Relation	rel;
@@ -1184,7 +1190,7 @@ ExecuteTruncate(TruncateStmt *stmt)
 	 * soon as we open it, to avoid a faux pas such as holding lock for a long
 	 * time on a rel we have no permissions for.
 	 */
-	if (stmt->behavior == DROP_CASCADE)
+	if (truncateStatement->behavior == DROP_CASCADE)
 	{
 		for (;;)
 		{
@@ -1222,7 +1228,7 @@ ExecuteTruncate(TruncateStmt *stmt)
 #ifdef USE_ASSERT_CHECKING
 	heap_truncate_check_FKs(rels, false);
 #else
-	if (stmt->behavior == DROP_RESTRICT)
+	if (truncateStatement->behavior == DROP_RESTRICT)
 		heap_truncate_check_FKs(rels, false);
 #endif
 
@@ -1246,7 +1252,7 @@ ExecuteTruncate(TruncateStmt *stmt)
 	{
 		ListCell	*lc;
 
-		CdbDispatchUtilityStatement((Node *) stmt,
+		CdbDispatchUtilityStatement((Node *) truncateStatement,
 									DF_CANCEL_ON_ERROR |
 									DF_WITH_SNAPSHOT |
 									DF_NEED_TWO_PHASE,

--- a/src/test/regress/expected/partition_with_user_defined_function_that_truncates.out
+++ b/src/test/regress/expected/partition_with_user_defined_function_that_truncates.out
@@ -1,0 +1,60 @@
+-- Given there is a partitioned table
+	create table some_partitioned_table_to_truncate
+	(
+		a integer
+	)
+	partition by range (a) (
+		partition b start (0)
+	);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "some_partitioned_table_to_truncate_1_prt_b" for table "some_partitioned_table_to_truncate"
+-- And a function that truncates the partitioned table
+	CREATE FUNCTION truncate_a_partition_table() RETURNS VOID AS
+	$$
+	BEGIN
+	    TRUNCATE some_partitioned_table_to_truncate;
+	END;
+	$$ LANGUAGE plpgsql;
+-- When I truncate the table twice
+	insert into some_partitioned_table_to_truncate
+	       select i from generate_series(1, 10) i;
+   	select count(*) from some_partitioned_table_to_truncate;
+ count 
+-------
+    10
+(1 row)
+
+	select truncate_a_partition_table();
+ truncate_a_partition_table 
+----------------------------
+ 
+(1 row)
+
+   	select count(*) from some_partitioned_table_to_truncate;	
+ count 
+-------
+     0
+(1 row)
+
+-- Then I get the same result both times (no rows)
+	insert into some_partitioned_table_to_truncate
+	       select i from generate_series(1, 10) i;
+   	select count(*) from some_partitioned_table_to_truncate;
+ count 
+-------
+    10
+(1 row)
+
+	select truncate_a_partition_table();
+ truncate_a_partition_table 
+----------------------------
+ 
+(1 row)
+
+   	select count(*) from some_partitioned_table_to_truncate;	
+ count 
+-------
+     0
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -64,7 +64,7 @@ test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 olap_group olap_window_se
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.
-test: partition partition1 partition_indexing parruleord partition_with_user_defined_function
+test: partition partition1 partition_indexing parruleord partition_with_user_defined_function partition_with_user_defined_function_that_truncates
 # 'partition_locking' gets confused if other backends run concurrently and
 # hold locks.
 test: partition_locking

--- a/src/test/regress/sql/partition_with_user_defined_function_that_truncates.sql
+++ b/src/test/regress/sql/partition_with_user_defined_function_that_truncates.sql
@@ -1,0 +1,31 @@
+-- Given there is a partitioned table
+	create table some_partitioned_table_to_truncate
+	(
+		a integer
+	)
+	partition by range (a) (
+		partition b start (0)
+	);
+
+-- And a function that truncates the partitioned table
+	CREATE FUNCTION truncate_a_partition_table() RETURNS VOID AS
+	$$
+	BEGIN
+	    TRUNCATE some_partitioned_table_to_truncate;
+	END;
+	$$ LANGUAGE plpgsql;
+
+-- When I truncate the table twice
+	insert into some_partitioned_table_to_truncate
+	       select i from generate_series(1, 10) i;
+	select count(*) from some_partitioned_table_to_truncate;
+	select truncate_a_partition_table();
+	select count(*) from some_partitioned_table_to_truncate;
+
+-- Then I get the same result both times (no rows)
+	insert into some_partitioned_table_to_truncate
+	       select i from generate_series(1, 10) i;
+	select count(*) from some_partitioned_table_to_truncate;
+	select truncate_a_partition_table();
+	select count(*) from some_partitioned_table_to_truncate;
+


### PR DESCRIPTION
User defined functions cache their plan, therefore if we modify the
plan during execution, we risk having invalid data during the next
execution of the cached plan.

ExecuteTruncate modifies the plan's relations when declaring partitions
that need truncation.

In 5x, we dispatch the modified statement to the segments with the
addition of the partition tables to be truncated. The segments do not
contain the catalog information for partitions, so it is necessary for
the dispatcher to determine all of the necessary tables before dispatching.

In this change, we make a copy of the TruncateStmt, so that the modified
statement can be dispatched to the segments, but the original
statement remains unchanged. This solution is different from the 6X
solution, but the core idea is the same - don't modify the cached
statement.

Somewhat cherry-picked from e3cf4f269153a488e2b18ca67fafbe18a7901c73.

Co-authored-by: Melanie Plageman <mplageman@pivotal.io>
