### PR TITLE
Modify pg_rewind to handle new tablespace layout.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1,7 +1,6 @@
 @gprecoverseg
 Feature: gprecoverseg tests
 
-    @skip  # tablespaces are being reworked and currently do not work with pg_rewind
     Scenario: incremental recovery works with tablespaces
         Given the database is running
           And a tablespace is created with data
@@ -19,7 +18,6 @@ Feature: gprecoverseg tests
           And the tablespace is valid
           And the other tablespace is valid
 
-    @skip  # tablespaces are being reworked and currently do not work with pg_rewind
     Scenario: full recovery works with tablespaces
         Given the database is running
           And a tablespace is created with data
@@ -228,7 +226,6 @@ Feature: gprecoverseg tests
         # validate the the new segment has the correct setting by getting admin connection to that segment
         Then the saved primary segment reports the same value for sql "show data_checksums" db "template1" as was saved
 
-    @skip  # tablespaces are being reworked and currently do not work with pg_rewind
     @concourse_cluster
     Scenario: incremental recovery works with tablespaces on a multi-host environment
         Given the database is running
@@ -247,7 +244,6 @@ Feature: gprecoverseg tests
           And the tablespace is valid
           And the other tablespace is valid
 
-    @skip  # tablespaces are being reworked and currently do not work with pg_rewind
     @concourse_cluster
     Scenario: full recovery works with tablespaces on a multi-host environment
         Given the database is running

--- a/src/bin/pg_rewind/Makefile
+++ b/src/bin/pg_rewind/Makefile
@@ -26,7 +26,11 @@ OBJS	= pg_rewind.o parsexlog.o xlogreader.o datapagemap.o timeline.o \
 
 EXTRA_CLEAN = xlogreader.c compat.c
 
-REGRESS = basictest extrafiles databases pg_xlog_symlink unclean_shutdown simple_no_rewind_required ao_rewind bitmaptest
+REGRESS = basictest extrafiles databases pg_xlog_symlink unclean_shutdown \
+	simple_no_rewind_required ao_rewind bitmaptest \
+	tablespaces_objects_created_before_promotion \
+	tablespaces_objects_created_after_promotion \
+	tablespaces_objects_removed_after_promotion
 REGRESS_OPTS=--use-existing --launcher=./launcher
 
 all: pg_rewind

--- a/src/bin/pg_rewind/copy_fetch.c
+++ b/src/bin/pg_rewind/copy_fetch.c
@@ -131,6 +131,13 @@ recurse_dir(const char *datadir, const char *parentpath,
 						 fullpath);
 			link_target[len] = '\0';
 
