### PR TITLE
Subq in normalization 5x

### DIFF
--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -198,7 +198,7 @@ CQueryMutators::NormalizeGroupByProjList
 		BOOL is_grouping_col = CTranslatorUtils::IsGroupingColumn(target_entry, derived_table_query->groupClause);
 		if (!is_grouping_col)
 		{
-			target_entry->expr = (Expr*) RunGroupByProjListMutator( (Node*) target_entry->expr, &context);
+			target_entry->expr = (Expr*) RunExtractAggregatesMutator((Node*) target_entry->expr, &context);
 			GPOS_ASSERT
 				(
 				(!IsA(target_entry->expr, Aggref) && !IsA(target_entry->expr, PercentileExpr)) && !IsA(target_entry->expr, GroupingFunc) &&
@@ -207,7 +207,7 @@ CQueryMutators::NormalizeGroupByProjList
 		}
 	}
 
-	derived_table_query->targetList = context.m_groupby_target_list;
+	derived_table_query->targetList = context.m_groupby_tlist;
 	new_query->targetList = target_list_copy;
 
 	ReassignSortClause(new_query, derived_table_query);
@@ -445,162 +445,6 @@ CQueryMutators::NeedsLevelsUpCorrection
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CQueryMutators::RunGroupByProjListMutator
-//
-//	@doc:
-// 		Traverse the project list of a groupby operator and extract all aggregate
-//		functions in an arbitrarily complex project element
-//---------------------------------------------------------------------------
-Node *
-CQueryMutators::RunGroupByProjListMutator
-	(
-	Node *node,
-	SContextGrpbyPlMutator *context
-	)
-{
-	if (NULL == node)
-	{
-		return NULL;
-	}
-
-	if (IsA(node, Const))
-	{
-		return (Node *) gpdb::CopyObject(node);
-	}
-
-
-	if (IsA(node, Var) && context->m_is_mutating_agg_arg)
-	{
-		// if we are mutating an aggregate argument do nothing since the aggregate will be place in the derived table's target list
-		// fix any outer references in the grouping column expression or arguments of an aggregate
-		return (Node *) IncrLevelsUpInVar((Var*) node);
-	}
-	
-	// if we find an aggregate or precentile expression then insert into the new derived table
-	// and refer to it in the top-level query
-
-	if (IsA(node, Aggref))
-	{
-		Aggref *old_aggref = (Aggref*) node;
-		Aggref *aggref = FlatCopyAggref(old_aggref);
-		aggref->agglevelsup = old_aggref->agglevelsup;
-
-		List *new_args = NIL;
-		ListCell *lc = NULL;
-
-		BOOL fAggregate = context->m_is_mutating_agg_arg;
-		context->m_is_mutating_agg_arg = true;
-
-		ForEach (lc, old_aggref->args)
-		{
-			Node *arg = (Node *) gpdb::CopyObject((Node*) lfirst(lc));
-			GPOS_ASSERT(NULL != arg);
-			// traverse each argument and fix levels up when needed
-			new_args = gpdb::LAppend
-						(
-						new_args,
-						gpdb::MutateQueryOrExpressionTree
-							(
-							arg,
-							(MutatorWalkerFn) CQueryMutators::RunGroupByProjListMutator,
-							(void *) context,
-							0 // flags -- mutate into cte-lists
-							)
-						);
-		}
-		context->m_is_mutating_agg_arg = fAggregate;
-		aggref->args = new_args;
-
-		const ULONG attno = gpdb::ListLength(context->m_groupby_target_list) + 1;
-		TargetEntry *target_entry = PteAggregateOrPercentileExpr(context->m_mp, context->m_md_accessor, (Node *) aggref, attno);
-
-		// Add a new target entry to the query
-		context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
-
-		Var *new_var = gpdb::MakeVar
-						(
-						1, // varno
-						(AttrNumber) attno,
-						gpdb::ExprType(node),
-						gpdb::ExprTypeMod(node),
-						0 // query levelsup
-						);
-
-		return (Node*) new_var;
-	}
-
-	if (IsA(node, PercentileExpr) || IsA(node, GroupingFunc))
-	{
-		Node *pnodeCopy = (Node *) gpdb::CopyObject(node);
-
-		const ULONG attno = gpdb::ListLength(context->m_groupby_target_list) + 1;
-		TargetEntry *target_entry = PteAggregateOrPercentileExpr(context->m_mp, context->m_md_accessor, pnodeCopy, attno);
-
-		// Add a new target entry to the query
-		context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
-
-		Var *new_var = gpdb::MakeVar
-								(
-								1, // varno
-								(AttrNumber) attno,
-								gpdb::ExprType(node),
-								gpdb::ExprTypeMod(node),
-								0 // query levelsup
-								);
-
-		return (Node*) new_var;
-	}
-
-	if (!context->m_is_mutating_agg_arg)
-	{
-		// if we find a target entry in the new derived table then return the appropriate var
-		// else investigate it to see if it needs to be added to the new derived table
-
-		TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
-
-		if (NULL != found_target_entry)
-		{
-			found_target_entry->resjunk = false;
-			Var *new_var = gpdb::MakeVar
-					(
-							1, // varno
-							found_target_entry->resno,
-							gpdb::ExprType((Node*) found_target_entry->expr),
-							gpdb::ExprTypeMod( (Node*) found_target_entry->expr),
-							0 // query levelsup
-					);
-
-			return (Node*) new_var;
-		}
-
-		// if it is grouping column then we have already added it to the derived table
-		// so merely refer to it in the top-level query
-		TargetEntry *new_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
-		if (NULL != new_target_entry)
-		{
-			return (Node *) gpdb::MakeVar
-							(
-							1, // varno
-							(AttrNumber) new_target_entry->resno,
-							gpdb::ExprType( (Node*) new_target_entry->expr),
-							gpdb::ExprTypeMod( (Node*) new_target_entry->expr),
-							0 // query levelsup
-							);
-		}
-	}
-
-	// do not traverse into sub queries as they will be inserted into top-level query as is
-	if (IsA(node, SubLink))
-	{
-		return (Node *) gpdb::CopyObject(node);
-	}
-
-	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunGroupByProjListMutator, context);
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
 //		CQueryMutators::RunGroupingColMutator
 //
 //	@doc:
