### PR TITLE
Replace C99 struct initialize with memset

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -1296,7 +1296,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 {
 	int 		size;
 	const int 	whole_rows = 1; /* gpfdist must not read data with partial rows */
-	struct fstream_filename_and_offset fos = {0};
+	struct fstream_filename_and_offset fos;
 
 	session_t *session = r->session;
 


### PR DESCRIPTION
Initializing a struct with zeroes using {0} is legal in C99, but cause a warning in Clang when the first member of the struct isn't a scalar variable:
```
gpfdist.c:1299:44: warning: suggest braces around initialization of subobject
                   [-Wmissing-braces]
        struct fstream_filename_and_offset fos = {0};
                                                  ^
                                                  {}
```
Fix by using an explicit memset instead. The struct will always be set before being read so zeroing out isn't entirely necessary, but it won't hurt either.