### PR TITLE
Prevent gpmovemirrors from deleting mirror directory

### DIFF
--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -176,31 +176,14 @@ def lookupGpdb(address, port, dataDirectory):
 
 
 # -------------------------------------------------------------------------
-def lookupFilespaces(gpdb):
-    """ Look up the segment's filespaces, and return map of filespace name : location. """
-
-    retValue = {}
-    gpdbFilespaceDict = gpdb.getSegmentFilespaces()
-
-    for oid in gpdbFilespaceDict:
-        if oid == SYSTEM_FILESPACE:
-            continue
-        name = gpArrayInstance.getFileSpaceName(oid)
-        location = gpdbFilespaceDict[oid]
-        retValue[name] = location
-    return retValue
-
-
-# -------------------------------------------------------------------------
 # -------------------------------------------------------------------------
 class Mirror:
     """ This class represents information about a mirror. """
 
-    def __init__(self, address, port, dataDirectory, filespaces):
+    def __init__(self, address, port, dataDirectory):
         self.address = address
         self.port = port
         self.dataDirectory = dataDirectory
-        self.filespaces = filespaces
 
     def __str__(self):
         tempStr = "address = " + str(self.address) + '\n'
@@ -217,7 +200,6 @@ class Configuration:
     def __init__(self):
         self.inputFile = None
         self.fileData = None
-        self.filespaceNames = []
         self.oldMirrorList = []
         self.newMirrorList = []
 
@@ -227,7 +209,7 @@ class Configuration:
         with open(inputFile) as f:
 
             for lineno, line in line_reader(f):
-                rowMap, newFilespaces = parse_gpmovemirrors_line(inputFile, lineno, line)
+                rowMap = parse_gpmovemirrors_line(inputFile, lineno, line)
 
                 oldAddress = rowMap['oldAddress']
                 oldPort = rowMap['oldPort']
@@ -242,11 +224,9 @@ class Configuration:
                         raise Exception(
                             "Old mirror segment is not currently in a mirror role: address = %s, port = %s, segment data directory = %s"
                             % (oldAddress, str(oldPort), oldDataDirectory))
-                oldFilespaces = {}
                 oldMirror = Mirror(address=oldAddress
                                    , port=oldPort
                                    , dataDirectory=oldDataDirectory
-                                   , filespaces=oldFilespaces
                                    )
                 self.oldMirrorList.append(oldMirror)
                 newAddress = rowMap['newAddress']
@@ -255,7 +235,6 @@ class Configuration:
                 newMirror = Mirror(address=newAddress
                                    , port=newPort
                                    , dataDirectory=newDataDirectory
-                                   , filespaces=newFilespaces
                                    )
                 self.newMirrorList.append(newMirror)
 
@@ -374,13 +353,6 @@ try:
             cmd = RemoveDirectory("remove old mirror segment directories", mirror.dataDirectory, ctxt=REMOTE,
                                   remoteHost=mirror.address)
             pool.addCommand(cmd)
-            for filespaceName in mirror.filespaces.keys():
-                logger.info(
-                    "About to remove old mirror filespace directory: " + filespaceName + " : " + mirror.filespaces[
-                        filespaceName])
-                cmd = RemoveDirectory("remove old mirror segment directories", mirror.filespaces[filespaceName],
-                                      ctxt=REMOTE, remoteHost=mirror.address)
-                pool.addCommand(cmd)
 
         # Wait for the segments to finish
         try:

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -180,10 +180,11 @@ def lookupGpdb(address, port, dataDirectory):
 class Mirror:
     """ This class represents information about a mirror. """
 
-    def __init__(self, address, port, dataDirectory):
+    def __init__(self, address, port, dataDirectory, inPlace=False):
         self.address = address
         self.port = port
         self.dataDirectory = dataDirectory
+        self.inPlace = inPlace
 
     def __str__(self):
         tempStr = "address = " + str(self.address) + '\n'
@@ -224,14 +225,21 @@ class Configuration:
                         raise Exception(
                             "Old mirror segment is not currently in a mirror role: address = %s, port = %s, segment data directory = %s"
                             % (oldAddress, str(oldPort), oldDataDirectory))
