### PR TITLE
Remove `planGen==PLANGEN_PLANNER` assert for after row insert triggers

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3323,9 +3323,6 @@ ExecInsert(TupleTableSlot *slot,
 		!isUpdate)
 	{
 		HeapTuple tuple = ExecFetchSlotHeapTuple(slot);
-
-		Assert(planGen == PLANGEN_PLANNER);
-
 		ExecARInsertTriggers(estate, resultRelInfo, tuple);
 	}
 }


### PR DESCRIPTION
Fix issue #7410

Ideally the `alter_table` test should already cover this, however, the test seems been falling back to the legacy planner on CI.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
