### PR TITLE
Change tablespace directory layout to correctly support multi-segment-one-host

### DIFF
--- a/contrib/pg_xlogdump/compat.c
+++ b/contrib/pg_xlogdump/compat.c
@@ -106,17 +106,3 @@ appendStringInfoChar(StringInfo str, char ch)
 	appendStringInfo(str, "%c", ch);
 }
 
-
-const char *
-tablespace_version_directory(void)
-{
-	static char path[MAXPGPATH] = "";
-
-	// GPDB_93_MERGE_FIXME: I hardcoded dbid 0 here, just to make this compile.
-	// Where do we get the actual value?
-	if (!path[0])
-		snprintf(path, MAXPGPATH, "%s_db%d", GP_TABLESPACE_VERSION_DIRECTORY,
-				 0 /* GpIdentity.dbid */);
-
-	return path;
-}

--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -69,22 +69,6 @@
 static bool IsAoSegmentClass(Form_pg_class reltuple);
 
 /*
- * Return directory name within tablespace location to use, for this server.
- * This is the GPDB replacement for PostgreSQL's TABLESPACE_VERSION_DIRECTORY
- * constant.
- */
-const char *
-tablespace_version_directory(void)
-{
-	static char path[MAXPGPATH] = "";
-
-	if (!path[0])
-		snprintf(path, MAXPGPATH, "%s_db%d", GP_TABLESPACE_VERSION_DIRECTORY, GpIdentity.dbid);
-
-	return path;
-}
-
-/*
  * Like relpath(), but gets the directory containing the data file
  * and the filename separately.
  */

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -733,6 +733,15 @@ increment_command_count()
 	MyProc->queryCommandId = gp_command_count;
 }
 
+int
+get_dbid_string_length()
+{
+	char *dbid_string = psprintf("%d", GpIdentity.dbid);
+	int length = strlen(dbid_string);
+	pfree(dbid_string);
+	return length;
+}
+
 Datum mpp_execution_segment(PG_FUNCTION_ARGS);
 Datum gp_execution_dbid(PG_FUNCTION_ARGS);
 

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -1026,7 +1026,7 @@ sendTablespace(char *path, bool sizeonly)
 	 * the version directory in it that belongs to us.
 	 */
 	snprintf(pathbuf, sizeof(pathbuf), "%s/%s", path,
-			 tablespace_version_directory());
+			 GP_TABLESPACE_VERSION_DIRECTORY);
 
 	/*
 	 * Store a directory entry in the tar file so we get the permissions
@@ -1044,7 +1044,7 @@ sendTablespace(char *path, bool sizeonly)
 		return 0;
 	}
 	if (!sizeonly)
-		_tarWriteHeader(tablespace_version_directory(), NULL, &statbuf);
+		_tarWriteHeader(GP_TABLESPACE_VERSION_DIRECTORY, NULL, &statbuf);
 	size = 512;					/* Size of the header just added */
 
 	/* Send all the files in the tablespace version directory */

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -73,6 +73,7 @@
 #include "access/xact.h"
 #include "catalog/catalog.h"
 #include "catalog/pg_tablespace.h"
+#include "cdb/cdbvars.h"
 #include "pgstat.h"
 #include "storage/fd.h"
 #include "storage/ipc.h"
@@ -1394,7 +1395,7 @@ GetTempFilePath(const char *filename, bool createdir)
 	{
 		/* All other tablespaces are accessed via symlinks */
 		snprintf(tempdirpath, sizeof(tempdirpath), "pg_tblspc/%u/%s/%s",
-				 tblspcOid, tablespace_version_directory(), PG_TEMP_FILES_DIR);
+				 tblspcOid, GP_TABLESPACE_VERSION_DIRECTORY, PG_TEMP_FILES_DIR);
 	}
 
 	/*
@@ -1442,7 +1443,7 @@ OpenTemporaryFileInTablespace(Oid tblspcOid, bool rejectError,
 	{
 		/* All other tablespaces are accessed via symlinks */
 		snprintf(tempdirpath, sizeof(tempdirpath), "pg_tblspc/%u/%s/%s",
-				 tblspcOid, tablespace_version_directory(), PG_TEMP_FILES_DIR);
+				 tblspcOid, GP_TABLESPACE_VERSION_DIRECTORY, PG_TEMP_FILES_DIR);
 	}
 
 	/*
@@ -2754,7 +2755,7 @@ CleanupTempFiles(bool isProcExit)
 void
 RemovePgTempFiles(void)
 {
-	char		temp_path[MAXPGPATH + 10 + strlen(tablespace_version_directory()) + 1 + sizeof(PG_TEMP_FILES_DIR)];
+	char		temp_path[MAXPGPATH + 11 + get_dbid_string_length() + 1 + sizeof(GP_TABLESPACE_VERSION_DIRECTORY) + sizeof(PG_TEMP_FILES_DIR)];
 	DIR		   *spc_dir;
 	struct dirent *spc_de;
 
@@ -2777,11 +2778,11 @@ RemovePgTempFiles(void)
 			continue;
 
 		snprintf(temp_path, sizeof(temp_path), "pg_tblspc/%s/%s/%s",
-				 spc_de->d_name, tablespace_version_directory(), PG_TEMP_FILES_DIR);
+				 spc_de->d_name, GP_TABLESPACE_VERSION_DIRECTORY, PG_TEMP_FILES_DIR);
 		RemovePgTempFilesInDir(temp_path, true, false);
 
 		snprintf(temp_path, sizeof(temp_path), "pg_tblspc/%s/%s",
-				 spc_de->d_name, tablespace_version_directory());
+				 spc_de->d_name, GP_TABLESPACE_VERSION_DIRECTORY);
 		RemovePgTempRelationFiles(temp_path);
 	}
 

--- a/src/backend/storage/file/reinit.c
+++ b/src/backend/storage/file/reinit.c
@@ -18,6 +18,7 @@
 
 #include "catalog/catalog.h"
 #include "catalog/pg_tablespace.h"
+#include "cdb/cdbvars.h"
 #include "common/relpath.h"
 #include "storage/copydir.h"
 #include "storage/fd.h"
@@ -49,7 +50,7 @@ typedef struct
 void
 ResetUnloggedRelations(int op)
 {
-	char		temp_path[MAXPGPATH + 10 + strlen(tablespace_version_directory()) + 1];
+	char		temp_path[MAXPGPATH + 11 + get_dbid_string_length() + 1 + sizeof(GP_TABLESPACE_VERSION_DIRECTORY)];
 	DIR		   *spc_dir;
 	struct dirent *spc_de;
 	MemoryContext tmpctx,
@@ -88,7 +89,7 @@ ResetUnloggedRelations(int op)
 			continue;
 
 		snprintf(temp_path, sizeof(temp_path), "pg_tblspc/%s/%s",
-				 spc_de->d_name, tablespace_version_directory());
+				 spc_de->d_name, GP_TABLESPACE_VERSION_DIRECTORY);
 		ResetUnloggedRelationsInTablespaceDir(temp_path, op);
 	}
 

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -153,7 +153,7 @@ calculate_database_size(Oid dbOid)
 	DIR		   *dirdesc;
 	struct dirent *direntry;
 	char		dirpath[MAXPGPATH];
-	char		pathname[MAXPGPATH + 12 + strlen(tablespace_version_directory()) + 1];
+	char		pathname[MAXPGPATH + 13 + get_dbid_string_length() + 1 + sizeof(GP_TABLESPACE_VERSION_DIRECTORY)];
 	AclResult	aclresult;
 
 	/* User must have connect privilege for target database */
