### PR TITLE
Compile pygresql on windows with CMake

### DIFF
--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/CMakeLists.txt
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.12)
+
+set (CMAKE_CONFIGURATION_TYPES Release RelWithDebInfo)
+project(pygresql C)
+
+find_package(Python2 COMPONENTS Interpreter Development)
+if (Python2_FOUND)
+    include_directories(${Python2_INCLUDE_DIRS})
+else ()
+    message(FATAL_ERROR "python2 not found")
+endif(Python2_FOUND)
+
+add_definitions("/D FRONTEND")
+
+set (CPPFLAGS "/MP /wd4996 /wd4018 /wd4090 /wd4102 /wd4244 /wd4267 /wd4273 /wd4715")
+add_definitions("${CPPFLAGS}")
+
+file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" "")
+set(GPDB_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
+include_directories(${GPDB_SRC_DIR}/src/include
+    ${GPDB_SRC_DIR}/src/interfaces/libpq
+    ${GPDB_SRC_DIR}/src/include/port
+    ${GPDB_SRC_DIR}/src/include/port/win32
+    ${GPDB_SRC_DIR}/src/include/port/win32_msvc
+    ${GPDB_SRC_DIR}/src/port
+    ${Python2_INCLUDE_DIRS})
+link_directories(${CMAKE_PREFIX_PATH}/lib)
+
+add_library (pygresql SHARED pgmodule.c)
+target_link_libraries(pygresql libpq libpgport libpgcommon ws2_32 secur32 ${Python2_LIBRARIES})
+set_target_properties(pygresql PROPERTIES OUTPUT_NAME "_pg")
+set_target_properties(pygresql PROPERTIES SUFFIX ".pyd")
+install(TARGETS pygresql DESTINATION lib/python/pygresql)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pg.py DESTINATION lib/python/pygresql)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pgdb.py DESTINATION lib/python/pygresql)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py DESTINATION lib/python/pygresql)
+
+file(TO_CMAKE_PATH ${CMAKE_PREFIX_PATH}/lib/libpq.dll LIBPQDLL)
+install(FILES ${LIBPQDLL} DESTINATION lib/python/pygresql)


### PR DESCRIPTION
Requires a working libpq.dll. Set CMAKE_PREFIX_PATH to a successful
client build.