### PR TITLE
Add a list of SQL keywords to the ref guide

### DIFF
--- a/gpdb-doc/dita/GPRefGuide.ditamap
+++ b/gpdb-doc/dita/GPRefGuide.ditamap
@@ -208,6 +208,8 @@
 	<chapter href="ref_guide/SQL2008_support.xml"/>
 	<chapter href="ref_guide/env_var_ref.xml" navtitle="Greenplum Environment Variables"
 		id="env_var_ref"/>
+	<chapter href="ref_guide/sql-keywords.xml" navtitle="Reserved Identifiers and SQL Key Words"
+		id="keyword_ref"/>
 	<chapter href="ref_guide/system_catalogs/catalog_ref.xml">
 		<topicref href="ref_guide/system_catalogs/catalog_ref-tables.xml"/>
 		<topicref href="ref_guide/system_catalogs/catalog_ref-views.xml"/>

--- a/gpdb-doc/dita/ref_guide/preface.xml
+++ b/gpdb-doc/dita/ref_guide/preface.xml
@@ -47,6 +47,9 @@
     <li>
      <xref href="env_var_ref.xml#topic1"/>
     </li>
+    <li>
+      <xref href="sql_keywords.xml#topic1"/>
+    </li>
     <li id="ac168706">
      <xref href="system_catalogs/catalog_ref.xml#topic1"/>
     </li>

--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -165,6 +165,7 @@
 		</topicref>
 		<topicref href="SQL2008_support.xml"/>
 		<topicref href="env_var_ref.xml" navtitle="Greenplum Environment Variables" id="env_var_ref"/>
+		<topicref href="sql-keywords.xml" navtitle="Reserved Identifiers and SQL Keywords" id="sql_keywords"/>
 		<topicref href="system_catalogs/catalog_ref.xml#topic1">
 			<topicref href="system_catalogs/catalog_ref-tables.xml#topic1"/>
 			<topicref href="system_catalogs/catalog_ref-views.xml#topic1"/>

