### PR TITLE
Make manual FTS probes wait until automated FTS probes finish.

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -580,7 +580,7 @@ cdbcomponent_updateCdbComponents(void)
 	}
 	PG_CATCH();
 	{
-		FtsNotifyProber();
+		FtsNotifyProber(true);
 
 		PG_RE_THROW();
 	}
@@ -610,7 +610,7 @@ cdbcomponent_getCdbComponents()
 	}
 	PG_CATCH();
 	{
-		FtsNotifyProber();
+		FtsNotifyProber(true);
 
 		PG_RE_THROW();
 	}

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -505,7 +505,7 @@ checkDispatchResult(CdbDispatcherState *ds,
 			 * FTS to perform a probe before checking the segment
 			 * state.
 			 */
-			FtsNotifyProber();
+			FtsNotifyProber(false);
 			checkSegmentAlive(pParms);
 
 			if (pParms->waitMode != DISPATCH_WAIT_NONE)

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -291,7 +291,7 @@ create_gang_retry:
 	}
 	PG_CATCH();
 	{
-		FtsNotifyProber();
+		FtsNotifyProber(false);
 		/* FTS shows some segment DBs are down */
 		if (FtsTestSegmentDBIsDown(newGangDefinition->db_descriptors, size))
 		{

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -833,7 +833,14 @@ gp_request_fts_probe_scan(PG_FUNCTION_ARGS)
 		PG_RETURN_BOOL(false);
 	}
 
-	FtsNotifyProber();
+	FtsNotifyProber(true);
 
 	PG_RETURN_BOOL(true);
 }
+
+
+
+
+
+
+

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -35,6 +35,7 @@ typedef struct FtsProbeInfo
 	volatile uint8		fts_statusVersion;
 	volatile uint8		probeTick;
 	volatile uint8		fts_status[FTS_MAX_DBS];
+	volatile bool       inProgress;
 } FtsProbeInfo;
 
 #define FTS_MAX_TRANSIENT_STATE 100
@@ -57,6 +58,6 @@ extern bool FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor **, int);
 extern bool verifyFtsSyncCount(void);
 extern void ftsLock(void);
 extern void ftsUnlock(void);
-extern void FtsNotifyProber(void);
+extern void FtsNotifyProber(bool wait_for_current_probe_to_finish);
 extern uint8 getFtsVersion(void);
 #endif   /* CDBFTS_H */


### PR DESCRIPTION
The fts probe from manually calling gp_request_fts_probe_scan() can be
unintentionally skipped sometimes by dispatcher's fts probe call since
both call FtsNotifyProber and both only wait for the
ftsProbeInfo->probeTick to increment. If both happen at the same time,
only one fts probe will happen.

Without this patch, running segwalrep isolation2 tests over and over
again will cause primary and mirror pairs to not be in their expected
states due to the heavy use of gp_request_fts_probe_scan() - trying to
cause a failover. Primary mirror pairs in the wrong states cause
test failures.

Runnning this script on master: 

`for i in $(seq 1 100); do date && time isolation2.sh segwalrep/fts_unblock_primary; done | tee -a /tmp/fts-unblock.log`

... we can reliably get hangs of 10+ minutes  in the test suite, which can cause build timeouts on CI

With this patch, I do not get hangs.