### PR TITLE
Revert equality assert for compression ratio

### DIFF
--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -550,7 +550,8 @@ insert into ao_compress_results values (pg_relation_size('ao_compress_table'), p
 insert into ao_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
 insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
 
-select get_ao_compression_ratio('ao_compress_table');
+-- compression ratio should be between 1.2 and 1.3
+select get_ao_compression_ratio('ao_compress_table') > 1.2 and get_ao_compression_ratio('ao_compress_table') < 1.3;
 select get_ao_distribution('ao_compress_table');
 
 truncate table ao_compress_table; -- after truncate, reclaim space from the table and index

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1185,10 +1185,11 @@ create index ao_compress_v_index on ao_compress_table (v);
 insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
 insert into ao_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
 insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
-select get_ao_compression_ratio('ao_compress_table');
- get_ao_compression_ratio 
---------------------------
-                     1.27
+-- compression ratio should be between 1.2 and 1.3
+select get_ao_compression_ratio('ao_compress_table') > 1.2 and get_ao_compression_ratio('ao_compress_table') < 1.3;
+ ?column? 
+----------
+ t
 (1 row)
 
 select get_ao_distribution('ao_compress_table');


### PR DESCRIPTION
This is a result of a test failure where the compression ratio returned was
1.22 instead of the expected 1.27. Although zlib is deterministic, the blocks
we feed zlib are not deterministic as they have padding bytes.

This partially reverts commit e6f37759bc
Co-authored-by: Jesse Zhang <jzhang@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
