### PR TITLE
Docs updates to gucs

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -8255,7 +8255,7 @@
           </thead>
           <tbody>
             <row>
-              <entry colname="col1">a comma- separated list of schema names</entry>
+              <entry colname="col1">a comma-separated list of schema names</entry>
               <entry colname="col2">$user,public</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
@@ -8782,7 +8782,7 @@
         about 64 bytes, per increment. However if a buffer is actually used, an additional 32768
         bytes will be consumed.</p>
       <p>You can set this parameter to the number of 32K blocks (for example, <codeph>1024</codeph>
-        to allow 32MB for buffers), or specify the maximum omount of memory to allow (for example
+        to allow 32MB for buffers), or specify the maximum amount of memory to allow (for example
           <codeph>'48MB'</codeph> for 1536 blocks). The <codeph>gpconfig</codeph> utility and
           <codeph>SHOW</codeph> command report the maximum amount of memory allowed for temporary
         buffers.</p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -1794,6 +1794,10 @@
         lower value makes it more likely sequential scans will be used. This parameter has no effect
         on the size of shared memory allocated by a Greenplum server instance, nor does it reserve
         kernel disk cache; it is used only for estimation purposes.</p>
+      <p>Set this parameter to a number of 32K blocks (for example, <codeph>512</codeph> for 16MB),
+        or specify the size of the effective cache (for example, <codeph>'32MB'</codeph> for 1024
+        blocks). The <codeph>gpconfig</codeph> utility and <codeph>SHOW</codeph> command display the
+        effective cache size value in units such as 'MB' or 'kB'.</p>
       <table id="effective_cache_size_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -1809,7 +1813,7 @@
           <tbody>
             <row>
               <entry colname="col1">floating point</entry>
-              <entry colname="col2">16GB</entry>
+              <entry colname="col2">512 (16GB)</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -8774,12 +8774,18 @@
   <topic id="temp_buffers">
     <title>temp_buffers</title>
     <body>
-      <p>Sets the maximum number of temporary buffers used by each database session. These are
-        session-local buffers used only for access to temporary tables. The setting can be changed
-        within individual sessions, but only up until the first use of temporary tables within a
-        session. The cost of setting a large value in sessions that do not actually need a lot of
-        temporary buffers is only a buffer descriptor, or about 64 bytes, per increment. However if
-        a buffer is actually used, an additional 8192 bytes will be consumed. </p>
+      <p>Sets the maximum memory, in blocks, to allow for temporary buffers by each database
+        session. These are session-local buffers used only for access to temporary tables. The
+        setting can be changed within individual sessions, but only up until the first use of
+        temporary tables within a session. The cost of setting a large value in sessions that do not
+        actually need a lot of temporary buffers is only a buffer descriptor for each block, or
+        about 64 bytes, per increment. However if a buffer is actually used, an additional 32768
+        bytes will be consumed.</p>
+      <p>You can set this parameter to the number of 32K blocks (for example, <codeph>1024</codeph>
+        to allow 32MB for buffers), or specify the maximum omount of memory to allow (for example
+          <codeph>'48MB'</codeph> for 1536 blocks). The <codeph>gpconfig</codeph> utility and
+          <codeph>SHOW</codeph> command report the maximum amount of memory allowed for temporary
+        buffers.</p>
       <table id="temp_buffers_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -8795,7 +8801,7 @@
           <tbody>
             <row>
               <entry colname="col1">integer</entry>
-              <entry colname="col2">1024</entry>
+              <entry colname="col2">1024 (32MB)</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -449,9 +449,6 @@
               <xref href="#krb_server_keyfile"/>
             </li>
             <li>
-              <xref href="#krb_srvname"/>
-            </li>
-            <li>
               <xref href="#lc_collate"/>
             </li>
             <li>
@@ -1421,7 +1418,7 @@
           <tbody>
             <row>
               <entry colname="col1">Boolean</entry>
-              <entry colname="col2">off</entry>
+              <entry colname="col2">on</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
@@ -1812,7 +1809,7 @@
           <tbody>
             <row>
               <entry colname="col1">floating point</entry>
-              <entry colname="col2">512MB</entry>
+              <entry colname="col2">16GB</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
@@ -5598,33 +5595,6 @@
               <entry colname="col1">path and file name</entry>
               <entry colname="col2">unset</entry>
               <entry colname="col3">master<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="krb_srvname">
-    <title>krb_srvname</title>
-    <body>
-      <p>Sets the Kerberos service name.</p>
-      <table id="krb_srvname_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">service name</entry>
-              <entry colname="col2">postgres</entry>
-              <entry colname="col3">master<p>system</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -150,9 +150,6 @@
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#krb_srvname" type="section">krb_srvname</xref>
-              </p>
-              <p>
                 <xref href="guc-list.xml#password_encryption" type="section"
                   >password_encryption</xref>
               </p>


### PR DESCRIPTION
-  **Reviewers: Is this intentional?** There is a cosmetic change in behavior for GUC `temp_buffers`. In 5X, there was a show hook function that divided the value by BLKSIZE (32768). Now that function is gone so gpconfig/SHOW report a value like '32MB' instead of 1024, as in 5X. This PR rewrites the description to match the 6X behavior. 

-  GUC `debug_pretty_print` has the default value off, but in the DB, `debug_pretty_print` has the default value on. Corrected the GUC reference to `on`.

-  GUC `effective_cache_size` has the default value 512MB: in the DB, it is 16GB. Changed the docs to `16GB`.

- Native support for Kerberos authentication (--with-krb5, etc) was removed in 9.4. This PR removes the `krb_srvname` guc from the reference doc. Removing native kerberos support throughout docs is in another story. 


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
