### PR TITLE
Fixups to src/backend/parser messaging

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1030,7 +1030,7 @@ transformGroupedWindows(ParseState *pstate, Query *qry)
 
     /* Begin rewriting the outer query in place.
      */
-	qry->hasAggs = false; /* by constuction */
+	qry->hasAggs = false; /* by construction */
 	/* qry->hasSubLinks -- reevaluate later. */
 
 	/* Core of outer query input table expression: */
@@ -1063,7 +1063,7 @@ transformGroupedWindows(ParseState *pstate, Query *qry)
 	rte->eref = copyObject(alias);
 	rte->alias = alias;
 
-	/* Accomodate depth change in new subquery, Q''.
+	/* Accommodate depth change in new subquery, Q''.
 	 */
 	IncrementVarSublevelsUpInTransformGroupedWindows((Node*)subq, 1, 1);
 
@@ -2531,7 +2531,7 @@ transformSetOperationTree_internal(ParseState *pstate, SelectStmt *stmt,
 				i++;
 
 				/*
-				 * It's possible that this leaf query has a differnet number
+				 * It's possible that this leaf query has a different number
 				 * of columns than the previous ones. That's an error, but
 				 * we don't throw it here because we don't have the context
 				 * needed for a good error message. We don't know which

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3626,9 +3626,7 @@ alter_table_partition_cmd:
 							if (e->subSpec)
 								ereport(ERROR,
 										(errcode(ERRCODE_SYNTAX_ERROR),
-										 errmsg("template cannot contain "
-												"specification for child "
-												"partition")));
+										 errmsg("template cannot contain specification for child partition")));
 						}
 					}
 
@@ -5283,9 +5281,7 @@ TabSubPartitionTemplate:
 							if (e->subSpec)
 								ereport(ERROR,
 										(errcode(ERRCODE_SYNTAX_ERROR),
-										 errmsg("template cannot contain "
-												"specification for child "
-												"partition")));
+										 errmsg("template cannot contain specification for child partition")));
 						}
 
 					}
@@ -5365,8 +5361,8 @@ CreateAsStmt:
 					if ($9)
 						ereport(ERROR,
                                 (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("Cannot create a partitioned table using CREATE TABLE AS SELECT"),
-                                 errhint("Use CREATE TABLE...LIKE (followed by INSERT...SELECT) instead")));
+								 errmsg("cannot create a partitioned table using CREATE TABLE AS SELECT"),
+								 errhint("Use CREATE TABLE...LIKE (followed by INSERT...SELECT) instead.")));
 
 					$4->skipData = !($7);
 					$$ = (Node *) ctas;
@@ -5426,7 +5422,7 @@ CreateExternalStmt:	CREATE OptWritable EXTERNAL OptWeb OptTemp TABLE qualified_n
 									ereport(ERROR,
 											(errcode(ERRCODE_SYNTAX_ERROR),
 										 	 errmsg("EXECUTE may not be used with a regular external table"),
-										 	 errhint("Use CREATE EXTERNAL WEB TABLE instead")));							
+											 errhint("Use CREATE EXTERNAL WEB TABLE instead.")));
 								
 								/* if no ON clause specified, default to "ON ALL" */
 								if(extdesc->on_clause == NIL)
@@ -5438,14 +5434,14 @@ CreateExternalStmt:	CREATE OptWritable EXTERNAL OptWeb OptTemp TABLE qualified_n
 								{
 									ereport(ERROR,
 											(errcode(ERRCODE_SYNTAX_ERROR),
-									 		 errmsg("ON clause may not be used with a writable external table")));							
+											 errmsg("ON clause may not be used with a writable external table")));
 								}
 							}
 
 							if(n->sreh && n->iswritable)
 								ereport(ERROR,
 										(errcode(ERRCODE_SYNTAX_ERROR),
-										 errmsg("Single row error handling may not be used with a writable external table")));							
+										 errmsg("single row error handling may not be used with a writable external table")));
 							
 							$$ = (Node *)n;							
 						}

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -794,7 +794,7 @@ static Node *makeIsNotDistinctFromNode(Node *expr, int position);
 /*
  * This is a bit ugly... To allow these to be column aliases without
  * the "AS" keyword, and not conflict with PostgreSQL's non-standard
- * suffix operators, we need to give these a precidence.
+ * suffix operators, we need to give these a precedence.
  */
 
 %nonassoc   ABORT_P

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -3801,12 +3801,11 @@ transformFrameOffset(ParseState *pstate, int frameOptions, Node *clause,
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("type mismatch between ORDER BY and RANGE "
-								"parameter in window specification"),
+						 errmsg("type mismatch between ORDER BY and RANGE parameter in window specification"),
 						 errhint("Operations between window specification "
 								 "the ORDER BY column and RANGE parameter "
 								 "must result in a data type which can be "
-								 "cast back to the ORDER BY column type"),
+								 "cast back to the ORDER BY column type."),
 						 parser_errposition(pstate, exprLocation((Node *) expr))));
 			}
 
