### PR TITLE
Revert "Skip analyzing root partitions by default in analyzedb (#7082)"

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -212,9 +212,12 @@ class AnalyzeDb(Operation):
         if self.parallel_level < 1 or self.parallel_level > 10:
             raise ProgramArgumentValidationException('option -p requires a value between 1 and 10')
 
-        if not self.rootstats:
-            logger.warning("--skip_root_stats is now enabled by default and this flag will be removed in GPDB6.")
-        self.rootstats = False
+        if self.rootstats:
+            qresult = execute_sql("SELECT version()", self.pg_port, self.dbname)
+            version = GpVersion(qresult[0][0])
+            if version < GpVersion('4.3.4.0'):
+                logger.debug("Adding --skip_root_stats option since Greenplum version is lower than 4.3.4.0")
+                self.rootstats = False
 
     def _preprocess_options(self):
 
@@ -324,6 +327,12 @@ class AnalyzeDb(Operation):
                 return 0
 
             root_partition_col_dict = {}
+            # root_partition_col_dict contains the mapping between the root partitions
+            # and its corresponding columns to be analyzed
+            # key: name of the root partition whose stats needs to be refreshed
+            # value: a set of column names to be analyzed, or '-1' meaning all columns of that table
+            if self.rootstats:
+                root_partition_col_dict = self._get_root_partition_col_dict(candidates, input_col_dict)
 
             ordered_candidates = self._get_ordered_candidates(candidates, root_partition_col_dict)
             target_list = []
@@ -1176,7 +1185,7 @@ def create_parser():
     parser.add_option('-p', type='int', dest='parallel_level', default=5, metavar="<parallel level>",
                       help="Parallel level, i.e. the number of tables to be analyzed in parallel. Valid numbers are between 1 and 10. Default value is 5.")
     parser.add_option('--skip_root_stats', action='store_false', dest='rootstats', default=True,
-                      help="DEPRECATED, this flag is now the default behavior. Skip refreshing root partition stats if any leaf partition is analyzed.")
+                      help="Skip refreshing root partition stats if any of the leaf partitions is analyzed.")
     parser.add_option('--gen_profile_only', action='store_true', dest='gen_profile_only', default=False,
                       help="Create cached state files to indicate specified table or all tables have been analyzed.")
     parser.add_option('--full', action='store_true', dest='full_analyze', default=False,

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1413,7 +1413,6 @@ Feature: Incrementally analyze the database
         When the user runs "analyzedb -a -d incr_analyze -t public.sales"
         Then output should contain both "-public.sales_1_prt_default_dates" and "-public.sales_1_prt_2"
         And output should contain both "-public.sales_1_prt_3" and "-public.sales_1_prt_4"
-        And output should not contain "analyze rootpartition public.sales"
         And "public.sales_1_prt_2" should appear in the latest state files
         And "public.sales_1_prt_3" should appear in the latest state files
         And "public.sales_1_prt_4" should appear in the latest state files
@@ -1429,7 +1428,6 @@ Feature: Incrementally analyze the database
         Then output should not contain "-public.sales_1_prt_default_dates"
         And output should not contain "-public.sales_1_prt_3"
         And output should contain both "-public.sales_1_prt_2" and "-public.sales_1_prt_4"
-        And output should not contain "analyze rootpartition public.sales"
         And "public.sales_1_prt_2" should appear in the latest state files
         And "public.sales_1_prt_4" should appear in the latest state files
 
@@ -1514,7 +1512,6 @@ Feature: Incrementally analyze the database
         Then output should not contain "-public.sales_1_prt_default_dates"
         And output should not contain "-public.sales_1_prt_3"
         And output should not contain "-public.sales_1_prt_4"
-        And output should not contain "analyze rootpartition public.sales"
         And analyzedb should print "-public.sales_1_prt_2" to stdout
         And "public.sales_1_prt_2" should appear in the latest state files
         And "public.sales_1_prt_4" should appear in the latest state files
@@ -1593,7 +1590,6 @@ Feature: Incrementally analyze the database
         When the user runs "analyzedb -a -d incr_analyze -t public.sales"
         Then output should contain both "-public.sales_1_prt_2" and "-public.sales_1_prt_3"
         And output should not contain "-public.sales_1_prt_4"
-        And output should not contain "analyze rootpartition public.sales"
         And analyzedb should print "-public.sales_1_prt_default_dates" to stdout
         And "public.sales_1_prt_2" should appear in the latest state files
         And "public.sales_1_prt_3" should appear in the latest state files
@@ -1696,6 +1692,7 @@ Feature: Incrementally analyze the database
         Then analyzedb should print "There are no tables or partitions to be analyzed" to stdout
         And "public.sales_1_prt_2" should appear in the latest state files
         And "public.sales_1_prt_3" should appear in the latest state files
+        And "public.sales" should appear in the latest report file
 
     # request mid-level
     @analyzedb_core @analyzedb_partition_tables


### PR DESCRIPTION
This reverts commit 2f4965d29307382e84704a892e4a3f2e237bbb2e.

analyze should update the statistics on the root partition when all the leaf
partitions have been analyzed, but since the analyzedb runs analyze on the leaf
partitions in parallel, it ends up not updating the stats on the root
partition. Without the correct stats on the root partition, ORCA ends up
picking a bad plan. So reverting this change for now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
