### PR TITLE
Disable FULL JOIN by default for ORCA

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -521,6 +521,11 @@ CConfigParamMapping::PackConfigParamInBitset
 		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfJoinAssociativity));
 	}
 
+	if (!optimizer_enable_full_join)
+	{
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfExpandFullOuterJoin));
+	}
+
 	return traceflag_bitset;
 }
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -534,6 +534,7 @@ bool		optimizer_enable_hashjoin;
 bool		optimizer_enable_dynamictablescan;
 bool		optimizer_enable_indexscan;
 bool		optimizer_enable_tablescan;
+bool		optimizer_enable_full_join;
 
 /* Optimizer plan enumeration related GUCs */
 bool		optimizer_enumerate_plans;
@@ -2997,6 +2998,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_enable_broadcast_nestloop_outer_child,
 		true, NULL, NULL
+	},
+	{
+		{"optimizer_enable_full_join", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enables the optimizer's support of full outer joins."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_full_join,
+		false, NULL, NULL
 	},
 	{
 		{"optimizer_enable_streaming_material", PGC_USERSET, DEVELOPER_OPTIONS,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -448,6 +448,7 @@ extern bool optimizer_enable_hashjoin;
 extern bool optimizer_enable_dynamictablescan;
 extern bool optimizer_enable_indexscan;
 extern bool optimizer_enable_tablescan;
+extern bool optimizer_enable_full_join;
 
 /* Optimizer plan enumeration related GUCs */
 extern bool optimizer_enumerate_plans;

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -583,57 +583,27 @@ create temporary table a as select generate_series(1, 5) as i distributed by (i)
 create temporary table b as select generate_series(2, 6) as i distributed by (i);
 create temporary table c as select generate_series(3, 7) as i distributed by (i);
 explain select * from a full join b on (a.i=b.i) full join c on (b.i=c.i);
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..4741.01 rows=12 width=12)
-   ->  Result  (cost=0.00..4741.01 rows=4 width=12)
-         ->  Sequence  (cost=0.00..4741.01 rows=4 width=12)
-               ->  Shared Scan (share slice:id 3:2)  (cost=0.00..2586.00 rows=4 width=1)
-                     ->  Materialize  (cost=0.00..2586.00 rows=4 width=1)
-                           ->  Sequence  (cost=0.00..2586.00 rows=4 width=68)
-                                 ->  Shared Scan (share slice:id 3:4)  (cost=0.00..431.00 rows=2 width=1)
-                                       ->  Materialize  (cost=0.00..431.00 rows=2 width=1)
-                                             ->  Table Scan on a  (cost=0.00..431.00 rows=2 width=34)
-                                 ->  Sequence  (cost=0.00..2155.00 rows=4 width=68)
-                                       ->  Shared Scan (share slice:id 3:5)  (cost=0.00..431.00 rows=2 width=1)
-                                             ->  Materialize  (cost=0.00..431.00 rows=2 width=1)
-                                                   ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=34)
-                                       ->  Append  (cost=0.00..1724.00 rows=4 width=68)
-                                             ->  Hash Left Join  (cost=0.00..862.00 rows=4 width=68)
-                                                   Hash Cond: share4_ref2.i = share5_ref2.i
-                                                   ->  Shared Scan (share slice:id 3:4)  (cost=0.00..431.00 rows=2 width=34)
-                                                   ->  Hash  (cost=431.00..431.00 rows=2 width=34)
-                                                         ->  Shared Scan (share slice:id 3:5)  (cost=0.00..431.00 rows=2 width=34)
-                                             ->  Result  (cost=0.00..862.00 rows=1 width=68)
-                                                   ->  Hash Left Anti Semi Join  (cost=0.00..862.00 rows=1 width=34)
-                                                         Hash Cond: share5_ref3.i = share4_ref3.i
-                                                         ->  Shared Scan (share slice:id 3:5)  (cost=0.00..431.00 rows=2 width=34)
-                                                         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-                                                               ->  Shared Scan (share slice:id 3:4)  (cost=0.00..431.00 rows=2 width=4)
-               ->  Sequence  (cost=0.00..2155.01 rows=4 width=12)
-                     ->  Shared Scan (share slice:id 3:3)  (cost=0.00..431.00 rows=2 width=1)
-                           ->  Materialize  (cost=0.00..431.00 rows=2 width=1)
-                                 ->  Table Scan on c  (cost=0.00..431.00 rows=2 width=34)
-                     ->  Append  (cost=0.00..1724.00 rows=4 width=12)
-                           ->  Hash Left Join  (cost=0.00..862.00 rows=4 width=102)
-                                 Hash Cond: share2_ref2.i = share3_ref2.i
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=68)
-                                       Hash Key: share2_ref2.i
-                                       ->  Shared Scan (share slice:id 1:2)  (cost=0.00..431.00 rows=2 width=68)
-                                 ->  Hash  (cost=431.00..431.00 rows=2 width=34)
-                                       ->  Shared Scan (share slice:id 3:3)  (cost=0.00..431.00 rows=2 width=34)
-                           ->  Result  (cost=0.00..862.00 rows=1 width=102)
-                                 ->  Hash Left Anti Semi Join  (cost=0.00..862.00 rows=1 width=34)
-                                       Hash Cond: share3_ref3.i = share2_ref3.i
-                                       ->  Shared Scan (share slice:id 3:3)  (cost=0.00..431.00 rows=2 width=34)
-                                       ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                                   Hash Key: share2_ref3.i
-                                                   ->  Result  (cost=0.00..431.00 rows=2 width=4)
-                                                         ->  Shared Scan (share slice:id 2:2)  (cost=0.00..431.00 rows=2 width=4)
- Settings:  gp_enable_fast_sri=on; optimizer=on
- Optimizer status: PQO version 3.9.0
-(48 rows)
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2000000005.48..2000000005.58 rows=5 width=12)
+   ->  Merge Full Join  (cost=2000000005.48..2000000005.58 rows=2 width=12)
+         Merge Cond: b.i = c.i
+         ->  Sort  (cost=1000000004.37..1000000004.39 rows=2 width=8)
+               Sort Key: b.i
+               ->  Merge Full Join  (cost=1000000004.22..1000000004.32 rows=2 width=8)
+                     Merge Cond: a.i = b.i
+                     ->  Sort  (cost=2.11..2.12 rows=2 width=4)
+                           Sort Key: a.i
+                           ->  Seq Scan on a  (cost=0.00..2.05 rows=2 width=4)
+                     ->  Sort  (cost=2.11..2.12 rows=2 width=4)
+                           Sort Key: b.i
+                           ->  Seq Scan on b  (cost=0.00..2.05 rows=2 width=4)
+         ->  Sort  (cost=1.11..1.12 rows=2 width=4)
+               Sort Key: c.i
+               ->  Seq Scan on c  (cost=0.00..1.05 rows=2 width=4)
+ Settings:  gp_enable_fast_sri=on
+ Optimizer status: legacy query optimizer
+(18 rows)
 
 select * from a full join b on (a.i=b.i) full join c on (b.i=c.i);
  i | i | i 

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -6563,6 +6563,7 @@ select rank() over(partition by a, case when b = 0 then a+b end order by b asc) 
 
 -- alias
 select foo.d from orca.foo full join orca.bar on (foo.d = bar.a) group by d;
+INFO:  GPORCA failed to produce a plan, falling back to planner
  d
 ----
   1
@@ -6608,7 +6609,8 @@ select foo.d from orca.foo full join orca.bar on (foo.d = bar.a) group by d;
 (40 rows)
 
 select 1 as v from orca.foo full join orca.bar on (foo.d = bar.a) group by d;
- v
+INFO:  GPORCA failed to produce a plan, falling back to planner
+ v 
 ---
  1
  1
@@ -6653,7 +6655,8 @@ select 1 as v from orca.foo full join orca.bar on (foo.d = bar.a) group by d;
 (40 rows)
 
 select * from orca.r where a in (select count(*)+1 as v from orca.foo full join orca.bar on (foo.d = bar.a) group by d+r.b);
- a | b
+INFO:  GPORCA failed to produce a plan, falling back to planner
+ a | b 
 ---+---
  2 | 2
 (1 row)


### PR DESCRIPTION
Full joins are sub-optimal in ORCA as they are implemented as a UNION of
Left Outer Join AND Left Anti-Semi Join. However, GPDB provides a full
outer join operator. Therefore, until ORCA implements a more optimal
FULL JOIN, it will fall back to the Postgres legacy query optimizer for
queries with FULL JOINs.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
