### PR TITLE
Fix gprecoverseg crash

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6691,17 +6691,6 @@ StartupXLOG(void)
 
 	LastRec = RecPtr = checkPointLoc;
 
-	CheckpointExtendedRecord ckptExtended;
-	UnpackCheckPointRecord(record, &ckptExtended);
-	if (ckptExtended.ptas)
-		SetupCheckpointPreparedTransactionList(ckptExtended.ptas);
-
-	/*
-	 * Find Xacts that are distributed committed from the checkpoint record and
-	 * store them such that they can utilized later during DTM recovery.
-	 */
-	XLogProcessCheckpointRecord(record);
-
 	ereport(DEBUG1,
 			(errmsg("redo record is at %X/%X; shutdown %s",
 				  (uint32) (checkPoint.redo >> 32), (uint32) checkPoint.redo,
@@ -8207,6 +8196,26 @@ ReadCheckpointRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 		}
 		return NULL;
 	}
+
+	/*
+	 * We should be wary of conflating "report" parameter.  It is currently
+	 * always true when we want to process the extended checkpoint record.
+	 * For now this seems fine as it avoids a diff with postgres.
+	 */
+	if (report)
+	{
+		CheckpointExtendedRecord ckptExtended;
+		UnpackCheckPointRecord(record, &ckptExtended);
+		if (ckptExtended.ptas)
+			SetupCheckpointPreparedTransactionList(ckptExtended.ptas);
+
+		/*
+		 * Find Xacts that are distributed committed from the checkpoint record and
+		 * store them such that they can utilized later during DTM recovery.
+		 */
+		XLogProcessCheckpointRecord(record);
+	}
+
 	return record;
 }
 
@@ -8884,6 +8893,8 @@ CreateCheckPoint(int flags)
 	 */
 	if (!shutdown && XLogStandbyInfoActive())
 		LogStandbySnapshot();
+
+	SIMPLE_FAULT_INJECTOR(CheckpointAfterRedoCalculated);
 
 	START_CRIT_SECTION();
 

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -257,6 +257,8 @@ FI_IDENT(CleanupQE, "cleanup_qe")
 FI_IDENT(XLogAoInsert, "xlog_ao_insert")
 /* inject fault just before commiting alter database set tablespace */
 FI_IDENT(InsideMoveDbTransaction, "inside_move_db_transaction")
