### PR TITLE
Introduce GUC optimizer_enable_dml

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -61,6 +61,7 @@ using namespace gpnaucrates;
 using namespace gpmd;
 
 extern bool	optimizer_enable_ctas;
+extern bool optimizer_enable_dml;
 extern bool optimizer_enable_dml_triggers;
 extern bool optimizer_enable_dml_constraints;
 extern bool optimizer_enable_multiple_distinct_aggs;
@@ -724,6 +725,11 @@ CTranslatorQueryToDXL::TranslateInsertQueryToDXL()
 	GPOS_ASSERT(CMD_INSERT == m_query->commandType);
 	GPOS_ASSERT(0 < m_query->resultRelation);
 
+	if (!optimizer_enable_dml)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("DML not enabled"));
+	}
+
 	CDXLNode *query_dxlnode = TranslateSelectQueryToDXL();
 	const RangeTblEntry *rte = (RangeTblEntry *) gpdb::ListNth(m_query->rtable, m_query->resultRelation - 1);
 
@@ -1141,6 +1147,11 @@ CTranslatorQueryToDXL::TranslateDeleteQueryToDXL()
 	GPOS_ASSERT(CMD_DELETE == m_query->commandType);
 	GPOS_ASSERT(0 < m_query->resultRelation);
 
+	if (!optimizer_enable_dml)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("DML not enabled"));
+	}
+
 	CDXLNode *query_dxlnode = TranslateSelectQueryToDXL();
 	const RangeTblEntry *rte = (RangeTblEntry *) gpdb::ListNth(m_query->rtable, m_query->resultRelation - 1);
 
@@ -1192,6 +1203,11 @@ CTranslatorQueryToDXL::TranslateUpdateQueryToDXL()
 {
 	GPOS_ASSERT(CMD_UPDATE == m_query->commandType);
 	GPOS_ASSERT(0 < m_query->resultRelation);
+
+	if (!optimizer_enable_dml)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("DML not enabled"));
+	}
 
 	CDXLNode *query_dxlnode = TranslateSelectQueryToDXL();
 	const RangeTblEntry *rte = (RangeTblEntry *) gpdb::ListNth(m_query->rtable, m_query->resultRelation - 1);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -336,6 +336,7 @@ bool		optimizer_enable_bitmapscan;
 bool		optimizer_enable_outerjoin_to_unionall_rewrite;
 bool		optimizer_enable_ctas;
 bool		optimizer_enable_partial_index;
+bool		optimizer_enable_dml;
 bool		optimizer_enable_dml_triggers;
 bool		optimizer_enable_dml_constraints;
 bool		optimizer_enable_master_only_queries;
@@ -2678,6 +2679,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_partial_index,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_dml", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable DML plans in Pivotal Optimizer (GPORCA)."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_dml,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -460,6 +460,7 @@ extern bool optimizer_enable_bitmapscan;
 extern bool optimizer_enable_outerjoin_to_unionall_rewrite;
 extern bool optimizer_enable_ctas;
 extern bool optimizer_enable_partial_index;
+extern bool optimizer_enable_dml;
 extern bool optimizer_enable_dml_triggers;
 extern bool	optimizer_enable_dml_constraints;
 extern bool optimizer_enable_direct_dispatch;

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -172,3 +172,32 @@ EXPLAIN INSERT INTO heap_t1 SELECT * FROM ONLY ext_table_no_fallback;
  Optimizer: Postgres query optimizer
 (5 rows)
 
+set optimizer_enable_dml=off;
+EXPLAIN INSERT INTO homer VALUES (1,0,40),(2,1,43),(3,2,41),(4,3,44);
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Insert on homer  (cost=0.00..0.05 rows=2 width=12)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.05 rows=4 width=12)
+         Hash Key: "*VALUES*".column1
+         ->  Values Scan on "*VALUES*"  (cost=0.00..0.05 rows=2 width=12)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN UPDATE ONLY homer SET c = c + 1;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Update on homer  (cost=0.00..1073.75 rows=25967 width=22)
+   ->  Seq Scan on homer  (cost=0.00..1073.75 rows=25967 width=22)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+EXPLAIN DELETE FROM ONLY homer WHERE a = 3;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Delete on homer  (cost=0.00..1073.75 rows=78 width=10)
+   ->  Seq Scan on homer  (cost=0.00..1073.75 rows=26 width=10)
+         Filter: (a = 3)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+set optimizer_enable_dml=on;

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -214,3 +214,38 @@ DETAIL:  Feature not supported: ONLY in the FROM clause
  Optimizer: Postgres query optimizer
 (5 rows)
 
+set optimizer_enable_dml=off;
+EXPLAIN INSERT INTO homer VALUES (1,0,40),(2,1,43),(3,2,41),(4,3,44);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: DML not enabled
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Insert on homer  (cost=0.00..0.05 rows=2 width=12)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.05 rows=4 width=12)
+         Hash Key: "*VALUES*".column1
+         ->  Values Scan on "*VALUES*"  (cost=0.00..0.05 rows=2 width=12)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN UPDATE ONLY homer SET c = c + 1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: DML not enabled
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Update on homer  (cost=0.00..1073.75 rows=25967 width=22)
+   ->  Seq Scan on homer  (cost=0.00..1073.75 rows=25967 width=22)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+EXPLAIN DELETE FROM ONLY homer WHERE a = 3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: DML not enabled
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Delete on homer  (cost=0.00..1073.75 rows=78 width=10)
+   ->  Seq Scan on homer  (cost=0.00..1073.75 rows=26 width=10)
+         Filter: (a = 3)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+set optimizer_enable_dml=on;

--- a/src/test/regress/sql/qp_orca_fallback.sql
+++ b/src/test/regress/sql/qp_orca_fallback.sql
@@ -83,3 +83,9 @@ CREATE EXTERNAL TABLE ext_table_no_fallback (a int, b int) LOCATION ('gpfdist://
 EXPLAIN SELECT * FROM ext_table_no_fallback;
 EXPLAIN SELECT * FROM ONLY ext_table_no_fallback;
 EXPLAIN INSERT INTO heap_t1 SELECT * FROM ONLY ext_table_no_fallback;
+
+set optimizer_enable_dml=off;
+EXPLAIN INSERT INTO homer VALUES (1,0,40),(2,1,43),(3,2,41),(4,3,44);
+EXPLAIN UPDATE ONLY homer SET c = c + 1;
+EXPLAIN DELETE FROM ONLY homer WHERE a = 3;
+set optimizer_enable_dml=on;


### PR DESCRIPTION
`optimizer_enable_dml` is set to true by default. When set to false, ORCA will
fall back to planner for all DML queries.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
