### PR TITLE
extend pg_get_expr() to hold a lock for parallel access

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -823,12 +823,12 @@ create view pg_partitions as
                       partition by pp.oid, cl.relname, pp.parlevel, cl3.relname
                       order by pr1.parisdefault, pr1.parruleord) 
                   end as partitionrank, 
-              pg_get_expr(pr1.parlistvalues, pr1.parchildrelid) as partitionlistvalues, 
-              pg_get_expr(pr1.parrangestart, pr1.parchildrelid) as partitionrangestart, 
+              pg_get_expr(pr1.parlistvalues, pr1.parchildrelid, false, true) as partitionlistvalues, 
+              pg_get_expr(pr1.parrangestart, pr1.parchildrelid, false, true) as partitionrangestart, 
               pr1.parrangestartincl as partitionstartinclusive, 
-              pg_get_expr(pr1.parrangeend, pr1.parchildrelid) as partitionrangeend, 
+              pg_get_expr(pr1.parrangeend, pr1.parchildrelid, false, true) as partitionrangeend, 
               pr1.parrangeendincl as partitionendinclusive, 
-              pg_get_expr(pr1.parrangeevery, pr1.parchildrelid) as partitioneveryclause, 
+              pg_get_expr(pr1.parrangeevery, pr1.parchildrelid, false, true) as partitioneveryclause, 
               min(pr1.parruleord) over(
                   partition by pp.oid, cl.relname, pp.parlevel, cl3.relname
                   order by pr1.parruleord) as partitionnodefault, 
@@ -923,12 +923,12 @@ p.parlevel as partitionlevel,
 pr1.parruleord as partitionposition,
 rank() over (partition by p.oid, cl.relname, p.parlevel 
 			 order by pr1.parruleord) as partitionrank,
-pg_get_expr(pr1.parlistvalues, p.parrelid) as partitionlistvalues,
-pg_get_expr(pr1.parrangestart, p.parrelid) as partitionrangestart,
+pg_get_expr(pr1.parlistvalues, p.parrelid, false, true) as partitionlistvalues,
+pg_get_expr(pr1.parrangestart, p.parrelid, false, true) as partitionrangestart,
 pr1.parrangestartincl as partitionstartinclusive,
-pg_get_expr(pr1.parrangeend, p.parrelid) as partitionrangeend,
+pg_get_expr(pr1.parrangeend, p.parrelid, false, true) as partitionrangeend,
 pr1.parrangeendincl as partitionendinclusive,
-pg_get_expr(pr1.parrangeevery, p.parrelid) as partitioneveryclause,
+pg_get_expr(pr1.parrangeevery, p.parrelid, false, true) as partitioneveryclause,
 
 min(pr1.parruleord) over (partition by p.oid, cl.relname, p.parlevel
 	order by pr1.parruleord) as partitionnodefault,

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -321,6 +321,7 @@ static char *pg_get_indexdef_worker(Oid indexrelid, int colno,
 					   int prettyFlags);
 static char *pg_get_constraintdef_worker(Oid constraintId, bool fullCommand,
 							int prettyFlags);
