### PR TITLE
6X backport: Print more detailed message for gp_replica_check test failure due to …

### DIFF
--- a/gpcontrib/gp_replica_check/gp_replica_check.py
+++ b/gpcontrib/gp_replica_check/gp_replica_check.py
@@ -83,6 +83,14 @@ def create_restartpoint_on_ckpt_record_replay(set):
         print res
     except subprocess.CalledProcessError, e:
         print 'returncode: (%s), cmd: (%s), output: (%s)' % (e.returncode, e.cmd, e.output)
+        if set:
+            print '''guc setting with gpconfig & then updating with "gpstop -u" failed.
+Probably there are some nodes could not be brought up and thus we
+can not run the test. That is probably because previous tests cause
+the instability of the cluster (indicate a bug usually) or because more time
+is needed for the cluster to be ready due to heavy load (consider increasing
+timeout configurations for this case). In any case we just fail and skip
+the test. Please check the server logs to find why.'''
         sys.exit(2)
 
 def install_extension(databases):


### PR DESCRIPTION
…bad cluster states. (#7556)

Previously we error out in gp_replica_check test if the cluster is not in
synced, which is usually due to bugs revealed by previous tests, instead of
gp_replica_check itself.

Print more detailed message so that people are not confused with the status and
this failure reason of the gp_replica_check test.