@@ -3829,7 +3828,7 @@ transformFrameOffset(ParseState *pstate, int frameOptions, Node *clause,
 						 errhint("Operations between window specification "
 								 "the ORDER BY column and RANGE parameter "
 								 "must result in a data type which can be "
-								 "cast back to the ORDER BY column type")));
+								 "cast back to the ORDER BY column type.")));
 		}
 
 		if (IsA(node, Const))

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -226,7 +226,7 @@ coerce_type(ParseState *pstate, Node *node,
 			if(elemoid == InvalidOid)
 				ereport(ERROR,
 					(errcode(ERRCODE_DATATYPE_MISMATCH), 
-					 errmsg("Cannot convert non-Array type to ANYARRAY")));
+					 errmsg("cannot convert non-Array type to ANYARRAY")));
 
 			memcpy(newcon, con, sizeof(Const));
 			newcon->consttype = ANYARRAYOID;

--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -1076,7 +1076,7 @@ checkWindowFuncInRecursiveTerm(SelectStmt *stmt, CteState *cstate)
 				{
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("Window Functions in a recursive query is not implemented"),
+							 errmsg("window functions in a recursive query is not implemented"),
 							 parser_errposition(cstate->pstate,
 												exprLocation((Node *) fc))));
 				}

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -2116,7 +2116,7 @@ checkTableFunctions_walker(Node *node, check_table_func_context *context)
 		return false;
 
 	/* 
-	 * TABLE() value expressions are currently only permited as parameters
+	 * TABLE() value expressions are currently only permitted as parameters
 	 * to table functions called in the FROM clause.
 	 */
 	if (IsA(node, TableValueExpr))

--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -209,7 +209,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-				 errmsg("Exceeded the maximum allowed level of partitioning of %d", gp_max_partition_level)));
+				 errmsg("exceeded the maximum allowed level of partitioning of %d", gp_max_partition_level)));
 	}
 
 	snprintf(depthstr, sizeof(depthstr), "%d", partDepth);
@@ -247,8 +247,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-				 errmsg("too many columns for RANGE partition%s -- "
-						"only one column is allowed.",
+				 errmsg("too many columns for RANGE partition%s -- only one column is allowed",
 						at_depth),
 				 parser_errposition(cxt->pstate, pBy->location)));
 	}
@@ -278,8 +277,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 				if (list_member_int(key_attnums, i))
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("column \"%s\" specified more than once "
-									"in partitioning key",
+							 errmsg("column \"%s\" specified more than once in partitioning key",
 									colname),
 							 parser_errposition(cxt->pstate, pBy->location)));
 
@@ -372,11 +370,9 @@ transformPartitionBy(CreateStmtContext *cxt,
 				}
 				ereport(ERROR,
 						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-					  errmsg("%s constraint must contain all columns in the "
-							 "partition key",
-							 what),
-						 errhint("Include column \"%s\" in the %s constraint or create "
-								 "a part-wise UNIQUE index after creating the table instead.",
+						 errmsg("%s constraint must contain all columns in the partition key",
+								what),
+						 errhint("Include column \"%s\" in the %s constraint or create a part-wise UNIQUE index after creating the table instead.",
 								 strVal(partkeyname), what)));
 			}
 		}
@@ -433,8 +429,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-						 errmsg("missing SUBPARTITION BY clause for "
-								"subpartition specification%s",
+						 errmsg("missing SUBPARTITION BY clause for subpartition specification%s",
 								at_depth),
 						 parser_errposition(cxt->pstate, pBy->location)));
 			}
@@ -562,8 +557,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 				{
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("missing SUBPARTITION BY clause "
-									"for subpartition specification%s",
+							 errmsg("missing SUBPARTITION BY clause for subpartition specification%s",
 									at_depth),
 							 parser_errposition(cxt->pstate, pElem->location)));
 				}
