### PR TITLE
tablespace tests for CLI utilities

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -63,6 +63,10 @@ def after_feature(context, feature):
 
 
 def before_scenario(context, scenario):
+    if "skip" in scenario.effective_tags:
+        scenario.skip("skipping scenario tagged with @skip")
+        return
+
     if 'gpmovemirrors' in context.feature.tags:
         context.mirror_context = MirrorMgmtContext()
 

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -76,6 +76,10 @@ def before_scenario(context, scenario):
 
 
 def after_scenario(context, scenario):
+    if 'tablespaces' in context:
+        for tablespace in context.tablespaces.values():
+            tablespace.cleanup()
+
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpinitstandby']
     if set(context.feature.tags).intersection(tags_to_skip):
         return

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -60,3 +60,17 @@ Feature: gpactivatestandby
         Then the user runs command "gpstate -m" from standby master
         And verify gpstate with options "-m" output is correct
         And clean up and revert back to original master
+
+    Scenario: tablespaces work
+        Given the database is running
+          And the standby is not initialized
+          And a tablespace is created with data
+         When the user runs gpinitstandby with options " "
+         Then gpinitstandby should return a return code of 0
+          And verify the standby master entries in catalog
+         When the master goes down
+          And the user runs gpactivatestandby with options " "
+         Then gpactivatestandby should return a return code of 0
+          And verify the standby master is now acting as master
+          And the tablespace is valid on the standby master
+          And clean up and revert back to original master

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -1,6 +1,19 @@
 @gpaddmirrors
 Feature: Tests for gpaddmirrors
 
+    Scenario: tablespaces work
+        Given the cluster is generated with "3" primaries only
+          And a tablespace is created with data
+         When gpaddmirrors adds 3 mirrors
+          And an FTS probe is triggered
+          And the segments are synchronized
+         Then verify the database has mirrors
+          And the tablespace is valid
+
+         When user kills all primary processes
+          And user can start transactions
+         Then the tablespace is valid
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -56,6 +56,19 @@ Feature: Tests for gpmovemirrors
         And the segments are synchronized
         And verify that mirrors are recognized after a restart
 
+    Scenario: tablespaces work
+        Given a standard local demo cluster is created
+          And a tablespace is created with data
+          And a gpmovemirrors directory under '/tmp/gpmovemirrors' with mode '0700' is created
+          And a 'good' gpmovemirrors file is created
+         When the user runs gpmovemirrors
+         Then gpmovemirrors should return a return code of 0
+          And verify the database has mirrors
+          And all the segments are running
+          And the segments are synchronized
+          And verify that mirrors are recognized after a restart
+          And the tablespace is valid
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1,6 +1,7 @@
 @gprecoverseg
 Feature: gprecoverseg tests
 
+    @skip  # tablespaces are being reworked and currently do not work with pg_rewind
     Scenario: incremental recovery works with tablespaces
         Given the database is running
           And a tablespace is created with data
@@ -18,6 +19,7 @@ Feature: gprecoverseg tests
           And the tablespace is valid
           And the other tablespace is valid
 
+    @skip  # tablespaces are being reworked and currently do not work with pg_rewind
     Scenario: full recovery works with tablespaces
         Given the database is running
           And a tablespace is created with data

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1,6 +1,40 @@
 @gprecoverseg
 Feature: gprecoverseg tests
 
+    Scenario: incremental recovery works with tablespaces
+        Given the database is running
+          And a tablespace is created with data
+          And user kills a primary postmaster process
+          And user can start transactions
+         When the user runs "gprecoverseg -a"
+         Then gprecoverseg should return a return code of 0
+          And the segments are synchronized
+          And the tablespace is valid
+
+        Given another tablespace is created with data
+         When the user runs "gprecoverseg -ra"
+         Then gprecoverseg should return a return code of 0
+          And the segments are synchronized
+          And the tablespace is valid
+          And the other tablespace is valid
+
+    Scenario: full recovery works with tablespaces
+        Given the database is running
+          And a tablespace is created with data
+          And user kills a primary postmaster process
+          And user can start transactions
+         When the user runs "gprecoverseg -a -F"
+         Then gprecoverseg should return a return code of 0
+          And the segments are synchronized
+          And the tablespace is valid
+
+        Given another tablespace is created with data
+         When the user runs "gprecoverseg -ra"
+         Then gprecoverseg should return a return code of 0
+          And the segments are synchronized
+          And the tablespace is valid
+          And the other tablespace is valid
+
     Scenario: gprecoverseg should not output bootstrap error on success
         Given the database is running
         And user kills a primary postmaster process

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -60,6 +60,7 @@ def _write_datadir_config_for_three_mirrors():
     return datadir_config
 
 
