### PR TITLE
Fix potential NULL pointer dereference

### DIFF
--- a/src/bin/pg_dump/dumputils.c
+++ b/src/bin/pg_dump/dumputils.c
@@ -1482,7 +1482,7 @@ escape_fmtopts_string(const char *src)
 	int			len = strlen(src);
 	int			i;
 	int			j;
-	char	   *result = malloc(len * 2 + 1);
+	char	   *result = pg_malloc(len * 2 + 1);
 	bool		inString = false;
 
 	for (i = 0, j = 0; i < len; i++)

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13917,8 +13917,7 @@ dumpExternal(Archive *fout, TableInfo *tbinfo, PQExpBuffer q, PQExpBuffer delq)
 		appendPQExpBuffer(q, "FORMAT '%s' (%s)\n",
 						  tabfmt,
 						  customfmt ? customfmt : tmpstring);
-		free(tmpstring);
-		tmpstring = NULL;
+		pg_free(tmpstring);
 		if (customfmt)
 		{
 			free(customfmt);


### PR DESCRIPTION
Allocating memory manually with `malloc()` requires checking that the allocation was granted before dereferencing the pointer. To fix use `pg_malloc0()` which is guaranteed to return a valid pointer or error out. Also update the reclaim to use a matching `pg_free()` call (explicitly setting to NULL is useless as the variable isn't used anymore and that call would quite likely be optimized away anyways).

Spotted while reading #7533 