### PR TITLE
Remove transaction state DTX_STATE_ACTIVE_NOT_DISTRIBUTED

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2309,8 +2309,8 @@ StartTransaction(void)
 			if (gp_enable_slow_writer_testmode)
 				pg_usleep(500000);
 
-			if (QEDtxContextInfo.distributedXid ==
-				InvalidDistributedTransactionId)
+			if (DistributedTransactionContext != DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT &&
+				QEDtxContextInfo.distributedXid == InvalidDistributedTransactionId)
 			{
 				elog(ERROR,
 					 "distributed transaction id is invalid in context %s",

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -432,6 +432,17 @@ GetAllTransactionXids(
 	*subXid = s->subTransactionId;
 }
 
+DistributedTransactionId
+GetCurrentDistributedTransactionId(void)
+{
+	return currentDistribXid;
+}
+
+void
+SetCurrentDistributedTransactionId(DistributedTransactionId gxid)
+{
+	currentDistribXid = gxid;
+}
 /*
  *	GetTopTransactionId
  *
@@ -2268,14 +2279,13 @@ StartTransaction(void)
 		case DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE:
 		{
 			/*
-			 * MPP: we're the dispatcher.
-			 *
-			 * Create distributed transaction which will map the
-			 * distributed transaction to a local transaction id for the
-			 * master database.
+			 * Generate the distributed transaction ID and save it.
+			 * it's not really needed by a select-only implicit transaction, but
+			 * currently gpfdist and pxf is using it.
+			 * We should probably replace xid with "session id + command id" in
+			 * identify a query in gpfdist and pxf.
 			 */
-			setCurrentGxact();
-			currentDistribXid = MyTmGxact->gxid;
+			currentDistribXid = generateGID();
 
 			if (SharedLocalSnapshotSlot != NULL)
 			{

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -216,9 +216,7 @@ getDistributedTransactionId(void)
 {
 	if (isQDContext())
 	{
-		return currentGxact == NULL
-			? InvalidDistributedTransactionId
-			: currentGxact->gxid;
+		return GetCurrentDistributedTransactionId();
 	}
 	else if (isQEContext())
 	{
@@ -1667,8 +1665,7 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 	needTwoPhase = isMppTxOptions_NeedTwoPhase(txnOptions);
 	explicitBegin = isMppTxOptions_ExplicitBegin(txnOptions);
 
-	haveDistributedSnapshot =
-		(dtxContextInfo->distributedXid != InvalidDistributedTransactionId);
+	haveDistributedSnapshot = dtxContextInfo->haveDistributedSnapshot;
 	isSharedLocalSnapshotSlotPresent = (SharedLocalSnapshotSlot != NULL);
 
 	if (DEBUG5 >= log_min_messages || Debug_print_full_dtm)

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -852,6 +852,9 @@ prepareDtxTransaction(void)
 
 	if (currentGxact == NULL)
 	{
+		Assert(MyTmGxact->gxid == InvalidDistributedTransactionId);
+		Assert(MyTmGxact->state == DTX_STATE_NONE);
+		initGxact(MyTmGxact, false);
 		return;
 	}
 
@@ -1329,24 +1332,22 @@ dispatchDtxCommand(const char *cmd)
 
 /* initialize a global transaction context */
 void
-initGxact(TMGXACT *gxact)
+initGxact(TMGXACT *gxact, bool resetXid)
 {
-	MemSet(gxact->gid, 0, TMGIDSIZE);
-	gxact->gxid = InvalidDistributedTransactionId;
-	setGxactState(gxact, DTX_STATE_NONE);
+	if (resetXid)
+	{
+		MemSet(gxact->gid, 0, TMGIDSIZE);
+		gxact->gxid = InvalidDistributedTransactionId;
+		setGxactState(gxact, DTX_STATE_NONE);
+	}
 
 	/*
 	 * Memory only fields.
 	 */
-
 	gxact->sessionId = gp_session_id;
-
 	gxact->explicitBeginRemembered = false;
-
 	gxact->xminDistributedSnapshot = InvalidDistributedTransactionId;
-
 	gxact->badPrepareGangs = false;
-
 	gxact->writerGangLost = false;
 	gxact->twophaseSegmentsMap = NULL;
 	gxact->twophaseSegments = NIL;

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -242,7 +242,7 @@ getDistributedTransactionIdentifier(char *id)
 			 */
 			sprintf(id, "%u-%.10u", *shmDistribTimeStamp, gxid);
 			if (strlen(id) >= TMGIDSIZE)
-				elog(PANIC, "Distribute transaction identifier too long (%d)",
+				elog(PANIC, "distributed transaction identifier too long (%d)",
 					 (int) strlen(id));
 			return true;
 		}
@@ -252,7 +252,7 @@ getDistributedTransactionIdentifier(char *id)
 		if (QEDtxContextInfo.distributedXid != InvalidDistributedTransactionId)
 		{
 			if (strlen(QEDtxContextInfo.distributedId) >= TMGIDSIZE)
-				elog(PANIC, "Distribute transaction identifier too long (%d)",
+				elog(PANIC, "distributed transaction identifier too long (%d)",
 					 (int) strlen(QEDtxContextInfo.distributedId));
 			memcpy(id, QEDtxContextInfo.distributedId, TMGIDSIZE);
 			return true;
@@ -330,21 +330,14 @@ notifyCommittedDtxTransaction(void)
 	doNotifyingCommitPrepared();
 }
 
-/*
- * @param needsTwoPhaseCommit if true then marks the current Distributed Transaction as needing to use the
- *       2 phase commit protocol.
- */
 void
-setupTwoPhaseTransaction(bool needsTwoPhaseCommit)
+setupTwoPhaseTransaction(void)
 {
-	if (!needsTwoPhaseCommit)
-		return;
-
 	if (!IsTransactionState())
 		elog(ERROR, "DTM transaction is not active");
 
 	if (currentGxact == NULL)
-		setCurrentGxact();
+		activeCurrentGxact();
 
 	if (currentGxact->state != DTX_STATE_ACTIVE_DISTRIBUTED)
 		elog(ERROR, "DTM transaction state (%s) is invalid", DtxStateToString(currentGxact->state));
@@ -374,7 +367,7 @@ doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType)
 	if (cmdType == DTX_PROTOCOL_COMMAND_SUBTRANSACTION_BEGIN_INTERNAL &&
 		currentGxact ==  NULL)
 	{
-		setCurrentGxact();
+		activeCurrentGxact();
 	}
 
 	serializedDtxContextInfo = qdSerializeDtxContextInfo(
@@ -1374,7 +1367,7 @@ getNextDistributedXactStatus(TMGALLXACTSTATUS *allDistributedXactStatus, TMGXACT
 }
 
 void
-setCurrentGxact(void)
+activeCurrentGxact(void)
 {
 	DistributedTransactionId gxid;
 	currentGxact = MyTmGxact;
@@ -1955,7 +1948,7 @@ sendDtxExplicitBegin(void)
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
 
-	setupTwoPhaseTransaction(true);
+	setupTwoPhaseTransaction();
 
 	rememberDtxExplicitBegin();
 
@@ -2303,14 +2296,13 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 void
 markCurrentGxactWriterGangLost(void)
 {
-	if (currentGxact)
-		currentGxact->writerGangLost = true;
+	MyTmGxact->writerGangLost = true;
 }
 
 bool
 currentGxactWriterGangLost(void)
 {
-	return currentGxact == NULL ? false : currentGxact->writerGangLost;
+	return MyTmGxact->writerGangLost;
 }
 
 /*

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1392,11 +1392,6 @@ setCurrentGxact(void)
 	if (strlen(currentGxact->gid) >= TMGIDSIZE)
 		elog(PANIC, "Distribute transaction identifier too long (%d)",
 				(int) strlen(currentGxact->gid));
-	/*
-	 * Until we get our first distributed snapshot, we use our distributed
-	 * transaction identifier for the minimum.
-	 */
-	currentGxact->xminDistributedSnapshot = gxid;
 
 	setCurrentGxactState(DTX_STATE_ACTIVE_DISTRIBUTED);
 

--- a/src/backend/cdb/cdbtmutils.c
+++ b/src/backend/cdb/cdbtmutils.c
@@ -46,8 +46,6 @@ DtxStateToString(DtxState state)
 	{
 		case DTX_STATE_NONE:
 			return "None";
-		case DTX_STATE_ACTIVE_NOT_DISTRIBUTED:
-			return "Active Not Distributed";
 		case DTX_STATE_ACTIVE_DISTRIBUTED:
 			return "Active Distributed";
 		case DTX_STATE_PREPARING:

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -251,11 +251,6 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 	ListCell   *le;
 	ErrorData *qeError = NULL;
 
-	dtmPreCommand("CdbDispatchSetCommand", strCommand, NULL,
-				  false /* no two-phase commit needed for SET */,
-				  false, /* no snapshot needed for SET */
-				  false /* inCursor */ );
-
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
 		 "CdbDispatchSetCommand for command = '%s'",
 		 strCommand);
@@ -341,9 +336,7 @@ CdbDispatchCommandToSegments(const char *strCommand,
 	bool needTwoPhase = flags & DF_NEED_TWO_PHASE;
 	bool withSnapshot = flags & DF_WITH_SNAPSHOT;
 
-	dtmPreCommand("CdbDispatchCommand", strCommand,
-				  NULL, needTwoPhase, withSnapshot,
-				  false /* inCursor */ );
+	setupTwoPhaseTransaction(needTwoPhase);
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchCommand: %s (needTwoPhase = %s)",
@@ -381,10 +374,7 @@ CdbDispatchUtilityStatement(struct Node *stmt,
 	bool needTwoPhase = flags & DF_NEED_TWO_PHASE;
 	bool withSnapshot = flags & DF_WITH_SNAPSHOT;
 
-	dtmPreCommand("CdbDispatchUtilityStatement",
-				  debug_query_string ? debug_query_string : "(none)",
-				  NULL, needTwoPhase, withSnapshot,
-				  false /* inCursor */ );
+	setupTwoPhaseTransaction(needTwoPhase);
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchUtilityStatement: %s (needTwoPhase = %s)",
@@ -1412,10 +1402,7 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	bool needTwoPhase = flags & DF_NEED_TWO_PHASE;
 	bool withSnapshot = flags & DF_WITH_SNAPSHOT;
 
-	dtmPreCommand("CdbDispatchCopyStart",
-				  debug_query_string ? debug_query_string : "(none)",
-				  NULL, needTwoPhase, withSnapshot,
-				  false /* inCursor */ );
+	setupTwoPhaseTransaction(needTwoPhase);
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchCopyStart: %s (needTwoPhase = %s)",

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -334,9 +334,9 @@ CdbDispatchCommandToSegments(const char *strCommand,
 {
 	DispatchCommandQueryParms *pQueryParms;
 	bool needTwoPhase = flags & DF_NEED_TWO_PHASE;
-	bool withSnapshot = flags & DF_WITH_SNAPSHOT;
 
-	setupTwoPhaseTransaction(needTwoPhase);
+	if (needTwoPhase)
+		setupTwoPhaseTransaction();
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchCommand: %s (needTwoPhase = %s)",
@@ -372,9 +372,9 @@ CdbDispatchUtilityStatement(struct Node *stmt,
 {
 	DispatchCommandQueryParms *pQueryParms;
 	bool needTwoPhase = flags & DF_NEED_TWO_PHASE;
-	bool withSnapshot = flags & DF_WITH_SNAPSHOT;
 
-	setupTwoPhaseTransaction(needTwoPhase);
+	if (needTwoPhase)
+		setupTwoPhaseTransaction();
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchUtilityStatement: %s (needTwoPhase = %s)",
@@ -1400,9 +1400,9 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	Gang *primaryGang;
 	ErrorData *error = NULL;
 	bool needTwoPhase = flags & DF_NEED_TWO_PHASE;
-	bool withSnapshot = flags & DF_WITH_SNAPSHOT;
 
-	setupTwoPhaseTransaction(needTwoPhase);
+	if (needTwoPhase)
+		setupTwoPhaseTransaction();
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchCopyStart: %s (needTwoPhase = %s)",

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -652,8 +652,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 * work for this query.
 			 */
 			needDtxTwoPhase = ExecutorSaysTransactionDoesWrites();
-			dtmPreCommand("ExecutorStart", "(none)", queryDesc->plannedstmt,
-						  needDtxTwoPhase, true /* wantSnapshot */, queryDesc->extended_query );
+			setupTwoPhaseTransaction(needDtxTwoPhase);
 
 			if (queryDesc->ddesc != NULL)
 			{

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -652,7 +652,8 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 * work for this query.
 			 */
 			needDtxTwoPhase = ExecutorSaysTransactionDoesWrites();
-			setupTwoPhaseTransaction(needDtxTwoPhase);
+			if (needDtxTwoPhase)
+				setupTwoPhaseTransaction();
 
 			if (queryDesc->ddesc != NULL)
 			{

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -407,7 +407,7 @@ ProcArrayEndGxact(void)
 	if (InvalidDistributedTransactionId != gxid &&
 		TransactionIdPrecedes(ShmemVariableCache->latestCompletedDxid, gxid))
 		ShmemVariableCache->latestCompletedDxid = gxid;
-	initGxact(MyTmGxact);
+	initGxact(MyTmGxact, true);
 }
 
 /*

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1934,26 +1934,17 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 		DistributedTransactionId gxid;
 		DistributedTransactionId dxid;
 
+		/* Update globalXminDistributedSnapshots to be the smallest valid dxid */
+		dxid = gxact_candidate->xminDistributedSnapshot;
+		if (dxid != InvalidDistributedTransactionId && dxid < globalXminDistributedSnapshots)
+			globalXminDistributedSnapshots = dxid;
+
 		/* just fetch once */
 		gxid = gxact_candidate->gxid;
 		if (gxid == InvalidDistributedTransactionId)
 			continue;
 
-		/*
-		 * NB: We must include transactions in DTX_STATE_ACTIVE_NOT_DISTRIBUTED
-		 * state. All transactions start in that state, even if they become
-		 * distribute later on.
-		 */
-
 		Assert(gxact_candidate->state != DTX_STATE_NONE);
-
-		/* Update globalXminDistributedSnapshots to be the smallest valid dxid */
-		dxid = gxact_candidate->xminDistributedSnapshot;
-		if ((dxid != InvalidDistributedTransactionId) &&
-			dxid < globalXminDistributedSnapshots)
-		{
-			globalXminDistributedSnapshots = dxid;
-		}
 
 		/*
 		 * Include the current distributed transaction in the min/max
@@ -2012,7 +2003,7 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	ds->xmax = xmax;
 	ds->count = count;
 
-	if (xmin < MyTmGxact->xminDistributedSnapshot)
+	if (MyTmGxact->xminDistributedSnapshot == InvalidDistributedTransactionId)
 		MyTmGxact->xminDistributedSnapshot = xmin;
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),

--- a/src/backend/storage/ipc/test/procarray_test.c
+++ b/src/backend/storage/ipc/test/procarray_test.c
@@ -63,7 +63,7 @@ test__CreateDistributedSnapshot(void **state)
 	/* This is going to act as our gxact */
 	allTmGxact[procArray->pgprocnos[0]].gxid = 20;
 	allTmGxact[procArray->pgprocnos[0]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
-	allTmGxact[procArray->pgprocnos[0]].xminDistributedSnapshot = 20;
+	allTmGxact[procArray->pgprocnos[0]].xminDistributedSnapshot = InvalidDistributedTransactionId;
 
 	procArray->numProcs = 1;
 
@@ -88,6 +88,8 @@ test__CreateDistributedSnapshot(void **state)
 	 * differ from xminAllDistributedSnapshots. Also, validates xmin and xmax
 	 * get adjusted correctly based on in-progress.
 	 */
+	allTmGxact[procArray->pgprocnos[0]].xminDistributedSnapshot = InvalidDistributedTransactionId;
+
 	allTmGxact[procArray->pgprocnos[1]].gxid = 10;
 	allTmGxact[procArray->pgprocnos[1]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
 	allTmGxact[procArray->pgprocnos[1]].xminDistributedSnapshot = 5;
@@ -114,6 +116,8 @@ test__CreateDistributedSnapshot(void **state)
 	 * Add more elemnets, just to have validation that in-progress array is in
 	 * ascending sorted order with distributed transactions.
 	 */
+	allTmGxact[procArray->pgprocnos[0]].xminDistributedSnapshot = InvalidDistributedTransactionId;
+
 	allTmGxact[procArray->pgprocnos[3]].gxid = 15;
 	allTmGxact[procArray->pgprocnos[3]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
 	allTmGxact[procArray->pgprocnos[3]].xminDistributedSnapshot = 12;

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -504,7 +504,7 @@ InitProcess(void)
 	MyProc->queryCommandId = -1;
 
 	/* Init gxact */
-	initGxact(MyTmGxact);
+	initGxact(MyTmGxact, true);
 
 	/*
 	 * Arrange to clean up at backend exit.

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -518,15 +518,12 @@ standard_ProcessUtility(Node *parsetree,
 
 							Assert(PointerIsValid(name));
 
-							if (Gp_role == GP_ROLE_DISPATCH)
-							{
-								/* We already checked that we're in a
-								 * transaction; need to make certain
-								 * that the BEGIN has been dispatched
-								 * before we start dispatching our savepoint.
-								 */
-								sendDtxExplicitBegin();
-							}
+							/* We already checked that we're in a
+							 * transaction; need to make certain
+							 * that the BEGIN has been dispatched
+							 * before we start dispatching our savepoint.
+							 */
+							sendDtxExplicitBegin();
 
 							DefineDispatchSavepoint(
 									name);

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -406,7 +406,6 @@ errstart(int elevel, const char *filename, int lineno,
 					break;
 
 				case DTX_STATE_NONE:
-				case DTX_STATE_ACTIVE_NOT_DISTRIBUTED:
 				case DTX_STATE_ACTIVE_DISTRIBUTED:
 				case DTX_STATE_INSERTING_FORGET_COMMITTED:
 				case DTX_STATE_INSERTED_FORGET_COMMITTED:

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -237,6 +237,8 @@ extern void GetAllTransactionXids(
 	DistributedTransactionId	*distribXid,
 	TransactionId				*localXid,
 	TransactionId				*subXid);
+extern DistributedTransactionId GetCurrentDistributedTransactionId(void);
+extern void SetCurrentDistributedTransactionId(DistributedTransactionId gxid);
 extern TransactionId GetTopTransactionId(void);
 extern TransactionId GetTopTransactionIdIfAny(void);
 extern TransactionId GetCurrentTransactionId(void);

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -294,7 +294,7 @@ extern DistributedTransactionId getDistributedTransactionId(void);
 extern bool getDistributedTransactionIdentifier(char *id);
 
 extern void initGxact(TMGXACT *gxact);
-extern void setCurrentGxact(void);
+extern void activeCurrentGxact(void);
 extern void	prepareDtxTransaction(void);
 extern bool isPreparedDtxTransaction(void);
 extern void getDtxLogInfo(TMGXACT_LOG *gxact_log);
@@ -310,7 +310,7 @@ extern void redoDtxCheckPoint(TMGXACT_CHECKPOINT *gxact_checkpoint);
 extern void redoDistributedCommitRecord(TMGXACT_LOG *gxact_log);
 extern void redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log);
 
-extern void setupTwoPhaseTransaction(bool needsTwoPhaseCommit);
+extern void setupTwoPhaseTransaction(void);
 extern bool isCurrentDtxTwoPhase(void);
 extern DtxState getCurrentDtxState(void);
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -310,9 +310,7 @@ extern void redoDtxCheckPoint(TMGXACT_CHECKPOINT *gxact_checkpoint);
 extern void redoDistributedCommitRecord(TMGXACT_LOG *gxact_log);
 extern void redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log);
 
-/* @param stmt used because some plans are annotated with dispatch details which the DTM needs. */
-extern void dtmPreCommand(const char *debugCaller, const char *debugDetail, PlannedStmt *stmt,
-							bool needsTwoPhaseCommit, bool dispatchToPrimaries, bool dispatchToMirrors );
+extern void setupTwoPhaseTransaction(bool needsTwoPhaseCommit);
 extern bool isCurrentDtxTwoPhase(void);
 extern DtxState getCurrentDtxState(void);
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -293,7 +293,7 @@ extern void dtxCrackOpenGid(const char	*gid,
 extern DistributedTransactionId getDistributedTransactionId(void);
 extern bool getDistributedTransactionIdentifier(char *id);
 
-extern void initGxact(TMGXACT *gxact);
+extern void initGxact(TMGXACT *gxact, bool resetXid);
 extern void activeCurrentGxact(void);
 extern void	prepareDtxTransaction(void);
 extern bool isPreparedDtxTransaction(void);

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -31,12 +31,6 @@ typedef enum
 	DTX_STATE_NONE = 0,
 
 	/**
-	 * The distributed transaction is active but distributed coordination
-	 *   is not required (because it is auto-commit on the QEs).
-	 */
-	DTX_STATE_ACTIVE_NOT_DISTRIBUTED,
-
-	/**
 	 * The distributed transaction is active and requires distributed coordination
 	 *   (because it is explicit or an implicit writer transaction)
 	 */
@@ -362,5 +356,6 @@ extern bool currentGxactWriterGangLost(void);
 extern void addToGxactTwophaseSegments(struct Gang* gp);
 
 extern int dtx_recovery_start(void);
+extern DistributedTransactionId generateGID(void);
 
 #endif   /* CDBTM_H */


### PR DESCRIPTION
DTX_STATE_ACTIVE_NOT_DISTRIBUTED indicates the transaction is started on QD and
two-phase commit is not required yet, in this state, distributed transaction ID
is also generated. If this transaction is not a two-phase transaction, e.g. implicit
select-only transaction, it will also need to acquire the ProcArrayLock to clear
the distributed transaction ID, and that leads to unnecessary lock contention.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
