### PR TITLE
gpconfig: Update GUC quoting logic

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -365,16 +365,10 @@ def do_change(options):
         LOGGER.info("completed successfully with parameters '%s'" % params)
 
 
-# If the value is a string, escape and single-quote it as per the behavior of
-# the quote_literal() function in Postgres.
 def quote_string(guc, value):
     if value is not None and guc and guc.vartype == "string":
-        # Remove any existing single-quoting
-        if len(value) > 2 and value[0] == "'" and value[-1] == "'":
-            value = value[1:-1]
-        # Escape single quotes and backslashes
-        value = value.replace("'", "''").replace("\\", "\\\\")
-        # Single-quote the whole string
+        # Properly escape single quotes, turning \' into ''
+        value = value.replace("\\'", "'").replace("'", "''")
         value  = "'" + value + "'"
     return value
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -485,7 +485,7 @@ class GpConfig(GpTestCase):
 
     def test_quote_string_already_quoted(self):
         value = "'teststring'"
-        expected = "'teststring'"
+        expected = "'''teststring'''"
         result = self.subject.quote_string(self.guc, value)
         self.assertEqual(result, expected)
 
@@ -503,13 +503,13 @@ class GpConfig(GpTestCase):
 
     def test_quote_string_with_internal_backslash(self):
         value = "test\\string"
-        expected = "'test\\\\string'"
+        expected = "'test\\string'"
         result = self.subject.quote_string(self.guc, value)
         self.assertEqual(result, expected)
 
-    def test_quote_string_with_single_quote_and_backslash(self):
+    def test_quote_string_with_backslashed_single_quote(self):
         value = "test\\'string"
-        expected = "'test\\\\''string'"
+        expected = "'test''string'"
         result = self.subject.quote_string(self.guc, value)
         self.assertEqual(result, expected)
 
@@ -536,13 +536,6 @@ class GpConfig(GpTestCase):
 
     def test_change_of_unquoted_string_to_quoted_succeeds(self):
         self.setup_for_testing_quoting_string_values(vartype='string', value='baz')
-        self.subject.do_main()
-        self.validation_for_testing_quoting_string_values(expected_value="'baz'")
-
-    def test_change_of_master_value_with_quotes_succeeds(self):
-        already_quoted_master_value = "'baz'"
-        vartype = 'string'
-        self.setup_for_testing_quoting_string_values(vartype=vartype, value='baz', additional_args=['--mastervalue', already_quoted_master_value])
         self.subject.do_main()
         self.validation_for_testing_quoting_string_values(expected_value="'baz'")
 


### PR DESCRIPTION
The way gpconfig was previously handling string GUCs with single quotes at the start and end of the string was incorrect, as it was treating them as enclosing quotation marks when they were in fact part of the string value.  It also unnecessarily escaped backslashes, when only a backslash that would escape single quote needs to be handled specially.  This commit fixes those issues.