### PR TITLE
Add how to set value to empty string to gpconfig ref

### DIFF
--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
@@ -83,6 +83,7 @@
             value, enter either two single quotes or backslash and quote (<codeph>\'</codeph>).</pd>
           <pd>The utility encloses the value in single quotes when adding the setting to the
               <codeph>postgresql.conf</codeph> files.</pd>
+          <pd>To set the value to an empty string, enter empty single quotes (<codeph>''</codeph>). </pd>
         </plentry>
         <plentry>
           <pt>-m | --mastervalue <varname>master_value</varname></pt>


### PR DESCRIPTION
Trivial addition to note it's now possible to set an empty string. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
