### PR TITLE
Remove references to replication ports

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -211,8 +211,7 @@ class GpMirrorBuildCalculator:
 
     def getGroupMirrors(self):
         """
-         Side-effect: self.__gpArray and other fields are updated to contain the returned segments AND
-                      to change the replication port values of the primaries as needed
+         Side-effect: self.__gpArray and other fields are updated to contain the returned segments
         """
 
         hosts = self.__primariesByHost.keys()
@@ -231,8 +230,7 @@ class GpMirrorBuildCalculator:
 
     def getSpreadMirrors(self):
         """
-         Side-effect: self.__gpArray is updated to contain the returned segments AND to
-                      change the replication port values of the primaries as needed
+         Side-effect: self.__gpArray is updated to contain the returned segments
         """
 
         hosts = self.__primariesByHost.keys()

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -75,7 +75,7 @@ class PortAssigner:
 
     def findAndReservePort(self, hostName, address):
         """
-        Find an unused port of the given type (normal postmaster or replication port)
+        Find a port not used by any postmaster process.
         When found, add an entry:  usedPorts[port] = True   and return the port found
         Otherwise raise an exception labeled with the given address
         """

--- a/gpMgmt/bin/gppylib/system/ComputeCatalogUpdate.py
+++ b/gpMgmt/bin/gppylib/system/ComputeCatalogUpdate.py
@@ -96,7 +96,7 @@ class ComputeCatalogUpdate:
 
         # create a map of the segments which we can't update in the 
         # ordinary way either because they were on the forceMap or
-        # they differ in an attribute other than mode, status or replication port
+        # they differ in an attribute other than mode or status
         removeandaddmap = {}
         for seg in initial_segment_to_update:
             dbid = seg.getSegmentDbId()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
@@ -106,10 +106,6 @@ class GpAddMirrorsTest(GpTestCase):
             result = fp.readlines()
 
         self.assertIn("41000", result[0])
-        # GPDB_SEGWALREP_FIXME: we have removed the replication port; what other
-		# fallout is there from that decision?
-        #self.assertIn("42000", result[0])
-        #self.assertIn("43000", result[0])
 
     def test_generated_file_contains_port_offsets(self):
         datadir_config = _write_datadir_config(self.mdd)
@@ -124,10 +120,6 @@ class GpAddMirrorsTest(GpTestCase):
             result = fp.readlines()
 
         self.assertIn("45000", result[0])
-        # GPDB_SEGWALREP_FIXME: we have removed the replication port; what other
-		# fallout is there from that decision?
-        #self.assertIn("50000", result[0])
-        #self.assertIn("55000", result[0])
 
     @patch('gppylib.programs.clsAddMirrors.Command')
     def test_pghbaconf_updated_successfully(self, mock):

--- a/gpMgmt/doc/gpaddmirrors_help
+++ b/gpMgmt/doc/gpaddmirrors_help
@@ -157,14 +157,11 @@ OPTIONS
 -p <port_offset>
 
  Optional. This number is used to calculate the database ports 
- and replication ports used for mirror segments. The default offset 
- is 1000. Mirror port assignments are calculated as follows: 
+ used for mirror segments. The default offset is 1000. Mirror
+ port assignments are calculated as follows:
 	primary port + offset = mirror database port
-	primary port + (2 * offset) = mirror replication port
-	primary port + (3 * offset) = primary replication port
  For example, if a primary segment has port 50001, then its mirror 
- will use a database port of 51001, a mirror replication port of 
- 52001, and a primary replication port of 53001 by default.
+ will use a database port of 51001 by default.
 
 
 -s
@@ -199,8 +196,8 @@ EXAMPLES
 
 Add mirroring to an existing Greenplum Database system using 
 the same set of hosts as your primary data. Calculate the mirror 
-database and replication ports by adding 100 to the current 
-primary segment port numbers:
+database ports by adding 100 to the current primary segment port
+numbers:
 
   $ gpaddmirrors -p 100
 

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_config
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_config
@@ -51,14 +51,6 @@ ENCODING=UNICODE
 #### are calculated.
 #MIRROR_PORT_BASE=7000
 
-#### Base number by which primary file replication port 
-#### numbers are calculated.
-#REPLICATION_PORT_BASE=8000
-
-#### Base number by which mirror file replication port 
-#### numbers are calculated. 
-#MIRROR_REPLICATION_PORT_BASE=9000
-
 #### File system location(s) where mirror segment data directories 
 #### will be created. The number of mirror locations must equal the
 #### number of primary locations as specified in the 

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_test
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_test
@@ -51,14 +51,6 @@ ENCODING=UNICODE
 #### are calculated.
 MIRROR_PORT_BASE=7000
 
-#### Base number by which primary file replication port 
-#### numbers are calculated.
-REPLICATION_PORT_BASE=8000
-
-#### Base number by which mirror file replication port 
-#### numbers are calculated. 
-MIRROR_REPLICATION_PORT_BASE=9000
-
 #### File system location(s) where mirror segment data directories 
 #### will be created. The number of mirror locations must equal the
 #### number of primary locations as specified in the 

--- a/gpMgmt/doc/gpinitsystem_help
+++ b/gpMgmt/doc/gpinitsystem_help
@@ -364,27 +364,6 @@ MIRROR_PORT_BASE
  calculated by PORT_BASE.
 
 
-REPLICATION_PORT_BASE
-
- Optional. This specifies the base number by which the port numbers 
- for the primary file replication process are calculated. The 
- first replication port on a host is set as REPLICATION_PORT_BASE, 
- and then incremented by one for each additional primary segment 
- on that host. Valid values range from 1 through 65535 and cannot 
- conflict with the ports calculated by PORT_BASE or MIRROR_PORT_BASE.
-
-
-MIRROR_REPLICATION_PORT_BASE
-
- Optional. This specifies the base number by which the port numbers 
- for the mirror file replication process are calculated. The first 
- mirror replication port on a host is set as MIRROR_REPLICATION_PORT_BASE, 
- and then incremented by one for each additional mirror segment on 
- that host. Valid values range from 1 through 65535 and cannot conflict 
- with the ports calculated by PORT_BASE, MIRROR_PORT_BASE, 
- or REPLICATION_PORT_BASE.
-
-
 MIRROR_DATA_DIRECTORY
 
  Optional. This specifies the data storage location(s) where the utility 


### PR DESCRIPTION
This is a backport to 6X_STABLE from master.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
