### PR TITLE
Disable SSL renegotiation by default.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1853,7 +1853,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_UNIT_KB,
 		},
 		&ssl_renegotiation_limit,
-		512 * 1024, 0, MAX_KILOBYTES, NULL, NULL
+		0, 0, MAX_KILOBYTES, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
Set the default to zero, which disables renegotiation.

From the upstream Postgresql documentation:

'Due to bugs in OpenSSL enabling ssl renegotiation, by configuring a
non-zero ssl_renegotiation_limit, is likely to lead to problems like
long-lived connections breaking.'