+static text *pg_get_expr_internal(text *expr, Oid relid, bool pretty, bool trylock);
 static text *pg_get_expr_worker(text *expr, Oid relid, const char *relname,
 				   int prettyFlags);
 static int print_function_arguments(StringInfo buf, HeapTuple proctup,
@@ -1739,12 +1740,48 @@ decompile_column_index_array(Datum column_index_array, Oid relId,
 Datum
 pg_get_expr(PG_FUNCTION_ARGS)
 {
-	text	   *expr = PG_GETARG_TEXT_P(0);
-	Oid			relid = PG_GETARG_OID(1);
-	int			prettyFlags;
-	char	   *relname;
+	text	*expr = pg_get_expr_internal(PG_GETARG_TEXT_P(0),
+										 PG_GETARG_INT32(1),
+										 false, false);
+	if (expr)
+		PG_RETURN_TEXT_P(expr);
+	else
+		PG_RETURN_NULL();
+}
 
-	prettyFlags = PRETTYFLAG_INDENT;
+Datum
+pg_get_expr_ext(PG_FUNCTION_ARGS)
+{
+	text	*expr = pg_get_expr_internal(PG_GETARG_TEXT_P(0),
+										 PG_GETARG_INT32(1),
+										 PG_GETARG_BOOL(2),
+										 false);
+	if (expr)
+		PG_RETURN_TEXT_P(expr);
+	else
+		PG_RETURN_NULL();
+}
+
+Datum
+pg_get_expr_ext_lock(PG_FUNCTION_ARGS)
+{
+	text	*expr = pg_get_expr_internal(PG_GETARG_TEXT_P(0),
+										 PG_GETARG_INT32(1),
+										 PG_GETARG_BOOL(2),
+										 PG_GETARG_BOOL(3));
+	if (expr)
+		PG_RETURN_TEXT_P(expr);
+	else
+		PG_RETURN_NULL();
+}
+
+static text *
+pg_get_expr_internal(text *expr, Oid relid, bool pretty, bool trylock)
+{
+	char		*relname;
+	Relation	rel = NULL;
+	text		*result;
+	int			prettyFlags = pretty ? (PRETTYFLAG_PAREN | PRETTYFLAG_INDENT | PRETTYFLAG_SCHEMA) : PRETTYFLAG_INDENT;
 
 	if (OidIsValid(relid))
 	{
@@ -1758,37 +1795,37 @@ pg_get_expr(PG_FUNCTION_ARGS)
 		 * examining catalog entries for just-deleted relations.
 		 */
 		if (relname == NULL)
-			PG_RETURN_NULL();
+			return NULL;
 	}
 	else
 		relname = NULL;
 
-	PG_RETURN_TEXT_P(pg_get_expr_worker(expr, relid, relname, prettyFlags));
-}
-
-Datum
-pg_get_expr_ext(PG_FUNCTION_ARGS)
-{
-	text	   *expr = PG_GETARG_TEXT_P(0);
-	Oid			relid = PG_GETARG_OID(1);
-	bool		pretty = PG_GETARG_BOOL(2);
-	int			prettyFlags;
-	char	   *relname;
-
-	prettyFlags = pretty ? (PRETTYFLAG_PAREN | PRETTYFLAG_INDENT | PRETTYFLAG_SCHEMA) : PRETTYFLAG_INDENT;
-
-	if (OidIsValid(relid))
+	/*
+	 * CDB: hold the AccessShareLock in case some transactions drop it concurrently.
+	 *
+	 * Since here, if the table that the relid tells is dropped, an error will raise
+	 * later when opening the relation to get column names.
+	 *
+	 * pg_get_expr() is used by GPDB add-on view 'pg_partitions' which is widely
+	 * used by regression tests for partition tables. Lots of parallel test cases
+	 * issue view pg_partitions and drop partitions concurrently, so those cases
+	 * are very flaky. Serialize test cases will cost more testing time and be
+	 * fragile, so GPDB holds a AccessShareLock here to make tests stable.
+	 */
+	if (trylock)
 	{
-		/* Get the name for the relation */
-		relname = get_rel_name(relid);
-		/* See notes above */
-		if (relname == NULL)
-			PG_RETURN_NULL();
-	}
-	else
-		relname = NULL;
+		rel = try_relation_open(relid, AccessShareLock, false);
 
-	PG_RETURN_TEXT_P(pg_get_expr_worker(expr, relid, relname, prettyFlags));
+		if (!rel)
+			return NULL;
+	}
+
+	result = pg_get_expr_worker(expr, relid, relname, prettyFlags);
+
+	if (trylock)
+		relation_close(rel, AccessShareLock);
+
+	return result;
 }
 
 static text *

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301905011
+#define CATALOG_VERSION_NO	301905081
 
 #endif

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -2021,6 +2021,8 @@ DATA(insert OID = 1387 (  pg_get_constraintdef PGNSP PGUID 12 1 0 0 0 f f f f t 
 DESCR("constraint description");
 DATA(insert OID = 1716 (  pg_get_expr		   PGNSP PGUID 12 1 0 0 0 f f f f t f s 2 0 25 "194 26" _null_ _null_ _null_ _null_ pg_get_expr _null_ _null_ _null_ ));
 DESCR("deparse an encoded expression");
+DATA(insert OID = 7021 (  pg_get_expr		   PGNSP PGUID 12 1 0 0 0 f f f f t f s 4 0 25 "194 26 16 16" _null_ _null_ _null_ _null_ pg_get_expr_ext_lock _null_ _null_ _null_ ));
+DESCR("deparse an encoded expression");
 DATA(insert OID = 1665 (  pg_get_serial_sequence	PGNSP PGUID 12 1 0 0 0 f f f f t f s 2 0 25 "25 25" _null_ _null_ _null_ _null_ pg_get_serial_sequence _null_ _null_ _null_ ));
 DESCR("name of sequence for a serial column");
 DATA(insert OID = 2098 (  pg_get_functiondef	PGNSP PGUID 12 1 0 0 0 f f f f t f s 1 0 25 "26" _null_ _null_ _null_ _null_	pg_get_functiondef _null_ _null_ _null_ ));

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -720,6 +720,7 @@ extern char *pg_get_constraintdef_string(Oid constraintId);
 extern char *pg_get_constraintexpr_string(Oid constraintId);
 extern Datum pg_get_expr(PG_FUNCTION_ARGS);
 extern Datum pg_get_expr_ext(PG_FUNCTION_ARGS);
+extern Datum pg_get_expr_ext_lock(PG_FUNCTION_ARGS);
 extern Datum pg_get_userbyid(PG_FUNCTION_ARGS);
 extern Datum pg_get_serial_sequence(PG_FUNCTION_ARGS);
 extern Datum pg_get_functiondef(PG_FUNCTION_ARGS);


### PR DESCRIPTION
In pg_get_expr(), after getting the relname, if the table that the relid tells
is dropped, an error will raise later when opening the relation to get column
names.

pg_get_expr() is used by GPDB add-on view 'pg_partitions' which is widely used
by regression tests for partition tables. Lots of parallel test cases issue view
pg_partitions and drop partition tables concurrently, so those cases are very
flaky. Serialize test cases will cost more testing time and be fragile, so GPDB
holds a AccessShareLock here to make tests stable.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
