### PR TITLE
6X backport: Fix bug missing initializing timeout

### DIFF
--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -50,6 +50,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/tqual.h"
+#include "utils/timeout.h"
 
 #include "catalog/pg_authid.h"
 #include "catalog/pg_database.h"
@@ -88,6 +89,7 @@ static pid_t ftsprobe_forkexec(void);
 #endif
 NON_EXEC_STATIC void ftsMain(int argc, char *argv[]);
 static void FtsLoop(void);
+static void TimeoutHandler(void);
 
 static CdbComponentDatabases *readCdbComponentInfoAndUpdateStatus(MemoryContext);
 
@@ -212,7 +214,7 @@ ftsMain(int argc, char *argv[])
 	pqsignal(SIGINT, sigIntHandler);
 	pqsignal(SIGTERM, die);
 	pqsignal(SIGQUIT, quickdie); /* we don't do any ftsprobe specific cleanup, just use the standard. */
-	pqsignal(SIGALRM, SIG_IGN);
+	InitializeTimeouts();		/* establishes SIGALRM handler */
 
 	pqsignal(SIGPIPE, SIG_IGN);
 	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
@@ -220,6 +222,11 @@ ftsMain(int argc, char *argv[])
 	pqsignal(SIGUSR2, RequestShutdown);
 	pqsignal(SIGFPE, FloatExceptionHandler);
 	pqsignal(SIGCHLD, SIG_DFL);
+
+	RegisterTimeout(DEADLOCK_TIMEOUT, TimeoutHandler);
+	RegisterTimeout(STATEMENT_TIMEOUT, TimeoutHandler);
+	RegisterTimeout(LOCK_TIMEOUT, TimeoutHandler);
+	RegisterTimeout(GANG_TIMEOUT, TimeoutHandler);
 
 	/*
 	 * Copied from bgwriter
@@ -580,4 +587,10 @@ bool
 FtsIsActive(void)
 {
 	return (!skipFtsProbe && !shutdown_requested);
+}
+
+static void
+TimeoutHandler(void)
+{
+	kill(MyProcPid, SIGINT);
 }


### PR DESCRIPTION
We found that if gp_segment_configuration is locked, then it will
fail by triggering FTS. We got the stack below
	#2  0x0000000000a6bb29 in ExceptionalCondition at assert.c:66
	#3  0x0000000000aac19a in enable_timeout timeout.c:143
	#4  0x0000000000aacb6c in enable_timeout_after timeout.c:473
	#5  0x00000000008e86ef in ProcSleep at proc.c:1300
	#6  0x00000000008deb70 in WaitOnLock at lock.c:1894
	#7  0x00000000008e019e in LockAcquireExtended at lock.c:1205
	#8  0x00000000008dd2d8 in LockRelationOid at lmgr.c:102
	#9  0x000000000051c928 in heap_open at heapam.c:1083
	#10 0x0000000000b7feaf in getCdbComponentInfo at cdbutil.c:173
	#11 0x0000000000b81365 in cdbcomponent_getCdbComponents at cdbutil.c:606
	#12 0x00000000007603e1 in ftsMain at fts.c:351
	#13 0x0000000000760715 in ftsprobe_start at fts.c:121
	#14 0x00000000004cc7b0 in ServerLoop ()
	#15 0x00000000008769bf in PostmasterMain at postmaster.c:1531
	#16 0x000000000079098b in main ()
So it is that FTS hasn't initialized timeout. Any process that
wants to use timeout must call initilization first. This is the
root cause gpexpand job fails on master pipeline in build 71 and 79.
We added this initialization in FTS and GDD.


--------------------------

This is a cherry-pick from master to 6X. The commit is already in the Master branch. And we have got the green light from PMs. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
