### PR TITLE
Remove rd_cdbDefaultStatsWarningIssued Relation member

### DIFF
--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1019,8 +1019,6 @@ RelationBuildDesc(Oid targetRelId, bool insertIt)
 		MemoryContextSwitchTo(oldcontext);
 	}
 
-    relation->rd_cdbDefaultStatsWarningIssued = false;
-
 	/*
 	 * now we can free the memory allocated for pg_class_tuple
 	 */
@@ -5071,7 +5069,6 @@ load_relcache_init_file(bool shared)
 		rel->rd_amcache = NULL;
 		MemSet(&rel->pgstat_info, 0, sizeof(rel->pgstat_info));
         rel->rd_cdbpolicy = NULL;
-        rel->rd_cdbDefaultStatsWarningIssued = false;
 
 		/*
 		 * Recompute lock and physical addressing info.  This is needed in

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -109,7 +109,6 @@ typedef struct RelationData
 	MemoryContext rd_rulescxt;	/* private memory cxt for rd_rules, if any */
 	TriggerDesc *trigdesc;		/* Trigger info, or NULL if rel has none */
     struct GpPolicy *rd_cdbpolicy; /* Partitioning info if distributed rel */
-    bool        rd_cdbDefaultStatsWarningIssued;
 
 	/* data managed by RelationGetIndexList: */
 	List	   *rd_indexlist;	/* list of OIDs of indexes on relation */


### PR DESCRIPTION
The `rd_cdbDefaultStatsWarningIssued` struct member in `RelationData` is no longer used since the rewrite of `ANALYZE`. As there is no point in carrying this dead storage in every `Relation` structure, remove the field.