### PR TITLE
Waiting relation in GDD should consider lock conflict map.

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -4609,3 +4609,21 @@ setFPHoldTillEndXact(Oid relid)
 
 	return result;
 }
+
+/*
+ * Check whether a waiter's request lockmode conflict with
+ * the holder's hold mask
+ */
+bool
+CheckWaitLockModeConflictHoldMask(LOCKTAG tag, LOCKMODE waitLockMode, LOCKMASK holderMask)
+{
+	int			waiterConflictMask;
+	LOCKMETHODID lockmethodid = (LOCKMETHODID) tag.locktag_lockmethodid;
+
+	Assert(0 < lockmethodid && lockmethodid < lengthof(LockMethods));
+
+	waiterConflictMask = LockMethods[lockmethodid]->conflictTab[waitLockMode];
+	if (holderMask & waiterConflictMask)
+		return true;
+	return false;
+}

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -641,4 +641,6 @@ extern void VirtualXactLockTableInsert(VirtualTransactionId vxid);
 extern void VirtualXactLockTableCleanup(void);
 extern bool VirtualXactLock(VirtualTransactionId vxid, bool wait);
 
+/* Check whether a waiter's request lockmode conflict with the holder's hold mask */
+extern bool CheckWaitLockModeConflictHoldMask(LOCKTAG tag, LOCKMODE waitLockMode, LOCKMASK holderMask);
 #endif   /* LOCK_H */

--- a/src/test/isolation2/expected/gdd/non-lock-108.out
+++ b/src/test/isolation2/expected/gdd/non-lock-108.out
@@ -1,0 +1,50 @@
+DROP TABLE IF EXISTS t108;
+DROP
+CREATE TABLE t108 (id int, val int);
+CREATE
+INSERT INTO t108 (id, val) SELECT i, i FROM generate_series(1, 100) i;
+INSERT 100
+
+10: BEGIN;
+BEGIN
+20: BEGIN;
+BEGIN
+30: BEGIN;
+BEGIN
+
+10: INSERT INTO t108 VALUES(segid(1,1),segid(1,1));
+INSERT 1
+
+20: INSERT INTO t108 VALUES(segid(1,1),segid(1,1));
+INSERT 1
+
+30: INSERT INTO t108 VALUES(segid(1,1),segid(1,1));
+INSERT 1
+
+-- ANALYZE holds ShareUpdateExclusiveLock, they conflict with each other.
+-- But they are not conflict with INSERT, So GDD graph on seg1 should be
+-- 20 -> 10 and 30 -> 10 and no cycle in this case.
+10: ANALYZE t108;
+ANALYZE
+
+20&: ANALYZE t108;  <waiting ...>
+
+30&: ANALYZE t108;  <waiting ...>
+
+SELECT pg_sleep(20);
+ pg_sleep 
+----------
+          
+(1 row)
+
+-- con10/20/30 should finish normally.
+10q: ... <quitting>
+
+20<:  <... completed>
+ANALYZE
+20q: ... <quitting>
+
+30<:  <... completed>
+ANALYZE
+30q: ... <quitting>
+

--- a/src/test/isolation2/sql/gdd/non-lock-108.sql
+++ b/src/test/isolation2/sql/gdd/non-lock-108.sql
@@ -1,0 +1,34 @@
+DROP TABLE IF EXISTS t108;
+CREATE TABLE t108 (id int, val int);
+INSERT INTO t108 (id, val) SELECT i, i FROM generate_series(1, 100) i;
+
+10: BEGIN;
+20: BEGIN;
+30: BEGIN;
+
+10: INSERT INTO t108 VALUES(segid(1,1),segid(1,1));
+
+20: INSERT INTO t108 VALUES(segid(1,1),segid(1,1));
+
+30: INSERT INTO t108 VALUES(segid(1,1),segid(1,1));
+
+-- ANALYZE holds ShareUpdateExclusiveLock, they conflict with each other.
+-- But they are not conflict with INSERT, So GDD graph on seg1 should be
+-- 20 -> 10 and 30 -> 10 and no cycle in this case.
+10: ANALYZE t108;
+
+20&: ANALYZE t108;
+
+30&: ANALYZE t108;
+
+SELECT pg_sleep(20);
+
+-- con10/20/30 should finish normally.
+10q:
+
+20<:
+20q:
+
+30<:
+30q:
+


### PR DESCRIPTION
When determine waiting relation in global dead lock detector,
we should also check whether the waiter's lockmode conflict with
holder's holdmask.

Co-authored-by: Ning Yu <nyu@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