--- a/gpdb-doc/dita/ref_guide/sql-keywords.xml
+++ b/gpdb-doc/dita/ref_guide/sql-keywords.xml
@@ -1,0 +1,2434 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="et150574">Reserved Identifiers and SQL Key Words</title>
+  <body>
+    <p>This topic describes Greenplum Database reserved identifiers and object names, and SQL key
+      words recognized by the Greenplum Database and PostgreSQL command parsers.</p>
+    <section>
+      <title>Reserved Identifiers </title>
+    </section>
+    <p>Greenplum Database has built-in database objects that are a part of the database management
+      system. These objects include schemas, tables, views, functions, tablespaces, resource queues,
+      resource groups, and many others. The names of these <i>system objects</i> are reserved, and
+      should not generally be used in user applications.</p>
+    <p>Names beginning with <codeph>gp_</codeph> and <codeph>pg_</codeph> are reserved for Greenplum
+      Database and PostgreSQL. The parser does not complain unless you attempt to use a name that is
+      already in use, but avoiding names beginning with these prefixes prevents conflicts that could
+      occur in future versions of Greenplum Database.</p>
+    <p>The resource group names <codeph>admin_group</codeph>, <codeph>default_group</codeph>, and
+        <codeph>none</codeph> are reserved. The resource queue name <codeph>pg_default</codeph> is
+      reserved.</p>
+    <p>The tablespace names <codeph>pg_default</codeph> and <codeph>pg_global</codeph> are
+      reserved.</p>
+    <p>The role names <codeph>gpadmin</codeph> and <codeph>gpmon</codeph> are reserved.
+        <codeph>gpadmin</codeph> is the default Greenplum Database superuser role. The
+        <codeph>gpmon</codeph> role owns the <codeph>gpperfmon</codeph> database<ph
+        otherprops="pivotal"> and is also used by Greenplum Command Center</ph>.</p>
+    <p>In data files, the characters that delimit fields (columns) and rows have a special meaning.
+      If they appear within the data you must escape them so that Greenplum Database treats them as
+      data and not as delimiters. The backslash character (<codeph>\</codeph>) is the default escape
+      character. See <xref href="../admin_guide/load/topics/g-escaping.xml#topic99"/> for
+      details.</p>
+    <p>See <xref href="https://www.postgresql.org/docs/9.4/sql-syntax.html" format="html"
+        scope="external">SQL Syntax</xref> in the PostgreSQL documentation for more information
+      about SQL identifiers, constants, operators, and expressions.</p>
+    <section>
+      <title>SQL Key Words</title>
+      <p><xref href="#topic1/table_yjz_3hb_jhb" format="dita"/> lists all tokens that are key words
+        in Greenplum Database 6 and PostgreSQL 9.4.</p>
+      <p>ANSI SQL distinguishes between <i>reserved</i> and <i>unreserved</i> key words. According
+        to the standard, reserved key words are the only real key words; they are never allowed as
+        identifiers. Unreserved key words only have a special meaning in particular contexts and can
+        be used as identifiers in other contexts. Most unreserved key words are actually the names
+        of built-in tables and functions specified by SQL. The concept of unreserved key words
+        essentially only exists to declare that some predefined meaning is attached to a word in
+        some contexts.</p>
+      <p>In the Greenplum Database and PostgreSQL parsers there are several different classes of
+        tokens ranging from those that can never be used as an identifier to those that have
+        absolutely no special status in the parser as compared to an ordinary identifier. (The
+        latter is usually the case for functions specified by SQL.) Even reserved key words are not
+        completely reserved, but can be used as column labels (for example, <codeph>SELECT 55 AS
+          CHECK</codeph>, even though <codeph>CHECK</codeph> is a reserved key word).</p>
+      <p><xref href="#topic1/table_yjz_3hb_jhb" format="dita"/> classifies as
+        "unreserved" those key words that are explicitly known to the parser but are allowed as
+        column or table names. Some key words that are otherwise unreserved cannot be used as
+        function or data type names and are marked accordingly. (Most of these words represent
+        built-in functions or data types with special syntax. The function or type is still
+        available but it cannot be redefined by the user.) Key words labeled "reserved" are not
+        allowed as column or table names. Some reserved key words are allowable as names for
+        functions or data types; this is also shown in the table. If not so marked, a reserved key
+        word is only allowed as an "AS" column label name.</p>
+      <p>If you get spurious parser errors for commands that contain any of the listed key words as
+        an identifier you should try to quote the identifier to see if the problem goes away.</p>
+      <p>Before studying the table, note that that the fact that a key word is not reserved does not
+        mean that the feature related to the word is not implemented. Conversely, the presence of a
+        key word does not indicate the existence of a feature.</p>
+      <table id="table_yjz_3hb_jhb">
+        <title>SQL Key Words</title>
+        <tgroup cols="3">
+          <colspec colname="col1" colwidth="1*" rowsep="0" colnum="1" align="left"/>
+          <colspec colname="col2" colwidth="2*" colnum="2" align="left"/>
+          <colspec colname="col3" colwidth="2*" colnum="3" align="left"/>
+          <thead>
+            <row>
+              <entry>Key Word</entry>
+              <entry>Greenplum Database</entry>
+              <entry>PostgreSQL 9.4</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry>ABORT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ABSOLUTE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ACCESS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ACTION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ACTIVE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>ADD</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ADMIN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>AFTER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>AGGREGATE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ALL</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ALSO</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ALTER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ALWAYS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ANALYSE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ANALYZE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>AND</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ANY</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ARRAY</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>AS</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ASC</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ASSERTION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ASSIGNMENT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ASYMMETRIC</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>AT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ATTRIBUTE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>AUTHORIZATION</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>BACKWARD</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>BEFORE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>BEGIN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>BETWEEN</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>BIGINT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>BINARY</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>BIT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>BOOLEAN</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>BOTH</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>BY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CACHE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CALLED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CASCADE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CASCADED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CASE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CAST</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CATALOG</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CHAIN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CHAR</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>CHARACTER</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>CHARACTERISTICS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CHECK</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CHECKPOINT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CLASS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CLOSE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CLUSTER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>COALESCE</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>COLLATE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>COLLATION</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>COLUMN</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>COMMENT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>COMMENTS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>COMMIT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>COMMITTED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CONCURRENCY</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>CONCURRENTLY</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>CONFIGURATION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CONNECTION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CONSTRAINT</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CONSTRAINTS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CONTAINS</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>CONTENT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CONTINUE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CONVERSION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>COPY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>COST</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CPU_RATE_LIMIT</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>CPUSET</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>CREATE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CREATEEXTTABLE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>CROSS</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>CSV</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CUBE</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>CURRENT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CURRENT_CATALOG</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CURRENT_DATE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CURRENT_ROLE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CURRENT_SCHEMA</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>CURRENT_TIME</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CURRENT_TIMESTAMP</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CURRENT_USER</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>CURSOR</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>CYCLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DATA</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DATABASE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DAY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DEALLOCATE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DEC</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>DECIMAL</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>DECLARE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DECODE</entry>
+              <entry>reserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>DEFAULT</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>DEFAULTS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DEFERRABLE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>DEFERRED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DEFINER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DELETE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DELIMITER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DELIMITERS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DENY</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>DESC</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>DICTIONARY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DISABLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DISCARD</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DISTINCT</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>DISTRIBUTED</entry>
+              <entry>reserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>DO</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>DOCUMENT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DOMAIN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DOUBLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DROP</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>DXL</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>EACH</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ELSE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ENABLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ENCODING</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ENCRYPTED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>END</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ENUM</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ERRORS</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>ESCAPE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>EVENT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>EVERY</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>EXCEPT</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>EXCHANGE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>EXCLUDE</entry>
+              <entry>reserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>EXCLUDING</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>EXCLUSIVE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>EXECUTE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>EXISTS</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>EXPAND</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>EXPLAIN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>EXTENSION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>EXTERNAL</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>EXTRACT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>FALSE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>FAMILY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>FETCH</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>FIELDS</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>FILL</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>FILTER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>FIRST</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>FLOAT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>FOLLOWING</entry>
+              <entry>reserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>FOR</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>FORCE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>FOREIGN</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>FORMAT</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>FORWARD</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>FREEZE</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>FROM</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>FULL</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>FULLSCAN</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>FUNCTION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>FUNCTIONS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>GLOBAL</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>GRANT</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>GRANTED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>GREATEST</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>GROUP</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>GROUP_ID</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>GROUPING</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>HANDLER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>HASH</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>HAVING</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>HEADER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>HOLD</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>HOST</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>HOUR</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>IDENTITY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>IF</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>IGNORE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>ILIKE</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>IMMEDIATE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>IMMUTABLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>IMPLICIT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>IN</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>INCLUDING</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INCLUSIVE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>INCREMENT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INDEX</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INDEXES</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INHERIT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INHERITS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INITIALLY</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>INLINE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INNER</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>INOUT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>INPUT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INSENSITIVE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INSERT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INSTEAD</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>INT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>INTEGER</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>INTERSECT</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>INTERVAL</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>INTO</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>INVOKER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>IS</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>ISNULL</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>ISOLATION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>JOIN</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>KEY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LABEL</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LANGUAGE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LARGE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LAST</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LATERAL</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>LC_COLLATE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LC_CTYPE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LEADING</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>LEAKPROOF</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LEAST</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>LEFT</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>LEVEL</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LIKE</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>LIMIT</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>LIST</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>LISTEN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LOAD</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LOCAL</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LOCALTIME</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>LOCALTIMESTAMP</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>LOCATION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LOCK</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>LOG</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>MAPPING</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>MASTER</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>MATCH</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>MATERIALIZED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>MAXVALUE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>MEDIAN</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>MEMORY_LIMIT</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>MEMORY_SHARED_QUOTA</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>MEMORY_SPILL_RATIO</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>MINUTE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>MINVALUE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>MISSING</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>MODE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>MODIFIES</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>MONTH</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>MOVE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>NAME</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>NAMES</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>NATIONAL</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>NATURAL</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>NCHAR</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>NEWLINE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>NEXT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>NO</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>NOCREATEEXTTABLE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>NONE</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>NOOVERCOMMIT</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>NOT</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>NOTHING</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>NOTIFY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>NOTNULL</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>NOWAIT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>NULL</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>NULLIF</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>NULLS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>NUMERIC</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>OBJECT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>OF</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>OFF</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>OFFSET</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>OIDS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ON</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ONLY</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>OPERATOR</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>OPTION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>OPTIONS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>OR</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ORDER</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>ORDERED</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>ORDINALITY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>OTHERS</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>OUT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>OUTER</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>OVER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>OVERCOMMIT</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>OVERLAPS</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>OVERLAY</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>OWNED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>OWNER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PARSER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PARTIAL</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PARTITION</entry>
+              <entry>reserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PARTITIONS</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>PASSING</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PASSWORD</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PERCENT</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>PLACING</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>PLANS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>POSITION</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>PRECEDING</entry>
+              <entry>reserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PRECISION</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>PREPARE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PREPARED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PRESERVE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PRIMARY</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>PRIOR</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PRIVILEGES</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PROCEDURAL</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PROCEDURE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PROGRAM</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>PROTOCOL</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>QUEUE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>QUOTE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RANDOMLY</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>RANGE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>READ</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>READABLE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>READS</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>REAL</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>REASSIGN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RECHECK</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RECURSIVE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>REF</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>REFERENCES</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>REFRESH</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>REINDEX</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>REJECT</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>RELATIVE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RELEASE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RENAME</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>REPEATABLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>REPLACE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>REPLICA</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>REPLICATED</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>RESET</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RESOURCE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>RESTART</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RESTRICT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RETURNING</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>RETURNS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>REVOKE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RIGHT</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>ROLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ROLLBACK</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ROLLUP</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>ROOTPARTITION</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>ROW</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>ROWS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>RULE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SAVEPOINT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SCATTER</entry>
+              <entry>reserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>SCHEMA</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SCROLL</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SEARCH</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SECOND</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SECURITY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SEGMENT</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>SEGMENTS</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>SELECT</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>SEQUENCE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SEQUENCES</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SERIALIZABLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SERVER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SESSION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SESSION_USER</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>SET</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SETOF</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>SETS</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>SHARE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SHOW</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SIMILAR</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>SIMPLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SMALLINT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>SNAPSHOT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SOME</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>SPLIT</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>SQL</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>STABLE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>STANDALONE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>START</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>STATEMENT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>STATISTICS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>STDIN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>STDOUT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>STORAGE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>STRICT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>STRIP</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SUBPARTITION</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>SUBSTRING</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>SYMMETRIC</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>SYSID</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>SYSTEM</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TABLE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>TABLES</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TABLESPACE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TEMP</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TEMPLATE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TEMPORARY</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TEXT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>THEN</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>THRESHOLD</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>TIES</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>TIME</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>TIMESTAMP</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>TO</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>TRAILING</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>TRANSACTION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TREAT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>TRIGGER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TRIM</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>TRUE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>TRUNCATE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TRUSTED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TYPE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>TYPES</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>UNBOUNDED</entry>
+              <entry>reserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>UNCOMMITTED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>UNENCRYPTED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>UNION</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>UNIQUE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>UNKNOWN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>UNLISTEN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>UNLOGGED</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>UNTIL</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>UPDATE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>USER</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>USING</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>VACUUM</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>VALID</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>VALIDATE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>VALIDATION</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>VALIDATOR</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>VALUE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>VALUES</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>VARCHAR</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>VARIADIC</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>VARYING</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>VERBOSE</entry>
+              <entry>reserved (can be function or type name)</entry>
+              <entry>reserved (can be function or type name)</entry>
+            </row>
+            <row>
+              <entry>VERSION</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>VIEW</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>VIEWS</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>VOLATILE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>WEB</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>WHEN</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>WHERE</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>WHITESPACE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>WINDOW</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>WITH</entry>
+              <entry>reserved</entry>
+              <entry>reserved</entry>
+            </row>
+            <row>
+              <entry>WITHIN</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>WITHOUT</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>WORK</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>WRAPPER</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>WRITABLE</entry>
+              <entry>unreserved</entry>
+              <entry> </entry>
+            </row>
+            <row>
+              <entry>WRITE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>XML</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>XMLATTRIBUTES</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>XMLCONCAT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>XMLELEMENT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>XMLEXISTS</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>XMLFOREST</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>XMLPARSE</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>XMLPI</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>XMLROOT</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>XMLSERIALIZE</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+              <entry>unreserved (cannot be function or type name)</entry>
+            </row>
+            <row>
+              <entry>YEAR</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>YES</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+            <row>
+              <entry>ZONE</entry>
+              <entry>unreserved</entry>
+              <entry>unreserved</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </section>
+
+
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql-keywords.xml
+++ b/gpdb-doc/dita/ref_guide/sql-keywords.xml
@@ -9,14 +9,9 @@
     <section>
       <title>Reserved Identifiers </title>
     </section>