+			if(parentpath && strcmp(parentpath, "pg_tblspc") == 0)
+			{
+				/* Lop off the dbid before sending the link target. */
+				char *file_sep_before_dbid_in_link_target = strrchr(link_target, '/');
+				*file_sep_before_dbid_in_link_target = '\0';
+			}
+
 			callback(path, FILE_TYPE_SYMLINK, 0, link_target);
 
 			/*

--- a/src/bin/pg_rewind/expected/tablespaces_objects_created_after_promotion.out
+++ b/src/bin/pg_rewind/expected/tablespaces_objects_created_after_promotion.out
@@ -1,0 +1,43 @@
+-- start_matchsubs
+-- m/tmp_check_local/
+-- s/tmp_check_local/tmp_check/
+-- m/tmp_check_remote/
+-- s/tmp_check_remote/tmp_check/
+-- m/\/.*data_master/
+-- s/\/.*data_master/some_data_master_parent_dir\/data_master/
+-- m/\/.*\/tmp_check/
+-- s/\/.*\/tmp_check/some_location\/tmp_check/
+-- end_matchsubs
+Master initialized.
+Master running.
+Standby initialized and running.
+Standby promoted.
+CREATE TABLESPACE ts LOCATION 'some_location/tmp_check/tablespaces_objects_created_after_promotion/ts';
+CREATE TABLESPACE
+CREATE TABLE t_heap(i int) TABLESPACE ts;
+CREATE TABLE
+CREATE INDEX t_heap_idx ON t_heap(i) TABLESPACE ts;
+CREATE INDEX
+INSERT INTO t_heap VALUES(generate_series(1, 100));
+INSERT 0 100
+CREATE TABLE t_ao(i int) WITH (appendonly=true) TABLESPACE ts;
+CREATE TABLE
+INSERT INTO t_ao VALUES(generate_series(1, 100));
+INSERT 0 100
+CHECKPOINT;
+CHECKPOINT
+Running pg_rewind...
+some_location/tmp_check/tablespaces_objects_created_after_promotion/ts/2
+symlink target directory for tablespace ts exists.
+6
+Old master restarted after rewind.
+SELECT state FROM pg_stat_replication;
+   state   
+-----------
+ streaming
+(1 row)
+
+Master promoted.
+100
+100
+5

--- a/src/bin/pg_rewind/expected/tablespaces_objects_created_before_promotion.out
+++ b/src/bin/pg_rewind/expected/tablespaces_objects_created_before_promotion.out
@@ -1,0 +1,55 @@
+-- start_matchsubs
+-- m/tmp_check_local/
+-- s/tmp_check_local/tmp_check/
+-- m/tmp_check_remote/
+-- s/tmp_check_remote/tmp_check/
+-- m/\/.*data_master/
+-- s/\/.*data_master/some_data_master_parent_dir\/data_master/
+-- m/\/.*\/tmp_check/
+-- s/\/.*\/tmp_check/some_location\/tmp_check/
+-- end_matchsubs
+Master initialized.
+Master running.
+Standby initialized and running.
+CREATE TABLESPACE ts LOCATION 'some_location/tmp_check/tablespaces_objects_created_before_promotion/ts';
+CREATE TABLESPACE
+CREATE TABLE t_heap(i int) TABLESPACE ts;
+CREATE TABLE
+CREATE INDEX t_heap_idx ON t_heap(i) TABLESPACE ts;
+CREATE INDEX
+INSERT INTO t_heap VALUES(generate_series(1, 100));
+INSERT 0 100
+CREATE TABLE t_ao(i int) WITH (appendonly=true) TABLESPACE ts;
+CREATE TABLE
+INSERT INTO t_ao VALUES(generate_series(1, 100));
+INSERT 0 100
+CHECKPOINT;
+CHECKPOINT
+Standby promoted.
+CREATE TABLE t_heap_after_promotion(i int) TABLESPACE ts;
+CREATE TABLE
+INSERT INTO t_heap_after_promotion VALUES(generate_series(1, 100));
+INSERT 0 100
+INSERT INTO t_heap VALUES(generate_series(1, 100));
+INSERT 0 100
+INSERT INTO t_ao VALUES(generate_series(1, 100));
+INSERT 0 100
+CHECKPOINT;
+CHECKPOINT
+Running pg_rewind...
+some_location/tmp_check/tablespaces_objects_created_before_promotion/ts/2
+symlink target directory for tablespace ts exists.
+7
+Old master restarted after rewind.
+SELECT state FROM pg_stat_replication;
+   state   
+-----------
+ streaming
+(1 row)
+
+Master promoted.
+200
+200
+5
+5
+100

--- a/src/bin/pg_rewind/expected/tablespaces_objects_removed_after_promotion.out
+++ b/src/bin/pg_rewind/expected/tablespaces_objects_removed_after_promotion.out
@@ -1,0 +1,51 @@
+-- start_matchsubs
+-- m/tmp_check_local/
+-- s/tmp_check_local/tmp_check/
+-- m/tmp_check_remote/
+-- s/tmp_check_remote/tmp_check/
+-- m/\/.*data_master/
+-- s/\/.*data_master/some_data_master_parent_dir\/data_master/
+-- m/\/.*\/tmp_check/
+-- s/\/.*\/tmp_check/some_location\/tmp_check/
+-- end_matchsubs
+Master initialized.
+Master running.
+Standby initialized and running.
+CREATE TABLESPACE ts LOCATION 'some_location/tmp_check/tablespaces_objects_removed_after_promotion/ts';
+CREATE TABLESPACE
+CREATE TABLESPACE drop_ts LOCATION 'some_location/tmp_check/tablespaces_objects_removed_after_promotion/drop_ts';
+CREATE TABLESPACE
+CREATE TABLE t_heap(i int) TABLESPACE ts;
+CREATE TABLE
+CREATE INDEX t_heap_idx ON t_heap(i) TABLESPACE ts;
+CREATE INDEX
+INSERT INTO t_heap VALUES(generate_series(1, 100));
+INSERT 0 100
+CREATE TABLE t_ao(i int) WITH (appendonly=true) TABLESPACE ts;
+CREATE TABLE
+INSERT INTO t_ao VALUES(generate_series(1, 100));
+INSERT 0 100
+CHECKPOINT;
+CHECKPOINT
+Standby promoted.
+DROP TABLE t_heap;
+DROP TABLE
+DROP TABLE t_ao;
+DROP TABLE
+DROP TABLESPACE drop_ts;
+DROP TABLESPACE
+CHECKPOINT;
+CHECKPOINT
+Running pg_rewind...
+some_location/tmp_check/tablespaces_objects_removed_after_promotion/ts/2
+symlink target directory for tablespace ts exists.
+0
+drop_ts tablespace link removed.
+Old master restarted after rewind.
+SELECT state FROM pg_stat_replication;
+   state   
+-----------
+ streaming
+(1 row)
+
+Master promoted.

--- a/src/bin/pg_rewind/file_ops.c
+++ b/src/bin/pg_rewind/file_ops.c
@@ -34,7 +34,7 @@ static void create_target_dir(const char *path);
 static void remove_target_dir(const char *path);
 static void create_target_symlink(const char *path, const char *link);
 static void remove_target_symlink(const char *path);
-
+static void create_target_tablespace_layout(const char *path, const char *link);
 /*
  * Open a target file for writing. If 'trunc' is true and the file already
  * exists, it will be truncated.
@@ -156,7 +156,10 @@ create_target(file_entry_t *entry)
 			break;
 
 		case FILE_TYPE_SYMLINK:
-			create_target_symlink(entry->path, entry->link_target);
+			if(entry->is_gp_tablespace)
+				create_target_tablespace_layout(entry->path, entry->link_target);
+			else
+				create_target_symlink(entry->path, entry->link_target);
 			break;
 
 		case FILE_TYPE_REGULAR:
@@ -272,6 +275,32 @@ remove_target_symlink(const char *path)
 		pg_fatal("could not remove symbolic link \"%s\": %s\n",
 				 dstpath, strerror(errno));
 }
+
+/* Create symlink for tablespace, create tablespace target dir */
+static void
+create_target_tablespace_layout(const char *path, const char *link)
+{
+	char		dstpath[MAXPGPATH];
+
+	if (dry_run)
+		return;
+
+	/* Append the target dbid to the symlink target. */
+	link = psprintf("%s/%d", link, dbid_target);
+
+	snprintf(dstpath, sizeof(dstpath), "%s/%s", datadir_target, path);
+	if (symlink(link, dstpath) != 0)
+		pg_fatal("could not create symbolic link at \"%s\": %s\n",
+				 dstpath, strerror(errno));
+
+	/* We need to create the directory at the symlink target. */
+	if (mkdir(link, S_IRWXU) != 0)
+		pg_fatal("could not create directory \"%s\": %s\n",
+				 dstpath, strerror(errno));
+
+	pfree(link);
+}
+
 
 
 /*

--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -156,6 +156,7 @@ process_source_file(const char *path, file_type_t type, size_t newsize,
 					const char *link_target)
 {
 	bool		exists;
+	bool		is_gp_tablespace = false;
 	char		localpath[MAXPGPATH];
 	struct stat statbuf;
 	filemap_t  *map = filemap;
@@ -241,7 +242,11 @@ process_source_file(const char *path, file_type_t type, size_t newsize,
 			}
 
 			if (!exists)
+			{
+				is_gp_tablespace =
+						 strncmp(path, "pg_tblspc/", strlen("pg_tblspc/")) == 0;
 				action = FILE_ACTION_CREATE;
+			}
 			else
 				action = FILE_ACTION_NONE;
 			oldsize = 0;
@@ -324,6 +329,7 @@ process_source_file(const char *path, file_type_t type, size_t newsize,
 	entry->pagemap.bitmap = NULL;
 	entry->pagemap.bitmapsize = 0;
 	entry->isrelfile = isRelDataFile(path);
+	entry->is_gp_tablespace = is_gp_tablespace;
 
 	if (map->last)
 	{

--- a/src/bin/pg_rewind/filemap.h
+++ b/src/bin/pg_rewind/filemap.h
@@ -56,6 +56,7 @@ typedef struct file_entry_t
 
 	/* for a symlink */
 	char	   *link_target;
