### PR TITLE
gpbackup and gprestore will not run if expand in process

### DIFF
--- a/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
@@ -77,7 +77,9 @@
             <li>After data redistribution, the query optimizer creates more efficient execution
               plans when data is not skewed.</li>
           </ul><p>When all tables have been redistributed, the expansion is complete.</p></li>
-      </ul></p>
+      </ul><note type="important">The <codeph>gprestore</codeph> utility cannot restore backups you
+        made before the expansion with the <codeph>gpbackup</codeph> utility, so back up your
+        databases immediately after the system expansion is complete.</note></p>
     <p>Redistributing table data is a long-running process that creates a large volume of network
       and disk activity. It can take days to redistribute some very large databases. To minimize the
       effects of the increased activity on business operations, system administrators can pause and
@@ -115,7 +117,7 @@
       <li id="no165990">To remove the expansion schema:<codeblock>gpexpand -c</codeblock></li>
     </ol>
     <p>For information about the <codeph><xref
-          href="../../utility_guide/admin_utilities/gpexpand.xml">gpexand</xref></codeph> utility
+          href="../../utility_guide/admin_utilities/gpexpand.xml">gpexpand</xref></codeph> utility
       and the other utilities that are used for system expansion, see the <i>Greenplum Database
         Utility Guide</i>. </p>
   </body>

--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -228,15 +228,16 @@
         factors related to hardware performance. In most environments, the initialization of new
         segments requires less than thirty minutes offline.</p>
       <p>These utilities cannot be run while <codeph>gpexpand</codeph> is performing segment
-          initialization.<ul id="ul_c3w_wdp_lgb">
-          <li><codeph>gppkg</codeph></li>
-          <li><codeph>gpconfig</codeph></li>
+          initialization.
+        <ul id="ul_c3w_wdp_lgb">
+          <li><codeph>gpbackup</codeph></li>
           <li><codeph>gpcheck</codeph></li>
           <li><codeph>gpcheckcat</codeph></li>
+          <li><codeph>gpconfig</codeph></li>
+          <li><codeph>gppkg</codeph></li>
+          <li><codeph>gprestore</codeph></li>
         </ul></p>
-      <note type="warning">Do not run <codeph>gpbackup</codeph> or <codeph>gprestore</codeph> during
-        system expansion. Locks obtained for backups can interfere with the expansion process and
-        invalid backup sets could be created. </note>
+
       <note type="important">After you begin initializing new segments, you can no longer restore
         the system using backup files created for the pre-expansion system. When initialization
         successfully completes, the expansion is committed and cannot be rolled back. </note>

--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -186,6 +186,18 @@
                     expansion, use <codeph>gpexpand -a</codeph>, and post-expansion, use
                       <codeph>analyze</codeph>.</p></entry>
               </row>
+              <row>
+                <entry namest="c1" nameend="c2"><p><b>Back Up Databases</b></p><ph>* System is up
+                    and available</ph></entry>
+              </row>
+              <row>
+                <entry><image href="../graphics/green-checkbox.jpg" width="29px" height="28px"
+                    id="image_ogk_mj4_lhb"/></entry>
+                <entry>Back up databases using the <codeph>gpbackup</codeph> utility. Backups you
+                  created before you began the system expansion cannot be restored to the newly
+                  expanded system because the <codeph>gprestore</codeph> utility can only restore
+                  backups to a Greenplum Database system with the same number of segments.</entry>
+              </row>
             </tbody>
           </tgroup>
         </table></p>

--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -71,6 +71,10 @@
               be dropped during a backup, you can exclude the tables from a backup with a
                 <codeph>gpbackup</codeph> table filtering option such as
                 <codeph>--exclude-table</codeph> or <codeph>--exclude-schema</codeph>.</p></li>
+          <li>A backup created with <codeph>gpbackup</codeph> can only be restored to a Greenplum
+            Database cluster with the same number of segment instances as the source cluster. If you
+            run <codeph>gpexpand</codeph> to add segments to the cluster, backups you made before
+            starting the expand cannot be restored after the expansion has completed.</li>
         </ul></p>
     </body>
   </topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpbackup.xml
@@ -68,14 +68,14 @@
         state.</p>
       <p>When a back up operation completes, <codeph>gpbackup</codeph> returns a status code. See
           <xref href="#topic1/return_codes" format="dita"/>. </p>
+      <p>The <codeph>gpbackup</codeph> utility cannot be run while <codeph>gpexpand</codeph> is
+        initializing new segments. Backups created before the expansion cannot be restored with
+          <codeph>gprestore</codeph> after the cluster expansion is completed.</p>
       <p><codeph>gpbackup</codeph> can send status email notifications after a back up operation
         completes. You specify when the utility sends the mail and the email recipients in a
         configuration file. See <xref
           href="../../admin_guide/managing/backup-gpbackup.xml#topic_qwd_d5d_tbb" format="dita"
         />.</p>
-      <note type="warning">Do not run the <codeph>gpbackup</codeph> utility during a Greenplum
-        Database system expansion. See <xref href="gpexpand.xml#topic1"/> for more information about
-        expanding a Greenplum Database system.</note>
       <note>This utility uses secure shell (SSH) connections between systems to perform its tasks.
         In large Greenplum Database deployments, cloud deployments, or deployments with a large
         number of segments per host, this utility may exceed the host's maximum threshold for

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
@@ -41,9 +41,16 @@
             <codeph>gpstart</codeph> options <codeph>-R</codeph> or <codeph>-m</codeph> cannot be
           specified to start Greenplum Database. </li>      
       </ul>
-      <note type="warning">Do not run the
-          <codeph>gpbackup</codeph> or <codeph>gprestore</codeph> utilities while system expansion is
-        in process.</note>
+      <note>These utilities cannot be run while <codeph>gpexpand</codeph> is performing segment
+        initialization.
+        <ul id="ul_c3w_wdp_lgb">
+          <li><codeph>gpbackup</codeph></li>
+          <li><codeph>gpcheck</codeph></li>
+          <li><codeph>gpcheckcat</codeph></li>
+          <li><codeph>gpconfig</codeph></li>
+          <li><codeph>gppkg</codeph></li>
+          <li><codeph>gprestore</codeph></li>
+        </ul></note>
       <p>For information about preparing a system for expansion, see <xref
           href="../../admin_guide/expand/expand-main.xml" scope="peer">Expanding a Greenplum
           System</xref><ph otherprops="op-print"> in the <cite>Greenplum Database Administrator

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprestore.xml
@@ -78,10 +78,6 @@
           href="../../admin_guide/managing/backup-gpbackup.xml#topic_qwd_d5d_tbb" format="dita"
         />.</p>
     </section>
-    <note type="warning">Do not run the <codeph>gprestore</codeph> utility during a Greenplum
-      Database system expansion. Also note that backup sets you created before the expansion may not
-      be compatible with the expanded cluster. See <xref href="gpexpand.xml#topic1"/> for more
-      information about expanding a Greenplum Database system.</note>
     <note>This utility uses secure shell (SSH) connections between systems to perform its tasks. In
       large Greenplum Database deployments, cloud deployments, or deployments with a large number of
       segments per host, this utility may exceed the host's maximum threshold for unauthenticated


### PR DESCRIPTION
- remove warnings not to run gpbackup during expand
- replace with note that gpbackup and gprestore will not run while expand is in process
- add limitation that backups can only be restored to a cluster with same number of segments
- note that backups created before gpexpand cannot be restored after gpexpand

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
