### PR TITLE
gpconfig: Update message when file has no GUC value

### DIFF
--- a/gpMgmt/bin/gpconfig_modules/compare_segment_guc.py
+++ b/gpMgmt/bin/gpconfig_modules/compare_segment_guc.py
@@ -70,10 +70,16 @@ class MultiValueGuc(SegmentGuc):
 
     def report_success_format(self):
         file_val = self.primary_file_seg_guc.get_value()
-        if self.db_seg_guc:
-            result = "%s value: %s | file: %s" % (self.get_label(), self.db_seg_guc.value, self._use_dash_when_none(file_val))
+        if file_val is not None:
+            if self.db_seg_guc:
+                result = "%s value: %s | file: %s" % (self.get_label(), self.db_seg_guc.value, file_val)
+            else:
+                result = "%s value: %s" % (self.get_label(), file_val)
         else:
-            result = "%s value: %s" % (self.get_label(), file_val)
+            if self.db_seg_guc:
+                result = "%s value: %s | not set in file" % (self.get_label(), self.db_seg_guc.value)
+            else:
+                result = "No value is set on %s" % ("master" if self.get_label() == "Master " else "segments")
         return result
 
     def report_fail_format(self):
@@ -87,16 +93,17 @@ class MultiValueGuc(SegmentGuc):
         return report
 
     def _report_fail_format_with_database_and_file_gucs(self, segment_guc_obj):
-        return "[context: %s] [dbid: %s] [name: %s] [value: %s | file: %s]" % (
+        if segment_guc_obj.value is None:
+            file_tag = "not set in file"
+        else:
+            file_tag = "file: %s" % segment_guc_obj.value
+
+        return "[context: %s] [dbid: %s] [name: %s] [value: %s | %s]" % (
             self.db_seg_guc.context,
             segment_guc_obj.dbid,
             self.db_seg_guc.name,
             self.db_seg_guc.value,
-            self._use_dash_when_none(segment_guc_obj.value))
-
-    def _use_dash_when_none(self, value):
-      return value if value is not None else "-"
-
+            file_tag)
 
     def is_internally_consistent(self):
         if not self.db_seg_guc:

--- a/gpMgmt/bin/gpconfig_modules/database_segment_guc.py
+++ b/gpMgmt/bin/gpconfig_modules/database_segment_guc.py
@@ -12,7 +12,9 @@ class DatabaseSegmentGuc(SegmentGuc):
         self.value = row[2]
 
     def report_success_format(self):
-        return "%s value: %s" % (self.get_label(), self.get_value())
+        if self.get_value() is not None:
+            return "%s value: %s" % (self.get_label(), self.get_value())
+        return "No value is set on %s" % ("master" if self.get_label() == "Master " else "segments")
 
     def report_fail_format(self):
         return ["[context: %s] [name: %s] [value: %s]" % (self.context, self.name, self.get_value())]

--- a/gpMgmt/bin/gpconfig_modules/file_segment_guc.py
+++ b/gpMgmt/bin/gpconfig_modules/file_segment_guc.py
@@ -13,17 +13,21 @@ class FileSegmentGuc(SegmentGuc):
         self.dbid = str(row[3])
 
     def report_success_format(self):
-        return "%s value: %s" % (self.get_label(), self._use_dash_when_none(self.get_value()))
+        if self.get_value() is not None:
+            return "%s value: %s" % (self.get_label(), self.get_value())
+        return "No value is set on %s" % ("master" if self.get_label() == "Master " else "segments")
 
     def report_fail_format(self):
-        return ["[context: %s] [dbid: %s] [name: %s] [value: %s]" % (self.context, self.dbid, self.name, self._use_dash_when_none(self.get_value()))]
+        value = self.get_value()
+        if value is not None:
+            value = 'value: %s' % value
+        else:
+            value = 'not set in file'
+
+        return ["[context: %s] [dbid: %s] [name: %s] [%s]" % (self.context, self.dbid, self.name, value)]
 
     def is_internally_consistent(self):
         return True
 
     def get_value(self):
         return self.value
-
-    def _use_dash_when_none(self, value):
-        return value if value is not None else "-"
-

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_file_segment_guc.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_file_segment_guc.py
@@ -21,6 +21,11 @@ class FileSegmentGucTest(GpTestCase):
         self.assertEquals(self.subject.report_fail_format(),
                           ["[context: contentid] [dbid: dbid] [name: guc_name] [value: value_from_file]"])
 
+    def test_report_fail_format_file_when_unset(self):
+        self.subject.value = None
+        self.assertEquals(self.subject.report_fail_format(),
+                          ["[context: contentid] [dbid: dbid] [name: guc_name] [not set in file]"])
+
     def test_init_with_insufficient_file_values_raises(self):
         row = ['contentid', 'guc_name', 'value_from_file']
         with self.assertRaisesRegexp(Exception, "must provide \['context', 'guc name', 'value', 'dbid'\]"):
