### PR TITLE
contrib: import uninteresting contrib files to match upstream

### DIFF
--- a/contrib/adminpack/Makefile
+++ b/contrib/adminpack/Makefile
@@ -1,0 +1,19 @@
+# contrib/adminpack/Makefile
+
+MODULE_big = adminpack
+OBJS = adminpack.o
+PG_CPPFLAGS = -I$(libpq_srcdir)
+
+EXTENSION = adminpack
+DATA = adminpack--1.0.sql
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/adminpack
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/contrib/adminpack/adminpack.control
+++ b/contrib/adminpack/adminpack.control
@@ -1,0 +1,6 @@
+# adminpack extension
+comment = 'administrative functions for PostgreSQL'
+default_version = '1.0'
+module_pathname = '$libdir/adminpack'
+relocatable = false
+schema = pg_catalog

--- a/contrib/chkpass/Makefile
+++ b/contrib/chkpass/Makefile
@@ -1,0 +1,20 @@
+# contrib/chkpass/Makefile
+
+MODULE_big = chkpass
+OBJS = chkpass.o
+
+EXTENSION = chkpass
+DATA = chkpass--1.0.sql chkpass--unpackaged--1.0.sql
+
+SHLIB_LINK = $(filter -lcrypt, $(LIBS))
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/chkpass
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/contrib/earthdistance/Makefile
+++ b/contrib/earthdistance/Makefile
@@ -1,0 +1,25 @@
+# contrib/earthdistance/Makefile
+
+MODULES = earthdistance
+
+EXTENSION = earthdistance
+DATA = earthdistance--1.0.sql earthdistance--unpackaged--1.0.sql
+
+REGRESS = earthdistance
+REGRESS_OPTS = --extra-install=contrib/cube
+
+LDFLAGS_SL += $(filter -lm, $(LIBS))
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/earthdistance
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
+
+installcheck:
+	true

--- a/contrib/intagg/Makefile
+++ b/contrib/intagg/Makefile
@@ -1,0 +1,15 @@
+# contrib/intagg/Makefile
+
+EXTENSION = intagg
+DATA = intagg--1.0.sql intagg--unpackaged--1.0.sql
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/intagg
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/contrib/lo/Makefile
+++ b/contrib/lo/Makefile
@@ -1,0 +1,17 @@
+# contrib/lo/Makefile
+
+MODULES = lo
+
+EXTENSION = lo
+DATA = lo--1.0.sql lo--unpackaged--1.0.sql
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/lo
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/contrib/lo/lo_test.sql
+++ b/contrib/lo/lo_test.sql
@@ -1,0 +1,79 @@
+/* contrib/lo/lo_test.sql */
+
+-- Adjust this setting to control where the objects get created.
+SET search_path = public;
+
+--
+-- This runs some common tests against the type
+--
+-- It's used just for development
+--
+-- XXX would be nice to turn this into a proper regression test
+--
+
+-- Check what is in pg_largeobject
+SELECT count(oid) FROM pg_largeobject_metadata;
+
+-- ignore any errors here - simply drop the table if it already exists
+DROP TABLE a;
+
+-- create the test table
+CREATE TABLE a (fname name,image lo);
+
+-- insert a null object
+INSERT INTO a VALUES ('empty');
+
+-- insert a large object based on a file
+INSERT INTO a VALUES ('/etc/group', lo_import('/etc/group')::lo);
+
+-- now select the table
+SELECT * FROM a;
+
+-- check that coercion to plain oid works
+SELECT *,image::oid from a;
+
+-- now test the trigger
+CREATE TRIGGER t_a
+BEFORE UPDATE OR DELETE ON a
+FOR EACH ROW
+EXECUTE PROCEDURE lo_manage(image);
+
+-- insert
+INSERT INTO a VALUES ('aa', lo_import('/etc/hosts'));
+SELECT * FROM a
+WHERE fname LIKE 'aa%';
+
+-- update
+UPDATE a SET image=lo_import('/etc/group')::lo
+WHERE fname='aa';
+SELECT * FROM a
+WHERE fname LIKE 'aa%';
+
+-- update the 'empty' row which should be null
+UPDATE a SET image=lo_import('/etc/hosts')
+WHERE fname='empty';
+SELECT * FROM a
+WHERE fname LIKE 'empty%';
+UPDATE a SET image=null
+WHERE fname='empty';
+SELECT * FROM a
+WHERE fname LIKE 'empty%';
+
+-- delete the entry
+DELETE FROM a
+WHERE fname='aa';
+SELECT * FROM a
+WHERE fname LIKE 'aa%';
+
+-- This deletes the table contents. Note, if you comment this out, and
+-- expect the drop table to remove the objects, think again. The trigger
+-- doesn't get fired by drop table.
+DELETE FROM a;
+
+-- finally drop the table
+DROP TABLE a;
+
+-- Check what is in pg_largeobject ... if different from original, trouble
+SELECT count(oid) FROM pg_largeobject_metadata;
+
+-- end of tests


### PR DESCRIPTION
The contrib/ directory in Greenplum had over the years had multiple files removed for various reasons. This tends to create confusion and pointless merge conflicts as we merge with upstream. This brings back a lot of files we generally don't really care about, to align us with upstream. See below for discussions on the various files:

* adminpack is already imported into Greenplum core in order to better support pgAdmin3
* earthdistance isn't supported as it relies on upstream features not present in Greenplum
* lo is not supported in Greenplum as large objects are disabled
* chkpass and intagg are uninteresting and obsolete modules which are being removed from upstream