### PR TITLE
Disable shareinputscan with outer refs.

### DIFF
--- a/src/backend/optimizer/plan/planshare.c
+++ b/src/backend/optimizer/plan/planshare.c
@@ -141,6 +141,15 @@ static ShareInputScan *make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 
 	Assert(IsA(inputplan, Material) || IsA(inputplan, Sort));
 
+	/*
+	 * Currently GPDB doesn't fully support shareinputscan referencing outer
+	 * rels.
+	 */
+	if (!bms_is_empty(inputplan->extParam))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("shareinputscan with outer refs is not supported by GPDB")));
+
 	sisc = makeNode(ShareInputScan);
 	incr_plan_nsharer(inputplan);
 
@@ -215,6 +224,8 @@ prepare_plan_for_sharing(PlannerInfo *root, Plan *common)
 		shared->plan_width = common->plan_width;
 		shared->dispatch = common->dispatch;
 		shared->flow = copyObject(common->flow); 
+		shared->extParam = bms_copy(common->extParam);
+		shared->allParam = bms_copy(common->allParam);
 
 		m->share_id = SHARE_ID_NOT_ASSIGNED;
 		m->share_type = SHARE_MATERIAL;

--- a/src/test/regress/expected/percentile.out
+++ b/src/test/regress/expected/percentile.out
@@ -885,11 +885,7 @@ select percentile_cont(0.1) within group (order by a),
 (1 row)
 
 select median(a - (select min(a) from percts)) from percts;
-       median       
---------------------
- @ 49 days 12 hours
-(1 row)
-
+ERROR:  shareinputscan with outer refs is not supported by GPDB
 select median(a), b from perct group by b order by b desc;
  median | b  
 --------+----

--- a/src/test/regress/expected/qp_functions_idf.out
+++ b/src/test/regress/expected/qp_functions_idf.out
@@ -700,21 +700,7 @@ select b+1 as col1 ,median(a+b) from perct group by b order by b desc;
 (11 rows)
 
 select b^2, median((select median(a) from perct) - (select sum(a)/10+ median(a) from perct ) + b + 500) from perct group by b order by b desc ;
- ?column? | median 
-----------+--------
-      100 |      5
-       81 |      4
-       64 |      3
-       49 |      2
-       36 |      1
-       25 |      0
-       16 |     -1
-        9 |     -2
-        4 |     -3
-        1 |     -4
-        0 |     -5
-(11 rows)
-
+ERROR:  shareinputscan with outer refs is not supported by GPDB
 -- PERCENTILE FUNCTION: SQL with math expression as input to IDF
 select b, percentile_disc(8*9/100 % 10 + 0.1::int) within group (order by a) from perct group by b order by b;
  b  | percentile_disc 

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -30,3 +30,10 @@ SELECT * FROM
 ---+---+---+---+---+---
 (0 rows)
 
+SELECT *,
+        (
+        WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
+        SELECT 1 FROM cte c1, cte c2
+        )
+        FROM bar;
+ERROR:  shareinputscan with outer refs is not supported by GPDB

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -27,3 +27,10 @@ SELECT * FROM
         JOIN bar ON b = c
         ) AS XY
         JOIN jazz on c = e AND b = f;
+
+SELECT *,
+        (
+        WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
+        SELECT 1 FROM cte c1, cte c2
+        )
+        FROM bar;


### PR DESCRIPTION
Currently shareinputscan doesn't handle rescan properly, and to fully
support it, there will be a lot of code changes. After some discussions,
we decide to disable shareinputscan with outer refs for now.

This patch is for github issue #7071.

Discussion: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/cCSV38aTn-8

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