@@ -782,7 +626,7 @@ CQueryMutators::FixGroupingCols
 {
 	GPOS_ASSERT(NULL != node);
 
-	ULONG arity = gpdb::ListLength(context->m_groupby_target_list) + 1;
+	ULONG arity = gpdb::ListLength(context->m_groupby_tlist) + 1;
 
 	// fix any outer references in the grouping column expression
 	Node *expr = (Node *) RunGroupingColMutator(node, context);
@@ -793,7 +637,7 @@ CQueryMutators::FixGroupingCols
 	new_target_entry->ressortgroupref = orginal_target_entry->ressortgroupref;
 	new_target_entry->resjunk = false;
 
-	context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, new_target_entry);
+	context->m_groupby_tlist = gpdb::LAppend(context->m_groupby_tlist, new_target_entry);
 
 	Var *new_var = gpdb::MakeVar
 			(
@@ -866,23 +710,19 @@ CQueryMutators::PteAggregateOrPercentileExpr
 	return gpdb::MakeTargetEntry((Expr*) node, (AttrNumber) attno, name, false);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CQueryMutators::RunHavingQualMutator
+// Traverse the entire tree under an arbitrarily complex project element (node)
+// to extract all aggregate functions out into the derived query's target list
 //
-//	@doc:
-// 		This mutator function checks to see if the current node is an AggRef
-//		or a correlated variable from the derived table.
-//		If it is an Aggref:
-//			Then replaces it with the appropriate attribute from the top-level query.
-//		If it is a correlated Var:
-//			Then replaces it with a attribute from the top-level query.
-//---------------------------------------------------------------------------
+// This mutator should be called after creating a derived query (a subquery in
+// the FROM clause), on each element in the old query's target list or qual to
+// update any AggRef & Var to refer to the output from the derived query.
+//
+// See comments below & in the callers for specific use cases.
 Node *
-CQueryMutators::RunHavingQualMutator
+CQueryMutators::RunExtractAggregatesMutator
 	(
 	Node *node,
-	SContextHavingQualMutator *context
+	SContextGrpbyPlMutator *context
 	)
 {
 	if (NULL == node)
@@ -895,34 +735,14 @@ CQueryMutators::RunHavingQualMutator
 		return (Node *) gpdb::CopyObject(node);
 	}
 
-	// check to see if the node is in the target list of the derived table.
-	// check if we have the corresponding target_entry entry in derived tables target list
-	if (0 == context->m_current_query_level)
-	{
-		if (IsA(node, Var) && context->m_is_mutating_agg_arg)
-		{
-			// fix outer references used in the aggregates
-			return (Node *) IncrLevelsUpInVar((Var*) node);
-		}
-
-		// check if an entry already exists, if so no need for duplicate
-		Node *found_node = FindNodeInTargetEntries(node, context);
-		if (NULL != found_node)
-		{
-			return found_node;
-		}
-
-		if (IsA(node, PercentileExpr) || IsA(node, GroupingFunc))
-		{
-			// create a new entry in the derived table and return its corresponding var
-			Node *node_copy = (Node*) gpdb::CopyObject(node);
-			return (Node *) MakeVarInDerivedTable(node_copy, context);
-		}
-	}
-
 	if (IsA(node, Aggref))
 	{
 		Aggref *old_aggref = (Aggref *) node;
+
+		// If the agglevelsup matches the current query level, this Aggref only
+		// uses vars from the top level query. This needs to be moved to the
+		// derived query, and the entire AggRef replaced with a Var referencing the
+		// derived table's target list.
 		if (old_aggref->agglevelsup == context->m_current_query_level)
 		{
 			Aggref *new_aggref = FlatCopyAggref(old_aggref);
@@ -947,7 +767,7 @@ CQueryMutators::RunHavingQualMutator
 									gpdb::MutateQueryOrExpressionTree
 											(
 											arg,
-											(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+											(MutatorWalkerFn) RunExtractAggregatesMutator,
 											(void *) context,
 											0 // mutate into cte-lists
 											)
@@ -957,36 +777,72 @@ CQueryMutators::RunHavingQualMutator
 			context->m_is_mutating_agg_arg = is_agg_old;
 			context->m_agg_levels_up = agg_levels_up;
 
+			// create a new entry in the derived table and return its corresponding var
+			return (Node *) MakeVarInDerivedTable((Node *) new_aggref, context);
+		}
+	}
+
+	if (0 == context->m_current_query_level)
+	{
+		if (IsA(node, Var) && context->m_is_mutating_agg_arg)
+		{
+			// This mutator may be run on a nested query object with aggregates on
+			// outer references. It pulls out any aggregates and moves it into the
+			// derived query (which is subquery), in effect, increasing the levels up
+			// any Var in the aggregate must now reference
+			//
+			// e.g SELECT (SELECT sum(o.o) + 1 FROM i GRP BY i.i) FROM o;
+			// becomes SELECT (SELECT x + 1 FROM (SELECT sum(o.o) GRP BY i.i)) FROM o;
+			// which means Var::varlevelup must be increased for o.o
+			return (Node *) IncrLevelsUpIfOuterRef((Var*) node);
+		}
+
+		if (IsA(node, PercentileExpr) || IsA(node, GroupingFunc))
+		{
+			// create a new entry in the derived table and return its corresponding var
+			Node *node_copy = (Node*) gpdb::CopyObject(node);
+			return (Node *) MakeVarInDerivedTable(node_copy, context);
+		}
+
+		if (!context->m_is_mutating_agg_arg)
+		{
 			// check if an entry already exists, if so no need for duplicate
-			Node *found_node = FindNodeInTargetEntries((Node*) new_aggref, context);
+			Node *found_node = FindNodeInGroupByTargetList(node, context);
 			if (NULL != found_node)
 			{
 				return found_node;
 			}
-
-			// create a new entry in the derived table and return its corresponding var
-			return (Node *) MakeVarInDerivedTable((Node *) new_aggref, context);
 		}
 	}
 
 	if (IsA(node, Var))
 	{
 		Var *var = (Var *) gpdb::CopyObject(node);
+
+		// Handle other top-level outer references in the project element
 		if (var->varlevelsup == context->m_current_query_level)
 		{
-			// process outer references
 			if (var->varlevelsup == context->m_agg_levels_up)
 			{
-				// an argument of an outer aggregate
+				// If Var references the top level query inside an Aggref that also
+				// references top level query, the Aggref is moved to the derived query
+				// (see comments in Aggref if-case above). Thus, these Vars reference
+				// are brought up to the top-query level.
 				var->varlevelsup = 0;
-
 				return (Node *) var;
 			}
 
-			var->varlevelsup = 0;
-			TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList( (Node*) var, context->m_groupby_target_list);
+			// For other top-level references, correct their varno & varattno, since
+			// they now must refer to the target list of the derived query - whose
+			// target list may be different from the original query.
 
-			if (NULL == found_target_entry)
+			// Set varlevelsup to 0 temporarily while searching in the target list
+			var->varlevelsup = 0;
+			TargetEntry *found_tle =
+				gpdb::FindFirstMatchingMemberInTargetList((Node*) var,
+													  context->m_groupby_tlist);
+
+			if (NULL == found_tle)
 			{
 				// Consider two table r(a,b) and s(c,d) and the following query
 				// SELECT 1 from r LEFT JOIN s on (r.a = s.c) group by r.a having count(*) > a
@@ -995,14 +851,15 @@ CQueryMutators::RunHavingQualMutator
 				// While r.a and a are equivalent, the algebrizer at this point cannot detect this.
 				// Therefore, found_target_entry will be NULL and we fall back.
 
-				context->m_should_fallback = true;
+				// TODO: Oct 14 2013, remove temporary fix (revert exception to assert) to avoid crash during algebrization
+				GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("No attribute"));
 				return NULL;
 			}
 
-			var->varlevelsup = context->m_current_query_level;
-			var->varno = 1;
-			var->varattno = found_target_entry->resno;
-			found_target_entry->resjunk = false;
+			var->varno = 1;  // derived query is the only table in FROM expression
+			var->varattno = found_tle->resno;
+			var->varlevelsup = context->m_current_query_level;  // reset varlevels up
+			found_tle->resjunk = false;
 
 			return (Node*) var;
 		}
@@ -1019,9 +876,9 @@ CQueryMutators::RunHavingQualMutator
 		cte->ctequery = gpdb::MutateQueryOrExpressionTree
 									(
 									cte->ctequery,
-									(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+									(MutatorWalkerFn) RunExtractAggregatesMutator,
 									(void *) context,
-									0 // flags --- mutate into cte-lists
+									0 // mutate into cte-lists
 									);
 
 		context->m_current_query_level--;
@@ -1040,9 +897,9 @@ CQueryMutators::RunHavingQualMutator
 		new_sublink->testexpr =	gpdb::MutateQueryOrExpressionTree
 										(
 										old_sublink->testexpr,
-										(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+										(MutatorWalkerFn) RunExtractAggregatesMutator,
 										(void *) context,
-										0 // flags -- mutate into cte-lists
+										0 // mutate into cte-lists
 										);
 		context->m_current_query_level++;
 
@@ -1051,9 +908,9 @@ CQueryMutators::RunHavingQualMutator
 		new_sublink->subselect = gpdb::MutateQueryOrExpressionTree
 										(
 										old_sublink->subselect,
-										(MutatorWalkerFn) CQueryMutators::RunHavingQualMutator,
+										(MutatorWalkerFn) RunExtractAggregatesMutator,
 										(void *) context,
-										0 // flags -- mutate into cte-lists
+										0 // mutate into cte-lists
 										);
 
 		context->m_current_query_level--;
@@ -1061,75 +918,68 @@ CQueryMutators::RunHavingQualMutator
 		return (Node *) new_sublink;
 	}
 	
-	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunHavingQualMutator, context);
+	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) RunExtractAggregatesMutator, context);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CQueryMutators::MakeVarInDerivedTable
-//
-//	@doc:
-//		Create a new entry in the derived table and return its corresponding var
-//---------------------------------------------------------------------------
+
+// Create a new entry in the derived table and return its corresponding var
 Var *
 CQueryMutators::MakeVarInDerivedTable
 	(
 	Node *node,
-	SContextHavingQualMutator *context
+	SContextGrpbyPlMutator *context
 	)
 {
 	GPOS_ASSERT(NULL != node);
 	GPOS_ASSERT(NULL != context);
 	GPOS_ASSERT(IsA(node, PercentileExpr) || IsA(node, Aggref) || IsA(node, GroupingFunc));
 
-	const ULONG attno = gpdb::ListLength(context->m_groupby_target_list) + 1;
-	TargetEntry *target_entry = PteAggregateOrPercentileExpr(context->m_mp, context->m_md_accessor, (Node *) node, attno);
-	context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
+	// Append a new target entry for the node to the derived target list ...
+	const ULONG attno = gpdb::ListLength(context->m_groupby_tlist) + 1;
+	TargetEntry *tle = PteAggregateOrPercentileExpr(context->m_mp, context->m_mda, node, attno);
+	context->m_groupby_tlist = gpdb::LAppend(context->m_groupby_tlist, tle);
 
-	Var *new_var = gpdb::MakeVar
-					(
-					1, // varno
-					attno,
-					gpdb::ExprType((Node*) node),
-					gpdb::ExprTypeMod((Node*) node),
-					context->m_current_query_level
-					);
+	// ... and return a Var referring to it in its stead
+	// NB: Since the new tle is appended at the top query level, Var::varlevelsup
+	// should equal the current nested level. This will take care of any outer references
+	// to the original tlist.
+	Var *new_var = gpdb::MakeVar(1 /* varno */,
+								 attno,
+								 gpdb::ExprType((Node*) node),
+								 gpdb::ExprTypeMod((Node*) node),
+								 context->m_current_query_level /* varlevelsup */);
 
 	return new_var;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CQueryMutators::FindNodeInTargetEntries
-//
-//	@doc:
-//		Check if a matching entry already exists in the list of target
-//		entries, if yes return its corresponding var, otherwise return NULL
-//---------------------------------------------------------------------------
+
+// Check if a matching entry already exists in the list of target
+// entries, if yes return its corresponding var, otherwise return NULL
 Node *
-CQueryMutators::FindNodeInTargetEntries
+CQueryMutators::FindNodeInGroupByTargetList
 	(
 	Node *node,
-	SContextHavingQualMutator *context
+	SContextGrpbyPlMutator *context
 	)
 {
 	GPOS_ASSERT(NULL != node);
 	GPOS_ASSERT(NULL != context);
 	
-	TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
-	if (NULL != found_target_entry)
+	TargetEntry *found_tle =
+		gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_tlist);
+
+	if (NULL != found_tle)
 	{
 		gpdb::GPDBFree(node);
-		Var *new_var = gpdb::MakeVar
-						(
-						1, // varno
-						found_target_entry->resno,
-						gpdb::ExprType( (Node*) found_target_entry->expr),
-						gpdb::ExprTypeMod( (Node*) found_target_entry->expr),
-						context->m_current_query_level
-						);
+		// NB: Var::varlevelsup is set to the current query level since the created
+		// Var must reference the group by targetlist at the top level.
+		Var *new_var = gpdb::MakeVar(1 /* varno */,
+									 found_tle->resno,
+									 gpdb::ExprType( (Node*) found_tle->expr),
+									 gpdb::ExprTypeMod( (Node*) found_tle->expr),
+									 context->m_current_query_level /* varlevelsup */);
 
-		found_target_entry->resjunk = false;
+		found_tle->resjunk = false;
 		return (Node*) new_var;
 	}
 
@@ -1162,15 +1012,10 @@ CQueryMutators::FlatCopyAggref
 	return new_aggref;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CQueryMutators::IncrLevelsUpInVar
-//
-//	@doc:
-//		Increment the levels up of outer references
-//---------------------------------------------------------------------------
+
+// Increment the levels up of outer references
 Var *
-CQueryMutators::IncrLevelsUpInVar
+CQueryMutators::IncrLevelsUpIfOuterRef
 	(
 	Var *var
 	)
@@ -1242,17 +1087,10 @@ CQueryMutators::NormalizeHaving
 		}
 	}
 
