### PR TITLE
Rename instances of "PQO" to "Pivotal Optimizer (GPORCA)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ More information can be found on the [project website](https://greenplum.org/).
 ## Building Greenplum Database with GPORCA
 GPORCA is a cost-based optimizer which is used by Greenplum Database in
 conjunction with the PostgreSQL planner.  It is also known as just ORCA,
-and Pivotal Query Optimizer (PQO). The code for GPORCA resides in a
+and Pivotal Optimizer. The code for GPORCA resides in a
 separate repository, below are steps outlining how to build Greenplum with
 GPORCA enabled.
 

--- a/concourse/scripts/perfsummary.py
+++ b/concourse/scripts/perfsummary.py
@@ -123,7 +123,7 @@ class FileState:
                 self.plans.append(self.curr_plan)
                 self.curr_plan = []
         elif optimizerMatch:
-            if (not re.search(' PQO ', line)):
+            if (not re.search(' PQO ', line) or not re.search(' Pivotal Optimizer ', line)):
                 if self.planning_time1 < 0:
                     self.comment1 = self.comment1 + "Fallback "
                 else:

--- a/concourse/scripts/perfsummary.py
+++ b/concourse/scripts/perfsummary.py
@@ -125,7 +125,7 @@ class FileState:
         elif optimizerMatch:
             # Since this script can be used on older explain logs, match both
             # original and new ORCA names
-            if (not re.search(' PQO ', line) or not re.search(' Pivotal Optimizer ', line)):
+            if (not re.search(' PQO ', line) and not re.search(' Pivotal Optimizer ', line)):
                 if self.planning_time1 < 0:
                     self.comment1 = self.comment1 + "Fallback "
                 else:

--- a/concourse/scripts/perfsummary.py
+++ b/concourse/scripts/perfsummary.py
@@ -123,6 +123,8 @@ class FileState:
                 self.plans.append(self.curr_plan)
                 self.curr_plan = []
         elif optimizerMatch:
+            # Since this script can be used on older explain logs, match both
+            # original and new ORCA names
             if (not re.search(' PQO ', line) or not re.search(' Pivotal Optimizer ', line)):
                 if self.planning_time1 < 0:
                     self.comment1 = self.comment1 + "Fallback "

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-fallback.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-fallback.xml
@@ -15,7 +15,7 @@
             <codeph>optimizer=on</codeph> and GPORCA version are displayed at
           the end of the query plan. For
             example.<codeblock> Settings:  <b>optimizer=on</b>
- Optimizer status: <b>PQO version 1.584</b></codeblock><p>When
+ Optimizer status: <b>Pivotal Optimizer (GPORCA) version 1.584</b></codeblock><p>When
               Greenplum Database falls back to the Postgres optimizer to generate the
             plan, the setting <codeph>optimizer=on</codeph> and <codeph>Postgres query
               optimizer</codeph> are displayed at the end of the query plan. For

--- a/gpdb-doc/dita/admin_guide/query/topics/query-profiling.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-profiling.xml
@@ -199,7 +199,7 @@ Gather Motion 2:1 (slice1; segments: 2) (cost=0.00..20.88 rows=1 width=13)
          ->  Aggregate  (cost=0.00..294.10 rows=1 width=8)
                ->  Seq Scan on part  (cost=0.00..97.69 rows=100040 width=1)
  Settings:  <b>optimizer=on</b>
- Optimizer status: <b>PQO version 1.584</b>
+ Optimizer status: <b>Pivotal Optimizer (GPORCA) version 1.584</b>
 (5 rows)</codeblock>
             <codeblock>explain select count(*) from part;
 

--- a/gpdb-doc/dita/best_practices/tuning_queries.xml
+++ b/gpdb-doc/dita/best_practices/tuning_queries.xml
@@ -78,7 +78,7 @@
                                  ->  Sort  (cost=0.00..431.00 rows=7 width=4)
                                        Sort Key: gp_segment_id
                                        ->  Seq Scan on table1  (cost=0.00..431.00 rows=7 width=4)
- Optimizer status: PQO version 2.56.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.56.0
 (14 rows)</codeblock>
       <p>This plan has eight nodes &#x2013; Seq Scan, Sort, GroupAggregate, Result,
         Redistribute Motion, Sort, GroupAggregate, and finally Gather Motion. Each node contains three cost

--- a/gpdb-doc/dita/ref_guide/sql_commands/EXPLAIN.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/EXPLAIN.xml
@@ -193,7 +193,7 @@ ROLLBACK;</codeblock></note>
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.27 rows=1 width=58)
    ->  Seq Scan on names  (cost=0.00..431.27 rows=1 width=58)
          Filter: (name = 'Joelle'::text)
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (4 rows)</codeblock>
 
       <p>If we read the plan from the bottom up, the query optimizer starts by doing a sequential
@@ -216,7 +216,7 @@ ROLLBACK;</codeblock></note>
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on names
          Filter: (name = 'Joelle'::text)
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (4 rows)</codeblock> 
 
       <p>Here is the same query, with JSON formatting:</p>
@@ -254,7 +254,7 @@ ROLLBACK;</codeblock></note>
        ]                                      +
      },                                       +
      "Settings": {                            +
-       "Optimizer": "PQO version 3.23.0"      +
+       "Optimizer": "Pivotal Optimizer (GPORCA) version 3.23.0"      +
      }                                        +
    }                                          +
  ]
@@ -292,7 +292,7 @@ ROLLBACK;</codeblock></note>
          Plan Width: 70                                      +
          Index Cond: "(location = 'Sydney, Australia'::text)"+
    Settings:                                                 +
-     Optimizer: "PQO version 3.23.0"
+     Optimizer: "Pivotal Optimizer (GPORCA) version 3.23.0"
 (1 row)</codeblock></p>    </section>
     <section id="section7">
       <title>Compatibility</title>

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -647,7 +647,7 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 		ExplainProperty("Optimizer", "Postgres query optimizer", false, es);
 #ifdef USE_ORCA
 	else
-		ExplainPropertyStringInfo("Optimizer", es, "PQO version %s", OptVersion());
+		ExplainPropertyStringInfo("Optimizer", es, "Pivotal Optimizer (GPORCA) version %s", OptVersion());
 #endif
 
 	/* We only list the non-default GUCs in verbose mode */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14868,7 +14868,7 @@ ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
 
 		/* Step (a) */
 		/*
-		 * Force the use of Postgres query optimizer, since PQO will not
+		 * Force the use of Postgres query optimizer, since Pivotal Optimizer (GPORCA) will not
 		 * redistribute the tuples if the current and required distributions
 		 * are both RANDOM even when reorganize is set to "true"
 		 */
@@ -15382,7 +15382,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			ldistro = make_distributedby_for_rel(rel);
 
 		/*
-		 * Force the use of Postgres query optimizer, since PQO will not
+		 * Force the use of Postgres query optimizer, since Pivotal Optimizer (GPORCA) will not
 		 * redistribute the tuples if the current and required distributions
 		 * are both RANDOM even when reorganize is set to "true"
 		 */

--- a/src/backend/optimizer/README.orca
+++ b/src/backend/optimizer/README.orca
@@ -36,7 +36,7 @@ Physical plan:
                        Output: $0,
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
                              Output: true