@@ -574,8 +568,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("subpartition configuration conflicts "
-									"with subpartition template"),
+							 errmsg("subpartition configuration conflicts with subpartition template"),
 							 parser_errposition(cxt->pstate, psubBy->location)));
 				}
 
@@ -583,7 +576,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 				{
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("Multi-level partitioned tables without templates are not supported")));
+							 errmsg("multi-level partitioned tables without templates are not supported")));
 				}
 
 				newSub = makeNode(PartitionBy);
@@ -2376,8 +2369,7 @@ validate_partition_spec(CreateStmtContext *cxt,
 				{
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("multiple default partitions are not "
-									"allowed"),
+							 errmsg("multiple default partitions are not allowed"),
 							 parser_errposition(cxt->pstate, pElem->location)));
 
 				}
@@ -2388,14 +2380,11 @@ validate_partition_spec(CreateStmtContext *cxt,
 				{
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("invalid use of boundary specification "
-									"for DEFAULT partition%s%s",
+							 errmsg("invalid use of boundary specification for DEFAULT partition%s%s",
 									namBuf,
 									at_depth),
 							 parser_errposition(cxt->pstate, pElem->location)));
-
 				}
-
 			}					/* end if is default */
 
 			if (pElem->partName)
@@ -2488,8 +2477,7 @@ validate_partition_spec(CreateStmtContext *cxt,
 	if (partNumber > -1 && partno != partNumber)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-				 errmsg("PARTITIONS \"%d\" must match \"%d\" elements "
-						"in specification%s",
+				 errmsg("PARTITIONS \"%d\" must match \"%d\" elements in specification%s",
 						partNumber, partno, vstate->at_depth),
 				 parser_errposition(cxt->pstate, pBy->location)));
 
@@ -2754,7 +2742,7 @@ preprocess_range_spec(partValidationState *vstate)
 									 errmsg("could not identify operator for partitioning operation between type \"%s\" and type \"%s\"",
 											format_type_be(typ->typeOid),
 											format_type_be(rtypeId)),
-									 errhint("Add an explicit cast to the partitioning parameters")));
+									 errhint("Add an explicit cast to the partitioning parameters.")));
 
 
 						newrtypeId = ((Form_pg_operator) GETSTRUCT(optup))->oprright;
@@ -3135,8 +3123,7 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-						 errmsg("invalid use of boundary specification "
-								"for DEFAULT partition%s%s",
+						 errmsg("invalid use of boundary specification for DEFAULT partition%s%s",
 								namBuf,
 								at_depth),
 						 parser_errposition(pstate, pElem->location)));
@@ -3147,8 +3134,7 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-						 errmsg("invalid use of LIST boundary specification "
-								"in partition%s of type RANGE%s",
+						 errmsg("invalid use of LIST boundary specification in partition%s of type RANGE%s",
 								namBuf,
 								at_depth),
 				/* MPP-4249: use value spec location if have one */
@@ -3176,8 +3162,7 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-					 errmsg("EVERY clause in partition%s "
-							"requires START and END%s",
+					 errmsg("EVERY clause in partition%s requires START and END%s",
 							namBuf,
 							at_depth),
 					 parser_errposition(pstate, pBSpec->location)));
@@ -3241,8 +3226,7 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-					 errmsg("mismatch between EVERY, START and END "
-							"in partition%s%s",
+					 errmsg("mismatch between EVERY, START and END in partition%s%s",
 							namBuf,
 							at_depth),
 					 parser_errposition(pstate, pBSpec->location)));
@@ -3409,8 +3393,7 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 						ereport(ERROR,
 								(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 								 errmsg("EVERY parameter produces ambiguous partition rule"),
-								 parser_errposition(pstate,
-													exprLocation(n3))));
+								 parser_errposition(pstate, exprLocation(n3))));
 
 				}
 
