### PR TITLE
Allow faults to be injected on mirror and use them for master/standby replication tests

### DIFF
--- a/gpcontrib/gp_inject_fault/Makefile
+++ b/gpcontrib/gp_inject_fault/Makefile
@@ -5,6 +5,8 @@ DATA = gp_inject_fault--1.0.sql
 
 REGRESS = inject_fault_test
 
+PG_CPPFLAGS = -I$(libpq_srcdir)
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
@@ -46,3 +46,55 @@ CREATE FUNCTION gp_wait_until_triggered_fault(
 RETURNS boolean
 AS $$ select gp_inject_fault($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3) $$
 LANGUAGE SQL;
+
+CREATE FUNCTION gp_inject_fault2(
+  faultname text,
+  type text,
+  ddl text,
+  database text,
+  tablename text,
+  start_occurrence int4,
+  end_occurrence int4,
+  extra_arg int4,
+  db_id int4,
+  hostname text,
+  port int4)
+RETURNS text
+AS 'MODULE_PATHNAME'
+LANGUAGE C VOLATILE STRICT NO SQL;
+
+-- Simpler version, trigger only one time, occurrence start at 1 and
+-- end at 1, no sleep and no ddl/database/tablename.
+CREATE FUNCTION gp_inject_fault2(
+  faultname text,
+  type text,
+  db_id int4,
+  hostname text,
+  port int4)
+RETURNS text
+AS $$ select gp_inject_fault2($1, $2, '', '', '', 1, 1, 0, $3, $4, $5) $$
+LANGUAGE SQL;
+
+-- Simpler version, always trigger until fault is reset.
+CREATE FUNCTION gp_inject_fault_infinite2(
+  faultname text,
+  type text,
+  db_id int4,
+  hostname text,
+  port int4)
+RETURNS text
+AS $$ select gp_inject_fault2($1, $2, '', '', '', 1, -1, 0, $3, $4, $5) $$
+LANGUAGE SQL;
+
+-- Simpler version to avoid confusion for wait_until_triggered fault.
+-- occurrence in call below defines wait until number of times the
+-- fault hits.
+CREATE FUNCTION gp_wait_until_triggered_fault2(
+  faultname text,
+  numtimestriggered int4,
+  db_id int4,
+  hostname text,
+  port int4)
+RETURNS text
+AS $$ select gp_inject_fault2($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3, $4, $5) $$
+LANGUAGE SQL;

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -172,8 +172,6 @@ SendFtsResponse(FtsResponse *response, const char *messagetype)
 {
 	StringInfoData buf;
 
-	initStringInfo(&buf);
-
 	BeginCommand(messagetype, DestRemote);
 
 	pq_beginmessage(&buf, 'T');

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -1029,6 +1029,12 @@ XLogWalRcvFlush(bool dying)
 {
 	if (LogstreamResult.Flush < LogstreamResult.Write)
 	{
+#ifdef FAULT_INJECTOR
+		/* Simulate the case that the standby / mirror is lagging behind. */
+		if (SIMPLE_FAULT_INJECTOR(WalRecvSkipFlush) == FaultInjectorTypeSkip)
+			return;
+#endif
+
 		/* use volatile pointer to prevent code rearrangement */
 		volatile WalRcvData *walrcv = WalRcv;
 

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -1956,6 +1956,8 @@ WalSndLoop(WalSndSendDataCallback send_data)
 		if (pq_flush_if_writable() != 0)
 			WalSndShutdown();
 
+		SIMPLE_FAULT_INJECTOR(WalSenderAfterCaughtupWithinRange);
+
 		/* If nothing remains to be sent right now ... */
 		if (WalSndCaughtUp && !pq_is_send_pending())
 		{

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -56,6 +56,7 @@
 #include "storage/procarray.h"
 #include "storage/procsignal.h"
 #include "storage/spin.h"
+#include "utils/faultinjector.h"
 #include "utils/timeout.h"
 #include "utils/timestamp.h"
 
@@ -318,7 +319,7 @@ InitProcess(void)
 	 * such as mppSessionId being valid and mppIsWriter set to true.
 	 */
 	if (IsAutoVacuumWorkerProcess() || am_walsender || am_ftshandler ||
-		am_ftsprobe)
+		am_ftsprobe || IsFaultHandler)
 		Gp_role = GP_ROLE_UTILITY;
 
 	/*

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -45,6 +45,7 @@
 #include "storage/proc.h"
 #include "storage/procarray.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 #include "utils/gdd.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
@@ -472,6 +473,7 @@ InitializeSessionUserIdStandalone(void)
 				|| am_startup
 				|| am_dtx_recovery
 				|| (am_ftshandler && am_mirror)
+				|| (IsFaultHandler && am_mirror)
 				|| am_global_deadlock_detector);
 
 	/* call only once */

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -414,7 +414,9 @@ FaultInjector_InjectFaultNameIfSet(
 							entryLocal->faultName,
 							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));
 
-			for (ii=0; ii < cnt; ii++)
+			for (ii=0;
+				 ii < cnt && FaultInjector_LookupHashEntry(entryLocal->faultName);
+				 ii++)
 			{
 				pg_usleep(1000000L); // sleep for 1 sec (1 sec * 3600 = 1 hour)
 				CHECK_FOR_INTERRUPTS();
@@ -1128,7 +1130,10 @@ InjectFault(char *faultName, char *type, char *ddlStatement, char *databaseName,
 		if (faultEntry.faultInjectorType == FaultInjectorTypeStatus)
 			appendStringInfo(buf, "%s", faultEntry.bufOutput);
 		else
+		{
 			appendStringInfo(buf, "Success:");
+			elog(LOG, "injected fault '%s' type '%s'", faultName, type);
+		}
 	}
 	else
 		appendStringInfo(buf, "Failure: %s", faultEntry.bufOutput);

--- a/src/backend/utils/resource_manager/resource_manager.c
+++ b/src/backend/utils/resource_manager/resource_manager.c
@@ -19,6 +19,7 @@
 #include "executor/spi.h"
 #include "postmaster/fts.h"
 #include "replication/walsender.h"
+#include "utils/faultinjector.h"
 #include "utils/guc.h"
 #include "utils/resource_manager.h"
 #include "utils/resgroup-ops.h"
@@ -88,7 +89,7 @@ InitResManager(void)
 	else if  (IsResGroupEnabled() &&
 			 (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) &&
 			 IsUnderPostmaster &&
-			 !am_walsender && !am_ftshandler)
+			 !am_walsender && !am_ftshandler && !IsFaultHandler)
 	{
 		/*
 		 * InitResManager() is called under PostgresMain(), so resource group is not

--- a/src/include/libpq/pqcomm.h
+++ b/src/include/libpq/pqcomm.h
@@ -218,5 +218,6 @@ typedef struct CancelRequestPacket
 
 #define GPCONN_TYPE "gpconntype"
 #define GPCONN_TYPE_FTS "fts"
+#define GPCONN_TYPE_FAULT "fault"
 
 #endif   /* PQCOMM_H */

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -17,6 +17,9 @@
 
 #define INFINITE_END_OCCURRENCE -1
 
+#define Natts_fault_message_response 1
+#define Anum_fault_message_response_status 0
+
 /*
  *
  */
@@ -118,13 +121,21 @@ extern int FaultInjector_SetFaultInjection(
 extern bool FaultInjector_IsFaultInjected(
 							char* faultName);
 
+extern char *InjectFault(
+	char *faultName, char *type, char *ddlStatement, char *databaseName,
+	char *tableName, int startOccurrence, int endOccurrence, int extraArg);
+
+extern void HandleFaultMessage(const char* msg);
 
 #ifdef FAULT_INJECTOR
+extern bool am_faulthandler;
+#define IsFaultHandler am_faulthandler
 #define SIMPLE_FAULT_INJECTOR(FaultIdentifier) \
 	FaultInjector_InjectFaultIfSet(FaultIdentifier, DDLNotSpecified, "", "")
 #define SIMPLE_FAULT_NAME_INJECTOR(FaultName) \
 	FaultInjector_InjectFaultNameIfSet(FaultName, DDLNotSpecified, "", "")
 #else
+#define IsFaultHandler false
 #define SIMPLE_FAULT_INJECTOR(FaultIdentifier)
 #define SIMPLE_FAULT_NAME_INJECTOR(FaultName)
 #endif

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -218,6 +218,8 @@ FI_IDENT(BeforeReadCommand, "before_read_command")
 FI_IDENT(CheckPointDtxInfo, "checkpoint_dtx_info")
 /* inject fault at WalSndLoop() function */
 FI_IDENT(WalSenderLoop, "wal_sender_loop")
+/* inject fault after WAL sender has processed caughtup within range */
+FI_IDENT(WalSenderAfterCaughtupWithinRange, "wal_sender_after_caughtup_within_range")
 /* inject fault at SyncRepWaitForLSN function for QueryCancelPending */
 FI_IDENT(SyncRepQueryCancel, "sync_rep_query_cancel")
 /* inject fault at start of function DistributedLog_AdvanceOldestXmin() */

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -261,6 +261,8 @@ FI_IDENT(InsideMoveDbTransaction, "inside_move_db_transaction")
 FI_IDENT(CheckpointAfterRedoCalculated, "checkpoint_after_redo_calculated")
 /* inject fault at the beginning of heap insert */
 FI_IDENT(HeapInsert, "heap_insert")
+/* inject fault to skip WAL flush on WAL receiver */
+FI_IDENT(WalRecvSkipFlush, "walrecv_skip_flush")
 #endif
 
 /*

--- a/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
@@ -55,3 +55,135 @@ CREATE
 -- for insert.
 insert into commit_blocking_on_standby_t1 values (1);
 INSERT 1
+
+
+-- Scenario2: In CATCHUP phase, commits should not block until standby
+-- has caught up within range.  And thereafter, commits should start
+-- blocking.
+
+-- In order to get master and standby in CATCHUP state, existing
+-- connection, which is in STREAMING state must be closed.  A new
+-- connection will then be initiated by standby, beginning in STARTUP
+-- then CATCHUP to STREAMING.  Faults are used to suspend WAL sender
+-- before entering STREAMING state.
+
+-- Suspend WAL sender in main loop.  "infinite_loop" fault type does
+-- not block signals.
+select gp_inject_fault_infinite2('wal_sender_loop', 'infinite_loop', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault_infinite2 
+---------------------------
+ Success:                  
+(1 row)
+
+-- Inject fault on standby to skip WAL flush.
+select gp_inject_fault_infinite2('walrecv_skip_flush', 'skip', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='m';
+ gp_inject_fault_infinite2 
+---------------------------
+ Success:                  
+(1 row)
+
+-- Kill existing walsender.  WAL sender and WAL receiver processes
+-- will be restarted and new connection will be established.  Note
+-- that the faults injected are still in effect and will affect the
+-- newly forked WAL sender and receiver processes.
+select pg_terminate_backend(pid), sync_state from pg_stat_replication;
+ pg_terminate_backend | sync_state 
+----------------------+------------
+ t                    | sync       
+(1 row)
+
+-- Should be set to 1 WAL segment by default.  Standby is considered
+-- caught up if its flush_location is less than 1 WAL segment (64MB)
+-- away from sent_location.
+show repl_catchup_within_range;
+ repl_catchup_within_range 
+---------------------------
+ 1                         
+(1 row)
+
+-- Start a transaction, execute a DDL and commit.  The commit should
+-- not block.
+begin;
+BEGIN
+
+create or replace function wait_until_standby_in_state(targetstate text) returns void as $$ declare replstate text; /* in func */ begin loop select state into replstate from pg_stat_replication; /* in func */ exit when replstate = targetstate; /* in func */ perform pg_sleep(0.1); /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
+select wait_until_standby_in_state('catchup');
+ wait_until_standby_in_state 
+-----------------------------
+                             
+(1 row)
+
+select gp_wait_until_triggered_fault2('wal_sender_loop', 1, dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
+ gp_wait_until_triggered_fault2 
+--------------------------------
+ Success:                       
+(1 row)
+
+-- WAL sender should be stuck in CATCHUP state.
+select application_name, state, sync_state from pg_stat_replication;
+ application_name | state   | sync_state 
+------------------+---------+------------
+ gp_walreceiver   | catchup | async      
+(1 row)
+
+-- This commit should NOT block because WAL sender has not yet
+-- processed caughtup within range as it is stuck at the beginning of
+-- main loop.
+commit;
+COMMIT
+
+select gp_inject_fault2('wal_sender_after_caughtup_within_range', 'suspend', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault2 
+------------------
+ Success:         
+(1 row)
+
+select gp_inject_fault2('wal_sender_loop', 'reset', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault2 
+------------------
+ Success:         
+(1 row)
+
+-- Once this fault is triggered, WAL sender should have set
+-- caughtup_within_range to true because difference between
+-- sent_location and flush_location is within 1 WAL segment (64) MB.
+select gp_wait_until_triggered_fault2( 'wal_sender_after_caughtup_within_range', 1, dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
+ gp_wait_until_triggered_fault2 
+--------------------------------
+ Success:                       
+(1 row)
+
+-- Should block because standby is considered to have caughtup within
+-- range.
+1&: create table commit_blocking_on_standby_t3 (a int) distributed by (a);  <waiting ...>
+
+-- The create table command should be seen as blocked.
+select datname, waiting_reason, query from pg_stat_activity where waiting_reason = 'replication';
+ datname        | waiting_reason | query                                                                  
+----------------+----------------+------------------------------------------------------------------------
+ isolation2test | replication    | create table commit_blocking_on_standby_t3 (a int) distributed by (a); 
+(1 row)
+
+-- Reset faults on primary as well as mirror.
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where content=-1;
+ gp_inject_fault2 
+------------------
+ Success:         
+ Success:         
+(2 rows)
+
+1<:  <... completed>
+CREATE
+
+-- Create table transaction must have committed and the table should
+-- be ready for insert.
+insert into commit_blocking_on_standby_t3 values (1);
+INSERT 1
+
+select wait_until_standby_in_state('streaming');
+ wait_until_standby_in_state 
+-----------------------------
+                             
+(1 row)

--- a/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
@@ -1,0 +1,57 @@
+--
+-- Master/standby commit blocking scenarios.  These are different from
+-- primary/mirror commit blocking because there is no FTS or a
+-- third-party as external arbiter in case of master/standby.
+--
+-- Scenario1: Commits should block until standby confirms WAL flush
+-- upto commit LSN.
+
+-- Check that are starting with a clean slate, standby must be in sync
+-- with master.
+select application_name, state, sync_state from pg_stat_replication;
+ application_name | state     | sync_state 
+------------------+-----------+------------
+ gp_walreceiver   | streaming | sync       
+(1 row)
+
+-- Inject fault on standby to skip WAL flush.
+select gp_inject_fault_infinite2('walrecv_skip_flush', 'skip', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='m';
+ gp_inject_fault_infinite2 
+---------------------------
+ Success:                  
+(1 row)
+
+-- Should block in commit (SyncrepWaitForLSN()), waiting for commit
+-- LSN to be flushed on standby.
+1&: create table commit_blocking_on_standby_t1 (a int) distributed by (a);  <waiting ...>
+
+select gp_wait_until_triggered_fault2('walrecv_skip_flush', 1, dbid, hostname, port) from gp_segment_configuration where content=-1 and role='m';
+ gp_wait_until_triggered_fault2 
+--------------------------------
+ Success:                       
+(1 row)
+
+-- The create table command should be seen as blocked.
+select datname, waiting_reason, query from pg_stat_activity where waiting_reason = 'replication';
+ datname        | waiting_reason | query                                                                  
+----------------+----------------+------------------------------------------------------------------------
+ isolation2test | replication    | create table commit_blocking_on_standby_t1 (a int) distributed by (a); 
+(1 row)
+
+select gp_inject_fault2('walrecv_skip_flush', 'reset', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='m';
+ gp_inject_fault2 
+------------------
+ Success:         
+(1 row)
+
+-- Ensure that commits are no longer blocked.
+create table commit_blocking_on_standby_t2 (a int) distributed by (a);
+CREATE
+
+1<:  <... completed>
+CREATE
+
+-- The blocked commit must have finished and the table should be ready
+-- for insert.
+insert into commit_blocking_on_standby_t1 values (1);
+INSERT 1

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -155,6 +155,7 @@ test: segwalrep/cancel_commit_pending_replication
 test: segwalrep/twophase_tolerance_with_mirror_promotion
 test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby
+test: segwalrep/commit_blocking_on_standby
 test: pg_basebackup
 test: pg_basebackup_with_tablespaces
 

--- a/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
@@ -36,3 +36,101 @@ create table commit_blocking_on_standby_t2 (a int) distributed by (a);
 -- The blocked commit must have finished and the table should be ready
 -- for insert.
 insert into commit_blocking_on_standby_t1 values (1);
+
+
+-- Scenario2: In CATCHUP phase, commits should not block until standby
+-- has caught up within range.  And thereafter, commits should start
+-- blocking.
+
+-- In order to get master and standby in CATCHUP state, existing
+-- connection, which is in STREAMING state must be closed.  A new
+-- connection will then be initiated by standby, beginning in STARTUP
+-- then CATCHUP to STREAMING.  Faults are used to suspend WAL sender
+-- before entering STREAMING state.
+
+-- Suspend WAL sender in main loop.  "infinite_loop" fault type does
+-- not block signals.
+select gp_inject_fault_infinite2('wal_sender_loop', 'infinite_loop',
+       dbid, hostname, port)
+       from gp_segment_configuration where content=-1 and role='p';
+
+-- Inject fault on standby to skip WAL flush.
+select gp_inject_fault_infinite2('walrecv_skip_flush', 'skip',
+       dbid, hostname, port)
+       from gp_segment_configuration where content=-1 and role='m';
+
+-- Kill existing walsender.  WAL sender and WAL receiver processes
+-- will be restarted and new connection will be established.  Note
+-- that the faults injected are still in effect and will affect the
+-- newly forked WAL sender and receiver processes.
+select pg_terminate_backend(pid), sync_state from pg_stat_replication;
+
+-- Should be set to 1 WAL segment by default.  Standby is considered
+-- caught up if its flush_location is less than 1 WAL segment (64MB)
+-- away from sent_location.
+show repl_catchup_within_range;
+
+-- Start a transaction, execute a DDL and commit.  The commit should
+-- not block.
+begin;
+
+create or replace function wait_until_standby_in_state(targetstate text)
+returns void as $$
+declare
+   replstate text; /* in func */
+begin
+   loop
+      select state into replstate from pg_stat_replication; /* in func */
+      exit when replstate = targetstate; /* in func */
+      perform pg_sleep(0.1); /* in func */
+   end loop; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
+select wait_until_standby_in_state('catchup');
+
+select gp_wait_until_triggered_fault2('wal_sender_loop', 1,
+       dbid, hostname, port)
+       from gp_segment_configuration where content=-1 and role='p';
+
+-- WAL sender should be stuck in CATCHUP state.
+select application_name, state, sync_state from pg_stat_replication;
+
+-- This commit should NOT block because WAL sender has not yet
+-- processed caughtup within range as it is stuck at the beginning of
+-- main loop.
+commit;
+
+select gp_inject_fault2('wal_sender_after_caughtup_within_range', 'suspend',
+       dbid, hostname, port) from gp_segment_configuration
+       where content=-1 and role='p';
+
+select gp_inject_fault2('wal_sender_loop', 'reset', dbid, hostname, port)
+       from gp_segment_configuration where content=-1 and role='p';
+
+-- Once this fault is triggered, WAL sender should have set
+-- caughtup_within_range to true because difference between
+-- sent_location and flush_location is within 1 WAL segment (64) MB.
+select gp_wait_until_triggered_fault2(
+       'wal_sender_after_caughtup_within_range', 1, dbid, hostname, port)
+       from gp_segment_configuration where content=-1 and role='p';
+
+-- Should block because standby is considered to have caughtup within
+-- range.
+1&: create table commit_blocking_on_standby_t3 (a int) distributed by (a);
+
+-- The create table command should be seen as blocked.
+select datname, waiting_reason, query from pg_stat_activity
+where waiting_reason = 'replication';
+
+-- Reset faults on primary as well as mirror.
+select gp_inject_fault2('all', 'reset', dbid, hostname, port)
+       from gp_segment_configuration where content=-1;
+
+1<:
+
+-- Create table transaction must have committed and the table should
+-- be ready for insert.
+insert into commit_blocking_on_standby_t3 values (1);
+
+select wait_until_standby_in_state('streaming');

--- a/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
@@ -1,0 +1,38 @@
+--
+-- Master/standby commit blocking scenarios.  These are different from
+-- primary/mirror commit blocking because there is no FTS or a
+-- third-party as external arbiter in case of master/standby.
+--
+-- Scenario1: Commits should block until standby confirms WAL flush
+-- upto commit LSN.
+
+-- Check that are starting with a clean slate, standby must be in sync
+-- with master.
+select application_name, state, sync_state from pg_stat_replication;
+
+-- Inject fault on standby to skip WAL flush.
+select gp_inject_fault_infinite2('walrecv_skip_flush', 'skip', dbid, hostname, port)
+from gp_segment_configuration where content=-1 and role='m';
+
+-- Should block in commit (SyncrepWaitForLSN()), waiting for commit
+-- LSN to be flushed on standby.
+1&: create table commit_blocking_on_standby_t1 (a int) distributed by (a);
+
+select gp_wait_until_triggered_fault2('walrecv_skip_flush', 1, dbid, hostname, port)
+from gp_segment_configuration where content=-1 and role='m';
+
+-- The create table command should be seen as blocked.
+select datname, waiting_reason, query from pg_stat_activity
+where waiting_reason = 'replication';
+
+select gp_inject_fault2('walrecv_skip_flush', 'reset', dbid, hostname, port)
+from gp_segment_configuration where content=-1 and role='m';
+
+-- Ensure that commits are no longer blocked.
+create table commit_blocking_on_standby_t2 (a int) distributed by (a);
+
+1<:
+
+-- The blocked commit must have finished and the table should be ready
+-- for insert.
+insert into commit_blocking_on_standby_t1 values (1);

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -11,14 +11,18 @@
 (1 row)
 
 \dx+ gp_inject*
-                       Objects in extension "gp_inject_fault"
-                                 Object Description                                 
-------------------------------------------------------------------------------------
- function gp_inject_fault_infinite(text,text,integer)
+                              Objects in extension "gp_inject_fault"
+                                        Object Description                                        
+--------------------------------------------------------------------------------------------------
  function gp_inject_fault(text,text,integer)
  function gp_inject_fault(text,text,text,text,text,integer,integer,integer,integer)
+ function gp_inject_fault2(text,text,integer,text,integer)
+ function gp_inject_fault2(text,text,text,text,text,integer,integer,integer,integer,text,integer)
+ function gp_inject_fault_infinite(text,text,integer)
+ function gp_inject_fault_infinite2(text,text,integer,text,integer)
  function gp_wait_until_triggered_fault(text,integer,integer)
-(4 rows)
+ function gp_wait_until_triggered_fault2(text,integer,integer,text,integer)
+(8 rows)
 
 --
 -- Test extended \du flags


### PR DESCRIPTION
This patch changes fault injector to send a libpq message to inject a fault rather than dispatching the SQL query: `select gp_inject_fault()...`.   One advantage of this is GPDB segments that are acting as mirrors or standby can also accept the fault message and act accordingly.  This is similar to how FTS messages are handled by mirrors today.

Two isolation2 tests are added to implement scenarios that old TINC tests used to exercise.  The scenarios pertain to master/standby replication.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