+	bool 		is_gp_tablespace;
 
 	struct file_entry_t *next;
 } file_entry_t;

--- a/src/bin/pg_rewind/pg_rewind.h
+++ b/src/bin/pg_rewind/pg_rewind.h
@@ -27,6 +27,8 @@ extern bool debug;
 extern bool showprogress;
 extern bool dry_run;
 
+extern int32 dbid_target;
+
 extern const char *progname;
 
 /* in parsexlog.c */

--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -80,6 +80,9 @@ PG_VERSION_NUM=90401
 PORT_MASTER=`expr $PG_VERSION_NUM % 16384 + 49152`
 PORT_STANDBY=`expr $PORT_MASTER + 1`
 
+MASTER_DBID=2
+STANDBY_DBID=5
+
 PGOPTIONS_UTILITY='-c gp_session_role=utility'
 MASTER_PSQL="psql -a --no-psqlrc -p $PORT_MASTER"
 STANDBY_PSQL="psql -a --no-psqlrc -p $PORT_STANDBY"
@@ -89,9 +92,9 @@ STANDBY_PSQL_TUPLES_ONLY="psql -t --no-psqlrc -p $PORT_STANDBY"
 # log checking and hence enable vacuuming the tables in pg_rewind
 # tests. If pg_rewind tests use full GPDB cluster, -m option will not
 # be needed.
