### PR TITLE
gpstart: skip filespace check for down segments

### DIFF
--- a/gpMgmt/bin/gppylib/operations/filespace.py
+++ b/gpMgmt/bin/gppylib/operations/filespace.py
@@ -297,7 +297,9 @@ class CheckFilespaceConsistency(Operation):
                                                                            PG_SYSTEM_FILESPACE).run()).run()
         cur_filespace_entries = GetFilespaceEntriesDict(GetCurrentFilespaceEntries(self.gparray,
                                                                                    self.file_type).run()).run()
-        for seg in self.gparray.getDbList():
+        # Don't check segments that are down, as their flat files may be missing
+        upSegments = [seg for seg in self.gparray.getDbList() if seg.isSegmentUp()]
+        for seg in upSegments:
             dbid = seg.getSegmentDbId()
             flat_file_location = os.path.join(pg_system_fs_entries[dbid][2],
                                               flat_file)

--- a/gpMgmt/bin/gppylib/operations/filespace.py
+++ b/gpMgmt/bin/gppylib/operations/filespace.py
@@ -297,9 +297,7 @@ class CheckFilespaceConsistency(Operation):
                                                                            PG_SYSTEM_FILESPACE).run()).run()
         cur_filespace_entries = GetFilespaceEntriesDict(GetCurrentFilespaceEntries(self.gparray,
                                                                                    self.file_type).run()).run()
-        # Don't check segments that are down, as their flat files may be missing
-        upSegments = [seg for seg in self.gparray.getDbList() if seg.isSegmentUp()]
-        for seg in upSegments:
+        for seg in self.gparray.getDbList():
             dbid = seg.getSegmentDbId()
             flat_file_location = os.path.join(pg_system_fs_entries[dbid][2],
                                               flat_file)

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -143,14 +143,10 @@ class GpStart:
             else:
                 logger.info("Skipping Standby activation status checking.")
 
-            filespace_configured = is_filespace_configured()
-            inconsistent_filespace = False
-            if filespace_configured:
-                # Check for filespace consistency
+            if is_filespace_configured():
                 if not CheckFilespaceConsistency(self.gparray, FileType.TRANSACTION_FILES).run() or \
                         not CheckFilespaceConsistency(self.gparray, FileType.TEMPORARY_FILES).run():
