### PR TITLE
contrib: formatter_fixedwidth error message cleanup

### DIFF
--- a/contrib/formatter_fixedwidth/fixedwidth.c
+++ b/contrib/formatter_fixedwidth/fixedwidth.c
@@ -23,7 +23,7 @@ Datum fixedwidth_in(PG_FUNCTION_ARGS);
 typedef struct formatConfig
 {
 	/*
-	 * Normaly we would have only one list of structs, each struct containing three fields:
+	 * Normally we would have only one list of structs, each struct containing three fields:
 	 * name, size, index. The reason we use three lists here is because we work with the infrastructure
 	 * function CopyGetAttnums, which expects as input a list of names and returns a list of indexes.
 	 * fldIndexes - holds the index of each field fetched from the file, into the fields description array
@@ -36,7 +36,7 @@ typedef struct formatConfig
 	int         fields_tot_size;
 	
 	/*
-	 * formating parameters
+	 * formatting parameters
 	 */
 	int         preserve_blanks;
 	char       *null_value;
@@ -266,7 +266,7 @@ make_null_val_with_blanks(char *value, int field_size)
 /*
  * make_val_with_blanks
  *
- * Pad one string value with blanks, so the size will corespond to the fixedwidth 
+ * Pad one string value with blanks, so the size will correspond to the fixedwidth
  * required by the format. Make sure to encode the string into external table
  * encoding before writing it out (if conversion is needed).
  *
@@ -707,8 +707,8 @@ fixedwidth_in(PG_FUNCTION_ARGS)
 	else 
 	{
 		/*
-		 * This line is not finish. Next buffer will bring the remaining of the line.
-		 * So the line number shpuld not grow.
+		 * This line is not finished. Next buffer will bring the remaining of the line.
+		 * So the line number should not grow.
 		 */
 		if (eof_is_lf)
 			myData->lineno--;			
@@ -773,8 +773,8 @@ fixedwidth_in(PG_FUNCTION_ARGS)
 			else 
 			{
 				/*
-				 * This line is not finish. Next buffer will bring the remaining of the line.
-				 * So the line number shpuld not grow.
+				 * This line is not finished. Next buffer will bring the remaining of the line.
+				 * So the line number should not grow.
 				 */
 				if (eof_is_lf)
 					myData->lineno--;			

--- a/contrib/formatter_fixedwidth/output/readable_query10.source
+++ b/contrib/formatter_fixedwidth/output/readable_query10.source
@@ -10,7 +10,8 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in',
 -- Note field "col_null" is always loaded with null value
 -- regardless null string and preserve_blanks settings.
 select * from tbl_ext_fixedwidth where col_null is null order by s1;
-ERROR:  the fixed width formatter requires a length specification for each one of the external table columns being used (currently <5>, however format string has <4>  (seg0 slice1 killnz1:64100 pid=5914)
+ERROR:  mismatch in column length specification
+DETAIL:  The fixed width formatter requires a length specification for each one of the external table columns being used (currently 5, however format string has 4).
 CONTEXT:  External table tbl_ext_fixedwidth
 -- This is true even using "LIKE other table" syntax when creating ext table
 -- Create heap table "missing_col_null", which has default value 'NULL' for column "col_null"
@@ -59,5 +60,6 @@ Execute on: all segments
 
 -- Note field "col_null" is loaded with null value
 select * from tbl_ext_fixedwidth where col_null is null order by s1;
-ERROR:  the fixed width formatter requires a length specification for each one of the external table columns being used (currently <5>, however format string has <4>  (seg1 slice1 killnz1:64101 pid=5916)
+ERROR:  mismatch in column length specification
+DETAIL:  The fixed width formatter requires a length specification for each one of the external table columns being used (currently 5, however format string has 4).
 CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query12.source
+++ b/contrib/formatter_fixedwidth/output/readable_query12.source
@@ -9,5 +9,5 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
     s2='10', s3='10', dt='20',n1='5', n2='10',
     n3='10', n4='10', n5='10', n6='10', n7='15');
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
-ERROR:  Expected line size from the formatting string: 120, but the actual size is: 119  (seg0 slice1 rh55-qavm55:7532 pid=23898)
+ERROR:  expected line size from the formatting string is 120, actual size is 119
 CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query13.source
+++ b/contrib/formatter_fixedwidth/output/readable_query13.source
@@ -10,5 +10,5 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
     s2='10', s3='10', dt='20',n1='5', n2='10',
     n3='10', n4='10', n5='10', n6='10', n7='15');
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
-ERROR:  Expected line size from the formatting string: 120, but the actual size is: 105  (seg0 slice1 rh55-qavm55:7532 pid=23951)
+ERROR:  expected line size from the formatting string is 120, actual size is 105
 CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query18.source
+++ b/contrib/formatter_fixedwidth/output/readable_query18.source
@@ -8,5 +8,6 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
     s_2='10', s3='10', dt='20',n1='5', n2='10', n3='10', n4='10',
     n5='10', n6='10', n7='15');
 select * from tbl_ext_fixedwidth order by s1;
-ERROR:  the fixed width formatter requires a length specification for each one of the external table columns being used (missing field <s_2>  (seg0 slice1 killnz1:64100 pid=7503)
+ERROR:  missing column definition in length specification
+DETAIL:  The fixed width formatter requires a length specification for each one of the external table columns being used (missing field "s_2").
 CONTEXT:  External table tbl_ext_fixedwidth

--- a/contrib/formatter_fixedwidth/output/readable_query29.source
+++ b/contrib/formatter_fixedwidth/output/readable_query29.source
@@ -7,5 +7,6 @@ LOCATION ('file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct_whitespac
 FORMAT 'CUSTOM' (formatter='fixedwidth_in', preserve_blanks='on',
     s1='10',s2='10', s3='10');
 select * from tbl_ext_fixedwidth order by s1;
-ERROR:  A null_value was not defined. When preserve_blanks is on, a null_value 								 must be defined in the formatter arguments string  (seg1 slice1 rh55-qavm55:7533 pid=30448)
+ERROR:  null_value was not defined
+DETAIL:  When preserve_blanks is on, a null_value must be defined in the formatter arguments string.
 CONTEXT:  External table tbl_ext_fixedwidth

--- a/src/bin/gpfdist/regress/output/custom_format.source
+++ b/src/bin/gpfdist/regress/output/custom_format.source
@@ -83,8 +83,8 @@ CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth
 LOCATION ('gpfdist://@hostname@:7575/fixedwidth_small_error_toomanyfields.tbl')       
 FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10', s2='10', s3='10', dt='20',n1='5', n2='10', n3='10', n4='10', n5='10', n6='10', n7='15');
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
-ERROR:  Expected line size from the formatting string: 120, but the actual size is: 125  (seg0 slice1 @hostname@:40000 pid=11440)
-DETAIL:  External table tbl_ext_fixedwidth
+ERROR:  expected line size from the formatting string is 120, actual size is 125
+CONTEXT:  External table tbl_ext_fixedwidth
 -- 4.  import data into table with string and numeric fields - too few fields error  -- no reject limit
 DROP EXTERNAL TABLE IF EXISTS tbl_ext_fixedwidth;
 CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth 
@@ -92,8 +92,8 @@ CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth
 LOCATION ('gpfdist://@hostname@:7575/fixedwidth_small_error_toofewfields.tbl')       
 FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10', s2='10', s3='10', dt='20',n1='5', n2='10', n3='10', n4='10', n5='10', n6='10', n7='15');
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
-ERROR:  Expected line size from the formatting string: 120, but the actual size is: 105  (seg1 slice1 @hostname@:40001 pid=11441)
-DETAIL:  External table tbl_ext_fixedwidth
+ERROR:  expected line size from the formatting string is 120, actual size is 105
+CONTEXT:  External table tbl_ext_fixedwidth
 -- 5.  import data into table with string and numeric fields - field too long error -- no reject limit
 DROP EXTERNAL TABLE IF EXISTS tbl_ext_fixedwidth;
 CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth 
@@ -194,8 +194,8 @@ CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth
 LOCATION ('gpfdist://@hostname@:7575/fixedwidth_small_correct.tbl')       
 FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10', n1='5', s2='10', s3='10', dt='20', n2='10', n3='10', n4='10', n5='10', n6='10', n7='15');
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
-ERROR:  the fixed width formatter requires a length specification for each one of the external table columns being used (missing field <s3>  (seg1 slice1 @hostname@:40001 pid=11441)
-DETAIL:  External table tbl_ext_fixedwidth
+ERROR:  missing column definition in length specification
+CONTEXT:  External table tbl_ext_fixedwidth
 -- 12. import data into table with string and numeric fields -- NULL value loaded when NULL value defined
 DROP EXTERNAL TABLE IF EXISTS tbl_ext_fixedwidth;
 CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth 
@@ -270,8 +270,8 @@ CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth
 LOCATION ('gpfdist://@hostname@:7575/fixedwidth_small_blankfields.tbl')       
 FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10', s2='10', s3='10', dt='20', n1='5', n2='10', n3='10', n4='10', n5='10', n6='10', n7='15', preserve_blanks='on');
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
-ERROR:  A null_value was not defined. When preserve_blanks is on, a null_value 								 must be defined in the formatter arguments string  (seg0 slice1 @hostname@:40000 pid=11440)
-DETAIL:  External table tbl_ext_fixedwidth
+ERROR:  null_value was not defined
+CONTEXT:  External table tbl_ext_fixedwidth
 -- 15. import data into table with string and numeric fields - FORMAT string syntax error  -- preserve_blanks with NULL defined
 --     trailing blanks are loaded, blank fields are loaded as  strings, only fields with the null value are loaded as NULL
 DROP EXTERNAL TABLE IF EXISTS tbl_ext_fixedwidth;


### PR DESCRIPTION
Noticed while doing contrib work that formatter_fixedwidth had a wildly incorrectly linebroken errmsg, causing a very large section of whitespace in the middle of the error message to the user.

While fixing this, also fixed all other ereport() calls to have messages according to the style guide, and converted an internal error to elog() instead.

Also fixed some typos and egregious whitespace offences in surrounding lines, but left the bulk of the offences to a pgindent run.

This PR is either blocked by, or blocks, #7404 as it touches the same files.