### PR TITLE
gpconfig: Add support for empty-string values

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -98,19 +98,19 @@ def validate_mutual_options(options):
         log_and_raise("'--file' option and '--file-compare' option cannot be used together")
     if options.file and "MASTER_DATA_DIRECTORY" not in os.environ:
         log_and_raise("--file option requires that MASTER_DATA_DIRECTORY be set")
-    if options.remove and (options.value or options.primaryvalue or options.mirrorvalue or options.mastervalue):
+    if options.remove and (options.value is not None or options.primaryvalue is not None or options.mirrorvalue is not None or options.mastervalue is not None):
         log_and_raise("remove action does not take a value, primary value, mirror value or master value parameter")
     if options.change and options.remove:
         log_and_raise("Multiple actions specified.  See the --help info.")
-    if options.change and (not options.value and (not options.mirrorvalue and not options.primaryvalue)):
+    if options.change and (options.value is None and options.mirrorvalue is None and options.primaryvalue is None):
         log_and_raise("change requested but value not specified")
-    if options.change and options.mastervalue and options.masteronly:
+    if options.change and options.mastervalue is not None and options.masteronly:
         log_and_raise("when changing a parameter on the master only specify the --value not --mastervalue")
-    if options.change and (options.value and (options.primaryvalue or options.mirrorvalue)):
+    if options.change and (options.value is not None and (options.primaryvalue is not None or options.mirrorvalue is not None)):
         log_and_raise("cannot use both value option and primaryvalue/mirrorvalue option")
-    if (options.masteronly or options.mastervalue) and options.entry in SAMEVALUE_GUCS:
+    if (options.masteronly or options.mastervalue is not None) and options.entry in SAMEVALUE_GUCS:
         log_and_raise("%s value cannot be different on master and segments" % options.entry)
-    if options.value and (not options.mastervalue):
+    if options.value is not None and options.mastervalue is None:
         options.mastervalue = options.value
 
 
@@ -361,17 +361,27 @@ def do_change(options):
     pool.haltWork()
     pool.joinWorkers()
 
-    params = " ".join(sys.argv[1:])
+    # Replace literal empty strings with empty quotes, or it will look like the
+    # user passed in an incorrect argument, which would be misleading
+    params = [pipes.quote(arg) for arg in sys.argv[1:]]
+    params = " ".join(params)
     if failure:
         LOGGER.error("finished with errors, parameter string '%s'" % params)
     else:
         LOGGER.info("completed successfully with parameters '%s'" % params)
 
 
+# If the value is a string, escape and single-quote it as per the behavior of
+# the quote_literal() function in Postgres.
 def quote_string(guc, value):
-    if value and guc and guc.vartype == "string":
-        if not value.startswith("'") and not value.endswith("'"):
-            value = "'" + value + "'"
+    if value is not None and guc and guc.vartype == "string":
+        # Remove any existing single-quoting
+        if len(value) > 2 and value[0] == "'" and value[-1] == "'":
+            value = value[1:-1]
+        # Escape single quotes and backslashes
+        value = value.replace("'", "''").replace("\\", "\\\\")
+        # Single-quote the whole string
+        value  = "'" + value + "'"
     return value
 
 
@@ -533,7 +543,7 @@ def do_main():
         do_show(options)
 
     elif options.remove or options.change:
-        # gpconfig should check gpexpand runnning status when
+        # gpconfig should check gpexpand running status when
         # it wants to modify configurations
         check_gpexpand()
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -89,6 +89,10 @@ class GpConfig(GpTestCase):
         ])
         sys.argv = ["gpconfig"]  # reset to relatively empty args list
 
+        # GUC object for testing string quoting
+        self.guc = Mock()
+        self.guc.vartype = "string"
+
         shared_dir = os.path.join(self.temp_dir, ParseGuc.DESTINATION_DIR)
         _mkdir_p(shared_dir, 0755)
         self.guc_disallowed_readonly_file = os.path.abspath(os.path.join(shared_dir, ParseGuc.DESTINATION_FILENAME))
@@ -481,6 +485,42 @@ class GpConfig(GpTestCase):
         except Exception:
             pass
         self.assertEqual(len(self.subject.read_only_gucs), 2)