@@ -186,7 +186,7 @@ calculate_database_size(Oid dbOid)
 			continue;
 
 		snprintf(pathname, sizeof(pathname), "pg_tblspc/%s/%s/%u",
-				 direntry->d_name, tablespace_version_directory(), dbOid);
+				 direntry->d_name, GP_TABLESPACE_VERSION_DIRECTORY, dbOid);
 		totalsize += db_dir_size(pathname);
 	}
 
@@ -277,7 +277,7 @@ calculate_tablespace_size(Oid tblspcOid)
 		snprintf(tblspcPath, MAXPGPATH, "global");
 	else
 		snprintf(tblspcPath, MAXPGPATH, "pg_tblspc/%u/%s", tblspcOid,
-				 tablespace_version_directory());
+				 GP_TABLESPACE_VERSION_DIRECTORY);
 
 	dirdesc = AllocateDir(tblspcPath);
 

--- a/src/backend/utils/adt/misc.c
+++ b/src/backend/utils/adt/misc.c
@@ -301,7 +301,7 @@ pg_tablespace_databases(PG_FUNCTION_ARGS)
 				fctx->location = psprintf("base");
 			else
 				fctx->location = psprintf("pg_tblspc/%u/%s", tablespaceOid,
-										  tablespace_version_directory());
+										  GP_TABLESPACE_VERSION_DIRECTORY);
 
 			fctx->dirdesc = AllocateDir(fctx->location);
 
@@ -404,6 +404,13 @@ pg_tablespace_location(PG_FUNCTION_ARGS)
 				(errmsg("symbolic link \"%s\" target is too long",
 						sourcepath)));
 	targetpath[rllen] = '\0';
+	
+	get_parent_directory(targetpath);
+	if (strcmp(targetpath, "") == 0)
+		ereport(ERROR,
+				(errmsg("path to tablespace is not a valid path: \"%s\"",
+					sourcepath)));
+
 
 	PG_RETURN_TEXT_P(cstring_to_text(targetpath));
 #else

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -5446,7 +5446,7 @@ RelationCacheInitFileRemove(void)
 	const char *tblspcdir = "pg_tblspc";
 	DIR		   *dir;
 	struct dirent *de;
-	char		path[MAXPGPATH + 10 + strlen(tablespace_version_directory()) + 1];
+	char		path[MAXPGPATH + 11 + get_dbid_string_length() + 1 + sizeof(GP_TABLESPACE_VERSION_DIRECTORY)];
 
 	snprintf(path, sizeof(path), "global/%s",
 			 RELCACHE_INIT_FILENAME);
@@ -5470,7 +5470,7 @@ RelationCacheInitFileRemove(void)
 		{
 			/* Scan the tablespace dir for per-database dirs */
 			snprintf(path, sizeof(path), "%s/%s/%s",
-					 tblspcdir, de->d_name, tablespace_version_directory());
+					 tblspcdir, de->d_name, GP_TABLESPACE_VERSION_DIRECTORY);
 			RelationCacheInitFileRemoveInDir(path);
 		}
 	}

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1181,10 +1181,10 @@ ReceiveAndUnpackTarFile(PGconn *conn, PGresult *res, int rownum)
 		/* 
 		 * Construct the new tablespace path using the given target gp dbid
 		 */
-		snprintf(gp_tablespace_filename, sizeof(filename), "%s/%s_db%d",
-				 current_path,
-				 GP_TABLESPACE_VERSION_DIRECTORY,
-				 target_gp_dbid);
+		snprintf(gp_tablespace_filename, sizeof(filename), "%s/%d/%s",
+				current_path,
+				target_gp_dbid,
+				GP_TABLESPACE_VERSION_DIRECTORY);
 	}
 
 	/*
@@ -1366,14 +1366,16 @@ ReceiveAndUnpackTarFile(PGconn *conn, PGresult *res, int rownum)
 					filename[strlen(filename) - 1] = '\0';		/* Remove trailing slash */
 
 					mapped_tblspc_path = get_tablespace_mapping(&copybuf[157]);
-					if (symlink(mapped_tblspc_path, filename) != 0)
+					char *mapped_tblspc_path_with_dbid = psprintf("%s/%d", mapped_tblspc_path, target_gp_dbid);
+					if (symlink(mapped_tblspc_path_with_dbid, filename) != 0)
 					{
 						fprintf(stderr,
 								_("%s: could not create symbolic link from \"%s\" to \"%s\": %s\n"),
-								progname, filename, mapped_tblspc_path,
+								progname, filename, mapped_tblspc_path_with_dbid,
 								strerror(errno));
 						disconnect_and_exit(1);
 					}