-                oldMirror = Mirror(address=oldAddress
-                                   , port=oldPort
-                                   , dataDirectory=oldDataDirectory
-                                   )
-                self.oldMirrorList.append(oldMirror)
                 newAddress = rowMap['newAddress']
                 newPort = rowMap['newPort']
                 newDataDirectory = rowMap['newDataDirectory']
+
+                inPlace = (oldAddress == newAddress and oldDataDirectory == newDataDirectory)
+                if inPlace and oldPort == newPort:
+                    logger.warn("input file %s contained request to move a mirror with identical attributes (%s, %s, %s)"
+                                % (inputFile, newAddress, newPort, newDataDirectory))
+
+                oldMirror = Mirror(address=oldAddress
+                                   , port=oldPort
+                                   , dataDirectory=oldDataDirectory
+                                   , inPlace=inPlace
+                                   )
+                self.oldMirrorList.append(oldMirror)
                 newMirror = Mirror(address=newAddress
                                    , port=newPort
                                    , dataDirectory=newDataDirectory
@@ -344,11 +352,12 @@ try:
     cmd.run(validateAfter=True)
 
     """ Delete old mirror directories. """
-    totalDirsToDelete = len(newConfig.oldMirrorList)
+    mirrorsToDelete = [mirror for mirror in newConfig.oldMirrorList if not mirror.inPlace]
+    totalDirsToDelete = len(mirrorsToDelete)
     numberOfWorkers = min(totalDirsToDelete, options.batch_size)
     if numberOfWorkers > 1:
         pool = WorkerPool(numWorkers=numberOfWorkers)
-        for mirror in newConfig.oldMirrorList:
+        for mirror in mirrorsToDelete:
             logger.info("About to remove old mirror segment directory: " + mirror.dataDirectory)
             cmd = RemoveDirectory("remove old mirror segment directories", mirror.dataDirectory, ctxt=REMOTE,
                                   remoteHost=mirror.address)

--- a/gpMgmt/bin/gppylib/parseutils.py
+++ b/gpMgmt/bin/gppylib/parseutils.py
@@ -359,31 +359,28 @@ def parse_gpmovemirrors_line(filename, lineno, line):
     """
     Parse a line in the gpmovemirrors configuration file other than the first.
 
-    >>> line = "[::1]:40001:/Users/ctaylor/data/m2/gpseg1 [::2]:40101:50101:/Users/ctaylor/data/m2/gpseg1:/fs1"
-    >>> fixed, flex = parse_gpmovemirrors_line('file', 1, line, ['fs1'])
-    >>> fixed["oldAddress"], fixed["newAddress"]
+    >>> line = "[::1]:40001:/Users/ctaylor/data/m2/gpseg1 [::2]:40101:/Users/ctaylor/data/m2/gpseg1"
+    >>> rows = parse_gpmovemirrors_line('file', 1, line)
+    >>> rows["oldAddress"], rows["newAddress"]
     ('::1', '::2')
-    >>> flex
-    {'fs1': '/fs1'}
 
     """
     groups = len(line.split())
     if groups != 2:
         msg = "need two groups of fields delimited by a space for old and new mirror, not %d" % groups
         raise ExceptionNoStackTraceNeeded("%s:%s:%s LINE >>%s\n%s" % (filename, lineno, caller(), line, msg))
-    fixed = {}
-    flexible = {}
+    rows = {}
     p = LineParser(caller(), filename, lineno, line)
-    p.handle_field('[oldAddress]', fixed) # [oldAddress] indicates possible IPv6 address
-    p.handle_field('oldPort', fixed)
-    p.handle_field('oldDataDirectory', fixed, delimiter=' ', stripchars=' \t') # MPP-15675 note stripchars here and next line
-    p.handle_field('[newAddress]', fixed, stripchars=' \t') # [newAddress] indicates possible IPv6 address
-    p.handle_field('newPort', fixed)
-    p.handle_field('newDataDirectory', fixed)
+    p.handle_field('[oldAddress]', rows) # [oldAddress] indicates possible IPv6 address
+    p.handle_field('oldPort', rows)
+    p.handle_field('oldDataDirectory', rows, delimiter=' ', stripchars=' \t') # MPP-15675 note stripchars here and next line
+    p.handle_field('[newAddress]', rows, stripchars=' \t') # [newAddress] indicates possible IPv6 address
+    p.handle_field('newPort', rows)
+    p.handle_field('newDataDirectory', rows)
     if p.rest is not None:
         msg = "unexpected characters after mirror fields >>%s" % p.rest
         raise ExceptionNoStackTraceNeeded("%s:%s:%s LINE >>%s\n%s" % (filename, lineno, caller(), line, msg))
-    return fixed, flexible
+    return rows
 
 
 ################

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -33,6 +33,29 @@ Feature: Tests for gpmovemirrors
         And the segments are synchronized
         And verify that mirrors are recognized after a restart
 
+    Scenario: gpmovemirrors can change the port of mirrors within a single host
+        Given a standard local demo cluster is created
+        And a gpmovemirrors directory under '/tmp/gpmovemirrors' with mode '0700' is created
+        And a 'samedir' gpmovemirrors file is created
+        When the user runs gpmovemirrors
+        Then gpmovemirrors should return a return code of 0
+        And verify the database has mirrors
+        And all the segments are running
+        And the segments are synchronized
+        And verify that mirrors are recognized after a restart
+
+    Scenario: gpmovemirrors gives a warning when passed identical attributes for new and old mirrors
+        Given a standard local demo cluster is created
+        And a gpmovemirrors directory under '/tmp/gpmovemirrors' with mode '0700' is created
+        And a 'identicalAttributes' gpmovemirrors file is created
+        When the user runs gpmovemirrors
+        Then gpmovemirrors should return a return code of 0
+	And gpmovemirrors should print a "request to move a mirror with identical attributes" warning
+	And verify the database has mirrors
+        And all the segments are running
+        And the segments are synchronized
+        And verify that mirrors are recognized after a restart
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -417,7 +417,6 @@ def impl(context, HOST, port, dir, ctxt):
                       gp_source_file)
     gpfdist.cleanupGpfdist()
 