@@ -3579,8 +3562,7 @@ validate_range_partition(partValidationState *vstate)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-					 errmsg("invalid use of %s boundary "
-							"specification in partition clause",
+					 errmsg("invalid use of %s boundary specification in partition clause",
 							specTName),
 			/* MPP-4249: use value spec location if have one */
 					 parser_errposition(pstate,
@@ -3630,9 +3612,7 @@ validate_range_partition(partValidationState *vstate)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-					 errmsg("invalid use of mixed named and "
-							"unnamed RANGE boundary "
-							"specifications%s",
+					 errmsg("invalid use of mixed named and unnamed RANGE boundary specifications%s",
 							vstate->at_depth),
 					 parser_errposition(pstate, spec->location)));
 
@@ -3701,8 +3681,7 @@ validate_range_partition(partValidationState *vstate)
 					/* XXX: better message */
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("START of partition%s less "
-									"than START of previous%s",
+							 errmsg("START of partition%s less than START of previous%s",
 									vstate->namBuf,
 									vstate->at_depth),
 							 parser_errposition(pstate,
@@ -3746,9 +3725,7 @@ validate_range_partition(partValidationState *vstate)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-					 errmsg("cannot derive starting value of "
-							"partition%s based upon ending of "
-							"previous%s",
+					 errmsg("cannot derive starting value of partition%s based upon ending of previous%s",
 							vstate->namBuf,
 							vstate->at_depth),
 					 parser_errposition(pstate, spec->location)));
@@ -3832,9 +3809,7 @@ L_setprevElem:
 							vstate->namBuf,
 							vstate->at_depth),
 					 parser_errposition(pstate, spec->location)));
-
 		}
-
 	}
 
 	if (NIL == vstate->allRangeVals)
@@ -3867,8 +3842,7 @@ L_setprevElem:
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-					 errmsg("starting value of partition%s "
-							"overlaps previous range%s",
+					 errmsg("starting value of partition%s overlaps previous range%s",
 							vstate->namBuf,
 							vstate->at_depth),
 					 parser_errposition(pstate, spec->location)));
@@ -3895,8 +3869,7 @@ L_setprevElem:
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-					 errmsg("starting value of partition%s "
-							"overlaps previous range%s",
+					 errmsg("starting value of partition%s overlaps previous range%s",
 							vstate->namBuf,
 							vstate->at_depth),
 					 parser_errposition(pstate, spec->location)));
@@ -4303,12 +4276,10 @@ validate_list_partition(partValidationState *vstate)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-				 errmsg("missing boundary specification in "
-						"partition%s of type LIST%s",
+				 errmsg("missing boundary specification in partition%s of type LIST%s",
 						vstate->namBuf,
 						vstate->at_depth),
-			   parser_errposition(pstate, vstate->pElem->location)));
-
+				 parser_errposition(pstate, vstate->pElem->location)));
 	}
 
 	if (!IsA(n, PartitionValuesSpec))
@@ -4316,9 +4287,7 @@ validate_list_partition(partValidationState *vstate)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 				 errmsg("invalid boundary specification for LIST partition"),
-			   parser_errposition(pstate, vstate->pElem->location)));
-
-
+				 parser_errposition(pstate, vstate->pElem->location)));
 	}
 
 	spec = (PartitionValuesSpec *) n;
@@ -4343,8 +4312,7 @@ validate_list_partition(partValidationState *vstate)
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-					  errmsg("partition key has %i column%s but %i column%s "
-							 "specified in VALUES clause",
+						 errmsg("partition key has %i column%s but %i column%s specified in VALUES clause",
 							 list_length(vstate->pBy->keys),
 							 list_length(vstate->pBy->keys) ? "s" : "",
 							 nvals,
@@ -4403,8 +4371,7 @@ validate_list_partition(partValidationState *vstate)
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-								 errmsg("duplicate VALUES "
-										"in partition%s%s",
+								 errmsg("duplicate VALUES in partition%s%s",
 										vstate->namBuf,
 										vstate->at_depth),
 						parser_errposition(pstate, spec->location)));
@@ -4452,8 +4419,8 @@ transformPartitionStorageEncodingClauses(List *enc)
 				if (!equal(a->encoding, b->encoding))
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("conflicting ENCODING clauses for column "
-									"\"%s\"", a->column ? a->column : "DEFAULT")));
+							 errmsg("conflicting ENCODING clauses for column \"%s\"",
+									a->column ? a->column : "DEFAULT")));
 
 				/*
 				 * We found an identical directive on the same column. You'd
@@ -4529,8 +4496,7 @@ merge_partition_encoding(ParseState *pstate, PartitionElem *elem, List *penc)
 		if (elem->colencs)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("ENCODING clause only supported with "
-							"column oriented partitions"),
+					 errmsg("ENCODING clause only supported with column oriented partitions"),
 					 parser_errposition(pstate, elem->location)));
 		else
 			return;				/* nothing more to do */
@@ -4626,7 +4592,7 @@ range_partition_walker(Node *node, void *context)
 		if (c->constisnull)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-				errmsg("cannot use NULL with range partition specification"),