-                    logger.error('Filespaces are inconsistent. Abort Greenplum Database start.')
-                    inconsistent_filespace = True
+                    logger.warning('Filespaces are inconsistent.')
 
             logger.info("Shutting down master")
             cmd = gp.GpStop("Shutting down master", masterOnly=True,
@@ -162,11 +158,6 @@ class GpStart:
             cmd.run()
             logger.debug("results of forcing master shutdown: %s" % cmd)
             # TODO: check results of command.
-
-            # in order to fail out here we must have filespace configured and also
-            # have failed the consistency check
-            if filespace_configured and inconsistent_filespace:
-                return 1
 
         finally:
             # Reenable Ctrl-C

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -87,12 +87,14 @@ Feature: Validate command line arguments
         And all the segments are running
         and the segments are synchronized
 
-    Scenario: Skip checking for filespace consistency on a down segment during startup
+        @wip
+    Scenario: gpstart succeeds and prints a warning when filespaces are inconsistent
         Given the database is running
           And all the segments are running
           And the segments are synchronized
-          And the user " " creates filespace_config file for "new_filespace" on host "localhost" with gpdb port "15432" and config "new_filespace_config" in "/tmp" directory
-          And the user " " creates filespace on host "localhost" with gpdb port "15432" and config "new_filespace_config" in "/tmp" directory
+          And a filespace_config_file for filespace "new_filespace" is created using config file "new_filespace_config" in directory "/tmp"
+          And a filespace is created using config file "new_filespace_config" in directory "/tmp"
+          And temporary files are moved to the filespace new_filespace
           And the information of a "mirror" segment on any host is saved
          When user kills a mirror process with the saved information
           And the mirror with content id "0" is forcibly marked down in config
@@ -102,4 +104,10 @@ Feature: Validate command line arguments
          When the temporary filespace file is deleted on saved "mirror" segment
           And the user runs "gpstart -a"
          Then gpstart should return a return code of 0
+                # TODO: And a warning is printed
           And user can start transactions
+                # restore moving temporary files back to the default location
+		# TODO: The step below is failing because we have deleted the temporary filespace
+		#       file on the mirror
+         And temporary files are moved to the filespace default
+         And sql "drop filespace new_filespace" is executed in "template1" db

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -89,18 +89,17 @@ Feature: Validate command line arguments
 
     Scenario: Skip checking for filespace consistency on a down segment during startup
         Given the database is running
-        And all the segments are running
-        And the segments are synchronized
-	And the user " " creates filespace_config file for "new_filespace" on host "localhost" with gpdb port "15432" and config "new_filespace_config" in "/tmp" directory
-	And the user " " creates filespace on host "localhost" with gpdb port "15432" and config "new_filespace_config" in "/tmp" directory
-        And the information of a "mirror" segment on any host is saved
-	When user kills a mirror process with the saved information
-	And the mirror with content id "0" is forcibly marked down in config
-        And the user runs "gpstop -aM fast"
-        And gpstop should return a return code of 0
-	Then the temporary filespace file is deleted on saved "mirror" segment
-        And the user runs "gpstart -a"
-        And gpstart should return a return code of 0
-        And all the segments are running
-        And the segments are synchronized
+          And all the segments are running
+          And the segments are synchronized
+          And the user " " creates filespace_config file for "new_filespace" on host "localhost" with gpdb port "15432" and config "new_filespace_config" in "/tmp" directory
+          And the user " " creates filespace on host "localhost" with gpdb port "15432" and config "new_filespace_config" in "/tmp" directory
+          And the information of a "mirror" segment on any host is saved
+         When user kills a mirror process with the saved information
+          And the mirror with content id "0" is forcibly marked down in config
+          And the user runs "gpstop -aM fast"
+         Then gpstop should return a return code of 0
 
+         When the temporary filespace file is deleted on saved "mirror" segment
+          And the user runs "gpstart -a"
+         Then gpstart should return a return code of 0
+          And user can start transactions

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -87,3 +87,20 @@ Feature: Validate command line arguments
         And all the segments are running
         and the segments are synchronized
 
+    Scenario: Skip checking for filespace consistency on a down segment during startup
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+	And the user " " creates filespace_config file for "new_filespace" on host "localhost" with gpdb port "15432" and config "new_filespace_config" in "/tmp" directory
+	And the user " " creates filespace on host "localhost" with gpdb port "15432" and config "new_filespace_config" in "/tmp" directory
+        And the information of a "mirror" segment on any host is saved
+	When user kills a mirror process with the saved information
+	And the mirror with content id "0" is forcibly marked down in config
+        And the user runs "gpstop -aM fast"
+        And gpstop should return a return code of 0
+	Then the temporary filespace file is deleted on saved "mirror" segment
+        And the user runs "gpstart -a"
+        And gpstart should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -612,7 +612,7 @@ def impl(context, USER, fs_name, HOST, PORT, config_file, dir):
 @when(
     'the user "{USER}" creates filespace on host "{HOST}" with gpdb port "{PORT}" and config "{config_file}" in "{dir}" directory')
 def impl(context, USER, HOST, PORT, config_file, dir):
-    user = "-U %s" % os.environ.get(USER) if USER else None
+    user = "-U %s" % os.environ.get(USER) if USER else ""
     host = os.environ.get(HOST)
     port = os.environ.get(PORT)
     if not dir.startswith("/"):
@@ -637,10 +637,11 @@ def impl(context, config_file, dir):
     run_command(context, cmdStr)
 
 
-@given('transaction files are moved to the filespace {fs_name}')
-@then('transaction files are moved to the filespace {fs_name}')
-def impl(context, fs_name):
-    cmdStr = 'gpfilespace  --movetransfilespace "%s"' % fs_name
+@given('{fs_type} files are moved to the filespace {fs_name}')
+@then('{fs_type} files are moved to the filespace {fs_name}')
+def impl(context, fs_type, fs_name):
+    arg = "--movetransfilespace" if fs_type == "transaction" else "--movetempfilespace"
+    cmdStr = 'gpfilespace %s %s' % (arg, fs_name)
     run_command(context, cmdStr)
 
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4059,7 +4059,7 @@ def impl(context, seg):
     cmd.run(validateAfter=True)
 
 
-@then('the temporary filespace file is deleted on saved "{seg}" segment')
+@when('the temporary filespace file is deleted on saved "{seg}" segment')
 def impl(context, seg):
     if seg == "primary":
         data_dir = context.primary_datadir

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -33,6 +33,7 @@ from gppylib.commands.gp import SegmentStart, GpStandbyStart, MasterStop
 from gppylib.commands.unix import findCmdInPath, Scp
 from gppylib.operations.backup_utils import Context
 from gppylib.operations.dump import get_partition_state
+from gppylib.operations.filespace import GP_TEMPORARY_FILES_FILESPACE
 from gppylib.operations.startSegments import MIRROR_MODE_MIRRORLESS
 from gppylib.operations.unix import ListRemoteFilesByPattern, CheckRemoteFile
 from test.behave_utils.gpfdist_utils.gpfdist_mgmt import Gpfdist
@@ -596,11 +597,8 @@ def impl(context, dir, dbconn):
     'the user "{USER}" creates filespace_config file for "{fs_name}" on host "{HOST}" with gpdb port "{PORT}" and config "{config_file}" in "{dir}" directory')
 @then(
     'the user "{USER}" creates filespace_config file for "{fs_name}" on host "{HOST}" with gpdb port "{PORT}" and config "{config_file}" in "{dir}" directory')
