### PR TITLE
docs - address pxf jdbc ddl vs. server config

### DIFF
--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -13,9 +13,9 @@ To access data in an external SQL database with the PXF JDBC Connector, you must
 - Register a compatible JDBC driver JAR file
 - Specify the JDBC driver class name, database URL, and client credentials
 
-In previous releases of Greenplum Database, you may have specified the JDBC driver class name, database URL, and client credentials via options that you provided in the `CREATE EXTERNAL TABLE` command. PXF now supports file-based server configuration for the JDBC Connector. This configuration, described below, allows you to specify these options and credentials in a file.
+In previous releases of Greenplum Database, you may have specified the JDBC driver class name, database URL, and client credentials via options in the `CREATE EXTERNAL TABLE` command. PXF now supports file-based server configuration for the JDBC Connector. This configuration, described below, allows you to specify these options and credentials in a file.
 
-**Note**: PXF external tables that you previously created that directly specified the JDBC connection options will continue to work. If you want to move these tables to use JDBC file-based server configuration, you must create a server configuration, drop the external tables, and then recreate them specifying an appropriate `SERVER=<servercfg>` clause.
+**Note**: PXF external tables that you previously created that directly specified the JDBC connection options will continue to work. If you want to move these tables to use JDBC file-based server configuration, you must create a server configuration, drop the external tables, and then recreate the tables specifying an appropriate `SERVER=<servercfg>` clause.
 
 ### <a id="cfg_jar"></a>JDBC Driver JAR Registration
 

--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -13,6 +13,10 @@ To access data in an external SQL database with the PXF JDBC Connector, you must
 - Register a compatible JDBC driver JAR file
 - Specify the JDBC driver class name, database URL, and client credentials
 
+In previous releases of Greenplum Database, you may have specified the JDBC driver class name, database URL, and client credentials via options that you provided in the `CREATE EXTERNAL TABLE` command. PXF now supports file-based server configuration for the JDBC Connector. This configuration, described below, allows you to specify these options and credentials in a file.
+
+**Note**: PXF external tables that you previously created that directly specified the JDBC connection options will continue to work. If you want to move these tables to use JDBC file-based server configuration, you must create a server configuration, drop the external tables, and then recreate them specifying an appropriate `SERVER=<servercfg>` clause.
+
 ### <a id="cfg_jar"></a>JDBC Driver JAR Registration
 
 The PXF JDBC connector is installed with the `postgresql-8.4-702.jdbc4.jar` JAR file. If you require a different JDBC driver, ensure that you install the JDBC driver JAR file for the external SQL database in the `$PXF_CONF/lib` directory on each segment host. Be sure to install JDBC driver JAR files that are compatible with your JRE version. See [Registering PXF JAR Dependencies](reg_jar_depend.html) for additional information.

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -35,7 +35,8 @@ Before you access an external SQL database using the PXF JDBC connector, ensure 
 - You can identify the PXF user configuration directory (`$PXF_CONF`).
 - Connectivity exists between all Greenplum Database segment hosts and the external SQL database.
 - You have configured your external SQL database for user access from all Greenplum Database segment hosts.
-- You have registered any JDBC driver JAR dependencies, and you have created one or more named PXF JDBC Connector server configurations as described in [Configuring the PXF JDBC Connector](jdbc_cfg.html).
+- You have registered any JDBC driver JAR dependencies.
+- (Recommended) You have created one or more named PXF JDBC Connector server configurations as described in [Configuring the PXF JDBC Connector](jdbc_cfg.html).
 
 ## <a id="datatypes"></a>Data Types Supported
 


### PR DESCRIPTION
in this PR:
- address previously-created pxf external tables with jdbc connection options specified in DDL
- jdbc server config recommended, not required
