### PR TITLE
Zero out padding bytes for memtuple.

### DIFF
--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -628,7 +628,7 @@ MemTuple memtuple_form_to(
 	if(!destlen)
 	{
 		Assert(!mtup);
-		mtup = (MemTuple) palloc(len);
+		mtup = (MemTuple) palloc0(len);
 	}
 	else if(*destlen < len)
 	{
@@ -659,6 +659,7 @@ MemTuple memtuple_form_to(
 	{
 		*destlen = len;
 		Assert(mtup);
+		memset(mtup, 0, len);
 	}
 
 	/* Set mtlen, this set the lead bit, len, and clears hasnull bit 
@@ -690,9 +691,6 @@ MemTuple memtuple_form_to(
 		/* if null bitmap is more than 4 bytes, add needed space */
 		start += pbind->null_bitmap_extra_size;
 		varlen_start += pbind->null_bitmap_extra_size;
-
-		/* clear null bitmap. */
-		memset(nullp, 0, memtuple_get_nullp_len(pbind));
 	}
 
 	/* It is very important to setup the null bitmap first before we 


### PR DESCRIPTION
heaptuple_form_to() zero's out the buffer, so this commit does same
for memtuple_form_to(). This is done to have zeros in padding areas
and hence help get good compression for AO tables.
    
This also helps to eliminate the flakiness seen in appendonly test for
compression ratio. Now given same input the compression ratio will be
same.
    
Discussion:
https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/1N5Qi-4WPis/EAIdwvy9CAAJ