-def impl(context, USER, HOST, PORT, fs_name, config_file, dir):
-    if USER:
-        user = os.environ.get(USER)
-    else:
-        user = None
+def impl(context, USER, fs_name, HOST, PORT, config_file, dir):
+    user = os.environ.get(USER)
     host = os.environ.get(HOST)
     port = os.environ.get(PORT)
     if not dir.startswith("/"):
@@ -614,10 +612,7 @@ def impl(context, USER, HOST, PORT, fs_name, config_file, dir):
 @when(
     'the user "{USER}" creates filespace on host "{HOST}" with gpdb port "{PORT}" and config "{config_file}" in "{dir}" directory')
 def impl(context, USER, HOST, PORT, config_file, dir):
-    if USER:
-        user = "-U %s" % os.environ.get(USER)
-    else:
-        user = ""
+    user = "-U %s" % os.environ.get(USER) if USER else None
     host = os.environ.get(HOST)
     port = os.environ.get(PORT)
     if not dir.startswith("/"):
@@ -4068,7 +4063,7 @@ def impl(context, seg):
         data_dir = context.mirror_datadir
         hostname = context.mirror_segdbname
 
-    cmd = Command(name="Remove filespace file", cmdStr='rm -f %s' % (os.path.join(data_dir, 'gp_temporary_files_filespace')),
+    cmd = Command(name="Remove filespace file", cmdStr='rm -f %s' % (os.path.join(data_dir, GP_TEMPORARY_FILES_FILESPACE)),
                   remoteHost=hostname, ctxt=REMOTE)
     cmd.run(validateAfter=True)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -135,6 +135,11 @@ def impl(context, cid):
     if row_count != 1:
         raise Exception('Expected mirror segment cid %s to be down, but it is up.' % cid)
 
+@when('the mirror with content id "{cid}" is forcibly marked down in config')
+def impl(context, cid):
+    with dbconn.connect(dbconn.DbURL(dbname='postgres')) as conn:
+        dbconn.execSQL(conn, "SET allow_system_table_mods='dml'; UPDATE gp_segment_configuration SET status='d' WHERE role='m' AND content=%s" % cid)
+
 @given('user runs the command "{cmd}" on segment "{cid}"')
 @when('user runs the command "{cmd}" on segment "{cid}"')
 @then('user runs the command "{cmd}" on segment "{cid}"')


### PR DESCRIPTION
If a segment is marked down and is missing the flat files for the transaction or temporary filespaces (for instance, because a host went down), gpstart will fail to start up.

This commit changes `CheckFilespaceConsistency` to ignore those segments, because the issue will be fixed when the segments are recovered.

Co-Authored-By: Jamie McAtamney <jmcatamney@pivotal.io>
