### PR TITLE
Remove autoconf check for CURLOPT_MAIL_FROM

### DIFF
--- a/configure
+++ b/configure
@@ -1928,52 +1928,6 @@ $as_echo "$ac_res" >&6; }
 
 } # ac_fn_c_check_func
 
-# ac_fn_c_check_decl LINENO SYMBOL VAR INCLUDES
-# ---------------------------------------------
-# Tests whether SYMBOL is declared in INCLUDES, setting cache variable VAR
-# accordingly.
-ac_fn_c_check_decl ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  as_decl_name=`echo $2|sed 's/ *(.*//'`
-  as_decl_use=`echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g'`
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
-$as_echo_n "checking whether $as_decl_name is declared... " >&6; }
-if eval \${$3+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$4
-int
-main ()
-{
-#ifndef $as_decl_name
-#ifdef __cplusplus
-  (void) $as_decl_use;
-#else
-  (void) $as_decl_name;
-#endif
-#endif
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  eval "$3=yes"
-else
-  eval "$3=no"
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-eval ac_res=\$$3
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-
-} # ac_fn_c_check_decl
-
 # ac_fn_cxx_try_link LINENO
 # -------------------------
 # Try to link conftest.$ac_ext, and return whether this succeeded.
@@ -2647,6 +2601,52 @@ rm -f conftest.val
   as_fn_set_status $ac_retval
 
 } # ac_fn_c_compute_int
+
+# ac_fn_c_check_decl LINENO SYMBOL VAR INCLUDES
+# ---------------------------------------------
+# Tests whether SYMBOL is declared in INCLUDES, setting cache variable VAR
+# accordingly.
+ac_fn_c_check_decl ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  as_decl_name=`echo $2|sed 's/ *(.*//'`
+  as_decl_use=`echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g'`
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
+$as_echo_n "checking whether $as_decl_name is declared... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+#ifndef $as_decl_name
+#ifdef __cplusplus
+  (void) $as_decl_use;
+#else
+  (void) $as_decl_name;
+#endif
+#endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$3=yes"
+else
+  eval "$3=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_decl
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -12099,7 +12099,6 @@ fi
 fi
 
 # Check for curl.
-# CURLOPT_MAIL_FROM is introduced in curl 7.20 and only needed for email alerts.
 if test "$with_libcurl" = yes ; then
 
   succeeded=no
@@ -12195,18 +12194,6 @@ $as_echo "$CURL_LIBS" >&6; }
   LIBS="$LIBS $CURL_LIBS"
 
 $as_echo "#define USE_CURL 1" >>confdefs.h
-
-  ac_fn_c_check_decl "$LINENO" "CURLOPT_MAIL_FROM" "ac_cv_have_decl_CURLOPT_MAIL_FROM" "#include <curl/curl.h>
-"
-if test "x$ac_cv_have_decl_CURLOPT_MAIL_FROM" = xyes; then :
-  ac_have_decl=1
-else
-  ac_have_decl=0
-fi
-
-cat >>confdefs.h <<_ACEOF
-#define HAVE_DECL_CURLOPT_MAIL_FROM $ac_have_decl
-_ACEOF
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -1415,14 +1415,12 @@ if test "$with_libxml" = yes ; then
 fi
 
 # Check for curl.
-# CURLOPT_MAIL_FROM is introduced in curl 7.20 and only needed for email alerts.
 if test "$with_libcurl" = yes ; then
   AC_CHECK_CURL([7.19.0])
   CFLAGS="$CFLAGS $CURL_CFLAGS"
   LIBS="$LIBS $CURL_LIBS"
   AC_DEFINE([USE_CURL], 1,
           [Define to 1 to build with libcurl support. (--with-libcurl)])
-  AC_CHECK_DECLS([CURLOPT_MAIL_FROM], [], [], [#include <curl/curl.h>])
 fi
 
 # Check for bzip2

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -133,10 +133,6 @@
 /* define if the compiler supports basic C++11 syntax */
 #undef HAVE_CXX11
 
-/* Define to 1 if you have the declaration of `CURLOPT_MAIL_FROM', and to 0 if
-   you don't. */
-#undef HAVE_DECL_CURLOPT_MAIL_FROM
-
 /* Define to 1 if you have the declaration of `fdatasync', and to 0 if you
    don't. */
 #undef HAVE_DECL_FDATASYNC


### PR DESCRIPTION
The functionality to send alerts via email (and snmp was removed in commit 65822b80193b02368110e312c5d47e7170639d but I missed removing the autoconf check for the libcurl feature required. Since there are no more consumers, remove the check.