### PR TITLE
docs - add optional procedure to cfg pxf host/port

### DIFF
--- a/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -35,6 +35,7 @@
               </li>
               <li><a href="/6-0/pxf/objstore_cfg.html" format="markdown">Configuring Connectors to Azure, Google Cloud Storage, Minio, and S3 Object Stores (Optional)</a> </li>
               <li><a href="/6-0/pxf/jdbc_cfg.html" format="markdown">Configuring the JDBC Connector (Optional)</a> </li>
+              <li><a href="/6-0/pxf/cfghostport.html" format="markdown">Configuring the PXF Agent Host and Port (Optional)</a> </li>
             </ul>
           </lie>
           <li><a href="/6-0/pxf/upgrade_pxf.html" format="markdown">Upgrading PXF</a></li>

--- a/gpdb-doc/markdown/pxf/cfghostport.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfghostport.html.md.erb
@@ -2,14 +2,14 @@
 title: Configuring the PXF Agent Host and Port (Optional)
 ---
 
-By default, a PXF agent started on a segment host listens on port number `5888` on `localhost`. You can configure PXF to start on a different port number, or use a different hostname or IP address to identify the host. If your Greenplum Database cluster requires this custom configuration, you will set one or both of the environment variables identified below:
+By default, a PXF agent started on a segment host listens on port number `5888` on `localhost`. You can configure PXF to start on a different port number, or use a different hostname or IP address. To change the default configuration, you will set one or both of the environment variables identified below:
 
 |   Environment Variable  |  Description      |
 --------------------------+--------------------
-|   PXF_HOST  | The name of the host. The default host name is `localhost`.  |
+|   PXF_HOST  | The name of the host or IP address. The default host name is `localhost`.  |
 |   PXF_PORT  | The port number on which the PXF agent listens for requests on the host. The default port number is `5888`.  |
 
-You set the environment variables in the `gpadmin` user's `.bashrc` shell login file on each segment host.
+Set the environment variables in the `gpadmin` user's `.bashrc` shell login file on each segment host.
 
 <div class="note">You must restart both Greenplum Database and PXF when you configure the agent host and/or port in this manner. Consider performing this configuration during a scheduled down time.</div>
 

--- a/gpdb-doc/markdown/pxf/cfghostport.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfghostport.html.md.erb
@@ -1,0 +1,46 @@
+---
+title: Configuring the PXF Agent Host and Port (Optional)
+---
+
+By default, a PXF agent started on a segment host listens on port number `5888` on `localhost`. You can configure PXF to start on a different port number, or use a different hostname or IP address to identify the host. If your Greenplum Database cluster requires this custom configuration, you will set one or both of the environment variables identified below:
+
+|   Environment Variable  |  Description      |
+--------------------------+--------------------
+|   PXF_HOST  | The name of the host. The default host name is `localhost`.  |
+|   PXF_PORT  | The port number on which the PXF agent listens for requests on the host. The default port number is `5888`.  |
+
+You set the environment variables in the `gpadmin` user's `.bashrc` shell login file on each segment host.
+
+<div class="note">You must restart both Greenplum Database and PXF when you configure the agent host and/or port in this manner. Consider performing this configuration during a scheduled down time.</div>
+
+## <a id="proc"></a>Procedure
+
+Perform the following procedure to configure the PXF agent host and/or port number on one or more Greenplum Database segment hosts:
+
+1. Log in to your Greenplum Database master node:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    ```
+
+2. For each Greenplum Database segment host:
+
+    1. Identify the host name or IP address of the PXF agent.
+    2. Identify the port number on which you want the PXF agent to run.
+    3. Log in to the Greenplum Database segment host:
+
+        ``` shell
+        $ ssh gpadmin@<seghost>
+        ```
+    4. Open the `~/.bashrc` file in the editor of your choice.
+    5. Set the `PXF_HOST` and/or `PXF_PORT` environment variables. For example, to set the PXF agent port number to 5998, add the following to the `.bashrc` file:
+
+        ``` shell
+        export PXF_PORT=5998
+        ```
+    4. Save the file and exit the editor.
+
+3. Restart Greenplum Database as described in [Restarting Greenplum Database](../admin_guide/managing/startstop.html#task_gpdb_restart).
+
+4. Restart PXF on each Greenplum Database segment host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).
+


### PR DESCRIPTION
in this PR:
- create new page "Configuring the PXF Agent Host and Port (Optional)", nest under the "Configuring PXF" left subnav entry
- this task is not a mainline configuration task; adding only to the subnav, not referenced on the "Configuring PXF" page

doc review site link:  http://docs-lisa-pxfhostport.cfapps.io/6-0/pxf/cfghostport.html
