### PR TITLE
Remove transaction state DTX_STATE_ACTIVE_NOT_DISTRIBUTED

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -432,6 +432,17 @@ GetAllTransactionXids(
 	*subXid = s->subTransactionId;
 }
 
+DistributedTransactionId
+GetCurrentDistributedTransactionId(void)
+{
+	return currentDistribXid;
+}
+
+void
+SetCurrentDistributedTransactionId(DistributedTransactionId gxid)
+{
+	currentDistribXid = gxid;
+}
 /*
  *	GetTopTransactionId
  *
@@ -2268,14 +2279,13 @@ StartTransaction(void)
 		case DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE:
 		{
 			/*
-			 * MPP: we're the dispatcher.
-			 *
-			 * Create distributed transaction which will map the
-			 * distributed transaction to a local transaction id for the
-			 * master database.
+			 * Generate the distributed transaction ID and save it.
+			 * it's not really needed by a select-only implicit transaction, but
+			 * currently gpfdist and pxf is using it.
+			 * We should probably replace xid with "session id + command id" in
+			 * identify a query in gpfdist and pxf.
 			 */
-			setCurrentGxact();
-			currentDistribXid = MyTmGxact->gxid;
+			currentDistribXid = generateGID();
 
 			if (SharedLocalSnapshotSlot != NULL)
 			{
@@ -2299,8 +2309,8 @@ StartTransaction(void)
 			if (gp_enable_slow_writer_testmode)
 				pg_usleep(500000);
 
-			if (QEDtxContextInfo.distributedXid ==
-				InvalidDistributedTransactionId)
+			if (DistributedTransactionContext != DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT &&
+				QEDtxContextInfo.distributedXid == InvalidDistributedTransactionId)
 			{
 				elog(ERROR,
 					 "distributed transaction id is invalid in context %s",

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -120,7 +120,6 @@ typedef struct InDoubtDtx
 /*=========================================================================
  * FUNCTIONS PROTOTYPES
  */
-static DistributedTransactionId generateGID(void);
 static void clearAndResetGxact(void);
 static void resetCurrentGxact(void);
 static void recoverTM(void);
@@ -261,9 +260,7 @@ getDistributedTransactionId(void)
 {
 	if (isQDContext())
 	{
-		return currentGxact == NULL
-			? InvalidDistributedTransactionId
-			: currentGxact->gxid;
+		return GetCurrentDistributedTransactionId();
 	}
 	else if (isQEContext())
 	{
@@ -280,16 +277,17 @@ getDistributedTransactionIdentifier(char *id)
 {
 	if (isQDContext())
 	{
-		if (currentGxact != NULL)
+		DistributedTransactionId gxid = GetCurrentDistributedTransactionId();
+		if (gxid != InvalidDistributedTransactionId)
 		{
 			/*
 			 * The length check here requires the identifer have a trailing
 			 * NUL character.
 			 */
-			if (strlen(currentGxact->gid) >= TMGIDSIZE)
-				elog(PANIC, "Distribute transaction identifier too long (%d)",
-					 (int) strlen(currentGxact->gid));
-			memcpy(id, currentGxact->gid, TMGIDSIZE);
+			sprintf(id, "%u-%.10u", *shmDistribTimeStamp, gxid);
+			if (strlen(id) >= TMGIDSIZE)
+				elog(PANIC, "distributed transaction identifier too long (%d)",
+					 (int) strlen(id));
 			return true;
 		}
 	}
@@ -298,7 +296,7 @@ getDistributedTransactionIdentifier(char *id)
 		if (QEDtxContextInfo.distributedXid != InvalidDistributedTransactionId)
 		{
 			if (strlen(QEDtxContextInfo.distributedId) >= TMGIDSIZE)
-				elog(PANIC, "Distribute transaction identifier too long (%d)",
+				elog(PANIC, "distributed transaction identifier too long (%d)",
 					 (int) strlen(QEDtxContextInfo.distributedId));
 			memcpy(id, QEDtxContextInfo.distributedId, TMGIDSIZE);
 			return true;
@@ -376,40 +374,17 @@ notifyCommittedDtxTransaction(void)
 	doNotifyingCommitPrepared();
 }
 
-/*
- * @param needsTwoPhaseCommit if true then marks the current Distributed Transaction as needing to use the
- *       2 phase commit protocol.
- */
 void
-dtmPreCommand(const char *debugCaller, const char *debugDetail, PlannedStmt *stmt,
-			  bool needsTwoPhaseCommit, bool wantSnapshot, bool inCursor)
+setupTwoPhaseTransaction(void)
 {
-	Assert(debugCaller != NULL);
-	Assert(debugDetail != NULL);
+	if (!IsTransactionState())
+		elog(ERROR, "DTM transaction is not active");
 
-	/**
-	 * If two-phase commit then begin transaction.
-	 */
-	if (needsTwoPhaseCommit)
-	{
-		if (currentGxact == NULL)
-		{
-			elog(ERROR, "DTM transaction is not active (%s, detail = '%s')", debugCaller, debugDetail);
-		}
-		else if (currentGxact->state == DTX_STATE_ACTIVE_NOT_DISTRIBUTED)
-		{
-			setCurrentGxactState(DTX_STATE_ACTIVE_DISTRIBUTED);
-		}
-		else if (currentGxact->state == DTX_STATE_ACTIVE_DISTRIBUTED)
-		{
-			/* already distributed, no need to change */
-		}
-		else
-		{
-			elog(ERROR, "DTM transaction is not active (state = %s, %s, detail = '%s')",
-				 DtxStateToString(currentGxact->state), debugCaller, debugDetail);
-		}
-	}
+	if (currentGxact == NULL)
+		activeCurrentGxact();
+
+	if (currentGxact->state != DTX_STATE_ACTIVE_DISTRIBUTED)
+		elog(ERROR, "DTM transaction state (%s) is invalid", DtxStateToString(currentGxact->state));
 }
 
 
@@ -434,8 +409,10 @@ doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType)
 	}
 
 	if (cmdType == DTX_PROTOCOL_COMMAND_SUBTRANSACTION_BEGIN_INTERNAL &&
-		currentGxact->state == DTX_STATE_ACTIVE_NOT_DISTRIBUTED)
-		setCurrentGxactState(DTX_STATE_ACTIVE_DISTRIBUTED);
+		currentGxact ==  NULL)
+	{
+		activeCurrentGxact();
+	}
 
 	serializedDtxContextInfo = qdSerializeDtxContextInfo(
 														 &serializedDtxContextInfoLen,
@@ -963,16 +940,9 @@ prepareDtxTransaction(void)
 
 	if (currentGxact == NULL)
 	{
-		return;
-	}
-
-	if (currentGxact->state == DTX_STATE_ACTIVE_NOT_DISTRIBUTED)
-	{
-		/*
-		 * This transaction did not go distributed.
-		 */
-		clearAndResetGxact();
-		elog(DTM_DEBUG5, "prepareDtxTransaction ignoring not distributed gid = %s", currentGxact->gid);
+		Assert(MyTmGxact->gxid == InvalidDistributedTransactionId);
+		Assert(MyTmGxact->state == DTX_STATE_NONE);
+		initGxact(MyTmGxact, false);
 		return;
 	}
 
@@ -981,6 +951,8 @@ prepareDtxTransaction(void)
 		 DtxStateToString(currentGxact->state));
 
 	Assert(currentGxact->state == DTX_STATE_ACTIVE_DISTRIBUTED);
+	Assert(currentGxact->gxid > FirstDistributedTransactionId);
+	Assert(strlen(currentGxact->gid) > 0);
 
 	/*
 	 * Broadcast PREPARE TRANSACTION to segments.
@@ -1012,14 +984,6 @@ rollbackDtxTransaction(void)
 
 	switch (currentGxact->state)
 	{
-		case DTX_STATE_ACTIVE_NOT_DISTRIBUTED:
-
-			/*
-			 * Let go of these...
-			 */
-			clearAndResetGxact();
-			return;
-
 		case DTX_STATE_ACTIVE_DISTRIBUTED:
 			setCurrentGxactState(DTX_STATE_NOTIFYING_ABORT_NO_PREPARED);
 			break;
@@ -1969,24 +1933,22 @@ dispatchDtxCommand(const char *cmd)
 
 /* initialize a global transaction context */
 void
-initGxact(TMGXACT *gxact)
+initGxact(TMGXACT *gxact, bool resetXid)
 {
-	MemSet(gxact->gid, 0, TMGIDSIZE);
-	gxact->gxid = InvalidDistributedTransactionId;
-	setGxactState(gxact, DTX_STATE_NONE);
+	if (resetXid)
+	{
+		MemSet(gxact->gid, 0, TMGIDSIZE);
+		gxact->gxid = InvalidDistributedTransactionId;
+		setGxactState(gxact, DTX_STATE_NONE);
+	}
 
 	/*
 	 * Memory only fields.
 	 */
-
 	gxact->sessionId = gp_session_id;
-
 	gxact->explicitBeginRemembered = false;
-
 	gxact->xminDistributedSnapshot = InvalidDistributedTransactionId;
-
 	gxact->badPrepareGangs = false;
-
 	gxact->writerGangLost = false;
 	gxact->twophaseSegmentsMap = NULL;
 	gxact->twophaseSegments = NIL;
@@ -2007,12 +1969,18 @@ getNextDistributedXactStatus(TMGALLXACTSTATUS *allDistributedXactStatus, TMGXACT
 }
 
 void
-setCurrentGxact(void)
+activeCurrentGxact(void)
 {
-	DistributedTransactionId gxid = generateGID();
-	Assert(gxid != InvalidDistributedTransactionId);
-
+	DistributedTransactionId gxid;
 	currentGxact = MyTmGxact;
+
+	gxid = GetCurrentDistributedTransactionId();
+	if (gxid == InvalidDistributedTransactionId)
+	{
+		gxid = generateGID();
+		SetCurrentDistributedTransactionId(gxid);
+		Assert(gxid != InvalidDistributedTransactionId);
+	}
 
 	Assert(*shmDistribTimeStamp != 0);
 	sprintf(currentGxact->gid, "%u-%.10u", *shmDistribTimeStamp, gxid);
@@ -2020,13 +1988,7 @@ setCurrentGxact(void)
 		elog(PANIC, "Distribute transaction identifier too long (%d)",
 				(int) strlen(currentGxact->gid));
 
-	/*
-	 * Until we get our first distributed snapshot, we use our distributed
-	 * transaction identifier for the minimum.
-	 */
-	currentGxact->xminDistributedSnapshot = gxid;
-
-	setCurrentGxactState(DTX_STATE_ACTIVE_NOT_DISTRIBUTED);
+	setCurrentGxactState(DTX_STATE_ACTIVE_DISTRIBUTED);
 
 	currentGxact->gxid = gxid;
 }
@@ -2081,7 +2043,7 @@ insertedDistributedCommitted(void)
 }
 
 /* generate global transaction id */
-static DistributedTransactionId
+DistributedTransactionId
 generateGID(void)
 {
 	DistributedTransactionId gxid;
@@ -2562,8 +2524,7 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 	needTwoPhase = isMppTxOptions_NeedTwoPhase(txnOptions);
 	explicitBegin = isMppTxOptions_ExplicitBegin(txnOptions);
 
-	haveDistributedSnapshot =
-		(dtxContextInfo->distributedXid != InvalidDistributedTransactionId);
+	haveDistributedSnapshot = dtxContextInfo->haveDistributedSnapshot;
 	isSharedLocalSnapshotSlotPresent = (SharedLocalSnapshotSlot != NULL);
 
 	if (DEBUG5 >= log_min_messages || Debug_print_full_dtm)
@@ -2837,10 +2798,7 @@ finishDistributedTransactionContext(char *debugCaller, bool aborted)
 static void
 rememberDtxExplicitBegin(void)
 {
-	if (currentGxact == NULL)
-	{
-		return;
-	}
+	Assert (currentGxact != NULL);
 
 	if (!currentGxact->explicitBeginRemembered)
 	{
@@ -2864,15 +2822,12 @@ sendDtxExplicitBegin(void)
 {
 	char		cmdbuf[100];
 
-	if (currentGxact == NULL)
-	{
+	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
-	}
+
+	setupTwoPhaseTransaction();
 
 	rememberDtxExplicitBegin();
-
-	dtmPreCommand("sendDtxExplicitBegin", "(none)", NULL,
-				   /* is two-phase */ true, /* withSnapshot */ true, /* inCursor */ false);
 
 	/*
 	 * Be explicit about both the isolation level and the access mode since in
@@ -3218,14 +3173,13 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 void
 markCurrentGxactWriterGangLost(void)
 {
-	if (currentGxact)
-		currentGxact->writerGangLost = true;
+	MyTmGxact->writerGangLost = true;
 }
 
 bool
 currentGxactWriterGangLost(void)
 {
-	return currentGxact == NULL ? false : currentGxact->writerGangLost;
+	return MyTmGxact->writerGangLost;
 }
 
 /*

--- a/src/backend/cdb/cdbtmutils.c
+++ b/src/backend/cdb/cdbtmutils.c
@@ -46,8 +46,6 @@ DtxStateToString(DtxState state)
 	{
 		case DTX_STATE_NONE:
 			return "None";
-		case DTX_STATE_ACTIVE_NOT_DISTRIBUTED:
-			return "Active Not Distributed";
 		case DTX_STATE_ACTIVE_DISTRIBUTED:
 			return "Active Distributed";
 		case DTX_STATE_PREPARING:

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -251,11 +251,6 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 	ListCell   *le;
 	ErrorData *qeError = NULL;
 
-	dtmPreCommand("CdbDispatchSetCommand", strCommand, NULL,
-				  false /* no two-phase commit needed for SET */,
-				  false, /* no snapshot needed for SET */
-				  false /* inCursor */ );
-
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
 		 "CdbDispatchSetCommand for command = '%s'",
 		 strCommand);
@@ -339,11 +334,9 @@ CdbDispatchCommandToSegments(const char *strCommand,
 {
 	DispatchCommandQueryParms *pQueryParms;
 	bool needTwoPhase = flags & DF_NEED_TWO_PHASE;
-	bool withSnapshot = flags & DF_WITH_SNAPSHOT;
 
-	dtmPreCommand("CdbDispatchCommand", strCommand,
-				  NULL, needTwoPhase, withSnapshot,
-				  false /* inCursor */ );
+	if (needTwoPhase)
+		setupTwoPhaseTransaction();
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchCommand: %s (needTwoPhase = %s)",
@@ -379,12 +372,9 @@ CdbDispatchUtilityStatement(struct Node *stmt,
 {
 	DispatchCommandQueryParms *pQueryParms;
 	bool needTwoPhase = flags & DF_NEED_TWO_PHASE;
-	bool withSnapshot = flags & DF_WITH_SNAPSHOT;
 
-	dtmPreCommand("CdbDispatchUtilityStatement",
-				  debug_query_string ? debug_query_string : "(none)",
-				  NULL, needTwoPhase, withSnapshot,
-				  false /* inCursor */ );
+	if (needTwoPhase)
+		setupTwoPhaseTransaction();
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchUtilityStatement: %s (needTwoPhase = %s)",
@@ -1410,12 +1400,9 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	Gang *primaryGang;
 	ErrorData *error = NULL;
 	bool needTwoPhase = flags & DF_NEED_TWO_PHASE;
-	bool withSnapshot = flags & DF_WITH_SNAPSHOT;
 
-	dtmPreCommand("CdbDispatchCopyStart",
-				  debug_query_string ? debug_query_string : "(none)",
-				  NULL, needTwoPhase, withSnapshot,
-				  false /* inCursor */ );
+	if (needTwoPhase)
+		setupTwoPhaseTransaction();
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchCopyStart: %s (needTwoPhase = %s)",

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -652,8 +652,8 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 * work for this query.
 			 */
 			needDtxTwoPhase = ExecutorSaysTransactionDoesWrites();
-			dtmPreCommand("ExecutorStart", "(none)", queryDesc->plannedstmt,
-						  needDtxTwoPhase, true /* wantSnapshot */, queryDesc->extended_query );
+			if (needDtxTwoPhase)
+				setupTwoPhaseTransaction();
 
 			if (queryDesc->ddesc != NULL)
 			{

--- a/src/backend/storage/ipc/test/procarray_test.c
+++ b/src/backend/storage/ipc/test/procarray_test.c
@@ -63,7 +63,7 @@ test__CreateDistributedSnapshot(void **state)
 	/* This is going to act as our gxact */
 	allTmGxact[procArray->pgprocnos[0]].gxid = 20;
 	allTmGxact[procArray->pgprocnos[0]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
-	allTmGxact[procArray->pgprocnos[0]].xminDistributedSnapshot = 20;
+	allTmGxact[procArray->pgprocnos[0]].xminDistributedSnapshot = InvalidDistributedTransactionId;
 
 	procArray->numProcs = 1;
 
@@ -88,6 +88,8 @@ test__CreateDistributedSnapshot(void **state)
 	 * differ from xminAllDistributedSnapshots. Also, validates xmin and xmax
 	 * get adjusted correctly based on in-progress.
 	 */
+	allTmGxact[procArray->pgprocnos[0]].xminDistributedSnapshot = InvalidDistributedTransactionId;
+
 	allTmGxact[procArray->pgprocnos[1]].gxid = 10;
 	allTmGxact[procArray->pgprocnos[1]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
 	allTmGxact[procArray->pgprocnos[1]].xminDistributedSnapshot = 5;
@@ -114,6 +116,8 @@ test__CreateDistributedSnapshot(void **state)
 	 * Add more elemnets, just to have validation that in-progress array is in
 	 * ascending sorted order with distributed transactions.
 	 */
+	allTmGxact[procArray->pgprocnos[0]].xminDistributedSnapshot = InvalidDistributedTransactionId;
+
 	allTmGxact[procArray->pgprocnos[3]].gxid = 15;
 	allTmGxact[procArray->pgprocnos[3]].state = DTX_STATE_ACTIVE_DISTRIBUTED;
 	allTmGxact[procArray->pgprocnos[3]].xminDistributedSnapshot = 12;

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -504,7 +504,7 @@ InitProcess(void)
 	MyProc->queryCommandId = -1;
 
 	/* Init gxact */
-	initGxact(MyTmGxact);
+	initGxact(MyTmGxact, true);
 
 	/*
 	 * Arrange to clean up at backend exit.

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -518,15 +518,12 @@ standard_ProcessUtility(Node *parsetree,
 
 							Assert(PointerIsValid(name));
 
-							if (Gp_role == GP_ROLE_DISPATCH)
-							{
-								/* We already checked that we're in a
-								 * transaction; need to make certain
-								 * that the BEGIN has been dispatched
-								 * before we start dispatching our savepoint.
-								 */
-								sendDtxExplicitBegin();
-							}
+							/* We already checked that we're in a
+							 * transaction; need to make certain
+							 * that the BEGIN has been dispatched
+							 * before we start dispatching our savepoint.
+							 */
+							sendDtxExplicitBegin();
 
 							DefineDispatchSavepoint(
 									name);

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -406,7 +406,6 @@ errstart(int elevel, const char *filename, int lineno,
 					break;
 
 				case DTX_STATE_NONE:
-				case DTX_STATE_ACTIVE_NOT_DISTRIBUTED:
 				case DTX_STATE_ACTIVE_DISTRIBUTED:
 				case DTX_STATE_INSERTING_FORGET_COMMITTED:
 				case DTX_STATE_INSERTED_FORGET_COMMITTED:

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -237,6 +237,8 @@ extern void GetAllTransactionXids(
 	DistributedTransactionId	*distribXid,
 	TransactionId				*localXid,
 	TransactionId				*subXid);
+extern DistributedTransactionId GetCurrentDistributedTransactionId(void);
+extern void SetCurrentDistributedTransactionId(DistributedTransactionId gxid);
 extern TransactionId GetTopTransactionId(void);
 extern TransactionId GetTopTransactionIdIfAny(void);
 extern TransactionId GetCurrentTransactionId(void);

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -31,12 +31,6 @@ typedef enum
 	DTX_STATE_NONE = 0,
 
 	/**
-	 * The distributed transaction is active but distributed coordination
-	 *   is not required (because it is auto-commit on the QEs).
-	 */
-	DTX_STATE_ACTIVE_NOT_DISTRIBUTED,
-
-	/**
 	 * The distributed transaction is active and requires distributed coordination
 	 *   (because it is explicit or an implicit writer transaction)
 	 */
@@ -295,8 +289,8 @@ extern void dtxCrackOpenGid(const char	*gid,
 extern DistributedTransactionId getDistributedTransactionId(void);
 extern bool getDistributedTransactionIdentifier(char *id);
 
-extern void initGxact(TMGXACT *gxact);
-extern void setCurrentGxact(void);
+extern void initGxact(TMGXACT *gxact, bool resetXid);
+extern void activeCurrentGxact(void);
 extern void	prepareDtxTransaction(void);
 extern bool isPreparedDtxTransaction(void);
 extern void getDtxLogInfo(TMGXACT_LOG *gxact_log);
@@ -312,9 +306,7 @@ extern void redoDtxCheckPoint(TMGXACT_CHECKPOINT *gxact_checkpoint);
 extern void redoDistributedCommitRecord(TMGXACT_LOG *gxact_log);
 extern void redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log);
 
-/* @param stmt used because some plans are annotated with dispatch details which the DTM needs. */
-extern void dtmPreCommand(const char *debugCaller, const char *debugDetail, PlannedStmt *stmt,
-							bool needsTwoPhaseCommit, bool dispatchToPrimaries, bool dispatchToMirrors );
+extern void setupTwoPhaseTransaction(void);
 extern bool isCurrentDtxTwoPhase(void);
 extern DtxState getCurrentDtxState(void);
 
@@ -353,5 +345,7 @@ extern void markCurrentGxactWriterGangLost(void);
 extern bool currentGxactWriterGangLost(void);
 
 extern void addToGxactTwophaseSegments(struct Gang* gp);
+
+extern DistributedTransactionId generateGID(void);
 
 #endif   /* CDBTM_H */


### PR DESCRIPTION
DTX_STATE_ACTIVE_NOT_DISTRIBUTED indicates the transaction is started on QD and
two-phase commit is not required yet, in this state, distributed transaction ID
is also generated. If this transaction is not a two-phase transaction, e.g. implicit
select-only transaction, it will also need to acquire the ProcArrayLock to clear
the distributed transaction ID, and that leads to unnecessary lock contention.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
