### PR TITLE
6X backport: Fix missing_xlog test failure due to bad function argument. (#7366)

### DIFF
--- a/src/test/walrep/expected/missing_xlog.out
+++ b/src/test/walrep/expected/missing_xlog.out
@@ -248,7 +248,7 @@ select count(*) = 2 as mirror_up from gp_segment_configuration
 -- make sure leave the test only after mirror is in sync to avoid
 -- affecting other tests. Thumb rule: leave cluster in same state as
 -- test started.
-select wait_for_mirror_sync((select dbid::smallint from gp_segment_configuration c where c.role='p' and c.content=0));
+select wait_for_mirror_sync(0::smallint);
  wait_for_mirror_sync 
 ----------------------
  

--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -174,5 +174,5 @@ select count(*) = 2 as mirror_up from gp_segment_configuration
 -- make sure leave the test only after mirror is in sync to avoid
 -- affecting other tests. Thumb rule: leave cluster in same state as
 -- test started.
-select wait_for_mirror_sync((select dbid::smallint from gp_segment_configuration c where c.role='p' and c.content=0));
+select wait_for_mirror_sync(0::smallint);
 select role, preferred_role, content, mode, status from gp_segment_configuration;


### PR DESCRIPTION
wait_for_mirror_sync() uses contentid as argument, but the missing_xlog test
case uses dbid as input, so in this test wait_for_mirror_sync() is not really
useful - this makes the test flaky.

Co-authored-by: Haozhou Wang <hawang@pivotal.io>

Reviewed-by: Jimmy Yih
