### PR TITLE
Remove unused init_file regular expressions

### DIFF
--- a/src/test/isolation2/init_file_resgroup
+++ b/src/test/isolation2/init_file_resgroup
@@ -9,9 +9,6 @@ s/^[0-9:]+\sgpconfig:[^:]+:[^-]*-\[/TIMESTAMP gpconfig:SEGMENT:USER-[/
 m/\[\S+:cgroup is not properly configured:/
 s/\[\S+:cgroup is not properly configured:/\[SEGMENT:cgroup is not properly configured:/
 
-m/^ERROR:  Resource group [0-9]+ was concurrently dropped$/
-s/group [0-9]+ was/group OID was/
-
 m/^ERROR:  Out of memory  (seg\d slice\d \d+.\d+.\d+.\d+:\d+ pid=\d+)$/
 s/(seg\d+ slice\d+ \d+.\d+.\d+.\d+:\d+ pid=\d+)/(SEG SLICE ADDR:PORT pid=PID)/
 

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -103,15 +103,10 @@ s/Hash Cond: \(pg_temp_\d+/Hash Cond: \(pg_temp_#####/
 m/\d+ was concurrently dropped/
 s/\d+ was concurrently dropped/##### was concurrently dropped/
 
-# Segment number is not predictable
-m/ERROR:  There are more external files \(URLs\) than primary segments that can read them.*/
-s/ERROR:  There are more external files \(URLs\) than primary segments that can read them.*/ERROR:  There are more external files (URLs) than primary segments that can read them./
-
 # Mask out linenumber of the erroring file
 m/ERROR:  ANALYZE cannot merge since not all non-empty leaf partitions have consistent hyperloglog statistics for merge.*/
 s/ERROR:  ANALYZE cannot merge since not all non-empty leaf partitions have consistent hyperloglog statistics for merge.*/ERROR:  ANALYZE cannot merge since not all non-empty leaf partitions have consistent hyperloglog statistics for merge (analyze.c:XXX)/
-m/ERROR:  Cannot run ANALYZE MERGE since not all non-empty leaf partitions have available statistics for the merge.*/
-s/ERROR:  Cannot run ANALYZE MERGE since not all non-empty leaf partitions have available statistics for the merge.*/ERROR:  Cannot run ANALYZE MERGE since not all non-empty leaf partitions have available statistics for the merge (analyze.c:XXX)/
+
 m/ERROR:  invalid partition constraint on "[^"]+".*/
 s/ERROR:  invalid partition constraint on "[^"]+".*/ERROR:  invalid partition constraint on "[^"]+".*(cdbpartition.c:XXX)/
 


### PR DESCRIPTION
The output for these rules have either never existed, or has been changed over time such that the rule is no longer hitting anything. Remove to shave hairs off the regress test runtimes.