### PR TITLE
CREATE TABLE .. LIKE INCLUDING fixes for AO and EXTERNAL tables

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17615,7 +17615,7 @@ make_distributedby_for_rel(Relation rel)
  * Given a relation, get all column encodings for that relation as a list of
  * ColumnReferenceStorageDirective structures.
  */
-static List *
+List *
 rel_get_column_encodings(Relation rel)
 {
 	List **colencs = RelationGetUntransformedAttributeOptions(rel);

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -877,6 +877,12 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 	setup_parser_errposition_callback(&pcbstate, cxt->pstate,
 									  table_like_clause->relation->location);
 
+	/* LIKE INCLUDING is not supported for external tables */
+	if (forceBareCol && table_like_clause->options != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("LIKE INCLUDING may not be used with this kind of relation")));
+
 	/* we could support LIKE in many cases, but worry about it another day */
 	if (cxt->isforeign)
 		ereport(ERROR,
@@ -919,11 +925,6 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 
 	tupleDesc = RelationGetDescr(relation);
 	constr = tupleDesc->constr;
-
-	if (forceBareCol && table_like_clause->options != 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("LIKE INCLUDING may not be used with this kind of relation")));
 
 	/*
 	 * Initialize column number map for map_variable_attnos().  We need this

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -137,4 +137,6 @@ extern void RangeVarCallbackOwnsTable(const RangeVar *relation,
 
 extern void RangeVarCallbackOwnsRelation(const RangeVar *relation,
 							 Oid relId, Oid oldRelId, void *noCatalogs);
+
+extern List * rel_get_column_encodings(Relation rel);
 #endif   /* TABLECMDS_H */

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -1,0 +1,54 @@
+-- AO/AOCS
+CREATE TABLE t_ao (a integer, b text) WITH (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t_ao_enc (a integer, b text ENCODING (compresstype=zlib,compresslevel=1,blocksize=32768)) WITH (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t_ao_a (LIKE t_ao INCLUDING ALL);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+CREATE TABLE t_ao_b (LIKE t_ao INCLUDING STORAGE);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+CREATE TABLE t_ao_c (LIKE t_ao); -- Should create a heap table
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+CREATE TABLE t_ao_enc_a (LIKE t_ao_enc INCLUDING STORAGE);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+-- Verify created tables and attributes
+SELECT
+	c.relname,
+	c.relstorage,
+	a.columnstore,
+	a.compresstype,
+	a.compresslevel
+FROM
+	pg_catalog.pg_class c
+		LEFT OUTER JOIN pg_catalog.pg_appendonly a ON (c.oid = a.relid)
+WHERE
+	c.relname LIKE 't_ao%';
+  relname   | relstorage | columnstore | compresstype | compresslevel 
+------------+------------+-------------+--------------+---------------
+ t_ao       | c          | t           |              |             0
+ t_ao_enc   | c          | t           |              |             0
+ t_ao_a     | c          | t           |              |             0
+ t_ao_b     | c          | t           |              |             0
+ t_ao_c     | h          |             |              |              
+ t_ao_enc_a | c          | t           |              |             0
+(6 rows)
+
+SELECT
+	c.relname,
+	a.attnum,
+	a.attoptions
+FROM
+	pg_catalog.pg_class c
+		JOIN pg_catalog.pg_attribute_encoding a ON (a.attrelid = c.oid)
+WHERE
+	c.relname like 't_ao_enc%';
+  relname   | attnum |                     attoptions                      
+------------+--------+-----------------------------------------------------
+ t_ao_enc   |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ t_ao_enc   |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ t_ao_enc_a |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ t_ao_enc_a |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+(4 rows)
+

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -52,3 +52,28 @@ WHERE
  t_ao_enc_a |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
 (4 rows)
 
+-- EXTERNAL TABLE
+CREATE EXTERNAL TABLE t_ext (a integer) LOCATION ('file://127.0.0.1/tmp/foo') FORMAT 'text';
+CREATE EXTERNAL TABLE t_ext_a (LIKE t_ext INCLUDING ALL) LOCATION ('file://127.0.0.1/tmp/foo') FORMAT 'text';
+ERROR:  LIKE INCLUDING may not be used with this kind of relation
+LINE 1: CREATE EXTERNAL TABLE t_ext_a (LIKE t_ext INCLUDING ALL) LOC...
+                                            ^
+CREATE EXTERNAL TABLE t_ext_b (LIKE t_ext) LOCATION ('file://127.0.0.1/tmp/foo') FORMAT 'text';
+-- Verify created tables
+SELECT
+	c.relname,
+	c.relstorage,
+	e.urilocation,
+	e.execlocation,
+	e.fmtopts
+FROM
+	pg_catalog.pg_class c
+		LEFT OUTER JOIN pg_catalog.pg_exttable e ON (c.oid = e.reloid)
+WHERE
+	c.relname LIKE 't_ext%';
+ relname | relstorage |        urilocation         |  execlocation  |                fmtopts                 
+---------+------------+----------------------------+----------------+----------------------------------------
+ t_ext   | x          | {file://127.0.0.1/tmp/foo} | {ALL_SEGMENTS} | delimiter '     ' null '\N' escape '\'
+ t_ext_b | x          | {file://127.0.0.1/tmp/foo} | {ALL_SEGMENTS} | delimiter '     ' null '\N' escape '\'
+(2 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -30,7 +30,7 @@ test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parame
 test: spi_processed64bit
 test: python_processed64bit
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp replication_slots
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp replication_slots create_table_like_gp
 
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
 

--- a/src/test/regress/sql/create_table_like_gp.sql
+++ b/src/test/regress/sql/create_table_like_gp.sql
@@ -30,3 +30,21 @@ FROM
 		JOIN pg_catalog.pg_attribute_encoding a ON (a.attrelid = c.oid)
 WHERE
 	c.relname like 't_ao_enc%';
+
+-- EXTERNAL TABLE
+CREATE EXTERNAL TABLE t_ext (a integer) LOCATION ('file://127.0.0.1/tmp/foo') FORMAT 'text';
+CREATE EXTERNAL TABLE t_ext_a (LIKE t_ext INCLUDING ALL) LOCATION ('file://127.0.0.1/tmp/foo') FORMAT 'text';
+CREATE EXTERNAL TABLE t_ext_b (LIKE t_ext) LOCATION ('file://127.0.0.1/tmp/foo') FORMAT 'text';
+
+-- Verify created tables
+SELECT
+	c.relname,
+	c.relstorage,
+	e.urilocation,
+	e.execlocation,
+	e.fmtopts
+FROM
+	pg_catalog.pg_class c
+		LEFT OUTER JOIN pg_catalog.pg_exttable e ON (c.oid = e.reloid)
+WHERE
+	c.relname LIKE 't_ext%';

--- a/src/test/regress/sql/create_table_like_gp.sql
+++ b/src/test/regress/sql/create_table_like_gp.sql
@@ -1,0 +1,32 @@
+-- AO/AOCS
+CREATE TABLE t_ao (a integer, b text) WITH (appendonly=true, orientation=column);
+CREATE TABLE t_ao_enc (a integer, b text ENCODING (compresstype=zlib,compresslevel=1,blocksize=32768)) WITH (appendonly=true, orientation=column);
+
+CREATE TABLE t_ao_a (LIKE t_ao INCLUDING ALL);
+CREATE TABLE t_ao_b (LIKE t_ao INCLUDING STORAGE);
+CREATE TABLE t_ao_c (LIKE t_ao); -- Should create a heap table
+
+CREATE TABLE t_ao_enc_a (LIKE t_ao_enc INCLUDING STORAGE);
+
+-- Verify created tables and attributes
+SELECT
+	c.relname,
+	c.relstorage,
+	a.columnstore,
+	a.compresstype,
+	a.compresslevel
+FROM
+	pg_catalog.pg_class c
+		LEFT OUTER JOIN pg_catalog.pg_appendonly a ON (c.oid = a.relid)
+WHERE
+	c.relname LIKE 't_ao%';
+
+SELECT
+	c.relname,
+	a.attnum,
+	a.attoptions
+FROM
+	pg_catalog.pg_class c
+		JOIN pg_catalog.pg_attribute_encoding a ON (a.attrelid = c.oid)
+WHERE
+	c.relname like 't_ao_enc%';


### PR DESCRIPTION
`INCLUDING STORAGE` was introduced in PostgreSQL 9.0, but support for setting the AO/AOCS/ENCODING storage options on the created table was never supported as we merged upstream. This extends support for copying over the table storage type as well as attribute encodings when creating a table with `INCLUDING STORAGE` or `INCLUDING ALL`.

Also moves the errorpath for `EXTERNAL TABLE` in `LIKE INCLUDING` in under the context aware error handling. This makes the error when creating an external table the same as when creating a foreign table. As a bonus it avoids a few checks in case of error.

Tests for both are added as well.