### PR TITLE
contrib: enable file_fdw

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -46,7 +46,7 @@ html man:
 
 install:
 	$(MAKE) -C contrib/auto_explain $@
-	#$(MAKE) -C contrib/file_fdw $@ # GPDB_91_MERGE_FIXME: disable installation until it's officially supported.
+	$(MAKE) -C contrib/file_fdw $@
 	$(MAKE) -C contrib/formatter $@
 	$(MAKE) -C contrib/formatter_fixedwidth $@
 	$(MAKE) -C contrib/fuzzystrmatch $@
@@ -142,6 +142,7 @@ $(call recurse,installcheck-world, \
 			   src/pl \
 			   src/interfaces/gppc \
 			   contrib/auto_explain \
+			   contrib/file_fdw \
 			   contrib/formatter_fixedwidth \
 			   contrib/extprotocol \
 			   contrib/dblink \

--- a/contrib/file_fdw/output/file_fdw_optimizer.source
+++ b/contrib/file_fdw/output/file_fdw_optimizer.source
@@ -173,7 +173,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_csv;
    Output: a, b
    Foreign File: @abs_srcdir@/data/agg.csv
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
+ Settings: optimizer=on
 
 \t off
 PREPARE st(int) AS SELECT * FROM agg_csv WHERE a = $1;
@@ -247,7 +247,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_text WHERE a > 0;
    Filter: (agg_text.a > 0)
    Foreign File: @abs_srcdir@/data/agg.data
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
+ Settings: optimizer=on
 
 \t off
 -- privilege tests for object


### PR DESCRIPTION
Build, test and install file_fdw by default.

Also for the benefit of testing more FDW functions, since this is the
first built-in FDW extension.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [x] Pass `make installcheck`
