### PR TITLE
Fix reference leak when ORCA falls back to planner for queries involving foreign tables

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -562,6 +562,7 @@ CTranslatorRelcacheToDXL::RetrieveRel
 	if (RelationIsForeign(rel))
 	{
 		// GPORCA does not support foreign data wrappers
+		gpdb::CloseRelation(rel);
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Foreign Data"));
 	}
 


### PR DESCRIPTION
Fixes issue https://github.com/greenplum-db/gpdb/issues/7508

The `contrib/file_fdw` installcheck tests pass with this fix, so https://github.com/greenplum-db/gpdb/pull/7528 should be able to be pushed.

Authored-by: Chris Hajas <chajas@pivotal.io>