### PR TITLE
6X: gpcloud: sleep and retry if AWS returns "NoSuchKey" error

### DIFF
--- a/gpcontrib/gpcloud/include/s3exception.h
+++ b/gpcontrib/gpcloud/include/s3exception.h
@@ -13,6 +13,9 @@ class S3Exception {
 
     virtual ~S3Exception() {
     }
+    virtual string getCode() {
+        return "";
+    }
     virtual string getMessage() {
         return "";
     }
@@ -128,6 +131,10 @@ class S3LogicError : public S3Exception {
     }
     virtual ~S3LogicError() {
     }
+    virtual string getCode() {
+        return awscode;
+    }
+
     virtual string getMessage() {
         return "AWS returns error " + awscode + " : " + message;
     }

--- a/gpcontrib/gpcloud/src/s3interface.cpp
+++ b/gpcontrib/gpcloud/src/s3interface.cpp
@@ -31,6 +31,7 @@ S3InterfaceService::~S3InterfaceService() {
 
 Response S3InterfaceService::getResponseWithRetries(const string &url, HTTPHeaders &headers,
                                                     uint64_t retries) {
+    string code;
     string message;
     uint64_t retry = retries;
 
@@ -43,6 +44,14 @@ Response S3InterfaceService::getResponseWithRetries(const string &url, HTTPHeade
                 S3_DIE(S3QueryAbort, "Downloading is interrupted");
             }
             S3WARN("Failed to get a good response in GET from '%s', retrying ...", url.c_str());
+        } catch (S3LogicError &e) {
+            code = e.getCode();
+            if (code == "NoSuchKey") {
+                sleep(1);
+                continue;
+            } else {
+                throw e;
+            }
         }
     };
 


### PR DESCRIPTION
CI reported some read failures just after the write action, it's
probably because the write action is not flushed yet by AWS.

Sleep and retry if AWS returns "NoSuchKey" error. Update the workflow
but not the test cases because users might have the same issue.