-PG_CTL_COMMON_OPTIONS="--gp_dbid=2 --gp_contentid=0 -m"
-MASTER_PG_CTL_OPTIONS="-p ${PORT_MASTER} $PG_CTL_COMMON_OPTIONS"
-STANDBY_PG_CTL_OPTIONS="-p ${PORT_STANDBY} $PG_CTL_COMMON_OPTIONS"
+PG_CTL_COMMON_OPTIONS="--gp_contentid=0 -m"
+MASTER_PG_CTL_OPTIONS="--gp_dbid=${MASTER_DBID} -p ${PORT_MASTER} $PG_CTL_COMMON_OPTIONS"
+STANDBY_PG_CTL_OPTIONS="--gp_dbid=${STANDBY_DBID} -p ${PORT_STANDBY} $PG_CTL_COMMON_OPTIONS"
 MASTER_PG_CTL_STOP_MODE="fast"
 
 function wait_for_promotion {

--- a/src/bin/pg_rewind/sql/tablespaces_objects_created_after_promotion.sql
+++ b/src/bin/pg_rewind/sql/tablespaces_objects_created_after_promotion.sql
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# This file has the .sql extension, but it is actually launched as a shell
+# script. This contortion is necessary because pg_regress normally uses
+# psql to run the input scripts, and requires them to have the .sql
+# extension, but we use a custom launcher script that runs the scripts using
+# a shell instead.
+
+TESTNAME=tablespaces_objects_created_after_promotion
+
+. sql/config_test.sh
+
+MASTER_PG_CTL_STOP_MODE="fast"
+
+TABLESPACE_LOCATION=$TESTROOT/$TESTNAME/ts
+
+cat <<EOF
+-- start_matchsubs
+-- m/tmp_check_local/
+-- s/tmp_check_local/tmp_check/
+-- m/tmp_check_remote/
+-- s/tmp_check_remote/tmp_check/
+-- m/\/.*data_master/
+-- s/\/.*data_master/some_data_master_parent_dir\/data_master/
+-- m/\/.*\/tmp_check/
+-- s/\/.*\/tmp_check/some_location\/tmp_check/
+-- end_matchsubs
+EOF
+
+# Create tablespace location directory
+function before_master
+{
+rm -rf $TABLESPACE_LOCATION
+mkdir $TABLESPACE_LOCATION
+}
+
+# This script runs after the standby has been promoted.
+function after_promotion
+{
+# Create a new tablespace in the standby that will not be on the old master.
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "CREATE TABLESPACE ts LOCATION '$TABLESPACE_LOCATION';"
+# Now create objects in that tablespace
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "CREATE TABLE t_heap(i int) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "CREATE INDEX t_heap_idx ON t_heap(i) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "INSERT INTO t_heap VALUES(generate_series(1, 100));"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "CREATE TABLE t_ao(i int) WITH (appendonly=true) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "INSERT INTO t_ao VALUES(generate_series(1, 100));"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "CHECKPOINT;"
+}
+
+function before_master_restart_after_rewind
+{
+# Confirm that after rewind the master has the correct symlink set up.
+local ts_oid=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_STANDBY -A -q --tuples-only -c "SELECT oid from pg_tablespace where spcname='ts';")
+local db_oid=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_STANDBY -A -q --tuples-only -c "SELECT oid from pg_database where datname='$PGDATABASE';")
+local ts_target_dir=$(readlink $TEST_MASTER/pg_tblspc/${ts_oid})
+echo $ts_target_dir
+# Confirm that after rewind the tablespace symlink target directory has been created.
+[ -d $ts_target_dir ] && echo "symlink target directory for tablespace ts exists."
+
+# Test that relfilenodes appear after rewind completes in master.
+local num_relfiles=$(ls $ts_target_dir/GPDB_*/${db_oid}/ | wc -l)
+# Expect 6 relfiles (for t_heap, t_heap_idx and t_ao (with its 3 metadata tables))
+echo $num_relfiles
+}
+
+function after_rewind
+{
+# Confirm that the heap and ao table data is intact
+local count_rows_t_heap=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_MASTER -A -q --tuples-only -c "SELECT count(*) from t_heap;")
+# Expect 100 rows in t_heap
+echo ${count_rows_t_heap}
+local count_rows_t_ao=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_MASTER -A -q --tuples-only -c "SELECT count(*) from t_ao;")
+# Expect 100 rows in t_ao
+echo ${count_rows_t_ao}
+# Confirm that the heap index is useable in order to query the heap table
+local some_specific_value=5
+PGOPTIONS="${PGOPTIONS_UTILITY} -c enable_seqscan=off -c optimizer_enable_tablescan=off" psql --no-psqlrc -p $PORT_MASTER -A -q --tuples-only -c "SELECT i FROM t_heap WHERE i=${some_specific_value};"
+}
+
+# Run the test
+. sql/run_test.sh