-    <p>Greenplum Database has built-in database objects that are a part of the database management
-      system. These objects include schemas, tables, views, functions, tablespaces, resource queues,
-      resource groups, and many others. The names of these <i>system objects</i> are reserved, and
-      should not generally be used in user applications.</p>
-    <p>Names beginning with <codeph>gp_</codeph> and <codeph>pg_</codeph> are reserved for Greenplum
-      Database and PostgreSQL. The parser does not complain unless you attempt to use a name that is
-      already in use, but avoiding names beginning with these prefixes prevents conflicts that could
-      occur in future versions of Greenplum Database.</p>
+    <p>In the Greenplum Database system, names beginning with <codeph>gp_</codeph> and
+        <codeph>pg_</codeph> are reserved and should not be used as names for user-created objects,
+      such as tables, views, and functions.</p>
     <p>The resource group names <codeph>admin_group</codeph>, <codeph>default_group</codeph>, and
         <codeph>none</codeph> are reserved. The resource queue name <codeph>pg_default</codeph> is
       reserved.</p>

--- a/gpdb-doc/dita/ref_guide/sql-keywords.xml
+++ b/gpdb-doc/dita/ref_guide/sql-keywords.xml
@@ -62,9 +62,9 @@
         word is only allowed as an "AS" column label name.</p>
       <p>If you get spurious parser errors for commands that contain any of the listed key words as
         an identifier you should try to quote the identifier to see if the problem goes away.</p>
-      <p>Before studying the table, note that that the fact that a key word is not reserved does not
-        mean that the feature related to the word is not implemented. Conversely, the presence of a
-        key word does not indicate the existence of a feature.</p>
+      <p>Before studying the table, note the fact that a key word is not reserved does not mean that
+        the feature related to the word is not implemented. Conversely, the presence of a key word
+        does not indicate the existence of a feature.</p>
       <table id="table_yjz_3hb_jhb">
         <title>SQL Key Words</title>
         <tgroup cols="3">


### PR DESCRIPTION
This PR adds to the GPDB Reference Guide a table of SQL keywords similar to the upstream table, but without the ANSI SQL columns. The keyword list is the union of pg_get_keywords() from GPDB 6.0 and PostgreSQL 9.4.18 with separate descriptions for each of them. There are not too many differences between them. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
