### PR TITLE
docs - clarify pxf filter partitioning support for hive

### DIFF
--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -76,6 +76,5 @@ If you update your Hadoop, Hive, or HBase configuration while the PXF service is
 gpadmin@gpmaster$ cd $PXF_CONF/servers/default
 gpadmin@gpmaster$ scp hiveuser@hivehost:/etc/hive/conf/hive-site.xml .
 gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
-gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster stop
 ```
 

--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -27,7 +27,6 @@ Perform the following procedure to configure the desired PXF Hadoop-related conn
 2. PXF requires information from `core-site.xml` and other Hadoop configuration files. Copy the `core-site.xml`, `hdfs-site.xml`, `mapred-site.xml`, and `yarn-site.xml` Hadoop configuration files from your Hadoop cluster NameNode host to the current host using your tool of choice. (Your file paths may differ based on the Hadoop distribution in use.) For example, these commands use `scp` to copy the files:
 
     ``` shell
-    gpadmin@gpmaster$ cd $PXF_CONF/servers/default
     gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/core-site.xml .
     gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/hdfs-site.xml .
     gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/mapred-site.xml .
@@ -70,9 +69,11 @@ Perform the following procedure to configure the desired PXF Hadoop-related conn
 
 ## <a id="client-cfg-update"></a>Updating Hadoop Configuration
 
-If you update your Hadoop, Hive, or HBase configuration while the PXF service is running, you must re-sync the PXF configuration to your Greenplum Database cluster and restart PXF on each segment host in the cluster. For example:
+If you update your Hadoop, Hive, or HBase configuration while the PXF service is running, you must copy the updated configuration to the `$PXF_CONF/servers/default` directory, re-sync the PXF configuration to your Greenplum Database cluster, and then restart PXF on each segment host in the cluster. For example:
 
 ``` shell
+gpadmin@gpmaster$ cd $PXF_CONF/servers/default
+gpadmin@gpmaster$ scp hiveuser@hivehost:/etc/hive/conf/hive-site.xml .
 gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
 gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster stop
 gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster start

--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -27,6 +27,7 @@ Perform the following procedure to configure the desired PXF Hadoop-related conn
 2. PXF requires information from `core-site.xml` and other Hadoop configuration files. Copy the `core-site.xml`, `hdfs-site.xml`, `mapred-site.xml`, and `yarn-site.xml` Hadoop configuration files from your Hadoop cluster NameNode host to the current host using your tool of choice. (Your file paths may differ based on the Hadoop distribution in use.) For example, these commands use `scp` to copy the files:
 
     ``` shell
+    gpadmin@gpmaster$ cd $PXF_CONF/servers/default
     gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/core-site.xml .
     gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/hdfs-site.xml .
     gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/mapred-site.xml .
@@ -69,13 +70,12 @@ Perform the following procedure to configure the desired PXF Hadoop-related conn
 
 ## <a id="client-cfg-update"></a>Updating Hadoop Configuration
 
-If you update your Hadoop, Hive, or HBase configuration while the PXF service is running, you must copy the updated configuration to the `$PXF_CONF/servers/default` directory, re-sync the PXF configuration to your Greenplum Database cluster, and then restart PXF on each segment host in the cluster. For example:
+If you update your Hadoop, Hive, or HBase configuration while the PXF service is running, you must copy the updated configuration to the `$PXF_CONF/servers/default` directory and re-sync the PXF configuration to your Greenplum Database cluster. For example:
 
 ``` shell
 gpadmin@gpmaster$ cd $PXF_CONF/servers/default
 gpadmin@gpmaster$ scp hiveuser@hivehost:/etc/hive/conf/hive-site.xml .
 gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
 gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster stop
-gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster start
 ```
 

--- a/gpdb-doc/markdown/pxf/filter_push.html.md.erb
+++ b/gpdb-doc/markdown/pxf/filter_push.html.md.erb
@@ -62,5 +62,5 @@ To summarize, all of the following criteria must be met for filter pushdown to o
 * The external data source that you are accessing must support pushdown. For example, HBase and Hive support pushdown.
 * For queries on external tables that you create with the `pxf` protocol, the underlying PXF connector must also support filter pushdown. For example, the PXF Hive, HBase, and JDBC connectors support pushdown.
 