--- a/src/bin/pg_rewind/sql/tablespaces_objects_created_before_promotion.sql
+++ b/src/bin/pg_rewind/sql/tablespaces_objects_created_before_promotion.sql
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# This file has the .sql extension, but it is actually launched as a shell
+# script. This contortion is necessary because pg_regress normally uses
+# psql to run the input scripts, and requires them to have the .sql
+# extension, but we use a custom launcher script that runs the scripts using
+# a shell instead.
+
+TESTNAME=tablespaces_objects_created_before_promotion
+
+. sql/config_test.sh
+
+MASTER_PG_CTL_STOP_MODE="fast"
+
+TABLESPACE_LOCATION=$TESTROOT/$TESTNAME/ts
+
+cat <<EOF
+-- start_matchsubs
+-- m/tmp_check_local/
+-- s/tmp_check_local/tmp_check/
+-- m/tmp_check_remote/
+-- s/tmp_check_remote/tmp_check/
+-- m/\/.*data_master/
+-- s/\/.*data_master/some_data_master_parent_dir\/data_master/
+-- m/\/.*\/tmp_check/
+-- s/\/.*\/tmp_check/some_location\/tmp_check/
+-- end_matchsubs
+EOF
+
+# Create tablespace location directory
+function before_master
+{
+rm -rf $TABLESPACE_LOCATION
+mkdir $TABLESPACE_LOCATION
+}
+
+# This script runs after the standby has been started.
+function standby_following_master
+{
+# Create a new tablespace that will be both on the master and the standby.
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CREATE TABLESPACE ts LOCATION '$TABLESPACE_LOCATION';"
+# Now create objects in that tablespace
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CREATE TABLE t_heap(i int) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CREATE INDEX t_heap_idx ON t_heap(i) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "INSERT INTO t_heap VALUES(generate_series(1, 100));"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CREATE TABLE t_ao(i int) WITH (appendonly=true) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "INSERT INTO t_ao VALUES(generate_series(1, 100));"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CHECKPOINT;"
+}
+
+# This script runs after the standby has been promoted.
+function after_promotion
+{
+# Create a new table in the standby that will not be on the old master.
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "CREATE TABLE t_heap_after_promotion(i int) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "INSERT INTO t_heap_after_promotion VALUES(generate_series(1, 100));"
+# Modify objects created before the standby was promoted
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "INSERT INTO t_heap VALUES(generate_series(1, 100));"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "INSERT INTO t_ao VALUES(generate_series(1, 100));"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "CHECKPOINT;"
+}
+
+function before_master_restart_after_rewind
+{
+# Confirm that after rewind the master has the correct symlink set up.
+local ts_oid=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_STANDBY -A -q --tuples-only -c "SELECT oid from pg_tablespace where spcname='ts';")
+local db_oid=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_STANDBY -A -q --tuples-only -c "SELECT oid from pg_database where datname='$PGDATABASE';")
+local ts_target_dir=$(readlink $TEST_MASTER/pg_tblspc/${ts_oid})
+echo $ts_target_dir
+# Confirm that after rewind the tablespace symlink target directory has been created.
+[ -d $ts_target_dir ] && echo "symlink target directory for tablespace ts exists."
+
+# Test that relfilenodes appear after rewind completes in master.
+local num_relfiles=$(ls $ts_target_dir/GPDB_*/${db_oid}/ | wc -l)
+# Expect 7 relfiles (for t_heap, t_heap_idx, t_ao (with its 3 metadata tables) and t_heap_after_promotion)
+echo $num_relfiles
+}
+
+function after_rewind
+{
+# Confirm that the heap and ao table data is intact
+local count_rows_t_heap=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_MASTER -A -q --tuples-only -c "SELECT count(*) from t_heap;")
+# Expect 200 rows in t_heap
+echo ${count_rows_t_heap}
+local count_rows_t_ao=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_MASTER -A -q --tuples-only -c "SELECT count(*) from t_ao;")
+# Expect 200 rows in t_ao
+echo ${count_rows_t_ao}
+# Confirm that the heap index is useable in order to query the heap table. Expect two tuples as we did two inserts.
+local some_specific_value=5
+PGOPTIONS="${PGOPTIONS_UTILITY} -c enable_seqscan=off -c optimizer_enable_tablescan=off" psql --no-psqlrc -p $PORT_MASTER -A -q --tuples-only -c "SELECT i FROM t_heap WHERE i=${some_specific_value};"
+local count_rows_t_heap_after_promotion=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_MASTER -A -q --tuples-only -c "SELECT count(*) from t_heap_after_promotion;")
+# Expect 100 rows in t_heap_after_promotion
+echo ${count_rows_t_heap_after_promotion}
+}
+
+# Run the test
+. sql/run_test.sh

