### PR TITLE
Resolve fixme for GetCatalogSnapshot modification of DistributedTransactionContext

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2123,29 +2123,29 @@ AtSubCleanup_Memory(void)
  * DOH: this totally ignores subtransactions for now!
  */
 void
-SetSharedTransactionId_writer(void)
+SetSharedTransactionId_writer(DtxContext distributedTransactionContext)
 {
 	Assert(SharedLocalSnapshotSlot != NULL);
 	Assert(LWLockHeldByMe(SharedLocalSnapshotSlot->slotLock));
 
-	Assert(DistributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE ||
-		   DistributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER ||
-		   DistributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
-		   DistributedTransactionContext == DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT);
+	Assert(distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT);
 
 	ereportif(Debug_print_full_dtm, LOG,
 			  (errmsg("%s setting shared xid %u -> %u",
-					  DtxContextToString(DistributedTransactionContext),
+					  DtxContextToString(distributedTransactionContext),
 					  SharedLocalSnapshotSlot->xid,
 					  TopTransactionStateData.transactionId)));
 	SharedLocalSnapshotSlot->xid = TopTransactionStateData.transactionId;
 }
 
 void
-SetSharedTransactionId_reader(TransactionId xid, CommandId cid)
+SetSharedTransactionId_reader(TransactionId xid, CommandId cid, DtxContext distributedTransactionContext)
 {
-	Assert(DistributedTransactionContext == DTX_CONTEXT_QE_READER ||
-		   DistributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON);
+	Assert(distributedTransactionContext == DTX_CONTEXT_QE_READER ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON);
 
 	/*
 	 * For DTX_CONTEXT_QE_READER or DTX_CONTEXT_QE_ENTRY_DB_SINGLETON, during

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -165,6 +165,7 @@ qdSerializeDtxContextInfo(int *size, bool wantSnapshot, bool inCursor,
 	Snapshot	snapshot = NULL;
 	int			serializedLen;
 	DtxContextInfo *pDtxContextInfo = NULL;
+	DtxContext currentDistributedTransactionContext = DistributedTransactionContext;
 
 	/*
 	 * If 'wantSnapshot' is set, then serialize the ActiveSnapshot. The
@@ -179,7 +180,7 @@ qdSerializeDtxContextInfo(int *size, bool wantSnapshot, bool inCursor,
 		snapshot = GetActiveSnapshot();
 	}
 
-	switch (DistributedTransactionContext)
+	switch (currentDistributedTransactionContext)
 	{
 		case DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE:
 		case DTX_CONTEXT_LOCAL_ONLY:
@@ -191,8 +192,11 @@ qdSerializeDtxContextInfo(int *size, bool wantSnapshot, bool inCursor,
 			if (DistributedTransactionContext ==
 				DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && snapshot != NULL)
 			{
-				updateSharedLocalSnapshot(&TempQDDtxContextInfo, snapshot,
-										  "qdSerializeDtxContextInfo");
+				updateSharedLocalSnapshot(
+					&TempQDDtxContextInfo,
+					currentDistributedTransactionContext,
+					snapshot,
+					"qdSerializeDtxContextInfo");
 			}
 
 			pDtxContextInfo = &TempQDDtxContextInfo;

--- a/src/backend/storage/ipc/test/procarray_test.c
+++ b/src/backend/storage/ipc/test/procarray_test.c
@@ -73,7 +73,7 @@ test__CreateDistributedSnapshot(void **state)
 	 * Basic case, no other in progress transaction in system
 	 */
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
-	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
+	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping, DTX_CONTEXT_LOCAL_ONLY);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 20);
@@ -101,7 +101,7 @@ test__CreateDistributedSnapshot(void **state)
 	procArray->numProcs = 3;
 
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
-	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
+	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping, DTX_CONTEXT_LOCAL_ONLY);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 5);
@@ -129,7 +129,7 @@ test__CreateDistributedSnapshot(void **state)
 	procArray->numProcs = 5;
 
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
-	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
+	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping, DTX_CONTEXT_LOCAL_ONLY);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 5);

