### PR TITLE
Bump timeout to six hours

### DIFF
--- a/concourse/server_pipeline/master_pipeline.yml
+++ b/concourse/server_pipeline/master_pipeline.yml
@@ -27,7 +27,7 @@ tasks:
   - &task
     image: image
     file: gpdb_src/concourse/server_pipeline/task.yml
-    timeout: 3h
+    timeout: 6h
     
   - &test_installcheck_world_with_planner
     <<: *task


### PR DESCRIPTION
Our concern right now is with flakes, not build time.