-	SContextHavingQualMutator context(mp, md_accessor, num_target_entries, derived_table_query->targetList);
+	SContextGrpbyPlMutator context(mp, md_accessor, derived_table_query, derived_table_query->targetList);
 
 	// fix outer references in the qual
-	new_query->jointree->quals = RunHavingQualMutator(derived_table_query->havingQual, &context);
-
-	if (context.m_should_fallback)
-	{
-		// TODO: Oct 14 2013, remove temporary fix (revert exception to assert) to avoid crash during algebrization
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError, GPOS_WSZ_LIT("No attribute"));
-	}
-
+	new_query->jointree->quals = RunExtractAggregatesMutator(derived_table_query->havingQual, &context);
 	derived_table_query->havingQual = NULL;
 
 	ReassignSortClause(new_query, rte->subquery);
@@ -1712,8 +1550,8 @@ CQueryMutators::NormalizeWindowProjList
 		{
 			// insert the target list entry used in the window specification as is
 			TargetEntry *new_target_entry = (TargetEntry *) gpdb::CopyObject(target_entry);
-			new_target_entry->resno = gpdb::ListLength(context.m_groupby_target_list) + 1;
-			context.m_groupby_target_list = gpdb::LAppend(context.m_groupby_target_list, new_target_entry);
+			new_target_entry->resno = gpdb::ListLength(context.m_groupby_tlist) + 1;
+			context.m_groupby_tlist = gpdb::LAppend(context.m_groupby_tlist, new_target_entry);
 
 			if (!target_entry->resjunk || CTranslatorUtils::IsSortingColumn(target_entry, query->sortClause))
 			{
@@ -1741,14 +1579,13 @@ CQueryMutators::NormalizeWindowProjList
 		else
 		{
 			// normalize target list entry
-			context.m_sort_group_ref = target_entry->ressortgroupref;
 			Expr *pexprNew = (Expr*) RunWindowProjListMutator( (Node*) target_entry->expr, &context);
 			TargetEntry *new_target_entry = gpdb::MakeTargetEntry(pexprNew, ulResNoNew, target_entry->resname, target_entry->resjunk);
 			new_target_entry->ressortgroupref = target_entry->ressortgroupref;
 			new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry);
 		}
 	}