--- a/src/backend/storage/lmgr/predicate.c
+++ b/src/backend/storage/lmgr/predicate.c
@@ -1704,7 +1704,7 @@ GetSerializableTransactionSnapshotInt(Snapshot snapshot,
 
 	/* Get the snapshot, or check that it's safe to use */
 	if (!TransactionIdIsValid(sourcexid))
-		snapshot = GetSnapshotData(snapshot);
+		snapshot = GetSnapshotData(snapshot, DistributedTransactionContext);
 	else if (!ProcArrayInstallImportedXmin(snapshot->xmin, sourcexid))
 	{
 		ReleasePredXact(sxact);

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -341,7 +341,9 @@ ScanPgRelation(Oid targetRelId, bool indexOK, bool force_non_historic)
 	 * relfilenode of non mapped system relations during decoding.
 	 */
 	if (force_non_historic)
-		snapshot = GetNonHistoricCatalogSnapshot(RelationRelationId);
+		snapshot = GetNonHistoricCatalogSnapshot(
+			RelationRelationId,
+			DistributedTransactionContext);
 	else
 		snapshot = GetCatalogSnapshot(RelationRelationId);
 

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -747,7 +747,7 @@ dumpSharedLocalSnapshot_forCursor(void)
 }
 
 void
-readSharedLocalSnapshot_forCursor(Snapshot snapshot)
+readSharedLocalSnapshot_forCursor(Snapshot snapshot, DtxContext distributedTransactionContext)
 {
 	BufFile *f;
 	char *fname=NULL;
@@ -872,7 +872,10 @@ readSharedLocalSnapshot_forCursor(Snapshot snapshot)
 	/* we're done with file. */
 	BufFileClose(f);
 
-	SetSharedTransactionId_reader(localXid, snapshot->curcid);
+	SetSharedTransactionId_reader(
+		localXid,
+		snapshot->curcid,
+		distributedTransactionContext);
 
 	return;
 }

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -208,7 +208,7 @@ GetTransactionSnapshot(void)
 			if (IsolationIsSerializable())
 				CurrentSnapshot = GetSerializableTransactionSnapshot(&CurrentSnapshotData);
 			else
-				CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData);
+				CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DistributedTransactionContext);
 			/* Make a saved copy */
 			CurrentSnapshot = CopySnapshot(CurrentSnapshot);
 			FirstXactSnapshot = CurrentSnapshot;
@@ -217,7 +217,7 @@ GetTransactionSnapshot(void)
 			RegisteredSnapshots++;
 		}
 		else
-			CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData);
+			CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DistributedTransactionContext);
 
 		FirstSnapshotSet = true;
 		return CurrentSnapshot;
@@ -243,7 +243,7 @@ GetTransactionSnapshot(void)
 	/* Don't allow catalog snapshot to be older than xact snapshot. */
 	InvalidateCatalogSnapshot();
 
-	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData);
+	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DistributedTransactionContext);
 
 	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
 		 "[Distributed Snapshot #%u] (gxid = %u, '%s')",
@@ -272,7 +272,7 @@ GetLatestSnapshot(void)
 	if (!FirstSnapshotSet)
 		return GetTransactionSnapshot();
 
-	SecondarySnapshot = GetSnapshotData(&SecondarySnapshotData);
+	SecondarySnapshot = GetSnapshotData(&SecondarySnapshotData, DistributedTransactionContext);
 
 	return SecondarySnapshot;
 }
@@ -305,7 +305,7 @@ GetCatalogSnapshot(Oid relid)
 	DtxContext		saveDistributedTransactionContext = DistributedTransactionContext;
 	DistributedTransactionContext = DTX_CONTEXT_LOCAL_ONLY;
 
-	Snapshot snapshot = GetNonHistoricCatalogSnapshot(relid);
+	Snapshot snapshot = GetNonHistoricCatalogSnapshot(relid, DistributedTransactionContext);
 
 	DistributedTransactionContext = saveDistributedTransactionContext;
 	return snapshot;
@@ -318,7 +318,7 @@ GetCatalogSnapshot(Oid relid)
  *		up.
  */
 Snapshot
-GetNonHistoricCatalogSnapshot(Oid relid)
+GetNonHistoricCatalogSnapshot(Oid relid, DtxContext distributedTransactionContext)
 {
 	/*
 	 * If the caller is trying to scan a relation that has no syscache, no
@@ -335,7 +335,9 @@ GetNonHistoricCatalogSnapshot(Oid relid)
 	if (CatalogSnapshot == NULL)
 	{
 		/* Get new snapshot. */
-		CatalogSnapshot = GetSnapshotData(&CatalogSnapshotData);
+		CatalogSnapshot = GetSnapshotData(
+			&CatalogSnapshotData,
+			distributedTransactionContext);
 
 		/*
 		 * Make sure the catalog snapshot will be accounted for in decisions
@@ -439,7 +441,7 @@ SetTransactionSnapshot(Snapshot sourcesnap, TransactionId sourcexid)
 	 * two variables in exported snapshot files, but it seems better to have
 	 * snapshot importers compute reasonably up-to-date values for them.)
 	 */
-	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData);
+	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DistributedTransactionContext);
 
 	/*
 	 * Now copy appropriate fields from the source snapshot.

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -295,20 +295,7 @@ GetCatalogSnapshot(Oid relid)
 	if (HistoricSnapshotActive())
 		return HistoricSnapshot;
 
-	/*
-	 * GPDB_94_MERGE_FIXME: This is typically the way SnapshotNow was.
-	 * I think it makes sense to use a local snapshot for this.. But
-	 * update comments, and verify all the places where this is used.
-	 * Also, do we need a TRY-CATCH block to reset DistributedTransactionContext
-	 * on error?
-	 */
-	DtxContext		saveDistributedTransactionContext = DistributedTransactionContext;
-	DistributedTransactionContext = DTX_CONTEXT_LOCAL_ONLY;
-
-	Snapshot snapshot = GetNonHistoricCatalogSnapshot(relid, DistributedTransactionContext);
-
-	DistributedTransactionContext = saveDistributedTransactionContext;
-	return snapshot;
+	return GetNonHistoricCatalogSnapshot(relid, DTX_CONTEXT_LOCAL_ONLY);
 }
 
 /*

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -19,6 +19,7 @@
 #include "storage/relfilenode.h"
 
 #include "cdb/cdbpublic.h"
+#include "cdb/cdbtm.h"
 
 /*
  * Xact isolation levels
@@ -226,8 +227,8 @@ typedef struct xl_xact_distributed_forget
  */
 
 /* Greenplum Database specific */ 
