### PR TITLE
Compile gpfdist on windows with CMake

### DIFF
--- a/src/bin/gpfdist/CMakeLists.txt
+++ b/src/bin/gpfdist/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.12)
+project(gpfdist)
+
+set(GPDB_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../)
+
+add_definitions("/D FRONTEND")
+
+set (CPPFLAGS "/MP /wd4996 /wd4018 /wd4090 /wd4102 /wd4244 /wd4267 /wd4273 /wd4715")
+add_definitions("${CPPFLAGS}")
+
+
+set(HEADER_DIRS
+    ${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/include/port
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+    ${GPDB_SRC_DIR}/src/backend
+    ${GPDB_SRC_DIR}/src/port
+)
+
+set(APR_LIB "${CMAKE_PREFIX_PATH}/lib/libapr-1.lib")
+set(APR_DLL "${CMAKE_PREFIX_PATH}/bin/libapr-1.dll")
+set(EVENT_LIB "${CMAKE_PREFIX_PATH}/lib/event.lib")
+
+#set include dirs
+include_directories("${CMAKE_PREFIX_PATH}/include")
+include_directories(${HEADER_DIRS})
+link_directories(${CMAKE_INSTALL_PREFIX}/lib)
+
+#set source files
+add_executable(gpfdist gpfdist.c gpfdist_helper.c
+    ${GPDB_SRC_DIR}/src/backend/utils/misc/fstream/gfile.c
+    ${GPDB_SRC_DIR}/src/backend/utils/misc/fstream/fstream.c
+    ${GPDB_SRC_DIR}/src/port/glob.c)
+
+include(FindOpenSSL)
+if (OPENSSL_FOUND)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+else ()
+    message(FATAL_ERROR "openssl not found")
+endif(OPENSSL_FOUND)
+
+find_package(ZLIB REQUIRED)
+if (ZLIB_FOUND)
+    include_directories(${ZLIB_INCLUDE_DIRS})
+else ()
+    message(FATAL_ERROR "zlib not found")
+endif(ZLIB_FOUND)
+
+#set lib dirs
+target_link_libraries(gpfdist ${ZLIB_LIBRARIES} ${APR_LIB} ${EVENT_LIB} ${OPENSSL_LIBRARIES} libpgport ws2_32 Crypt32)
+
+set_target_properties(gpfdist PROPERTIES FOLDER bin)
+install(TARGETS gpfdist DESTINATION bin)
+install(FILES ${APR_DLL} DESTINATION bin)

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -19,7 +19,9 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef WIN32
 #include <strings.h>
+#endif
 #ifdef GPFXDIST
 #include <regex.h>
 #include <gpfxdist.h>
@@ -1294,7 +1296,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 {
 	int 		size;
 	const int 	whole_rows = 1; /* gpfdist must not read data with partial rows */
-	struct fstream_filename_and_offset fos = {};
+	struct fstream_filename_and_offset fos = {0};
 
 	session_t *session = r->session;
 
@@ -2141,6 +2143,8 @@ static void do_accept(int fd, short event, void* arg)
 	r->id = ++REQUEST_SEQ;
 	r->pool = pool;
 	r->sock = sock;
+
+	event_set(&r->ev, 0, 0, 0, 0);
 
 	/* use the block size specified by -m option */
 	r->outblock.data = palloc_safe(r, pool, opt.m, "out of memory when allocating buffer: %d bytes", opt.m);
@@ -4216,7 +4220,7 @@ static void do_close(int fd, short event, void *arg)
 		gwarning(r, "gpfdist shutdown the connection, while have not received response from segment");
 	}
 
-	int ret = read(r->sock, buffer, sizeof(buffer) - 1);
+	int ret = recv(r->sock, buffer, sizeof(buffer) - 1, 0);
 	if (ret < 0)
 	{
 		gwarning(r, "gpfdist read error after shutdown. errno: %d, msg: %s", errno, strerror(errno));


### PR DESCRIPTION
- Don't include strings.h when build with MSVC
- C99 Syntax fix for struct initializer.
- Call event_set to initialize event struct. Later libevent version
expect this behavior.
- Use recv instead of read. Latest CRT implementation of read only
works on files, not sockets.
- Fix pipe issue.