+
+    def test_quote_string_not_already_quoted(self):
+        value = "teststring"
+        expected = "'teststring'"
+        result = self.subject.quote_string(self.guc, value)
+        self.assertEqual(result, expected)
+
+    def test_quote_string_already_quoted(self):
+        value = "'teststring'"
+        expected = "'teststring'"
+        result = self.subject.quote_string(self.guc, value)
+        self.assertEqual(result, expected)
+
+    def test_quote_string_quoted_with_double_quotes(self):
+        value = "\"teststring\""
+        expected = "'\"teststring\"'"
+        result = self.subject.quote_string(self.guc, value)
+        self.assertEqual(result, expected)
+
+    def test_quote_string_with_internal_single_quote(self):
+        value = "test'string"
+        expected = "'test''string'"
+        result = self.subject.quote_string(self.guc, value)
+        self.assertEqual(result, expected)
+
+    def test_quote_string_with_internal_backslash(self):
+        value = "test\\string"
+        expected = "'test\\\\string'"
+        result = self.subject.quote_string(self.guc, value)
+        self.assertEqual(result, expected)
+
+    def test_quote_string_with_single_quote_and_backslash(self):
+        value = "test\\'string"
+        expected = "'test\\\\''string'"
+        result = self.subject.quote_string(self.guc, value)
+        self.assertEqual(result, expected)
 
     def setup_for_testing_quoting_string_values(self, vartype, value, additional_args=None):
         sys.argv = ["gpconfig", "--change", "my_property_name", "--value", value]

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -5,8 +5,6 @@ Feature: gpconfig integration tests
     # because any existing postgresql.conf file could already have the first value in it a priori
     # NOTE: since we are restarting the database with the given paramaters, do not change parameters
     #   that will cause the database to not restart given your machine setup.
-    # TODO: TODO_XX below are strings that work on master but not on 6X_STABLE because PR 7602 has
-    #   not yet been backported.
 
     @concourse_cluster
     @demo_cluster
@@ -74,9 +72,8 @@ Feature: gpconfig integration tests
         | gp_resource_group_cpu_limit |  real    | 0.4        | 0.5      | 0.5        | 0.5        | 0.33              | 0.33                   | 0.7          | 0.7               | 0.7               |
         | application_name            |  string  | xxxxxx     | bodhi    | 'bodhi'    | bodhi      | lucy              | 'lucy'                 | bengie       | 'bengie'          | bengie            |
         | application_name            |  string  | yyyyyy     | 'bod hi' | 'bod hi'   | bod hi     | 'lu cy'           | 'lu cy'                | 'ben gie'    | 'ben gie'         | ben gie           |
-#TODO_XX| application_name            |  string  | zzzzzz     | ''       | ''         |            | ''                | ''                     | ''           | ''                |                   |
+        | application_name            |  string  | zzzzzz     | ''       | ''         |            | ''                | ''                     | ''           | ''                |                   |
 
-    @skip
     @concourse_cluster
     @demo_cluster
     Scenario Outline: gpconfig edge cases for type: <type>
@@ -109,7 +106,7 @@ Feature: gpconfig integration tests
     # NOTE: <value> is a command-line value
     Examples:
         | guc              | type     | seed_value | value   | file_value | live_value |
-#TODO_XX| application_name |  string  |  boo       |  "'\''" | '\\'''     |  \'        |
+        | application_name |  string  |  boo       |  "'\''" | '\\'''     |  \'        |
        #| application_name |  string  |  boo       |  'C:\\home\\fun'  | 'C:\\home\\fun' | 'C:\\home\\fun' |
 
     @concourse_cluster
@@ -177,4 +174,4 @@ Feature: gpconfig integration tests
         | gp_resource_group_cpu_limit |  real    | 0.4        |
         | application_name            |  string  | bengie     |
         | application_name            |  string  | 'ben gie'  |
-#TODO_XX| application_name            |  string  | ''         |
+        | application_name            |  string  | ''         |


### PR DESCRIPTION
Previously, gpconfig would not allow setting a GUC to a value of empty string
(that is, "gpconfig -c guc_name -v ''" or the like) because it conflated passing
an empty string with not setting the flag at all, so this commit fixes that and
ensures that empty-string values print nicely.

Authored-by: Jamie McAtamney <jmcatamney@pivotal.io>
(cherry-picked from commit 941ef0d2891ef099b6ecd95da5717b96053768f7)