- Optimizer: PQO version 2.55.2
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.2
 (13 rows)
 ```
 

--- a/src/test/isolation/expected/drop-index-concurrently-1_optimizer.out
+++ b/src/test/isolation/expected/drop-index-concurrently-1_optimizer.out
@@ -18,7 +18,7 @@ Gather Motion 3:1  (slice1; segments: 3)
         Sort Key: id, data
         ->  Index Scan using test_dc_data on test_dc
               Index Cond: (data = 34)
-Optimizer: PQO version 2.74.0
+Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 step explains: EXPLAIN (COSTS OFF) EXECUTE getrow_seq;
 QUERY PLAN     
 
@@ -28,7 +28,7 @@ Gather Motion 3:1  (slice1; segments: 3)
         Sort Key: id, data
         ->  Seq Scan on test_dc
               Filter: ((data)::text = '34'::text)
-Optimizer: PQO version 2.74.0
+Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 step select2: SELECT * FROM test_dc WHERE data=34 ORDER BY id,data;
 id             data           
 

--- a/src/test/isolation/init_file
+++ b/src/test/isolation/init_file
@@ -1,3 +1,3 @@
 -- start_matchignore
-m/^Optimizer: PQO version .*/
+m/^Optimizer: Pivotal Optimizer \(GPORCA\) version .*/
 -- end_matchignore

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -70,7 +70,7 @@ explain update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
                                        ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
                                              Hash Key: r.b
                                              ->  Seq Scan on r  (cost=0.00..431.07 rows=3334 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (13 rows)
 
 update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
@@ -87,7 +87,7 @@ explain delete from s where exists (select 1 from r where s.a = r.b);
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
                                  Hash Key: r.b
                                  ->  Seq Scan on r  (cost=0.00..431.07 rows=3334 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (11 rows)
 
 delete from s where exists (select 1 from r where s.a = r.b);

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -620,7 +620,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Seq Scan on tenk1
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (5 rows)
 
 select min(unique1) from tenk1;
@@ -637,7 +637,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Seq Scan on tenk1
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (5 rows)
 
 select max(unique1) from tenk1;
@@ -655,7 +655,7 @@ explain (costs off)
          ->  Aggregate
                ->  Index Scan using tenk1_unique1 on tenk1
                      Index Cond: (unique1 < 42)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
 
 select max(unique1) from tenk1 where unique1 < 42;
@@ -673,7 +673,7 @@ explain (costs off)
          ->  Aggregate
                ->  Index Scan using tenk1_unique1 on tenk1
                      Index Cond: (unique1 > 42)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
 
 select max(unique1) from tenk1 where unique1 > 42;
@@ -693,7 +693,7 @@ explain (costs off)
          ->  Aggregate
                ->  Index Scan using tenk1_unique1 on tenk1
                      Index Cond: (unique1 > 42000)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
 
 select max(unique1) from tenk1 where unique1 > 42000;
@@ -713,7 +713,7 @@ explain (costs off)
          ->  Aggregate
                ->  Index Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = 33)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
 
 select max(tenthous) from tenk1 where thousand = 33;
@@ -731,7 +731,7 @@ explain (costs off)
          ->  Aggregate
                ->  Index Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = 33)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
 
 select min(tenthous) from tenk1 where thousand = 33;
@@ -758,7 +758,7 @@ explain (costs off)
                  ->  Materialize
                        ->  Gather Motion 3:1  (slice2; segments: 3)
                              ->  Seq Scan on tenk1
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (11 rows)
 
 select f1, (select min(unique1) from tenk1 where unique1 > f1) AS gt
@@ -781,7 +781,7 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Seq Scan on tenk1
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (5 rows)
 
 select distinct max(unique2) from tenk1;
@@ -800,7 +800,7 @@ explain (costs off)
          ->  Gather Motion 3:1  (slice1; segments: 3)
                ->  Aggregate
                      ->  Seq Scan on tenk1
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (7 rows)
 
 select max(unique2) from tenk1 order by 1;
@@ -819,7 +819,7 @@ explain (costs off)
          ->  Gather Motion 3:1  (slice1; segments: 3)
                ->  Aggregate
                      ->  Seq Scan on tenk1
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (7 rows)
 
 select max(unique2) from tenk1 order by max(unique2);
@@ -840,7 +840,7 @@ explain (costs off)
                      ->  Gather Motion 3:1  (slice1; segments: 3)
                            ->  Aggregate
                                  ->  Seq Scan on tenk1
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (9 rows)
 
 select max(unique2) from tenk1 order by max(unique2)+1;
@@ -860,7 +860,7 @@ explain (costs off)
                ->  Gather Motion 3:1  (slice1; segments: 3)
                      ->  Aggregate
                            ->  Seq Scan on tenk1
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (8 rows)
 
 select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -270,7 +270,7 @@ select max(b) over (partition by a) from foo order by 1;
  ccc
 (3 rows)
 
-select count_operator('select max(b) over (partition by a) from foo order by 1;', 'PQO');
+select count_operator('select max(b) over (partition by a) from foo order by 1;', 'Pivotal Optimizer (GPORCA)');
  count_operator 
 ----------------
               0

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -269,7 +269,7 @@ select max(b) over (partition by a) from foo order by 1;
  ccc
 (3 rows)
 
-select count_operator('select max(b) over (partition by a) from foo order by 1;', 'PQO');
+select count_operator('select max(b) over (partition by a) from foo order by 1;', 'Pivotal Optimizer (GPORCA)');
  count_operator 
 ----------------
               1
@@ -1585,7 +1585,7 @@ explain select string_agg(a, '') from mpp14125 group by b;
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=34 width=55)
                            Hash Key: b
                            ->  Seq Scan on mpp14125  (cost=0.00..431.00 rows=34 width=55)
- Optimizer: PQO version 2.55.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.0
 (10 rows)
 
 -- end MPP-14125

--- a/src/test/regress/expected/bfv_catalog_optimizer.out
+++ b/src/test/regress/expected/bfv_catalog_optimizer.out
@@ -262,7 +262,7 @@ explain select pg_column_size('mpp_bfv_2');
  Result  (cost=0.00..0.00 rows=1 width=4)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.23.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.23.0
 (4 rows)
 
 explain select pg_lock_status();
@@ -271,7 +271,7 @@ explain select pg_lock_status();
  Result  (cost=0.00..0.00 rows=1 width=8)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.23.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.23.0
 (4 rows)
 
 select pg_get_constraintdef(pg_constraint.oid) from pg_constraint, pg_class where conrelid=pg_class.oid and pg_class.relname='mpp_bfv_2';

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -188,7 +188,7 @@ explain update update_pk_test set b = 5;
          ->  Split  (cost=0.00..431.00 rows=1 width=22)
                ->  Result  (cost=0.00..431.00 rows=1 width=22)
                      ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=18)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 update update_pk_test set b = 5;
@@ -211,7 +211,7 @@ explain update update_pk_test set a = 5;
                            ->  Split  (cost=0.00..431.00 rows=1 width=22)
                                  ->  Result  (cost=0.00..431.00 rows=1 width=22)
                                        ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=18)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (11 rows)
 
 update update_pk_test set a = 5;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -32,7 +32,7 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
          ->  Index Scan using bfv_tab1_idx1 on bfv_tab1  (cost=0.00..2.00 rows=1 width=244)
                Index Cond: unique1 = "Values".column1
                Filter: stringu1::text = "Values".column2
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
 set gp_enable_relsize_collection=on;
@@ -48,7 +48,7 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
          ->  Index Scan using bfv_tab1_idx1 on bfv_tab1  (cost=0.00..2.00 rows=1 width=244)
                Index Cond: unique1 = "Values".column1
                Filter: stringu1::text = "Values".column2
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
 reset gp_enable_relsize_collection;
@@ -171,7 +171,7 @@ AND ft.id = dt1.id;
                                                    ->  Dynamic Seq Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=7 width=6)
                                        ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                                              ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (20 rows)
 
 -- start_ignore
@@ -494,7 +494,7 @@ explain select * from nestloop_x as x, nestloop_y as y where x.i + x.j < y.j;
                ->  Seq Scan on nestloop_x  (cost=0.00..431.00 rows=7 width=8)
          ->  Index Scan using nestloop_y_idx on nestloop_y  (cost=0.00..112.01 rows=1 width=8)
                Index Cond: j > (nestloop_x.i + nestloop_x.j)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (8 rows)
 
 select * from nestloop_x as x, nestloop_y as y where x.i + x.j < y.j;
@@ -521,7 +521,7 @@ explain select * from nestloop_x as x, nestloop_y as y where y.j > x.i + x.j + 2
                ->  Seq Scan on nestloop_x  (cost=0.00..431.00 rows=7 width=8)
          ->  Index Scan using nestloop_y_idx on nestloop_y  (cost=0.00..112.01 rows=1 width=8)
                Index Cond: j > (nestloop_x.i + nestloop_x.j + 2)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (8 rows)
 
 select * from nestloop_x as x, nestloop_y as y where y.j > x.i + x.j + 2;
@@ -590,7 +590,7 @@ explain select * from shape_heap where c && '<(5,5), 1>'::circle;
    ->  Index Scan using shape_heap_bb_idx on shape_heap  (cost=0.00..6.00 rows=1 width=24)
          Index Cond: c && '<(5,5),1>'::circle
          Filter: c && '<(5,5),1>'::circle
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (5 rows)
 
 explain select * from shape_ao   where c && '<(5,5), 1>'::circle;
@@ -601,7 +601,7 @@ explain select * from shape_ao   where c && '<(5,5), 1>'::circle;
          Recheck Cond: c && '<(5,5),1>'::circle
          ->  Bitmap Index Scan on shape_ao_bb_idx  (cost=0.00..0.00 rows=0 width=0)
                Index Cond: c && '<(5,5),1>'::circle
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (6 rows)
 
 explain select * from shape_aocs where c && '<(5,5), 1>'::circle;
@@ -612,7 +612,7 @@ explain select * from shape_aocs where c && '<(5,5), 1>'::circle;
          Recheck Cond: c && '<(5,5),1>'::circle
          ->  Bitmap Index Scan on shape_aocs_bb_idx  (cost=0.00..0.00 rows=0 width=0)
                Index Cond: c && '<(5,5),1>'::circle
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (6 rows)
 
 -- Test that they return correct results.

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -669,7 +669,7 @@ explain select 1 as mrs_t1 where 1 <= ALL (select x from z);
                      ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=1)
                            Filter: 1 > x
  Settings:  optimizer=on
- Optimizer status: PQO version 1.621
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
 (10 rows)
 
 --
@@ -3091,7 +3091,7 @@ ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = r
                ->  Redistribute Motion 3:3  (slice4; segments: 3)
                      Hash Key: (region.county_name)::text
                      ->  Seq Scan on region
- Optimizer: PQO version 2.69.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.69.0
 (23 rows)
 
 -- Test colocated equijoins on coerced distribution keys
@@ -3148,7 +3148,7 @@ explain select * from nlj1, nlj2 where nlj1.a = nlj2.a;
          Join Filter: (nlj1.a = nlj2.a)
          ->  Seq Scan on nlj1  (cost=0.00..431.00 rows=1 width=8)
          ->  Seq Scan on nlj2  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 3.2.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.2.0
 (6 rows)
 
 select * from nlj1, nlj2 where nlj1.a = nlj2.a;
@@ -3165,7 +3165,7 @@ explain select * from nlj1, nlj2 where nlj1.a is not distinct from nlj2.a;
          Join Filter: (NOT (nlj1.a IS DISTINCT FROM nlj2.a))
          ->  Seq Scan on nlj1  (cost=0.00..431.00 rows=1 width=8)
          ->  Seq Scan on nlj2  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 3.2.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.2.0
 (6 rows)
 
 select * from nlj1, nlj2 where nlj1.a is not distinct from nlj2.a;
@@ -3188,7 +3188,7 @@ explain select * from nlj1, (select NULL a, b from nlj2) other where nlj1.a is n
                      ->  Result  (cost=0.00..431.00 rows=1 width=8)
                            ->  Result  (cost=0.00..431.00 rows=1 width=8)
                                  ->  Seq Scan on nlj2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 3.2.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.2.0
 (11 rows)
 
 select * from nlj1, (select NULL a, b from nlj2) other where nlj1.a is not distinct from other.a;
@@ -3208,7 +3208,7 @@ explain select * from nlj1, nlj2 where nlj1.a is distinct from nlj2.a;
          ->  Materialize  (cost=0.00..431.00 rows=2 width=8)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
                      ->  Seq Scan on nlj2  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 3.2.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.2.0
 (8 rows)
 
 select * from nlj1, nlj2 where nlj1.a is distinct from nlj2.a;
@@ -3298,7 +3298,7 @@ explain (costs off) select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
                            ->  Seq Scan on b
          ->  Index Scan using c_i_j_idx on c
                Index Cond: (j = (a.i + b.i))
- Optimizer: PQO version 3.21.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.21.0
 (12 rows)
 
 select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -1151,7 +1151,7 @@ EXPLAIN SELECT b FROM bar GROUP BY b;
                      Partitions selected: 2 (out of 2)
                ->  Dynamic Seq Scan on bar (dynamic scan id: 1)  (cost=0.00..431.01 rows=334 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (9 rows)
 
 -- CLEANUP
@@ -1199,7 +1199,7 @@ explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 5.260 ms
 (19 rows)
 
@@ -1244,7 +1244,7 @@ EXPLAIN SELECT * FROM part_tbl WHERE profile_key = 99999999;
                Partitions selected: 2 (out of 2)
          ->  Dynamic Index Scan on part_tbl (dynamic scan id: 1)  (cost=0.00..2.00 rows=1 width=24)
                Index Cond: profile_key = 99999999::numeric
- Optimizer status: PQO version 2.31.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.31.0
 (7 rows)
 
 SELECT * FROM part_tbl WHERE profile_key = 99999999;
@@ -1328,7 +1328,7 @@ explain select * from r_part r1, r_part r2 where r1.a=1; -- should eliminate par
                                  Partitions selected: 1 (out of 9)
                            ->  Dynamic Seq Scan on r_part (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
                                  Filter: a = 1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (15 rows)
 
 -- the numbers in the filter should be both on segment 0
@@ -1341,7 +1341,7 @@ explain select * from r_part where a in (7,8); -- should eliminate partitions
                Partitions selected: 2 (out of 9)
          ->  Dynamic Seq Scan on r_part (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
                Filter: a = ANY ('{7,8}'::integer[])
- Optimizer: PQO version 2.71.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.71.0
 (7 rows)
 
 -- Test partition elimination in prepared statements
@@ -1379,7 +1379,7 @@ explain select * from r_part where a = 1 order by a,b; -- should eliminate parti
                ->  Dynamic Seq Scan on r_part (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
                      Filter: a = 1
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (12 rows)
 
 --force_explain
@@ -1397,7 +1397,7 @@ explain execute f1(1); -- should eliminate partitions
                ->  Dynamic Seq Scan on r_part (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
                      Filter: a = 1
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (12 rows)
 
 --force_explain
@@ -1415,7 +1415,7 @@ explain execute f2(2); -- should eliminate partitions
                ->  Dynamic Seq Scan on r_part (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
                      Filter: a = 2
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (12 rows)
 
 -- Test partition elimination on CO tables
@@ -1432,7 +1432,7 @@ explain select * from r_co where a=2; -- should eliminate partitions
          ->  Dynamic Seq Scan on r_co (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
                Filter: a = 2
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (9 rows)
 
 -- test partition elimination in prepared statements on CO tables
@@ -1452,7 +1452,7 @@ explain execute f3(2); -- should eliminate partitions
                ->  Dynamic Seq Scan on r_co (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
                      Filter: a = 2
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (12 rows)
 
 -- start_ignore
@@ -1494,7 +1494,7 @@ explain select * from fact where dd < '2009-01-02'::date; -- partitions eliminat
          ->  Dynamic Seq Scan on fact (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
                Filter: dd < '01-02-2009'::date
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (9 rows)
 
 explain select * from fact where dd < to_date('2009-01-02','YYYY-MM-DD'); -- partitions eliminated
@@ -1508,7 +1508,7 @@ explain select * from fact where dd < to_date('2009-01-02','YYYY-MM-DD'); -- par
          ->  Dynamic Seq Scan on fact (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
                Filter: dd < '01-02-2009'::date
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (9 rows)
 
 explain select * from fact where dd < current_date; --partitions eliminated
@@ -1522,7 +1522,7 @@ explain select * from fact where dd < current_date; --partitions eliminated
          ->  Dynamic Seq Scan on fact (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
                Filter: dd < '10-22-2017'::date
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (9 rows)
 
 -- Test partition elimination in prepared statements
@@ -1539,7 +1539,7 @@ explain execute f1('2009-01-02'::date); -- should eliminate partitions
          ->  Dynamic Seq Scan on fact (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
                Filter: dd < '01-02-2009'::date
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (9 rows)
 
 -- force_explain
@@ -1554,7 +1554,7 @@ explain execute f1(to_date('2009-01-02', 'YYYY-MM-DD')); -- should eliminate par
          ->  Dynamic Seq Scan on fact (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
                Filter: dd < '01-02-2009'::date
  Settings:  optimizer=on
- Optimizer status: PQO version 2.47.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.47.1
 (9 rows)
 
 -- start_ignore

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -21,7 +21,7 @@ explain select * from bfv_statistics_foo where a is not null and b >= 1;
    ->  Seq Scan on bfv_statistics_foo  (cost=0.00..431.00 rows=1 width=8)
          Filter: NOT a IS NULL AND b >= 1
  Settings:  optimizer=on
- Optimizer status: PQO version 2.32.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.32.0
 (5 rows)
 
 create table bfv_statistics_foo2(a int) distributed by (a);
@@ -49,7 +49,7 @@ explain select a from bfv_statistics_foo2 where a > 1 order by a;
          ->  Seq Scan on bfv_statistics_foo2  (cost=0.00..431.00 rows=5 width=4)
                Filter: a > 1
  Settings:  optimizer=on
- Optimizer status: PQO version 2.32.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.32.0
 (8 rows)
 
 -- change stats manually so that MCV and MCF numbers do not match
@@ -69,7 +69,7 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
          ->  Seq Scan on bfv_statistics_foo2  (cost=0.00..431.00 rows=3 width=4)
                Filter: a > 1
  Settings:  optimizer=on
- Optimizer status: PQO version 2.32.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.32.0
 (8 rows)
 
 --
@@ -135,7 +135,7 @@ explain select a from bfv_statistics_foo4 where a > 888;
    ->  Seq Scan on bfv_statistics_foo4  (cost=0.00..431.00 rows=1 width=4)
          Filter: a > 888
  Settings:  optimizer=on
- Optimizer status: PQO version 2.32.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.32.0
 (5 rows)
 
 --
@@ -418,7 +418,7 @@ EXPLAIN SELECT * FROM test_join_card1 t1, test_join_card2 t2, test_join_card3 t3
                ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.20 rows=3334 width=8)
                      Hash Key: (test_join_card3.b)::text
                      ->  Seq Scan on test_join_card3  (cost=0.00..431.07 rows=3334 width=8)
- Optimizer: PQO version 3.19.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.19.0
 (17 rows)
 
 -- start_ignore

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -492,7 +492,7 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
                  ->  Result  (cost=0.00..0.00 rows=1 width=6)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.46.3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.46.3
 (9 rows)
 
 DROP TABLE A;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -616,7 +616,7 @@ explain select * from unlogged_test where c1 = 100;
          Recheck Cond: c1 = 100
          ->  Bitmap Index Scan on unlogged_test_idx  (cost=0.00..0.00 rows=0 width=0)
                Index Cond: c1 = 100
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (6 rows)
 
 select * from unlogged_test where c1 = 100;

--- a/src/test/regress/expected/bitmapops_optimizer.out
+++ b/src/test/regress/expected/bitmapops_optimizer.out
@@ -64,7 +64,7 @@ EXPLAIN SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
                      Index Cond: (c = 1)
                      Filter: ((a = 1) AND (b = 1))
  Planning time: 49.715 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (8 rows)
 
 SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
@@ -88,7 +88,7 @@ EXPLAIN SELECT count(*) FROM bmscantest2 WHERE a = 1 OR b = 1 OR c = 1;
                ->  Seq Scan on bmscantest2  (cost=0.00..435.26 rows=853 width=1)
                      Filter: ((a = 1) OR (b = 1) OR (c = 1))
  Planning time: 41.055 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (7 rows)
 
 SELECT count(*) FROM bmscantest2 WHERE a = 1 OR b = 1 OR c = 1;
@@ -131,7 +131,7 @@ EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
                            ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (c = 1)
  Planning time: 44.164 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (15 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
@@ -160,7 +160,7 @@ EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND 
                            ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (d = 1)
  Planning time: 19.186 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (18 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
@@ -186,7 +186,7 @@ EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 OR b = 1 OR c = 1;
                            ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (c = 1)
  Planning time: 15.467 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (15 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 OR b = 1 OR c = 1;
@@ -215,7 +215,7 @@ EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 OR (b = 1 AND c = 1) OR d
                            ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (d = 1)
  Planning time: 14.342 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (18 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 OR (b = 1 AND c = 1) OR d = 1;
@@ -252,7 +252,7 @@ EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
                            ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (c = 1)
  Planning time: 41.653 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (15 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
@@ -281,7 +281,7 @@ EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AN
                            ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (d = 1)
  Planning time: 22.854 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (18 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
@@ -307,7 +307,7 @@ EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 OR b = 1 OR c = 1;
                            ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (c = 1)
  Planning time: 13.135 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (15 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 OR b = 1 OR c = 1;
@@ -336,7 +336,7 @@ EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 OR (b = 1 AND c = 1) OR
                            ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (d = 1)
  Planning time: 14.755 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (18 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 OR (b = 1 AND c = 1) OR d = 1;

--- a/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
+++ b/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
@@ -21,7 +21,7 @@ explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b wh
                Recheck Cond: id = bar.id
                ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..0.00 rows=0 width=0)
                      Index Cond: id = bar.id
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
@@ -45,7 +45,7 @@ explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b wh
                Recheck Cond: id = bar.id
                ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..0.00 rows=0 width=0)
                      Index Cond: id = bar.id
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
@@ -70,7 +70,7 @@ explain select f.id from co_nestloop_idxscan.bar b, co_nestloop_idxscan.foo f wh
                Recheck Cond: id = bar.id
                ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..0.00 rows=0 width=0)
                      Index Cond: id = bar.id
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -386,7 +386,7 @@ SELECT * FROM fast_emp4000
                      ->  Index Scan using grect2ind on fast_emp4000
                            Index Cond: (home_base @ '(2000,1000),(200,200)'::box)
                            Filter: (home_base @ '(2000,1000),(200,200)'::box)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (10 rows)
 
 SELECT * FROM fast_emp4000
@@ -408,7 +408,7 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base && '(1000,1000,0,0)'::box;
                ->  Index Scan using grect2ind on fast_emp4000
                      Index Cond: (home_base && '(1000,1000),(0,0)'::box)
                      Filter: (home_base && '(1000,1000),(0,0)'::box)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM fast_emp4000 WHERE home_base && '(1000,1000,0,0)'::box;
@@ -449,7 +449,7 @@ SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
                      ->  Index Scan using gpolygonind on polygon_tbl
                            Index Cond: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
                            Filter: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (10 rows)
 
 SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
@@ -472,7 +472,7 @@ SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
                      ->  Index Scan using gcircleind on circle_tbl
                            Index Cond: (f1 && '<(1,-2),1>'::circle)
                            Filter: (f1 && '<(1,-2),1>'::circle)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (9 rows)
 
 SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
@@ -495,7 +495,7 @@ SELECT count(*) FROM gpolygon_tbl WHERE f1 && '(1000,1000,0,0)'::polygon;
                ->  Index Scan using ggpolygonind on gpolygon_tbl
                      Index Cond: (f1 && '((1000,1000),(0,0))'::polygon)
                      Filter: (f1 && '((1000,1000),(0,0))'::polygon)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM gpolygon_tbl WHERE f1 && '(1000,1000,0,0)'::polygon;
@@ -514,7 +514,7 @@ SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
                ->  Index Scan using ggcircleind on gcircle_tbl
                      Index Cond: (f1 && '<(500,500),500>'::circle)
                      Filter: (f1 && '<(500,500),500>'::circle)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
@@ -533,7 +533,7 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <@ '(100,100),(0,0)'::box)
                      Filter: (f1 <@ '(100,100),(0,0)'::box)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
@@ -552,7 +552,7 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <@ '(100,100),(0,0)'::box)
                      Filter: (f1 <@ '(100,100),(0,0)'::box)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
@@ -571,7 +571,7 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
                      Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
@@ -590,7 +590,7 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <@ '<(50,50),50>'::circle)
                      Filter: (f1 <@ '<(50,50),50>'::circle)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
@@ -609,7 +609,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 << '(0,0)'::point)
                      Filter: (f1 << '(0,0)'::point)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
@@ -628,7 +628,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 >> '(0,0)'::point)
                      Filter: (f1 >> '(0,0)'::point)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
@@ -647,7 +647,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <^ '(0,0)'::point)
                      Filter: (f1 <^ '(0,0)'::point)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
@@ -666,7 +666,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 >^ '(0,0)'::point)
                      Filter: (f1 >^ '(0,0)'::point)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
@@ -685,7 +685,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 ~= '(-5,-12)'::point)
                      Filter: (f1 ~= '(-5,-12)'::point)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
@@ -768,7 +768,7 @@ SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0
                      ->  Index Scan using gpointind on point_tbl
                            Index Cond: (f1 <@ '(10,10),(-10,-10)'::box)
                            Filter: (f1 <@ '(10,10),(-10,-10)'::box)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (9 rows)
 
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
@@ -1335,7 +1335,7 @@ SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0
                      ->  Index Scan using gpointind on point_tbl
                            Index Cond: (f1 <@ '(10,10),(-10,-10)'::box)
                            Filter: (f1 <@ '(10,10),(-10,-10)'::box)
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (9 rows)
 
 SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
@@ -2993,7 +2993,7 @@ SELECT * FROM tenk1
    ->  Index Scan using tenk1_thous_tenthous on tenk1
          Index Cond: (thousand = 42)
          Filter: ((tenthous = 1) OR (tenthous = 3) OR (tenthous = 42))
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (5 rows)
 
 SELECT * FROM tenk1
@@ -3014,7 +3014,7 @@ SELECT count(*) FROM tenk1
                ->  Index Scan using tenk1_hundred on tenk1
                      Index Cond: (hundred = 42)
                      Filter: ((thousand = 42) OR (thousand = 99))
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (7 rows)
 
 SELECT count(*) FROM tenk1
@@ -3045,7 +3045,7 @@ EXPLAIN (COSTS OFF)
                ->  Index Scan using dupindexcols_i on dupindexcols
                      Index Cond: ((f1 >= 'WA'::text) AND (f1 <= 'ZZZ'::text) AND (id < 1000))
                      Filter: (f1 ~<~ 'YX'::text)
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (7 rows)
 
 SELECT count(*) FROM dupindexcols
@@ -3147,6 +3147,6 @@ explain (costs off)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on tenk1
          Filter: (((thousand = 1) AND (tenthous = 1001)) OR NULL::boolean)
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (4 rows)
 

--- a/src/test/regress/expected/create_view_optimizer.out
+++ b/src/test/regress/expected/create_view_optimizer.out
@@ -1543,7 +1543,7 @@ explain (costs off) select * from tt18v;
    ->  Append
          ->  Seq Scan on int8_tbl
          ->  Seq Scan on int8_tbl int8_tbl_1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (5 rows)
 
 -- check display of ScalarArrayOp with a sub-select

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -458,7 +458,7 @@ EXPLAIN SELECT a.* FROM MPP_22019_a a INNER JOIN MPP_22019_b b ON a.i = b.i WHER
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on mpp_22019_a mpp_22019_a_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (18 rows)
 
 SELECT a.* FROM MPP_22019_a a INNER JOIN MPP_22019_b b ON a.i = b.i WHERE a.j NOT IN (SELECT j FROM MPP_22019_a a2 where a2.j = b.j) and a.i = 1;

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -83,7 +83,7 @@ explain select * from t, pt where tid = ptid;
                      Partitions selected: 6 (out of 6)
                ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
                      Index Cond: ptid = $0
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (11 rows)
 
 select * from t, pt where tid = ptid;
@@ -122,7 +122,7 @@ explain select * from t, pt where tid + 1 = ptid;
                      Partitions selected: 6 (out of 6)
                ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
                      Index Cond: ptid = ($0 + 1)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (11 rows)
 
 select * from t, pt where tid + 1 = ptid;
@@ -162,7 +162,7 @@ explain select * from t, pt where tid = ptid and t1 = 'hello' || tid;
                      Partitions selected: 6 (out of 6)
                ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..27.00 rows=3 width=31)
                      Index Cond: ptid = $0
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (12 rows)
 
 select * from t, pt where tid = ptid and t1 = 'hello' || tid;
@@ -202,7 +202,7 @@ explain select * from t, pt where t1 = pt1 and ptid = tid;
                ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=31)
                      Index Cond: pt1 = $1
                      Filter: ptid = $0
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (12 rows)
 
 select * from t, pt where t1 = pt1 and ptid = tid;
@@ -229,7 +229,7 @@ explain select * from pt where ptid in (select tid from t where t1 = 'hello' || 
                            ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=4)
                                  Filter: t1 = ('hello'::text || tid::text)
  Settings:  gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (12 rows)
 
 select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
@@ -271,7 +271,7 @@ explain select * from pt where exists (select 1 from t where tid = ptid and t1 =
                                        ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=4)
                                              Filter: t1 = ('hello'::text || tid::text)
  Settings:  gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (14 rows)
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
@@ -315,7 +315,7 @@ explain select count(*) from t, pt where tid = ptid;
                                  Partitions selected: 6 (out of 6)
                            ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=1)
                                  Index Cond: ptid = $0
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (13 rows)
 
 select count(*) from t, pt where tid = ptid;
@@ -345,7 +345,7 @@ explain select *, rank() over (order by ptid,pt1) from t, pt where tid = ptid;
                                  Partitions selected: 6 (out of 6)
                            ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
                                  Index Cond: ptid = $0
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (16 rows)
 
 select *, rank() over (order by ptid,pt1) from t, pt where tid = ptid;
@@ -399,7 +399,7 @@ explain select * from t, pt where tid = ptid
                            Partitions selected: 6 (out of 6)
                      ->  Dynamic Index Scan on pt pt_1 (dynamic scan id: 2)  (cost=0.00..12.00 rows=3 width=31)
                            Index Cond: ptid = ($1 + 2)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (21 rows)
 
 select * from t, pt where tid = ptid
@@ -477,7 +477,7 @@ explain select count(*) from
                                        Partitions selected: 6 (out of 6)
                                  ->  Dynamic Index Scan on pt pt_1 (dynamic scan id: 2)  (cost=0.00..12.00 rows=3 width=31)
                                        Index Cond: ptid = ($1 + 2)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (23 rows)
 
 select count(*) from
@@ -509,7 +509,7 @@ explain select * from t, pt where tid = ptid;
                      Partitions selected: 6 (out of 6)
                ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
                      Index Cond: ptid = $0
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (11 rows)
 
 select * from t, pt where tid = ptid;
@@ -560,7 +560,7 @@ explain select * from t, pt where tid = ptid and pt1 = 'hello0';
                                  Partitions selected: 6 (out of 6)
                            ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=31)
                                  Index Cond: pt1 = 'hello0'::text
- Optimizer: PQO version 2.73.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.73.0
 (15 rows)
 
 select * from t, pt where tid = ptid and pt1 = 'hello0';
@@ -589,7 +589,7 @@ explain select * from t, pt where tid = ptid;
                      Partitions selected: 6 (out of 6)
                ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31)
                      Index Cond: ptid = $0
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (11 rows)
 
 select * from t, pt where tid = ptid;
@@ -635,7 +635,7 @@ explain select * from t, pt where t1 = pt1;
                      Partitions selected: 6 (out of 6)
                ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=31)
                      Index Cond: pt1 = $0
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (11 rows)
 
 select * from t, pt where t1 = pt1;
@@ -658,7 +658,7 @@ explain select * from t, pt where tid < ptid;
                      Partitions selected: 6 (out of 6)
                ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..108.01 rows=6 width=31)
                      Index Cond: ptid > $0
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (11 rows)
 
 select * from t, pt where tid < ptid;
@@ -768,7 +768,7 @@ explain select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
    ->  Hash  (cost=431.00..431.00 rows=1 width=19)
          ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=19)
                ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=19)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (15 rows)
 
 select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
@@ -834,7 +834,7 @@ explain analyze select * from t, pt where tid = ptid;
    (slice2)    Executor memory: 155K bytes avg x 3 workers, 155K bytes max (seg0).
    (slice3)    
  Memory used:  128000kB
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
  Total runtime: 2.810 ms
 (17 rows)
 
@@ -862,7 +862,7 @@ explain select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' ord
                                        ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..3.00 rows=1 width=31)
                                              Index Cond: pt1 = 'hello0'::text
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (18 rows)
 
 select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt1.dist;
@@ -898,7 +898,7 @@ explain select count(*) from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hell
                                                    ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..3.00 rows=1 width=11)
                                                          Index Cond: pt1 = 'hello0'::text
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (18 rows)
 
 select count(*) from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0';
@@ -946,7 +946,7 @@ explain select * from t, pt where a = b;
                                  Partitions selected: 5 (out of 5)
                            ->  Dynamic Seq Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=2 width=8)
  Settings:  enable_bitmapscan=off; enable_hashjoin=off; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=on; enable_seqscan=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.26.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.26.0
 (15 rows)
 
 select * from t, pt where a = b;
@@ -997,7 +997,7 @@ explain select * from t, pt where a = b;
                      Filter: pt.b = t.a
                      ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=4)
  Settings:  enable_bitmapscan=off; enable_hashjoin=off; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=on; enable_seqscan=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.29.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.29.0
 (10 rows)
 
 select * from t, pt where a = b;
@@ -1075,7 +1075,7 @@ explain select * from dim1 inner join fact1 on (dim1.pid=fact1.pid and dim1.code
                                  Partitions selected: 12 (out of 12)
                            ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=20)
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=off; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (14 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid and dim1.code=fact1.code) order by fact1.u;
@@ -1150,7 +1150,7 @@ explain select * from dim1 inner join fact1 on (dim1.pid=fact1.pid and dim1.code
                                  Partitions selected: 12 (out of 12)
                            ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=20)
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (14 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid and dim1.code=fact1.code) order by fact1.u;
@@ -1228,7 +1228,7 @@ explain select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fac
                                  Partitions selected: 12 (out of 12)
                            ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=20)
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=off; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (14 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fact1.u;
@@ -1353,7 +1353,7 @@ explain select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fac
                                  Partitions selected: 12 (out of 12)
                            ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=20)
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (14 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fact1.u;
@@ -1483,7 +1483,7 @@ explain select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) and fact1.co
                            ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=20)
                                  Filter: code = 'OH'::text
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=off; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (16 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) and fact1.code = 'OH' order by fact1.u;
@@ -1560,7 +1560,7 @@ explain select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) and fact1.co
                            ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=20)
                                  Filter: code = 'OH'::text
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (16 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) and fact1.code = 'OH' order by fact1.u;
@@ -1647,7 +1647,7 @@ explain select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact
                                                          ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                                                ->  Seq Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=off; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (23 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
@@ -1683,7 +1683,7 @@ explain select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact
                                                          ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                                                ->  Seq Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (23 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
@@ -1820,7 +1820,7 @@ explain select * from apart as a, b, c where a.t = b.t and a.id = c.id;
                      Filter: c.id = c.id
                      ->  Seq Scan on c  (cost=0.00..431.00 rows=7 width=6)
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=off; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.13.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.13.0
 (15 rows)
 
 select * from apart as a, b, c where a.t = b.t and a.id = c.id;
@@ -1851,7 +1851,7 @@ explain select * from apart as a, b, c where a.t = b.t and a.id = c.id;
                      Filter: c.id = c.id
                      ->  Seq Scan on c  (cost=0.00..431.00 rows=7 width=6)
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.13.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.13.0
 (15 rows)
 
 select * from apart as a, b, c where a.t = b.t and a.id = c.id;
@@ -1905,7 +1905,7 @@ explain select * from (select count(*) over (order by a rows between 1 preceding
                            Partitions selected: 5 (out of 5)
                      ->  Dynamic Seq Scan on pat (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
  Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.5.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
 (17 rows)
 
 select * from (select count(*) over (order by a rows between 1 preceding and 1 following), a, b from jpat)jpat inner join pat using(b);

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -60,7 +60,7 @@ explain analyze select d, count(*) from smallt group by d;
    (slice1)    Executor memory: 110K bytes avg x 3 workers, 110K bytes max (seg0).  Work_mem: 33K bytes max.
    (slice2)    Executor memory: 138K bytes avg x 3 workers, 138K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
  Total runtime: 3.718 ms
 (19 rows)
 
@@ -86,7 +86,7 @@ explain analyze select count(*) from (select i, t, d, count(*) from bigt group b
    (slice1)  * Executor memory: 3180K bytes avg x 3 workers, 3180K bytes max (seg0).  Work_mem: 2461K bytes max, 4866K bytes wanted.
  Memory used:  2560kB
  Memory wanted:  5265kB
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
  Total runtime: 363.922 ms
 (14 rows)
 
@@ -122,7 +122,7 @@ explain analyze select count(distinct d) from smallt;
    (slice1)    Executor memory: 110K bytes avg x 3 workers, 110K bytes max (seg0).  Work_mem: 33K bytes max.
    (slice2)    Executor memory: 82K bytes avg x 3 workers, 82K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
  Total runtime: 3.325 ms
 (21 rows)
 
@@ -151,7 +151,7 @@ explain analyze select count(distinct d) from bigt;
    (slice1)    Executor memory: 1171K bytes avg x 3 workers, 1171K bytes max (seg0).
    (slice2)    Executor memory: 1006K bytes avg x 3 workers, 1006K bytes max (seg0).
  Memory used:  2560kB
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
  Total runtime: 397.691 ms
 (17 rows)
 
@@ -232,7 +232,7 @@ where t1.d = t2.d;
    (slice2)    Executor memory: 166K bytes avg x 3 workers, 166K bytes max (seg0).
    (slice3)    Executor memory: 1226K bytes avg x 3 workers, 1226K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 7.014 ms
 (38 rows)
 
@@ -287,7 +287,7 @@ where t1.i = t2.i;
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 1238K bytes avg x 3 workers, 1238K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 2.471 ms
 (23 rows)
 
@@ -325,7 +325,7 @@ explain analyze select d, count(*) from smallt group by d limit 5;
    (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).  Work_mem: 65K bytes max.
    (slice2)    Executor memory: 170K bytes avg x 3 workers, 170K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
  Total runtime: 4.148 ms
 (20 rows)
 
@@ -1349,7 +1349,7 @@ explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i;
    (slice0)    Executor memory: 322K bytes.
    (slice1)    Executor memory: 4198K bytes avg x 3 workers, 4206K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 4.129 ms
 (13 rows)
 
@@ -1430,7 +1430,7 @@ where i < (select count(*) from smallt where smallt.i = smallt2.i);
                                  ->  Sort  (cost=0.00..431.00 rows=34 width=4)
                                        Sort Key: smallt.i
                                        ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4)
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
 (14 rows)
 
 -- Sort in MergeJoin
@@ -1660,7 +1660,7 @@ explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i an
    (slice0)    Executor memory: 322K bytes.
    (slice1)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 3.631 ms
 (15 rows)
 
@@ -1791,7 +1791,7 @@ explain analyze select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d an
    (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
    (slice3)    Executor memory: 4186K bytes avg x 3 workers, 4186K bytes max (seg0).  Work_mem: 2K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 5.688 ms
 (20 rows)
 
@@ -1857,7 +1857,7 @@ and smallt.d = '2011-01-04'::date;
    (slice0)    Executor memory: 450K bytes.
    (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
  Total runtime: 3.325 ms
 (14 rows)
 
@@ -1928,7 +1928,7 @@ and smallt.d = '2011-01-04'::date;
    (slice0)    Executor memory: 450K bytes.
    (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
  Total runtime: 5.131 ms
 (14 rows)
 

--- a/src/test/regress/expected/equivclass_optimizer.out
+++ b/src/test/regress/expected/equivclass_optimizer.out
@@ -110,7 +110,7 @@ explain (costs off)
    ->  Index Scan using ec0_pkey on ec0
          Index Cond: (ff = 42::bigint)
          Filter: ((f1 = 42::bigint) AND (ff = f1))
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (5 rows)
 
 explain (costs off)
@@ -131,7 +131,7 @@ explain (costs off)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on ec1
          Filter: ((ff = f1) AND (f1 = '42'::int8alias1))
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (4 rows)
 
 explain (costs off)
@@ -141,7 +141,7 @@ explain (costs off)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on ec1
          Filter: ((ff = f1) AND (f1 = '42'::int8alias2))
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (4 rows)
 
 explain (costs off)
@@ -156,7 +156,7 @@ explain (costs off)
                ->  Seq Scan on ec2
          ->  Index Scan using ec1_pkey on ec1
                Index Cond: ((ff = ec2.x1) AND (ff = 42::bigint))
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (9 rows)
 
 explain (costs off)
@@ -186,7 +186,7 @@ explain (costs off)
                      Filter: (42::bigint = x1)
          ->  Index Scan using ec1_pkey on ec1
                Index Cond: (ff = ec2.x1)
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (9 rows)
 
 explain (costs off)
@@ -201,7 +201,7 @@ explain (costs off)
                      Filter: (x1 = '42'::int8alias1)
          ->  Index Scan using ec1_pkey on ec1
                Index Cond: (ff = ec2.x1)
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (9 rows)
 
 explain (costs off)
@@ -216,7 +216,7 @@ explain (costs off)
                      Filter: (x1 = '42'::int8alias2)
          ->  Index Scan using ec1_pkey on ec1
                Index Cond: (ff = ec2.x1)
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (9 rows)
 
 create index ec1_expr1 on ec1((ff + 1));
@@ -250,7 +250,7 @@ explain (costs off)
                                              ->  Seq Scan on ec1 ec1_1
                            ->  Result
                                  ->  Seq Scan on ec1 ec1_2
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (17 rows)
 
 explain (costs off)
@@ -281,7 +281,7 @@ explain (costs off)
                                              ->  Seq Scan on ec1 ec1_1
                            ->  Result
                                  ->  Seq Scan on ec1 ec1_2
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (18 rows)
 
 explain (costs off)
@@ -331,7 +331,7 @@ explain (costs off)
                                              ->  Seq Scan on ec1 ec1_5
                            ->  Result
                                  ->  Seq Scan on ec1 ec1_6
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (31 rows)
 
 -- let's try that as a mergejoin
@@ -384,7 +384,7 @@ explain (costs off)
                                              ->  Seq Scan on ec1 ec1_5
                            ->  Result
                                  ->  Seq Scan on ec1 ec1_6
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (31 rows)
 
 -- check partially indexed scan
@@ -418,7 +418,7 @@ explain (costs off)
                                              ->  Seq Scan on ec1 ec1_1
                            ->  Result
                                  ->  Seq Scan on ec1 ec1_2
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (17 rows)
 
 -- let's try that as a mergejoin
@@ -451,6 +451,6 @@ explain (costs off)
                                              ->  Seq Scan on ec1 ec1_1
                            ->  Result
                                  ->  Seq Scan on ec1 ec1_2
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (17 rows)
 

--- a/src/test/regress/expected/errors.out
+++ b/src/test/regress/expected/errors.out
@@ -459,8 +459,8 @@ create function infinite_recurse() returns int as
 -- # mpp-2756
 -- m/(ERROR|WARNING|CONTEXT|NOTICE):.*stack depth limit exceeded\s+at\s+character/
 -- s/\s+at\s+character.*//
--- m/ERROR:.*GPDB exception. Aborting PQO.*/
--- s/ERROR:.*GPDB exception. Aborting PQO.*//
+-- m/ERROR:.*GPDB exception. Aborting Pivotal Optimizer \(GPORCA\).*/
+-- s/ERROR:.*GPDB exception. Aborting Pivotal Optimizer \(GPORCA\).*//
 -- end_matchsubs
 -- start_ignore
 select infinite_recurse();

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -98,8 +98,8 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Execution Time: \d+\.\d+/Execution Time: ##.###/
 -- m/Segments: \d+/
 -- s/Segments: \d+/Segments: #/
--- m/PQO version \d+\.\d+\.\d+",?/
--- s/PQO version \d+\.\d+\.\d+",?/PQO version ##.##.##"/
+-- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
+-- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\) version ##.##.##"/
 -- m/ Memory: \d+/
 -- s/ Memory: \d+/ Memory: ###/
 -- m/Maximum Memory Used: \d+/
@@ -428,8 +428,8 @@ QUERY PLAN
 -- Check JSON format
 --
 -- start_matchsubs
--- m/PQO version \d+\.\d+\.\d+/
--- s/PQO version \d+\.\d+\.\d+/PQO version ##.##.##/
+-- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/
+-- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/Pivotal Optimizer \(GPORCA\) version ##.##.##/
 -- end_matchsubs
 -- explain_processing_off
 EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -43,7 +43,7 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
                            Index Cond: (id = boxes.apple_id)
          ->  Index Scan using box_locations_pkey on box_locations  (cost=0.00..12.00 rows=1 width=12)
                Index Cond: (id = boxes.location_id)
- Optimizer: PQO version 3.23.1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.1
 (15 rows)
 
 -- explain_processing_on
@@ -74,7 +74,7 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
    (slice4)    
    (slice5)    
  Memory used:  128000kB
- Optimizer: PQO version 3.23.1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.1
  Execution time: 23.433 ms
 (24 rows)
 
@@ -100,8 +100,8 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Execution Time: \d+\.\d+/Execution Time: ##.###/
 -- m/Segments: \d+/
 -- s/Segments: \d+/Segments: #/
--- m/PQO version \d+\.\d+\.\d+",?/
--- s/PQO version \d+\.\d+\.\d+",?/PQO version ##.##.##"/
+-- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
+-- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\) version ##.##.##"/
 -- m/ Memory: \d+/
 -- s/ Memory: \d+/ Memory: ###/
 -- m/Maximum Memory Used: \d+/
@@ -220,7 +220,7 @@ QUERY PLAN
             Plan Width: 12
             Index Cond: "(id = boxes.location_id)"
   Settings: 
-    Optimizer: "PQO version 3.23.1"
+    Optimizer: "Pivotal Optimizer (GPORCA) version 3.23.1"
 (1 row)
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
@@ -388,7 +388,7 @@ QUERY PLAN
   Statement statistics: 
     Memory used: 128000
   Settings: 
-    Optimizer: "PQO version 3.23.1"
+    Optimizer: "Pivotal Optimizer (GPORCA) version 3.23.1"
   Execution Time: 3.332
 (1 row)
 -- explain_processing_on
@@ -400,8 +400,8 @@ QUERY PLAN
 -- Check JSON format
 --
 -- start_matchsubs
--- m/PQO version \d+\.\d+\.\d+/
--- s/PQO version \d+\.\d+\.\d+/PQO version ##.##.##/
+-- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/
+-- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/Pivotal Optimizer \(GPORCA\) version ##.##.##/
 -- end_matchsubs
 -- explain_processing_off
 EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
@@ -414,7 +414,7 @@ QUERY PLAN
       "Alias": "generate_series"
     },
     "Settings": {
-      "Optimizer": "PQO version 3.23.1"
+      "Optimizer": "Pivotal Optimizer (GPORCA) version 3.23.1"
     }
   }
 ]
@@ -429,7 +429,7 @@ QUERY PLAN
       <Alias>generate_series</Alias>
     </Plan>
     <Settings>
-      <Optimizer>PQO version 3.23.1</Optimizer>
+      <Optimizer>Pivotal Optimizer (GPORCA) version 3.23.1</Optimizer>
     </Settings>
   </Query>
 </explain>

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -322,7 +322,7 @@ explain select * from srf_testtab, test_srf();
          ->  Seq Scan on srf_testtab  (cost=0.00..431.00 rows=1 width=6)
          ->  Function Scan on test_srf  (cost=0.00..0.01 rows=334 width=8)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.45.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.45.0
 (7 rows)
 
 explain select * from srf_testtab, test_srf() where test_srf = srf_testtab.t;
@@ -336,7 +336,7 @@ explain select * from srf_testtab, test_srf() where test_srf = srf_testtab.t;
          ->  Hash  (cost=431.00..431.00 rows=1 width=6)
                ->  Seq Scan on srf_testtab  (cost=0.00..431.00 rows=1 width=6)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.45.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.45.0
 (9 rows)
 
 -- Test ALTER FUNCTION, and that \df displays the EXECUTE ON correctly

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -31,7 +31,7 @@ explain (costs off) select count(distinct d) from dqa_t1;
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
                ->  Seq Scan on dqa_t1
- Optimizer: PQO version 3.11.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.11.0
 (5 rows)
 
 select count(distinct d) from dqa_t1 group by i;
@@ -66,7 +66,7 @@ explain (costs off) select count(distinct d) from dqa_t1 group by i;
                                  ->  Sort
                                        Sort Key: i, d
                                        ->  Seq Scan on dqa_t1
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (13 rows)
 
 select count(distinct d), count(distinct dt) from dqa_t1;
@@ -253,7 +253,7 @@ explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dq
                      ->  Seq Scan on dqa_t1
                      ->  Hash
                            ->  Seq Scan on dqa_t2
- Optimizer: PQO version 3.11.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.11.0
 (9 rows)
 
 select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d group by dqa_t2.dt;
@@ -336,7 +336,7 @@ explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dq
                                              ->  Seq Scan on dqa_t2
                                              ->  Hash
                                                    ->  Seq Scan on dqa_t1
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (17 rows)
 
 -- Distinct keys are not distribution keys
@@ -362,7 +362,7 @@ explain (costs off) select count(distinct c) from dqa_t1;
                                  ->  Sort
                                        Sort Key: c
                                        ->  Seq Scan on dqa_t1
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (14 rows)
 
 select count(distinct c) from dqa_t1 group by dt;
@@ -421,7 +421,7 @@ explain (costs off) select count(distinct c) from dqa_t1 group by dt;
                                        ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                              Hash Key: c
                                              ->  Seq Scan on dqa_t1
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (15 rows)
 
 select count(distinct c) from dqa_t1 group by d;
@@ -469,7 +469,7 @@ explain (costs off) select count(distinct c) from dqa_t1 group by d;
                                        ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                              Hash Key: c
                                              ->  Seq Scan on dqa_t1
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (15 rows)
 
 select count(distinct c), count(distinct dt) from dqa_t1;
@@ -634,7 +634,7 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                                              ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                                    Hash Key: dqa_t2.c
                                                    ->  Seq Scan on dqa_t2
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (20 rows)
 
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
@@ -723,7 +723,7 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                                                          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                                                Hash Key: dqa_t2.c
                                                                ->  Seq Scan on dqa_t2
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (23 rows)
 
 -- MPP-19037

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -154,7 +154,7 @@ explain (costs off) select count(*) over (partition by g) from generate_series(1
 -- The default init_file rules contain a line to mask this out in normal
 -- text-format EXPLAIN output, but it doesn't catch these alternative formats.
 -- start_matchignore
--- m/Optimizer.*PQO version .*/
+-- m/Optimizer.*Pivotal Optimizer \(GPORCA\) version .*/
 -- end_matchignore
 CREATE EXTERNAL WEB TABLE dummy_ext_tab (x text) EXECUTE 'echo foo' FORMAT 'text';
 -- External Table Scan

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -40,7 +40,7 @@ EXPLAIN ANALYZE SELECT * FROM explaintest;
    (slice0)    Executor memory: 290K bytes.
    (slice1)    Executor memory: 135K bytes avg x 3 workers, 135K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
  Total runtime: 0.710 ms
 (7 rows)
 
@@ -94,7 +94,7 @@ WHERE mpp22263.unique1 = v.i and mpp22263.stringu1 = v.j;
          ->  Index Scan using mpp22263_idx1 on mpp22263  (cost=0.00..2.00 rows=1 width=244)
                Index Cond: unique1 = "Values".column1
                Filter: stringu1::text = "Values".column2
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
 -- atmsort.pm masks out differences in the Filter line, so just memorizing
@@ -151,7 +151,7 @@ explain (costs off) select count(*) over (partition by g) from generate_series(1
          ->  Sort
                Sort Key: generate_series
                ->  Function Scan on generate_series
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (7 rows)
 
 --
@@ -160,38 +160,38 @@ explain (costs off) select count(*) over (partition by g) from generate_series(1
 -- The default init_file rules contain a line to mask this out in normal
 -- text-format EXPLAIN output, but it doesn't catch these alternative formats.
 -- start_matchignore
--- m/Optimizer.*PQO version .*/
+-- m/Optimizer.*Pivotal Optimizer \(GPORCA\) version .*/
 -- end_matchignore
 CREATE EXTERNAL WEB TABLE dummy_ext_tab (x text) EXECUTE 'echo foo' FORMAT 'text';
 -- External Table Scan
 explain (format json, costs off) SELECT * FROM dummy_ext_tab;
                  QUERY PLAN                  
 ---------------------------------------------
- [                                          +
-   {                                        +
-     "Plan": {                              +
-       "Node Type": "Gather Motion",        +
-       "Senders": 3,                        +
-       "Receivers": 1,                      +
-       "Slice": 1,                          +
-       "Segments": 3,                       +
-       "Gang Type": "primary reader",       +
-       "Plans": [                           +
-         {                                  +
-           "Node Type": "External Scan",    +
-           "Parent Relationship": "Outer",  +
-           "Slice": 1,                      +
-           "Segments": 3,                   +
-           "Gang Type": "primary reader",   +
-           "Relation Name": "dummy_ext_tab",+
-           "Alias": "dummy_ext_tab"         +
-         }                                  +
-       ]                                    +
-     },                                     +
-     "Settings": {                          +
-       "Optimizer": "PQO version 2.70.0"    +
-     }                                      +
-   }                                        +
+ [                                                             +
+   {                                                           +
+     "Plan": {                                                 +
+       "Node Type": "Gather Motion",                           +
+       "Senders": 3,                                           +
+       "Receivers": 1,                                         +
+       "Slice": 1,                                             +
+       "Segments": 3,                                          +
+       "Gang Type": "primary reader",                          +
+       "Plans": [                                              +
+         {                                                     +
+           "Node Type": "External Scan",                       +
+           "Parent Relationship": "Outer",                     +
+           "Slice": 1,                                         +
+           "Segments": 3,                                      +
+           "Gang Type": "primary reader",                      +
+           "Relation Name": "dummy_ext_tab",                   +
+           "Alias": "dummy_ext_tab"                            +
+         }                                                     +
+       ]                                                       +
+     },                                                        +
+     "Settings": {                                             +
+       "Optimizer": "Pivotal Optimizer (GPORCA) version 2.70.0"+
+     }                                                         +
+   }                                                           +
  ]
 (1 row)
 
@@ -202,23 +202,23 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 explain (format yaml, costs off) SELECT * FROM dummy_aotab;
               QUERY PLAN              
 --------------------------------------
- - Plan:                             +
-     Node Type: "Gather Motion"      +
-     Senders: 3                      +
-     Receivers: 1                    +
-     Slice: 1                        +
-     Segments: 3                     +
-     Gang Type: "primary reader"     +
-     Plans:                          +
-       - Node Type: "Seq Scan"       +
-         Parent Relationship: "Outer"+
-         Slice: 1                    +
-         Segments: 3                 +
-         Gang Type: "primary reader" +
-         Relation Name: "dummy_aotab"+
-         Alias: "dummy_aotab"        +
-   Settings:                         +
-     Optimizer: "PQO version 2.70.0"
+ - Plan:                                                   +
+     Node Type: "Gather Motion"                            +
+     Senders: 3                                            +
+     Receivers: 1                                          +
+     Slice: 1                                              +
+     Segments: 3                                           +
+     Gang Type: "primary reader"                           +
+     Plans:                                                +
+       - Node Type: "Seq Scan"                             +
+         Parent Relationship: "Outer"                      +
+         Slice: 1                                          +
+         Segments: 3                                       +
+         Gang Type: "primary reader"                       +
+         Relation Name: "dummy_aotab"                      +
+         Alias: "dummy_aotab"                              +
+   Settings:                                               +
+     Optimizer: "Pivotal Optimizer (GPORCA) version 2.70.0"
 (1 row)
 
 -- DML node (with ORCA)
@@ -271,7 +271,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
        </Plans>                                                        +
      </Plan>                                                           +
      <Settings>                                                        +
-       <Optimizer>PQO version 2.70.0</Optimizer>                       +
+       <Optimizer>Pivotal Optimizer (GPORCA) version 2.70.0</Optimizer>                       +
      </Settings>                                                       +
    </Query>                                                            +
  </explain>
@@ -319,7 +319,7 @@ explain analyze SELECT * FROM explaintest;
    (slice0)    Executor memory: 290K bytes.
    (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: PQO version 3.2.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.2.0
  Total runtime: 1.577 ms
 (8 rows)
 

--- a/src/test/regress/expected/gpdiffcheck_optimizer.out
+++ b/src/test/regress/expected/gpdiffcheck_optimizer.out
@@ -162,7 +162,7 @@ explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c
    (slice2)    Executor memory: 126K bytes avg x 3 workers, 126K bytes max (seg0).
    (slice3)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 19.681 ms
 (24 rows)
 
@@ -183,7 +183,7 @@ explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from 
                ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                      ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                            ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (15 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
@@ -228,7 +228,7 @@ explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from 
                      ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=14 width=12)
                            ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=12)
                      ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=2)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (16 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
@@ -278,7 +278,7 @@ explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c
    (slice3)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
    (slice4)    Executor memory: 4198K bytes avg x 3 workers, 4198K bytes max (seg0).  Work_mem: 2K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 6.345 ms
 (25 rows)
 

--- a/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
@@ -132,7 +132,7 @@ explain (costs off) select * from legacy_int a inner join legacy_int b on a.id =
          ->  Seq Scan on legacy_int
          ->  Hash
                ->  Seq Scan on legacy_int legacy_int_1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (7 rows)
 
 select * from legacy_int a inner join legacy_int b on a.id = b.id;
@@ -176,7 +176,7 @@ explain (costs off) select * from modern_int a inner join modern_int b on a.id =
          ->  Seq Scan on modern_int
          ->  Hash
                ->  Seq Scan on modern_int modern_int_1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (7 rows)
 
 select * from modern_int a inner join modern_int b on a.id = b.id;
@@ -224,7 +224,7 @@ explain (costs off) select * from legacy_domain_over_int a inner join legacy_dom
          ->  Seq Scan on legacy_domain_over_int
          ->  Hash
                ->  Seq Scan on legacy_domain_over_int legacy_domain_over_int_1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (7 rows)
 
 explain (costs off) select * from legacy_int a inner join legacy_domain_over_int b on a.id = b.id;
@@ -236,7 +236,7 @@ explain (costs off) select * from legacy_int a inner join legacy_domain_over_int
          ->  Seq Scan on legacy_int
          ->  Hash
                ->  Seq Scan on legacy_domain_over_int
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (7 rows)
 
 explain (costs off) select * from modern_int a inner join legacy_domain_over_int b on a.id = b.id;
@@ -265,7 +265,7 @@ explain (costs off) select * from legacy_enum a inner join legacy_enum b on a.co
          ->  Seq Scan on legacy_enum
          ->  Hash
                ->  Seq Scan on legacy_enum legacy_enum_1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (7 rows)
 
 select * from legacy_enum a inner join legacy_enum b on a.color = b.color;

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -654,7 +654,7 @@ explain (costs off) select even.i from even left outer join odd on (even.i = odd
                      ->  Seq Scan on even
                      ->  Hash
                            ->  Seq Scan on odd
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (11 rows)
 
 -- But this does.
@@ -677,7 +677,7 @@ explain (costs off) select even.i from even right outer join odd on (even.i = od
                                        ->  Seq Scan on odd
                                        ->  Hash
                                              ->  Seq Scan on even
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (17 rows)
 
 -- Check that we can track the distribution through multiple FULL OUTER JOINs.

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -2414,7 +2414,7 @@ from orca.bar1 inner join orca.bar2 on (bar1.x2 = bar2.x2) order by bar1.x1;
                                    ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
                                          ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=4)
  Settings:  optimizer_segments=3
- Optimizer status: PQO version 3.9.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 3.9.0
 (23 rows)
 
 select case when bar1.x2 = bar2.x2 then coalesce((select 1 from orca.foo where bar1.x2 = bar2.x2 and bar1.x2 = random() and foo.x2 = bar2.x2),0) else 1 end as col1, bar1.x1
@@ -3493,7 +3493,7 @@ explain  select * from orca.r, orca.s where r.a is not distinct from s.c;
          ->  Seq Scan on s  (cost=0.00..431.00 rows=10 width=8)
          ->  Hash  (cost=431.00..431.00 rows=7 width=8)
                ->  Seq Scan on r  (cost=0.00..431.00 rows=7 width=8)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (7 rows)
 
 -- explain Hash Join with equality join condition
@@ -3507,7 +3507,7 @@ explain select * from orca.r, orca.s where r.a = s.c;
          ->  Seq Scan on s  (cost=0.00..431.00 rows=10 width=8)
          ->  Index Scan using r_a on r  (cost=0.00..60.00 rows=1 width=8)
                Index Cond: a = s.c
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (7 rows)
 
 -- sort
@@ -8187,7 +8187,7 @@ explain select * from orca.t order by 1,2;
                Sort Key: timest, user_id
                ->  Dynamic Seq Scan on t (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=32)
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.630
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.630
 (10 rows)
 
 select tag2, tag1 from orca.t order by 1, 2;;
@@ -8277,7 +8277,7 @@ explain select * from orca.t_date where user_id=9;
                            Index Cond: user_id = 9::numeric
                      ->  Dynamic Seq Scan on t_date t_date_1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=50)
                            Filter: user_id = 9::numeric
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (11 rows)
 
 select * from orca.t_date where user_id=9;
@@ -8331,7 +8331,7 @@ explain select * from orca.t_text where user_id=9;
                            Index Cond: user_id = 9::numeric
                      ->  Dynamic Seq Scan on t_text t_text_1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=50)
                            Filter: user_id = 9::numeric
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (11 rows)
 
 select * from orca.t_text where user_id=9;
@@ -8391,7 +8391,7 @@ explain select * from orca.t_employee where user_id = 2;
          ->  Dynamic Index Scan on t_employee (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=28)
                Index Cond: user_id = 2::numeric
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.602
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.602
 (8 rows)
 
 select * from orca.t_employee where user_id = 2;
@@ -8440,7 +8440,7 @@ explain select * from orca.t_ceeval_ints where user_id=4;
                            Index Cond: user_id = 4::numeric
                      ->  Dynamic Seq Scan on t_ceeval_ints t_ceeval_ints_1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=51)
                            Filter: user_id = 4::numeric
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (11 rows)
 
 select * from orca.t_ceeval_ints where user_id=4;
@@ -9580,7 +9580,7 @@ where c.cid = s.cid and s.date_sk = d.date_sk and
                                  ->  Seq Scan on datedim  (cost=0.00..431.00 rows=1 width=12)
                                        Filter: year = 2001 OR moy = 4
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.602
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.602
 (19 rows)
 
 reset optimizer_segments;
@@ -9603,7 +9603,7 @@ explain select * from orca.bm_test where i=2 and t='2';
          ->  Bitmap Index Scan on bm_test_idx  (cost=0.00..0.00 rows=0 width=0)
                Index Cond: i = 2
  Settings:  optimizer=on
- Optimizer status: PQO version 1.602
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.602
 (8 rows)
 
 select * from orca.bm_test where i=2 and t='2';
@@ -9661,7 +9661,7 @@ explain select * from orca.bm_dyn_test where i=2 and t='2';
                ->  Dynamic Bitmap Index Scan on bm_dyn_test_1_prt_part0_i_idx  (cost=0.00..0.00 rows=0 width=0)
                      Index Cond: (i = 2)
  Planning time: 26.274 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (11 rows)
 
 select * from orca.bm_dyn_test where i=2 and t='2';
@@ -10120,7 +10120,7 @@ ORDER BY 1 asc ;
                                                                ->  Dynamic Index Scan on my_tq_agg_opt_part my_tq_agg_opt_part_1 (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=70)
                                                                      Index Cond: ets <= share0_ref3.event_ts
                                                                      Filter: sym::bpchar = share0_ref3.symbol AND bid_price::numeric < share0_ref3.trade_price AND share0_ref3.event_ts < end_ts
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (34 rows)
 
 reset optimizer_segments;
@@ -10202,7 +10202,7 @@ where ordernum between 10 and 20;
                      Hash Key: idxscan_inner.productid
                      ->  Index Scan using idxscan_inner_ordernum_key on idxscan_inner  (cost=0.00..6.00 rows=1 width=9)
                            Index Cond: ((ordernum >= 10) AND (ordernum <= 20))
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (10 rows)
 
 select id, comment from idxscan_outer as o join idxscan_inner as i on o.id = i.productid
@@ -10255,7 +10255,7 @@ explain select * from orca.index_test where a = 5;
    ->  Index Scan using index_test_pkey on index_test  (cost=0.00..2.00 rows=1 width=20)
          Index Cond: a = 5
  Settings:  optimizer=on
- Optimizer status: PQO version 1.602
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.602
 (5 rows)
 
 -- force_explain
@@ -10266,7 +10266,7 @@ explain select * from orca.index_test where c = 5;
    ->  Index Scan using index_test_pkey on index_test  (cost=0.00..2.00 rows=1 width=20)
          Index Cond: c = 5
  Settings:  optimizer=on
- Optimizer status: PQO version 1.602
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.602
 (5 rows)
 
 -- force_explain
@@ -10277,7 +10277,7 @@ explain select * from orca.index_test where a = 5 and c = 5;
    ->  Index Scan using index_test_pkey on index_test  (cost=0.00..2.00 rows=1 width=20)
          Index Cond: a = 5 AND c = 5
  Settings:  optimizer=on
- Optimizer status: PQO version 1.602
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.602
 (5 rows)
 
 -- renaming columns
@@ -10422,7 +10422,7 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in (1);
          ->  Bitmap Index Scan on bitmap_index  (cost=0.00..0.00 rows=0 width=0)
                Index Cond: a = 1
  Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
- Optimizer status: PQO version 2.48.9
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.9
 (7 rows)
 
 EXPLAIN SELECT * FROM bitmap_test WHERE a in (1, 47);
@@ -10434,7 +10434,7 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in (1, 47);
          ->  Bitmap Index Scan on bitmap_index  (cost=0.00..0.00 rows=0 width=0)
                Index Cond: a = ANY ('{1,47}'::integer[])
  Settings:  optimizer=on; optimizer_metadata_caching=on
- Optimizer status: PQO version 1.647
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.647
 (7 rows)
 
 EXPLAIN SELECT * FROM bitmap_test WHERE a in ('2', 47);
@@ -10446,7 +10446,7 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in ('2', 47);
          ->  Bitmap Index Scan on bitmap_index  (cost=0.00..0.00 rows=0 width=0)
                Index Cond: a = ANY ('{2,47}'::integer[])
  Settings:  optimizer=on; optimizer_metadata_caching=on
- Optimizer status: PQO version 1.647
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.647
 (7 rows)
 
 EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2');
@@ -10458,7 +10458,7 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2');
          ->  Bitmap Index Scan on bitmap_index  (cost=0.00..0.00 rows=0 width=0)
                Index Cond: a = ANY ('{1,2}'::integer[])
  Settings:  optimizer=on; optimizer_metadata_caching=on
- Optimizer status: PQO version 1.647
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.647
 (7 rows)
 
 EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2', 47);
@@ -10468,7 +10468,7 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2', 47);
    ->  Seq Scan on bitmap_test  (cost=0.00..431.00 rows=2 width=4)
          Filter: a = ANY ('{1,2,47}'::integer[])
  Settings:  optimizer=on; optimizer_metadata_caching=on
- Optimizer status: PQO version 1.647
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.647
 (5 rows)
 
 -- Test Logging for unsupported features in ORCA
@@ -10647,7 +10647,7 @@ explain select * from foo where b in ('1', '2');
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=12)
          Filter: b::text = ANY ('{1,2}'::text[])
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (4 rows)
 
 set optimizer_enable_ctas = off;
@@ -10696,7 +10696,7 @@ explain (costs off) select count(*), t2.c from input_tab1 t1 left join input_tab
                                              ->  Seq Scan on input_tab1
                                              ->  Hash
                                                    ->  Seq Scan on input_tab2
- Optimizer: PQO version 2.70.1
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.1
 (18 rows)
 
 select count(*), t2.c from input_tab1 t1 left join input_tab2 t2 on t1.a = t2.c group by t2.c;
@@ -10753,7 +10753,7 @@ FROM   (SELECT *
                                              ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
                      ->  Result  (cost=0.00..431.00 rows=1 width=16)
                            ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 2.70.2
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.2
 (17 rows)
 
 SELECT Count(*)
@@ -10973,7 +10973,7 @@ EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 TH
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                    ->  Seq Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
- Optimizer status: PQO version 2.51.3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.51.3
 (11 rows)
 
 SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
@@ -10999,7 +10999,7 @@ EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 TH
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                    ->  Seq Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
- Optimizer status: PQO version 2.51.3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.51.3
 (11 rows)
 
 SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
@@ -11023,7 +11023,7 @@ EXPLAIN SELECT a FROM ggg WHERE a NOT IN (NULL, '');
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=2)
    ->  Seq Scan on ggg  (cost=0.00..431.00 rows=1 width=2)
          Filter: a <> ALL ('{NULL,""}'::bpchar[])
- Optimizer: PQO version 2.54.5
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.54.5
 (4 rows)
 
 EXPLAIN SELECT a FROM ggg WHERE a IN (NULL, 'x');
@@ -11033,7 +11033,7 @@ EXPLAIN SELECT a FROM ggg WHERE a IN (NULL, 'x');
    ->  Seq Scan on ggg  (cost=0.00..431.00 rows=1 width=2)
          Filter: (a = ANY ('{NULL,x}'::bpchar[]))
  Planning time: 4.708 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (5 rows)
 
 -- result node with one time filter and filter
@@ -11095,7 +11095,7 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                                    ->  Result  (cost=0.00..431.00 rows=4 width=4)
                                          ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=4 width=4)
  Planning time: 65.338 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (46 rows)
 
 WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;

--- a/src/test/regress/expected/indexjoin_optimizer.out
+++ b/src/test/regress/expected/indexjoin_optimizer.out
@@ -50,7 +50,7 @@ ORDER BY 1 asc ;
                                              ->  Hash  (cost=431.01..431.01 rows=140 width=25)
                                                    ->  Seq Scan on my_tt_agg_small  (cost=0.00..431.01 rows=140 width=25)
  Settings:  optimizer=on; optimizer_nestloop_factor=1
- Optimizer status: PQO version 2.32.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.32.0
 (22 rows)
 
   
@@ -114,7 +114,7 @@ ORDER BY 1 asc ;
                                                    ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=676 width=20)
                                                          Hash Key: (my_tq_agg_small.sym)::bpchar
                                                          ->  Seq Scan on my_tq_agg_small  (cost=0.00..431.03 rows=676 width=20)
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (20 rows)
 
 reset optimizer_segments;

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1559,7 +1559,7 @@ ORDER BY thousand, tenthous;
          ->  Append
                ->  Seq Scan on tenk1
                ->  Seq Scan on tenk1 tenk1_1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (8 rows)
 
 explain (costs off)
@@ -1578,7 +1578,7 @@ ORDER BY thousand, tenthous;
                      ->  Seq Scan on tenk1
                ->  Result
                      ->  Seq Scan on tenk1 tenk1_1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 explain (costs off)
@@ -1596,7 +1596,7 @@ ORDER BY thousand, tenthous;
                ->  Seq Scan on tenk1
                ->  Result
                      ->  Seq Scan on tenk1 tenk1_1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (9 rows)
 
 -- Check min/max aggregate optimization
@@ -1615,7 +1615,7 @@ SELECT min(x) FROM
                ->  Append
                      ->  Seq Scan on tenk1
                      ->  Seq Scan on tenk1 tenk1_1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (7 rows)
 
 explain (costs off)
@@ -1632,7 +1632,7 @@ SELECT min(y) FROM
                      ->  Result
                            ->  Seq Scan on tenk1
                      ->  Seq Scan on tenk1 tenk1_1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (8 rows)
 
 -- XXX planner doesn't recognize that index on unique2 is sufficiently sorted
@@ -1651,7 +1651,7 @@ ORDER BY x, y;
          ->  Append
                ->  Seq Scan on tenk1
                ->  Seq Scan on tenk1 tenk1_1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (8 rows)
 
 -- exercise rescan code path via a repeatedly-evaluated subquery

--- a/src/test/regress/expected/interval_optimizer.out
+++ b/src/test/regress/expected/interval_optimizer.out
@@ -261,7 +261,7 @@ SELECT f1 FROM INTERVAL_TBL_OF r1 ORDER BY f1;
    ->  Sort
          Sort Key: f1
          ->  Seq Scan on interval_tbl_of
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (6 rows)
 
 SELECT f1 FROM INTERVAL_TBL_OF r1 ORDER BY f1;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -23,7 +23,7 @@ explain select * from nhtest a join nhtest b using (i);
          ->  Seq Scan on nhtest  (cost=0.00..431.00 rows=1 width=9)
          ->  Hash  (cost=431.00..431.00 rows=1 width=9)
                ->  Seq Scan on nhtest nhtest_1  (cost=0.00..431.00 rows=1 width=9)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (7 rows)
 
 select * from nhtest a join nhtest b using (i);
@@ -119,7 +119,7 @@ explain select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
                            ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
                                  Filter: x = 100
  Settings:  optimizer=on
- Optimizer status: PQO version 2.39.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.39.2
 (14 rows)
 
 select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
@@ -142,7 +142,7 @@ explain select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
                      Filter: x = 100
          ->  Seq Scan on t2  (cost=0.00..431.00 rows=34 width=12)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.39.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.39.2
 (9 rows)
 
 select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
@@ -172,7 +172,7 @@ explain select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=12)
                            Filter: y = 100
  Settings:  optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.39.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.39.2
 (15 rows)
 
 reset optimizer_segments;
@@ -330,7 +330,7 @@ explain select a from foo where a<1 and a>1 and not exists (select c from bar wh
    ->  Result  (cost=0.00..0.00 rows=0 width=4)
          One-Time Filter: false
  Settings:  optimizer=on
- Optimizer status: PQO version 2.39.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.39.2
 (5 rows)
 
 select a from foo where a<1 and a>1 and not exists (select c from bar where c=a);
@@ -546,7 +546,7 @@ explain select * from t5370 a , t5370_2 b where a.name=b.name;
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=334 width=7)
                      Hash Key: t5370_2.name
                      ->  Seq Scan on t5370_2  (cost=0.00..431.01 rows=334 width=7)
- Optimizer: PQO version 2.70.2
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.2
 (11 rows)
 
 drop table t5370;
@@ -639,7 +639,7 @@ explain (costs off) select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t
                                  ->  Seq Scan on t3
                ->  Hash
                      ->  Seq Scan on t2
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (14 rows)
 
 select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a IS NULL OR (t1.c = t3.c));
@@ -663,7 +663,7 @@ explain (costs off) select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                  ->  Seq Scan on t3
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (12 rows)
 
 select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a = t3.a);
@@ -688,7 +688,7 @@ explain (costs off) select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t
                                  ->  Seq Scan on t3
                ->  Hash
                      ->  Seq Scan on t2
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (14 rows)
 
 select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a is distinct from t3.a);
@@ -714,7 +714,7 @@ explain select * from t3 join (select t1.a t1a, t1.b t1b, t1.c t1c, t2.a t2a, t2
                            ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=12)
                ->  Hash  (cost=431.01..431.01 rows=333 width=12)
                      ->  Seq Scan on t2  (cost=0.00..431.01 rows=333 width=12)
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (13 rows)
 
 select * from t3 join (select t1.a t1a, t1.b t1b, t1.c t1c, t2.a t2a, t2.b t2b, t2.c t2c from t1 left join t2 on (t1.a = t2.a)) t on (t1a = t3.a) WHERE (t2a IS NULL OR (t1c = t3.a));
@@ -757,7 +757,7 @@ explain select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 lef
          ->  Hash  (cost=431.00..431.00 rows=2 width=12)
                ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=12)
                      ->  Seq Scan on t3 t3_1  (cost=0.00..431.00 rows=1 width=12)
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (28 rows)
 
 select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt 
@@ -801,7 +801,7 @@ explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
                            ->  Materialize  (cost=0.00..431.70 rows=10000 width=1)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.69 rows=10000 width=1)
                                        ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=1)
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (11 rows)
 
 select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2241,7 +2241,7 @@ where b.f1 = t.thousand and a.f1 = b.f1 and (a.f1+b.f1+999) = t.tenthous;
                            ->  Gather Motion 3:1  (slice3; segments: 3)
                                  ->  Aggregate
                                        ->  Seq Scan on int4_tbl int4_tbl_1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (21 rows)
 
 select a.f1, b.f1, t.thousand, t.tenthous from
@@ -2334,7 +2334,7 @@ select count(*) from
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: tenk1_1.unique2, tenk1_1.hundred, tenk1_1.unique2
                                  ->  Seq Scan on tenk1 tenk1_1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (13 rows)
 
 select count(*) from
@@ -2521,7 +2521,7 @@ where not exists (
                                                                                                    ->  Seq Scan on tt4x tt4x_3
                                                                                              ->  Hash
                                                                                                    ->  Seq Scan on tt4x tt4x_4
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (39 rows)
 
 --
@@ -2657,7 +2657,7 @@ select a.idv, b.idv from tidv a, tidv b where a.idv = b.idv;
                ->  Seq Scan on tidv
          ->  Index Scan using tidv_idv_idx on tidv tidv_1
                Index Cond: (idv = tidv.idv)
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (8 rows)
 
 set enable_mergejoin = 0;
@@ -2673,7 +2673,7 @@ select a.idv, b.idv from tidv a, tidv b where a.idv = b.idv;
                ->  Seq Scan on tidv
          ->  Index Scan using tidv_idv_idx on tidv tidv_1
                Index Cond: (idv = tidv.idv)
- Optimizer: PQO version 3.19.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.19.0
 (8 rows)
 
 rollback;
@@ -2920,7 +2920,7 @@ where nt3.id = 1 and ss2.b3;
                                        ->  Hash
                                              ->  Result
                                                    ->  Seq Scan on nt1
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (19 rows)
 
 select nt3.id
@@ -2977,7 +2977,7 @@ order by 1,2;
                                                ->  Materialize
                                                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                                            ->  Seq Scan on int8_tbl int8_tbl_2
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (26 rows)
 
 --
@@ -3094,7 +3094,7 @@ where q1 = thousand or q2 = thousand;
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on int4_tbl
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (16 rows)
 
 explain (costs off)
@@ -3121,7 +3121,7 @@ where thousand = (q1 + q2);
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on int4_tbl
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (17 rows)
 
 --
@@ -3150,7 +3150,7 @@ where thousand = a.q1 and tenthous = b.q1 and a.q2 = 1 and b.q2 = 2;
          ->  Hash
                ->  Seq Scan on int8_tbl int8_tbl_1
                      Filter: (q2 = 1)
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (16 rows)
 
 reset enable_nestloop;
@@ -3205,7 +3205,7 @@ where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
                      Hash Key: tenk1_1.unique2
                      ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
                            Index Cond: ((unique2 < 42) AND (unique2 = 11))
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (30 rows)
 
 --end_ignore
@@ -3263,7 +3263,7 @@ select * from tenk1 a join tenk1 b on
                      Filter: ((unique1 = 1) OR (unique2 = 3))
          ->  Seq Scan on tenk1
                Filter: ((unique1 = 2) OR (hundred = 4))
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (9 rows)
 
 explain (costs off)
@@ -3279,7 +3279,7 @@ select * from tenk1 a join tenk1 b on
                      Filter: ((unique1 = 1) OR (unique2 = 3))
          ->  Seq Scan on tenk1
                Filter: ((unique1 = 2) OR (ten = 4))
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (9 rows)
 
 explain (costs off)
@@ -3296,7 +3296,7 @@ select * from tenk1 a join tenk1 b on
                      Filter: ((unique1 = 1) OR ((unique2 = 3) OR (unique2 = 7)))
          ->  Seq Scan on tenk1
                Filter: ((unique1 = 2) OR (hundred = 4))
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (9 rows)
 
 --
@@ -3328,7 +3328,7 @@ where t1.unique1 = 1;
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Hash Key: tenk1_2.unique2
                                        ->  Seq Scan on tenk1 tenk1_2
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (20 rows)
 
 explain (costs off)
@@ -3358,7 +3358,7 @@ where t1.unique1 = 1;
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Hash Key: tenk1_2.unique2
                                        ->  Seq Scan on tenk1 tenk1_2
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (21 rows)
 
 explain (costs off)
@@ -3392,7 +3392,7 @@ select count(*) from
                            ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                  Hash Key: tenk1_2.thousand
                                  ->  Seq Scan on tenk1 tenk1_2
- Optimizer: PQO version 3.10.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.10.0
 (25 rows)
 
 select count(*) from
@@ -3444,7 +3444,7 @@ select b.unique1 from
                                        ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                              Hash Key: tenk1_2.thousand
                                              ->  Seq Scan on tenk1 tenk1_2
- Optimizer: PQO version 3.10.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.10.0
 (32 rows)
 
 select b.unique1 from
@@ -3488,7 +3488,7 @@ order by fault;
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                        Hash Key: (tenk1.unique2)::bigint
                                        ->  Seq Scan on tenk1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (17 rows)
 
 select * from
@@ -3550,7 +3550,7 @@ select q1, unique2, thousand, hundred
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Hash Key: (tenk1.unique2)::bigint
                            ->  Seq Scan on tenk1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (11 rows)
 
 select q1, unique2, thousand, hundred
@@ -3577,7 +3577,7 @@ select f1, unique2, case when unique2 is null then f1 else 0 end
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                  Hash Key: tenk1.unique2
                                  ->  Seq Scan on tenk1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (12 rows)
 
 select f1, unique2, case when unique2 is null then f1 else 0 end
@@ -3617,7 +3617,7 @@ select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
                      ->  Redistribute Motion 3:3  (slice3; segments: 3)
                            Hash Key: tenk1_2.unique2
                            ->  Seq Scan on tenk1 tenk1_2
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (21 rows)
 
 select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
@@ -3670,7 +3670,7 @@ using (join_key);
                                  Hash Key: tenk1.unique2
                                  ->  Seq Scan on public.tenk1
                                        Output: tenk1.unique2
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
  Settings: optimizer=on
 (27 rows)
 
@@ -3755,7 +3755,7 @@ select t1.* from
                      Output: int4_tbl.f1
                      ->  Seq Scan on public.int4_tbl
                            Output: int4_tbl.f1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
  Settings: optimizer=on
 (49 rows)
 
@@ -3841,7 +3841,7 @@ select t1.* from
                      Output: int4_tbl_1.f1
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
  Settings: optimizer=on
 (55 rows)
 
@@ -3932,7 +3932,7 @@ select t1.* from
                      Output: int4_tbl_1.f1
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
  Settings: optimizer=on
 (59 rows)
 
@@ -3997,7 +3997,7 @@ select * from
                      Output: int4_tbl.f1
                      ->  Seq Scan on public.int4_tbl
                            Output: int4_tbl.f1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
  Settings: optimizer=on
 (35 rows)
 
@@ -4206,7 +4206,7 @@ explain (costs off)
          ->  Gather Motion 3:1  (slice2; segments: 3)
                ->  Index Scan using tenk1_unique2 on tenk1
                      Index Cond: (unique2 = 0)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 explain (costs off)
@@ -4262,7 +4262,7 @@ explain (verbose, costs off)
                            Hash Key: COALESCE(int8_tbl_1.q1, 1::bigint)
                            ->  Seq Scan on public.int8_tbl int8_tbl_1
                                  Output: int8_tbl_1.q1
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
  Settings: enable_hashjoin=off, enable_mergejoin=on, enable_nestloop=off, optimizer=on
 (22 rows)
 
@@ -4308,7 +4308,7 @@ explain (costs off) SELECT a.* FROM a LEFT JOIN b ON a.b_id = b.id;
                ->  Seq Scan on a
          ->  Index Scan using b_pkey on b
                Index Cond: (id = a.b_id)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
 explain (costs off) SELECT b.* FROM b LEFT JOIN c ON b.c_id = c.id;
@@ -4322,7 +4322,7 @@ explain (costs off) SELECT b.* FROM b LEFT JOIN c ON b.c_id = c.id;
                ->  Seq Scan on b
          ->  Index Scan using c_pkey on c
                Index Cond: (id = b.c_id)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
 explain (costs off)
@@ -4346,7 +4346,7 @@ explain (costs off)
                                  ->  Seq Scan on b
                            ->  Index Scan using c_pkey on c
                                  Index Cond: (id = b.c_id)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (17 rows)
 
 -- check optimization of outer join within another special join
@@ -4366,7 +4366,7 @@ select id from a where id in (
                      ->  Seq Scan on b
                      ->  Index Scan using c_pkey on c
                            Index Cond: (id = b.id)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (11 rows)
 
 rollback;
@@ -4393,7 +4393,7 @@ explain (costs off)
          ->  Seq Scan on parent
          ->  Index Scan using child_k_key on child
                Index Cond: (k = parent.k)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (7 rows)
 
 -- this case is not
@@ -4420,7 +4420,7 @@ explain (costs off)
          ->  Hash
                ->  Result
                      ->  Seq Scan on child
- Optimizer: PQO version 2.54.2
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.54.2
 (8 rows)
 
 -- check for a 9.0rc1 bug: join removal breaks pseudoconstant qual handling
@@ -4440,7 +4440,7 @@ select p.* from
  Result
    ->  Result
          One-Time Filter: false
- Optimizer: PQO version 2.54.2
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.54.2
 (4 rows)
 
 select p.* from
@@ -4459,7 +4459,7 @@ select p.* from
  Result
    ->  Result
          One-Time Filter: false
- Optimizer: PQO version 2.54.2
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.54.2
 (4 rows)
 
 -- bug 5255: this is not optimizable by join removal
@@ -4526,7 +4526,7 @@ select t1.* from
                                  ->  Seq Scan on uniquetbl uniquetbl_1
          ->  Index Scan using uniquetbl_f1_key on uniquetbl uniquetbl_2
                Index Cond: (f1 = "outer".d1)
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (14 rows)
 
 explain (costs off)
@@ -4565,7 +4565,7 @@ where ss.stringu2 !~* ss.case1;
                                        Index Cond: (f1 = (tenk1.string4)::text)
          ->  Hash
                ->  Seq Scan on text_tbl
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (23 rows)
 
 select t0.*

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -86,7 +86,7 @@ explain select c1 from t1 where c1 not in
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (9 rows)
 
 select c1 from t1 where c1 not in 
@@ -122,7 +122,7 @@ explain select c1 from t1 where c1 not in
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                        ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (15 rows)
 
 select c1 from t1 where c1 not in 
@@ -168,7 +168,7 @@ explain select c1 from t1 where c1 not in
                                                    ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                                          ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (19 rows)
 
 select c1 from t1 where c1 not in 
@@ -206,7 +206,7 @@ explain select c1 from t1,
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (13 rows)
 
 select c1 from t1, 
@@ -242,7 +242,7 @@ explain select c1 from t1,
          ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (15 rows)
 
 select c1 from t1, 
@@ -270,7 +270,7 @@ explain select c1 from t1 where c1 not in
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (10 rows)
 
 select c1 from t1 where c1 not in 
@@ -300,7 +300,7 @@ explain select c1 from t1 where c1 > 6 and c1 not in
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (10 rows)
 
 select c1 from t1 where c1 > 6 and c1 not in 
@@ -331,7 +331,7 @@ explain select c1 from t1,t2 where c1 not in
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (13 rows)
 
 select c1 from t1,t2 where c1 not in 
@@ -493,7 +493,7 @@ explain select c1 from t1, t2 where c1 not in
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (21 rows)
 
 select c1 from t1, t2 where c1 not in 
@@ -563,7 +563,7 @@ explain select c1 from t1 where c1 not in
                                        ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
                                              Filter: c2 > 2 AND c2 > 3
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (15 rows)
 
 select c1 from t1 where c1 not in 
@@ -686,7 +686,7 @@ explain select (case when c1%2 = 0
                                                    ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                                                          ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                                                ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (30 rows)
 
 select (case when c1%2 = 0 
@@ -727,7 +727,7 @@ explain select c1 from t1 where not c1 >= some (select c2 from t2);
                                          ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                                                ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (16 rows)
 
 select c1 from t1 where not c1 >= some (select c2 from t2);
@@ -748,7 +748,7 @@ explain select c2 from t2 where not c2 < all (select c2 from t2);
            ->  Materialize  (cost=0.00..431.00 rows=5 width=4)
                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                        ->  Seq Scan on t2 t2_1  (cost=0.00..431.00 rows=2 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (8 rows)
 
 select c2 from t2 where not c2 < all (select c2 from t2);
@@ -782,7 +782,7 @@ explain select c3 from t3 where not c3 <> any (select c4 from t4);
                                          ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                                ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (16 rows)
 
 select c3 from t3 where not c3 <> any (select c4 from t4);
@@ -813,7 +813,7 @@ explain select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3
                                                    Sort Key: t2.c2
                                                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (18 rows)
 
 select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order by c1;
@@ -850,7 +850,7 @@ explain select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 
                                                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
                                                            Filter: c2 > (-1) AND c2 <= 1
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (16 rows)
 
 select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
@@ -873,7 +873,7 @@ explain select c1 from t1 where c1 <>all (select c2 from t2);
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (9 rows)
 
 select c1 from t1 where c1 <>all (select c2 from t2);
@@ -911,7 +911,7 @@ explain select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (sel
                                                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
                                                                        ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (20 rows)
 
 select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
@@ -948,7 +948,7 @@ explain select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all
                                      ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                            ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (14 rows)
 
 select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all (select c3 from t3));
@@ -992,7 +992,7 @@ explain select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all
                                                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                                                        ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (21 rows)
 
 select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select c3 from t3 where c3 = c1n));
@@ -1017,7 +1017,7 @@ explain select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (9 rows)
 
 select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
@@ -1038,7 +1038,7 @@ explain select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (8 rows)
 
 select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
@@ -1069,7 +1069,7 @@ explain select c1 from t1 where not exists (select c2 from t2 where c2 not in (s
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (13 rows)
 
 select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
@@ -1111,7 +1111,7 @@ explain select c1 from t1 where not exists (select c2 from t2 where exists (sele
                      ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                            ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  ->  Seq Scan on t3 t3_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (20 rows)
 
 select c1 from t1 where not exists (select c2 from t2 where exists (select c3 from t3) and c2 <>all (select c3 from t3) and c2 = c1);
@@ -1169,7 +1169,7 @@ explain select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
                            Filter: c2 > 4
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (11 rows)
 
 select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c1 is not null;
@@ -1233,7 +1233,7 @@ explain select c1 from t1 where c1::absint not in
                                                          ->  Materialize  (cost=0.00..431.00 rows=7 width=4)
                                                                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
                                                                      ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 3.27.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
 (21 rows)
 
 select c1 from t1 where c1::absint not in

--- a/src/test/regress/expected/olap_window_optimizer.out
+++ b/src/test/regress/expected/olap_window_optimizer.out
@@ -8354,7 +8354,7 @@ select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;
          ->  Sort
                Sort Key: generate_series
                ->  Function Scan on generate_series
- Optimizer: PQO version 3.30.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.30.0
 (7 rows)
 
 select unnest(array[a,a]), rank() over (order by a) from generate_series(2,3) a;

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7911,7 +7911,7 @@ explain select count(*) over (order by i), count(*) over (partition by i order b
                                  Sort Key: i
                                  ->  Seq Scan on redundant_sort_check  (cost=0.00..431.00 rows=1 width=8)
  Settings:  optimizer=on
- Optimizer status: PQO version 1.675
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.675
 (15 rows)
 
 -- End of MPP-13710
@@ -8120,7 +8120,7 @@ explain select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, 
                            ->  Hash  (cost=431.00..431.00 rows=5 width=4)
                                  ->  Seq Scan on foo  (cost=0.00..431.00 rows=5 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 1.622
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.622
 (16 rows)
 
 drop table foo, bar;
@@ -8192,7 +8192,7 @@ FROM foo;
                                                                      Sort Key: a, b, c, d
                                                                      ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=16)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.45.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.45.0
 (31 rows)
 
 drop table foo;
@@ -8227,7 +8227,7 @@ explain select k from ( select row_number() over()+2 as k from window_preds unio
                ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
                      ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                            ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (14 rows)
 
 select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
@@ -8257,7 +8257,7 @@ explain insert into window_preds select k from ( select row_number() over()+2 as
                                  ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
                                        ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                              ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (18 rows)
 
 insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
@@ -8285,7 +8285,7 @@ explain SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() O
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                  ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
                            ->  Seq Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (22 rows)
 
 SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
@@ -8317,7 +8317,7 @@ explain with CTE as (select i, row_number() over (partition by j) j from window_
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                  Hash Key: window_preds_1.j
                                  ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (21 rows)
 
 insert into window_preds with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where j = 1;
@@ -8336,7 +8336,7 @@ explain select k from ( select k from (select row_number() over() as k from wind
                Filter: "outer".k = 1
                ->  Result  (cost=0.00..431.00 rows=1 width=8)
                      ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (12 rows)
 
 select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
@@ -8385,7 +8385,7 @@ explain insert into window_preds select k from ( select k from (select row_numbe
                                  Filter: "outer".k = 1
                                  ->  Result  (cost=0.00..431.00 rows=1 width=8)
                                        ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (16 rows)
 
 insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
@@ -8412,7 +8412,7 @@ explain with CTE as (select i, row_number() over (partition by j) j from window_
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                        Hash Key: window_preds_1.j
                                        ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (21 rows)
 
 insert into window_preds with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where i = 1;
@@ -8560,7 +8560,7 @@ EXPLAIN WITH cte as (SELECT *, row_number() over () FROM window_part_sales) SELE
                      ->  Partition Selector for window_part_sales (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                            Partitions selected: 12 (out of 12)
                      ->  Dynamic Seq Scan on window_part_sales (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
- Optimizer: PQO version 3.33.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.33.0
 (9 rows)
 
 -- If there is a PARTITION BY in the window function, we can push down ONLY the predicates that match the PARTITION BY column.
@@ -8581,7 +8581,7 @@ EXPLAIN WITH cte as (SELECT *, row_number() over (PARTITION BY region) FROM wind
                                        Partitions selected: 6 (out of 12)
                                  ->  Dynamic Seq Scan on window_part_sales (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
                                        Filter: (region = 'usa'::text)
- Optimizer: PQO version 3.33.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.33.0
 (15 rows)
 
 -- When both columns in the filter predicates are in the window function, it is possible to push both down.
@@ -8600,7 +8600,7 @@ EXPLAIN WITH cte as (SELECT *, row_number() over (PARTITION BY date,region) FROM
                                  Partitions selected: 8 (out of 12)
                            ->  Dynamic Seq Scan on window_part_sales (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
                                  Filter: ((date > '03-01-2011'::date) AND (region = 'usa'::text))
- Optimizer: PQO version 3.33.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.33.0
 (13 rows)
 
 -- When the column in the filter predicates is also present in the window function, it is possible to push it down.
@@ -8619,7 +8619,7 @@ EXPLAIN WITH cte as (SELECT *, row_number() over (PARTITION BY date,region) FROM
                                  Partitions selected: 6 (out of 12)
                            ->  Dynamic Seq Scan on window_part_sales (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
                                  Filter: (region = 'usa'::text)
- Optimizer: PQO version 3.33.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.33.0
 (13 rows)
 
 -- When there is a disjunct in the filter predicates, it is not possible to push down either into the window function.
@@ -8638,7 +8638,7 @@ EXPLAIN WITH cte as (SELECT *, row_number() over (PARTITION BY date,region) FROM
                                  Partitions selected: 12 (out of 12)
                            ->  Dynamic Seq Scan on window_part_sales (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=16)
                                  Filter: ((date > '03-01-2011'::date) OR (region = 'usa'::text))
- Optimizer: PQO version 3.33.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.33.0
 (13 rows)
 
 -- End of Test

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6895,7 +6895,7 @@ explain select foo_p.b, foo_p.t from foo_p left outer join bar on foo_p.a = bar.
                      Hash Key: bar.k
                      ->  Seq Scan on bar  (cost=0.00..431.22 rows=6700 width=4)
  Settings:  optimizer=on; optimizer_nestloop_factor=1; optimizer_segments=3
- Optimizer status: PQO version 2.48.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.0
 (16 rows)
 
 reset optimizer_segments;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -137,7 +137,7 @@ EXPLAIN EXECUTE prep_prune_param(10);
                Partitions selected: 1 (out of 5)
          ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
                Filter: col2 = 10::numeric
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (7 rows)
 
 -- @description B-tree single index key = non-partitioning key
@@ -172,7 +172,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col1 < 10 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..20.00 rows=4 width=14)
                                  Index Cond: col1 < 10
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col1 > 50 ORDER BY col2,col3 LIMIT 5;
@@ -194,7 +194,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col1 > 50 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=14)
                            Index Cond: col1 > 50
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (12 rows)
 
 SELECT * FROM pt_lt_tab WHERE col1 = 25 ORDER BY col2,col3 LIMIT 5;
@@ -217,7 +217,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col1 = 25 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=14)
                            Index Cond: col1 = 25
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (12 rows)
 
 SELECT * FROM pt_lt_tab WHERE col1 <> 10 ORDER BY col2,col3 LIMIT 5;
@@ -245,7 +245,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col1 <> 10 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=17 width=14)
                                  Filter: col1 <> 10
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col1 > 10 AND col1 < 50 ORDER BY col2,col3 LIMIT 5;
@@ -273,7 +273,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col1 > 10 AND col1 < 50 ORDER BY col2,col3
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..78.00 rows=13 width=14)
                                  Index Cond: col1 > 10 AND col1 < 50
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col1 > 10 OR col1 = 25 ORDER BY col2,col3 LIMIT 5;
@@ -301,7 +301,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col1 > 10 OR col1 = 25 ORDER BY col2,col3 
                            ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=14 width=14)
                                  Filter: col1 > 10 OR col1 = 25
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col1 between 10 AND 25 ORDER BY col2,col3 LIMIT 5;
@@ -329,7 +329,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col1 between 10 AND 25 ORDER BY col2,col3 
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..30.00 rows=5 width=14)
                                  Index Cond: col1 >= 10 AND col1 <= 25
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 DROP INDEX idx1;
@@ -366,7 +366,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 < 10 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..20.00 rows=4 width=14)
                                  Index Cond: col2 < 10::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 > 50 ORDER BY col2,col3 LIMIT 5;
@@ -389,7 +389,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 > 50 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..2.00 rows=1 width=14)
                            Index Cond: col2 > 50::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 = 25 ORDER BY col2,col3 LIMIT 5;
@@ -413,7 +413,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 = 25 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..2.00 rows=1 width=14)
                            Index Cond: col2 = 25::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 <> 10 ORDER BY col2,col3 LIMIT 5;
@@ -442,7 +442,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 <> 10 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=17 width=14)
                                  Filter: col2 <> 10::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 > 10 AND col2 < 50 ORDER BY col2,col3 LIMIT 5;
@@ -471,7 +471,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 > 10 AND col2 < 50 ORDER BY col2,col3
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..80.00 rows=14 width=14)
                                  Index Cond: col2 > 10::numeric AND col2 < 50::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 > 10 OR col2 = 50 ORDER BY col2,col3 LIMIT 5;
@@ -500,7 +500,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 > 10 OR col2 = 50 ORDER BY col2,col3 
                            ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=14 width=14)
                                  Filter: col2 > 10::numeric OR col2 = 50::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 between 10 AND 50 ORDER BY col2,col3 LIMIT 5;
@@ -529,7 +529,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 between 10 AND 50 ORDER BY col2,col3 
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..80.00 rows=14 width=14)
                                  Index Cond: col2 >= 10::numeric AND col2 <= 50::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 DROP INDEX idx1;
@@ -565,7 +565,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col1 < 10 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..20.00 rows=4 width=14)
                                  Index Cond: col1 < 10
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col1 > 50 ORDER BY col2,col3 LIMIT 5;
@@ -587,7 +587,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col1 > 50 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=14)
                            Index Cond: col1 > 50
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (12 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 = 25 ORDER BY col2,col3 LIMIT 5;
@@ -611,7 +611,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 = 25 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..2.00 rows=1 width=14)
                            Index Cond: col2 = 25::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 <> 10 ORDER BY col2,col3 LIMIT 5;
@@ -640,7 +640,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 <> 10 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=17 width=14)
                                  Filter: col2 <> 10::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 > 10 AND col1 = 10 ORDER BY col2,col3 LIMIT 5;
@@ -663,7 +663,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 > 10 AND col1 = 10 ORDER BY col2,col3
                      ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=14)
                            Index Cond: col1 = 10 AND col2 > 10::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 > 10.00 OR col1 = 50 ORDER BY col2,col3 LIMIT 5;
@@ -691,7 +691,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 > 10.00 OR col1 = 50 ORDER BY col2,co
                            ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=14 width=14)
                                  Filter: col2 > 10.00 OR col1 = 50
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 between 10 AND 50 ORDER BY col2,col3 LIMIT 5;
@@ -720,7 +720,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 between 10 AND 50 ORDER BY col2,col3 
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..80.00 rows=14 width=14)
                                  Index Cond: col2 >= 10::numeric AND col2 <= 50::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 DROP INDEX idx1;
@@ -753,7 +753,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col1 < 10 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..18.31 rows=4 width=14)
                                  Index Cond: col1 < 10
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (13 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col1 > 50 ORDER BY col2,col3 LIMIT 5;
@@ -781,7 +781,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col1 > 50 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..18.31 rows=4 width=14)
                                  Index Cond: col1 > 50
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (13 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 = 25 ORDER BY col2,col3 LIMIT 5;
@@ -805,7 +805,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 = 25 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..2.00 rows=1 width=14)
                            Index Cond: col2 = 25::numeric
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (13 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 <> 10 ORDER BY col2,col3 LIMIT 5;
@@ -834,7 +834,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 <> 10 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..431.00 rows=21 width=14)
                                  Filter: col2 <> 10::numeric
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (14 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 > 10 AND col1 = 10 ORDER BY col2,col3 LIMIT 5;
@@ -857,7 +857,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 > 10 AND col1 = 10 ORDER BY col2,c
                      ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=14)
                            Index Cond: col2 > 10::numeric AND col1 = 10
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (13 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 > 10.00 OR col1 = 50 ORDER BY col2,col3 LIMIT 5;
@@ -885,7 +885,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 > 10.00 OR col1 = 50 ORDER BY col2
                            ->  Dynamic Seq Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=14)
                                  Filter: col2 > 10.00 OR col1 = 50
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (13 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 between 10 AND 50 ORDER BY col2,col3 LIMIT 5;
@@ -914,7 +914,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 between 10 AND 50 ORDER BY col2,co
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..83.27 rows=14 width=14)
                                  Index Cond: col2 >= 10::numeric AND col2 <= 50::numeric
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (14 rows)
 
 ALTER TABLE pt_lt_tab_df DROP CONSTRAINT col2_col1_unique;
@@ -950,7 +950,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 between 1 AND 50 ORDER BY col2,col3 L
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..100.01 rows=17 width=14)
                                  Index Cond: col2 >= 1::numeric AND col2 <= 50::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 > 5 ORDER BY col2,col3 LIMIT 5;
@@ -979,7 +979,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 > 5 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..90.00 rows=15 width=14)
                                  Index Cond: col2 > 5::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 = 5 ORDER BY col2,col3 LIMIT 5;
@@ -1003,7 +1003,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 = 5 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..2.00 rows=1 width=14)
                            Index Cond: col2 = 5::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 DROP INDEX idx1;
@@ -1043,7 +1043,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col1 between 1 AND 100 ORDER BY col1 LI
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..120.01 rows=20 width=14)
                                  Index Cond: col1 >= 1 AND col1 <= 100
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col1 > 50 ORDER BY col1 LIMIT 5;
@@ -1071,7 +1071,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col1 > 50 ORDER BY col1 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..16.80 rows=3 width=14)
                                  Index Cond: col1 > 50
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col1 < 50 ORDER BY col1 LIMIT 5;
@@ -1099,7 +1099,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col1 < 50 ORDER BY col1 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..100.80 rows=17 width=14)
                                  Index Cond: col1 < 50
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 DROP INDEX idx1;
@@ -1141,7 +1141,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 between 1 AND 100 ORDER BY col2,co
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..120.01 rows=20 width=14)
                                  Index Cond: col2 >= 1::numeric AND col2 <= 100::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 > 50 ORDER BY col2,col3 LIMIT 5;
@@ -1170,7 +1170,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 > 50 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..19.20 rows=4 width=14)
                                  Index Cond: col2 > 50::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 = 50 ORDER BY col2,col3 LIMIT 5;
@@ -1194,7 +1194,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 = 50 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..2.00 rows=1 width=14)
                            Index Cond: col2 = 50::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 <> 10 ORDER BY col2,col3 LIMIT 5;
@@ -1223,7 +1223,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 <> 10 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..431.00 rows=21 width=14)
                                  Filter: col2 <> 10::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 between 1 AND 100 ORDER BY col2,col3 LIMIT 5;
@@ -1252,7 +1252,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 between 1 AND 100 ORDER BY col2,co
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..120.01 rows=20 width=14)
                                  Index Cond: col2 >= 1::numeric AND col2 <= 100::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 < 50 AND col1 > 10 ORDER BY col2,col3 LIMIT 5;
@@ -1282,7 +1282,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 < 50 AND col1 > 10 ORDER BY col2,c
                                  Index Cond: col2 < 50::numeric
                                  Filter: col2 < 50::numeric AND col1 > 10
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (15 rows)
 
 DROP INDEX idx1;
@@ -1323,7 +1323,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 > 51 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..431.00 rows=3 width=14)
                                  Filter: col2 > 51::numeric
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 = 50 ORDER BY col2,col3 LIMIT 5;
@@ -1347,7 +1347,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 = 50 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Seq Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=14)
                            Filter: col2 = 50::numeric
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 DROP INDEX idx1;
@@ -1396,7 +1396,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 = 50 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..2.00 rows=1 width=14)
                            Index Cond: col2 = 50::numeric
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col2 > 10 AND col1 between 1 AND 100 ORDER BY col2,col3 LIMIT 5;
@@ -1425,7 +1425,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 > 10 AND col1 between 1 AND 100 OR
                            ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..100.81 rows=17 width=14)
                                  Index Cond: col2 > 10::numeric AND col1 >= 1 AND col1 <= 100
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 SELECT * FROM pt_lt_tab_df WHERE col1 = 10 ORDER BY col2,col3 LIMIT 5;
@@ -1448,7 +1448,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col1 = 10 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Index Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=14)
                            Index Cond: col1 = 10
  Settings:  optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (12 rows)
 
 DROP INDEX idx1;
@@ -1482,7 +1482,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 = 35 ORDER BY col2,col3 LIMIT 5;
                      ->  Dynamic Seq Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=14)
                            Filter: col2 = 35::numeric
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (13 rows)
 
 DROP INDEX idx1;
@@ -1518,7 +1518,7 @@ EXPLAIN SELECT * FROM pt_lt_tab_df WHERE col2 > 15 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab_df (dynamic scan id: 1)  (cost=0.00..431.00 rows=23 width=14)
                                  Filter: col2 > 15::numeric
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.7.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.7.0
 (14 rows)
 
 DROP INDEX idx1;
@@ -1566,7 +1566,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col4 is False ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=7 width=10)
                                  Filter: col4 IS FALSE
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col4 = False ORDER BY col2,col3 LIMIT 5;
@@ -1594,7 +1594,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col4 = False ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Index Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..59.94 rows=10 width=10)
                                  Index Cond: col4 = false
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (13 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 > 41 ORDER BY col2,col3 LIMIT 5;
@@ -1623,7 +1623,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 > 41 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=4 width=10)
                                  Filter: col2 > 41::numeric
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (14 rows)
 
 ALTER TABLE pt_lt_tab DROP column col4;
@@ -1653,7 +1653,7 @@ EXPLAIN SELECT * FROM pt_lt_tab WHERE col2 > 41 ORDER BY col2,col3 LIMIT 5;
                            ->  Dynamic Seq Scan on pt_lt_tab (dynamic scan id: 1)  (cost=0.00..431.00 rows=4 width=9)
                                  Filter: col2 > 41::numeric
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 2.48.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.2
 (14 rows)
 
 --
@@ -2839,7 +2839,7 @@ explain select * from sales where date = '2011-01-01' and region = 'usa';
                Index Cond: date = '01-01-2011'::date
                Filter: date = '01-01-2011'::date AND region = 'usa'::text
  Settings:  enable_bitmapscan=on; enable_indexscan=on; enable_seqscan=off
- Optimizer status: PQO version 2.32.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.32.0
 (10 rows)
 
 select * from sales where date = '2011-01-01' and region = 'usa';

--- a/src/test/regress/expected/pg_lsn_optimizer.out
+++ b/src/test/regress/expected/pg_lsn_optimizer.out
@@ -94,7 +94,7 @@ SELECT DISTINCT (i || '/' || j)::pg_lsn f
                                              ->  Function Scan on generate_series generate_series_1
                            ->  Materialize
                                  ->  Function Scan on generate_series
- Optimizer: PQO version 3.8.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.8.0
 (21 rows)
 
 SELECT DISTINCT (i || '/' || j)::pg_lsn f

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -184,7 +184,7 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
                                  ->  Seq Scan on c
                                  ->  Hash
                                        ->  Seq Scan on b
- Optimizer: PQO version 2.70.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
 (15 rows)
 
 select * from A where exists (select * from B where A.i in (select C.i from C where C.i = B.i));
@@ -224,7 +224,7 @@ select * from A,B where exists (select * from C where B.i not in (select C.i fro
                                    ->  Materialize
                                          ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                                ->  Seq Scan on c
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (26 rows)
 
 select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
@@ -428,7 +428,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                      ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (39 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
@@ -487,7 +487,7 @@ explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j a
                      ->  Materialize  (cost=0.00..431.00 rows=9 width=1)
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=1)
                                  ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=1)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (39 rows)
 
 select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
@@ -630,7 +630,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (30 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
@@ -684,7 +684,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C wh
                                                                ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                                      ->  Seq Scan on a a_1  (cost=0.00..431.00 rows=1 width=4)
                                                                            Filter: i = 10 AND i = 10
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (34 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
@@ -732,7 +732,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C whe
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (28 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
@@ -847,7 +847,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (48 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
@@ -901,7 +901,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C wh
                                                                ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                                      ->  Seq Scan on a  (cost=0.00..431.00 rows=1 width=4)
                                                                            Filter: i = 10 AND i = 10
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (34 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
@@ -939,7 +939,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C whe
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.55.13
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.13
 (28 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
@@ -1226,7 +1226,7 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
          ->  Result  (cost=0.00..0.00 rows=0 width=1)
                One-Time Filter: false
  Settings:  optimizer=on
- Optimizer status: PQO version 2.42.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.42.0
 (8 rows)
 
 select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 0);
@@ -1255,7 +1255,7 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                    ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.42.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.42.0
 (14 rows)
 
 select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
@@ -1284,7 +1284,7 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                    ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.42.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.42.0
 (14 rows)
 
 select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
@@ -1311,7 +1311,7 @@ explain select C.j from C where not exists (select max(B.i) from B  where C.i = 
                                        Sort Key: b.i
                                        ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (17 rows)
 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
@@ -1342,7 +1342,7 @@ explain select C.j from C where not exists (select max(B.i) from B  where C.i = 
                                                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
                                                      ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.34.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (17 rows)
 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
@@ -1380,7 +1380,7 @@ explain select C.j from C where not exists (select rank() over (order by B.i) fr
                                                ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
                                                      ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
                                                            ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
- Optimizer status: PQO version 2.44.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.44.0
 (19 rows)
 
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
@@ -1405,7 +1405,7 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
                      ->  Sort  (cost=0.00..431.00 rows=3 width=4)
                            Sort Key: c.i
                            ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer status: PQO version 2.46.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.46.1
 (11 rows)
 
 select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
@@ -1428,7 +1428,7 @@ explain select A.i from A where not exists (select B.i from B where B.i in (sele
                      ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                            ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.40.3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.40.3
 (12 rows)
 
 select A.i from A where not exists (select B.i from B where B.i in (select C.i from C) and B.i = A.i);
@@ -1461,7 +1461,7 @@ explain select * from B where not exists (select * from C,A where C.i in (select
                            ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                                  ->  Seq Scan on c c_1  (cost=0.00..431.00 rows=3 width=4)
                                        Filter: i <> 10
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (20 rows)
 
 select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
@@ -1502,7 +1502,7 @@ explain select * from A where A.i in (select C.j from C,B where B.i in (select i
                                                                ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
                                                    ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                                                          ->  Seq Scan on c c_1  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (27 rows)
 
 select * from A where A.i in (select C.j from C,B where B.i in (select i from C));
@@ -1526,7 +1526,7 @@ explain select * from A where not exists (select sum(c.i) from C where C.i = A.i
                            Sort Key: c.i
                            ->  Seq Scan on c  (cost=0.00..431.00 rows=2 width=4)
                                  Filter: i > 3
- Optimizer: PQO version 2.55.13
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.13
 (12 rows)
 
 select * from A where not exists (select sum(c.i) from C where C.i = A.i group by C.i having c.i > 3);
@@ -3637,7 +3637,7 @@ EXPLAIN SELECT a FROM qp_tab1 f1 LEFT JOIN qp_tab2 on a=c WHERE NOT EXISTS(SELEC
                            ->  Seq Scan on qp_tab1 qp_tab1_1  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on qp_tab2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (12 rows)
 
 EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
@@ -3666,7 +3666,7 @@ EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE
                                                                            ->  Seq Scan on qp_tab2  (cost=0.00..431.00 rows=1 width=4)
                                                                            ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                                                  ->  Seq Scan on qp_tab3  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.55.12
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.12
 (24 rows)
 
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
@@ -3696,7 +3696,7 @@ EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                      ->  Seq Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
                            Filter: f::text <> '-0'::text
- Optimizer: PQO version 2.72.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.72.0
 (9 rows)
 
 SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
@@ -3717,7 +3717,7 @@ EXPLAIN SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_n
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                      ->  Seq Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
                            Filter: CASE WHEN f::text = '-0'::text THEN 1::double precision ELSE (-1)::double precision END < 0::double precision
- Optimizer: PQO version 2.72.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.72.0
 (9 rows)
 
 SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
@@ -3738,7 +3738,7 @@ EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b
          ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                ->  Seq Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
                      Filter: i = 1 OR i = 2 OR i = 3
- Optimizer: PQO version 2.72.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.72.0
 (9 rows)
 
 SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
@@ -3757,7 +3757,7 @@ EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b
                Filter: i::numeric = ANY ('{1,2,3}'::numeric[])
          ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                ->  Seq Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
- Optimizer: PQO version 2.72.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.72.0
 (8 rows)
 
 SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);

--- a/src/test/regress/expected/qp_gist_indexes3_optimizer.out
+++ b/src/test/regress/expected/qp_gist_indexes3_optimizer.out
@@ -155,7 +155,7 @@ EXPLAIN SELECT id, property AS "Property" FROM GistTable3
          ->  Bitmap Index Scan on gistindex3a  (cost=0.00..0.00 rows=0 width=0)
                Index Cond: property ~= '(999,999),(998,998)'::box
  Settings:  enable_seqscan=off
- Optimizer status: PQO version 2.64.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.64.0
 (7 rows)
 
 VACUUM ANALYZE GistTable3;
@@ -175,7 +175,7 @@ EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable3
          Index Cond: property ~= '(999,999),(998,998)'::box
          Filter: property ~= '(999,999),(998,998)'::box
  Settings:  enable_seqscan=off
- Optimizer status: PQO version 2.64.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.64.0
 (6 rows)
 
 -- ----------------------------------------------------------------------
@@ -215,7 +215,7 @@ EXPLAIN SELECT id, property AS "Property" FROM GistTable3
          Index Cond: property ~= '(999,999),(998,998)'::box
          Filter: property ~= '(999,999),(998,998)'::box
  Settings:  enable_seqscan=off
- Optimizer status: PQO version 2.64.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.64.0
 (6 rows)
 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_gist_indexes4_optimizer.out
+++ b/src/test/regress/expected/qp_gist_indexes4_optimizer.out
@@ -199,7 +199,7 @@ EXPLAIN SELECT * FROM geometricTypes
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..436.30 rows=8013 width=129)
    ->  Seq Scan on geometrictypes  (cost=0.00..432.44 rows=2671 width=129)
          Filter: c ~= '<(1255,7955),1227>'::circle
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (4 rows)
 
 SELECT * FROM geometricTypes 
@@ -216,7 +216,7 @@ EXPLAIN SELECT * FROM geometricTypes
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..436.30 rows=8013 width=129)
    ->  Seq Scan on geometrictypes  (cost=0.00..432.44 rows=2671 width=129)
          Filter: b ~= '(7352,7352),(7350,-3128)'::box
- Optimizer status: PQO version 2.64.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.64.0
 (4 rows)
 
 SELECT * FROM geometricTypes 
@@ -233,7 +233,7 @@ EXPLAIN SELECT * FROM geometricTypes
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..436.30 rows=8013 width=129)
    ->  Seq Scan on geometrictypes  (cost=0.00..432.44 rows=2671 width=129)
          Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (4 rows)
 
 -- ----------------------------------------------------------------------
@@ -271,7 +271,7 @@ EXPLAIN SELECT * FROM geometricTypes
    ->  Index Scan using gt_index_c on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
          Index Cond: c ~= '<(1255,7955),1227>'::circle
          Filter: c ~= '<(1255,7955),1227>'::circle
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 SELECT * FROM geometricTypes 
@@ -289,7 +289,7 @@ EXPLAIN SELECT * FROM geometricTypes
    ->  Index Scan using gt_index_b on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
          Index Cond: b ~= '(7352,7352),(7350,-3128)'::box
          Filter: b ~= '(7352,7352),(7350,-3128)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 SELECT * FROM geometricTypes 
@@ -307,7 +307,7 @@ EXPLAIN SELECT * FROM geometricTypes
    ->  Index Scan using gt_index_p on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
          Index Cond: p ~= '((4679,8579),(4670,-3232))'::polygon
          Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 -- ----------------------------------------------------------------------
@@ -368,7 +368,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using gone_around_the_bend on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: already_gone ~= '<(-3176,7824),3174>'::circle
          Filter: already_gone ~= '<(-3176,7824),3174>'::circle
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -389,7 +389,7 @@ EXPLAIN SELECT * FROM gone
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
    ->  Seq Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
          Filter: already_gone ~= '<(-3176,7824),3174>'::circle
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (4 rows)
 
 SET optimizer_enable_tablescan = False;
@@ -412,7 +412,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using polly_wanna_cracker on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: paragon ~= '((7625,8425),(7643,7849))'::polygon
          Filter: paragon ~= '((7625,8425),(7643,7849))'::polygon
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -432,7 +432,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using polly_gone on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: paragon ~= '((7625,8425),(7643,7849))'::polygon
          Filter: paragon ~= '((7625,8425),(7643,7849))'::polygon
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 CREATE INDEX box_of_rain ON gone USING GiST (too_far_gone) 
@@ -456,7 +456,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -475,7 +475,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 BEGIN WORK;
@@ -495,7 +495,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -517,7 +517,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -538,7 +538,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 REINDEX TABLE gone;
@@ -557,7 +557,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 ROLLBACK WORK;
@@ -576,7 +576,7 @@ EXPLAIN SELECT * FROM gone
    ->  Index Scan using box_of_rain on gone  (cost=0.00..8001.36 rows=1334 width=129)
          Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
          Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 DROP TABLE IF EXISTS gone;
@@ -609,7 +609,7 @@ EXPLAIN SELECT * FROM geometricTypes
    ->  Index Scan using gt_index_c on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
          Index Cond: c ~= '<(1255,7955),1227>'::circle
          Filter: c ~= '<(1255,7955),1227>'::circle
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 SELECT * FROM geometricTypes 
@@ -627,7 +627,7 @@ EXPLAIN SELECT * FROM geometricTypes
    ->  Index Scan using gt_index_b on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
          Index Cond: b ~= '(7352,7352),(7350,-3128)'::box
          Filter: b ~= '(7352,7352),(7350,-3128)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 SELECT * FROM geometricTypes 
@@ -645,7 +645,7 @@ EXPLAIN SELECT * FROM geometricTypes
    ->  Index Scan using gt_index_p on geometrictypes  (cost=0.00..16027.52 rows=2671 width=129)
          Index Cond: p ~= '((4679,8579),(4670,-3232))'::polygon
          Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 -- ----------------------------------------------------------------------
@@ -677,7 +677,7 @@ EXPLAIN SELECT * FROM geometricTypes
    ->  Index Scan using gt_index_c on geometrictypes  (cost=0.00..6411.01 rows=1069 width=129)
          Index Cond: c ~= '<(-3197,7903),3150>'::circle AND c << '<(7879,8779),7868>'::circle
          Filter: c ~= '<(-3197,7903),3150>'::circle AND c << '<(7879,8779),7868>'::circle
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 SELECT * FROM geometricTypes 
@@ -695,7 +695,7 @@ EXPLAIN SELECT * FROM geometricTypes
    ->  Index Scan using gt_index_b on geometrictypes  (cost=0.00..6411.01 rows=1069 width=129)
          Index Cond: b ~= '(7352,7352),(7350,-3128)'::box AND b << '(8479,7579),(8441,-3121)'::box
          Filter: b ~= '(7352,7352),(7350,-3128)'::box AND b << '(8479,7579),(8441,-3121)'::box
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 SELECT * FROM geometricTypes 
@@ -713,7 +713,7 @@ EXPLAIN SELECT * FROM geometricTypes
    ->  Index Scan using gt_index_p on geometrictypes  (cost=0.00..6411.01 rows=1069 width=129)
          Index Cond: p ~= '((1252,8252),(1274,7975))'::polygon AND p << '((8778,6578),(8765,8265))'::polygon
          Filter: p ~= '((1252,8252),(1274,7975))'::polygon AND p << '((8778,6578),(8765,8265))'::polygon
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 -- ----------------------------------------------------------------------
@@ -766,7 +766,7 @@ EXPLAIN SELECT * FROM geometricTypesPartition
                ->  Dynamic Bitmap Index Scan on geometrictypespartition_1_prt_1_c_idx  (cost=0.00..0.00 rows=0 width=0)
                      Index Cond: (c ~= '<(8479,-3121),8441>'::circle)
  Planning time: 26.900 ms
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (10 rows)
 
 DROP TABLE IF EXISTS geometricTypesPartition;
@@ -815,7 +815,7 @@ EXPLAIN SELECT * FROM textSearch
    ->  Index Scan using text_index on textsearch  (cost=0.00..6.00 rows=1 width=17)
          Index Cond: t @@ '''test'''::tsquery
          Filter: t @@ '''test'''::tsquery
- Optimizer: PQO version 2.68.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
 (5 rows)
 
 DROP TABLE IF EXISTS textSearch;
@@ -868,7 +868,7 @@ EXPLAIN SELECT count(*) FROM gist_tbl, gist_tbl2
                      ->  Index Scan using poly_index on gist_tbl  (cost=0.00..568396.66 rows=2685 width=1)
                            Index Cond: p <@ gist_tbl2.p
                            Filter: p <@ gist_tbl2.p
- Optimizer: PQO version 2.69.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.69.0
 (11 rows)
 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -1200,7 +1200,7 @@ explain select cn, count(*) over (order by dt range between '2 day'::interval pr
                      Sort Key: dt
                      ->  Seq Scan on tbl5246_sale  (cost=0.00..431.00 rows=4 width=8)
  Settings:  enable_nestloop=on
- Optimizer status: PQO version 2.50.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.50.1
 (10 rows)
 
 drop table qp_misc_jiras.tbl5246_sale;
@@ -1637,7 +1637,7 @@ explain select * from qp_misc_jiras.tbl6833_anl; -- should not hit cdbRelSize();
                Partitions selected:  2 (out of 2)
          ->  Dynamic Seq Scan on tbl6833_anl (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
  Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (7 rows)
 
 select relname, reltuples, relpages from pg_class where relname like 'tbl6833_anl%'; -- should show relpages = 1.0
@@ -1661,7 +1661,7 @@ explain select * from qp_misc_jiras.tbl6833_vac; -- should not hit cdbRelSize();
                Partitions selected:  2 (out of 2)
          ->  Dynamic Seq Scan on tbl6833_vac (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
  Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (7 rows)
 
 select relname, reltuples, relpages from pg_class where relname like 'tbl6833_vac%'; -- should show relpages = 1.0
@@ -2344,7 +2344,7 @@ explain select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping 
                            Sort Key: share0_ref3.i, share0_ref3.i
                            ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
  Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; gp_enable_agg_distinct=off; gp_enable_agg_distinct_pruning=off; optimizer=on; optimizer_force_three_stage_scalar_dqa=off
- Optimizer status: PQO version 2.51.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.51.0
 (18 rows)
 
 select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
@@ -2386,7 +2386,7 @@ explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping 
                                              Sort Key: share0_ref3.j, share0_ref3.j
                                              ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=4)
  Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; gp_enable_agg_distinct=off; gp_enable_agg_distinct_pruning=off; optimizer=on; optimizer_force_three_stage_scalar_dqa=off
- Optimizer status: PQO version 2.51.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.51.0
 (30 rows)
 
 select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
@@ -3005,7 +3005,7 @@ explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_te
                                                    ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                          ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                                                ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (21 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
@@ -3030,7 +3030,7 @@ explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_te
                                                    ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
                                                    ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                          ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (20 rows)
 
 set enable_groupagg=on;
@@ -3058,7 +3058,7 @@ explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_te
                                                    ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                          ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                                                ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (21 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
@@ -3083,7 +3083,7 @@ explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_te
                                                    ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
                                                    ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                          ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (20 rows)
 
 drop table qp_misc_jiras.tbl5994_test;
@@ -3280,7 +3280,7 @@ group by 1, 2;
                                        ->  Seq Scan on bar_6325  (cost=0.00..431.00 rows=1 width=8)
                                  ->  Seq Scan on foo_6325  (cost=0.00..431.00 rows=1 width=8)
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (14 rows)
 
 -- start_ignore
@@ -3413,7 +3413,7 @@ explain select x, "median"(y) from qp_misc_jiras.tbl9613 group by x; -- this sho
                Sort Key: x
                ->  Seq Scan on tbl9613  (cost=0.00..431.00 rows=1 width=12)
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (8 rows)
 
 select x, "median"(y) from qp_misc_jiras.tbl9613 group by x; -- this should be allowed
@@ -3432,7 +3432,7 @@ explain select x, median2(y) from qp_misc_jiras.tbl9613 group by x; -- this shou
                Sort Key: x
                ->  Seq Scan on tbl9613  (cost=0.00..431.00 rows=1 width=12)
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (8 rows)
 
 select x, median2(y) from qp_misc_jiras.tbl9613 group by x; -- this should be disallowed
@@ -3548,7 +3548,7 @@ else 'Unidentify' end
                                        ->  Result  (cost=0.00..431.00 rows=1 width=16)
                                              ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (16 rows)
 
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
@@ -3740,7 +3740,7 @@ explain select  * from qp_misc_jiras.test_heap where ctid='(0,1)' and gp_segment
    ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=8)
          Filter: ctid = '(0,1)'::tid AND gp_segment_id >= 0
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (5 rows)
 
 select  * from qp_misc_jiras.test_heap where ctid='(0,1)' and gp_segment_id >= 0;
@@ -3763,7 +3763,7 @@ explain select  * from qp_misc_jiras.test_ao where ctid='(33554432,1)' and gp_se
    ->  Seq Scan on test_ao  (cost=0.00..431.00 rows=1 width=8)
          Filter: ctid = '(33554432,1)'::tid AND gp_segment_id >= 0
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (5 rows)
 
 select  * from qp_misc_jiras.test_ao where ctid='(33554432,1)' and gp_segment_id >= 0;
@@ -3786,7 +3786,7 @@ explain select  * from qp_misc_jiras.test_co where ctid='(33554432,1)' and gp_se
    ->  Seq Scan on test_co  (cost=0.00..431.00 rows=1 width=8)
          Filter: ctid = '(33554432,1)'::tid AND gp_segment_id >= 0
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (5 rows)
 
 select  * from qp_misc_jiras.test_co where ctid='(33554432,1)' and gp_segment_id >= 0;
@@ -3813,7 +3813,7 @@ explain analyze select count(*) from qp_misc_jiras.test_heap;
  Statement statistics:
    Memory used: 128000K bytes
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.684
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.684
  Total runtime: 10.892 ms
 (18 rows)
 
@@ -3925,7 +3925,7 @@ explain select * from qp_misc_jiras.r;
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.04 rows=1000 width=8)
    ->  Seq Scan on r  (cost=0.00..431.01 rows=334 width=8)
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (4 rows)
 
 explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
@@ -3955,7 +3955,7 @@ explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
  Statement statistics:
    Memory used: 1945600K bytes
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
  Total runtime: 87.064 ms
 (31 rows)
 
@@ -4532,7 +4532,7 @@ explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
                ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                      ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=1)
                            Filter: 1 > x
- Optimizer: PQO version 2.65.1
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.65.1
 (9 rows)
 
 set gp_enable_relsize_collection = on;
@@ -4552,7 +4552,7 @@ explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
                                        ->  Result  (cost=0.00..431.01 rows=321 width=8)
                                              ->  Seq Scan on tbl_z  (cost=0.00..431.01 rows=321 width=4)
          ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: PQO version 2.65.1
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.65.1
 (13 rows)
 
 drop table if exists tbl_z;

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -26,7 +26,7 @@ explain insert into constr_tab values (1,2,3);
                      ->  Result  (cost=0.00..0.00 rows=1 width=16)
                            ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.48.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.0
 (8 rows)
 
 -- The remaining tests require a row in the table.
@@ -64,7 +64,7 @@ explain update constr_tab set b = 10;
          ->  Split  (cost=0.00..431.00 rows=1 width=30)
                ->  Result  (cost=0.00..431.00 rows=1 width=30)
                      ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=26)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 -- Same, with NOT NULL constraint.
@@ -123,7 +123,7 @@ explain update constr_tab set a = 10;
                      ->  Split  (cost=0.00..431.00 rows=1 width=30)
                            ->  Result  (cost=0.00..431.00 rows=1 width=30)
                                  ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=26)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (9 rows)
 
 -- Test ORCA fallback on "FROM ONLY"
@@ -190,7 +190,7 @@ EXPLAIN SELECT * FROM ext_table_no_fallback;
 ---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..472.74 rows=1000000 width=8)
    ->  External Scan on ext_table_no_fallback  (cost=0.00..437.97 rows=333334 width=8)
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
 (3 rows)
 
 EXPLAIN SELECT * FROM ONLY ext_table_no_fallback;

--- a/src/test/regress/expected/qp_query_execution.out
+++ b/src/test/regress/expected/qp_query_execution.out
@@ -9,7 +9,7 @@ create or replace function qx_count_operator(query text, planner_operator text, 
 $$
 rv = plpy.execute('EXPLAIN '+ query)
 plan = '\n'.join([row['QUERY PLAN'] for row in rv])
-optimizer = plan.find('PQO')
+optimizer = plan.find('Pivotal Optimizer (GPORCA)')
 
 if optimizer >= 0:
     return plan.count(optimizer_operator)

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1083,7 +1083,7 @@ explain delete from TabDel1 where TabDel1.a not in (select a from TabDel3); -- d
                ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                            ->  Seq Scan on tabdel3  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (9 rows)
 
 explain delete from TabDel2 where TabDel2.a not in (select a from TabDel4); -- support this
@@ -1098,7 +1098,7 @@ explain delete from TabDel2 where TabDel2.a not in (select a from TabDel4); -- s
                      ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                  ->  Seq Scan on tabdel4  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 delete from TabDel2 where TabDel2.a not in (select a from TabDel4); 

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -550,7 +550,7 @@ explain select count(*) from mpp7638 where a =1;
                      ->  Dynamic Seq Scan on mpp7638 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
                            Filter: (a = 1)
  Planning time: 101.741 ms
- Optimizer: PQO version 3.6.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.6.0
 (10 rows)
 
 alter table mpp7638 set distributed by (a, b, c);
@@ -731,7 +731,7 @@ explain select * from (select * from mpp7620 where key=200) ss where key =200;
    ->  Seq Scan on mpp7620  (cost=0.00..431.00 rows=1 width=10)
          Filter: key = 200
  Settings:  optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (5 rows)
 
 explain insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
@@ -743,7 +743,7 @@ explain insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=20
                ->  Seq Scan on mpp7620  (cost=0.00..431.00 rows=1 width=4)
                      Filter: key = 200
  Settings:  optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (7 rows)
 
 explain select key from mpp7620 where mpp7620.key=200;
@@ -753,7 +753,7 @@ explain select key from mpp7620 where mpp7620.key=200;
    ->  Seq Scan on mpp7620  (cost=0.00..431.00 rows=1 width=4)
          Filter: key = 200
  Settings:  optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (5 rows)
 
 reset test_print_direct_dispatch_info;
@@ -791,7 +791,7 @@ explain select * from table_a where a0=3;
    ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=16)
          Filter: a0 = 3
  Settings:  optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (5 rows)
 
 explain select a0 from table_a where a0 in (select max(a1) from table_a);
@@ -809,7 +809,7 @@ explain select a0 from table_a where a0 in (select max(a1) from table_a);
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (13 rows)
 
 select a0 from table_a where a0 in (select max(a1) from table_a);
@@ -850,7 +850,7 @@ explain select a0 from table_a where a0 in (select max(a1) from table_a where a0
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 1.624
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
 (14 rows)
 
 reset test_print_direct_dispatch_info;

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1779,7 +1779,7 @@ order by 1,2;
                            ->  Aggregate
                                  ->  Gather Motion 3:1  (slice1; segments: 3)
                                        ->  Seq Scan on mergeappend_test mergeappend_test_1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (17 rows)
 
 -- This used to trip an assertion in MotionStateFinderWalker(), when we were
@@ -1831,7 +1831,7 @@ order by 1,2;
    (slice2)    Executor memory: 215K bytes (entry db).
    (slice3)    Executor memory: 229K bytes avg x 3 workers, 244K bytes max (seg0).  Work_mem: 49K bytes max.
  Memory used:  128000kB
- Optimizer: PQO version 3.18.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.18.0
  Execution time: 3.142 ms
 (26 rows)
 

--- a/src/test/regress/expected/select_views_optimizer.out
+++ b/src/test/regress/expected/select_views_optimizer.out
@@ -1346,7 +1346,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_normal WHERE f_leak(passwd);
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on customer
          Filter: ((name = 'regress_alice'::text) AND f_leak(passwd))
- Optimizer: PQO version 2.59.1
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.59.1
 (4 rows)
 
 SELECT * FROM my_property_secure WHERE f_leak(passwd);
@@ -1392,7 +1392,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_normal WHERE f_leak(cnum);
          ->  Index Scan using customer_dist_key_cid_key on customer
                Index Cond: ((dist_key = credit_card.dist_key) AND (cid = credit_card.cid))
                Filter: (name = 'regress_alice'::text)
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
 (9 rows)
 
 SELECT * FROM my_credit_card_secure WHERE f_leak(cnum);

--- a/src/test/regress/expected/select_views_optimizer_1.out
+++ b/src/test/regress/expected/select_views_optimizer_1.out
@@ -1346,7 +1346,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_normal WHERE f_leak(passwd);
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on customer
          Filter: ((name = 'regress_alice'::text) AND f_leak(passwd))
- Optimizer: PQO version 2.59.1
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.59.1
 (4 rows)
 
 SELECT * FROM my_property_secure WHERE f_leak(passwd);
@@ -1392,7 +1392,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_normal WHERE f_leak(cnum);
          ->  Index Scan using customer_dist_key_cid_key on customer
                Index Cond: ((dist_key = credit_card.dist_key) AND (cid = credit_card.cid))
                Filter: (name = 'regress_alice'::text)
- Optimizer: PQO version 2.67.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
 (9 rows)
 
 SELECT * FROM my_credit_card_secure WHERE f_leak(cnum);

--- a/src/test/regress/expected/subselect_gp_indexes_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_indexes_optimizer.out
@@ -82,7 +82,7 @@ explain select (select id1 from (select * from choose_seqscan_t2) foo where id2=
                  ->  Materialize  (cost=0.00..431.01 rows=50 width=8)
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=50 width=8)
                              ->  Seq Scan on choose_seqscan_t2  (cost=0.00..431.00 rows=17 width=8)
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (10 rows)
 
 -- then, a sequential scan is chosen because I need a motion to move choose_seqscan_t2
@@ -138,7 +138,7 @@ explain select (select id1 from (select * from choose_indexscan_t2) foo where id
          SubPlan 1  (slice1; segments: 3)
            ->  Seq Scan on choose_indexscan_t2  (cost=0.00..431.13 rows=1 width=4)
                  Filter: (id2 = choose_indexscan_t1.id2)
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (7 rows)
 
 -- then an indexscan is chosen because it is correct to do this on a replicated table since no motion is required

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -112,7 +112,7 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
                                                            ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
                                                                  Partitions selected: 4 (out of 4)
                                                            ->  Dynamic Seq Scan on csq_t2 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (26 rows)
 
 select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
@@ -145,7 +145,7 @@ explain select * from mrs_t1 where exists (select x from mrs_t1 where x < -1);
                            ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                  ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=1 width=1)
                                        Filter: x < (-1)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (11 rows)
 
 select * from mrs_t1 where exists (select x from mrs_t1 where x < -1) order by 1;
@@ -166,7 +166,7 @@ explain select * from mrs_t1 where exists (select x from mrs_t1 where x = 1);
                            ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=1)
                                  ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=1 width=1)
                                        Filter: x = 1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (11 rows)
 
 select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
@@ -217,7 +217,7 @@ explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
                                                    ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
                                                          ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
                                                                ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
- Optimizer: PQO version 3.27.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
 (21 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
@@ -397,7 +397,7 @@ explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; 
                                                                      ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                                                                            ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                                                                  ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 3.27.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
 (24 rows)
 
 select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
@@ -434,7 +434,7 @@ explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; 
                                                          ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
                                                                ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=9 width=4)
                                                                      ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 3.27.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
 (23 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
@@ -484,7 +484,7 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
          SubPlan 1  (slice1; segments: 3)
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (7 rows)
 
 SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
@@ -503,7 +503,7 @@ explain SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
          SubPlan 1  (slice1; segments: 3)
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (7 rows)
 
 SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
@@ -522,7 +522,7 @@ explain SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
            ->  Result  (cost=0.00..0.00 rows=1 width=1)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (8 rows)
 
 SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
@@ -542,7 +542,7 @@ explain SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
            ->  Result  (cost=0.00..0.00 rows=1 width=1)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (8 rows)
 
 SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
@@ -561,7 +561,7 @@ explain SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1)
            ->  Limit  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=4)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (8 rows)
 
 SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1);
@@ -580,7 +580,7 @@ explain SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
 (8 rows)
 
 SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
@@ -599,7 +599,7 @@ explain SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
 (8 rows)
 
 SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
@@ -623,7 +623,7 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
                  ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                              ->  Seq Scan on csq_r csq_r_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (12 rows)
 
 SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
@@ -666,7 +666,7 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                                  ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                                        Sort Key: csq_pullup_1.t
                                        ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (14 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
@@ -703,7 +703,7 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                                                          ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                                                                Sort Key: csq_pullup_1.v
                                                                ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (21 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
@@ -742,7 +742,7 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                                                          ->  Sort  (cost=0.00..431.00 rows=1 width=5)
                                                                Sort Key: csq_pullup_1.n
                                                                ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (23 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
@@ -770,7 +770,7 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=5)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.n + 1);
@@ -798,7 +798,7 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.i + 1);
@@ -826,7 +826,7 @@ explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t
                ->  Result  (cost=0.00..431.00 rows=1 width=4)
                      ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
                            Filter: i = 1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (9 rows)
 
 select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.t=t1.t and t1.i = 1);
@@ -851,7 +851,7 @@ explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t
                      ->  Result  (cost=0.00..431.00 rows=1 width=4)
                            ->  Result  (cost=0.00..431.00 rows=1 width=4)
                                  ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.i=t1.i + 1);
@@ -882,7 +882,7 @@ explain select * from subselect_t1 where x in (select y from subselect_t2);
          ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (7 rows)
 
 select * from subselect_t1 where x in (select y from subselect_t2);
@@ -910,7 +910,7 @@ explain select * from subselect_t1 where x in (select y from subselect_t2 union 
                            ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (13 rows)
 
 select * from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
@@ -931,7 +931,7 @@ explain select count(*) from subselect_t1 where x in (select y from subselect_t2
                      ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                            ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2);
@@ -960,7 +960,7 @@ explain select count(*) from subselect_t1 where x in (select y from subselect_t2
                                        ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                            ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (15 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
@@ -1041,7 +1041,7 @@ explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
    ->  Result  (cost=0.00..0.00 rows=0 width=4)
          One-Time Filter: false
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
 (5 rows)
 
 explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
@@ -1052,7 +1052,7 @@ select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
  Result  (cost=0.00..0.00 rows=0 width=4)
    One-Time Filter: false
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
 (4 rows)
 
 select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
@@ -1071,7 +1071,7 @@ where t1.a = foo.a;
    ->  Result  (cost=0.00..0.00 rows=0 width=8)
          One-Time Filter: false
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
 (5 rows)
 
 select * from t1,
@@ -1102,7 +1102,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on; optimizer_nestloop_factor=1; optimizer_segments=3
- Optimizer status: PQO version 2.44.1
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.44.1
 (14 rows)
 
 explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
@@ -1121,7 +1121,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on; optimizer_nestloop_factor=1; optimizer_segments=3
- Optimizer status: PQO version 2.39.2
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.39.2
 (14 rows)
 
 select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
@@ -1214,7 +1214,7 @@ from
                                                          ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                                                                Sort Key: t1_mpp_24563.id
                                                                ->  Seq Scan on t1_mpp_24563  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: PQO version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (21 rows)
 
 drop table t1_mpp_24563;
@@ -1275,7 +1275,7 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                                                                            ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
                                                                                  Partitions selected: 2 (out of 2)
                                                                            ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (29 rows)
 
 drop view v1_mpp_20470;
@@ -1442,7 +1442,7 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  Hash Key: subselect_tbl_1.f2
                                  ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (13 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
@@ -1470,7 +1470,7 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
                                                    ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=4)
                                              ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                                                    ->  Seq Scan on subselect_tbl subselect_tbl_2  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (21 rows)
 
 EXPLAIN SELECT '' AS three, f1, f2
@@ -1533,7 +1533,7 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
                      ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
                      ->  Hash  (cost=431.00..431.00 rows=3 width=8)
                            ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
- Optimizer: PQO version 2.75.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
 (11 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
@@ -1554,7 +1554,7 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=12)
                                  Hash Key: subselect_tbl_1.f2
                                  ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=12)
- Optimizer: PQO version 2.75.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
 (13 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
@@ -1576,7 +1576,7 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
                                    ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
                                          ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=2 width=4)
                                                Filter: f2 = f3::integer
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (14 rows)
 
 EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
@@ -1625,7 +1625,7 @@ EXPLAIN select count(*) from
                                              ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                    Group Key: tenk1_1.hundred
                                                    ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: PQO version 2.75.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
 (17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
@@ -1658,7 +1658,7 @@ EXPLAIN select count(distinct ss.ten) from
                                                                      ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                                            Group Key: tenk1_1.hundred
                                                                            ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: PQO version 2.75.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
 (26 rows)
 
 EXPLAIN select count(*) from
@@ -1682,7 +1682,7 @@ EXPLAIN select count(*) from
                                              ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                    Group Key: tenk1_1.hundred
                                                    ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: PQO version 2.75.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
 (17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
@@ -1715,7 +1715,7 @@ EXPLAIN select count(distinct ss.ten) from
                                                                      ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                                            Group Key: tenk1_1.hundred
                                                                            ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: PQO version 2.75.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
 (26 rows)
 
 --
@@ -1740,7 +1740,7 @@ EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) F
                                              Group Key: tenk1.unique1
                                              ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
  Settings:  optimizer=on
- Optimizer status: PQO version 2.36.0
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.36.0
 (14 rows)
 
 SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
@@ -1805,7 +1805,7 @@ EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup
                                                                      ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                                                                            Partitions selected: 1 (out of 1)
                                                                      ->  Dynamic Seq Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=4 width=4)
- Optimizer: PQO version 2.60.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.60.0
 (25 rows)
 
 SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
@@ -1836,7 +1836,7 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN 
                ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                      Hash Key: dedup_test1_1.b
                      ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (19 rows)
 
 EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT a FROM dedup_test1);
@@ -1858,7 +1858,7 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN 
                      ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=4)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (17 rows)
 
 EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b FROM dedup_test1) AND dedup_test3.b IN (SELECT b FROM dedup_test1);
@@ -1898,7 +1898,7 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b 
                                        ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                              ->  Limit  (cost=0.00..431.00 rows=1 width=1)
                                                    ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=1)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (35 rows)
 
 -- start_ignore

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -678,7 +678,7 @@ explain (verbose, costs off)
                      Output: 'regression'::name
                      ->  Result
                            Output: true
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
  Settings: optimizer=on
 (15 rows)
 
@@ -715,7 +715,7 @@ explain (verbose, costs off)
                      Output: 'regression'::name
                      ->  Result
                            Output: true
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
  Settings: optimizer=on
 (15 rows)
 
@@ -811,7 +811,7 @@ select * from int4_tbl where
                  Output: tenk1_1.ten
                  ->  Seq Scan on public.tenk1 tenk1_1
                        Output: tenk1_1.ten
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
  Settings: optimizer=on
 (27 rows)
 

--- a/src/test/regress/expected/tsearch_optimizer.out
+++ b/src/test/regress/expected/tsearch_optimizer.out
@@ -130,7 +130,7 @@ explain (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
                ->  Index Scan using wowidx on test_tsvector
                      Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
                      Filter: (a @@ '''wr'' | ''qh'''::tsquery)
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (7 rows)
 
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
@@ -204,7 +204,7 @@ explain (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
                ->  Index Scan using wowidx on test_tsvector
                      Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
                      Filter: (a @@ '''wr'' | ''qh'''::tsquery)
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (7 rows)
 
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
@@ -282,7 +282,7 @@ explain (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
          ->  Aggregate
                ->  Seq Scan on test_tsvector
                      Filter: (a @@ '''wr'' | ''qh'''::tsquery)
- Optimizer: PQO version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (6 rows)
 
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -488,7 +488,7 @@ explain (costs off)
                      ->  Seq Scan on t1
          ->  Index Scan using t2_pkey on t2
                Index Cond: (ab = 'ab'::text)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (9 rows)
 
 explain (costs off)
@@ -517,7 +517,7 @@ explain (costs off)
                                                    ->  Seq Scan on t1
                                        ->  Index Scan using t2_pkey on t2
                                              Index Cond: (ab = 'ab'::text)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (19 rows)
 
 --
@@ -620,7 +620,7 @@ explain (costs off)
                Filter: (t = 2)
                ->  Result
                      ->  Seq Scan on tenk1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 -- Test that we push quals into UNION sub-selects only when it's safe
@@ -640,7 +640,7 @@ WHERE x < 4;
    ->  Result
          ->  Result
                One-Time Filter: false
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (9 rows)
 
 SELECT * FROM
@@ -676,7 +676,7 @@ ORDER BY x;
                      ->  Result
                            ->  Result
                                  One-Time Filter: false
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (15 rows)
 
 SELECT * FROM
@@ -747,7 +747,7 @@ select * from
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on int4_tbl
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (10 rows)
 
 select * from

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -354,7 +354,7 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a=6 WHERE a=5;
                                  ->  Result
                                        ->  Index Scan using base_tbl_pkey on base_tbl
                                              Index Cond: ((a = 5) AND (a > 0))
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (12 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view1 WHERE a=5;
@@ -364,7 +364,7 @@ EXPLAIN (costs off) DELETE FROM rw_view1 WHERE a=5;
    ->  Result
          ->  Index Scan using base_tbl_pkey on base_tbl
                Index Cond: ((a = 5) AND (a > 0))
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (5 rows)
 
 DROP TABLE base_tbl CASCADE;
@@ -435,7 +435,7 @@ EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
                                  ->  Result
                                        ->  Index Scan using base_tbl_pkey on base_tbl
                                              Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (12 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE aaa=4;
@@ -445,7 +445,7 @@ EXPLAIN (costs off) DELETE FROM rw_view2 WHERE aaa=4;
    ->  Result
          ->  Index Scan using base_tbl_pkey on base_tbl
                Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (5 rows)
 
 DROP TABLE base_tbl CASCADE;
@@ -639,7 +639,7 @@ EXPLAIN (costs off) UPDATE rw_view2 SET a=3 WHERE a=2;
                                  Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
                                  ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
                                        Index Cond: (a > 0)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (13 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE a=2;
@@ -656,7 +656,7 @@ EXPLAIN (costs off) DELETE FROM rw_view2 WHERE a=2;
                            Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
                            ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
                                  Index Cond: (a > 0)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (12 rows)
 
 DROP TABLE base_tbl CASCADE;
@@ -2052,7 +2052,7 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
                                                          ->  Result
                                                                ->  Index Scan using base_tbl_pkey on base_tbl
                                                                      Index Cond: (id = 2)
- Optimizer: PQO version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
  
  Update
    ->  Result
@@ -2070,7 +2070,7 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
                                                          ->  Gather Motion 3:1  (slice1; segments: 3)
                                                                ->  Index Scan using base_tbl_pkey on base_tbl
                                                                      Index Cond: (id = 2)
- Optimizer: PQO version 3.11.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.11.0
 (38 rows)
 
 INSERT INTO rw_view1 VALUES (2, 'New row 2');

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -165,7 +165,7 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                                          ->  Hash
                                                                ->  Broadcast Motion 3:3  (slice6; segments: 3)
                                                                      ->  Seq Scan on keo2
- Optimizer: PQO version 3.19.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.19.0
 (41 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
@@ -204,7 +204,7 @@ EXPLAIN (COSTS OFF) DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS
                                              ->  Gather Motion 3:1  (slice1; segments: 3)
                                                    ->  Seq Scan on keo5 keo5_1
                                                          Filter: (x < 2)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (16 rows)
 
 DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS (SELECT x FROM keo5 WHERE x < 2));
@@ -512,7 +512,7 @@ explain update nosplitupdate set a=0 where a=1 and a<1;
                                  ->  Result  (cost=0.00..0.00 rows=0 width=18)
                                        One-Time Filter: false
  Planning time: 17.926 ms
- Optimizer: PQO version 3.16.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.16.0
 (10 rows)
 
 -- test split-update when split-node's flow is entry

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -346,7 +346,7 @@ EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
                      ->  Split
                            ->  Result
                                  ->  Seq Scan on tab3
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (9 rows)
 
 -- clean up

--- a/src/test/regress/expected/window_optimizer.out
+++ b/src/test/regress/expected/window_optimizer.out
@@ -640,7 +640,7 @@ select first_value(max(x)) over (), y
                                        Group Key: (ten + four)
                                        ->  Result
                                              ->  Seq Scan on tenk1
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (13 rows)
 
 -- test non-default frame specifications
@@ -1119,7 +1119,7 @@ FROM empsalary;
                            ->  Sort
                                  Sort Key: depname, salary, enroll_date
                                  ->  Seq Scan on empsalary
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (14 rows)
 
 -- Test pushdown of quals into a subquery containing window functions
@@ -1146,7 +1146,7 @@ WHERE depname = 'sales';
                                        Sort Key: depname
                                        ->  Seq Scan on empsalary
                                              Filter: ((depname)::text = 'sales'::text)
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (14 rows)
 
 -- pushdown is unsafe because there's a PARTITION BY clause without depname:
@@ -1175,7 +1175,7 @@ WHERE depname = 'sales';
                                        ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                              Hash Key: enroll_date
                                              ->  Seq Scan on empsalary
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (17 rows)
 
 -- pushdown is unsafe because the subquery contains window functions and the qual is volatile:
@@ -1201,7 +1201,7 @@ WHERE depname = 'sales' OR RANDOM() > 0.5;
                                        Sort Key: depname
                                        ->  Seq Scan on empsalary
                                              Filter: (((depname)::text = 'sales'::text) OR (random() > 0.5::double precision))
- Optimizer: PQO version 3.23.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
 (14 rows)
 
 -- cleanup

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -16,7 +16,7 @@ m/NOTICE:  extension "gp_debug_numsegments" already exists, skipping/
 m/^WARNING:  gpmon:.*Connection refused.*/
 
 m/^ Optimizer status:.*/
-m/^ Optimizer: PQO version .*/
+m/^ Optimizer: Pivotal Optimizer \(GPORCA\) version .*/
 m/^ Optimizer: Postgres query optimizer/
 m/^ Settings:.*/
 

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -84,7 +84,7 @@ SELECT owner, property FROM GistTable1
    ->  Index Scan using propertyboxindex on gisttable1
          Index Cond: (property ~= '(7052,250),(6050,20)'::box)
          Filter: (property ~= '(7052,250),(6050,20)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (5 rows)
 
 SELECT id, property FROM GistTable1 
@@ -130,7 +130,7 @@ SELECT owner, property FROM GistTable1
    ->  Index Scan using propertyboxindex on gisttable1
          Index Cond: (property ~= '(7052,250),(6050,20)'::box)
          Filter: (property ~= '(7052,250),(6050,20)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (5 rows)
 
 SELECT id, property FROM GistTable1 
@@ -582,7 +582,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
    ->  Index Scan using gistindex13 on gisttable13
          Index Cond: (property ~= '(999,999),(998,998)'::box)
          Filter: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (5 rows)
 
 VACUUM GistTable13;
@@ -602,7 +602,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
    ->  Index Scan using gistindex13 on gisttable13
          Index Cond: (property ~= '(999,999),(998,998)'::box)
          Filter: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (5 rows)
 
 TRUNCATE TABLE GistTable13;
@@ -632,7 +632,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
    ->  Index Scan using gistindex13 on gisttable13
          Index Cond: (property ~= '(999,999),(998,998)'::box)
          Filter: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (5 rows)
 
 -- ----------------------------------------------------------------------
@@ -672,7 +672,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                ->  Index Scan using propertyboxindex on gisttable1
                      Index Cond: (property ~= '(3,4),(1,2)'::box)
                      Filter: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (9 rows)
 
 REINDEX INDEX propertyBoxIndex;
@@ -699,7 +699,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                ->  Index Scan using propertyboxindex on gisttable1
                      Index Cond: (property ~= '(3,4),(1,2)'::box)
                      Filter: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (9 rows)
 
 DROP INDEX propertyBoxIndex;
@@ -726,7 +726,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
          Sort Key: id
          ->  Seq Scan on gisttable1
                Filter: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (7 rows)
 
 -- ----------------------------------------------------------------------
@@ -815,7 +815,7 @@ SELECT owner, property FROM GistTable1
          Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
                Index Cond: (property ~= '(7052,250),(6050,20)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 SELECT id, property FROM GistTable1 
@@ -1204,7 +1204,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 VACUUM GistTable13;
@@ -1225,7 +1225,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 TRUNCATE TABLE GistTable13;
@@ -1256,7 +1256,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 -- ----------------------------------------------------------------------
@@ -1297,7 +1297,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                      Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
                            Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 REINDEX INDEX propertyBoxIndex;
@@ -1325,7 +1325,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                      Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
                            Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 DROP INDEX propertyBoxIndex;
@@ -1352,7 +1352,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
          Sort Key: id
          ->  Seq Scan on gisttable1
                Filter: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (7 rows)
 
 -- ----------------------------------------------------------------------
@@ -1441,7 +1441,7 @@ SELECT owner, property FROM GistTable1
          Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
                Index Cond: (property ~= '(7052,250),(6050,20)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 SELECT id, property FROM GistTable1 
@@ -1830,7 +1830,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 VACUUM GistTable13;
@@ -1851,7 +1851,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 TRUNCATE TABLE GistTable13;
@@ -1882,7 +1882,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 -- ----------------------------------------------------------------------
@@ -1923,7 +1923,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                      Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
                            Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 REINDEX INDEX propertyBoxIndex;
@@ -1951,7 +1951,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                      Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
                            Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 DROP INDEX propertyBoxIndex;
@@ -1978,7 +1978,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
          Sort Key: id
          ->  Seq Scan on gisttable1
                Filter: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (7 rows)
 
 -- ----------------------------------------------------------------------
@@ -2067,7 +2067,7 @@ SELECT owner, property FROM GistTable1
          Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
                Index Cond: (property ~= '(7052,250),(6050,20)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 SELECT id, property FROM GistTable1 
@@ -2456,7 +2456,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 VACUUM GistTable13;
@@ -2477,7 +2477,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 TRUNCATE TABLE GistTable13;
@@ -2508,7 +2508,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 -- ----------------------------------------------------------------------
@@ -2549,7 +2549,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                      Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
                            Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 REINDEX INDEX propertyBoxIndex;
@@ -2577,7 +2577,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                      Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
                            Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 DROP INDEX propertyBoxIndex;
@@ -2604,7 +2604,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
          Sort Key: id
          ->  Seq Scan on gisttable1
                Filter: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (7 rows)
 
 -- ----------------------------------------------------------------------
@@ -2693,7 +2693,7 @@ SELECT owner, property FROM GistTable1
          Recheck Cond: (property ~= '(7052,250),(6050,20)'::box)
          ->  Bitmap Index Scan on propertyboxindex
                Index Cond: (property ~= '(7052,250),(6050,20)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 SELECT id, property FROM GistTable1 
@@ -3082,7 +3082,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 VACUUM GistTable13;
@@ -3103,7 +3103,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 TRUNCATE TABLE GistTable13;
@@ -3134,7 +3134,7 @@ EXPLAIN (COSTS OFF) SELECT id, property AS "ProperTee" FROM GistTable13
          Recheck Cond: (property ~= '(999,999),(998,998)'::box)
          ->  Bitmap Index Scan on gistindex13
                Index Cond: (property ~= '(999,999),(998,998)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (6 rows)
 
 -- ----------------------------------------------------------------------
@@ -3175,7 +3175,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                      Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
                            Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 REINDEX INDEX propertyBoxIndex;
@@ -3203,7 +3203,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
                      Recheck Cond: (property ~= '(3,4),(1,2)'::box)
                      ->  Bitmap Index Scan on propertyboxindex
                            Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (10 rows)
 
 DROP INDEX propertyBoxIndex;
@@ -3230,7 +3230,7 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
          Sort Key: id
          ->  Seq Scan on gisttable1
                Filter: (property ~= '(3,4),(1,2)'::box)
- Optimizer: PQO version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (7 rows)
 
 -- ----------------------------------------------------------------------

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -174,7 +174,7 @@ select string_agg(b, '') over (partition by a) from foo order by 1;
 select string_agg(b, '') over (partition by a,b) from foo order by 1;
 -- should not fall back
 select max(b) over (partition by a) from foo order by 1;
-select count_operator('select max(b) over (partition by a) from foo order by 1;', 'PQO');
+select count_operator('select max(b) over (partition by a) from foo order by 1;', 'Pivotal Optimizer (GPORCA)');
 -- fall back
 select string_agg(b, '') over (partition by a+1) from foo order by 1;
 select string_agg(b || 'txt', '') over (partition by a) from foo order by 1;

--- a/src/test/regress/sql/errors.sql
+++ b/src/test/regress/sql/errors.sql
@@ -388,8 +388,8 @@ create function infinite_recurse() returns int as
 -- # mpp-2756
 -- m/(ERROR|WARNING|CONTEXT|NOTICE):.*stack depth limit exceeded\s+at\s+character/
 -- s/\s+at\s+character.*//
--- m/ERROR:.*GPDB exception. Aborting PQO.*/
--- s/ERROR:.*GPDB exception. Aborting PQO.*//
+-- m/ERROR:.*GPDB exception. Aborting Pivotal Optimizer \(GPORCA\).*/
+-- s/ERROR:.*GPDB exception. Aborting Pivotal Optimizer \(GPORCA\).*//
 -- end_matchsubs
 -- start_ignore
 select infinite_recurse();

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -55,8 +55,8 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Execution Time: \d+\.\d+/Execution Time: ##.###/
 -- m/Segments: \d+/
 -- s/Segments: \d+/Segments: #/
--- m/PQO version \d+\.\d+\.\d+",?/
--- s/PQO version \d+\.\d+\.\d+",?/PQO version ##.##.##"/
+-- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
+-- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\) version ##.##.##"/
 -- m/ Memory: \d+/
 -- s/ Memory: \d+/ Memory: ###/
 -- m/Maximum Memory Used: \d+/
@@ -87,8 +87,8 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- Check JSON format
 --
 -- start_matchsubs
--- m/PQO version \d+\.\d+\.\d+/
--- s/PQO version \d+\.\d+\.\d+/PQO version ##.##.##/
+-- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/
+-- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/Pivotal Optimizer \(GPORCA\) version ##.##.##/
 -- end_matchsubs
 -- explain_processing_off
 EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -120,7 +120,7 @@ explain (costs off) select count(*) over (partition by g) from generate_series(1
 -- The default init_file rules contain a line to mask this out in normal
 -- text-format EXPLAIN output, but it doesn't catch these alternative formats.
 -- start_matchignore
--- m/Optimizer.*PQO version .*/
+-- m/Optimizer.*Pivotal Optimizer \(GPORCA\) version .*/
 -- end_matchignore
 
 CREATE EXTERNAL WEB TABLE dummy_ext_tab (x text) EXECUTE 'echo foo' FORMAT 'text';

--- a/src/test/regress/sql/qp_query_execution.sql
+++ b/src/test/regress/sql/qp_query_execution.sql
@@ -9,7 +9,7 @@ create or replace function qx_count_operator(query text, planner_operator text, 
 $$
 rv = plpy.execute('EXPLAIN '+ query)
 plan = '\n'.join([row['QUERY PLAN'] for row in rv])
-optimizer = plan.find('PQO')
+optimizer = plan.find('Pivotal Optimizer (GPORCA)')
 
 if optimizer >= 0:
     return plan.count(optimizer_operator)


### PR DESCRIPTION
ORCA Explain plans will now contain:
`Optimizer: Pivotal Optimizer (GPORCA) version 3.35.0`

instead of:
`Optimizer: PQO version 3.35.0`

Authored-by: Chris Hajas <chajas@pivotal.io>