### PR TITLE
Invalidate relcache for pg_appendonly change.

### DIFF
--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -1196,6 +1196,13 @@ CacheInvalidateHeapTuple(Relation relation,
 		relationId = gptup->localoid;
 		databaseId = MyDatabaseId;
 	}
+	else if (tupleRelId == AppendOnlyRelationId)
+	{
+		FormData_pg_appendonly *aotup = (FormData_pg_appendonly *) GETSTRUCT(tuple);
+
+		relationId = aotup->relid;
+		databaseId = MyDatabaseId;
+	}
 	else if (tupleRelId == IndexRelationId)
 	{
 		Form_pg_index indextup = (Form_pg_index) GETSTRUCT(tuple);


### PR DESCRIPTION
In Greenplum, data structure RelationData includes the related pg_appendonly
row for an ao table, when pg_appendonly changes for that ao table, we should
invalidate the relcache for it also to prevent possible inconsistency.

I can not find a real case to hit this after some try, but this is an issue
we could hit in theory.