-extern void SetSharedTransactionId_writer(void);
-extern void SetSharedTransactionId_reader(TransactionId xid, CommandId cid);
+extern void SetSharedTransactionId_writer(DtxContext distributedTransactionContext);
+extern void SetSharedTransactionId_reader(TransactionId xid, CommandId cid, DtxContext distributedTransactionContext);
 extern bool IsTransactionState(void);
 extern bool IsAbortInProgress(void);
 extern bool IsCommitInProgress(void);

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -19,6 +19,7 @@
 #include "utils/snapshot.h"
 
 #include "cdb/cdbpublic.h"
+#include "cdb/cdbtm.h"
 
 struct DtxContextInfo;         /* cdb/cdbdtxcontextinfo.h */
 struct SnapshotData;           /* utils/tqual.h */
@@ -47,7 +48,7 @@ extern void ExpireOldKnownAssignedTransactionIds(TransactionId xid);
 extern int	GetMaxSnapshotXidCount(void);
 extern int	GetMaxSnapshotSubxidCount(void);
 
-extern Snapshot GetSnapshotData(Snapshot snapshot);
+extern Snapshot GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext);
 
 extern bool ProcArrayInstallImportedXmin(TransactionId xmin,
 							 TransactionId sourcexid);
@@ -89,7 +90,7 @@ extern void XidCacheRemoveRunningXids(TransactionId xid,
 extern PGPROC *FindProcByGpSessionId(long gp_session_id);
 extern void UpdateSerializableCommandId(CommandId curcid);
 
-extern void updateSharedLocalSnapshot(struct DtxContextInfo *dtxContextInfo, struct SnapshotData *snapshot, char* debugCaller);
+extern void updateSharedLocalSnapshot(struct DtxContextInfo *dtxContextInfo, DtxContext distributedTransactionContext, struct SnapshotData *snapshot, char* debugCaller);
 
 extern void GetSlotTableDebugInfo(void **snapshotArray, int *maxSlots);
 

--- a/src/include/utils/sharedsnapshot.h
+++ b/src/include/utils/sharedsnapshot.h
@@ -50,7 +50,7 @@ extern void addSharedSnapshot(char *creatorDescription, int id);
 extern void lookupSharedSnapshot(char *lookerDescription, char *creatorDescription, int id);
 
 extern void dumpSharedLocalSnapshot_forCursor(void);
-extern void readSharedLocalSnapshot_forCursor(Snapshot snapshot);
+extern void readSharedLocalSnapshot_forCursor(Snapshot snapshot, DtxContext distributedTransactionContext);
 
 extern void AtEOXact_SharedSnapshot(void);
 

--- a/src/include/utils/snapmgr.h
+++ b/src/include/utils/snapmgr.h
@@ -16,6 +16,7 @@
 #include "fmgr.h"
 #include "utils/resowner.h"
 #include "utils/snapshot.h"
+#include "cdb/cdbtm.h"
 
 
 extern bool FirstSnapshotSet;
@@ -30,7 +31,7 @@ extern Snapshot GetLatestSnapshot(void);
 extern void SnapshotSetCommandId(CommandId curcid);
 
 extern Snapshot GetCatalogSnapshot(Oid relid);
-extern Snapshot GetNonHistoricCatalogSnapshot(Oid relid);
+extern Snapshot GetNonHistoricCatalogSnapshot(Oid relid, DtxContext distributedTransactionContext);
 extern void InvalidateCatalogSnapshot(void);
 extern void InvalidateCatalogSnapshotConditionally(void);
 


### PR DESCRIPTION
- The first commit is a pure refactoring. It removes the dependence on the global variable by threading the distributed transaction context through to GetSnapshotData.
- The second commit takes advantage of the refactoring introduced by the first commit.