--- a/src/bin/pg_rewind/sql/tablespaces_objects_removed_after_promotion.sql
+++ b/src/bin/pg_rewind/sql/tablespaces_objects_removed_after_promotion.sql
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# This file has the .sql extension, but it is actually launched as a shell
+# script. This contortion is necessary because pg_regress normally uses
+# psql to run the input scripts, and requires them to have the .sql
+# extension, but we use a custom launcher script that runs the scripts using
+# a shell instead.
+
+TESTNAME=tablespaces_objects_removed_after_promotion
+
+. sql/config_test.sh
+
+MASTER_PG_CTL_STOP_MODE="fast"
+
+TABLESPACE_LOCATION=$TESTROOT/$TESTNAME/ts
+DROP_TABLESPACE_LOCATION=$TESTROOT/$TESTNAME/drop_ts
+
+cat <<EOF
+-- start_matchsubs
+-- m/tmp_check_local/
+-- s/tmp_check_local/tmp_check/
+-- m/tmp_check_remote/
+-- s/tmp_check_remote/tmp_check/
+-- m/\/.*data_master/
+-- s/\/.*data_master/some_data_master_parent_dir\/data_master/
+-- m/\/.*\/tmp_check/
+-- s/\/.*\/tmp_check/some_location\/tmp_check/
+-- end_matchsubs
+EOF
+
+# Create tablespace location directory
+function before_master
+{
+rm -rf $TABLESPACE_LOCATION $DROP_TABLESPACE_LOCATION
+mkdir $TABLESPACE_LOCATION $DROP_TABLESPACE_LOCATION
+}
+
+# This script runs after the standby has been started.
+function standby_following_master
+{
+# Create two new tablespace that will be both on the master and the standby.
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CREATE TABLESPACE ts LOCATION '$TABLESPACE_LOCATION';"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CREATE TABLESPACE drop_ts LOCATION '$DROP_TABLESPACE_LOCATION';"
+DROP_TS_OID=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_MASTER -A -q --tuples-only -c "SELECT oid from pg_tablespace where spcname='drop_ts';")
+# Now create objects in that tablespace
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CREATE TABLE t_heap(i int) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CREATE INDEX t_heap_idx ON t_heap(i) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "INSERT INTO t_heap VALUES(generate_series(1, 100));"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CREATE TABLE t_ao(i int) WITH (appendonly=true) TABLESPACE ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "INSERT INTO t_ao VALUES(generate_series(1, 100));"
+PGOPTIONS=${PGOPTIONS_UTILITY} $MASTER_PSQL -c "CHECKPOINT;"
+}
+
+# This script runs after the standby has been promoted.
+function after_promotion
+{
+# Drop all objects in ts and drop the tablespace drop_ts
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "DROP TABLE t_heap;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "DROP TABLE t_ao;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "DROP TABLESPACE drop_ts;"
+PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "CHECKPOINT;"
+}
+
+function before_master_restart_after_rewind
+{
+# Confirm that after rewind the master still has the correct symlink set up for tablespace ts.
+local ts_oid=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_STANDBY -A -q --tuples-only -c "SELECT oid from pg_tablespace where spcname='ts';")
+local db_oid=$(PGOPTIONS=${PGOPTIONS_UTILITY} psql --no-psqlrc -p $PORT_STANDBY -A -q --tuples-only -c "SELECT oid from pg_database where datname='$PGDATABASE';")
+local ts_target_dir=$(readlink $TEST_MASTER/pg_tblspc/${ts_oid})
+echo $ts_target_dir
+# Confirm that after rewind the tablespace symlink target directory still exists.
+[ -d $ts_target_dir ] && echo "symlink target directory for tablespace ts exists."
+
+# Test that there are 0 relfilenodes as all objects have been deleted for tablespace ts.
+local num_relfiles=$(ls $ts_target_dir/GPDB_*/${db_oid}/ | wc -l)
+echo $num_relfiles
+
+# Confirm that drop_ts_oid directory has been removed from the pg_tblspc directory
+readlink $TEST_MASTER/pg_tblspc/$DROP_TS_OID || echo "drop_ts tablespace link removed."
+}
+
+# Run the test
+. sql/run_test.sh


### PR DESCRIPTION
This is a follow-up to https://github.com/greenplum-db/gpdb/pull/7473.

    * Add tests around pg_rewind's behavior with tablespaces.
    * pg_rewind now lops off the source dbid from the symlink target before populating the
    filemap.
    * pg_rewind now appends the target dbid to the symlink target when
    creating it and also creates the symlink target directory. Both of these
    actions are performed as a separate action: `create_tablespace_layout`.
    We distinguish tablespace symlinks with the `is_gp_tablespace` flag.
    * pg_rewind now fetches the target dbid by invoking the postgres binary.
    * Added test for pg_rewind with tablespaces which tests for objects
    created after promotion of the replica. We introduced a new hook in the
    pg_rewind suite: `before_master_restart_after_rewind`, which executes
    right after pg_rewind completes and the master is restarted.