### PR TITLE
Avoid comparing newline option twice

### DIFF
--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -510,8 +510,8 @@ CONTEXT:  COPY copy_regression_newline, line 1: "1|1
 "
 -- negative: invalid newline
 COPY copy_regression_newline from stdin with delimiter '|' newline 'blah';
-ERROR:  invalid value for NEWLINE (blah)
-HINT:  valid options are: 'LF', 'CRLF', 'CR'
+ERROR:  invalid value for NEWLINE "blah"
+HINT:  Valid options are: 'LF', 'CRLF' and 'CR'.
 -- negative: newline not yet supported for COPY TO
 COPY copy_regression_newline to stdout with delimiter '|' newline 'blah';
 ERROR:  newline currently available for data loading only, not unloading


### PR DESCRIPTION
This refactors the code to remove the separate step for setting the `eol_type` in `CopyEolStrToType()`, which induced a second pointless `pg_strcasecmp()` on the passed NEWLINE string. This function did more originally but upstream merges have made it redundant, and the function is refers to has never been in the Greenplum code at all.