### PR TITLE
Behave: cleanly shutdown segments using pg_ctl

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -20,7 +20,7 @@ Feature: Tests for gpaddmirrors
     @concourse_cluster
     Scenario: gprecoverseg works correctly on a newly added mirror
         Given a working directory of the test as '/tmp/gpaddmirrors'
-        And the database is killed on hosts "mdw,sdw1,sdw2"
+        And the database is not running
         And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2"
         And gpaddmirrors adds mirrors
         Then verify the database has mirrors
@@ -35,12 +35,12 @@ Feature: Tests for gpaddmirrors
     @concourse_cluster
     Scenario: gpaddmirrors puts mirrors on the same hosts when there is a standby configured
         Given a working directory of the test as '/tmp/gpaddmirrors'
-        And the database is killed on hosts "mdw,sdw1,sdw2,sdw3"
+        And the database is not running
         And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2, sdw3"
         And gpaddmirrors adds mirrors
         Then verify the database has mirrors
         And save the gparray to context
-        And the database is killed on hosts "mdw,sdw1,sdw2,sdw3"
+        And the database is not running
         And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2, sdw3"
         And the user runs gpinitstandby with options " "
         Then gpinitstandby should return a return code of 0
@@ -51,7 +51,7 @@ Feature: Tests for gpaddmirrors
     @concourse_cluster
     Scenario: gpaddmirrors puts mirrors on different host
         Given a working directory of the test as '/tmp/gpaddmirrors'
-        And the database is killed on hosts "mdw,sdw1,sdw2,sdw3"
+        And the database is not running
         And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2, sdw3"
         And gpaddmirrors adds mirrors in spread configuration
         Then verify that mirror segments are in "spread" configuration
@@ -61,7 +61,7 @@ Feature: Tests for gpaddmirrors
 
     Scenario: gpaddmirrors with a default master data directory
         Given a working directory of the test as '/tmp/gpaddmirrors'
-        And the database is killed on hosts "mdw,sdw1"
+        And the database is not running
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And gpaddmirrors adds mirrors
         Then verify the database has mirrors
@@ -70,7 +70,7 @@ Feature: Tests for gpaddmirrors
     @concourse_cluster
     Scenario: gpaddmirrors with a given master data directory [-d <master datadir>]
         Given a working directory of the test as '/tmp/gpaddmirrors'
-        And the database is killed on hosts "mdw,sdw1"
+        And the database is not running
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And gpaddmirrors adds mirrors with temporary data dir
         Then verify the database has mirrors
@@ -79,7 +79,7 @@ Feature: Tests for gpaddmirrors
     @concourse_cluster
     Scenario: gpaddmirrors mirrors are recognized after a cluster restart
         Given a working directory of the test as '/tmp/gpaddmirrors'
-        And the database is killed on hosts "mdw,sdw1"
+        And the database is not running
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         When gpaddmirrors adds mirrors
         Then verify the database has mirrors
@@ -95,7 +95,7 @@ Feature: Tests for gpaddmirrors
     @concourse_cluster
     Scenario: gpaddmirrors when the primaries have data
         Given a working directory of the test as '/tmp/gpaddmirrors'
-        And the database is killed on hosts "mdw,sdw1"
+        And the database is not running
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And database "gptest" exists
         And there is a "heap" table "public.heap_table" in "gptest" with "100" rows

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -10,7 +10,7 @@ Feature: Tests for gpaddmirrors
          Then verify the database has mirrors
           And the tablespace is valid
 
-         When user kills all primary processes
+         When user stops all primary processes
           And user can start transactions
          Then the tablespace is valid
 
@@ -104,7 +104,7 @@ Feature: Tests for gpaddmirrors
         And gpaddmirrors adds mirrors with temporary data dir
         And an FTS probe is triggered
         And the segments are synchronized
-        When user kills all primary processes
+        When user stops all primary processes
         And user can start transactions
         Then verify that there is a "heap" table "public.heap_table" in "gptest" with "100" rows
         Then verify that there is a "ao" table "public.ao_table" in "gptest" with "100" rows
