### PR TITLE
Remove add_missing_from GUC from all docs

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -1080,9 +1080,6 @@
           <strow>
             <stentry>
               <p>
-                <codeph>add_missing_from</codeph>
-              </p>
-              <p>
                 <codeph>array_nulls</codeph>
               </p>
               <p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -13,9 +13,6 @@
         <stentry>
           <ul id="ul_tc3_nlx_wp">
             <li>
-              <xref href="#add_missing_from"/>
-            </li>
-            <li>
               <xref href="#application_name"/>
             </li>
             <li>
@@ -829,34 +826,6 @@
       </strow>
     </simpletable>
   </body>
-  <topic id="add_missing_from">
-    <title>add_missing_from</title>
-    <body>
-      <p>Automatically adds missing table references to FROM clauses. Present for compatibility with
-        releases of PostgreSQL prior to 8.1, where this behavior was allowed by default.</p>
-      <table id="add_missing_from_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">Boolean</entry>
-              <entry colname="col2">off</entry>
-              <entry colname="col3">master<p>session</p><p>reload</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
   <topic id="application_name">
     <title>application_name</title>
     <body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1306,9 +1306,6 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#add_missing_from" type="section">add_missing_from</xref>
-              </p>
-              <p>
                 <xref href="guc-list.xml#array_nulls" type="section">array_nulls</xref>
               </p>
               <p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -26,7 +26,6 @@
             <topicref href="guc_category-list.xml#topic56"/>
         </topicref>
         <topicref href="guc-list.xml" linking="none">
-            <topicref href="guc-list.xml#add_missing_from"/>
             <topicref href="guc-list.xml#application_name"/>
             <topicref href="guc-list.xml#array_nulls"/>
             <topicref href="guc-list.xml#authentication_timeout"/>


### PR DESCRIPTION
Just removing stuff. There is one reference left in the SELECT command reference that says it's no longer allowed. 


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
