### PR TITLE
Enable recursive CTEs by default.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -288,7 +288,7 @@ bool		gp_dynamic_partition_pruning = true;
 bool		gp_log_dynamic_partition_pruning = false;
 bool		gp_cte_sharing = false;
 bool		gp_enable_relsize_collection = false;
-bool		gp_recursive_cte = false;
+bool		gp_recursive_cte = true;
 
 /* Optimizer related gucs */
 bool		optimizer;
@@ -1984,7 +1984,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_recursive_cte,
-		false, NULL, NULL
+		true, NULL, NULL
 	},
 
 	{
@@ -1994,7 +1994,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_recursive_cte,
-		false, NULL, NULL
+		true, NULL, NULL
 	},
 
 	{

--- a/src/test/regress/expected/index_constraint_naming_partition.out
+++ b/src/test/regress/expected/index_constraint_naming_partition.out
@@ -54,7 +54,6 @@ $fn$;
 --displays all dependencies and their types
 DROP FUNCTION IF EXISTS dependencies();
 NOTICE:  function dependencies() does not exist, skipping
-SET gp_recursive_cte TO on;
 CREATE FUNCTION dependencies() RETURNS TABLE( depname NAME, classtype "char", depnsoid OID,
                                               refname NAME, refclasstype "char", refnsoid OID,
                                               classid REGCLASS,  objid OID, objsubid INTEGER,

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -8,7 +8,6 @@
 --
 -- test numeric hash join
 --
-set gp_recursive_cte to on;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -8,7 +8,6 @@
 --
 -- test numeric hash join
 --
-set gp_recursive_cte to on;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2166,7 +2166,6 @@ SELECT * FROM y;
 -- Nested RECURSIVE queries with double self-referential joins are planned by
 -- joining two WorkTableScans, which GPDB cannot do yet. Ensure that we error
 -- out with a descriptive message.
-SET gp_recursive_cte TO ON;
 WITH RECURSIVE r1 AS (
 	SELECT 1 AS a
 	UNION ALL

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2165,7 +2165,6 @@ SELECT * FROM y;
 -- Nested RECURSIVE queries with double self-referential joins are planned by
 -- joining two WorkTableScans, which GPDB cannot do yet. Ensure that we error
 -- out with a descriptive message.
-SET gp_recursive_cte TO ON;
 WITH RECURSIVE r1 AS (
 	SELECT 1 AS a
 	UNION ALL

--- a/src/test/regress/sql/collate.linux.utf8.sql
+++ b/src/test/regress/sql/collate.linux.utf8.sql
@@ -1,6 +1,3 @@
--- start_ignore
-SET gp_recursive_cte TO ON;
--- end_ignore
 /*
  * This test is for Linux/glibc systems and assumes that a full set of
  * locales is installed.  It must be run in a database with UTF-8 encoding,

--- a/src/test/regress/sql/collate.sql
+++ b/src/test/regress/sql/collate.sql
@@ -1,6 +1,3 @@
--- start_ignore
-SET gp_recursive_cte TO ON;
--- end_ignore
 /*
  * This test is intended to pass on all platforms supported by Postgres.
  * We can therefore only assume that the default, C, and POSIX collations

--- a/src/test/regress/sql/ic.sql
+++ b/src/test/regress/sql/ic.sql
@@ -1,6 +1,3 @@
--- start_ignore
-SET gp_recursive_cte TO ON;
--- end_ignore
 /*
  * 
  * Functional tests

--- a/src/test/regress/sql/index_constraint_naming_partition.sql
+++ b/src/test/regress/sql/index_constraint_naming_partition.sql
@@ -54,7 +54,6 @@ $fn$;
 
 --displays all dependencies and their types
 DROP FUNCTION IF EXISTS dependencies();
-SET gp_recursive_cte TO on;
 CREATE FUNCTION dependencies() RETURNS TABLE( depname NAME, classtype "char", depnsoid OID,
                                               refname NAME, refclasstype "char", refnsoid OID,
                                               classid REGCLASS,  objid OID, objsubid INTEGER,

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -1,6 +1,3 @@
--- start_ignore
-SET gp_recursive_cte TO ON;
--- end_ignore
 --
 -- Test inheritance features
 --

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -11,8 +11,6 @@
 -- test numeric hash join
 --
 
-set gp_recursive_cte to on;
-
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -4,7 +4,6 @@
 
 --start_ignore
 set gp_cte_sharing to on;
-set gp_recursive_cte to on;
 --end_ignore
 
 -- Basic WITH

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -345,7 +345,6 @@ SELECT * FROM y;
 -- Nested RECURSIVE queries with double self-referential joins are planned by
 -- joining two WorkTableScans, which GPDB cannot do yet. Ensure that we error
 -- out with a descriptive message.
-SET gp_recursive_cte TO ON;
 WITH RECURSIVE r1 AS (
 	SELECT 1 AS a
 	UNION ALL


### PR DESCRIPTION
We've done the work to enable or disable specific combinations of
recursive CTEs. They are safe to use, and when they are not there
will be an error message disallowing the query.