@@ -124,6 +124,6 @@ Feature: Tests for gpaddmirrors
           And the segments are synchronized
          Then the tablespace is valid
 
-         When user kills all primary processes
+         When user stops all primary processes
           And user can start transactions
          Then the tablespace is valid

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -111,6 +111,6 @@ Feature: Tests for gpmovemirrors
           And verify that mirrors are recognized after a restart
           And the tablespace is valid
 
-         When user kills all primary processes
+         When user stops all primary processes
           And user can start transactions
          Then the tablespace is valid

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -5,7 +5,7 @@ Feature: gprecoverseg tests
     Scenario: incremental recovery works with tablespaces
         Given the database is running
           And a tablespace is created with data
-          And user kills a primary postmaster process
+          And user stops all primary processes
           And user can start transactions
          When the user runs "gprecoverseg -a"
          Then gprecoverseg should return a return code of 0
@@ -23,7 +23,7 @@ Feature: gprecoverseg tests
     Scenario: full recovery works with tablespaces
         Given the database is running
           And a tablespace is created with data
-          And user kills a primary postmaster process
+          And user stops all primary processes
           And user can start transactions
          When the user runs "gprecoverseg -a -F"
          Then gprecoverseg should return a return code of 0
@@ -39,7 +39,7 @@ Feature: gprecoverseg tests
 
     Scenario: gprecoverseg should not output bootstrap error on success
         Given the database is running
-        And user kills a primary postmaster process
+        And user stops all primary processes
         And user can start transactions
         When the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
@@ -54,7 +54,7 @@ Feature: gprecoverseg tests
         Given the database is running
         And all the segments are running
         And the segments are synchronized
-        And user kills all mirror processes
+        And user stops all mirror processes
         When user can start transactions
         And the user runs "gprecoverseg -F -a -s"
         Then gprecoverseg should return a return code of 0
@@ -67,7 +67,7 @@ Feature: gprecoverseg tests
         Given the database is running
         And all the segments are running
         And the segments are synchronized
-        And user kills all mirror processes
+        And user stops all mirror processes
         When user can start transactions
         And the user runs "gprecoverseg -F -a --no-progress"
         Then gprecoverseg should return a return code of 0
@@ -82,7 +82,7 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the "primary" segment information is saved
         When the postmaster.pid file on "primary" segment is saved
-        And user kills a primary postmaster process
+        And user stops all primary processes
         When user can start transactions
         And the background pid is killed on "primary" segment
         And we run a sample background script to generate a pid on "primary" segment
@@ -106,7 +106,7 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the "primary" segment information is saved
         When the postmaster.pid file on "primary" segment is saved
-        And user kills a primary postmaster process
+        And user stops all primary processes
         When user can start transactions
         And we generate the postmaster.pid file with a non running pid on the same "primary" segment
         And the user runs "gprecoverseg -a"
@@ -137,7 +137,7 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the "primary" segment information is saved
         When the postmaster.pid file on "primary" segment is saved
-        And user kills a primary postmaster process
+        And user stops all primary processes
         When user can start transactions
         And the background pid is killed on "primary" segment
         And we run a sample background script to generate a pid on "primary" segment
@@ -233,7 +233,7 @@ Feature: gprecoverseg tests
     Scenario: incremental recovery works with tablespaces on a multi-host environment
         Given the database is running
           And a tablespace is created with data
-          And user kills a primary postmaster process
+          And user stops all primary processes
           And user can start transactions
          When the user runs "gprecoverseg -a"
          Then gprecoverseg should return a return code of 0
@@ -252,7 +252,7 @@ Feature: gprecoverseg tests
     Scenario: full recovery works with tablespaces on a multi-host environment
         Given the database is running
           And a tablespace is created with data
-          And user kills a primary postmaster process
+          And user stops all primary processes
           And user can start transactions
          When the user runs "gprecoverseg -a -F"
          Then gprecoverseg should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -4,7 +4,7 @@ Feature: gpstate tests
     Scenario: gpstate -b logs cluster for a cluster where the mirrors failed over to primary
         Given a standard local demo cluster is running
         And the database is running
