### PR TITLE
docs - pxf init/sync support to master standby

### DIFF
--- a/gpdb-doc/markdown/pxf/access_hdfs.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_hdfs.html.md.erb
@@ -46,8 +46,8 @@ The PXF agent invokes the HDFS Java API to read the data and delivers it to the 
 
 Before working with Hadoop data using PXF, ensure that:
 
-- You have configured and initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring PXF](instcfg_pxf.html) for additional information.
-- You have configured the PXF Hadoop Connectors that you plan to use on each Greenplum Database segment host. Refer to [Configuring PXF Hadoop Connectors](client_instcfg.html) for instructions. If you plan to access JSON-formatted data stored in a Cloudera Hadoop cluster, PXF requires a Cloudera version 5.8 or later Hadoop distribution.
+- You have configured and initialized PXF, and PXF is running on each Greenplum Database segment host. See [Configuring PXF](instcfg_pxf.html) for additional information.
+- You have configured the PXF Hadoop Connectors that you plan to use. Refer to [Configuring PXF Hadoop Connectors](client_instcfg.html) for instructions. If you plan to access JSON-formatted data stored in a Cloudera Hadoop cluster, PXF requires a Cloudera version 5.8 or later Hadoop distribution.
 - If user impersonation is enabled (the default), ensure that you have granted read (and write as appropriate) permission to the HDFS files and directories that will be accessed as external tables in Greenplum Database to each Greenplum Database user/role name that will access the HDFS files and directories. If user impersonation is not enabled, you must grant this permission to the `gpadmin` user.
 - Time is synchronized between the Greenplum Database segment hosts and the external Hadoop systems.
 

--- a/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
@@ -27,8 +27,8 @@ PXF is installed with connectors to Azure Blob Storage, Azure Data Lake, Google 
 
 Before working with object store data using PXF, ensure that:
 
-- You have configured and initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring PXF](instcfg_pxf.html) for additional information.
-- You have configured the PXF Object Store Connectors that you plan to use on each Greenplum Database segment host. Refer to [Configuring Connectors to Azure, Google Cloud Storage, Minio, and S3 Object Stores](objstore_cfg.html) for instructions.
+- You have configured and initialized PXF, and PXF is running on each Greenplum Database segment host. See [Configuring PXF](instcfg_pxf.html) for additional information.
+- You have configured the PXF Object Store Connectors that you plan to use. Refer to [Configuring Connectors to Azure, Google Cloud Storage, Minio, and S3 Object Stores](objstore_cfg.html) for instructions.
 - Time is synchronized between the Greenplum Database segment hosts and the external object store systems.
 
 

--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -27,7 +27,7 @@ PXF provides two management commands:
 - `pxf cluster` - manage all PXF service instances in the Greenplum Database cluster
 - `pxf` - manage the PXF service instance on a specific Greenplum Database host
 
-The [`pxf cluster`](ref/pxf-cluster.html) command supports `init`, `start`, `stop`, and `sync` subcommands. When you run a `pxf cluster` subcommand on the Greenplum Database master host, you perform the operation on all segment hosts in the Greenplum Database cluster.
+The [`pxf cluster`](ref/pxf-cluster.html) command supports `init`, `start`, `stop`, and `sync` subcommands. When you run a `pxf cluster` subcommand on the Greenplum Database master host, you perform the operation on all segment hosts in the Greenplum Database cluster. PXF also runs the `init` and `sync` commands on the standby master host.
 
 The [`pxf`](ref/pxf.html) command supports `init`, `start`, `stop`, `restart`, and `status` operations. These operations run locally. That is, if you want to start or stop the PXF agent on a specific Greenplum Database segment host, you log in to the host and run the command. 
 
@@ -54,7 +54,7 @@ The `pxf-env.sh` file exposes the following PXF runtime configuration parameters
 | PXF_KEYTAB  | The absolute path to the PXF service Kerberos principal keytab file. | $PXF_CONF/keytabs/pxf.service.keytab |
 | PXF_PRINCIPAL  | The PXF service Kerberos principal. | gpadmin/\_HOST@EXAMPLE.COM |
 
-You must synchronize any changes that you make to `pxf-env.sh`, `pxf-log4j.properties`, or `pxf-profiles.xml` to each Greenplum Database segment host, and (re)start PXF on each host.
+You must synchronize any changes that you make to `pxf-env.sh`, `pxf-log4j.properties`, or `pxf-profiles.xml` to the Greenplum Database segment cluster, and (re)start PXF on each segment host.
 
 ### <a id="start_pxf_prereq" class="no-quick-link"></a>Prerequisites
 

--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -54,7 +54,7 @@ The `pxf-env.sh` file exposes the following PXF runtime configuration parameters
 | PXF_KEYTAB  | The absolute path to the PXF service Kerberos principal keytab file. | $PXF_CONF/keytabs/pxf.service.keytab |
 | PXF_PRINCIPAL  | The PXF service Kerberos principal. | gpadmin/\_HOST@EXAMPLE.COM |
 