-	derived_table_query->targetList = context.m_groupby_target_list;
+	derived_table_query->targetList = context.m_groupby_tlist;
 
 	GPOS_ASSERT(gpdb::ListLength(new_query->targetList) <= gpdb::ListLength(query->targetList));
 
@@ -1785,7 +1622,7 @@ CQueryMutators::RunWindowProjListMutator
 		return (Node *) gpdb::CopyObject(node);
 	}
 
-	const ULONG resno = gpdb::ListLength(context->m_groupby_target_list) + 1;
+	const ULONG resno = gpdb::ListLength(context->m_groupby_tlist) + 1;
 
 	if (IsA(node, WindowRef))
 	{
@@ -1795,7 +1632,7 @@ CQueryMutators::RunWindowProjListMutator
 
 		// get the function name and add it to the target list
 		CMDIdGPDB *mdid_func = GPOS_NEW(context->m_mp) CMDIdGPDB(window_ref->winfnoid);
-		const CWStringConst *str = CMDAccessorUtils::PstrWindowFuncName(context->m_md_accessor, mdid_func);
+		const CWStringConst *str = CMDAccessorUtils::PstrWindowFuncName(context->m_mda, mdid_func);
         mdid_func->Release();
 
 		TargetEntry *target_entry = gpdb::MakeTargetEntry
@@ -1805,7 +1642,7 @@ CQueryMutators::RunWindowProjListMutator
 								CTranslatorUtils::CreateMultiByteCharStringFromWCString(str->GetBuffer()),
 								false /* resjunk */
 								);
