### PR TITLE
contrib: update btree_gist to match upstream

### DIFF
--- a/contrib/btree_gist/expected/cash.out
+++ b/contrib/btree_gist/expected/cash.out
@@ -1,8 +1,10 @@
 -- money check
 -- In PostgreSQL, this test uses WITH OIDS, but in GPDB, OIDs are not unique
 -- across segments, so use a 'serial' column instead.
+-- start_ignore
 CREATE TABLE moneytmp (a money, oid serial);
 NOTICE:  CREATE TABLE will create implicit sequence "moneytmp_oid_seq" for serial column "moneytmp.oid"
+-- end_ignore
 \copy moneytmp (a) from 'data/cash.data'
 SET enable_seqscan=on;
 SELECT count(*) FROM moneytmp WHERE a <  '22649.64';
@@ -77,12 +79,15 @@ SELECT count(*) FROM moneytmp WHERE a >  '22649.64'::money;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '21472.79' FROM moneytmp ORDER BY a <-> '21472.79' LIMIT 3;
-                  QUERY PLAN                   
------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
-   ->  Index Scan using moneyidx on moneytmp
-         Order By: (a <-> '$21,472.79'::money)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> '$21,472.79'::money))
+         ->  Limit
+               ->  Index Scan using moneyidx on moneytmp
+                     Order By: (a <-> '$21,472.79'::money)
+(7 rows)
 
 SELECT a, a <-> '21472.79' FROM moneytmp ORDER BY a <-> '21472.79' LIMIT 3;
      a      | ?column? 

--- a/contrib/btree_gist/expected/date.out
+++ b/contrib/btree_gist/expected/date.out
@@ -74,12 +74,15 @@ SELECT count(*) FROM datetmp WHERE a >  '2001-02-13'::date;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '2001-02-13' FROM datetmp ORDER BY a <-> '2001-02-13' LIMIT 3;
-                  QUERY PLAN                  
-----------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Limit
-   ->  Index Scan using dateidx on datetmp
-         Order By: (a <-> '02-13-2001'::date)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> '02-13-2001'::date))
+         ->  Limit
+               ->  Index Scan using dateidx on datetmp
+                     Order By: (a <-> '02-13-2001'::date)
+(7 rows)
 
 SELECT a, a <-> '2001-02-13' FROM datetmp ORDER BY a <-> '2001-02-13' LIMIT 3;
      a      | ?column? 

--- a/contrib/btree_gist/expected/float4.out
+++ b/contrib/btree_gist/expected/float4.out
@@ -74,12 +74,15 @@ SELECT count(*) FROM float4tmp WHERE a >  -179.0::float4;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '-179.0' FROM float4tmp ORDER BY a <-> '-179.0' LIMIT 3;
-                  QUERY PLAN                   
------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
-   ->  Index Scan using float4idx on float4tmp
-         Order By: (a <-> (-179)::real)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> (-179)::real))
+         ->  Limit
+               ->  Index Scan using float4idx on float4tmp
+                     Order By: (a <-> (-179)::real)
+(7 rows)
 
 SELECT a, a <-> '-179.0' FROM float4tmp ORDER BY a <-> '-179.0' LIMIT 3;
     a     | ?column? 

--- a/contrib/btree_gist/expected/float8.out
+++ b/contrib/btree_gist/expected/float8.out
@@ -74,12 +74,15 @@ SELECT count(*) FROM float8tmp WHERE a >  -1890.0::float8;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '-1890.0' FROM float8tmp ORDER BY a <-> '-1890.0' LIMIT 3;
-                     QUERY PLAN                      
------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Limit
-   ->  Index Scan using float8idx on float8tmp
-         Order By: (a <-> (-1890)::double precision)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> (-1890)::double precision))
+         ->  Limit
+               ->  Index Scan using float8idx on float8tmp
+                     Order By: (a <-> (-1890)::double precision)
+(7 rows)
 
 SELECT a, a <-> '-1890.0' FROM float8tmp ORDER BY a <-> '-1890.0' LIMIT 3;
       a       |  ?column?  

--- a/contrib/btree_gist/expected/int2.out
+++ b/contrib/btree_gist/expected/int2.out
@@ -74,12 +74,15 @@ SELECT count(*) FROM int2tmp WHERE a >  237::int2;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '237' FROM int2tmp ORDER BY a <-> '237' LIMIT 3;
-                QUERY PLAN                 
--------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Limit
-   ->  Index Scan using int2idx on int2tmp
-         Order By: (a <-> 237::smallint)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> 237::smallint))
+         ->  Limit
+               ->  Index Scan using int2idx on int2tmp
+                     Order By: (a <-> 237::smallint)
+(7 rows)
 
 SELECT a, a <-> '237' FROM int2tmp ORDER BY a <-> '237' LIMIT 3;
   a  | ?column? 

