### PR TITLE
Fix gpperfmon flaky tests.

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmondb.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmondb.c
@@ -1657,7 +1657,7 @@ void upgrade_log_alert_table_distributed_key(PGconn* conn)
 	    INNER JOIN pg_attribute b on a.oid=b.attrelid\
 	    INNER JOIN gp_distribution_policy c on a.oid = c.localoid\
 	    INNER JOIN pg_namespace d on a.relnamespace = d.oid\
-	    WHERE a.relkind = 'r' AND b.attnum = any(c.attrnums) AND a.relname = 'log_alert_history'";
+	    WHERE a.relkind = 'r' AND b.attnum = any(c.distkey) AND a.relname = 'log_alert_history'";
 
 	PGresult* result = NULL;
 	const char* errmsg = gpdb_exec_only(conn, &result, qry);


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/7363 to 6X_STABLE.


Co-authored-by: Wenlin Zhang <wzhang@pivotal.io>
Co-authored-by: Bing Xu <bxu@pivotal.io>
