### PR TITLE
Fix storageWrite->maxLargeWriteLen name in Assert

### DIFF
--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -132,7 +132,7 @@ AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
 	storageWrite->maxBufferWithCompressionOverrrunLen =
 		storageWrite->maxBufferLen + storageWrite->compressionOverrunLen;
 	storageWrite->maxLargeWriteLen = 2 * storageWrite->maxBufferLen;
-	Assert(storageWrite->maxBufferWithCompressionOverrrunLen <= storageWrite->largeWriteLen);
+	Assert(storageWrite->maxBufferWithCompressionOverrrunLen <= storageWrite->maxLargeWriteLen);
 
 	memoryLen = BufferedAppendMemoryLen
 		(

--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -33,14 +33,14 @@ static void BufferedAppendWrite(
  * large write lengths.
  */
 int32
-BufferedAppendMemoryLen(int32 maxBufferLen,
+BufferedAppendMemoryLen(int32 maxBufferWithCompressionOverrrunLen,
 						int32 maxLargeWriteLen)
 {
-	Assert(maxBufferLen > 0);
-	Assert(maxLargeWriteLen >= maxBufferLen);
+	Assert(maxBufferWithCompressionOverrrunLen > 0);
+	Assert(maxLargeWriteLen >= maxBufferWithCompressionOverrrunLen);
 
 	/* Large write memory areas plus adjacent extra memory for 1 buffer. */
-	return (maxLargeWriteLen + maxBufferLen);
+	return (maxLargeWriteLen + maxBufferWithCompressionOverrrunLen);
 }
 
 /*
@@ -59,9 +59,9 @@ BufferedAppendInit(BufferedAppend *bufferedAppend,
 {
 	Assert(bufferedAppend != NULL);
 	Assert(memory != NULL);
-	Assert(maxBufferLen > 0);
-	Assert(maxLargeWriteLen >= maxBufferLen);
-	Assert(memoryLen >= BufferedAppendMemoryLen(maxBufferLen, maxLargeWriteLen));
+	Assert(maxBufferWithCompressionOverrrunLen> 0);
+	Assert(maxLargeWriteLen >= maxBufferWithCompressionOverrrunLen);
+	Assert(memoryLen >= BufferedAppendMemoryLen(maxBufferWithCompressionOverrrunLen, maxLargeWriteLen));
 
 	memset(bufferedAppend, 0, sizeof(BufferedAppend));
 
@@ -271,7 +271,7 @@ BufferedAppendGetBuffer(BufferedAppend *bufferedAppend,
 	currentLargeWriteLen = bufferedAppend->largeWriteLen;
 	Assert(currentLargeWriteLen + bufferLen <=
 		   bufferedAppend->maxLargeWriteLen +
-		   bufferedAppend->maxBufferLen);
+		   bufferedAppend->maxBufferWithCompressionOverrrunLen);
 
 	bufferedAppend->bufferLen = bufferLen;
 
@@ -339,7 +339,7 @@ BufferedAppendFinishBuffer(BufferedAppend *bufferedAppend,
 
 	newLen = bufferedAppend->largeWriteLen + usedLen;
 	Assert(newLen <= bufferedAppend->maxLargeWriteLen +
-		   bufferedAppend->maxBufferLen);
+		   bufferedAppend->maxBufferWithCompressionOverrrunLen);
 	if (newLen >= bufferedAppend->maxLargeWriteLen)
 	{
 		/*

--- a/src/include/cdb/cdbbufferedappend.h
+++ b/src/include/cdb/cdbbufferedappend.h
@@ -87,7 +87,7 @@ typedef struct BufferedAppend
  * large write lengths.
  */
 extern int32 BufferedAppendMemoryLen(
-    int32                maxBufferLen,
+    int32                maxBufferWithCompressionOverrrunLen,
     int32                maxLargeWriteLen);
 
 /*


### PR DESCRIPTION
This variable name is not renamed in commit cb447dc
And will lead to compile error when cassert enabled.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