-You must synchronize any changes that you make to `pxf-env.sh`, `pxf-log4j.properties`, or `pxf-profiles.xml` to the Greenplum Database segment cluster, and (re)start PXF on each segment host.
+You must synchronize any changes that you make to `pxf-env.sh`, `pxf-log4j.properties`, or `pxf-profiles.xml` to the Greenplum Database cluster, and (re)start PXF on each segment host.
 
 ### <a id="start_pxf_prereq" class="no-quick-link"></a>Prerequisites
 

--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -10,13 +10,13 @@ PXF is compatible with Cloudera, Hortonworks Data Platform, MapR, and generic Ap
 
 Configuring PXF Hadoop connectors involves copying configuration files from your Hadoop cluster to the Greenplum Database master host. If you are using the MapR Hadoop distribution, you must also copy certain JAR files to the master host. Before you configure the PXF Hadoop connectors, ensure that you can copy files from hosts in your Hadoop cluster to the Greenplum Database master.
 
-In this procedure, you copy Hadoop configuration files to the `$PXF_CONF/servers/default` directory on the Greenplum Database master host. You may also copy libraries to `$PXF_CONF/lib` for MapR support. You then synchronize the PXF configuration on the master host to the segment hosts. (PXF creates the`$PXF_CONF/*` directories when you run `pxf cluster init`.)
+In this procedure, you copy Hadoop configuration files to the `$PXF_CONF/servers/default` directory on the Greenplum Database master host. You may also copy libraries to `$PXF_CONF/lib` for MapR support. You then synchronize the PXF configuration on the master host to the standby master and segment hosts. (PXF creates the`$PXF_CONF/*` directories when you run `pxf cluster init`.)
 
 **Note**: After you complete the configuration procedure, you will have configured the PXF default Hadoop server. End users need not provide a `SERVER` option in a `CREATE EXTERNAL TABLE` command when they access the default Hadoop server configuration.
 
 ## <a id="client-pxf-config-steps"></a>Procedure
 
-Perform the following procedure to configure the desired PXF Hadoop-related connectors on the Greenplum Database master host. After you configure the connectors, you will use the `pxf cluster sync` command to copy the PXF configuration to the segment hosts in your Greenplum Database cluster.
+Perform the following procedure to configure the desired PXF Hadoop-related connectors on the Greenplum Database master host. After you configure the connectors, you will use the `pxf cluster sync` command to copy the PXF configuration to the Greenplum Database cluster.
 
 1. Log in to your Greenplum Database master node:
 
@@ -55,7 +55,7 @@ Perform the following procedure to configure the desired PXF Hadoop-related conn
     gpadmin@gpmaster$ scp mapruser@maprhost:/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/hadoop-common-2.7.0-mapr-1707.jar .
     ```
         
-5. Synchronize the PXF configuration to each Greenplum Database segment host. For example:
+5. Synchronize the PXF configuration to the Greenplum Database cluster. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
@@ -220,7 +220,7 @@ public class PxfExample_CustomWritable implements Writable {
     gpadmin@gpmaster$ cp /home/gpadmin/pxfex-customwritable.jar /usr/local/greenplum-pxf/lib/pxfex-customwritable.jar
     ```
 
-5. Synchronize the PXF configuration to each Greenplum Database segment host. For example:
+5. Synchronize the PXF configuration to the Greenplum Database cluster. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
@@ -56,7 +56,7 @@ Perform the following procedure to initialize PXF on each segment host in your G
     $ ssh gpadmin@<gpmaster>
     ```
 
-4. Run the `pxf cluster init` command to initialize the PXF service on the master and on each segment host. For example, the following command specifies `/usr/local/greenplum-pxf` as the PXF user configuration directory for initialization:
+4. Run the `pxf cluster init` command to initialize the PXF service on the master and, standby master, and on each segment host. For example, the following command specifies `/usr/local/greenplum-pxf` as the PXF user configuration directory for initialization:
 
     ``` shell
     gpadmin@gpmaster$ PXF_CONF=/usr/local/greenplum-pxf $GPHOME/pxf/bin/pxf cluster init
@@ -64,5 +64,5 @@ Perform the following procedure to initialize PXF on each segment host in your G
 
     The `init` command creates the PXF web application and initializes the internal PXF configuration. The `init` command also creates the `$PXF_CONF` user configuration directory if it does not exist, and populates the directory with user-customizable configuration templates.
 
-    **Note**: The PXF service runs only on the segment hosts. However,`pxf cluster init` also sets up the PXF user configuration directories on the Greenplum Database master host.
+    **Note**: The PXF service runs only on the segment hosts. However,`pxf cluster init` also sets up the PXF user configuration directories on the Greenplum Database master and standby master hosts.
 

--- a/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
@@ -56,7 +56,7 @@ Perform the following procedure to initialize PXF on each segment host in your G
     $ ssh gpadmin@<gpmaster>
     ```
 
-4. Run the `pxf cluster init` command to initialize the PXF service on the master and, standby master, and on each segment host. For example, the following command specifies `/usr/local/greenplum-pxf` as the PXF user configuration directory for initialization:
+4. Run the `pxf cluster init` command to initialize the PXF service on the master, standby master, and on each segment host. For example, the following command specifies `/usr/local/greenplum-pxf` as the PXF user configuration directory for initialization:
 
     ``` shell
     gpadmin@gpmaster$ PXF_CONF=/usr/local/greenplum-pxf $GPHOME/pxf/bin/pxf cluster init

