### PR TITLE
Add WebSocket protocols to ports & protocol table

### DIFF
--- a/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
+++ b/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
@@ -156,7 +156,7 @@ MIRROR_REPLICATION_PORT_BASE = 9000</codeblock></note>
           </row>
           <row otherprops="pivotal">
             <entry morerows="2">Greenplum Command Center (GPCC)</entry>
-            <entry>TCP 28080, HTTP/HTTPSj, WebSocket (WS), Secure WebSocket (WSS)</entry>
+            <entry>TCP 28080, HTTP/HTTPS, WebSocket (WS), Secure WebSocket (WSS)</entry>
             <entry>The GPCC web server (<codeph>gpccws</codeph> process) executes on the Greenplum Database master
               host or standby master host. The port number is configured at installation
               time.</entry>

--- a/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
+++ b/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
@@ -156,7 +156,7 @@ MIRROR_REPLICATION_PORT_BASE = 9000</codeblock></note>
           </row>
           <row otherprops="pivotal">
             <entry morerows="2">Greenplum Command Center (GPCC)</entry>
-            <entry>TCP 28080, HTTP/HTTPS</entry>
+            <entry>TCP 28080, HTTP/HTTPSj, WebSocket (WS), Secure WebSocket (WSS)</entry>
             <entry>The GPCC web server (<codeph>gpccws</codeph> process) executes on the Greenplum Database master
               host or standby master host. The port number is configured at installation
               time.</entry>


### PR DESCRIPTION
Adds WS and WSS protocols to the ports & protocols table for GPCC.

Target master, 5.x, 6.x. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
