### PR TITLE
gpcloud: sleep and retry if AWS returns "NoSuchKey" error

### DIFF
--- a/gpcontrib/gpcloud/include/s3exception.h
+++ b/gpcontrib/gpcloud/include/s3exception.h
@@ -13,6 +13,9 @@ class S3Exception {
 
     virtual ~S3Exception() {
     }
+    virtual string getCode() {
+        return "";
+    }
     virtual string getMessage() {
         return "";
     }
@@ -128,6 +131,10 @@ class S3LogicError : public S3Exception {
     }
     virtual ~S3LogicError() {
     }
+    virtual string getCode() {
+        return awscode;
+    }
+
     virtual string getMessage() {
         return "AWS returns error " + awscode + " : " + message;
     }


### PR DESCRIPTION
CI reported some read failures just after the write action, it's
probably because the write action is not flushed yet by AWS.

Sleep and retry if AWS returns "NoSuchKey" error. Update the workflow
but not the test cases because users might have the same issue.
