### PR TITLE
Remove unused variable in ATPExecPartSplit

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17701,7 +17701,6 @@ ATPExecPartSplit(Relation *rel,
 		int i;
 		AlterPartitionId *intopid1 = NULL;
 		AlterPartitionId *intopid2 = NULL;
-		int default_pos = 0;
 		Oid rel_to_drop = InvalidOid;
 		AlterPartitionId *aapid = NULL; /* just for alter partition pids */
 		Relation existrel;
@@ -17820,7 +17819,6 @@ ATPExecPartSplit(Relation *rel,
 
 			if (exists && isdef)
 			{
-				default_pos = 1;
 				intopid2 = (AlterPartitionId *)pc2->partid;
 				intopid1 = (AlterPartitionId *)pc2->arg1;
 				into_exists = 2;
@@ -17916,13 +17914,8 @@ ATPExecPartSplit(Relation *rel,
 				intopid1 = (AlterPartitionId *)pc2->partid;
 				intopid2 = (AlterPartitionId *)pc2->arg1;
 
-				if (isdef)
-				{
-					default_pos = 2;
-
-					if (intopid2->idtype == AT_AP_IDDefault)
+				if (isdef && intopid2->idtype == AT_AP_IDDefault)
 						 intopid2->partiddef = (Node *)makeString(parname);
-				}
 			}
 		}
 


### PR DESCRIPTION
The value set in default_pos was never used, so remove the variable entirely. The consumers were most likely removed in a refactoring at some point.