### PR TITLE
6X Backport: Fix flaky test fts_recovery_in_progress by increasing gang creation t…

### DIFF
--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -27,10 +27,10 @@ NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
 -- Allow extra time for mirror promotion to complete recovery to avoid
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
--- case segment is in recovery. Approximately we want to wait 30 seconds.
+-- case segment is in recovery. Approximately we want to wait 2 minutes at most.
 -- start_ignore
 \!gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly
-\!gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly
+\!gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly
 \!gpstop -u
 -- end_ignore
 -- Wait a few seconds, to ensure the config changes take effect.

--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -16,10 +16,10 @@ from gp_segment_configuration where content = 0 and role = 'p';
 -- Allow extra time for mirror promotion to complete recovery to avoid
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
--- case segment is in recovery. Approximately we want to wait 30 seconds.
+-- case segment is in recovery. Approximately we want to wait 2 minutes at most.
 -- start_ignore
 \!gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly
-\!gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly
+\!gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly
 \!gpstop -u
 -- end_ignore
 -- Wait a few seconds, to ensure the config changes take effect.


### PR DESCRIPTION
…imeout. (#7344)

Previously the test waits no more than 30 seconds until mirror promotion
finished, but 30 seconds are not enough in a real test environment. In this
patch, we increase the guc gp_gang_creation_retry_timer from 250 (ms) to 1000
(ms) so we that we wait for 2 minutes at most, given guc
gp_gang_creation_retry_count has been configured with its maximum value.

Co-authored-by: Haozhou Wang <hawang@pivotal.io>