+					pfree(mapped_tblspc_path_with_dbid);
 				}
 				else
 				{
@@ -1899,7 +1901,7 @@ BaseBackup(void)
 			char	   *path = (char *) get_tablespace_mapping(PQgetvalue(res, i, 1));
 			char path_with_subdir[MAXPGPATH];
 
-			sprintf(path_with_subdir, "%s/%s_db%d", path, GP_TABLESPACE_VERSION_DIRECTORY, target_gp_dbid);
+			sprintf(path_with_subdir, "%s/%d/%s", path, target_gp_dbid, GP_TABLESPACE_VERSION_DIRECTORY);
 
 			verify_dir_is_empty_or_create(path_with_subdir);
 		}

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -90,9 +90,9 @@ SKIP: {
 
 	command_fails(
 		[ 'pg_basebackup', '-D', "$tempdir/backup1", '-Fp',
-		  '--target-gp-dbid', '-1'
+		  '--target-gp-dbid', '1'
 		],
-		'plain format with tablespaces fails without tablespace mapping');
+		'plain format with tablespaces fails without tablespace mapping and target-gp-dbid as the test server dbid');
 
 	command_ok(
 		[   'pg_basebackup',    '-D',
@@ -100,7 +100,7 @@ SKIP: {
 			'--target-gp-dbid', '1',
 			"-T$shorter_tempdir/tblspc1=$tempdir/tbackup/tblspc1" ],
 		'plain format with tablespaces succeeds with tablespace mapping');
-		ok(-d "$tempdir/tbackup/tblspc1", 'tablespace was relocated');
+		ok(-d "$tempdir/tbackup/tblspc1/1", 'tablespace was relocated');
 	opendir(my $dh, "$tempdir/pgdata/pg_tblspc") or die;
 	ok( (   grep
 			{

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -106,7 +106,7 @@ SKIP: {
 			{
 				-l "$tempdir/backup1/pg_tblspc/$_"
 				  and readlink "$tempdir/backup1/pg_tblspc/$_" eq
-				  "$tempdir/tbackup/tblspc1"
+				  "$tempdir/tbackup/tblspc1/1"
 			  } readdir($dh)),
 		"tablespace symlink was updated");
 	closedir $dh;

--- a/src/common/relpath.c
+++ b/src/common/relpath.c
@@ -122,7 +122,7 @@ GetDatabasePath(Oid dbNode, Oid spcNode)
 	{
 		/* All other tablespaces are accessed via symlinks */
 		return psprintf("pg_tblspc/%u/%s/%u",
-						spcNode, tablespace_version_directory(), dbNode);
+						spcNode, GP_TABLESPACE_VERSION_DIRECTORY, dbNode);
 	}
 }
 
@@ -191,24 +191,24 @@ GetRelationPath(Oid dbNode, Oid spcNode, Oid relNode,
 		{
 			if (forkNumber != MAIN_FORKNUM)
 				path = psprintf("pg_tblspc/%u/%s/%u/%u_%s",
-								spcNode, tablespace_version_directory(),
+								spcNode, GP_TABLESPACE_VERSION_DIRECTORY,
 								dbNode, relNode,
 								forkNames[forkNumber]);
 			else
 				path = psprintf("pg_tblspc/%u/%s/%u/%u",
-								spcNode, tablespace_version_directory(),
+								spcNode, GP_TABLESPACE_VERSION_DIRECTORY,
 								dbNode, relNode);
 		}
 		else
 		{
 			if (forkNumber != MAIN_FORKNUM)
 				path = psprintf("pg_tblspc/%u/%s/%u/t_%u_%s",
-								spcNode, tablespace_version_directory(),
+								spcNode, GP_TABLESPACE_VERSION_DIRECTORY,
 								dbNode, relNode,
 								forkNames[forkNumber]);
 			else
 				path = psprintf("pg_tblspc/%u/%s/%u/t_%u",
-								spcNode, tablespace_version_directory(),
+								spcNode, GP_TABLESPACE_VERSION_DIRECTORY,
 								dbNode, relNode);
 		}
 	}

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -25,8 +25,7 @@
 
 #define OIDCHARS		10		/* max chars printed by %u */
 /*
- * In PostgreSQL, this is called just TABLESPACE_VERSION_DIRECTORY. But in 
- * GPDB, you should use tablespace_version_directory() function instead.
+ * In PostgreSQL, this is called just TABLESPACE_VERSION_DIRECTORY..
  * This constant has been renamed so that we catch and know to modify all
  * upstream uses of TABLESPACE_VERSION_DIRECTORY.
  */

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301902051
+#define CATALOG_VERSION_NO	301905011
 
 #endif

--- a/src/include/catalog/pg_tablespace.h
+++ b/src/include/catalog/pg_tablespace.h
@@ -65,6 +65,4 @@ DATA(insert OID = 1664 ( pg_global	PGUID _null_ _null_ ));
 #define DEFAULTTABLESPACE_OID 1663
 #define GLOBALTABLESPACE_OID 1664
 
-extern const char *tablespace_version_directory(void);
-
 #endif   /* PG_TABLESPACE_H */

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -860,6 +860,7 @@ typedef struct GpId
  * Global variable declaration for the data for the single row of gp_id table
  */
 extern GpId GpIdentity;
+extern int get_dbid_string_length(void);
 #define UNINITIALIZED_GP_IDENTITY_VALUE (-10000)
 #define IS_QUERY_DISPATCHER() (GpIdentity.segindex == MASTER_CONTENT_ID)
 

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -136,9 +136,18 @@ select content, preferred_role, role, status, mode from gp_segment_configuration
 -- set GUCs to speed-up the test
 !\retcode gpconfig -r gp_fts_probe_retries --masteronly;
 -- start_ignore
+
 -- end_ignore
 (exited with code 0)
 !\retcode gpconfig -r gp_fts_probe_timeout --masteronly;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Set GUC to force tablespace drop replay to complete on mirror before
+-- removing the directory
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -156,6 +165,9 @@ select content, preferred_role, role, status, mode from gp_segment_configuration
 
 -- create tablespace to test if it works with gprecoverseg -F (pg_basebackup)
 !\retcode mkdir /tmp/mirror_promotion_tablespace_loc;
+-- start_ignore
+
+-- end_ignore
 (exited with code 0)
 create tablespace mirror_promotion_tablespace location '/tmp/mirror_promotion_tablespace_loc';
 CREATE
@@ -172,7 +184,26 @@ drop table mirror_promotion_tblspc_heap_table;
 DROP
 drop tablespace mirror_promotion_tablespace;
 DROP
+-- Force the mirror to replay the drop before moving forward with tablespace
+-- directory deletion
+checkpoint;
+CHECKPOINT
 !\retcode rm -rf /tmp/mirror_promotion_tablespace_loc;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Reset create_restartpoint_on_ckpt_record_replay guc
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+
+-- end_ignore
 (exited with code 0)
 
 -- loop while segments come in sync

--- a/src/test/isolation2/helpers/gp_management_utils_helpers.sql
+++ b/src/test/isolation2/helpers/gp_management_utils_helpers.sql
@@ -45,3 +45,8 @@ create or replace function count_of_items_in_database_directory(user_path text, 
        results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
        return len([result for result in results.splitlines() if result != ''])
 $$ language plpythonu;
+
+create or replace function validate_tablespace_symlink(datadir text, tablespacedir text, dbid int, tablespace_oid oid) returns boolean as $$
+    import os
+    return os.readlink('%s/pg_tblspc/%d' % (datadir, tablespace_oid)) == ('%s/%d' % (tablespacedir, dbid))
+$$ language plpythonu;

--- a/src/test/isolation2/input/pg_basebackup_with_tablespaces.source
+++ b/src/test/isolation2/input/pg_basebackup_with_tablespaces.source
@@ -1,44 +1,50 @@
 include: helpers/gp_management_utils_helpers.sql;
 
 -- Given a segment with a database that has a tablespace
-!\retcode mkdir -p @testtablespace@/some_isolation2_pg_basebackup_tablespace;
+!\retcode mkdir -p @testtablespace@/some_basebackup_tablespace;
 
-drop tablespace if exists some_isolation2_pg_basebackup_tablespace;
-create tablespace some_isolation2_pg_basebackup_tablespace location '@testtablespace@/some_isolation2_pg_basebackup_tablespace';
+drop tablespace if exists some_basebackup_tablespace;
+create tablespace some_basebackup_tablespace location '@testtablespace@/some_basebackup_tablespace';
 
 -- And a database using the tablespace
 drop database if exists some_database_with_tablespace;
-create database some_database_with_tablespace tablespace some_isolation2_pg_basebackup_tablespace;
+create database some_database_with_tablespace tablespace some_basebackup_tablespace;
 
 -- And a database without using the tablespace
 drop database if exists some_database_without_tablespace;
 create database some_database_without_tablespace;
 
 -- And a table and index, temp table and index using the tablespace
-1:@db_name some_database_without_tablespace: CREATE TABLE test(a INT, b INT) TABLESPACE some_isolation2_pg_basebackup_tablespace;
-1:@db_name some_database_without_tablespace: CREATE INDEX test_index on test(a) TABLESPACE some_isolation2_pg_basebackup_tablespace;
-2:@db_name some_database_without_tablespace: CREATE TEMP TABLE test_tmp(a INT, b INT) TABLESPACE some_isolation2_pg_basebackup_tablespace;
-2:@db_name some_database_without_tablespace: CREATE INDEX test_tmp_index on test_tmp(a) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+1:@db_name some_database_without_tablespace: CREATE TABLE test(a INT, b INT) TABLESPACE some_basebackup_tablespace;
+1:@db_name some_database_without_tablespace: CREATE INDEX test_index on test(a) TABLESPACE some_basebackup_tablespace;
+2:@db_name some_database_without_tablespace: CREATE TEMP TABLE test_tmp(a INT, b INT) TABLESPACE some_basebackup_tablespace;
+2:@db_name some_database_without_tablespace: CREATE INDEX test_tmp_index on test_tmp(a) TABLESPACE some_basebackup_tablespace;
 
 1q:
 
 -- When we create a full backup
-select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false) from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
-select count_of_items_in_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/');
+select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/');
 
 -- Then we should have four files in newly created target tablespace under the some_database_without_tablespace, test, test_index, test_tmp, test_tmp_index
-select count_of_items_in_database_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/', oid) from pg_database where datname='some_database_without_tablespace';
+select count_of_items_in_database_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/', oid) from pg_database where datname='some_database_without_tablespace';
 
--- When we create a full backup using force overwrite
-select pg_basebackup(address, 200, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', true) from gp_segment_configuration where content = 0 and role = 'p';
+-- Then we should have the tablespace symlink link to the mapped tablespace directory
+select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '@testtablespace@/some_basebackup_tablespace', 100, oid) from pg_tablespace where spcname='some_basebackup_tablespace';
+
+-- When we create a full backup again for the same target using force overwrite
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', true) from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
-select count_of_items_in_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db200/');
+select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/');
 
 -- Then we should have four files in newly created target tablespace under the some_database_without_tablespace, test, test_index, test_tmp, test_tmp_index
-select count_of_items_in_database_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/', oid) from pg_database where datname='some_database_without_tablespace';
+select count_of_items_in_database_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/', oid) from pg_database where datname='some_database_without_tablespace';
+
+-- Then we should have the tablespace symlink link to the mapped tablespace directory
+select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '@testtablespace@/some_basebackup_tablespace', 100, oid) from pg_tablespace where spcname='some_basebackup_tablespace';
 
 2q:
 
