### PR TITLE
docs - note for pxf parquet date conversion

### DIFF
--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -50,7 +50,7 @@ To read and write Parquet primitive data types in Greenplum Database, map Parque
 | int64 | Bigint |
 | int96 | Timestamp |
 
-**Note**: When writing to Parquet, PXF converts a `timestamp` to universal time (UT) before converting to `int96`.
+**Note**: When writing to Parquet, PXF localizes a `timestamp` to the current system timezone and converts it to universal time (UT) before finally converting to `int96`.
 
 
 ## <a id="profile_cet"></a>Creating the External Table

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -50,6 +50,8 @@ To read and write Parquet primitive data types in Greenplum Database, map Parque
 | int64 | Bigint |
 | int96 | Timestamp |
 
+**Note**: When writing to Parquet, PXF converts a `timestamp` to universal time (UT) before converting to `int96`.
+
 
 ## <a id="profile_cet"></a>Creating the External Table
 


### PR DESCRIPTION
when writing to parquet, convert date to UT before converting to int96

