### PR TITLE
contrib: align Makefile with upstream

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -4,10 +4,19 @@ subdir = contrib
 top_builddir = ..
 include $(top_builddir)/src/Makefile.global
 
+# Greenplum specific changes to the targetlist:
+# tsearch2 and postgres_fdw are currently disabled due to test failures.
+# cube and the related earthdistance are disabled since GPDB define CUBE
+# as a keyword. lo is disabled since large objects aren't supported.
+# adminpack is disabled since the functionality has been imported into
+# GPDB.
+
 SUBDIRS = \
 		auth_delay	\
 		auto_explain	\
 		btree_gin	\
+		btree_gist	\
+		chkpass		\
 		citext		\
 		dblink		\
 		dict_int	\
@@ -16,7 +25,11 @@ SUBDIRS = \
 		file_fdw	\
 		fuzzystrmatch	\
 		hstore		\
+		intagg		\
 		intarray	\
+		isn		\
+		ltree		\
+		oid2name	\
 		pageinspect	\
 		passwordcheck	\
 		pg_archivecleanup \
@@ -35,21 +48,17 @@ SUBDIRS = \
 		pgrowlocks	\
 		pgstattuple	\
 		pg_xlogdump	\
-		postgres_fdw	\
 		seg		\
 		spi		\
+		tablefunc	\
 		tcn		\
 		test_decoding	\
 		test_parser	\
 		test_shm_mq	\
-		tsearch2	\
-		unaccent
-# GPDB_92_MERGE_FIXME: Why some files (especially Makefile) are missing under
-# these directories?
-#               seg         \
-#		tablefunc	\
-#		vacuumlo
-#		worker_spi 
+		unaccent	\
+		vacuumlo	\
+		worker_spi
+
 
 # Greenplum-specific additions (to ease merge pain).
 SUBDIRS += \


### PR DESCRIPTION
Align contrib/Makefile with upstream by adding the missing modules in the SUBDIRS targetlist. The set of modules built when issueing a root level "make install" is still based on GNUMakefile in the root, but this allows for "make -C contrib/" and have it do what one could reasonably expect - all modules that compiles are also compiled.

This removes a FIXME added when merging 9.2

This PR is blocked by the currently opened contrib PRs, which needs to merged first: #7395 and onwards.