@@ -46,7 +52,51 @@ select count_of_items_in_database_directory('@testtablespace@/some_isolation2_pg
 0U: select pg_drop_replication_slot('some_replication_slot');
 drop database some_database_with_tablespace;
 drop database some_database_without_tablespace;
-drop tablespace some_isolation2_pg_basebackup_tablespace;
-!\retcode rm -rf @testtablespace@/some_isolation2_pg_basebackup;
-!\retcode rm -rf @testtablespace@/some_isolation2_pg_basebackup_tablespace/*;
+drop tablespace some_basebackup_tablespace;
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on;
+!\retcode gpstop -u;
+checkpoint;
+!\retcode rm -rf @testtablespace@;
+
+-- Given a segment (content=0) with a tablespace mapped to a location different from that of other segments
+!\retcode mkdir -p @testtablespace@/some_basebackup_tablespace;
+!\retcode mkdir -p @testtablespace@/some_basebackup_tablespace_c0;
+!\retcode mkdir -p @testtablespace@/some_basebackup_datadir;
+
+create tablespace some_basebackup_tablespace LOCATION '@testtablespace@/some_basebackup_tablespace' WITH (content0='@testtablespace@/some_basebackup_tablespace_c0');
+
+-- And a database without using the tablespace
+drop database if exists some_database_without_tablespace;
+create database some_database_without_tablespace;
+
+-- And a table and index, temp table and index using the tablespace
+1:@db_name some_database_without_tablespace: CREATE TABLE test(a INT, b INT) TABLESPACE some_basebackup_tablespace;
+1:@db_name some_database_without_tablespace: CREATE INDEX test_index on test(a) TABLESPACE some_basebackup_tablespace;
+2:@db_name some_database_without_tablespace: CREATE TEMP TABLE test_tmp(a INT, b INT) TABLESPACE some_basebackup_tablespace;
+2:@db_name some_database_without_tablespace: CREATE INDEX test_tmp_index on test_tmp(a) TABLESPACE some_basebackup_tablespace;
+
+1q:
+
+-- When we create a full backup
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- Then we should have one directory in the newly created target tablespace, some_database_without_tablespace
+select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace_c0/100/GPDB_*/');
+
+-- Then we should have six directories under some_basebackup_tablespace - db id = {1, 3, 4, 6, 7, 8}. 100 should not be present.
+select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace');
+
+-- Then we should have the tablespace symlink link to the mapped tablespace directory
+select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '@testtablespace@/some_basebackup_tablespace_c0', 100, oid) from pg_tablespace where spcname='some_basebackup_tablespace';
+
+2q:
+
+-- Cleanup things we've created
+0U: select pg_drop_replication_slot('some_replication_slot');
+drop database some_database_without_tablespace;
+drop tablespace some_basebackup_tablespace;
+checkpoint;
+!\retcode rm -rf @testtablespace@;
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay;
+!\retcode gpstop -u;
 