--- a/contrib/btree_gist/expected/int4.out
+++ b/contrib/btree_gist/expected/int4.out
@@ -74,12 +74,15 @@ SELECT count(*) FROM int4tmp WHERE a >  237::int4;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '237' FROM int4tmp ORDER BY a <-> '237' LIMIT 3;
-                QUERY PLAN                 
--------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Limit
-   ->  Index Scan using int4idx on int4tmp
-         Order By: (a <-> 237)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> 237))
+         ->  Limit
+               ->  Index Scan using int4idx on int4tmp
+                     Order By: (a <-> 237)
+(7 rows)
 
 SELECT a, a <-> '237' FROM int4tmp ORDER BY a <-> '237' LIMIT 3;
   a  | ?column? 

--- a/contrib/btree_gist/expected/int8.out
+++ b/contrib/btree_gist/expected/int8.out
@@ -74,12 +74,15 @@ SELECT count(*) FROM int8tmp WHERE a >  464571291354841::int8;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '464571291354841' FROM int8tmp ORDER BY a <-> '464571291354841' LIMIT 3;
-                    QUERY PLAN                     
----------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Limit
-   ->  Index Scan using int8idx on int8tmp
-         Order By: (a <-> 464571291354841::bigint)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> 464571291354841::bigint))
+         ->  Limit
+               ->  Index Scan using int8idx on int8tmp
+                     Order By: (a <-> 464571291354841::bigint)
+(7 rows)
 
 SELECT a, a <-> '464571291354841' FROM int8tmp ORDER BY a <-> '464571291354841' LIMIT 3;
         a        |    ?column?    

--- a/contrib/btree_gist/expected/interval.out
+++ b/contrib/btree_gist/expected/interval.out
@@ -74,12 +74,15 @@ SELECT count(*) FROM intervaltmp WHERE a >  '199 days 21:21:23'::interval;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '199 days 21:21:23' FROM intervaltmp ORDER BY a <-> '199 days 21:21:23' LIMIT 3;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using intervalidx on intervaltmp
-         Order By: (a <-> '@ 199 days 21 hours 21 mins 23 secs'::interval)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> '@ 199 days 21 hours 21 mins 23 secs'::interval))
+         ->  Limit
+               ->  Index Scan using intervalidx on intervaltmp
+                     Order By: (a <-> '@ 199 days 21 hours 21 mins 23 secs'::interval)
+(7 rows)
 
 SELECT a, a <-> '199 days 21:21:23' FROM intervaltmp ORDER BY a <-> '199 days 21:21:23' LIMIT 3;
                   a                  |               ?column?               

--- a/contrib/btree_gist/expected/not_equal.out
+++ b/contrib/btree_gist/expected/not_equal.out
@@ -11,13 +11,14 @@ INSERT INTO test_ne VALUES('2011-09-01', 43.7);
 INSERT INTO test_ne SELECT '2009-01-01', 10.7 FROM generate_series(1,1000);
 SET enable_indexscan to false;
 EXPLAIN (COSTS OFF) SELECT * FROM test_ne WHERE a <> '2009-01-01' AND b <> 10.7;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Bitmap Heap Scan on test_ne
-   Recheck Cond: ((a <> 'Thu Jan 01 00:00:00 2009'::timestamp without time zone) AND (b <> 10.7))
-   ->  Bitmap Index Scan on test_ne_idx
-         Index Cond: ((a <> 'Thu Jan 01 00:00:00 2009'::timestamp without time zone) AND (b <> 10.7))
-(4 rows)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test_ne
+         Recheck Cond: ((a <> 'Thu Jan 01 00:00:00 2009'::timestamp without time zone) AND (b <> 10.7))
+         ->  Bitmap Index Scan on test_ne_idx
+               Index Cond: ((a <> 'Thu Jan 01 00:00:00 2009'::timestamp without time zone) AND (b <> 10.7))
+(6 rows)
 
 SELECT * FROM test_ne WHERE a <> '2009-01-01' AND b <> 10.7;
             a             |   b   
@@ -27,6 +28,9 @@ SELECT * FROM test_ne WHERE a <> '2009-01-01' AND b <> 10.7;
 (2 rows)
 
 RESET enable_indexscan;
+-- The below test use an exclusion constraint, which isn't supported in GPDB
+-- so we need to ignore this test
+-- start_ignore
 -- test search for "not equals" using an exclusion constraint
 CREATE TABLE zoo (
    cage   INTEGER,
@@ -39,3 +43,4 @@ INSERT INTO zoo VALUES(123, 'lion');
 ERROR:  conflicting key value violates exclusion constraint "zoo_cage_animal_excl"
 DETAIL:  Key (cage, animal)=(123, lion) conflicts with existing key (cage, animal)=(123, zebra).
 INSERT INTO zoo VALUES(124, 'lion');
+-- end_ignore

--- a/contrib/btree_gist/expected/time.out
+++ b/contrib/btree_gist/expected/time.out
@@ -74,12 +74,15 @@ SELECT count(*) FROM timetmp WHERE a >  '10:57:11'::time;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '10:57:11' FROM timetmp ORDER BY a <-> '10:57:11' LIMIT 3;
-                          QUERY PLAN                          
---------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Limit
-   ->  Index Scan using timeidx on timetmp
-         Order By: (a <-> '10:57:11'::time without time zone)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> '10:57:11'::time without time zone))
+         ->  Limit
+               ->  Index Scan using timeidx on timetmp
+                     Order By: (a <-> '10:57:11'::time without time zone)
+(7 rows)
 
 SELECT a, a <-> '10:57:11' FROM timetmp ORDER BY a <-> '10:57:11' LIMIT 3;
     a     |    ?column?     