+@when("gpaddmirrors adds 3 mirrors")
 def add_three_mirrors(context):
     datadir_config = _write_datadir_config_for_three_mirrors()
     mirror_config_output_file = "/tmp/test_gpaddmirrors.config"

--- a/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
@@ -42,13 +42,14 @@ class Tablespace:
 
         shutil.rmtree(self.path)
 
-    def verify(self):
+    def verify(self, hostname=None, port=0):
         """
         Verify tablespace functionality by ensuring the tablespace can be
         written to, read from, and the initial data is still correctly
         distributed.
         """
-        with dbconn.connect(dbconn.DbURL(dbname=self.dbname)) as conn:
+        url = dbconn.DbURL(hostname=hostname, port=port, dbname=self.dbname)
+        with dbconn.connect(url) as conn:
             db = pg.DB(conn)
             data = db.query("SELECT gp_segment_id, i FROM tbl").getresult()
 
@@ -152,6 +153,11 @@ def _create_tablespace_with_data(context, name):
 @then('the tablespace is valid')
 def impl(context):
     context.tablespaces["outerspace"].verify()
+
+
+@then('the tablespace is valid on the standby master')
+def impl(context):
+    context.tablespaces["outerspace"].verify(context.standby_hostname, context.standby_port)
 
 
 @then('the other tablespace is valid')

--- a/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
@@ -1,0 +1,81 @@
+import shutil
+import tempfile
+
+from behave import given, when, then
+from pygresql import pg
+
+from gppylib.db import dbconn
+
+
+class Tablespace:
+    def __init__(self, name):
+        self.name = name
+        self.path = tempfile.mkdtemp()
+        self.dbname = 'tablespace_db_%s' % name
+        self.table_counter = 0
+        self.initial_data = None
+
+        with dbconn.connect(dbconn.DbURL()) as conn:
+            db = pg.DB(conn)
+            db.query("CREATE TABLESPACE %s LOCATION '%s'" % (self.name, self.path))
+            db.query("CREATE DATABASE %s TABLESPACE %s" % (self.dbname, self.name))
+
+        with dbconn.connect(dbconn.DbURL(dbname=self.dbname)) as conn:
+            db = pg.DB(conn)
+            db.query("CREATE TABLE tbl (i int) DISTRIBUTED RANDOMLY")
+            db.query("INSERT INTO tbl VALUES (GENERATE_SERIES(0, 25))")
+            # save the distributed data for later verification
+            self.initial_data = db.query("SELECT gp_segment_id, i FROM tbl").getresult()
+
+    def cleanup(self):
+        with dbconn.connect(dbconn.DbURL()) as conn:
+            db = pg.DB(conn)
+            db.query("DROP DATABASE IF EXISTS %s" % self.dbname)
+            db.query("DROP TABLESPACE IF EXISTS %s" % self.name)
+
+        shutil.rmtree(self.path)
+
+    def verify(self):
+        """
+        Verify tablespace functionality by ensuring the tablespace can be
+        written to, read from, and the initial data is still correctly
+        distributed.
+        """
+        with dbconn.connect(dbconn.DbURL(dbname=self.dbname)) as conn:
+            db = pg.DB(conn)
+            data = db.query("SELECT gp_segment_id, i FROM tbl").getresult()
+
+            # verify that we can still write to the tablespace
+            self.table_counter += 1
+            db.query("CREATE TABLE tbl_%s (i int) DISTRIBUTED RANDOMLY" % self.table_counter)
+            db.query("INSERT INTO tbl_%s VALUES (GENERATE_SERIES(0, 25))" % self.table_counter)
+
+        if sorted(data) != sorted(self.initial_data):
+            raise Exception("Tablespace data is not identically distributed. Expected:\n%r\n but found:\n%r" % (
+                sorted(self.initial_data), sorted(data)))
+
+
+@given('a tablespace is created with data')
+def impl(context):
+    _create_tablespace_with_data(context, "outerspace")
+
+
+@given('another tablespace is created with data')
+def impl(context):
+    _create_tablespace_with_data(context, "myspace")
+
+
+def _create_tablespace_with_data(context, name):
+    if 'tablespaces' not in context:
+        context.tablespaces = {}
+    context.tablespaces[name] = Tablespace(name)
+
+
+@then('the tablespace is valid')
+def impl(context):
+    context.tablespaces["outerspace"].verify()
+
+
+@then('the other tablespace is valid')
+def impl(context):
+    context.tablespaces["myspace"].verify()

