### PR TITLE
Enable checkout option with subplan in updatable view

### DIFF
--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -190,6 +190,7 @@ plan_tree_mutator(Node *node,
 				FLATCOPY(newmt, mt, ModifyTable);
 				PLANMUTATE(newmt, mt);
 				MUTATE(newmt->plans, mt->plans, List *);
+				MUTATE(newmt->withCheckOptionLists, mt->withCheckOptionLists, List *);
 				return (Node *) newmt;
 			}
 			break;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3179,28 +3179,6 @@ ExecWithCheckOptions(ResultRelInfo *resultRelInfo,
 		ExprState  *wcoExpr = (ExprState *) lfirst(l2);
 
 		/*
-		 * GPDB_94_MERGE_FIXME
-		 * When we update the view, we need to check if the updated tuple belongs
-		 * to the view. Sometimes we need to execute a subplan to help check.
-		 * The subplan is executed under the update or delete node on segment.
-		 * But we can't correctly execute a mpp subplan in the segment. So let's
-		 * disable the check first.
-		 */
-		ListCell *l;
-		bool is_subplan = false;
-		foreach(l, (List*)wcoExpr)
-		{
-			ExprState  *clause = (ExprState *) lfirst(l);
-			if (*(clause->evalfunc) == (ExprStateEvalFunc)ExecAlternativeSubPlan)
-			{
-				is_subplan = true;
-				break;
-			}
-		}
-		if (is_subplan)
-			continue;
-
-		/*
 		 * WITH CHECK OPTION checks are intended to ensure that the new tuple
 		 * is visible in the view.  If the view's qual evaluates to NULL, then
 		 * the new tuple won't be included in the view.  Therefore we need to

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -1594,17 +1594,13 @@ CREATE VIEW rw_view1 AS
   WHERE EXISTS(SELECT 1 FROM ref_tbl r WHERE r.a = b.a)
   WITH CHECK OPTION;
 INSERT INTO rw_view1 VALUES (5); -- ok
---start_ignore
 INSERT INTO rw_view1 VALUES (15); -- should fail
 ERROR:  new row violates WITH CHECK OPTION for view "rw_view1"
 DETAIL:  Failing row contains (15).
---end_ignore
 UPDATE rw_view1 SET a = a + 5; -- ok
---start_ignore
 UPDATE rw_view1 SET a = a + 5; -- should fail
 ERROR:  new row violates WITH CHECK OPTION for view "rw_view1"
 DETAIL:  Failing row contains (15).
---end_ignore
 EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (5);
                    QUERY PLAN                    
 -------------------------------------------------
@@ -1614,10 +1610,12 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (5);
            ->  Result
                  Filter: (r.a = b.a)
                  ->  Materialize
-                       ->  Seq Scan on ref_tbl r
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Seq Scan on ref_tbl r
          SubPlan 2  (slice0; segments: 1)
            ->  Materialize
-                 ->  Seq Scan on ref_tbl r_1
+                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                       ->  Seq Scan on ref_tbl r_1
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -1637,12 +1635,14 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
            ->  Result
                  Filter: (r_1.a = b.a)
                  ->  Materialize
-                       ->  Seq Scan on ref_tbl r_1
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                             ->  Seq Scan on ref_tbl r_1
          SubPlan 2  (slice1; segments: 3)
            ->  Materialize
-                 ->  Seq Scan on ref_tbl r_2
+                 ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                       ->  Seq Scan on ref_tbl r_2
  Optimizer: Postgres query optimizer
-(18 rows)
+(20 rows)
 
 DROP TABLE base_tbl, ref_tbl CASCADE;
 NOTICE:  drop cascades to view rw_view1
@@ -2376,7 +2376,6 @@ CREATE VIEW v1 WITH (security_barrier = true) AS
 CREATE VIEW v2 WITH (security_barrier = true) AS
   SELECT * FROM v1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.cc = v1.c)
   WITH CHECK OPTION;
---start_ignore
 INSERT INTO v2 VALUES (2, 'two', 20); -- ok
 INSERT INTO v2 VALUES (-2, 'minus two', 20); -- not allowed
 ERROR:  new row violates WITH CHECK OPTION for view "v1"
@@ -2387,17 +2386,17 @@ DETAIL:  Failing row contains (3, three, 30).
 UPDATE v2 SET b = 'ONE' WHERE a = 1; -- ok
 UPDATE v2 SET a = -1 WHERE a = 1; -- not allowed
 ERROR:  new row violates WITH CHECK OPTION for view "v1"
-DETAIL:  Failing row contains (-1, one, 10).
+DETAIL:  Failing row contains (-1, ONE, 10).
 UPDATE v2 SET c = 30 WHERE a = 1; -- not allowed
 ERROR:  new row violates WITH CHECK OPTION for view "v2"
-DETAIL:  Failing row contains (1, one, 30).
+DETAIL:  Failing row contains (1, ONE, 30).
 DELETE FROM v2 WHERE a = 2; -- ok
 SELECT * FROM v2;
  a |  b  | c  
 ---+-----+----
- 1 | one | 10
+ 1 | ONE | 10
 (1 row)
---end_ignore
+
 DROP VIEW v2;
 DROP VIEW v1;
 DROP TABLE t2;

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -1613,17 +1613,13 @@ CREATE VIEW rw_view1 AS
   WHERE EXISTS(SELECT 1 FROM ref_tbl r WHERE r.a = b.a)
   WITH CHECK OPTION;
 INSERT INTO rw_view1 VALUES (5); -- ok
---start_ignore
 INSERT INTO rw_view1 VALUES (15); -- should fail
 ERROR:  new row violates WITH CHECK OPTION for view "rw_view1"
 DETAIL:  Failing row contains (15).
---end_ignore
 UPDATE rw_view1 SET a = a + 5; -- ok
---start_ignore
 UPDATE rw_view1 SET a = a + 5; -- should fail
 ERROR:  new row violates WITH CHECK OPTION for view "rw_view1"
 DETAIL:  Failing row contains (15).
---end_ignore
 EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (5);
                    QUERY PLAN                    
 -------------------------------------------------
@@ -1633,10 +1629,12 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (5);
            ->  Result
                  Filter: (r.a = b.a)
                  ->  Materialize
-                       ->  Seq Scan on ref_tbl r
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Seq Scan on ref_tbl r
          SubPlan 2  (slice0; segments: 1)
            ->  Materialize
-                 ->  Seq Scan on ref_tbl r_1
+                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                       ->  Seq Scan on ref_tbl r_1
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -1656,10 +1654,12 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
            ->  Result
                  Filter: (r_1.a = b.a)
                  ->  Materialize
-                       ->  Seq Scan on ref_tbl r_1
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                             ->  Seq Scan on ref_tbl r_1
          SubPlan 2  (slice1; segments: 3)
            ->  Materialize
-                 ->  Seq Scan on ref_tbl r_2
+                 ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                       ->  Seq Scan on ref_tbl r_2
  Optimizer: Postgres query optimizer
 (18 rows)
 
@@ -2407,24 +2407,27 @@ CREATE VIEW v1 WITH (security_barrier = true) AS
 CREATE VIEW v2 WITH (security_barrier = true) AS
   SELECT * FROM v1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.cc = v1.c)
   WITH CHECK OPTION;
---start_ignore
 INSERT INTO v2 VALUES (2, 'two', 20); -- ok
 INSERT INTO v2 VALUES (-2, 'minus two', 20); -- not allowed
 ERROR:  new row violates WITH CHECK OPTION for view "v1"
 DETAIL:  Failing row contains (-2, minus two, 20).
 INSERT INTO v2 VALUES (3, 'three', 30); -- not allowed
+ERROR:  new row violates WITH CHECK OPTION for view "v2"  (seg0 127.0.0.1:25432 pid=3720)
+DETAIL:  Failing row contains (3, three, 30).
 UPDATE v2 SET b = 'ONE' WHERE a = 1; -- ok
 UPDATE v2 SET a = -1 WHERE a = 1; -- not allowed
 ERROR:  new row violates WITH CHECK OPTION for view "v1"
 DETAIL:  Failing row contains (-1, ONE, 10).
 UPDATE v2 SET c = 30 WHERE a = 1; -- not allowed
+ERROR:  new row violates WITH CHECK OPTION for view "v2"  (seg1 127.0.0.1:25433 pid=1771)
+DETAIL:  Failing row contains (1, ONE, 30).
 DELETE FROM v2 WHERE a = 2; -- ok
 SELECT * FROM v2;
- a | b | c 
----+---+---
-(0 rows)
+ a |  b  | c  
+---+-----+----
+ 1 | ONE | 10
+(1 row)
 
---end_ignore
 DROP VIEW v2;
 DROP VIEW v1;
 DROP TABLE t2;

--- a/src/test/regress/sql/updatable_views.sql
+++ b/src/test/regress/sql/updatable_views.sql
@@ -738,14 +738,10 @@ CREATE VIEW rw_view1 AS
   WITH CHECK OPTION;
 
 INSERT INTO rw_view1 VALUES (5); -- ok
---start_ignore
 INSERT INTO rw_view1 VALUES (15); -- should fail
---end_ignore
 
 UPDATE rw_view1 SET a = a + 5; -- ok
---start_ignore
 UPDATE rw_view1 SET a = a + 5; -- should fail
---end_ignore
 
 EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (5);
 EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
@@ -1114,7 +1110,6 @@ CREATE VIEW v2 WITH (security_barrier = true) AS
   SELECT * FROM v1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.cc = v1.c)
   WITH CHECK OPTION;
 
---start_ignore
 INSERT INTO v2 VALUES (2, 'two', 20); -- ok
 INSERT INTO v2 VALUES (-2, 'minus two', 20); -- not allowed
 INSERT INTO v2 VALUES (3, 'three', 30); -- not allowed
@@ -1125,7 +1120,6 @@ UPDATE v2 SET c = 30 WHERE a = 1; -- not allowed
 
 DELETE FROM v2 WHERE a = 2; -- ok
 SELECT * FROM v2;
---end_ignore
 
 DROP VIEW v2;
 DROP VIEW v1;


### PR DESCRIPTION
In merge work of postgres94, the subplan of updatable view check option
was not parallelized correctly. So we disable the check option and add
a FIXME.
The root cause is The root cause of this problem is that we ignored
modifytable.withCheckOptionLists in plan_tree_mutator.
Add it and enable the check option with subplan.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