-		context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
+		context->m_groupby_tlist = gpdb::LAppend(context->m_groupby_tlist, target_entry);
 
 		// return a variable referring to the new derived table's corresponding target list entry
 		Var *new_var = gpdb::MakeVar
@@ -1824,7 +1661,7 @@ CQueryMutators::RunWindowProjListMutator
 	{
 		Var *new_var = NULL;
 
-		TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_target_list);
+		TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_tlist);
 		if (NULL == found_target_entry)
 		{
 			// insert target entry into the target list of the derived table
@@ -1836,7 +1673,7 @@ CQueryMutators::RunWindowProjListMutator
 									CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_unnamed_col.GetBuffer()),
 									false /* resjunk */
 									);
-			context->m_groupby_target_list = gpdb::LAppend(context->m_groupby_target_list, target_entry);
+			context->m_groupby_tlist = gpdb::LAppend(context->m_groupby_tlist, target_entry);
 
 			new_var = gpdb::MakeVar
 								(

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -55,61 +55,6 @@ namespace gpdxl
 		typedef Node *(*MutatorWalkerFn) ();
 		typedef BOOL (*FallbackWalkerFn) ();
 
-		typedef struct SContextHavingQualMutator
-		{
-			public:
-				// memory pool
-				IMemoryPool *m_mp;
-
-				// MD accessor for function names
-				CMDAccessor *m_md_accessor;
-
-				// the counter for Query's total number of target entries
-				ULONG m_num_target_entries;
-
-				// the target list of the new group by query
-				List *m_groupby_target_list;
-
-				// the current query level
-				ULONG m_current_query_level;
-
-		 	 	// indicate whether we are mutating the argument of an aggregate
-				BOOL m_is_mutating_agg_arg;
-
-				// indicate the levels up of the aggregate we are mutating
-				ULONG m_agg_levels_up;
-				
-				// fall back to the planner by raising an expression since we encountered an
-				// expression / attribute that we could not resolve
-				BOOL m_should_fallback;
-
-				// ctor
-				SContextHavingQualMutator
-					(
-					IMemoryPool *mp,
-					CMDAccessor *md_accessor,
-					ULONG num_target_entries,
-					List *groupby_target_list
-					)
-					:
-					m_mp(mp),
-					m_md_accessor(md_accessor),
-					m_num_target_entries(num_target_entries),
-					m_groupby_target_list(groupby_target_list),
-					m_current_query_level(0),
-					m_is_mutating_agg_arg(false),
-					m_agg_levels_up(gpos::ulong_max),
-					m_should_fallback(false)
-				{
-					GPOS_ASSERT(NULL != groupby_target_list);
-				}
-
-				// dtor
-				~SContextHavingQualMutator()
-				{}
-
-		} CContextHavingQualMutator;
-
 		typedef struct SContextGrpbyPlMutator
 		{
 			public:
@@ -118,19 +63,20 @@ namespace gpdxl
 				IMemoryPool *m_mp;
 
 				// MD accessor to get the function name
-				CMDAccessor *m_md_accessor;
+				CMDAccessor *m_mda;
 
 				// original query
+				// XXX I don't think this is really needed
 				Query *m_query;
 
-				// the new target list of the group by query
-				List *m_groupby_target_list;
+				// the new target list of the group by (derived) query
+				List *m_groupby_tlist;
 
 				// the current query level
 				ULONG m_current_query_level;
 
-				// the sorting / grouping reference of the original target list entry
-				ULONG m_sort_group_ref;
+				// indicate the levels up of the aggregate we are mutating
+				ULONG m_agg_levels_up;
 
 				// indicate whether we are mutating the argument of an aggregate
 				BOOL m_is_mutating_agg_arg;
@@ -139,17 +85,17 @@ namespace gpdxl
 				SContextGrpbyPlMutator
 					(
 					IMemoryPool *mp,
-					CMDAccessor *md_accessor,
+					CMDAccessor *mda,
 					Query *query,
-					List *groupby_target_list
+					List *groupby_tlist
 					)
-					:
+						:
 					m_mp(mp),
-					m_md_accessor(md_accessor),
+					m_mda(mda),
 					m_query(query),
-					m_groupby_target_list(groupby_target_list),
+					m_groupby_tlist(groupby_tlist),
 					m_current_query_level(0),
-					m_sort_group_ref(0),
+					m_agg_levels_up(gpos::ulong_max),
 					m_is_mutating_agg_arg(false)
 				{
 				}
@@ -259,15 +205,15 @@ namespace gpdxl
 
 			// create a new entry in the derived table and return its corresponding var
 			static
-			Var *MakeVarInDerivedTable(Node *node, SContextHavingQualMutator *context);
+			Var *MakeVarInDerivedTable(Node *node, SContextGrpbyPlMutator *context);
 
 			// check if a matching node exists in the list of target entries
 			static
-			Node *FindNodeInTargetEntries(Node *node, SContextHavingQualMutator *context);
+			Node *FindNodeInGroupByTargetList(Node *node, SContextGrpbyPlMutator *context);
 
 			// increment the levels up of outer references
 			static
-			Var *IncrLevelsUpInVar(Var *var);
+			Var *IncrLevelsUpIfOuterRef(Var *var);
 
 			// pull up having clause into a select
 			static
@@ -280,11 +226,6 @@ namespace gpdxl
 			// traverse the expression and fix the levels up of any CTE
 			static
 			Node *RunFixCTELevelsUpMutator(Node *node, SContextIncLevelsupMutator *context);
-
-			// traverse the project list of a groupby operator, to
-			// extract all aggregate functions in an arbitrarily complex project element,
-			static
-			Node *RunGroupByProjListMutator(Node *node, SContextGrpbyPlMutator *context);
 
 			// mutate the grouping columns, fix levels up when necessary
 			static
@@ -301,7 +242,7 @@ namespace gpdxl
 			// traverse the having qual to extract all aggregate functions,
 			// fix correlated vars and return the modified having qual
 			static
-			Node *RunHavingQualMutator(Node *node, SContextHavingQualMutator *context);
+			Node *RunExtractAggregatesMutator(Node *node, SContextGrpbyPlMutator *context);
 
 			// for a given an TE in the derived table, create a new TE to be added to the top level query
 			static

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -8499,6 +8499,12 @@ select sum(f1.b) from orca.fooh1 f1 group by f1.a;
    4
 (4 rows)
 
+select f1.a + 1 from fooh1 f1 group by f1.a+1 having sum(f1.a+1) + 1 > 20;
+ ?column? 
+----------
+        4
+(1 row)
+
 select 1 as one, f1.a from orca.fooh1 f1 group by f1.a having sum(f1.b) > 4;
  one | a
 -----+---
@@ -8622,6 +8628,152 @@ select sum(f1.a+1)+avg(f1.a+1), sum(f1.a), sum(f1.a+1) from orca.fooh1 f1 group 
        12 |   5 |  10
 (4 rows)
 
+--
+-- test algebrization of group by clause with subqueries
+--
+drop table if exists foo, bar, jazz;
+NOTICE:  table "jazz" does not exist, skipping
+create table foo (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar (d int, e int, f int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'd' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table jazz (g int, h int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'g' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo values (1, 1, 1), (2, 2, 2), (3, 3, 3);
+insert into bar values (1, 1, 1), (2, 2, 2), (3, 3, 3);
+insert into jazz values (2, 2, 2);
+-- subquery with outer reference with aggfunc in target list
+select a, (select sum(e) from bar where foo.b = bar.f), b, count(*) from foo, jazz where foo.c = jazz.g group by b, a, h;
+ a | ?column? | b | count 
+---+----------+---+-------
+ 2 |        2 | 2 |     1
+(1 row)
+
+-- complex agg expr in subquery
+select foo.a, (select (foo.a + foo.b) * count(bar.e) from bar), b, count(*) from foo group by foo.a, foo.b, foo.a + foo.b;
+ a | ?column? | b | count 
+---+----------+---+-------
+ 2 |       12 | 2 |     1
+ 1 |        6 | 1 |     1
+ 3 |       18 | 3 |     1
+(3 rows)
+
+-- aggfunc over an outer reference in a subquery
+select (select sum(foo.a + bar.d) from bar) from foo group by a, b;
+ ?column? 
+----------
+       12
+        9
+       15
+(3 rows)
+
+-- complex expression of aggfunc over an outer reference in a subquery
+select (select sum(foo.a + bar.d) + 1 from bar) from foo group by a, b;
+ ?column? 
+----------
+       13
+       10
+       16
+(3 rows)
+
+-- aggrefs with multiple agglevelsup
+select (select (select sum(foo.a + bar.d) from jazz) from bar) from foo group by a, b;
+ERROR:  correlated subquery with skip-level correlations is not supported
+-- aggrefs with multiple agglevelsup in an expression
+select (select (select sum(foo.a + bar.d) * 2 from jazz) from bar) from foo group by a, b;
+ERROR:  correlated subquery with skip-level correlations is not supported
+-- nested group by
+select (select max(f) from bar where d = 1 group by a, e) from foo group by a;
+ ?column? 
+----------
+        1
+        1
+        1
+(3 rows)
+
+-- cte with an aggfunc of outer ref
+select a, count(*), (with cte as (select min(d) dd from bar group by e) select max(a * dd) from cte) from foo group by a;
+ a | count | ?column? 
+---+-------+----------
+ 3 |     1 |        9
+ 1 |     1 |        3
+ 2 |     1 |        6
+(3 rows)
+
+-- cte with an aggfunc of outer ref in an complex expression
+select a, count(*), (with cte as (select e, min(d) as dd from bar group by e) select max(a) * sum(dd) from cte) from foo group by a;
+ a | count | ?column? 
+---+-------+----------
+ 1 |     1 |        6
+ 2 |     1 |       12
+ 3 |     1 |       18
+(3 rows)
+
+-- subquery in group by
+select max(a) from foo group by (select e from bar where bar.e = foo.a);
+ max 
+-----
+   1
+   2
+   3
+(3 rows)
+
+-- nested subquery in group by
+select max(a) from foo group by (select g from jazz where foo.a = (select max(a) from foo where c = 1 group by b));
+ max 
+-----
+   1
+   3
+(2 rows)
+
+-- group by inside groupby inside group by ;S
+select max(a) from foo group by (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h);
+ max 
+-----
+   2
+   3
+(2 rows)
+
+-- cte subquery in group by
+select max(a) from foo group by b, (with cte as (select min(g) from jazz group by h) select a from cte);
+ max 
+-----
+   3
+   2
+   1
+(3 rows)
+
+-- group by subquery in order by
+select * from foo order by ((select min(bar.e + 1) * 2 from bar group by foo.a) - foo.a);
+ a | b | c 
+---+---+---
+ 3 | 3 | 3
+ 2 | 2 | 2
+ 1 | 1 | 1
+(3 rows)
+
+-- everything in the kitchen sink
+select max(b), (select foo.a * count(bar.e) from bar), (with cte as (select e, min(d) as dd from bar group by e) select max(a) * sum(dd) from cte), count(*) from foo group by foo.a, (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h), (with cte as (select min(g) from jazz group by h) select a from cte) order by ((select min(bar.e + 1) * 2 from bar group by foo.a) - foo.a);
+ max | ?column? | ?column? | count 
+-----+----------+----------+-------
+   3 |        9 |       18 |     1
+   2 |        6 |       12 |     1
+   1 |        3 |        6 |     1
+(3 rows)
+
+-- complex expression in group by & targetlist
+select b + (a+1) from foo group by b, a+1;
+ ?column? 
+----------
+        7
+        3
+        5
+(3 rows)
+
+drop table foo, bar, jazz;
 create table orca.t77(C952 text) WITH (compresstype=zlib,compresslevel=2,appendonly=true,blocksize=393216,checksum=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c952' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -8505,6 +8505,12 @@ select sum(f1.b) from orca.fooh1 f1 group by f1.a;
    6
 (4 rows)
 
+select f1.a + 1 from fooh1 f1 group by f1.a+1 having sum(f1.a+1) + 1 > 20;
+ ?column? 
+----------
+        4
+(1 row)
+
 select 1 as one, f1.a from orca.fooh1 f1 group by f1.a having sum(f1.b) > 4;
  one | a
 -----+---
@@ -8628,6 +8634,164 @@ select sum(f1.a+1)+avg(f1.a+1), sum(f1.a), sum(f1.a+1) from orca.fooh1 f1 group 
        18 |  10 |  15
 (4 rows)
 
+--
+-- test algebrization of group by clause with subqueries
+--
+drop table if exists foo, bar, jazz;
+NOTICE:  table "jazz" does not exist, skipping
+create table foo (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar (d int, e int, f int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'd' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table jazz (g int, h int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'g' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo values (1, 1, 1), (2, 2, 2), (3, 3, 3);
+insert into bar values (1, 1, 1), (2, 2, 2), (3, 3, 3);
+insert into jazz values (2, 2, 2);
+-- subquery with outer reference with aggfunc in target list
+select a, (select sum(e) from bar where foo.b = bar.f), b, count(*) from foo, jazz where foo.c = jazz.g group by b, a, h;
+ a | ?column? | b | count 
+---+----------+---+-------
+ 2 |        2 | 2 |     1
+(1 row)
+
+-- complex agg expr in subquery
+select foo.a, (select (foo.a + foo.b) * count(bar.e) from bar), b, count(*) from foo group by foo.a, foo.b, foo.a + foo.b;
+ a | ?column? | b | count 
+---+----------+---+-------
+ 3 |       18 | 3 |     1
+ 1 |        6 | 1 |     1
+ 2 |       12 | 2 |     1
+(3 rows)
+
+-- aggfunc over an outer reference in a subquery
+select (select sum(foo.a + bar.d) from bar) from foo group by a, b;
+ ?column? 
+----------
+        9
+       12
+       15
+(3 rows)
+
+-- complex expression of aggfunc over an outer reference in a subquery
+select (select sum(foo.a + bar.d) + 1 from bar) from foo group by a, b;
+ ?column? 
+----------
+       10
+       13
+       16
+(3 rows)
+
+-- aggrefs with multiple agglevelsup
+select (select (select sum(foo.a + bar.d) from jazz) from bar) from foo group by a, b;
+ ?column? 
+----------
+        9
+       12
+       15
+(3 rows)
+
+-- aggrefs with multiple agglevelsup in an expression
+select (select (select sum(foo.a + bar.d) * 2 from jazz) from bar) from foo group by a, b;
+ ?column? 
+----------
+       18
+       24
+       30
+(3 rows)
+
+-- nested group by
+select (select max(f) from bar where d = 1 group by a, e) from foo group by a;
+ ?column? 
+----------
+        1
+        1
+        1
+(3 rows)
+
+-- cte with an aggfunc of outer ref
+select a, count(*), (with cte as (select min(d) dd from bar group by e) select max(a * dd) from cte) from foo group by a;
+ a | count | ?column? 
+---+-------+----------
+ 1 |     1 |        3
+ 2 |     1 |        6
+ 3 |     1 |        9
+(3 rows)
+
+-- cte with an aggfunc of outer ref in an complex expression
+select a, count(*), (with cte as (select e, min(d) as dd from bar group by e) select max(a) * sum(dd) from cte) from foo group by a;
+ a | count | ?column? 
+---+-------+----------
+ 3 |     1 |       18
+ 1 |     1 |        6
+ 2 |     1 |       12
+(3 rows)
+
+-- subquery in group by
+select max(a) from foo group by (select e from bar where bar.e = foo.a);
+ max 
+-----
+   3
+   1
+   2
+(3 rows)
+
+-- nested subquery in group by
+select max(a) from foo group by (select g from jazz where foo.a = (select max(a) from foo where c = 1 group by b));
+ max 
+-----
+   3
+   1
+(2 rows)
+
+-- group by inside groupby inside group by ;S
+select max(a) from foo group by (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h);
+ max 
+-----
+   2
+   3
+(2 rows)
+
+-- cte subquery in group by
+select max(a) from foo group by b, (with cte as (select min(g) from jazz group by h) select a from cte);
+ max 
+-----
+   3
+   1
+   2
+(3 rows)
+
+-- group by subquery in order by
+select * from foo order by ((select min(bar.e + 1) * 2 from bar group by foo.a) - foo.a);
+ a | b | c 
+---+---+---
+ 3 | 3 | 3
+ 2 | 2 | 2
+ 1 | 1 | 1
+(3 rows)
+
+-- everything in the kitchen sink
+select max(b), (select foo.a * count(bar.e) from bar), (with cte as (select e, min(d) as dd from bar group by e) select max(a) * sum(dd) from cte), count(*) from foo group by foo.a, (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h), (with cte as (select min(g) from jazz group by h) select a from cte) order by ((select min(bar.e + 1) * 2 from bar group by foo.a) - foo.a);
+ max | ?column? | ?column? | count 
+-----+----------+----------+-------
+   3 |        9 |       18 |     1
+   2 |        6 |       12 |     1
+   1 |        3 |        6 |     1
+(3 rows)
+
+-- complex expression in group by & targetlist
+select b + (a+1) from foo group by b, a+1;
+ ?column? 
+----------
+        3
+        5
+        7
+(3 rows)
+
+drop table foo, bar, jazz;
 create table orca.t77(C952 text) WITH (compresstype=zlib,compresslevel=2,appendonly=true,blocksize=393216,checksum=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c952' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -649,6 +649,7 @@ insert into orca.fooh1 select i%4, i%3, i from generate_series(1,20) i;
 insert into orca.fooh2 select i%3, i%2, i from generate_series(1,20) i;
 
 select sum(f1.b) from orca.fooh1 f1 group by f1.a;
+select f1.a + 1 from fooh1 f1 group by f1.a+1 having sum(f1.a+1) + 1 > 20;
 select 1 as one, f1.a from orca.fooh1 f1 group by f1.a having sum(f1.b) > 4;
 select f1.a, 1 as one from orca.fooh1 f1 group by f1.a having 10 > (select f2.a from orca.fooh2 f2 group by f2.a having sum(f1.a) > count(*) order by f2.a limit 1) order by f1.a;
 select 1 from orca.fooh1 f1 group by f1.a having 10 > (select f2.a from orca.fooh2 f2 group by f2.a having sum(f1.a) > count(*) order by f2.a limit 1) order by f1.a;
@@ -667,6 +668,68 @@ select f1.a, 1 as one from orca.fooh1 f1 group by f1.a having f1.a = (select f2.
 select sum(f1.a+1)+1 from orca.fooh1 f1 group by f1.a+1;
 select sum(f1.a+1)+sum(f1.a+1) from orca.fooh1 f1 group by f1.a+1;
 select sum(f1.a+1)+avg(f1.a+1), sum(f1.a), sum(f1.a+1) from orca.fooh1 f1 group by f1.a+1;
+
+--
+-- test algebrization of group by clause with subqueries
+--
+drop table if exists foo, bar, jazz;
+create table foo (a int, b int, c int);
+create table bar (d int, e int, f int);
+create table jazz (g int, h int, j int);
+
+insert into foo values (1, 1, 1), (2, 2, 2), (3, 3, 3);
+insert into bar values (1, 1, 1), (2, 2, 2), (3, 3, 3);
+insert into jazz values (2, 2, 2);
+
+-- subquery with outer reference with aggfunc in target list
+select a, (select sum(e) from bar where foo.b = bar.f), b, count(*) from foo, jazz where foo.c = jazz.g group by b, a, h;
+
+-- complex agg expr in subquery
+select foo.a, (select (foo.a + foo.b) * count(bar.e) from bar), b, count(*) from foo group by foo.a, foo.b, foo.a + foo.b;
+
+-- aggfunc over an outer reference in a subquery
+select (select sum(foo.a + bar.d) from bar) from foo group by a, b;
+
+-- complex expression of aggfunc over an outer reference in a subquery
+select (select sum(foo.a + bar.d) + 1 from bar) from foo group by a, b;
+
+-- aggrefs with multiple agglevelsup
+select (select (select sum(foo.a + bar.d) from jazz) from bar) from foo group by a, b;
+
+-- aggrefs with multiple agglevelsup in an expression
+select (select (select sum(foo.a + bar.d) * 2 from jazz) from bar) from foo group by a, b;
+
+-- nested group by
+select (select max(f) from bar where d = 1 group by a, e) from foo group by a;
+
+-- cte with an aggfunc of outer ref
+select a, count(*), (with cte as (select min(d) dd from bar group by e) select max(a * dd) from cte) from foo group by a;
+
+-- cte with an aggfunc of outer ref in an complex expression
+select a, count(*), (with cte as (select e, min(d) as dd from bar group by e) select max(a) * sum(dd) from cte) from foo group by a;
+
+-- subquery in group by
+select max(a) from foo group by (select e from bar where bar.e = foo.a);
+
+-- nested subquery in group by
+select max(a) from foo group by (select g from jazz where foo.a = (select max(a) from foo where c = 1 group by b));
+
+-- group by inside groupby inside group by ;S
+select max(a) from foo group by (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h);
+
+-- cte subquery in group by
+select max(a) from foo group by b, (with cte as (select min(g) from jazz group by h) select a from cte);
+
+-- group by subquery in order by
+select * from foo order by ((select min(bar.e + 1) * 2 from bar group by foo.a) - foo.a);
+
+-- everything in the kitchen sink
+select max(b), (select foo.a * count(bar.e) from bar), (with cte as (select e, min(d) as dd from bar group by e) select max(a) * sum(dd) from cte), count(*) from foo group by foo.a, (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h), (with cte as (select min(g) from jazz group by h) select a from cte) order by ((select min(bar.e + 1) * 2 from bar group by foo.a) - foo.a);
+
+-- complex expression in group by & targetlist
+select b + (a+1) from foo group by b, a+1;
+
+drop table foo, bar, jazz;
 
 create table orca.t77(C952 text) WITH (compresstype=zlib,compresslevel=2,appendonly=true,blocksize=393216,checksum=true);
 insert into orca.t77 select 'text'::text;


### PR DESCRIPTION
Ported from GPDB Master PR: https://github.com/greenplum-db/gpdb/pull/7193

ORCA's algebrizer must first normalize GROUP BYs in a query to a form
usable in ORCA. It must flatten expressions in the project list to
contain only aggregates and grouping columns
For example:

ORGINAL QUERY:
SELECT * from r where r.a > (SELECT max(c) + min(d)
FROM t where r.b = t.e)
NEW QUERY:
SELECT * from r where r.a > (SELECT x1+x2 as x3
FROM (SELECT max(c) as x2, min(d) as x2
FROM t where r.b = t.e) t2)

However this process did not support subqueries in the target list that
may contain outer references, sometimes in other (nested) subqueries. It
also did not support CTEs. All these would produce a normalization error
and fall back.

This commit fixes that by supported subqueries & CTEs.

I've separated the new tests & refactors into different commits for making
them easier to review. Please ignore the XXX items in the first few commits -
they should be removed in the refactor commits. Comments are also added
in the refactor commits.