### PR TITLE
Disable gpload test case 22

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -584,21 +584,23 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         copy_data('external_file_01.txt','data_file.txt')
         write_config_file(reuse_flag='true',formatOpts='text',file='data_file.txt',table='texttable',escape="E'\\\\'")
         self.doTest(21)
-    def test_22_gpload_error_count(self):
-        "22  gpload error count"
-        f = open(mkpath('query22.sql'),'a')
-        f.write("\! psql -d reuse_gptest -c 'select count(*) from csvtable;'")
-        f.close()
-        f = open(mkpath('data/large_file.csv'),'w')
-        for i in range(0, 10000):
-            if i % 2 == 0:
-                f.write('1997,Ford,E350,"ac, abs, moon",3000.00,a\n')
-            else:
-                f.write('1997,Ford,E350,"ac, abs, moon",3000.00\n')
-        f.close()
-        copy_data('large_file.csv','data_file.csv')
-        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='90000000')
-        self.doTest(22)
+    # case 22 is flaky on concourse. It may report: Fatal Python error: GC object already tracked during testing.
+    # This is seldom issue. we can't reproduce it locally, so we disable it, in order to not blocking others
+    #def test_22_gpload_error_count(self):
+    #    "22  gpload error count"
+    #    f = open(mkpath('query22.sql'),'a')
+    #    f.write("\! psql -d reuse_gptest -c 'select count(*) from csvtable;'")
+    #    f.close()
+    #    f = open(mkpath('data/large_file.csv'),'w')
+    #    for i in range(0, 10000):
+    #        if i % 2 == 0:
+    #            f.write('1997,Ford,E350,"ac, abs, moon",3000.00,a\n')
+    #        else:
+    #            f.write('1997,Ford,E350,"ac, abs, moon",3000.00\n')
+    #    f.close()
+    #    copy_data('large_file.csv','data_file.csv')
+    #    write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='90000000')
+    #   self.doTest(22)
     def test_23_gpload_error_count(self):
         "23  gpload error_table"
         file = mkpath('setup.sql')


### PR DESCRIPTION
Backport 2def0c1c0779f16904affe95aaa53f508d9dba61.

Author: Huiliang.liu <huiliang.lhl@qq.com>
Date:   Mon Apr 1 10:58:31 2019 +0800

    Disable gpload test case 22 (#7244)

    In the past several weeks, gpload test case 22 failed two times.
    It may report: Fatal Python error: GC object already tracked.
    We have reproduced this issue locally and in dev pipeline for 3
    days, but it can't be reproduced.
    So we decide to disable it now, in order to not blocking other PRs.