+/* inject fault just after calculating redo record and before committing checkpoint record */
+FI_IDENT(CheckpointAfterRedoCalculated, "checkpoint_after_redo_calculated")
 #endif
 
 /*

--- a/src/test/isolation2/expected/segwalrep/failover_with_many_records.out
+++ b/src/test/isolation2/expected/segwalrep/failover_with_many_records.out
@@ -1,0 +1,110 @@
+include: helpers/server_helpers.sql;
+CREATE
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+-- Allow extra time for mirror promotion to complete recovery to avoid
+-- gprecoverseg BEGIN failures due to gang creation failure as some primaries
+-- are not up. Setting these increase the number of retries in gang creation in
+-- case segment is in recovery. Approximately we want to wait 30 seconds.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+1:CREATE TABLE t(a int, b int);
+CREATE
+
+1:SELECT gp_inject_fault_infinite('checkpoint_after_redo_calculated', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ t                        
+(1 row)
+2&:CHECKPOINT;  <waiting ...>
+3:INSERT INTO t VALUES (1, 0);
+INSERT 1
+
+-- Force WAL to switch xlog files explicitly
+-- start_ignore
+1U:SELECT pg_switch_xlog();
+-- end_ignore
+3:INSERT INTO t SELECT 0, i FROM generate_series(1, 25)i;
+INSERT 25
+
+1:SELECT gp_inject_fault_infinite('checkpoint_after_redo_calculated', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ t                        
+(1 row)
+2<:  <... completed>
+CHECKPOINT
+
+-- Here we must force immediately shutdown primary without triggering another
+-- checkpoint otherwise we would undo all of our previous work to ensure that
+-- checkpoint record has redo record on another wal segment.
+-1U: SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration c WHERE c.role='p' AND c.content=1), 'stop', 'immediate');
+ pg_ctl                                               
+------------------------------------------------------
+ waiting for server to shut down done
+server stopped
+ 
+(1 row)
+
+-- Make sure we see the segment is down before trying to recover...
+4:SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+4:SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 1;
+ role | preferred_role 
+------+----------------
+ m    | p              
+ p    | m              
+(2 rows)
+
+!\retcode gprecoverseg -a;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select count(*) = 2 from gp_segment_configuration where content = 1 and mode = 's') then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
+DO
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select count(*) = 2 from gp_segment_configuration where content = 1 and mode = 's') then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
+DO
+
+-- verify no segment is down after recovery
+1:SELECT COUNT(*) FROM gp_segment_configuration WHERE status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -151,6 +151,7 @@ test: segwalrep/fts_unblock_primary
 test: segwalrep/mirror_promotion
 test: segwalrep/cancel_commit_pending_replication
 test: segwalrep/twophase_tolerance_with_mirror_promotion
+test: segwalrep/failover_with_many_records
 test: pg_basebackup
 test: pg_basebackup_with_tablespaces
 

--- a/src/test/isolation2/sql/segwalrep/failover_with_many_records.sql
+++ b/src/test/isolation2/sql/segwalrep/failover_with_many_records.sql
@@ -1,0 +1,69 @@
+include: helpers/server_helpers.sql;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- Allow extra time for mirror promotion to complete recovery to avoid
+-- gprecoverseg BEGIN failures due to gang creation failure as some primaries
+-- are not up. Setting these increase the number of retries in gang creation in
+-- case segment is in recovery. Approximately we want to wait 30 seconds.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+1:CREATE TABLE t(a int, b int);
+
+1:SELECT gp_inject_fault_infinite('checkpoint_after_redo_calculated', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+2&:CHECKPOINT;
+3:INSERT INTO t VALUES (1, 0);
+
+-- Force WAL to switch xlog files explicitly
+-- start_ignore
+1U:SELECT pg_switch_xlog();
+-- end_ignore
+3:INSERT INTO t SELECT 0, i FROM generate_series(1, 25)i;
+
+1:SELECT gp_inject_fault_infinite('checkpoint_after_redo_calculated', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+2<:
+
+-- Here we must force immediately shutdown primary without triggering another
+-- checkpoint otherwise we would undo all of our previous work to ensure that
+-- checkpoint record has redo record on another wal segment.
+-1U: SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration c WHERE c.role='p' AND c.content=1), 'stop', 'immediate');
+
+-- Make sure we see the segment is down before trying to recover...
+4:SELECT gp_request_fts_probe_scan();
+4:SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 1;
+
+!\retcode gprecoverseg -a;
+
+-- loop while segments come in sync
+do $$
+begin /* in func */
+  for i in 1..120 loop /* in func */
+    if (select count(*) = 2 from gp_segment_configuration where content = 1 and mode = 's') then /* in func */
+      return; /* in func */
+    end if; /* in func */
+    perform gp_request_fts_probe_scan(); /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$;
+
+!\retcode gprecoverseg -ar;
+
+-- loop while segments come in sync
+do $$
+begin /* in func */
+  for i in 1..120 loop /* in func */
+    if (select count(*) = 2 from gp_segment_configuration where content = 1 and mode = 's') then /* in func */
+      return; /* in func */
+    end if; /* in func */
+    perform gp_request_fts_probe_scan(); /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$;
+
+-- verify no segment is down after recovery
+1:SELECT COUNT(*) FROM gp_segment_configuration WHERE status = 'd';
+
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpstop -u;


### PR DESCRIPTION
Issue is encountered because XLogReaderState does not make any
guarantees to preserve the XLogRecord returned between calls to
ReadRecord. In this particular scenario we read the checkpoint and redo
records from the backup label. After reading the latter record we have
no guarantees that the former record is still pointing to unchanged
memory.

Backported cleanly from master