--- a/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
@@ -28,10 +28,17 @@ class Tablespace:
             self.initial_data = db.query("SELECT gp_segment_id, i FROM tbl").getresult()
 
     def cleanup(self):
-        with dbconn.connect(dbconn.DbURL()) as conn:
+        with dbconn.connect(dbconn.DbURL(dbname="postgres")) as conn:
             db = pg.DB(conn)
             db.query("DROP DATABASE IF EXISTS %s" % self.dbname)
             db.query("DROP TABLESPACE IF EXISTS %s" % self.name)
+
+            # Without synchronous_commit = 'remote_apply' introduced in 9.6, there
+            # is no guarantee that the mirrors have removed their tablespace
+            # directories by the time the DROP TABLESPACE command returns.
+            # We need those directories to no longer be in use by the mirrors
+            # before removing them below.
+            _checkpoint_and_wait_for_replication_replay(db)
 
         shutil.rmtree(self.path)
 
@@ -53,6 +60,77 @@ class Tablespace:
         if sorted(data) != sorted(self.initial_data):
             raise Exception("Tablespace data is not identically distributed. Expected:\n%r\n but found:\n%r" % (
                 sorted(self.initial_data), sorted(data)))
+
+
+def _checkpoint_and_wait_for_replication_replay(db):
+    """
+    Taken from src/test/walrep/sql/missing_xlog.sql
+    """
+    db.query("""
+-- checkpoint to ensure clean xlog replication before bring down mirror
+create or replace function checkpoint_and_wait_for_replication_replay (retries int) returns bool as
+$$
+declare
+	i int;
+	checkpoint_locs pg_lsn[];
+	replay_locs pg_lsn[];
+	failed_for_segment text[];
+	r record;
+	all_caught_up bool;
+begin
+	i := 0;
+
+	-- Issue a checkpoint.
+	checkpoint;
+
+	-- Get the WAL positions after the checkpoint records on every segment.
+	for r in select gp_segment_id, pg_current_xlog_location() as loc from gp_dist_random('gp_id') loop
+		checkpoint_locs[r.gp_segment_id] = r.loc;
+	end loop;
+	-- and the QD, too.
+	checkpoint_locs[-1] = pg_current_xlog_location();
+
+	-- Force some WAL activity, to nudge the mirrors to replay past the
+	-- checkpoint location. There are some cases where a non-transactional
+	-- WAL record is created right after the checkpoint record, which
+	-- doesn't get replayed on the mirror until something else forces it
+	-- out.
+	drop table if exists dummy;
+	create temp table dummy (id int4) distributed randomly;
+
+	-- Wait until all mirrors have replayed up to the location we
+	-- memorized above.
+	loop
+		all_caught_up = true;
+		for r in select gp_segment_id, replay_location as loc from gp_stat_replication loop
+			replay_locs[r.gp_segment_id] = r.loc;
+			if r.loc < checkpoint_locs[r.gp_segment_id] then
+				all_caught_up = false;
+				failed_for_segment[r.gp_segment_id] = 1;
+			else
+				failed_for_segment[r.gp_segment_id] = 0;
+			end if;
+		end loop;
+
+		if all_caught_up then
+			return true;
+		end if;
+
+		if i >= retries then
+			RAISE INFO 'checkpoint_locs:    %', checkpoint_locs;
+			RAISE INFO 'replay_locs:        %', replay_locs;
+			RAISE INFO 'failed_for_segment: %', failed_for_segment;
+			return false;
+		end if;
+		perform pg_sleep(0.1);
+		i := i + 1;
+	end loop;
+end;
+$$ language plpgsql;
+
+SELECT checkpoint_and_wait_for_replication_replay(0);
+DROP FUNCTION checkpoint_and_wait_for_replication_replay(int);
+    """)
 
 
 @given('a tablespace is created with data')


### PR DESCRIPTION
This PR verifies that tablespaces work with the utilities.

There may not be a specific tablespace test for each specific utility. But rather a single tablespace test may touch several utilities such as gpactivatestandby implicitly testing gpinitstandby. All utilities that interact with tablespaces should be tested in this PR.

We are currently skipping gprecoverseg tablespace tests as tablespaces do not work with pg_rewind yet. PR https://github.com/greenplum-db/gpdb/pull/7473 helps address that with another followup PR needed. A followup chore to remove the skip tag for the gprecoverseg tests has been added.

A full test pipeline is being run.