--- a/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
+++ b/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
@@ -2,21 +2,21 @@ include: helpers/gp_management_utils_helpers.sql;
 CREATE
 
 -- Given a segment with a database that has a tablespace
-!\retcode mkdir -p @testtablespace@/some_isolation2_pg_basebackup_tablespace;
+!\retcode mkdir -p @testtablespace@/some_basebackup_tablespace;
 -- start_ignore
 
 -- end_ignore
 (exited with code 0)
 
-drop tablespace if exists some_isolation2_pg_basebackup_tablespace;
+drop tablespace if exists some_basebackup_tablespace;
 DROP
-create tablespace some_isolation2_pg_basebackup_tablespace location '@testtablespace@/some_isolation2_pg_basebackup_tablespace';
+create tablespace some_basebackup_tablespace location '@testtablespace@/some_basebackup_tablespace';
 CREATE
 
 -- And a database using the tablespace
 drop database if exists some_database_with_tablespace;
 DROP
-create database some_database_with_tablespace tablespace some_isolation2_pg_basebackup_tablespace;
+create database some_database_with_tablespace tablespace some_basebackup_tablespace;
 CREATE
 
 -- And a database without using the tablespace
@@ -26,57 +26,71 @@ create database some_database_without_tablespace;
 CREATE
 
 -- And a table and index, temp table and index using the tablespace
-1:@db_name some_database_without_tablespace: CREATE TABLE test(a INT, b INT) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+1:@db_name some_database_without_tablespace: CREATE TABLE test(a INT, b INT) TABLESPACE some_basebackup_tablespace;
 CREATE
-1:@db_name some_database_without_tablespace: CREATE INDEX test_index on test(a) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+1:@db_name some_database_without_tablespace: CREATE INDEX test_index on test(a) TABLESPACE some_basebackup_tablespace;
 CREATE
-2:@db_name some_database_without_tablespace: CREATE TEMP TABLE test_tmp(a INT, b INT) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+2:@db_name some_database_without_tablespace: CREATE TEMP TABLE test_tmp(a INT, b INT) TABLESPACE some_basebackup_tablespace;
 CREATE
-2:@db_name some_database_without_tablespace: CREATE INDEX test_tmp_index on test_tmp(a) TABLESPACE some_isolation2_pg_basebackup_tablespace;
+2:@db_name some_database_without_tablespace: CREATE INDEX test_tmp_index on test_tmp(a) TABLESPACE some_basebackup_tablespace;
 CREATE
 
 1q: ... <quitting>
 
 -- When we create a full backup
-select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false) from gp_segment_configuration where content = 0 and role = 'p';
  pg_basebackup 
 ---------------
                
 (1 row)
 
 -- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
-select count_of_items_in_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/');
+select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/');
  count_of_items_in_directory 
 -----------------------------
  2                           
 (1 row)
 
 -- Then we should have four files in newly created target tablespace under the some_database_without_tablespace, test, test_index, test_tmp, test_tmp_index
-select count_of_items_in_database_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/', oid) from pg_database where datname='some_database_without_tablespace';
+select count_of_items_in_database_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/', oid) from pg_database where datname='some_database_without_tablespace';
  count_of_items_in_database_directory 
 --------------------------------------
  4                                    
 (1 row)
 