--- a/gpdb-doc/markdown/pxf/install_java.html.md.erb
+++ b/gpdb-doc/markdown/pxf/install_java.html.md.erb
@@ -13,7 +13,7 @@ Ensure that you have access to, or superuser permissions to install, Java versio
 
 ## <a id="proc"></a>Procedure
 
-Perform the following procedure to install Java on the master and on each segment host in your Greenplum Database cluster. You will use the `gpssh` utility where possible to run a command on multiple hosts.
+Perform the following procedure to install Java on the master, standby master, and on each segment host in your Greenplum Database cluster. You will use the `gpssh` utility where possible to run a command on multiple hosts.
 
 1. Log in to your Greenplum Database master node:
 
@@ -21,27 +21,28 @@ Perform the following procedure to install Java on the master and on each segmen
     $ ssh gpadmin@<gpmaster>
     ```
 
-2. Create a text file that lists your Greenplum Database segment hosts, one host name per line. For example, a file named `seghostfile` may include:
+2. Create a text file that lists your Greenplum Database standby master host and segment hosts, one host name per line. For example, a file named `gphostfile` may include:
 
     ``` pre
+    mstandby
     seghost1
     seghost2
     seghost3
     ```
 
-3. Install Java on the master and on each Greenplum Database segment host, and then set up the Java environment on each host.
+3. Install Java on the master, standby master, and on each Greenplum Database segment host, and then set up the Java environment on each host.
 
     1. Install the Java package. For example, to install Java version 1.8:
 
         ``` shell
         gpadmin@gpmaster$ sudo yum -y install java-1.8.0-openjdk-1.8.0*
-        gpadmin@gpmaster$ gpssh -e -v -f seghostfile sudo yum -y install java-1.8.0-openjdk-1.8.0*
+        gpadmin@gpmaster$ gpssh -e -v -f gphostfile sudo yum -y install java-1.8.0-openjdk-1.8.0*
         ```
 
-    2. Identify the Java base install directory. Update the `gpadmin` user's `.bashrc` file on each segment host to include this `$JAVA_HOME` setting if it is not already present. For example:
+    2. Identify the Java base install directory. Update the `gpadmin` user's `.bashrc` file on each host to include this `$JAVA_HOME` setting if it is not already present. For example:
 
         ``` shell
         gpadmin@gpmaster$ echo 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.x86_64/jre' >> /home/gpadmin/.bashrc
-        gpadmin@gpmaster$ gpssh -e -v -f seghostfile "echo 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.x86_64/jre' >> /home/gpadmin/.bashrc"
+        gpadmin@gpmaster$ gpssh -e -v -f gphostfile "echo 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.x86_64/jre' >> /home/gpadmin/.bashrc"
         ```
 

--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -42,7 +42,7 @@ When you configure the PXF JDBC Connector to access an external SQL database, yo
 2. Create the directory `$PXF_CONF/servers/<server_name>`.
 3. Copy the PXF `jdbc-site.xml` template configuration file to the new server directory.
 4. Fill in appropriate values for the properties in the template file.
-6. Synchronize the server configuration to each Greenplum Database segment host.
+6. Synchronize the server configuration to the Greenplum Database cluster.
 7. Publish the PXF server name(s) to your Greenplum Database end users as appropriate.
 
 The Greenplum Database user specifies the `<server_name>` in the `CREATE EXTERNAL TABLE` `LOCATION` clause `SERVER` option to access the external SQL database. For example, if you created a server configuration and named the server directory `pgsrvcfg`:
@@ -61,7 +61,7 @@ While not recommended, you can override a JDBC server configuration by directly 
 
 Ensure that you have initialized PXF before you configure a JDBC Connector server.
 
-In this procedure, you name and add a PXF JDBC server configuration for a PostgreSQL database and synchronize the server configuration(s) to all segment hosts.
+In this procedure, you name and add a PXF JDBC server configuration for a PostgreSQL database and synchronize the server configuration(s) to the Greenplum Database cluster.
 
 1. Log in to your Greenplum Database master node:
 
@@ -110,7 +110,7 @@ In this procedure, you name and add a PXF JDBC server configuration for a Postgr
     ```
 6. Save your changes and exit the editor.
 
-7. Use the `pxf cluster sync` command to copy the new server configurations to each Greenplum Database segment host. For example:
+7. Use the `pxf cluster sync` command to copy the new server configuration to the Greenplum Database cluster. For example:
     
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -222,7 +222,7 @@ Perform the following steps to create a PostgreSQL table named `forpxf_table1` i
 
 #### <a id="ex_jdbconfig"></a>Configure the JDBC Connector 
 
