### PR TITLE
Disable shareinputscan with outer refs.

### DIFF
--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -30,3 +30,10 @@ SELECT * FROM
 ---+---+---+---+---+---
 (0 rows)
 
+SELECT *,
+        (
+        WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
+        SELECT 1 FROM cte c1, cte c2
+        )
+        FROM bar;
+ERROR:  shareinputscan with outer refs is not supported by GPDB

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -27,3 +27,10 @@ SELECT * FROM
         JOIN bar ON b = c
         ) AS XY
         JOIN jazz on c = e AND b = f;
+
+SELECT *,
+        (
+        WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
+        SELECT 1 FROM cte c1, cte c2
+        )
+        FROM bar;


### PR DESCRIPTION
Currently shareinputscan doesn't handle rescan properly, and to fully
support it, there will be a lot of code changes. After some discussions,
we decide to disable shareinputscan with outer refs for now.

This patch is for github issue #7071.

Discussion: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/cCSV38aTn-8

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