--- When we create a full backup using force overwrite
-select pg_basebackup(address, 200, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', true) from gp_segment_configuration where content = 0 and role = 'p';
+-- Then we should have the tablespace symlink link to the mapped tablespace directory
+select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '@testtablespace@/some_basebackup_tablespace', 100, oid) from pg_tablespace where spcname='some_basebackup_tablespace';
+ validate_tablespace_symlink 
+-----------------------------
+ t                           
+(1 row)
+
+-- When we create a full backup again for the same target using force overwrite
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', true) from gp_segment_configuration where content = 0 and role = 'p';
  pg_basebackup 
 ---------------
                
 (1 row)
 
 -- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
-select count_of_items_in_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db200/');
+select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/');
  count_of_items_in_directory 
 -----------------------------
  2                           
 (1 row)
 
 -- Then we should have four files in newly created target tablespace under the some_database_without_tablespace, test, test_index, test_tmp, test_tmp_index
-select count_of_items_in_database_directory('@testtablespace@/some_isolation2_pg_basebackup_tablespace/GPDB_*db100/', oid) from pg_database where datname='some_database_without_tablespace';
+select count_of_items_in_database_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/', oid) from pg_database where datname='some_database_without_tablespace';
  count_of_items_in_database_directory 
 --------------------------------------
  4                                    
+(1 row)
+
+-- Then we should have the tablespace symlink link to the mapped tablespace directory
+select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '@testtablespace@/some_basebackup_tablespace', 100, oid) from pg_tablespace where spcname='some_basebackup_tablespace';
+ validate_tablespace_symlink 
+-----------------------------
+ t                           
 (1 row)
 
 2q: ... <quitting>
@@ -91,14 +105,117 @@ drop database some_database_with_tablespace;
 DROP
 drop database some_database_without_tablespace;
 DROP
-drop tablespace some_isolation2_pg_basebackup_tablespace;
+drop tablespace some_basebackup_tablespace;
 DROP
-!\retcode rm -rf @testtablespace@/some_isolation2_pg_basebackup;
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on;
 -- start_ignore
 
 -- end_ignore
 (exited with code 0)
-!\retcode rm -rf @testtablespace@/some_isolation2_pg_basebackup_tablespace/*;
+!\retcode gpstop -u;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+checkpoint;
+CHECKPOINT
+!\retcode rm -rf @testtablespace@;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Given a segment (content=0) with a tablespace mapped to a location different from that of other segments
+!\retcode mkdir -p @testtablespace@/some_basebackup_tablespace;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode mkdir -p @testtablespace@/some_basebackup_tablespace_c0;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode mkdir -p @testtablespace@/some_basebackup_datadir;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+create tablespace some_basebackup_tablespace LOCATION '@testtablespace@/some_basebackup_tablespace' WITH (content0='@testtablespace@/some_basebackup_tablespace_c0');
+CREATE
+
+-- And a database without using the tablespace
+drop database if exists some_database_without_tablespace;
+DROP
+create database some_database_without_tablespace;
+CREATE
+
+-- And a table and index, temp table and index using the tablespace
+1:@db_name some_database_without_tablespace: CREATE TABLE test(a INT, b INT) TABLESPACE some_basebackup_tablespace;
+CREATE
+1:@db_name some_database_without_tablespace: CREATE INDEX test_index on test(a) TABLESPACE some_basebackup_tablespace;
+CREATE
+2:@db_name some_database_without_tablespace: CREATE TEMP TABLE test_tmp(a INT, b INT) TABLESPACE some_basebackup_tablespace;
+CREATE
+2:@db_name some_database_without_tablespace: CREATE INDEX test_tmp_index on test_tmp(a) TABLESPACE some_basebackup_tablespace;
+CREATE
+
+1q: ... <quitting>
+
+-- When we create a full backup
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false) from gp_segment_configuration where content = 0 and role = 'p';
+ pg_basebackup 
+---------------
+               
+(1 row)
+
+-- Then we should have one directory in the newly created target tablespace, some_database_without_tablespace
+select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace_c0/100/GPDB_*/');
+ count_of_items_in_directory 
+-----------------------------
+ 1                           
+(1 row)
+
+-- Then we should have six directories under some_basebackup_tablespace - db id = {1, 3, 4, 6, 7, 8}. 100 should not be present.
+select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace');
+ count_of_items_in_directory 
+-----------------------------
+ 6                           
+(1 row)
+
+-- Then we should have the tablespace symlink link to the mapped tablespace directory
+select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '@testtablespace@/some_basebackup_tablespace_c0', 100, oid) from pg_tablespace where spcname='some_basebackup_tablespace';
+ validate_tablespace_symlink 
+-----------------------------
+ t                           
+(1 row)
+
+2q: ... <quitting>
+
+-- Cleanup things we've created
+0U: select pg_drop_replication_slot('some_replication_slot');
+ pg_drop_replication_slot 
+--------------------------
+                          
+(1 row)
+drop database some_database_without_tablespace;
+DROP
+drop tablespace some_basebackup_tablespace;
+DROP
+checkpoint;
+CHECKPOINT
+!\retcode rm -rf @testtablespace@;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
 -- start_ignore
 
 -- end_ignore

--- a/src/test/perl/TestLib.pm
+++ b/src/test/perl/TestLib.pm
@@ -188,7 +188,7 @@ sub start_test_server
 
 	$ret = system_log('pg_ctl', '-D', "$tempdir/pgdata", '-w', '-l',
 	  "$log_path/postmaster.log", '-o',
-	  "--log-statement=all -c gp_role=utility --gp_dbid=-1 --gp_contentid=-1 --logging-collector=off",
+	  "--log-statement=all -c gp_role=utility --gp_dbid=1 --gp_contentid=-1 --logging-collector=off",
 	  'start');
 
 	if ($ret != 0)
@@ -208,7 +208,7 @@ sub restart_test_server
 	print("### Restarting test server\n");
 	system_log('pg_ctl', '-D', $test_server_datadir, '-w', '-l',
 	  $test_server_logfile, '-o',
-	  "--log-statement=all -c gp_role=utility --gp_dbid=-1 --gp_contentid=-1 --logging-collector=off",
+	  "--log-statement=all -c gp_role=utility --gp_dbid=1 --gp_contentid=-1 --logging-collector=off",
 	  'restart');
 }
 

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -160,8 +160,16 @@ submake-contrib-dummy_seclabel:
 
 .PHONY: tablespace-setup
 tablespace-setup:
-	rm -rf ./testtablespace ./testtablespace_otherloc ./testtablespace_unlogged
-	mkdir ./testtablespace ./testtablespace_otherloc ./testtablespace_unlogged
+	rm -rf ./testtablespace ./testtablespace_otherloc ./testtablespace_unlogged ./testtablespace_existing_version_dir
+	mkdir -p ./testtablespace ./testtablespace_otherloc ./testtablespace_unlogged \
+	./testtablespace_existing_version_dir/1/GPDB_99_399999991/ \
+	./testtablespace_existing_version_dir/2/GPDB_99_399999991/ \
+	./testtablespace_existing_version_dir/3/GPDB_99_399999991/ \
+	./testtablespace_existing_version_dir/4/GPDB_99_399999991/ \
+	./testtablespace_existing_version_dir/5/GPDB_99_399999991/ \
+	./testtablespace_existing_version_dir/6/GPDB_99_399999991/ \
+	./testtablespace_existing_version_dir/7/GPDB_99_399999991/ \
+	./testtablespace_existing_version_dir/8/GPDB_99_399999991/
 
 # Check for include files that are not being shipped
 .PHONY: includecheck

--- a/src/test/regress/input/gp_tablespace.source
+++ b/src/test/regress/input/gp_tablespace.source
@@ -31,6 +31,10 @@ BEGIN
 END;
 $$ language plpgsql;
 
+CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
+	RETURNS TEXT
+	AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'
+    LANGUAGE C;
 
 -- create tablespaces we can use
 CREATE TABLESPACE testspace LOCATION '@testtablespace@';
@@ -47,6 +51,15 @@ SELECT gp_segment_id,
             ELSE 'testtablespace_unknown'
        END AS tblspc_loc
 FROM gp_tablespace_location((SELECT oid FROM pg_tablespace WHERE spcname='ul_testspace'));
+
+-- Test that test tablespaces have the catalog directory directly under their
+-- symlink
+SELECT pg_ls_dir('./pg_tblspc/' || oid) = get_tablespace_version_directory_name()
+         AS has_version_dir
+FROM pg_tablespace WHERE spcname = 'testspace';
+
+-- Confirm that all the dbid directories were created under the testtablespace path
+\! ls @testtablespace@;
 
 -- Test moving AO/AOCO tables from one tablespace to another.
 CREATE TABLE ao_ts_table (id int4, t text) with (appendonly=true, orientation=row) distributed by (id);
@@ -134,6 +147,30 @@ SELECT gp_segment_id,
        END AS tblspc_loc
 FROM gp_tablespace_location((SELECT oid FROM pg_tablespace WHERE spcname='testspace_otherloc'));
 
