### PR TITLE
Consider role expiration during distributed transaction recovery

### DIFF
--- a/contrib/citext/.gitignore
+++ b/contrib/citext/.gitignore
@@ -1,0 +1,1 @@
+citext.sql

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1369,11 +1369,16 @@ getSuperuser(Oid *userOid)
 	{
 		Datum   attrName;
 		Datum   attrNameOid;
+		Datum   attrRolvaliduntil;
+		bool    hasExpirationDate;
 
-		(void) heap_getattr(auth_tup, Anum_pg_authid_rolvaliduntil,
+		attrRolvaliduntil = heap_getattr(auth_tup, Anum_pg_authid_rolvaliduntil,
 							auth_rel->rd_att, &isNull);
+
 		/* we actually want it to be NULL, that means always valid */
-		if (!isNull)
+		hasExpirationDate = !isNull;
+
+		if (!canSuperuserPerformRecovery(hasExpirationDate, attrRolvaliduntil))
 			continue;
 
 		attrName = heap_getattr(auth_tup, Anum_pg_authid_rolname,
@@ -1397,6 +1402,17 @@ getSuperuser(Oid *userOid)
 	return suser;
 }
 
+
+bool
+canSuperuserPerformRecovery(bool hasExpirationTimestamp, TimestampTz expirationTimestamp)
+{
+  if (!hasExpirationTimestamp)
+     return true;
+
+  return expirationTimestamp >= GetCurrentTimestamp();
+}
+
+
 static char *
 ChangeToSuperuser()
 {
@@ -1410,8 +1426,13 @@ ChangeToSuperuser()
 		oldcontext = MemoryContextSwitchTo(TopMemoryContext);
 		newuser = getSuperuser(&userOid);
 		MemoryContextSwitchTo(oldcontext);
-
 		olduser = MyProcPort->user_name;
+
+		if (userOid == InvalidOid)
+		  ereport(ERROR, (errmsg("could not switch to superuser from %s", olduser),
+			       errdetail("No superuser found."),
+				  errhint("Use single-user mode to setup a valid superuser.")));
+
 		SetSessionUserId(userOid, true);
 		MyProcPort->user_name = newuser;
 	}

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -343,5 +343,6 @@ extern void UtilityModeFindOrCreateDtmRedoFile(void);
 extern void UtilityModeCloseDtmRedoFile(void);
 
 extern bool doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType);
+extern bool canSuperuserPerformRecovery(bool hasExpirationDate, TimestampTz expirationDate);
 
 #endif   /* CDBTM_H */

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -41,3 +41,6 @@ hooktest.out
 gpcopy.out
 query_info_hook_test.out
 /oid_wraparound.out
+autovacuum-template0.out
+resource_queue_function_resgroup.out
+session_reset.out

--- a/src/test/regress/expected/distributed_transaction_recovery_after_restart.out
+++ b/src/test/regress/expected/distributed_transaction_recovery_after_restart.out
@@ -1,0 +1,39 @@
+-- Given no superusers exist with a null rolvaliduntil value
+set allow_system_table_mods to dml;
+create table stored_superusers (role_name text, role_valid_until timestamp);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'role_name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into stored_superusers (role_name, role_valid_until) select rolname, rolvaliduntil from pg_authid where rolsuper = true;
+update pg_authid set rolvaliduntil = 'infinity' where rolsuper = true;
+-- And a non-superuser can log in
+create user testinguser with nocreatedb nosuperuser nocreaterole;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+create database testinguser;
+\! echo "local testinguser testinguser trust" >> $MASTER_DATA_DIRECTORY/pg_hba.conf;
+-- When the master server restarts
+\! pg_ctl -D $MASTER_DATA_DIRECTORY restart -w -m fast;
+waiting for server to shut down.... done
+server stopped
+waiting for server to start.... done
+server started
+-- And a non-superuser happens to be the first user to connect
+-- Then the connection should succeed
+\! psql -U testinguser -c 'select 1;';
+ ?column? 
+----------
+        1
+(1 row)
+
+-- cleanup
+\c
+drop database testinguser;
+drop user testinguser;
+set allow_system_table_mods to dml;
+update pg_authid set rolvaliduntil = stored_superusers.role_valid_until from stored_superusers where rolname=stored_superusers.role_name;
+drop table stored_superusers;
+\! sed -i 's/local testinguser testinguser trust//' $MASTER_DATA_DIRECTORY/pg_hba.conf
+\! pg_ctl -D $MASTER_DATA_DIRECTORY restart -w -m fast;
+waiting for server to shut down.... done
+server stopped
+waiting for server to start.... done
+server started

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -38,3 +38,4 @@ hooktest.sql
 gpcopy.sql
 query_info_hook_test.sql
 session_reset.sql
+autovacuum-template0.sql

--- a/src/test/regress/sql/distributed_transaction_recovery_after_restart.sql
+++ b/src/test/regress/sql/distributed_transaction_recovery_after_restart.sql
@@ -1,0 +1,28 @@
+-- Given no superusers exist with a null rolvaliduntil value
+set allow_system_table_mods to dml;
+create table stored_superusers (role_name text, role_valid_until timestamp);
+insert into stored_superusers (role_name, role_valid_until) select rolname, rolvaliduntil from pg_authid where rolsuper = true;
+update pg_authid set rolvaliduntil = 'infinity' where rolsuper = true;
+
+-- And a non-superuser can log in
+create user testinguser with nocreatedb nosuperuser nocreaterole;
+create database testinguser;
+\! echo "local testinguser testinguser trust" >> $MASTER_DATA_DIRECTORY/pg_hba.conf;
+
+-- When the master server restarts
+\! pg_ctl -D $MASTER_DATA_DIRECTORY restart -w -m fast;
+
+-- And a non-superuser happens to be the first user to connect
+-- Then the connection should succeed
+\! psql -U testinguser -c 'select 1;';
+
+-- cleanup
+\c
+drop database testinguser;
+drop user testinguser;
+set allow_system_table_mods to dml;
+update pg_authid set rolvaliduntil = stored_superusers.role_valid_until from stored_superusers where rolname=stored_superusers.role_name;
+drop table stored_superusers;
+
+\! sed -i 's/local testinguser testinguser trust//' $MASTER_DATA_DIRECTORY/pg_hba.conf
+\! pg_ctl -D $MASTER_DATA_DIRECTORY restart -w -m fast;


### PR DESCRIPTION
During session initialization, the cdb transaction manager switches to a superuser to perform distributed transaction recovery. To do so, it looks up superusers and
ensures that they are allowed to log in via their rolvaliduntil
date. Previously this code assumed that superusers would have a
rolvaliduntil value set to NULL, which means the role would never
expire.

This commit introduces validation that the rolvaliduntil is not in the
past. If the superuser is allowed to login, it is chosen to do
the work.

This fixes a crash. The superuser is not found, then when attempting
to become the original user, we attempt to free memory allocated for
the superuser's information - which was null, causing a sigsegv. In
one instance, all of the superusers for a cluster had a value of
'infinity' set for rolvaliduntil, which would cause all of the
superusers to be skipped - and none found.