### PR TITLE
Shutdown gpfdist SSL connection gracefully

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1280,6 +1280,9 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		/* set protocol */
 		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLVERSION, extssl_protocol);
 
+		/* disable session ID cache */
+		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSL_SESSIONID_CACHE, 0);
+
 		/* set debug */
 		if (CURLE_OK != (e = curl_easy_setopt(file->curl->handle, CURLOPT_VERBOSE, (long)extssl_libcurldebug)))
 		{

--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -4,10 +4,23 @@ include $(top_builddir)/src/Makefile.global
 default: installcheck
 
 REGRESS = exttab1 custom_format gpfdist2
+
+ifeq ($(enable_gpfdist),yes)
+ifeq ($(with_openssl),yes)
+	REGRESS += gpfdist_ssl
+endif
+endif
+
 PSQLDIR = $(prefix)/bin
 REGRESS_OPTS = --init-file=init_file
 
 installcheck: watchdog
+ifeq ($(enable_gpfdist),yes)
+ifeq ($(with_openssl),yes)
+	cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists data/gpfdist_ssl/certs_matching
+	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_not_matching
+endif
+endif
 	$(top_builddir)/src/test/regress/pg_regress --psqldir=$(PSQLDIR) --dbname=gpfdist_regression $(REGRESS) $(REGRESS_OPTS)
 
 watchdog:


### PR DESCRIPTION
GPDB uses libcurl-gnutls.so.4 as default libcurl on ubuntu. gpfdist SSL
connection reports error (56 - Failure when receiving data from the peer)
on handling POST message. We find it shutdown socket directly without sending
close_notify to client. So we call SSL_shutdown() before socket shutdown.

But SSL_accept() will return error with above patch on Centos, because
GPDB curl reuses SSL session ID in the second client hello on Centos, but server considers
that session is shutdown, so it won't accept that session ID.
The solution is disabling SSL session ID cache by setting curl option.
Then both Centos and ubuntu work well.

Enable gpfdist SSL test case.
