### PR TITLE
Fix bump gpdb version to 7.0.0-alpha.0

### DIFF
--- a/gpMgmt/demo/gppkg/gppkg_spec.yml
+++ b/gpMgmt/demo/gppkg/gppkg_spec.yml
@@ -2,7 +2,7 @@ Pkgname: sample
 Architecture: x86_64
 OS: rhel6
 Version: sample-0.0.1-7.0.0-x86_64
-GPDBVersion: 6
+GPDBVersion: 7
 Description: Sample GPDB 7 package
 PostInstall:
 # On master node only


### PR DESCRIPTION
In commit e9d21573, the GPDBVersion is not updated, which causes gppkg
test failure. Because the gpversion of the demo gppkg mismatches the major
version of gpdb

Co-authored-by: Haozhou Wang <hawang@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
