### PR TITLE
Silece stringop-overflow warning and protect against invalid read

### DIFF
--- a/src/bin/pg_dump/dumputils.c
+++ b/src/bin/pg_dump/dumputils.c
@@ -1539,7 +1539,7 @@ custom_fmtopts_string(const char *src)
 	if (!src)
 		return NULL;
 
-	to_free = srcdup = pstrdup(src);
+	to_free = srcdup = pg_strdup(src);
 	srcdup_end = srcdup + strlen(srcdup);
 	initPQExpBuffer(&result);
 
@@ -1584,7 +1584,7 @@ custom_fmtopts_string(const char *src)
 	if (last >= 0 && (result.data[last] == ',' || result.data[last] == '='))
 		result.data[last] = '\0';
 
-	free(to_free);
+	pg_free(to_free);
 	return result.data;
 }
 

--- a/src/bin/pg_dump/dumputils.c
+++ b/src/bin/pg_dump/dumputils.c
@@ -1539,7 +1539,7 @@ custom_fmtopts_string(const char *src)
 	if (!src)
 		return NULL;
 
-	to_free = srcdup = strdup(src);
+	to_free = srcdup = pstrdup(src);
 	srcdup_end = srcdup + strlen(srcdup);
 	initPQExpBuffer(&result);
 


### PR DESCRIPTION
strncat, unfortunately, takes a misleading size argument which means
at most size from src. It is a bit of an antipattern in the string
family of functions and for that compilers will emit a warning if
it happens that the size argument matches the size of src, since that
is not what usually users of strncat want to do.

The usage of the function in the code was correct. However instead
of silencing the compiler, strncat was replaced with the portable
a version of strlcat that comes with postgres and takes the full size
of dst as size argument.

Also, protect against an invalid read in case that the size of the
result is zero.
