### PR TITLE
Accurately report to ORCA whether a trigger will fire

### DIFF
--- a/src/test/regress/expected/rowsecurity.out
+++ b/src/test/regress/expected/rowsecurity.out
@@ -3942,7 +3942,6 @@ ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
 -- Updates records in both
 -- not supported in GPDB
 UPDATE r1 SET a = a+5;
-ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
 -- Remove FORCE from r2
 ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
 -- As owner, we now bypass RLS

--- a/src/test/regress/expected/triggers.out
+++ b/src/test/regress/expected/triggers.out
@@ -2646,7 +2646,6 @@ insert into trig_table values
   (3, 'three a'),
   (3, 'three b');
 update refd_table set a = 11 where b = 'one';
-ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
 select * from trig_table;
  a |    b    
 ---+---------


### PR DESCRIPTION
pg_trigger.tgenabled was changed in upstream Postgres 8.3 commit
postgres/postgres@0fe16500d3ae68b8 to support finer-grained control of
trigger firing mechanism. We merged that in during Greenplum 5
development cycle but ORCA didn't quite get the memo. This can lead to
extremely obscure bugs, like greenplum-db/gpdb#7410: assigning an 8-bit
integer to a boolean is an undefined behavior, and the compiler is
permitted to only look at the least significant bit of the value.

Fixes greenplum-db/gpdb#7410

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [x] Review a PR in return to support the community
