### PR TITLE
PrepareTempTablespaces directly before making temp file

### DIFF
--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -400,9 +400,6 @@ ExecHashTableCreate(HashState *hashState, HashJoinState *hjstate, List *hashOper
 		 */
 		hashtable->innerBatchFile = (BufFile **) palloc0(nbatch * sizeof(BufFile *));
 		hashtable->outerBatchFile = (BufFile **) palloc0(nbatch * sizeof(BufFile *));
-		/* The files will not be opened until needed... */
-		/* ... but make sure we have temp tablespaces established for them */
-		PrepareTempTablespaces();
 	}
 
 	/*
@@ -739,8 +736,6 @@ ExecHashIncreaseNumBatches(HashJoinTable hashtable)
 		/* we had no file arrays before */
 		hashtable->innerBatchFile = (BufFile **) palloc0(nbatch * sizeof(BufFile *));
 		hashtable->outerBatchFile = (BufFile **) palloc0(nbatch * sizeof(BufFile *));
-		/* time to establish the temp tablespaces, too */
-		PrepareTempTablespaces();
 	}
 	else
 	{

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -63,6 +63,7 @@
 #include <zstd.h>
 #endif
 
+#include "commands/tablespace.h"
 #include "executor/instrument.h"
 #include "storage/fd.h"
 #include "storage/buffile.h"
@@ -200,7 +201,16 @@ BufFileCreateTempInSet(workfile_set *work_set, bool interXact)
 	char		filePrefix[MAXPGPATH];
 
 	snprintf(filePrefix, MAXPGPATH, "_%s_", work_set->prefix);
-
+	/*
+	 * In upstream, PrepareTempTablespaces() is called by callers of
+	 * BufFileCreateTemp*. Since we were burned once by forgetting to call it
+	 * for hyperhashagg spill files, we moved it into BufFileCreateTempInSet,
+	 * as we didn't see a reason not to.
+	 * We also posed the question upstream
+	 * https://www.postgresql.org/message-id/
+	 * CAAKRu_YwzjuGAmmaw4-8XO=OVFGR1QhY_Pq-t3wjb9ribBJb_Q@mail.gmail.com
+	 */
+	PrepareTempTablespaces();
 	pfile = OpenTemporaryFile(interXact, filePrefix);
 	Assert(pfile >= 0);
 

--- a/src/test/regress/input/workfile_mgr_test.source
+++ b/src/test/regress/input/workfile_mgr_test.source
@@ -16,4 +16,12 @@ $$
 $$
 LANGUAGE SQL;
 
+-- setup for workfile made in temp tablespace test
+\! mkdir -p '@testtablespace@/workfile_mgr';
+CREATE TABLESPACE ts1 LOCATION '@testtablespace@/workfile_mgr';
+
+SELECT gp_workfile_mgr_test('workfile_made_in_temp_tablespace');
+
+DROP TABLESPACE ts1;
+
 SELECT gp_workfile_mgr_test('fd_tests');

--- a/src/test/regress/output/workfile_mgr_test.source
+++ b/src/test/regress/output/workfile_mgr_test.source
@@ -13,6 +13,19 @@ $$
 	SELECT C.* FROM gp_workfile_mgr_test_on_segments($1) as C;
 $$
 LANGUAGE SQL;
+-- setup for workfile made in temp tablespace test
+\! mkdir -p '@testtablespace@/workfile_mgr';
+CREATE TABLESPACE ts1 LOCATION '@testtablespace@/workfile_mgr';
+SELECT gp_workfile_mgr_test('workfile_made_in_temp_tablespace');
+ gp_workfile_mgr_test 
+----------------------
+ t
+ t
+ t
+ t
+(4 rows)
+
+DROP TABLESPACE ts1;
 SELECT gp_workfile_mgr_test('fd_tests');
  gp_workfile_mgr_test 
 ----------------------


### PR DESCRIPTION
`PrepareTempTablespaces` is called by almost all callers of
`BufFileCreateTemp`* and seems like it would be easier from a readability
perspective and as a developer when writing some code that is going to
make temp files, I would prefer not to have to remember to check and set
the value that the user set for temp tablespaces GUC. It seems like that
is an unnecessary chore that is easily forgotten.

For example, for HashAgg, we have our own spilling implementation and
forgot to call `PrepareTempTablespaces`, so spill files were not getting
created in the temp tablespace specified by the user.

The test added leverages the workfile manager unittest framework, but,
because we had to set a GUC first, there are a few setup lines in the
SQL.

Upstream Postgres does not call `PrepareTempTablespaces`in `BufFileCreateTemp` but it is not clear why. Almost all of the callers call `PrepareTempTablespaces` on their own before calling `BufFileCreateTemp`, so it seems like it would be much easier to move it inside. 
We are trying to understand if there is a reason.
If there is no good reason not to, we will propose this change upstream.