-        When user kills all primary processes
+        When user stops all primary processes
         And user can start transactions
         And the user runs "gpstate -b"
         Then gpstate output has rows with keys values
@@ -42,7 +42,7 @@ Feature: gpstate tests
     Scenario: gpstate -c logs cluster info for a cluster where all mirrors are failed over
         Given a standard local demo cluster is running
         And the database is running
-        When user kills all primary processes
+        When user stops all primary processes
         And user can start transactions
         And the user runs "gpstate -c"
         Then gpstate output looks like
@@ -54,7 +54,7 @@ Feature: gpstate tests
 
     Scenario: gpstate -c logs cluster info for a cluster that is unsynchronized
         Given a standard local demo cluster is running
-        When user kills all mirror processes
+        When user stops all mirror processes
         And user can start transactions
         And the user runs "gpstate -c"
         Then gpstate output looks like
@@ -104,7 +104,7 @@ Feature: gpstate tests
 
     Scenario: gpstate -e logs errors when mirrors have failed over
         Given a standard local demo cluster is running
-          And user kills all primary processes
+          And user stops all primary processes
           And user can start transactions
         When the user runs "gpstate -e"
         Then gpstate should print "Segments with Primary and Mirror Roles Switched" to stdout
@@ -199,7 +199,7 @@ Feature: gpstate tests
 
     Scenario: gpstate -m warns when mirrors have failed over to primary
         Given a standard local demo cluster is running
-          And user kills all primary processes
+          And user stops all primary processes
           And user can start transactions
         When the user runs "gpstate -m"
         Then gpstate should print "Current GPDB mirror list and status" to stdout
@@ -349,7 +349,7 @@ Feature: gpstate tests
 
     Scenario: gpstate -i warns if any mirrors are marked down
         Given a standard local demo cluster is running
-          And user kills all mirror processes
+          And user stops all mirror processes
           And user can start transactions
         When the user runs "gpstate -i"
         Then gpstate output looks like
@@ -366,7 +366,7 @@ Feature: gpstate tests
 
     Scenario: gpstate -i warns if any up mirrors cannot be contacted
         Given a standard local demo cluster is running
-          And user kills all mirror processes
+          And user stops all mirror processes
           # We intentionally do not wait for an FTS probe here; we want the
           # mirrors to still be marked up when we try to get their version.
         When the user runs "gpstate -i"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -812,16 +812,9 @@ def _process_exists(pid, host):
     return cmd.get_return_code() == 0
 
 
-@given('user kills a primary postmaster process')
-@when('user kills a primary postmaster process')
-@then('user kills a primary postmaster process')
-def impl(context):
-    stop_segments(context, "primary")
-
-
-@given('user kills all {segment_type} processes')
-@when('user kills all {segment_type} processes')
-@then('user kills all {segment_type} processes')
+@given('user stops all {segment_type} processes')
+@when('user stops all {segment_type} processes')
+@then('user stops all {segment_type} processes')
 def stop_segments(context, segment_type):
     if segment_type not in ("primary", "mirror"):
         raise Exception("Expected segment_type to be 'primary' or 'mirror', but found '%s'." % segment_type)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1335,19 +1335,6 @@ def impl(context, filename, output):
         if output not in cmd.get_stdout():
             raise Exception('File %s on host %s does not contain "%s"' % (filepath, host, output))
 
-@then('the user waits for "{process_name}" to finish running')
-def impl(context, process_name):
-    run_command(context, "ps ux | grep `which %s` | grep -v grep | awk '{print $2}' | xargs" % process_name)
-    pids = context.stdout_message.split()
-    while len(pids) > 0:
-        for pid in pids:
-            try:
-                os.kill(int(pid), 0)
-            except OSError:
-                pids.remove(pid)
-        time.sleep(10)
-
-
 @given('the gpfdists occupying port {port} on host "{hostfile}"')
 def impl(context, port, hostfile):
     remote_gphome = os.environ.get('GPHOME')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -228,8 +228,10 @@ def impl(context, checksum_toggle):
         if ('PGDATABASE' in os.environ):
             run_command(context, "createdb %s" % os.getenv('PGDATABASE'))
 