-
 @then('{command} should print "{err_msg}" error message')
 def impl(context, command, err_msg):
     check_err_msg(context, err_msg)
@@ -425,6 +424,7 @@ def impl(context, command, err_msg):
 
 @when('{command} should print "{out_msg}" to stdout')
 @then('{command} should print "{out_msg}" to stdout')
+@then('{command} should print a "{out_msg}" warning')
 def impl(context, command, out_msg):
     check_stdout_msg(context, out_msg)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -233,6 +233,20 @@ def impl(context, file_type):
                                        mirror.getSegmentPort(),
                                        context.mirror_context.working_directory)
         contents = '%s %s' % (valid_config, badhost_config)
+    elif file_type == 'samedir':
+        valid_config_with_same_dir = '%s:%s:%s' % (
+            mirror.getSegmentHostName(),
+            mirror.getSegmentPort() + 1000,
+            mirror.getSegmentDataDirectory()
+        )
+        contents = '%s %s' % (valid_config, valid_config_with_same_dir)
+    elif file_type == 'identicalAttributes':
+        valid_config_with_identical_attributes = '%s:%s:%s' % (
+            mirror.getSegmentHostName(),
+            mirror.getSegmentPort(),
+            mirror.getSegmentDataDirectory()
+        )
+        contents = '%s %s' % (valid_config, valid_config_with_identical_attributes)
     elif file_type == 'good':
         valid_config_with_different_dir = '%s:%s:%s' % (
             mirror.getSegmentHostName(),
@@ -281,7 +295,7 @@ def impl(context, mirror_config):
     input_filename = "/tmp/gpmovemirrors_input_%s" % mirror_config
     line_template = "%s:%d:%s %s:%d:%s\n"
 
-    # The mirrors for contents 0 and 3 are excluded from the two maps below because they are the same in either configuration    
+    # The mirrors for contents 0 and 3 are excluded from the two maps below because they are the same in either configuration
     # NOTE: this configuration of the GPDB cluster assumes that configuration set up in concourse's
     #   gpinitsystem task.  The maps below are from {contentID : (port|hostname)}.
 


### PR DESCRIPTION
In the case where the user wants to change the port of a mirror, but leave it in the same directory on the same host, gpmovemirrors was previously deleting the directory as part of the cleanup because it did not recognize that the old and new directories were the same.  This PR adds a check to prevent that.

We also log a warning if the move_config_file contains identical attributes(host,port,data directory) for the old and new mirror.

Also, we removed some leftover filespace references in a separate commit.