@@ -33,7 +38,7 @@ class FileSegmentGucTest(GpTestCase):
         self.assertEquals(self.subject.report_success_format(), "Master  value: value")
         self.assertEqual(self.subject.dbid, '0')
 
-    def test_when_value_none_report_success_uses_hyphen(self):
+    def test_when_value_none_report_success_prints_message(self):
         self.subject.value = None
 
-        self.assertEquals(self.subject.report_success_format(), "Segment value: -")
+        self.assertEquals(self.subject.report_success_format(), "No value is set on segments")

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_guccollection.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_guccollection.py
@@ -89,8 +89,7 @@ class GucCollectionTest(GpTestCase):
         row = ['-1', 'guc_name', 'master_value', 'dbid']
         self.subject.update(FileSegmentGuc(row))
 
-        self.assertIn("Master  value: master_value | file: master_value", self.subject.report())
-        self.assertIn("Segment value: value | file: value", self.subject.report())
+        self.assertIn("Master  value: master_value | file: master_value\nSegment value: value | file: value", self.subject.report())
 
     def test_when_file_value_empty_file_compare_succeeds(self):
         row = ['0', 'guc_name', None, 'dbid']
@@ -98,8 +97,19 @@ class GucCollectionTest(GpTestCase):
         row = ['-1', 'guc_name', None, 'dbid']
         self.subject.update(FileSegmentGuc(row))
 
-        self.assertIn("Master  value: master_value | file: -", self.subject.report())
-        self.assertIn("Segment value: value | file: -", self.subject.report())
+        self.assertIn("Master  value: master_value | not set in file", self.subject.report())
+        self.assertIn("Segment value: value | not set in file", self.subject.report())
+
+    def test_values_unset_in_file_only(self):
+        self.subject = GucCollection() # remove existing DatabaseSegmentGucs
+
+        row = ['0', 'guc_name', None, 'dbid']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', None, 'dbid']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("No value is set on master", self.subject.report())
+        self.assertIn("No value is set on segments", self.subject.report())
 
     def test_when_multiple_dbids_per_contentid_reports_failure(self):
         row = ['-1', 'guc_name', 'master_value', '1']
@@ -197,7 +207,7 @@ class GucCollectionTest(GpTestCase):
         row = ['0', 'guc_name', 'value', 'dbid4']
         self.subject.update(FileSegmentGuc(row))
 
-        self.assertIn("[context: -1] [dbid: dbid1] [name: guc_name] [value: -]\n", self.subject.report())
+        self.assertIn("[context: -1] [dbid: dbid1] [name: guc_name] [not set in file]\n", self.subject.report())
         self.assertIn("[context: -1] [dbid: dbid3] [name: guc_name] [value: master_value]\n", self.subject.report())
         self.assertIn("[context: 0] [dbid: dbid2] [name: guc_name] [value: value]\n", self.subject.report())
         self.assertIn("[context: 0] [dbid: dbid4] [name: guc_name] [value: value]", self.subject.report())
@@ -217,7 +227,7 @@ class GucCollectionTest(GpTestCase):
         row = ['1', 'guc_name', 'value', 'dbid5']
         self.subject.update(FileSegmentGuc(row))
 
-        self.assertEquals("[context: -1] [dbid: dbid1] [name: guc_name] [value: -]\n"
+        self.assertEquals("[context: -1] [dbid: dbid1] [name: guc_name] [not set in file]\n"
                           "[context: -1] [dbid: dbid3] [name: guc_name] [value: master_value]\n"
                           "[context: 0] [dbid: dbid2] [name: guc_name] [value: value]\n"
                           "[context: 0] [dbid: dbid4] [name: guc_name] [value: value]\n"

--- a/gpMgmt/doc/gpconfig_help
+++ b/gpMgmt/doc/gpconfig_help
@@ -12,7 +12,7 @@ gpconfig -c <param_name> -v <value> [-m <master_value> | --masteronly]
        | -l 
    [--skipvalidation] [--verbose] [--debug]
 
-gpconfig -s <param_name> [--flag] [--verbose] [--debug]
+gpconfig -s <param_name> [--file | --file-compare] [--verbose] [--debug]
 
 gpconfig --help
 


### PR DESCRIPTION
Because users may find it confusing when gpconfig prints '-' or 'None'
when no GUC value is found in the file, this commit updates gpconfig to
output a clearer message.

Co-Authored-By: Jamie McAtamney <jmcatamney@pivotal.io>
Co-Authored-By: Larry Hamel <lhamel@pivotal.io>