### PR TITLE
contrib: fix pg_trgm testcases for Greenplum

### DIFF
--- a/contrib/pg_trgm/expected/pg_trgm.out
+++ b/contrib/pg_trgm/expected/pg_trgm.out
@@ -2330,12 +2330,15 @@ select t,similarity(t,'gwertyu1988') as sml from test_trgm where t % 'gwertyu198
 
 explain (costs off)
 select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
-                    QUERY PLAN                     
----------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Limit
-   ->  Index Scan using trgm_idx on test_trgm
-         Order By: (t <-> 'q0987wertyu0988'::text)
-(3 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((t <-> 'q0987wertyu0988'::text))
+         ->  Limit
+               ->  Index Scan using trgm_idx on test_trgm
+                     Order By: (t <-> 'q0987wertyu0988'::text)
+(7 rows)
 
 select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
  ?column? |      t      
@@ -3494,23 +3497,25 @@ create index test2_idx_gin on test2 using gin (t gin_trgm_ops);
 set enable_seqscan=off;
 explain (costs off)
   select * from test2 where t like '%BCD%';
-                QUERY PLAN                
-------------------------------------------
- Bitmap Heap Scan on test2
-   Recheck Cond: (t ~~ '%BCD%'::text)
-   ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t ~~ '%BCD%'::text)
-(4 rows)
+                   QUERY PLAN                   
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~~ '%BCD%'::text)
+         ->  Bitmap Index Scan on test2_idx_gin
+               Index Cond: (t ~~ '%BCD%'::text)
+(6 rows)
 
 explain (costs off)
   select * from test2 where t ilike '%BCD%';
-                QUERY PLAN                 
--------------------------------------------
- Bitmap Heap Scan on test2
-   Recheck Cond: (t ~~* '%BCD%'::text)
-   ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t ~~* '%BCD%'::text)
-(4 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~~* '%BCD%'::text)
+         ->  Bitmap Index Scan on test2_idx_gin
+               Index Cond: (t ~~* '%BCD%'::text)
+(6 rows)
 
 select * from test2 where t like '%BCD%';
  t 
@@ -3555,23 +3560,25 @@ select * from test2 where t like '  z foo%';
 
 explain (costs off)
   select * from test2 where t ~ '[abc]{3}';
-                 QUERY PLAN                 
---------------------------------------------
- Bitmap Heap Scan on test2
-   Recheck Cond: (t ~ '[abc]{3}'::text)
-   ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t ~ '[abc]{3}'::text)
-(4 rows)
+                    QUERY PLAN                    
+--------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~ '[abc]{3}'::text)
+         ->  Bitmap Index Scan on test2_idx_gin
+               Index Cond: (t ~ '[abc]{3}'::text)
+(6 rows)
 
 explain (costs off)
   select * from test2 where t ~* 'DEF';
-                QUERY PLAN                
-------------------------------------------
- Bitmap Heap Scan on test2
-   Recheck Cond: (t ~* 'DEF'::text)
-   ->  Bitmap Index Scan on test2_idx_gin
-         Index Cond: (t ~* 'DEF'::text)
-(4 rows)
+                   QUERY PLAN                   
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~* 'DEF'::text)
+         ->  Bitmap Index Scan on test2_idx_gin
+               Index Cond: (t ~* 'DEF'::text)
+(6 rows)
 
 select * from test2 where t ~ '[abc]{3}';
    t    
@@ -3695,19 +3702,21 @@ create index test2_idx_gist on test2 using gist (t gist_trgm_ops);
 set enable_seqscan=off;
 explain (costs off)
   select * from test2 where t like '%BCD%';
-                QUERY PLAN                
-------------------------------------------
- Index Scan using test2_idx_gist on test2
-   Index Cond: (t ~~ '%BCD%'::text)
-(2 rows)
+                   QUERY PLAN                   
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using test2_idx_gist on test2
+         Index Cond: (t ~~ '%BCD%'::text)
+(4 rows)
 
 explain (costs off)
   select * from test2 where t ilike '%BCD%';
-                QUERY PLAN                
-------------------------------------------
- Index Scan using test2_idx_gist on test2
-   Index Cond: (t ~~* '%BCD%'::text)
-(2 rows)
+                   QUERY PLAN                   
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using test2_idx_gist on test2
+         Index Cond: (t ~~* '%BCD%'::text)
+(4 rows)
 
 select * from test2 where t like '%BCD%';
  t 
@@ -3752,19 +3761,21 @@ select * from test2 where t like '  z foo%';
 
 explain (costs off)
   select * from test2 where t ~ '[abc]{3}';
-                QUERY PLAN                
-------------------------------------------
- Index Scan using test2_idx_gist on test2
-   Index Cond: (t ~ '[abc]{3}'::text)
-(2 rows)
+                   QUERY PLAN                   
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using test2_idx_gist on test2
+         Index Cond: (t ~ '[abc]{3}'::text)
+(4 rows)
 
 explain (costs off)
   select * from test2 where t ~* 'DEF';
-                QUERY PLAN                
-------------------------------------------
- Index Scan using test2_idx_gist on test2
-   Index Cond: (t ~* 'DEF'::text)
-(2 rows)
+                   QUERY PLAN                   
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using test2_idx_gist on test2
+         Index Cond: (t ~* 'DEF'::text)
+(4 rows)
 
 select * from test2 where t ~ '[abc]{3}';
    t    


### PR DESCRIPTION
Update the pg_trgm testcase to match for expected Greenplum explain plans in order to make it test green. This creates a diff from the upstream expected file, but it's hard to avoid for plan tests (not being able to test it at all, or have a duplicated expected file seems like worse ideas).

This still requires the patch for using the Greenplum init_file in pg_regress before it is green due to the planner output printing.