+					 errmsg("cannot use NULL with range partition specification"),
 					 parser_errposition(ctx->pstate, ctx->location)));
 		return false;
 	}
@@ -4637,7 +4603,7 @@ range_partition_walker(Node *node, void *context)
 		if (IsA(&c->val, Null))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-				errmsg("cannot use NULL with range partition specification"),
+					 errmsg("cannot use NULL with range partition specification"),
 					 parser_errposition(ctx->pstate, ctx->location)));
 		return false;
 	}

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1956,7 +1956,7 @@ isSimplyUpdatableRelation(Oid relid, bool noerror)
 		if (!noerror)
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("Invalid oid: %d is not simply updatable", relid)));
+					 errmsg("invalid oid: %d is not simply updatable", relid)));
 		return false;
 	}
 

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -594,7 +594,7 @@ scanRTEForColumn(ParseState *pstate, RangeTblEntry *rte, char *colname,
 	{
 		/* In GPDB, system columns like gp_segment_id, ctid, xmin/xmax seem to be
 		 * ambiguous for replicated table, replica in each segment has different
-		 * value of those columns, between sessions, different replicas are choosen
+		 * value of those columns, between sessions, different replicas are chosen
 		 * to provide data, so it's weird for users to see different system columns
 		 * between sessions. So for replicated table, we don't expose system columns
 		 * unless it's GP_ROLE_UTILITY for debug purpose.

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -815,7 +815,7 @@ transformTableConstraint(CreateStmtContext *cxt, Constraint *constraint)
 	if (constraint->contype == CONSTR_EXCLUSION)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("GPDB does not support exclusion constraints.")));
+				 errmsg("GPDB does not support exclusion constraints")));
 
 	switch (constraint->contype)
 	{
@@ -1676,8 +1676,7 @@ transformCreateExternalStmt(CreateExternalStmt *stmt, const char *queryString)
 				if(srehDesc && srehDesc->into_file)
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("External web table with ON MASTER clause "
-									"cannot use LOG ERRORS feature.")));
+							 errmsg("external web table with ON MASTER clause cannot use LOG ERRORS feature")));
 			}
 		}
 	}
@@ -2500,7 +2499,7 @@ transformIndexConstraints(CreateStmtContext *cxt, bool mayDefer)
 		if(constraint->contype == CONSTR_EXCLUSION)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("GPDB does not support exclusion constraints.")));
+						errmsg("GPDB does not support exclusion constraints")));
 
 		Assert(constraint->contype == CONSTR_PRIMARY ||
 			   constraint->contype == CONSTR_UNIQUE);
@@ -2611,8 +2610,7 @@ transformIndexConstraints(CreateStmtContext *cxt, bool mayDefer)
 			
 				ereport(DEBUG1,
 						(errmsg("deferring index creation for table \"%s\"",
-								cxt->relation->relname)
-						 ));
+								cxt->relation->relname)));
 				cxt->dlist = lappend(cxt->dlist, index);
 			}
 			else

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -411,8 +411,8 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString, bool createPartit
 	}
 
 	/*
-	 * Transform DISTRIBUTED BY (or constuct a default one, if not given
-	 *  explicitly). Not for foreign tables, though.
+	 * Transform DISTRIBUTED BY (or construct a default one, if not given
+	 * explicitly). Not for foreign tables, though.
 	 */
 	if (stmt->relKind == RELKIND_RELATION)
 	{
@@ -1775,7 +1775,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 		/* Otherwise use DEFAULT as numsegments */
 		numsegments = GP_POLICY_DEFAULT_NUMSEGMENTS();
 
-	/* Explictly specified distributed randomly, no futher check needed */
+	/* Explicitly specified distributed randomly, no further check needed */
 	if (distributedBy &&
 		(distributedBy->ptype == POLICYTYPE_PARTITIONED && distributedBy->keyCols == NIL))
 	{
@@ -4468,7 +4468,7 @@ transformAttributeEncoding(List *stenc, CreateStmt *stmt, CreateStmtContext *cxt
 		newenc = lappend(newenc, c);
 	}
 
-	/* Check again incase we expanded a some column encoding clauses */
+	/* Check again in case we expanded a some column encoding clauses */
 	if (!can_enc)
 	{
 		if (found_enc)

--- a/src/test/regress/expected/index_constraint_naming.out
+++ b/src/test/regress/expected/index_constraint_naming.out
@@ -174,7 +174,7 @@ ERROR:  relation "st_pk_pkey" already exists
 -- EXCLUSION CONSTRAINT
 -- EXCLUSION CONSTRAINT: GPDB does not support exclusion constraints
 CREATE TABLE st_x (a int, b int, EXCLUDE (a with =, b with =));
-ERROR:  GPDB does not support exclusion constraints.
+ERROR:  GPDB does not support exclusion constraints
 -- Should fail
 SELECT table_name,constraint_name,index_name,constraint_type FROM constraints_and_indices() WHERE (constraint_name::text=index_name::text AND constraint_type='x');
  table_name | constraint_name | index_name | constraint_type 

--- a/src/test/regress/expected/index_constraint_naming_partition.out
+++ b/src/test/regress/expected/index_constraint_naming_partition.out
@@ -727,7 +727,7 @@ CONTEXT:  SQL function "recreate_two_level_table" statement 2
 (1 row)
 
 ALTER TABLE r ADD EXCLUDE (r_key WITH =,r_name WITH =);
-ERROR:  GPDB does not support exclusion constraints.
+ERROR:  GPDB does not support exclusion constraints
 SELECT * FROM dependencies_show_for_cons_idx();
       depname       | classtype |      refname       | refclasstype |    classid    | objsubid |  refclassid   | refobjsubid | deptype 
 --------------------+-----------+--------------------+--------------+---------------+----------+---------------+-------------+---------

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -76,7 +76,7 @@ partition by range (b,d)
 partition aa start (2007,1) end (2008,2),
 partition bb start (2008,2) end (2009,3)
 );
-ERROR:  too many columns for RANGE partition -- only one column is allowed.
+ERROR:  too many columns for RANGE partition -- only one column is allowed
 LINE 3: partition by range (b,d)
                      ^
 drop table ggg cascade;
@@ -571,7 +571,7 @@ partition by range (b,d)
 partition aa start (2007,1) end (2008,2),
 partition bb start (2008,2) end (2009,3)
 );
-ERROR:  too many columns for RANGE partition -- only one column is allowed.
+ERROR:  too many columns for RANGE partition -- only one column is allowed
 LINE 3: partition by range (b,d)
                      ^
 drop table ggg cascade;
@@ -734,8 +734,8 @@ end (date '2006-01-01') every (interval '1 year')) (
 partition boys values ('M'),
 partition girls values ('F')
 );
-ERROR:  Cannot create a partitioned table using CREATE TABLE AS SELECT
-HINT:  Use CREATE TABLE...LIKE (followed by INSERT...SELECT) instead
+ERROR:  cannot create a partitioned table using CREATE TABLE AS SELECT
+HINT:  Use CREATE TABLE...LIKE (followed by INSERT...SELECT) instead.
 -- like is ok
 create table rank2 (like rank1)
 DISTRIBUTED BY (id, gender, year)
@@ -1458,7 +1458,7 @@ partition by range (i, j)
  start(15, '2010-01-01') end (30, '2011-01-01'),
  start(1, '2011-01-01') end (100, '2012-01-01')
 );
-ERROR:  too many columns for RANGE partition -- only one column is allowed.
+ERROR:  too many columns for RANGE partition -- only one column is allowed
 LINE 2: partition by range (i, j)
                      ^
 -- should work
@@ -1517,7 +1517,7 @@ start(2000.99, '2007-01-01 00:00:00', 'BBB')
 start(4000.95, '2007-01-01 00:00:00', 'AAA')
   end (7000.95, '2007-02-02 15:00:00', 'BBB')
 );
-ERROR:  too many columns for RANGE partition -- only one column is allowed.
+ERROR:  too many columns for RANGE partition -- only one column is allowed
 LINE 3: partition by range(n, t, s)
                      ^
 -- should work

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -1034,7 +1034,7 @@ WITH RECURSIVE x(n) AS (
 	UNION ALL
 	SELECT level+1, row_number() over() FROM x, bar)
   SELECT * FROM x LIMIT 10;
-ERROR:  Window Functions in a recursive query is not implemented
+ERROR:  window functions in a recursive query is not implemented
 LINE 4:  SELECT level+1, row_number() over() FROM x, bar)
                          ^
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;


### PR DESCRIPTION
This aligns Greenplum error messages in `src/backend/parser` with the upstream error message style guide that we try to follow closely, as well as fixes multiple typos in that same directory.

Disclaimer: I was too lazy to run a full ICW with these changes so it's highly likely that a message change needs to he mimicked in the regression tests output.