### PR TITLE
Docs - change default log_rotation_size to 1GB

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/maintain.xml
+++ b/gpdb-doc/dita/admin_guide/managing/maintain.xml
@@ -276,15 +276,27 @@ VACUUM cust_info;</codeblock></p>
       <title id="np157220">Database Server Log Files</title>
       <body>
         <p>Greenplum Database log output tends to be voluminous, especially at higher debug levels,
-          and you do not need to save it indefinitely. Administrators rotate the log files
-          periodically so new log files are started and old ones are removed.</p>
-        <p>Greenplum Database has log file rotation enabled on the master and all segment instances.
-          Daily log files are created in the <codeph>pg_log</codeph> subdirectory of the master and
-          each segment data directory using the following naming convention:
-              <codeph>gpdb-<i>YYYY</i>-<i>MM</i>-<i>DD_hhmmss</i>.csv</codeph>. Although log files
-          are rolled over daily, they are not automatically truncated or deleted. Administrators
-          need to implement scripts or programs to periodically clean up old log files in the
+          and you do not need to save it indefinitely. Administrators should purge older log files
+          periodically.</p>
+        <p>Greenplum Database by default has log file rotation enabled for the master and segment
+          database logs. Log files are created in the <codeph>pg_log</codeph> subdirectory of the
+          master and each segment data directory using the following naming convention:
+              <codeph>gpdb-<i>YYYY</i>-<i>MM</i>-<i>DD_hhmmss</i>.csv</codeph>. Administrators need
+          to implement scripts or programs to periodically clean up old log files in the
             <codeph>pg_log</codeph> directory of the master and each segment instance.</p>
+        <p>Log rotation can be triggered by the size of the current log file or the age of the
+          current log file. The <codeph>log_rotation_size</codeph> configuration parameter sets the
+          size of an individual log file that triggers log rotation. When the log file size is equal
+          to or greater than the specified size, the file is closed and a new log file is created.
+          The <codeph>log_rotation_size</codeph> value is specified in kilobytes. The default is
+          1048576 kilobytes, or 1GB. If <codeph>log_rotation_size</codeph> is set to 0, size-based
+          rotation is disabled.</p>
+        <p>The <codeph>log_rotation_age</codeph> configuration parameter specifies the age of a log
+          file that triggers rotation. When the specified amount of time has elapsed since the log
+          file was created, the file is closed and a new log file is created. The default
+            <codeph>log_rotation_age</codeph>, 1d, creates a new log file 24 hours after the current
+          log file was created. If <codeph>log_rotation_age</codeph> is set to 0, time-based
+          rotation is disabled.</p>
         <p>For information about viewing the database server log files, see <xref
             href="monitor.xml#topic28" type="topic" format="dita"/>.</p>
       </body>

--- a/gpdb-doc/dita/admin_guide/managing/monitor.xml
+++ b/gpdb-doc/dita/admin_guide/managing/monitor.xml
@@ -555,7 +555,7 @@ Distributed by: (sale_id)
     <title id="kj166926">Viewing the Database Server Log Files</title>
     <body>
       <p>Every database instance in Greenplum Database (master and segments) runs a PostgreSQL
-        database server with its own server log file. Daily log files are created in the
+        database server with its own server log file. Log files are created in the
           <codeph>pg_log</codeph> directory of the master and each segment data directory.</p>
     </body>
     <topic id="topic29" xml:lang="en">

--- a/gpdb-doc/dita/best_practices/logfiles.xml
+++ b/gpdb-doc/dita/best_practices/logfiles.xml
@@ -118,9 +118,14 @@
     <p>To search log files on the segment hosts, use the Greenplum <codeph>gplogfilter</codeph>
       utility with <codeph>gpssh</codeph> to connect to segment hosts from the master host. You can
       identify corresponding log entries in segment logs by the <codeph>statement_id</codeph>. </p>
-    <p>The <codeph>log_rotation_age</codeph> configuration parameter specifies when a new log file
-      is automatically created while a database instance is running. By default, a new log file is
-      created every day. </p>
+    <p>Greenplum Database can be configured to rotate database logs based on the size or age of the
+      current log file. The <codeph>log_rotation_size</codeph> configuration parameter sets the size
+      of an individual log file that triggers rotation. When the current log file size is equal to
+      or greater than this size, the file is closed and a new log file is created. The
+        <codeph>log_rotation_age</codeph> configuration parameter specifies the age of the current
+      log file that triggers rotation. When the specified time has elapsed since the current log
+      file was created, a new log file is created. The default <codeph>log_rotation_age</codeph>,
+      1d, creates a new log file 24 hours after the current log file was created.</p>
 
   </body>
 </topic>

