### PR TITLE
Should not use RBM_ZERO_AND_LOCK to read meta page in _bitmap_xlog_in…

### DIFF
--- a/src/backend/access/bitmap/bitmapxlog.c
+++ b/src/backend/access/bitmap/bitmapxlog.c
@@ -112,10 +112,12 @@ _bitmap_xlog_insert_lovitem(XLogRecPtr lsn, XLogRecord *record)
 		Buffer		metabuf;
 
 		metabuf = XLogReadBufferExtended(xlrec->bm_node, xlrec->bm_fork,
-												BM_METAPAGE, RBM_ZERO_AND_LOCK);
+										 BM_METAPAGE, RBM_NORMAL);
 		if (!BufferIsValid(metabuf))
  			return;
-		
+
+		LockBuffer(metabuf, BUFFER_LOCK_EXCLUSIVE);
+
 		metapage = (BMMetaPage) PageGetContents(BufferGetPage(metabuf));
 		if (PageGetLSN(BufferGetPage(metabuf)) < lsn)
 		{


### PR DESCRIPTION
…sert_lovitem()

fix issue  #7416
