### PR TITLE
Isolate PR pipelines for 6x and master.

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -17,6 +17,7 @@ resources:
       ignore_paths:
       - gpdb-doc/*
       - README*
+      base_branch: 6X_STABLE
 
   - name: ubuntu-gpdb-dev-16
     type: docker-image

--- a/concourse/server_pipeline/pr_pipeline.yml
+++ b/concourse/server_pipeline/pr_pipeline.yml
@@ -14,6 +14,7 @@ resources:
       ignore_paths:
       - gpdb-doc/*
       - README*
+      base_branch: master
 
   - name: docker-image
     type: docker-image


### PR DESCRIPTION
I haven't flown a pipeline yet for this change. I will, and then I'll post a link here.

We'll need to make some changes to the 5X concourse setup to setup a full pipeline because it currently depends on the 6X pipeline scripting.