### PR TITLE
Remove implication that transactions restart themselves after segment…

### DIFF
--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-overview-of-segment-mirroring.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-overview-of-segment-mirroring.xml
@@ -8,8 +8,12 @@
             instances: <i>primary</i> and <i>mirror</i>. Each primary segment has one corresponding
             mirror segment. A primary segment instance receives requests from the master to make
             changes to the segment data and then replicates those changes to the corresponding
-            mirror. If a primary segment becomes unavailable, database queries fail over to the
-            mirror segment.</p>
+            mirror. If Greenplum Database detects that a primary segment has failed or become
+            unavailable, it changes the role of its mirror segment to primary segment and the role
+            of the unavailable primary segment to mirror segment. Transactions in progress when the
+            failure occurred roll back and must be restarted. The administrator must then recover
+            the mirror segment, allow the mirror to syncronize with the current primary segment, and
+            then exchange the primary and mirror segments so they are in their preferred roles.</p>
         <p>If segment mirroring is not enabled, the Greenplum Database system shuts down if a
             segment instance fails. Administrators must manually recover all failed segments before
             Greenplum Database operations can resume.</p>

--- a/gpdb-doc/dita/admin_guide/managing/highavail.xml
+++ b/gpdb-doc/dita/admin_guide/managing/highavail.xml
@@ -253,10 +253,13 @@ mirror3=3:sdw2:sdw2-2:52002:53002:54002:/gpdata/mir1/gp3
     <title id="ki155550">Detecting a Failed Segment</title>
     <body>
       <p>With mirroring enabled, Greenplum Database automatically fails over to a mirror segment
-        when a primary segment goes down. Provided one segment instance is online per portion of
-        data, users may not realize a segment is down. If a transaction is in progress when a fault
-        occurs, the in-progress transaction rolls back and restarts automatically on the
-        reconfigured set of segments.</p>
+        when a primary segment goes down. The mirror segment assumes the role of the primary segment
+        and the failed primary segment becomes the mirror. Transactions in progress when a fault
+        occurs roll back and must be restarted. When restarted the transactions run on the new
+        primary segment.</p>
+      <p>To return the Greenplum Database cluster to full redundancy and balance, an administrator
+        recovers the down mirror segment and exchanges the roles of the primary and mirror
+        segments so that both segments are in their preferred roles.</p>
       <p>If the entire Greenplum Database system becomes nonoperational due to a segment failure
         (for example, if mirroring is not enabled or not enough segments are online to access all
         user data), users will see errors when trying to connect to a database. The errors returned


### PR DESCRIPTION
… failure. 

Overviews of gpdb segment mirroring appear to suggest that transactions fail over to the mirror segment when primary fails. But they roll back and have to be restarted. 

This is a problem in all versions of the GPDB documentation. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