+-- Create a tablespace with an existing GP_TABLESPACE_VERSION_DIRECTORY for
+-- another version of GPDB.
+CREATE TABLESPACE testspace_existing_version_dir LOCATION '@testtablespace@_existing_version_dir';
+
+SELECT * FROM
+  (SELECT pg_ls_dir('pg_tblspc/' || oid) AS versiondirs
+    FROM pg_tablespace
+    WHERE spcname = 'testspace_existing_version_dir'
+  ) a
+WHERE a.versiondirs != get_tablespace_version_directory_name();
+
+SELECT count(*) FROM
+  (SELECT pg_ls_dir('pg_tblspc/' || oid) AS versiondirs
+    FROM pg_tablespace
+    WHERE spcname = 'testspace_existing_version_dir'
+  ) a
+WHERE a.versiondirs = get_tablespace_version_directory_name();
+
+-- Do not drop the dbid directory, nor the existing version directory if you
+-- drop this tablespace
+DROP TABLESPACE testspace_existing_version_dir;
+
+\! ls @testtablespace@_existing_version_dir/*;
+
 -- Test alter tablespace: PG does not seem to test these.
 
 -- test SET & OWNER
@@ -160,3 +197,4 @@ SELECT COUNT(*) FROM tblspc_otherloc_heap;
 
 DROP TABLE tblspc_otherloc_heap;
 DROP TABLESPACE testspace_otherloc;
+

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -29,6 +29,10 @@ BEGIN
 	return has_init_file_for_oid(relation_id);
 END;
 $$ language plpgsql;
+CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
+	RETURNS TEXT
+	AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'
+    LANGUAGE C;
 -- create tablespaces we can use
 CREATE TABLESPACE testspace LOCATION '@testtablespace@';
 CREATE TABLESPACE ul_testspace LOCATION '@testtablespace@_unlogged';
@@ -60,6 +64,26 @@ FROM gp_tablespace_location((SELECT oid FROM pg_tablespace WHERE spcname='ul_tes
             -1 | testtablespace_unlogged
 (4 rows)
 
+-- Test that test tablespaces have the catalog directory directly under their
+-- symlink
+SELECT pg_ls_dir('./pg_tblspc/' || oid) = get_tablespace_version_directory_name()
+         AS has_version_dir
+FROM pg_tablespace WHERE spcname = 'testspace';
+ has_version_dir 
+-----------------
+ t
+(1 row)
+
+-- Confirm that all the dbid directories were created under the testtablespace path
+\! ls @testtablespace@;
+1
+2
+3
+4
+5
+6
+7
+8
 -- Test moving AO/AOCO tables from one tablespace to another.
 CREATE TABLE ao_ts_table (id int4, t text) with (appendonly=true, orientation=row) distributed by (id);
 CREATE TABLE aoco_ts_table (id int4, t text) with (appendonly=true, orientation=column) distributed by (id);
@@ -240,6 +264,58 @@ FROM gp_tablespace_location((SELECT oid FROM pg_tablespace WHERE spcname='testsp
             -1 | testtablespace
 (4 rows)
 
+-- Create a tablespace with an existing GP_TABLESPACE_VERSION_DIRECTORY for
+-- another version of GPDB.
+CREATE TABLESPACE testspace_existing_version_dir LOCATION '@testtablespace@_existing_version_dir';
+SELECT * FROM
+  (SELECT pg_ls_dir('pg_tblspc/' || oid) AS versiondirs
+    FROM pg_tablespace
+    WHERE spcname = 'testspace_existing_version_dir'
+  ) a
+WHERE a.versiondirs != get_tablespace_version_directory_name();
+    versiondirs    
+-------------------
+ GPDB_99_399999991
+(1 row)
+
+SELECT count(*) FROM
+  (SELECT pg_ls_dir('pg_tblspc/' || oid) AS versiondirs
+    FROM pg_tablespace
+    WHERE spcname = 'testspace_existing_version_dir'
+  ) a
+WHERE a.versiondirs = get_tablespace_version_directory_name();
+ count 
+-------
+     1
+(1 row)
+
+-- Do not drop the dbid directory, nor the existing version directory if you
+-- drop this tablespace
+DROP TABLESPACE testspace_existing_version_dir;
+\! ls @testtablespace@_existing_version_dir/*;
+@testtablespace@_existing_version_dir/1:
+GPDB_99_399999991
+
+@testtablespace@_existing_version_dir/2:
+GPDB_99_399999991
+
+@testtablespace@_existing_version_dir/3:
+GPDB_99_399999991
+
+@testtablespace@_existing_version_dir/4:
+GPDB_99_399999991
+
+@testtablespace@_existing_version_dir/5:
+GPDB_99_399999991
+
+@testtablespace@_existing_version_dir/6:
+GPDB_99_399999991
+
+@testtablespace@_existing_version_dir/7:
+GPDB_99_399999991
+
+@testtablespace@_existing_version_dir/8:
+GPDB_99_399999991
 -- Test alter tablespace: PG does not seem to test these.
 -- test SET & OWNER
 ALTER TABLESPACE testspace_otherloc SET (random_page_cost=20.0);

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -26,6 +26,7 @@
 #include "pgstat.h"
 #include "access/transam.h"
 #include "access/xact.h"
+#include "catalog/catalog.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_type.h"
 #include "cdb/memquota.h"
@@ -2099,4 +2100,11 @@ broken_int4out(PG_FUNCTION_ARGS)
 				 errdetail("The trigger value was 1234")));
 
 	return DirectFunctionCall1(int4out, Int32GetDatum(arg));
+}
+
+PG_FUNCTION_INFO_V1(get_tablespace_version_directory_name);
+Datum
+get_tablespace_version_directory_name(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_TEXT_P(CStringGetTextDatum(GP_TABLESPACE_VERSION_DIRECTORY));
 }


### PR DESCRIPTION
This PR (follow-up from #7295 ) contains changes to the tablespace directory layout on the server and 
includes changes to pg_basebackup in response to those changes. Changes 
to pg_rewind follow as a separate PR. Details of the two commits are below:

## Introduce new tablespace directory layout.

This commit includes changes to the server to ensure that the utilities:
pg_rewind and pg_basebackup can be changed to support recovery in a
multi-segment-singular-host setting. We link pg_tblspc to a <dbid>
subdirectory of the tablespace, rather than to the path of the
tablespace directly, and we remove the <dbid> from the tablespace
version directory. At the same time, we have designed towards preserving
the response to pg_tablespace_location(<tablespace_oid>) such that it
does not return the dbid suffix. The design is such that it is the
responsibility of the utilities to append the dbid as and when required.

Before this commit:
  * the symlink to the tablespace directory looks like:
      pg_tblspc/spcoid/ -> /<tablespace_location>/
  * Under the symlink target, we would have the following:
    GPDB_MAJORVER_CATVER/dboid/relfilenode
  * pg_tablespace_location(tsoid) returns: <tablespace_location>
e.g.
  * pg_tblspc/20981/ -> /data1/tsp1
  * Under /data1/tsp1: GPDB_6_201902061_db1/19849/192814
  * pg_tablespace_location(20981) returns: /data1/tsp1

After this commit:
  * the symlink to the tablespace directory looks like:
      pg_tblspc/spcoid/ -> /<tablespace_location>/<dbid>
  * Under the symlink target, we would have the following:
      GPDB_MAJORVER_CATVER_db<dbid>/dboid/relfilenode
  * pg_tablespace_location(tsoid) returns: <tablespace_location>

e.g.
  * pg_tblspc/20981/ -> /data1/tsp1/1
  * Under /data1/tsp1/1: GPDB_6_201902061/19849/192814
  * pg_tablespace_location(20981) returns: /data1/tsp1

Motivation:

When tablespaces were aligned to upstream postgres, while removing
filespaces, we added the `tablespace_version_directory()` function to
supply each segment with a unique tablespace directory name. This was
accomplished by appending the 'magic' `GpIdentity.dbid` global variable
to the `GP_TABLESPACE_VERSION_DIRECTORY` in `tablespace_version_directory()`.

This is problematic for several reasons- but perhaps most severely is
the fact that in order to use any code in libpgcommon.so that references
this value, you need to first set the `GpIdentity.dbid` global,
otherwise any functions that deal with tablespaces will be broken in
unpredictable ways.

An example is pg_rewind- where `GetRelationPath()` will not return a valid
relation unless you repeatedly toggle the `GpIdentity.dbid` between the
value of the source or target segment dependant on the context of which
relfiles are being examined.

## Use new tablespace layout for pg_basebackup

The server now removes the source dbid from the end of any tablespace symlink
target found in its response to BASE_BACKUP: This means that it removes it from
the tablespace header as well as any tar directory entries for a given
tablespace.  The pg_basebackup client now adds the target dbid at the end of
the symlink target returned from the server response in order to create the
correct symlink:
<target_datadir>/pg_tblspc/<tablespace_oid> -> <tablespace_location>/<target_db_id>

Note: All of the above is applicable to user-defined tablespaces.

Also, we renamed some of the ddl objects in the isolation2 tests for
tablespaces as they were too long. Also, reducing the length of the LOCATION
clause of the tablespace object helped us avoid the tar header limit of 100
characters for symlinks.