--- a/contrib/btree_gist/expected/timestamp.out
+++ b/contrib/btree_gist/expected/timestamp.out
@@ -74,12 +74,15 @@ SELECT count(*) FROM timestamptmp WHERE a >  '2004-10-26 08:55:08'::timestamp;
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '2004-10-26 08:55:08' FROM timestamptmp ORDER BY a <-> '2004-10-26 08:55:08' LIMIT 3;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using timestampidx on timestamptmp
-         Order By: (a <-> 'Tue Oct 26 08:55:08 2004'::timestamp without time zone)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> 'Tue Oct 26 08:55:08 2004'::timestamp without time zone))
+         ->  Limit
+               ->  Index Scan using timestampidx on timestamptmp
+                     Order By: (a <-> 'Tue Oct 26 08:55:08 2004'::timestamp without time zone)
+(7 rows)
 
 SELECT a, a <-> '2004-10-26 08:55:08' FROM timestamptmp ORDER BY a <-> '2004-10-26 08:55:08' LIMIT 3;
             a             |              ?column?              

--- a/contrib/btree_gist/expected/timestamptz.out
+++ b/contrib/btree_gist/expected/timestamptz.out
@@ -194,12 +194,15 @@ SELECT count(*) FROM timestamptztmp WHERE a >  '2018-12-18 10:59:54 GMT+4'::time
 
 EXPLAIN (COSTS OFF)
 SELECT a, a <-> '2018-12-18 10:59:54 GMT+2' FROM timestamptztmp ORDER BY a <-> '2018-12-18 10:59:54 GMT+2' LIMIT 3;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit
-   ->  Index Scan using timestamptzidx on timestamptztmp
-         Order By: (a <-> 'Tue Dec 18 04:59:54 2018 PST'::timestamp with time zone)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((a <-> 'Tue Dec 18 04:59:54 2018 PST'::timestamp with time zone))
+         ->  Limit
+               ->  Index Scan using timestamptzidx on timestamptztmp
+                     Order By: (a <-> 'Tue Dec 18 04:59:54 2018 PST'::timestamp with time zone)
+(7 rows)
 
 SELECT a, a <-> '2018-12-18 10:59:54 GMT+2' FROM timestamptztmp ORDER BY a <-> '2018-12-18 10:59:54 GMT+2' LIMIT 3;
               a               |             ?column?              

--- a/contrib/btree_gist/init_file
+++ b/contrib/btree_gist/init_file
@@ -15,4 +15,6 @@
 # of messages.
 -- start_matchignore
 m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
+
+m/^ Optimizer: Postgres query optimizer/
 -- end_matchignore

--- a/contrib/btree_gist/sql/cash.sql
+++ b/contrib/btree_gist/sql/cash.sql
@@ -2,7 +2,9 @@
 
 -- In PostgreSQL, this test uses WITH OIDS, but in GPDB, OIDs are not unique
 -- across segments, so use a 'serial' column instead.
+-- start_ignore
 CREATE TABLE moneytmp (a money, oid serial);
+-- end_ignore
 
 \copy moneytmp (a) from 'data/cash.data'
 

--- a/contrib/btree_gist/sql/not_equal.sql
+++ b/contrib/btree_gist/sql/not_equal.sql
@@ -22,6 +22,9 @@ SELECT * FROM test_ne WHERE a <> '2009-01-01' AND b <> 10.7;
 
 RESET enable_indexscan;
 
+-- The below test use an exclusion constraint, which isn't supported in GPDB
+-- so we need to ignore this test
+-- start_ignore
 -- test search for "not equals" using an exclusion constraint
 
 CREATE TABLE zoo (
@@ -34,3 +37,4 @@ INSERT INTO zoo VALUES(123, 'zebra');
 INSERT INTO zoo VALUES(123, 'zebra');
 INSERT INTO zoo VALUES(123, 'lion');
 INSERT INTO zoo VALUES(124, 'lion');
+-- end_ignore


### PR DESCRIPTION
Import the upstream testfiles for contrib/btree_gist in order to make it compile and test green in Greenplum.

This still requires the patch for using the Greenplum init_file in pg_regress before it is green due to the planner output printing.