### PR TITLE
Fix flaky gpcloud S3KeyReaderTest unit test

### DIFF
--- a/gpcontrib/gpcloud/test/s3key_reader_test.cpp
+++ b/gpcontrib/gpcloud/test/s3key_reader_test.cpp
@@ -753,7 +753,9 @@ TEST_F(S3KeyReaderTest, MTReadWithUnexpectedFetchDataAtSecondRound) {
     params.setChunkSize(64);
 
     EXPECT_CALL(s3Interface, fetchData(0, _, _, _)).WillOnce(Invoke(MockFetchData(64, 64)));
-    EXPECT_CALL(s3Interface, fetchData(64, _, _, _)).WillOnce(Invoke(MockFetchData(64, 64)));
+    EXPECT_CALL(s3Interface, fetchData(64, _, _, _))
+	.Times(AtMost(1))
+	.WillOnce(Invoke(MockFetchData(64, 64)));
     EXPECT_CALL(s3Interface, fetchData(128, _, _, _))
         .WillOnce(Throw(S3PartialResponseError(63, 64)));
     EXPECT_CALL(s3Interface, fetchData(192, _, _, _))


### PR DESCRIPTION
S3KeyReaderTest.MTReadWithUnexpectedFetchDataAtSecondRound is a
flaky case, related to multithread timing.

The case setup S3KeyReader and try to download in parallel with 2
chunks(threads). When any of them encounters an error, all thread
will abort with the shared error.

The case assumed that the first created thread will call fetchData()
twice before another thread fetch with error. But if the first
thread is never scheduled to run, the second thread will call
fetchData() first and sets the shared error. Then the first thread
continues and will exit at the first call to fetchData(), reporting
shared error.

Modify the second call to fetchData() to be at most once.