### PR TITLE
Bump up the pipeline timeouts.

### DIFF
--- a/concourse/server_pipeline/master_pipeline.yml
+++ b/concourse/server_pipeline/master_pipeline.yml
@@ -27,7 +27,7 @@ tasks:
   - &task
     image: image
     file: gpdb_src/concourse/server_pipeline/task.yml
-    timeout: 2h
+    timeout: 3h
     
   - &test_installcheck_world_with_planner
     <<: *task

--- a/concourse/server_pipeline/pr_pipeline.yml
+++ b/concourse/server_pipeline/pr_pipeline.yml
@@ -58,7 +58,7 @@ tasks:
   - &task
     image: image
     file: gpdb_src/concourse/server_pipeline/task.yml
-    timeout: 2h
+    timeout: 3h
     
   - &test_installcheck_world_with_planner
     <<: *task


### PR DESCRIPTION
Our goal with these pipelines is to find flakes, and the timeouts are getting in the way of that goal.