-You must create a JDBC server configuration for PostgreSQL, download the PostgreSQL driver JAR file to your system, copy the JAR file to the PXF user configuration directory, synchronize PXF configuration, and then restart PXF.
+You must create a JDBC server configuration for PostgreSQL, download the PostgreSQL driver JAR file to your system, copy the JAR file to the PXF user configuration directory, synchronize the PXF configuration, and then restart PXF.
 
 1. Log in to the Greenplum Database master node:
 
@@ -262,7 +262,7 @@ You must create a JDBC server configuration for PostgreSQL, download the Postgre
     gpadmin@gpmaster$ cp postgresql-42.2.5.jar $PXF_CONF/lib/postgresql-42.2.5.jar
     ``` 
 
-3. Synchronize PXF configuration to the Greenplum Database cluster. For example:
+3. Synchronize the PXF configuration to the Greenplum Database cluster. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -31,7 +31,7 @@ This section describes how to use the PXF JDBC connector to access data in an ex
 
 Before you access an external SQL database using the PXF JDBC connector, ensure that:
 
-- You have configured and initialized PXF on your Greenplum Database segment hosts, and PXF is running on each host. See [Configuring PXF](instcfg_pxf.html) for additional information.
+- You have configured and initialized PXF, and PXF is running on each Greenplum Database segment host. See [Configuring PXF](instcfg_pxf.html) for additional information.
 - You can identify the PXF user configuration directory (`$PXF_CONF`).
 - Connectivity exists between all Greenplum Database segment hosts and the external SQL database.
 - You have configured your external SQL database for user access from all Greenplum Database segment hosts.
@@ -262,7 +262,7 @@ You must create a JDBC server configuration for PostgreSQL, download the Postgre
     gpadmin@gpmaster$ cp postgresql-42.2.5.jar $PXF_CONF/lib/postgresql-42.2.5.jar
     ``` 
 
-3. Synchronize PXF configuration to all Greenplum Database segment hosts. For example:
+3. Synchronize PXF configuration to the Greenplum Database cluster. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -46,7 +46,7 @@ When you configure a PXF object store connector, you add at least one named PXF 
 3. Copy the PXF template configuration file corresponding to the object store to the new server directory.
 4. Fill in appropriate values for the properties in the template file.
 5. Add additional properties and values if required for your environment.
-6. Synchronize the server configuration to each Greenplum Database segment host.
+6. Synchronize the server configuration to the Greenplum Database cluster.
 7. Publish the PXF server names to your Greenplum Database end users as appropriate.
 
 The Greenplum Database user specifies the server name in the `CREATE EXTERNAL TABLE` `LOCATION` clause `SERVER` option to access the object store. For example:
@@ -224,7 +224,7 @@ To enable SSE-C for a specific S3 bucket, use the property name variants that in
 
 Ensure that you have initialized PXF before you configure an object store connector.
 
-In this procedure, you name and add a PXF server configuration in the `$PXF_CONF/servers` directory on the Greenplum Database master host for each object store connector that you plan to use. You then use the `pxf cluster sync` command to sync the server configuration(s) to all segment hosts.
+In this procedure, you name and add a PXF server configuration in the `$PXF_CONF/servers` directory on the Greenplum Database master host for each object store connector that you plan to use. You then use the `pxf cluster sync` command to sync the server configuration(s) to the Greenplum Database cluster.
 
 1. Log in to your Greenplum Database master node:
 
@@ -275,7 +275,7 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_CONF
 
     6. Repeat Step 3 to configure the next object store connector.
 
-4. Use the `pxf cluster sync` command to copy the new server configurations to each Greenplum Database segment host. For example:
+4. Use the `pxf cluster sync` command to copy the new server configurations to the Greenplum Database cluster. For example:
     
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
@@ -30,7 +30,7 @@ Perform the following procedure to turn PXF user impersonation on or off in your
     PXF_USER_IMPERSONATION="true"
     ```
 
-4. Use the `pxf cluster sync` command to copy the updated `pxf-env.sh` file to each Greenplum Database segment host. For example:
+4. Use the `pxf cluster sync` command to copy the updated `pxf-env.sh` file to the Greenplum Database cluster. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
@@ -63,7 +63,7 @@ When PXF user personation is enabled (the default), you must configure the Hadoo
     ```
 4. After changing `core-site.xml`, you must restart Hadoop for your changes to take effect.
 
-5. Copy the updated `core-site.xml` file to the PXF Hadoop configuration directory `$PXF_CONF/servers/default` on the master and on each Greenplum Database segment host.
+5. Copy the updated `core-site.xml` file to the PXF Hadoop configuration directory `$PXF_CONF/servers/default` on the master, standby master, and on each Greenplum Database segment host.
 
 ## <a id="hive"></a>Hive User Impersonation
 

--- a/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
@@ -2,7 +2,7 @@
 title: pxf cluster
 ---
 
-Manage PXF configuration and the PXF service instance on all Greenplum Database hosts.
+Manage the PXF configuration and the PXF service instance on all Greenplum Database hosts.
 
 ## <a id="topic1__section2"></a>Synopsis
 
@@ -22,7 +22,7 @@ sync
 
 ## <a id="topic1__section3"></a>Description
 
