### PR TITLE
Updates the docker file to use OpenSSL's version of libcurl.

### DIFF
--- a/concourse/server_pipeline/docker/Dockerfile
+++ b/concourse/server_pipeline/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt update && apt install -y \
     inetutils-ping \
     libapr1-dev \
     libbz2-dev \
-    libcurl4-gnutls-dev \
+    libcurl4-openssl-dev \
     libevent-dev \
     libkrb5-dev \
     libpam-dev \


### PR DESCRIPTION
Attempting to solve https://github.com/greenplum-db/gpdb/issues/7539

This build is running with this change. If it passes, this is the correct change: 

https://server.ci.gpdb.pivotal.io/teams/main/pipelines/greenplum-server-master/jobs/compile_and_test_gpdb/builds/124