-    - Refer to Hive [Partition Filter Pushdown](hive_pxf.html#partitionfiltering) for more information about about Hive support for this feature.
+    - Refer to Hive [Partition Filter Pushdown](hive_pxf.html#partitionfiltering) for more information about Hive support for this feature.
 

--- a/gpdb-doc/markdown/pxf/filter_push.html.md.erb
+++ b/gpdb-doc/markdown/pxf/filter_push.html.md.erb
@@ -34,25 +34,26 @@ SET gp_external_enable_filter_pushdown TO 'on';
 
 PXF accesses data sources using different connectors, and filter pushdown support is determined by the specific connector implementation. The following PXF connectors support filter pushdown:
 
-- Hive Connector
+- Hive Connector, all profiles
 - HBase Connector
 - JDBC Connector
 
-PXF filter pushdown can be used with these data types:
+PXF filter pushdown can be used with these data types (connector-specific):
 
-- `INT`
+- `INT2`, `INT4`, `INT8`
+- `CHAR`, `TEXT`
 - `FLOAT`
 - `NUMERIC`
 - `BOOL`
-- `CHAR`, `TEXT`
 - `DATE`, `TIMESTAMP` (JDBC connector only)
 
-PXF filter pushdown can be used with these operators:
+You can use PXF filter pushdown with these operators:
 
 - `<`, `<=`, `>=`, `>`
 - `<>`, `=`
-- `IN` operator on arrays of `INT` and `TEXT`
-- `LIKE` (only for `TEXT` fields) (JDBC connector only)
+- `AND`, `OR`
+- `IN` operator on arrays of `INT` and `TEXT` (JDBC connector only)
+- `LIKE` (`TEXT` fields, JDBC connector only)
 
 To summarize, all of the following criteria must be met for filter pushdown to occur:
 
@@ -60,4 +61,6 @@ To summarize, all of the following criteria must be met for filter pushdown to o
 * The Greenplum Database protocol that you use to access external data source must support filter pushdown. The `pxf` external table protocol supports pushdown.
 * The external data source that you are accessing must support pushdown. For example, HBase and Hive support pushdown.
 * For queries on external tables that you create with the `pxf` protocol, the underlying PXF connector must also support filter pushdown. For example, the PXF Hive, HBase, and JDBC connectors support pushdown.
+
+    - Refer to Hive [Partition Filter Pushdown](hive_pxf.html#partitionfiltering) for more information about about Hive support for this feature.
 

--- a/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
@@ -661,14 +661,14 @@ In the following example, you will create and populate a Hive table stored in OR
 
 ## <a id="partitionfiltering"></a>Partition Filter Pushdown
 
-The PXF Hive connector supports Hive partitioning pruning and directory structure. This enables partition exclusion on selected HDFS files comprising a Hive table. To use the partition filtering feature to reduce network traffic and I/O, run a query on a PXF external table using a `WHERE` clause that refers to a specific partition column in a partitioned Hive table.
+The PXF Hive connector supports Hive partitioning pruning and the Hive partition directory structure. This enables partition exclusion on selected HDFS files comprising a Hive table. To use the partition filtering feature to reduce network traffic and I/O, run a query on a PXF external table using a `WHERE` clause that refers to a specific partition column in a partitioned Hive table.
 
 The PXF Hive Connector partition filtering support for Hive string and integral types is described below:
 
-- The relational operators `=`, `<`, `<=`, `>`, `>=`, and `<>` are supported on string types
-- The relational operators `=` and `<>` are supported on integral types (To use partition filtering with Hive integral types, you must update the Hive configuration as described in the [Prerequisites](#prereq).)
-- The logical operators `AND` and `OR` are supported when used with the relational operators mentioned above
-- The `LIKE` string operator is not supported
+- The relational operators `=`, `<`, `<=`, `>`, `>=`, and `<>` are supported on string types.
+- The relational operators `=` and `<>` are supported on integral types (To use partition filtering with Hive integral types, you must update the Hive configuration as described in the [Prerequisites](#prereq)).
+- The logical operators `AND` and `OR` are supported when used with the relational operators mentioned above.
+- The `LIKE` string operator is not supported.
 
 To take advantage of PXF partition filtering pushdown, the Hive and PXF partition field names must be the same. Otherwise, PXF ignores partition filtering and the filtering is performed on the Greenplum Database side, impacting performance.
 

--- a/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
@@ -672,7 +672,7 @@ The PXF Hive Connector partition filtering support for Hive string and integral 
 
 To take advantage of PXF partition filtering pushdown, the Hive and PXF partition field names must be the same. Otherwise, PXF ignores partition filtering and the filtering is performed on the Greenplum Database side, impacting performance.
 
-<div class="note">The PXF Hive connector filters only on partition columns, not on other table attributes. Additionally, filter pushdown is supported only for those data types and operators identified above. Disable filter pushdown when your query includes unsupported operators and data types.</div>
+<div class="note">The PXF Hive connector filters only on partition columns, not on other table attributes. Additionally, filter pushdown is supported only for those data types and operators identified above.</div>
 
 PXF filter pushdown is enabled by default. You configure PXF filter pushdown as described in [About Filter Pushdown](filter_push.html).
 

--- a/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
@@ -29,7 +29,7 @@ The PXF Hive connector reads data stored in a Hive table. This section describes
 
 Before working with Hive table data using PXF, ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq).
 
-If you plan to use PXF filter pushdown with Hive, ensure that the `hive-site.xml` configuration parameter `hive.metastore.integral.jdo.pushdown` exists and is set to `true`.
+*If you plan to use PXF filter pushdown with Hive integral types*, ensure that the configuration parameter `hive.metastore.integral.jdo.pushdown` exists and is set to `true` in the `hive-site.xml` in both your Hadoop cluster **and** `$PXF_CONF/servers/default/hive-site.xml`. Refer to [Updating Hadoop Configuration](client_instcfg.html#client-cfg-update) for more information.
 
 
 ## <a id="hive_fileformats"></a>Hive Data Formats
@@ -661,13 +661,18 @@ In the following example, you will create and populate a Hive table stored in OR
 
 ## <a id="partitionfiltering"></a>Partition Filter Pushdown
 
-The PXF Hive connector supports the Hive partitioning feature and directory structure. This enables partition exclusion on selected HDFS files comprising a Hive table. To use the partition filtering feature to reduce network traffic and I/O, run a query on a PXF external table using a `WHERE` clause that refers to a specific partition column in a partitioned Hive table.
+The PXF Hive connector supports Hive partitioning pruning and directory structure. This enables partition exclusion on selected HDFS files comprising a Hive table. To use the partition filtering feature to reduce network traffic and I/O, run a query on a PXF external table using a `WHERE` clause that refers to a specific partition column in a partitioned Hive table.
+
+The PXF Hive Connector partition filtering support for Hive string and integral types is described below:
+
+- The relational operators `=`, `<`, `<=`, `>`, `>=`, and `<>` are supported on string types
+- The relational operators `=` and `<>` are supported on integral types (To use partition filtering with Hive integral types, you must update the Hive configuration as described in the [Prerequisites](#prereq).)
+- The logical operators `AND` and `OR` are supported when used with the relational operators mentioned above
+- The `LIKE` string operator is not supported
 
 To take advantage of PXF partition filtering pushdown, the Hive and PXF partition field names must be the same. Otherwise, PXF ignores partition filtering and the filtering is performed on the Greenplum Database side, impacting performance.
 
-<div class="note">The PXF Hive connector filters only on partition columns, not on other table attributes. Additionally, filter pushdown is supported only for those data types and operators identified in <a href="filter_push.html">About Filter Pushdown</a>. Disable filter pushdown when your query includes unsupported operators and data types.</div>
-
-To use PXF filter pushdown with Hive, the `hive-site.xml` configuration parameter `hive.metastore.integral.jdo.pushdown` must be set to `true`.
+<div class="note">The PXF Hive connector filters only on partition columns, not on other table attributes. Additionally, filter pushdown is supported only for those data types and operators identified above. Disable filter pushdown when your query includes unsupported operators and data types.</div>
 
 PXF filter pushdown is enabled by default. You configure PXF filter pushdown as described in [About Filter Pushdown](filter_push.html).
 


### PR DESCRIPTION
in this PR:
- call out the specific data types and operators supported for Hive on the hive "using" page
- set hive.metastore.integral.jdo.pushdown only if using partition filtering on hive *integral* types
- misc updates to the "about pxf filter pushdown" landing page, add xref to hive section
- misc edits to "updating hadoop configuration" page