### PR TITLE
Recursive CTE enabled wrap-up

### DIFF
--- a/contrib/citext/citext--unpackaged--1.0.sql
+++ b/contrib/citext/citext--unpackaged--1.0.sql
@@ -89,8 +89,6 @@ ALTER EXTENSION citext ADD function translate(citext,citext,text);
 -- default collation is pinned.
 --
 
-SET gp_recursive_cte TO ON;
-
 WITH RECURSIVE typeoids(typoid) AS
   ( SELECT 'citext'::pg_catalog.regtype UNION
     SELECT oid FROM pg_catalog.pg_type, typeoids
@@ -199,5 +197,4 @@ WHERE indclass[7] IN (
   WHERE opcintype = typeoids.typoid
 );
 
-SET gp_recursive_cte TO OFF;
 -- somewhat arbitrarily, we assume no citext indexes have more than 8 columns

--- a/gpdb-doc/dita/admin_guide/query/topics/CTE-query.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/CTE-query.xml
@@ -24,11 +24,10 @@
           contain a data-modifying command.</li>
       </ul></note>
     <p>By default, the <codeph>RECURSIVE</codeph> keyword for the <codeph>WITH</codeph> clause is
-      disabled. <codeph>RECURSIVE</codeph> can be enabled by setting the server configuration
+      enabled. <codeph>RECURSIVE</codeph> can be disabled by setting the server configuration
       parameter <codeph><xref
           href="../../../ref_guide/config_params/guc-list.xml#gp_recursive_cte"/></codeph>
-      to <codeph>true</codeph>.
-      <note type="warning">The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</note></p>
+      to <codeph>false</codeph>.</p>
   </body>
   <topic id="topic_xyn_dgh_5gb">
     <title>SELECT in a WITH Clause</title>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4340,21 +4340,18 @@
   <topic id="gp_recursive_cte">
     <title>gp_recursive_cte</title>
     <body>
-      <p>Controls the availability of the <codeph>RECURSIVE</codeph> keyword (Beta) in the
+      <p>Controls the availability of the <codeph>RECURSIVE</codeph> keyword in the
           <codeph>WITH</codeph> clause of a <codeph>SELECT [INTO]</codeph> command, or a
           <codeph>DELETE</codeph>, <codeph>INSERT</codeph> or <codeph>UPDATE</codeph> command. The
         keyword allows a subquery in the <codeph>WITH</codeph> clause of a command to reference
         itself. The default value is <codeph>false</codeph>, the <codeph>RECURSIVE</codeph> keyword
         is not allowed in the <codeph>WITH</codeph> clause of a command.</p>
-      <note type="warning">The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</note>
       <p>For information about the <codeph>RECURSIVE</codeph> keyword (Beta), see the
             <codeph><xref href="../sql_commands/SELECT.xml">SELECT</xref></codeph> command and <xref
           href="../../admin_guide/query/topics/CTE-query.xml"/>.</p>
       <p>The parameter can be set for a database system, an individual database, or a session or
         query.</p>
-      <note>This parameter will be removed if the <codeph>RECURSIVE</codeph> keyword is promoted
-        from Beta, or if the keyword is removed from Greenplum Database.
-        This parameter was previously named <codeph>gp_recursive_cte_prototype</codeph>, but
+      <note>This parameter was previously named <codeph>gp_recursive_cte_prototype</codeph>, but
         has been renamed to reflect the current status of the implementation.</note>
       <table id="table_j4s_yyx_1bb">
         <tgroup cols="3">
@@ -4371,7 +4368,7 @@
           <tbody>
             <row>
               <entry colname="col1">Boolean</entry>
-              <entry colname="col2">false</entry>
+              <entry colname="col2">true</entry>
               <entry colname="col3">master<p>session</p><p>restart</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_VIEW.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_VIEW.xml
@@ -5,10 +5,7 @@
     [ WITH ( view_option_name [= view_option_value] [, ... ] ) ]
     AS <varname>query</varname>
     [ WITH [ CASCADED | LOCAL ] CHECK OPTION ]</codeblock></section><section id="section3"><title>Description</title>
-      <note type="warning">The <codeph>RECURSIVE</codeph> keyword is a Beta feature and is not
-        recommended for production use. <p>The <codeph>RECURSIVE</codeph> keyword can be enabled by
-          setting the server configuration parameter <codeph>gp_recursive_cte_prototype</codeph> to
-            <codeph>true</codeph>.</p></note><p><codeph>CREATE VIEW</codeph> defines a view of a query. The view is
+      <p><codeph>CREATE VIEW</codeph> defines a view of a query. The view is
 not physically materialized. Instead, the query is run every time the
 view is referenced in a query. </p><p><codeph>CREATE OR REPLACE VIEW</codeph> is similar, but if a view of the same
 name already exists, it is replaced. The new query must generate the same

--- a/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
@@ -68,11 +68,6 @@ DELETE FROM [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
                             <codeph>WITH</codeph> clause cannot contain a data-modifying command
                             (<codeph>INSERT</codeph>, <codeph>UPDATE</codeph>, or
                             <codeph>DELETE</codeph>). </pd>
-                    <pd>The <codeph>RECURSIVE</codeph> keyword is a Beta feature. By default, The
-                            <codeph>RECURSIVE</codeph> keyword is not available. The keyword can be
-                        enabled by setting the server configuration parameter <codeph><xref
-                                href="../config_params/guc-list.xml#gp_recursive_cte"
-                            /></codeph> to <codeph>true</codeph>. </pd>
                     <pd>See <xref
                             href="../../admin_guide/query/topics/CTE-query.xml#topic_zhs_r1s_w1b"/>
                         and <codeph><xref href="SELECT.xml#topic1"/></codeph> for details. </pd>

--- a/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
@@ -7,13 +7,11 @@
     <p id="sql_command_desc">Creates new rows in a table.</p>
     <section id="section2">
       <title>Synopsis</title>
-      <codeblock id="sql_command_synopsis">[ WITH [ RECURSIVE<sup>1</sup> ] <varname>with_query</varname> [, ...] ]
+      <codeblock id="sql_command_synopsis">[ WITH [ RECURSIVE ] <varname>with_query</varname> [, ...] ]
 INSERT INTO <varname>table</varname> [( <varname>column</varname> [, ...] )]
    {DEFAULT VALUES | VALUES ( {<varname>expression</varname> | DEFAULT} [, ...] ) [, ...] | <varname>query</varname>}
    [RETURNING * | <varname>output_expression</varname> [[AS] <varname>output_name</varname>] [, ...]]</codeblock>
     </section>
-    <p><b>Note:</b>
-      <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</p>
     <section id="section3">
       <title>Description</title>
       <p><codeph>INSERT</codeph> inserts new rows into a table. One can insert one or more rows
@@ -63,11 +61,6 @@ INSERT INTO <varname>table</varname> [( <varname>column</varname> [, ...] )]
               <codeph>WITH</codeph> clause. In such a case both sets of
               <varname>with_query</varname> can be referenced within the <codeph>INSERT</codeph>
             query, but the second one takes precedence since it is more closely nested.</pd>
-          <pd>The <codeph>RECURSIVE</codeph> keyword is a Beta feature. By default, The
-              <codeph>RECURSIVE</codeph> keyword is not available. The keyword can be enabled by
-            setting the server configuration parameter <codeph><xref
-                href="../config_params/guc-list.xml#gp_recursive_cte"/></codeph> to
-              <codeph>true</codeph>. </pd>
           <pd>See <xref href="../../admin_guide/query/topics/CTE-query.xml#topic_zhs_r1s_w1b"/> and
                 <codeph><xref href="SELECT.xml#topic1"/></codeph> for details. </pd>
         </plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SELECT.xml
@@ -141,11 +141,7 @@ ROWS FROM( function_name ( [ argument [, ...] ] ) [ AS ( column_definition [, ..
           each query in the <codeph>WITH</codeph> clause. Optionally, a list of column names can be
           specified; if the list of column names is omitted, the names are inferred from the
           subquery. The primary query and the <codeph>WITH</codeph> queries are all (notionally)
-          executed at the same time. </p><p>The <codeph>RECURSIVE</codeph> keyword can be enabled by setting the server configuration
-          parameter <codeph>gp_recursive_cte</codeph> to <codeph>true</codeph>. For
-          information about the parameter, see <xref href="../config_params/guc_config.xml#topic1"
-            />.<note type="note">The <codeph>RECURSIVE</codeph> keyword is a Beta
-          feature.</note></p><p>If <codeph>RECURSIVE</codeph> is specified, it
+          executed at the same time. </p><p>If <codeph>RECURSIVE</codeph> is specified, it
           allows a <codeph>SELECT</codeph> subquery to reference itself by name. Such a subquery has
           the general
           form</p><codeblock><varname>non_recursive_term</varname> UNION [ALL | DISTINCT] <varname>recursive_term</varname></codeblock><p>where

--- a/gpdb-doc/dita/ref_guide/sql_commands/SELECT_INTO.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/SELECT_INTO.xml
@@ -7,7 +7,7 @@
         <p id="sql_command_desc">Defines a new table from the results of a query.</p>
         <section id="section2">
             <title>Synopsis</title>
-            <codeblock id="sql_command_synopsis">[ WITH [ RECURSIVE<sup>1</sup> ] <varname>with_query</varname> [, ...] ]
+            <codeblock id="sql_command_synopsis">[ WITH [ RECURSIVE ] <varname>with_query</varname> [, ...] ]
 SELECT [ALL | DISTINCT [ON ( <varname>expression</varname> [, ...] )]]
     * | <varname>expression</varname> [AS <varname>output_name</varname>] [, ...]
     INTO [TEMPORARY | TEMP | UNLOGGED ] [TABLE] <varname>new_table</varname>
@@ -24,17 +24,11 @@ SELECT [ALL | DISTINCT [ON ( <varname>expression</varname> [, ...] )]]
     [...]]</codeblock>
         </section>
         <section id="section3">
-            <p><b>Note:</b>
-                <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</p>
             <title>Description</title>
             <p><codeph>SELECT INTO</codeph> creates a new table and fills it with data computed by a
                 query. The data is not returned to the client, as it is with a normal
                     <codeph>SELECT</codeph>. The new table's columns have the names and data types
                 associated with the output columns of the <codeph>SELECT</codeph>. </p>
-            <p>The <codeph>RECURSIVE</codeph> keyword can be enabled by setting the server
-                configuration parameter <codeph>gp_recursive_cte</codeph> to
-                    <codeph>true</codeph>.<note type="note">The <codeph>RECURSIVE</codeph> keyword
-                    is a Beta feature.</note></p>
         </section>
         <section id="section4">
             <title>Parameters</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
@@ -7,14 +7,12 @@
     <p id="sql_command_desc">Updates rows of a table.</p>
     <section id="section2">
       <title>Synopsis</title>
-      <codeblock id="sql_command_synopsis">[ WITH [ RECURSIVE<sup>1</sup> ] <varname>with_query</varname> [, ...] ]
+      <codeblock id="sql_command_synopsis">[ WITH [ RECURSIVE ] <varname>with_query</varname> [, ...] ]
 UPDATE [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
    SET {<varname>column</varname> = {<varname>expression</varname> | DEFAULT} |
    (<varname>column</varname> [, ...]) = ({<varname>expression</varname> | DEFAULT} [, ...])} [, ...]
    [FROM <varname>fromlist</varname>]
    [WHERE <varname>condition </varname>| WHERE CURRENT OF <varname>cursor_name</varname> ]</codeblock>
-      <p><b>Note:</b>
-        <sup>1</sup>The <codeph>RECURSIVE</codeph> keyword is a Beta feature.</p>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -64,11 +62,6 @@ UPDATE [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
               <codeph>WITH</codeph> clause. In such a case both sets of
               <varname>with_query</varname> can be referenced within the <codeph>UPDATE</codeph>
             query, but the second one takes precedence since it is more closely nested.</pd>
-          <pd>The <codeph>RECURSIVE</codeph> keyword is a Beta feature. By default, The
-              <codeph>RECURSIVE</codeph> keyword is not available. The keyword can be enabled by
-            setting the server configuration parameter <codeph><xref
-                href="../config_params/guc-list.xml#gp_recursive_cte"/></codeph> to
-              <codeph>true</codeph>. </pd>
           <pd>See <xref href="../../admin_guide/query/topics/CTE-query.xml#topic_zhs_r1s_w1b"/> and
                 <codeph><xref href="SELECT.xml#topic1"/></codeph> for details. </pd>
         </plentry>

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -2418,8 +2418,6 @@ buildMatViewRefreshDependencies(Archive *fout)
 
 	query = createPQExpBuffer();
 
-	ExecuteSqlStatement(fout, "SET gp_recursive_cte TO ON;");
-
 	appendPQExpBufferStr(query, "WITH RECURSIVE w AS "
 						 "( "
 					"SELECT d1.objid, d2.refobjid, c2.relkind AS refrelkind "

--- a/src/bin/pg_rewind/libpq_fetch.c
+++ b/src/bin/pg_rewind/libpq_fetch.c
@@ -176,7 +176,6 @@ libpqProcessFileList(void)
 	 * directory, they won't be copied correctly.
 	 */
 	sql =
-		"SET gp_recursive_cte TO ON;\n"
 		"WITH RECURSIVE files (path, filename, size, isdir) AS (\n"
 		"  SELECT '' AS path, filename, size, isdir FROM\n"
 		"  (SELECT pg_ls_dir('.', true, false) AS filename) AS fn,\n"


### PR DESCRIPTION
Commit 4e337a3 enabled RECURSIVE CTEs by default, so let's remove the final instances where we did override the previous default value and update the docs to reflect the current state of the GUC.