### PR TITLE
Zero out compression buffer for AO and CO tables.

### DIFF
--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -118,7 +118,7 @@ AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
 
 	if (storageWrite->storageAttributes.compress)
 	{
-		storageWrite->uncompressedBuffer = (uint8 *) palloc(storageWrite->maxBufferLen * sizeof(uint8));
+		storageWrite->uncompressedBuffer = (uint8 *) palloc0(storageWrite->maxBufferLen * sizeof(uint8));
 	}
 	else
 	{


### PR DESCRIPTION
This is done to zero out the padding bytes and hence have consistent compression
ratios. Plus, zero bytes usually compress better.

Suggested by Heikki Linnakangas.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
