### PR TITLE
Change metricsQueryType from int to int8

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -63,6 +63,10 @@
 	{ appendBinaryStringInfo(str, (const char *)&node->fldname, sizeof(int)); }
 
 /* Write an integer field  */
+#define WRITE_INT8_FIELD(fldname) \
+	{ appendBinaryStringInfo(str, (const char *)&node->fldname, sizeof(int8)); }
+
+/* Write an integer field  */
 #define WRITE_INT16_FIELD(fldname) \
 	{ appendBinaryStringInfo(str, (const char *)&node->fldname, sizeof(int16)); }
 
@@ -375,7 +379,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
-	WRITE_UINT_FIELD(metricsQueryType);
+	WRITE_INT8_FIELD(metricsQueryType);
 }
 
 static void

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -323,7 +323,7 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
-	WRITE_UINT_FIELD(metricsQueryType);
+	WRITE_INT_FIELD(metricsQueryType);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -65,6 +65,10 @@ static Bitmapset *bitmapsetRead(void);
 #define READ_INT_FIELD(fldname) \
 	memcpy(&local_node->fldname, read_str_ptr, sizeof(int));  read_str_ptr+=sizeof(int)
 
+/* Read an int8 field  */
+#define READ_INT8_FIELD(fldname) \
+	memcpy(&local_node->fldname, read_str_ptr, sizeof(int8));  read_str_ptr+=sizeof(int8)
+
 /* Read an int16 field  */
 #define READ_INT16_FIELD(fldname) \
 	memcpy(&local_node->fldname, read_str_ptr, sizeof(int16));  read_str_ptr+=sizeof(int16)
@@ -1427,7 +1431,7 @@ _readPlannedStmt(void)
 	READ_UINT64_FIELD(query_mem);
 	READ_NODE_FIELD(intoClause);
 	READ_NODE_FIELD(copyIntoClause);
-	READ_UINT_FIELD(metricsQueryType);
+	READ_INT8_FIELD(metricsQueryType);
 	READ_DONE();
 }
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -148,7 +148,7 @@ typedef struct PlannedStmt
 	/* 
  	 * GPDB: whether a query is a SPI inner query for extension usage 
  	 */
-	uint		metricsQueryType;
+	int8		metricsQueryType;
 } PlannedStmt;
 
 /*


### PR DESCRIPTION
After #7362 merged, `madlib_build_gppkg` job fails with `unknown type name ‘uint’`, so this PR changes the type of metricsQueryType from `uint` to `int`, then the job should not fail anymore.