-The `pxf cluster` utility command manages PXF on the standby master and all Greenplum Database segment hosts. You can use the utility to start and stop the PXF service instance on all segment hosts. You can also initialize and synchronize PXF configuration from the Greenplum Database master host to the standby master and to all segment hosts.
+The `pxf cluster` utility command manages PXF on the standby master and on all Greenplum Database segment hosts. You can use the utility to start and stop the PXF service instance on all segment hosts. You can also initialize and synchronize the PXF configuration from the Greenplum Database master host to the standby master and to all segment hosts.
 
 `pxf cluster` requires a running Greenplum Database cluster. You must run the utility on the Greenplum Database master host.
 
@@ -43,7 +43,7 @@ If you want to manage the PXF service instance on a specific segment host, use t
 <dd>Stop the PXF service instance on all segment hosts.</dd>
 
 <dt>sync  </dt>
-<dd>Synchronize PXF configuration from the master to the standby master and to all Greenplum Database segment hosts. If you have updated the PXF user configuration or added JAR files, you must also restart PXF after you synchronize PXF configuration.</dd>
+<dd>Synchronize the PXF configuration from the master to the standby master and to all Greenplum Database segment hosts. If you have updated the PXF user configuration or added JAR files, you must also restart PXF after you synchronize the PXF configuration.</dd>
 
 ## <a id="topic1__section5"></a>Examples
 

--- a/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
@@ -2,7 +2,7 @@
 title: pxf cluster
 ---
 
-Manage the PXF service instance on all Greenplum Database segment hosts.
+Manage PXF configuration and the PXF service instance on all Greenplum Database hosts.
 
 ## <a id="topic1__section2"></a>Synopsis
 
@@ -22,7 +22,7 @@ sync
 
 ## <a id="topic1__section3"></a>Description
 
-The `pxf cluster` utility command manages the PXF service instance on all Greenplum Database segment hosts. You can use the utility to initialize, start, and stop the PXF service instance on all segment hosts. You can also sync PXF configuration from the Greenplum Database master host to all segment hosts.
+The `pxf cluster` utility command manages PXF on the standby master and all Greenplum Database segment hosts. You can use the utility to start and stop the PXF service instance on all segment hosts. You can also initialize and synchronize PXF configuration from the Greenplum Database master host to the standby master and to all segment hosts.
 
 `pxf cluster` requires a running Greenplum Database cluster. You must run the utility on the Greenplum Database master host.
 
@@ -34,7 +34,7 @@ If you want to manage the PXF service instance on a specific segment host, use t
 <dd>Display the `pxf cluster` help message and then exit.</dd>
 
 <dt>init</dt>
-<dd>Initialize the PXF service instance on the master and on all segment hosts. When you initialize PXF across your Greenplum Database cluster, you must identify the PXF user configuration directory via an environment variable named `$PXF_CONF`. If you do not set `$PXF_CONF` prior to initializing PXF, PXF returns an error.</dd>
+<dd>Initialize the PXF service instance on the master, standby master, and on all segment hosts. When you initialize PXF across your Greenplum Database cluster, you must identify the PXF user configuration directory via an environment variable named `$PXF_CONF`. If you do not set `$PXF_CONF` prior to initializing PXF, PXF returns an error.</dd>
 
 <dt>start</dt>
 <dd>Start the PXF service instance on all segment hosts.</dd>
@@ -43,7 +43,7 @@ If you want to manage the PXF service instance on a specific segment host, use t
 <dd>Stop the PXF service instance on all segment hosts.</dd>
 
 <dt>sync  </dt>
-<dd>Synchronize PXF configuration from the master to all Greenplum Database segment hosts. If you have updated the PXF user configuration or added JAR files, you must also restart PXF after you synchronize PXF configuration.</dd>
+<dd>Synchronize PXF configuration from the master to the standby master and to all Greenplum Database segment hosts. If you have updated the PXF user configuration or added JAR files, you must also restart PXF after you synchronize PXF configuration.</dd>
 
 ## <a id="topic1__section5"></a>Examples
 

--- a/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
@@ -22,7 +22,11 @@ sync
 
 ## <a id="topic1__section3"></a>Description
 
-The `pxf cluster` utility command manages PXF on the standby master and on all Greenplum Database segment hosts. You can use the utility to start and stop the PXF service instance on all segment hosts. You can also initialize and synchronize the PXF configuration from the Greenplum Database master host to the standby master and to all segment hosts.
+The `pxf cluster` utility command manages PXF on the master, standby master, and on all Greenplum Database segment hosts. You can use the utility to:
+
+- Initialize PXF configuration on all hosts in the Greenplum Database cluster.
+- Start and stop the PXF service instance on all segment hosts.
+- Synchronize the PXF configuration from the Greenplum Database master host to the standby master and to all segment hosts.
 
 `pxf cluster` requires a running Greenplum Database cluster. You must run the utility on the Greenplum Database master host.
 

--- a/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
@@ -70,7 +70,7 @@ The `pxf init` command takes the following option:
 <dt>-y </dt>
 <dd>Do not prompt, use the default `$PXF_CONF` directory location if the environment variable is not set.</dd>
 