--- a/gpdb-doc/dita/best_practices/logfiles.xml
+++ b/gpdb-doc/dita/best_practices/logfiles.xml
@@ -118,7 +118,7 @@
     <p>To search log files on the segment hosts, use the Greenplum <codeph>gplogfilter</codeph>
       utility with <codeph>gpssh</codeph> to connect to segment hosts from the master host. You can
       identify corresponding log entries in segment logs by the <codeph>statement_id</codeph>. </p>
-    <p>Greenplum Database can be configured to rotate database logs based on the size or age of the
+    <p>Greenplum Database can be configured to rotate database logs based on the size and/or age of the
       current log file. The <codeph>log_rotation_size</codeph> configuration parameter sets the size
       of an individual log file that triggers rotation. When the current log file size is equal to
       or greater than this size, the file is closed and a new log file is created. The

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -6250,9 +6250,9 @@
   <topic id="log_rotation_age">
     <title>log_rotation_age</title>
     <body>
-      <p>Determines the lifetime of an individual log file. When this amount of time has elapsed, 
-        the file is closed and a new log file is created. Set to zero to disable time-based creation of new log
-        files.</p>
+      <p>Determines the amount of time Greenplum Database writes messages to the active log file.
+        When this amount of time has elapsed, the file is closed and a new log file is created. Set
+        to zero to disable time-based creation of new log files.</p>
       <table id="log_rotation_age_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -6250,8 +6250,8 @@
   <topic id="log_rotation_age">
     <title>log_rotation_age</title>
     <body>
-      <p>Determines the maximum lifetime of an individual log file. After this time has elapsed, a
-        new log file will be created. Set to zero to disable time-based creation of new log
+      <p>Determines the lifetime of an individual log file. When this amount of time has elapsed, 
+        the file is closed and a new log file is created. Set to zero to disable time-based creation of new log
         files.</p>
       <table id="log_rotation_age_table">
         <tgroup cols="3">
@@ -6279,9 +6279,9 @@
   <topic id="log_rotation_size">
     <title>log_rotation_size</title>
     <body>
-      <p>Determines the maximum size of an individual log file. After this many kilobytes have been
-        emitted into a log file, a new log file will be created. Set to zero to disable size-based
-        creation of new log files.</p>
+      <p>Determines the size of an individual log file that triggers rotation. When the log file
+        size is equal to or greater than this size, the file is closed and a new log file is
+        created. Set to zero to disable size-based creation of new log files. </p>
       <p>The maximum value is INT_MAX/1024. If an invalid value is specified, the default value is
         used. INT_MAX is the largest value that can be stored as an integer on your system. </p>
       <table id="log_rotation_size_table">
@@ -6299,7 +6299,7 @@
           <tbody>
             <row>
               <entry colname="col1">number of kilobytes</entry>
-              <entry colname="col2">0</entry>
+              <entry colname="col2">1048576</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/security-guide/topics/Auditing.xml
+++ b/gpdb-doc/dita/security-guide/topics/Auditing.xml
@@ -679,7 +679,7 @@
               <entry>1048576</entry>
               <entry>
                 <p>When greater than 0, a new log file is created when this number of kilobytes have
-                  been written to the log. </p>
+                  been written to the log. Set to zero to disable size-based creation of new log files. </p>
               </entry>
             </row>
             <row>

--- a/gpdb-doc/dita/security-guide/topics/Auditing.xml
+++ b/gpdb-doc/dita/security-guide/topics/Auditing.xml
@@ -673,6 +673,17 @@
             </row>
             <row>
               <entry>
+                <p>log_rotation_size</p>
+              </entry>
+              <entry>0 - INT_MAX/1024 kilobytes</entry>
+              <entry>1048576</entry>
+              <entry>
+                <p>When greater than 0, a new log file is created when this number of kilobytes have
+                  been written to the log. </p>
+              </entry>
+            </row>
+            <row>
+              <entry>
                 <p> log_rotation_age </p>
               </entry>
               <entry>
@@ -682,9 +693,9 @@
                 <p> 1d </p>
               </entry>
               <entry>
-                <p> Determines the maximum lifetime of an individual log file. After this time has
-                  elapsed, a new log file will be created. Set to zero to disable time-based
-                  creation of new log files. </p>
+                <p> Determines the lifetime of an individual log file. When this amount of time has
+                  elapsed since the current log file was created, a new log file will be created.
+                  Set to zero to disable time-based creation of new log files. </p>
               </entry>
             </row>
             <row>


### PR DESCRIPTION
- Also clarify how and when log rotation occurs, i.e., log_rotation_size triggers rotation, it's not a maximum file size.
- For log_rotation_age, log is rotated when the current log file reaches specified age, not "once a day".

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
