### PR TITLE
docs - add content for pxf cluster status cmd

### DIFF
--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -27,7 +27,7 @@ PXF provides two management commands:
 - `pxf cluster` - manage all PXF service instances in the Greenplum Database cluster
 - `pxf` - manage the PXF service instance on a specific Greenplum Database host
 
-The [`pxf cluster`](ref/pxf-cluster.html) command supports `init`, `start`, `stop`, and `sync` subcommands. When you run a `pxf cluster` subcommand on the Greenplum Database master host, you perform the operation on all segment hosts in the Greenplum Database cluster. PXF also runs the `init` and `sync` commands on the standby master host.
+The [`pxf cluster`](ref/pxf-cluster.html) command supports `init`, `start`, `status`, `stop`, and `sync` subcommands. When you run a `pxf cluster` subcommand on the Greenplum Database master host, you perform the operation on all segment hosts in the Greenplum Database cluster. PXF also runs the `init` and `sync` commands on the standby master host.
 
 The [`pxf`](ref/pxf.html) command supports `init`, `start`, `stop`, `restart`, and `status` operations. These operations run locally. That is, if you want to start or stop the PXF agent on a specific Greenplum Database segment host, you log in to the host and run the command. 
 

--- a/gpdb-doc/markdown/pxf/monitor_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/monitor_pxf.html.md.erb
@@ -21,11 +21,11 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-To display PXF status, you must explicitly request the status of the PXF service instance on each segment host in your Greenplum Database cluster.
+The `pxf cluster status` command displays the status of the PXF service instance on all segment hosts in your Greenplum Database cluster. `pxf status` displays the status of the PXF service instance on the local (segment) host.
 
 Only the `gpadmin` user can request the status of the PXF service.
 
-Perform the following procedure to request the PXF status on each segment host in your Greenplum Database cluster.
+Perform the following procedure to request the PXF status of your Greenplum Database cluster.
 
 1. Log in to the Greenplum Database master node:
 
@@ -33,9 +33,9 @@ Perform the following procedure to request the PXF status on each segment host i
     $ ssh gpadmin@<gpmaster>
     ```
 
-2. Use the `gpssh` command and a seghostfile to run the `pxf status` command on each segment host:
+2. Run the `pxf cluster status` command:
 
     ```shell
-    gpadmin@gpmaster$ gpssh -e -v -f seghostfile "/usr/local/greenplum-db/pxf/bin/pxf status"
+    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster status
     ```
 

--- a/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
@@ -16,6 +16,7 @@ where `<command>` is:
 help
 init
 start
+status
 stop
 sync
 ```
@@ -26,11 +27,12 @@ The `pxf cluster` utility command manages PXF on the master, standby master, and
 
 - Initialize PXF configuration on all hosts in the Greenplum Database cluster.
 - Start and stop the PXF service instance on all segment hosts.
+- Display the status of the PXF service instance on all segment hosts.
 - Synchronize the PXF configuration from the Greenplum Database master host to the standby master and to all segment hosts.
 
 `pxf cluster` requires a running Greenplum Database cluster. You must run the utility on the Greenplum Database master host.
 
-If you want to manage the PXF service instance on a specific segment host, use the `pxf` utility. See [`pxf`](pxf.html#topic1).
+(If you want to manage the PXF service instance on a specific segment host, use the `pxf` utility. See [`pxf`](pxf.html#topic1).)
 
 ## <a id="commands"></a>Commands
 
@@ -42,6 +44,9 @@ If you want to manage the PXF service instance on a specific segment host, use t
 
 <dt>start</dt>
 <dd>Start the PXF service instance on all segment hosts.</dd>
+
+<dt>status  </dt>
+<dd>Display the status of the PXF service instance on all segment hosts.</dd>
 
 <dt>stop  </dt>
 <dd>Stop the PXF service instance on all segment hosts.</dd>

--- a/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
@@ -32,7 +32,7 @@ You can initialize PXF on the master, master standby, or a specific segment host
 
 You can start, stop, or restart the PXF service instance on a specific segment host, or display the status of the PXF service instance running on a segment host.
 
-Use the [`pxf cluster`](pxf-cluster.html#topic1) command to initialize PXF on all hosts, synchronize the PXF configuration to the Greenplum Database cluster, or to start and stop the PXF service instance on all segment hosts in the cluster.
+(Use the [`pxf cluster`](pxf-cluster.html#topic1) command to initialize PXF on all hosts, synchronize the PXF configuration to the Greenplum Database cluster, or to start, stop, or display the status of the PXF service instance on all segment hosts in the cluster.)
 
 ## <a id="commands"></a>Commands
 


### PR DESCRIPTION
pxf now supports "pxf cluster status".  add to docs.
