### PR TITLE
Don't compile clients python file in compile_gpdb.bash

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -170,7 +170,6 @@ function export_gpdb_clients() {
   TARBALL="${GPDB_ARTIFACTS_DIR}/${GPDB_CL_FILENAME}"
   pushd ${GREENPLUM_CL_INSTALL_DIR}
     source ./greenplum_clients_path.sh
-    python -m compileall -q -x test .
     chmod -R 755 .
     tar -czf "${TARBALL}" ./*
   popd


### PR DESCRIPTION
gpdb6 clients package includes pre-compiled gpload.pyc . It is not necessary in clients package, and may conflict with gpdb6 server's gpload.pyc.
so we just remove it.