### PR TITLE
Fix gpperfmon partition flaky test.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -171,6 +171,5 @@ Feature: gpperfmon
         When the user runs command "pkill gpmmon"
         Then wait until the process "gpmmon" is up
         And wait until the process "gpsmon" is up
-        Then waiting "2" seconds
         # Note that the code considers partition_age + 1 as the number of partitions to keep
-        Then wait until the results from boolean sql "SELECT count(*) = 6 FROM pg_partitions WHERE tablename = 'diskspace_history'" is "true"
+        Then wait until the results from boolean sql "SELECT count(*) = 6 FROM pg_namespace n INNER JOIN pg_class cl ON cl.relnamespace = n.oid INNER JOIN pg_partition pp ON pp.parrelid = cl.oid INNER JOIN pg_partition_rule ppr ON ppr.paroid = pp.oid WHERE n.nspname = 'public' AND cl.relname = 'diskspace_history'" is "true"


### PR DESCRIPTION
Rewrite test SQL to verify partition numbers after drop partitions to workaround this issue https://github.com/greenplum-db/gpdb/issues/7361

Before this PR, when we drop partitions then verify if it drops excess partitions successfully by `select count(*) from pg_partitions`, it will cause `relation not found (OID XXX)` Error. 

In the`pg_partitions` view, ` pg_get_expr(pr1.parlistvalues, pr1.parchildrelid)` is the root cause of that Error due to inconsistentence issue.

Co-authored-by: Wenlin Zhang <wzhang@pivotal.io>
Co-authored-by: Bing Xu <bxu@pivotal.io>