+
 @given('the database is not running')
 @when('the database is not running')
+@then('the database is not running')
 def impl(context):
     stop_database_if_started(context)
     if has_exception(context):
@@ -2373,16 +2375,6 @@ def impl(context, hostnames):
     if hasattr(context, "temp_base_dir"):
         reset_hosts(hosts, context.temp_base_dir)
 
-@then('the database is killed on hosts "{hostnames}"')
-@given('the database is killed on hosts "{hostnames}"')
-def impl(context, hostnames):
-    hosts = hostnames.split(",")
-    for host in hosts:
-        cmd = Command(name='pkill postgres',
-                      cmdStr="pkill postgres || true",
-                      ctxt=REMOTE,
-                      remoteHost=host)
-        cmd.run(validateAfter=True)
 
 @given('user has created expansiontest tables')
 @then('user has created expansiontest tables')

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 import fileinput
 import os
+import pipes
 import re
 import signal
 import stat
 import time
 import glob
 import shutil
+import subprocess
 import difflib
 
 import yaml
@@ -190,6 +192,7 @@ def stop_database(context):
     if context.exception:
         raise context.exception
 
+
 def stop_primary(context, content_id):
     get_psegment_sql = 'select datadir, hostname from gp_segment_configuration where content=%i and role=\'p\';' % content_id
     with dbconn.connect(dbconn.DbURL(dbname='template1')) as conn:
@@ -197,8 +200,13 @@ def stop_primary(context, content_id):
         rows = cur.fetchall()
         seg_data_dir = rows[0][0]
         seg_host = rows[0][1]
-    pid = get_pid_for_segment(seg_data_dir, seg_host)
-    kill_process(pid)
+
+    # For demo_cluster tests that run on the CI gives the error 'bash: pg_ctl: command not found'
+    # Thus, need to add pg_ctl to the path when ssh'ing to a demo cluster.
+    subprocess.check_call(['ssh', seg_host,
+                           'source %s/greenplum_path.sh && pg_ctl stop -m fast -D %s' % (
+                               pipes.quote(os.environ.get("GPHOME")), pipes.quote(seg_data_dir))
+                           ])
 
 
 def trigger_fts_probe():
@@ -625,36 +633,6 @@ def get_all_hostnames_as_list(context, dbname):
         hosts.append(master[0].strip())
 
     return hosts
-
-
-def get_pid_for_segment(seg_data_dir, seg_host):
-    cmd = Command(name='get list of postmaster processes',
-                  cmdStr='ps -eaf | grep %s' % seg_data_dir,
-                  ctxt=REMOTE,
-                  remoteHost=seg_host)
-    cmd.run(validateAfter=True)
-
-    pid = None
-    results = cmd.get_results().stdout.strip().split('\n')
-    for res in results:
-        if 'grep' not in res:
-            pid = res.split()[1]
-
-    if pid is None:
-        return None
-
-    return int(pid)
-
-
-def kill_process(pid, host=None, sig=signal.SIGTERM):
-    if host is not None:
-        cmd = Command('kill process on a given host',
-                      cmdStr='kill -%d %d' % (sig, pid),
-                      ctxt=REMOTE,
-                      remoteHost=host)
-        cmd.run(validateAfter=True)
-    else:
-        os.kill(pid, sig)
 
 def has_process_eventually_stopped(proc, host=None):
     start_time = current_time = datetime.now()


### PR DESCRIPTION
Cleanly shutdown segments using pg_ctl instead of using signals to avoid potential race conditions by grep'ing for the pid via ps. This is a much simpler approach to help with maintainability and extensibility.

This helps address the concerns outlined in PR https://github.com/greenplum-db/gpdb/pull/7525#issuecomment-486304092.

A chore has been created to refactor Command usages (ie: `run_cmd`) in behave to use something like the subprocess module as that is not within the scope of this PR.

Test pipelines are running. And a backport to 6X will follow.