-The `pxf sync` command takes the following option:
+The `pxf sync` command, run on the Greenplum Database master host, takes the following option:
 
 <dt>\<gphost\> </dt>
 <dd>The Greenplum Database host to which to synchronize the PXF configuration. `<gphost>` must identify the standy master host or a segment host.</dd>

--- a/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
@@ -2,7 +2,7 @@
 title: pxf
 ---
 
-Manage the PXF service instance on a segment host.
+Manage PXF configuration and the PXF service instance on the local Greenplum Database host.
 
 ## <a id="topic1__section2"></a>Synopsis
 
@@ -26,16 +26,18 @@ version
 
 ## <a id="topic1__section3"></a>Description
 
-The `pxf` utility manages the PXF service instances on Greenplum Database segment hosts.
+The `pxf` utility manages the PXF configuration and the PXF service instance on the local Greenplum Database host.
 
-You can initialize, start, stop, restart the PXF service instance on a specific segment host. You can display the status of the PXF service instance running on a host. You can also synchronize PXF configuration from the master to a specific Greenplum Database segment host.
+You can initialize PXF on the master, master standby, or a specific segment host. You can also synchronize PXF configuration from the master to these hosts.
 
-To initialize, start, and stop the PXF service instance on all segment hosts in the Greenplum Database cluster, use the `pxf cluster` command. See [`pxf cluster`](pxf-cluster.html#topic1).
+You can start, stop, restart the PXF service instance on a specific segment host, or display the status of the PXF service instance running on a segment host.
+
+Use the [`pxf cluster`](pxf-cluster.html#topic1) command to initialize PXF on all hosts, synchronize PXF configuration to the Greenplum Database cluster, or to start and stop the PXF service instance on all segment hosts in the cluster.
 
 ## <a id="commands"></a>Commands
 
 <dt>cluster</dt>
-<dd>Manage the PXF service instance on all Greenplum Database segment hosts. See [`pxf cluster`](pxf-cluster.html#topic1).</dd>
+<dd>Manage PXF configuration and the PXF service instance on all Greenplum Database hosts. See [`pxf cluster`](pxf-cluster.html#topic1).</dd>
 
 <dt>help</dt>
 <dd>Display the `pxf` management utility help message and then exit.</dd>
@@ -56,7 +58,7 @@ To initialize, start, and stop the PXF service instance on all segment hosts in 
 <dd>Stop the PXF service instance running on the segment host.</dd>
 
 <dt>sync  </dt>
-<dd>Synchronize PXF configuration from the master to a specific Greenplum Database segment host. You must run `pxf sync` on the master host. See [Options](pxf.html#options).</dd>
+<dd>Synchronize PXF configuration from the master to a specific Greenplum Database host. You must run `pxf sync` on the master host. See [Options](pxf.html#options).</dd>
 
 <dt>version  </dt>
 <dd>Display the PXF version and then exit.</dd>
@@ -70,8 +72,8 @@ The `pxf init` command takes the following option:
 
 The `pxf sync` command takes the following option:
 
-<dt>\<seghost\> </dt>
-<dd>The segment host to which to synchronize PXF configuration.</dd>
+<dt>\<gphost\> </dt>
+<dd>The Greenplum Database host to which to synchronize PXF configuration. `<gphost>` must identify the standy master host or a segment host.</dd>
 
 ## <a id="topic1__section5"></a>Examples
 

--- a/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
@@ -2,7 +2,7 @@
 title: pxf
 ---
 
-Manage PXF configuration and the PXF service instance on the local Greenplum Database host.
+Manage the PXF configuration and the PXF service instance on the local Greenplum Database host.
 
 ## <a id="topic1__section2"></a>Synopsis
 
@@ -28,16 +28,16 @@ version
 
 The `pxf` utility manages the PXF configuration and the PXF service instance on the local Greenplum Database host.
 
-You can initialize PXF on the master, master standby, or a specific segment host. You can also synchronize PXF configuration from the master to these hosts.
+You can initialize PXF on the master, master standby, or a specific segment host. You can also synchronize the PXF configuration from the master to these hosts.
 
-You can start, stop, restart the PXF service instance on a specific segment host, or display the status of the PXF service instance running on a segment host.
+You can start, stop, or restart the PXF service instance on a specific segment host, or display the status of the PXF service instance running on a segment host.
 
-Use the [`pxf cluster`](pxf-cluster.html#topic1) command to initialize PXF on all hosts, synchronize PXF configuration to the Greenplum Database cluster, or to start and stop the PXF service instance on all segment hosts in the cluster.
+Use the [`pxf cluster`](pxf-cluster.html#topic1) command to initialize PXF on all hosts, synchronize the PXF configuration to the Greenplum Database cluster, or to start and stop the PXF service instance on all segment hosts in the cluster.
 
 ## <a id="commands"></a>Commands
 
 <dt>cluster</dt>
-<dd>Manage PXF configuration and the PXF service instance on all Greenplum Database hosts. See [`pxf cluster`](pxf-cluster.html#topic1).</dd>
+<dd>Manage the PXF configuration and the PXF service instance on all Greenplum Database hosts. See [`pxf cluster`](pxf-cluster.html#topic1).</dd>
 
 <dt>help</dt>
 <dd>Display the `pxf` management utility help message and then exit.</dd>
@@ -58,7 +58,7 @@ Use the [`pxf cluster`](pxf-cluster.html#topic1) command to initialize PXF on al
 <dd>Stop the PXF service instance running on the segment host.</dd>
 
 <dt>sync  </dt>
-<dd>Synchronize PXF configuration from the master to a specific Greenplum Database host. You must run `pxf sync` on the master host. See [Options](pxf.html#options).</dd>
+<dd>Synchronize the PXF configuration from the master to a specific Greenplum Database host. You must run `pxf sync` on the master host. See [Options](pxf.html#options).</dd>
 
 <dt>version  </dt>
 <dd>Display the PXF version and then exit.</dd>
@@ -73,7 +73,7 @@ The `pxf init` command takes the following option:
 The `pxf sync` command takes the following option:
 
 <dt>\<gphost\> </dt>
-<dd>The Greenplum Database host to which to synchronize PXF configuration. `<gphost>` must identify the standy master host or a segment host.</dd>
+<dd>The Greenplum Database host to which to synchronize the PXF configuration. `<gphost>` must identify the standy master host or a segment host.</dd>
 
 ## <a id="topic1__section5"></a>Examples
 

--- a/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
@@ -58,7 +58,7 @@ Use the [`pxf cluster`](pxf-cluster.html#topic1) command to initialize PXF on al
 <dd>Stop the PXF service instance running on the segment host.</dd>
 
 <dt>sync  </dt>
-<dd>Synchronize the PXF configuration from the master to a specific Greenplum Database host. You must run `pxf sync` on the master host. See [Options](pxf.html#options).</dd>
+<dd>Synchronize the PXF configuration from the master to a specific Greenplum Database standby master or segment host. You must run `pxf sync` on the master host. See [Options](pxf.html#options).</dd>
 
 <dt>version  </dt>
 <dd>Display the PXF version and then exit.</dd>

--- a/gpdb-doc/markdown/pxf/reg_jar_depend.html.md.erb
+++ b/gpdb-doc/markdown/pxf/reg_jar_depend.html.md.erb
@@ -25,7 +25,7 @@ You use PXF to access data stored on external systems. Depending upon the extern
 
 PXF depends on JAR files and other configuration information provided by these additional components. The `$GPHOME/pxf/conf/pxf-private.classpath` file identifies PXF internal JAR dependencies. In most cases, PXF manages the `pxf-private.classpath` file, adding entries as necessary based on the connectors that you use.
 
-Should you need to add an additional JAR dependency for PXF, for example a JDBC driver JAR file, you must log in to the Greenplum Database master host, copy the JAR file to the PXF user configuration runtime library directory (`$PXF_CONF/lib`), sync the PXF configuration to each segment host, and then restart PXF on each host. For example:
+Should you need to add an additional JAR dependency for PXF, for example a JDBC driver JAR file, you must log in to the Greenplum Database master host, copy the JAR file to the PXF user configuration runtime library directory (`$PXF_CONF/lib`), sync the PXF configuration to the Greenplum Database cluster, and then restart PXF on each segment host. For example:
 
 ``` shell
 $ ssh gpadmin@<gpmaster>

--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -124,7 +124,7 @@ dbname=# SET client_min_messages=NOTICE;
 
 Because a single PXF agent (JVM) serves multiple segments on a segment host, the PXF heap size can be a limiting runtime factor. This will be more evident under concurrent workloads and/or queries against large files. You may run into situations where a query will hang or fail due to insufficient memory or the Java garbage collector impacting response times. To avert or remedy these situations, first try increasing the Java maximum heap size or decreasing the Tomcat maximum number of threads, depending upon what works best for your system configuration.
 
-**Note**: The configuration changes described in this topic require modifying config files on *each* segment node in your Greenplum Database cluster. After you perform the updates, be sure to synchronize the PXF configuration to the Greenplum Database cluster.
+**Note**: The configuration changes described in this topic require modifying config files on *each* node in your Greenplum Database cluster. After you perform the updates on the master, be sure to synchronize the PXF configuration to the Greenplum Database cluster.
 
 You will need to re-apply these configuration changes after any PXF version upgrades.
 

--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -56,7 +56,7 @@ PXF provides more detailed logging when the `DEBUG` level is enabled. To configu
     #log4j.logger.org.greenplum.pxf=DEBUG
     ```
 
-2. Use the `pxf cluster sync` command to copy the updated `pxf-log4j.properties` file to each segment host. For example:
+2. Use the `pxf cluster sync` command to copy the updated `pxf-log4j.properties` file to the Greenplum Database cluster. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
@@ -124,7 +124,7 @@ dbname=# SET client_min_messages=NOTICE;
 
 Because a single PXF agent (JVM) serves multiple segments on a segment host, the PXF heap size can be a limiting runtime factor. This will be more evident under concurrent workloads and/or queries against large files. You may run into situations where a query will hang or fail due to insufficient memory or the Java garbage collector impacting response times. To avert or remedy these situations, first try increasing the Java maximum heap size or decreasing the Tomcat maximum number of threads, depending upon what works best for your system configuration.
 
-**Note**: The configuration changes described in this topic require modifying config files on *each* segment node in your Greenplum Database cluster. After you perform the updates, be sure to synchronize the PXF configuration to each segment host in the cluster.
+**Note**: The configuration changes described in this topic require modifying config files on *each* segment node in your Greenplum Database cluster. After you perform the updates, be sure to synchronize the PXF configuration to the Greenplum Database cluster.
 
 You will need to re-apply these configuration changes after any PXF version upgrades.
 
@@ -152,7 +152,7 @@ Perform the following procedure to increase the heap size for the PXF agent runn
     PXF_JVM_OPTS="-Xmx3g -Xms3g"
     ```
 
-4. Use the `pxf cluster sync` command to copy the updated `pxf-env.sh` file to each Greenplum Database segment host. For example:
+4. Use the `pxf cluster sync` command to copy the updated `pxf-env.sh` file to the Greenplum Database cluster. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
@@ -189,10 +189,10 @@ Perform the following procedure to decrease the maximum number of Tomcat threads
               namePrefix="tomcat-http--"/>
     ```
 
-4. Copy the updated `server.xml` file to each Greenplum Database segment host. For example, if `seghostfile` contains a list, one-host-per-line, of the segment hosts in your Greenplum Database cluster:
+4. Copy the updated `server.xml` file to the standby master and each Greenplum Database segment host. For example, if `gphostfile` contains a list, one-host-per-line, of the standby master and segment hosts in your Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ gpscp -v -f seghostfile $GPHOME/pxf/pxf-service/conf/server.xml =:/usr/local/greenplum-db/pxf/pxf-service/conf/server.xml
+    gpadmin@gpmaster$ gpscp -v -f gphostfile $GPHOME/pxf/pxf-service/conf/server.xml =:/usr/local/greenplum-db/pxf/pxf-service/conf/server.xml
     ```
 
 5. Restart PXF on each Greenplum Database segment host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).
@@ -217,5 +217,5 @@ export PXF_JVM_OPTS="<current_settings> -Duser.timezone=America/Chicago"
 
 You can use the `PXF_JVM_OPTS` property to set other Java options as well.
 
-As described in previous sections, you must synchronize the updated PXF configuration to each Greenplum Database segment host and restart the PXF server on each host.
+As described in previous sections, you must synchronize the updated PXF configuration to the Greenplum Database cluster and restart the PXF server on each segment host.
 

--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -74,7 +74,7 @@ After you upgrade to the new version of Greenplum Database, perform the followin
     5. Starting in Greenplum Database version 5.15, PXF requires that the Hadoop configuration files reside in the `$PXF_CONF/servers/default` directory. If you configured PXF Hadoop connectors in your *PXF.from* installation, copy the Hadoop configuration files in `/etc/<hadoop_service>/conf` to `$PXF_CONF/servers/default` on the Greenplum Database master host.
     5. Starting in Greenplum Database version 5.15, the default Kerberos keytab file location for PXF is `$PXF_CONF/keytabs`. If you previously configured PXF for secure HDFS and the PXF keytab file is located in a *PXF.from* installation directory (for example, `$GPHOME/pxf/conf`), consider relocating the keytab file to `$PXF_CONF/keytabs`. Alternatively, update the `PXF_KEYTAB` property setting in the `$PXF_CONF/conf/pxf-env.sh` file to reference your keytab file.
 
-5. Synchronize PXF configuration from the master host to the standby master and each Greenplum Database segment host. For example:
+5. Synchronize the PXF configuration from the master host to the standby master and each Greenplum Database segment host. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -74,7 +74,7 @@ After you upgrade to the new version of Greenplum Database, perform the followin
     5. Starting in Greenplum Database version 5.15, PXF requires that the Hadoop configuration files reside in the `$PXF_CONF/servers/default` directory. If you configured PXF Hadoop connectors in your *PXF.from* installation, copy the Hadoop configuration files in `/etc/<hadoop_service>/conf` to `$PXF_CONF/servers/default` on the Greenplum Database master host.
     5. Starting in Greenplum Database version 5.15, the default Kerberos keytab file location for PXF is `$PXF_CONF/keytabs`. If you previously configured PXF for secure HDFS and the PXF keytab file is located in a *PXF.from* installation directory (for example, `$GPHOME/pxf/conf`), consider relocating the keytab file to `$PXF_CONF/keytabs`. Alternatively, update the `PXF_KEYTAB` property setting in the `$PXF_CONF/conf/pxf-env.sh` file to reference your keytab file.
 
-5. Synchronize PXF configuration from the master host to each Greenplum Database segment host. For example:
+5. Synchronize PXF configuration from the master host to the standby master and each Greenplum Database segment host. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync


### PR DESCRIPTION
in this PR:
- minor updates, but does touch several files
- call out init/sync to standby master and segment hosts a few times.
- intro to most sync commands now says "... synchronize configuration to the greenplum database cluster" rather than explicitly call out "segment hosts"

