### PR TITLE
Refactor GetSnapshotData

### DIFF
--- a/src/backend/access/transam/gp_distributed_log.c
+++ b/src/backend/access/transam/gp_distributed_log.c
@@ -17,6 +17,7 @@
 #include "access/distributedlog.h"
 #include "access/transam.h"
 #include "cdb/cdbvars.h"                /* GpIdentity.segindex */
+#include "cdb/cdbtm.h"
 
 Datum		gp_distributed_log(PG_FUNCTION_ARGS);
 
@@ -119,11 +120,7 @@ gp_distributed_log(PG_FUNCTION_ARGS)
 			values[1] = Int16GetDatum((int16)GpIdentity.dbid);
 			values[2] = TransactionIdGetDatum(distribXid);
 
-			sprintf(distribId, "%u-%.10u",
-					distribTimeStamp, distribXid);
-		
-			Assert(strlen(distribId) < TMGIDSIZE);
-
+			dtxFormGID(distribId, distribTimeStamp, distribXid);
 			values[3] = CStringGetTextDatum(distribId);
 
 			/*

--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -21,6 +21,7 @@
 #include "cdb/cdbvars.h"
 #include "utils/guc.h"
 #include "utils/snapmgr.h"
+#include "storage/procarray.h"
 
 /*
  * DistributedSnapshotWithLocalMapping_CommittedTest
@@ -55,7 +56,7 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 	 * through our cache in distributed snapshot looking for a possible
 	 * corresponding local xid only if it has value in checking.
 	 */
-	if (dslm->currentLocalXidsCount)
+	if (dslm->currentLocalXidsCount > 0)
 	{
 		Assert(TransactionIdIsNormal(dslm->minCachedLocalXid));
 		Assert(TransactionIdIsNormal(dslm->maxCachedLocalXid));
@@ -196,10 +197,9 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 			 * the distributed committed log in a subsequent check. We can
 			 * only record local xids till cache size permits.
 			 */
-			if (dslm->currentLocalXidsCount < dslm->maxLocalXidsCount)
+			if (dslm->currentLocalXidsCount < ds->count)
 			{
 				Assert(dslm->inProgressMappedLocalXids != NULL);
-
 				dslm->inProgressMappedLocalXids[dslm->currentLocalXidsCount++] =
 					localXid;
 
@@ -248,15 +248,22 @@ DistributedSnapshot_Reset(DistributedSnapshot *distributedSnapshot)
 	distributedSnapshot->xmin = InvalidDistributedTransactionId;
 	distributedSnapshot->xmax = InvalidDistributedTransactionId;
 	distributedSnapshot->count = 0;
-
-	/* maxCount and inProgressXidArray left untouched */
-	if (distributedSnapshot->maxCount < 0)
-		elog(ERROR, "cannot reset a copied distributed snapshot");
+	if (distributedSnapshot->inProgressXidArray == NULL)
+	{
+		distributedSnapshot->inProgressXidArray =
+			(DistributedTransactionId*) malloc(GetMaxSnapshotXidCount() * sizeof(DistributedTransactionId));
+		if (distributedSnapshot->inProgressXidArray == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_OUT_OF_MEMORY),
+					 errmsg("out of memory")));
+	}
 }
 
 /*
  * Make a copy of a DistributedSnapshot, allocating memory for the in-progress
  * array if necessary.
+ *
+ * Note: 'target' should be from a static variable, like the argument of GetSnapshotData()
  */
 void
 DistributedSnapshot_Copy(DistributedSnapshot *target,
@@ -264,61 +271,40 @@ DistributedSnapshot_Copy(DistributedSnapshot *target,
 {
 	DistributedSnapshot_Reset(target);
 
+	Assert(source->xminAllDistributedSnapshots);
+	Assert(source->xminAllDistributedSnapshots <= source->xmin);
+
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedSnapshot_Copy target maxCount %d, inProgressXidArray %p, and "
-		 "source maxCount %d, count %d, inProgressXidArray %p",
-		 target->maxCount,
+		 "DistributedSnapshot_Copy target inProgressXidArray %p, and "
+		 "source count %d, inProgressXidArray %p",
 		 target->inProgressXidArray,
-		 source->maxCount,
 		 source->count,
 		 source->inProgressXidArray);
-
-	/*
-	 * If we have allocated space for the in-progress distributed
-	 * transactions, check against that space.  Otherwise, use the source
-	 * maxCount as guide in allocating space.
-	 */
-	if (target->inProgressXidArray)
-	{
-		if (target->maxCount < source->count)
-		{
-			free(target->inProgressXidArray);
-			target->maxCount = 0;
-			target->inProgressXidArray = NULL;
-		}
-	}
-
-	/*
-	 * Allocate the XID array if necessary. Make it large enough to hold
-	 * the snapshot we're copying, plus a little headroom to make it more
-	 * likely that the space can be reused on next call.
-	 */
-	if (target->inProgressXidArray == NULL)
-	{
-#define EXTRA_XID_ARRAY_HEADROOM 10
-		int			maxCount = source->count + EXTRA_XID_ARRAY_HEADROOM;
-
-		target->inProgressXidArray =
-			(DistributedTransactionId *)
-			malloc(maxCount * sizeof(DistributedTransactionId));
-		if (target->inProgressXidArray == NULL)
-			ereport(ERROR,
-					(errcode(ERRCODE_OUT_OF_MEMORY),
-					 errmsg("out of memory")));
-		target->maxCount = maxCount;
-	}
 
 	target->distribTransactionTimeStamp = source->distribTransactionTimeStamp;
 	target->xminAllDistributedSnapshots = source->xminAllDistributedSnapshots;
 	target->distribSnapshotId = source->distribSnapshotId;
-
 	target->xmin = source->xmin;
 	target->xmax = source->xmax;
 	target->count = source->count;
 
+	if (source->count == 0)
+		return;
+
+	if (target->inProgressXidArray == NULL)
+	{
+		target->inProgressXidArray =
+			(DistributedTransactionId*) malloc(GetMaxSnapshotXidCount() * sizeof(DistributedTransactionId));
+		if (target->inProgressXidArray == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_OUT_OF_MEMORY),
+					 errmsg("out of memory")));
+	}
+
+	Assert(source->count <= GetMaxSnapshotXidCount());
 	memcpy(target->inProgressXidArray,
-		   source->inProgressXidArray,
-		   source->count * sizeof(DistributedTransactionId));
+			source->inProgressXidArray,
+			source->count * sizeof(DistributedTransactionId));
 }
 
 int
@@ -364,7 +350,6 @@ int
 DistributedSnapshot_Deserialize(const char *buf, DistributedSnapshot *ds)
 {
 	const char *p = buf;
-	int32		count;
 
 	memcpy(&ds->distribTransactionTimeStamp, p, sizeof(DistributedTransactionTimeStamp));
 	p += sizeof(DistributedTransactionTimeStamp);
@@ -376,53 +361,27 @@ DistributedSnapshot_Deserialize(const char *buf, DistributedSnapshot *ds)
 	p += sizeof(DistributedTransactionId);
 	memcpy(&ds->xmax, p, sizeof(DistributedTransactionId));
 	p += sizeof(DistributedTransactionId);
-	memcpy(&count, p, sizeof(int32));
+	memcpy(&ds->count, p, sizeof(int32));
 	p += sizeof(int32);
 
-	/*
-	 * If we have allocated space for the in-progress distributed
-	 * transactions, check against that space.  Otherwise, use the received
-	 * maxCount as guide in allocating space.
-	 */
-	if (ds->inProgressXidArray)
+	if (ds->count > 0)
 	{
-		if (ds->maxCount <= 0)
-			elog(ERROR, "Bad allocation of in-progress array");
+		int xipsize = sizeof(DistributedTransactionId) * ds->count;
 
-		if (ds->maxCount < count)
-		{
-			free(ds->inProgressXidArray);
-			ds->maxCount = 0;
-			ds->inProgressXidArray = NULL;
-		}
-	}
-
-	if (ds->inProgressXidArray == NULL)
-	{
-		int			maxCount = count + 10;
-
-		ds->inProgressXidArray = (DistributedTransactionId *)
-			malloc(maxCount * sizeof(DistributedTransactionId));
 		if (ds->inProgressXidArray == NULL)
-			ereport(ERROR,
-					(errcode(ERRCODE_OUT_OF_MEMORY),
-					 errmsg("out of memory")));
-		ds->maxCount = maxCount;
-	}
+		{
+			ds->inProgressXidArray =
+				(DistributedTransactionId *)malloc(sizeof(DistributedTransactionId) * GetMaxSnapshotXidCount());
+			if (ds->inProgressXidArray == NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_OUT_OF_MEMORY),
+						 errmsg("out of memory")));
+		}
 
-	if (count > 0)
-	{
-		int			xipsize;
-
-		Assert(ds->inProgressXidArray != NULL);
-
-		xipsize = sizeof(DistributedTransactionId) * count;
 		memcpy(ds->inProgressXidArray, p, xipsize);
 		p += xipsize;
 	}
-	ds->count = count;
 
 	Assert((p - buf) == DistributedSnapshot_SerializeSize(ds));
-
 	return (p - buf);
 }

--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -65,8 +65,6 @@ DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo,
 		}
 
 		dtxContextInfo->distributedTimeStamp = getDtxStartTime();
-
-		getDistributedTransactionIdentifier(dtxContextInfo->distributedId);
 		dtxContextInfo->curcid = curcid;
 	}
 	else
@@ -184,11 +182,6 @@ DtxContextInfo_Serialize(char *buffer, DtxContextInfo *dtxContextInfo)
 	{
 		memcpy(p, &dtxContextInfo->distributedTimeStamp, sizeof(DistributedTransactionTimeStamp));
 		p += sizeof(DistributedTransactionTimeStamp);
-		if (strlen(dtxContextInfo->distributedId) >= TMGIDSIZE)
-			elog(PANIC, "Distribute transaction identifier too long (%d)",
-				 (int) strlen(dtxContextInfo->distributedId));
-		memcpy(p, dtxContextInfo->distributedId, TMGIDSIZE);
-		p += TMGIDSIZE;
 		memcpy(p, &dtxContextInfo->curcid, sizeof(CommandId));
 		p += sizeof(CommandId);
 	}
@@ -266,8 +259,6 @@ DtxContextInfo_Reset(DtxContextInfo *dtxContextInfo)
 {
 	dtxContextInfo->distributedTimeStamp = 0;
 	dtxContextInfo->distributedXid = InvalidDistributedTransactionId;
-	memcpy(dtxContextInfo->distributedId, TmGid_Init, TMGIDSIZE);
-	Assert(strlen(dtxContextInfo->distributedId) < TMGIDSIZE);
 
 	dtxContextInfo->curcid = 0;
 	dtxContextInfo->segmateSync = 0;
@@ -289,12 +280,6 @@ DtxContextInfo_Copy(
 
 	target->distributedTimeStamp = source->distributedTimeStamp;
 	target->distributedXid = source->distributedXid;
-	Assert(strlen(source->distributedId) < TMGIDSIZE);
-	memcpy(
-		   target->distributedId,
-		   source->distributedId,
-		   TMGIDSIZE);
-
 	target->segmateSync = source->segmateSync;
 	target->nestingLevel = source->nestingLevel;
 
@@ -310,11 +295,10 @@ DtxContextInfo_Copy(
 	target->distributedTxnOptions = source->distributedTxnOptions;
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DtxContextInfo_Copy distributed {timestamp %u, xid %u}, id = %s, "
+		 "DtxContextInfo_Copy distributed {timestamp %u, xid %u}, "
 		 "command id %d",
 		 target->distributedTimeStamp,
 		 target->distributedXid,
-		 target->distributedId,
 		 target->curcid);
 
 	if (target->haveDistributedSnapshot)
@@ -355,11 +339,6 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 		{
 			memcpy(&dtxContextInfo->distributedTimeStamp, p, sizeof(DistributedTransactionTimeStamp));
 			p += sizeof(DistributedTransactionTimeStamp);
-			memcpy(dtxContextInfo->distributedId, p, TMGIDSIZE);
-			if (strlen(dtxContextInfo->distributedId) >= TMGIDSIZE)
-				elog(PANIC, "Distribute transaction identifier too long (%d)",
-					 (int) strlen(dtxContextInfo->distributedId));
-			p += TMGIDSIZE;
 			memcpy(&dtxContextInfo->curcid, p, sizeof(CommandId));
 			p += sizeof(CommandId);
 		}
@@ -401,11 +380,9 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 		if (DEBUG5 >= log_min_messages || Debug_print_full_dtm)
 		{
 			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "DtxContextInfo_Deserialize distributedTimeStamp %u, distributedXid = %u, "
-				 "distributedId = %s",
+				 "DtxContextInfo_Deserialize distributedTimeStamp %u, distributedXid = %u",
 				 dtxContextInfo->distributedTimeStamp,
-				 dtxContextInfo->distributedXid,
-				 dtxContextInfo->distributedId);
+				 dtxContextInfo->distributedXid);
 
 			if (dtxContextInfo->haveDistributedSnapshot)
 			{

--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -107,13 +107,12 @@ DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo,
 			 getDistributedTransactionId());
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
 			 "DtxContextInfo_CreateOnMaster distributedXid = %u, "
-			 "distributedSnapshotHeader (xminAllDistributedSnapshots %u, xmin = %u, xmax = %u, count = %d, maxCount %d)",
+			 "distributedSnapshotHeader (xminAllDistributedSnapshots %u, xmin = %u, xmax = %u, count = %d)",
 			 dtxContextInfo->distributedXid,
 			 ds->xminAllDistributedSnapshots,
 			 ds->xmin,
 			 ds->xmax,
-			 ds->count,
-			 ds->maxCount);
+			 ds->count);
 
 		for (i = 0; i < ds->count; i++)
 		{
@@ -230,12 +229,11 @@ DtxContextInfo_Serialize(char *buffer, DtxContextInfo *dtxContextInfo)
 		if (dtxContextInfo->haveDistributedSnapshot)
 		{
 			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "distributedSnapshotHeader (xminAllDistributedSnapshots %u, xmin = %u, xmax = %u, count = %d, maxCount = %d)",
+				 "distributedSnapshotHeader (xminAllDistributedSnapshots %u, xmin = %u, xmax = %u, count = %d)",
 				 ds->xminAllDistributedSnapshots,
 				 ds->xmin,
 				 ds->xmax,
-				 ds->count,
-				 ds->maxCount);
+				 ds->count);
 			for (i = 0; i < ds->count; i++)
 			{
 				elog((Debug_print_full_dtm ? LOG : DEBUG5),
@@ -387,12 +385,11 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 			if (dtxContextInfo->haveDistributedSnapshot)
 			{
 				elog((Debug_print_full_dtm ? LOG : DEBUG5),
-					 "distributedSnapshotHeader (xminAllDistributedSnapshots %u, xmin = %u, xmax = %u, count = %d, maxCount = %d)",
+					 "distributedSnapshotHeader (xminAllDistributedSnapshots %u, xmin = %u, xmax = %u, count = %d)",
 					 ds->xminAllDistributedSnapshots,
 					 ds->xmin,
 					 ds->xmax,
-					 ds->count,
-					 ds->maxCount);
+					 ds->count);
 
 				for (i = 0; i < ds->count; i++)
 				{

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -203,10 +203,8 @@ isQEContext()
 DistributedTransactionTimeStamp
 getDtxStartTime(void)
 {
-	if (shmDistribTimeStamp != NULL)
-		return *shmDistribTimeStamp;
-	else
-		return 0;
+	Assert(shmDistribTimeStamp != NULL);
+	return *shmDistribTimeStamp;
 }
 
 DistributedTransactionId
@@ -238,10 +236,7 @@ getDistributedTransactionIdentifier(char *id)
 			 * The length check here requires the identifer have a trailing
 			 * NUL character.
 			 */
-			sprintf(id, "%u-%.10u", *shmDistribTimeStamp, gxid);
-			if (strlen(id) >= TMGIDSIZE)
-				elog(PANIC, "distributed transaction identifier too long (%d)",
-					 (int) strlen(id));
+			dtxFormGID(id, getDtxStartTime(), gxid);
 			return true;
 		}
 	}
@@ -249,10 +244,7 @@ getDistributedTransactionIdentifier(char *id)
 	{
 		if (QEDtxContextInfo.distributedXid != InvalidDistributedTransactionId)
 		{
-			if (strlen(QEDtxContextInfo.distributedId) >= TMGIDSIZE)
-				elog(PANIC, "distributed transaction identifier too long (%d)",
-					 (int) strlen(QEDtxContextInfo.distributedId));
-			memcpy(id, QEDtxContextInfo.distributedId, TMGIDSIZE);
+			dtxFormGID(id, QEDtxContextInfo.distributedTimeStamp, QEDtxContextInfo.distributedXid);
 			return true;
 		}
 	}
@@ -280,9 +272,7 @@ getDtxLogInfo(TMGXACT_LOG *gxact_log)
 		elog(FATAL, "getDtxLogInfo found current distributed transaction is NULL");
 	}
 
-	if (strlen(currentGxact->gid) >= TMGIDSIZE)
-		elog(PANIC, "Distribute transaction identifier too long (%d)",
-			 (int) strlen(currentGxact->gid));
+	Assert(strlen(currentGxact->gid) < TMGIDSIZE);
 	memcpy(gxact_log->gid, currentGxact->gid, TMGIDSIZE);
 	gxact_log->gxid = currentGxact->gxid;
 }
@@ -482,9 +472,8 @@ doInsertForgetCommitted(void)
 
 	setCurrentGxactState(DTX_STATE_INSERTING_FORGET_COMMITTED);
 
-	if (strlen(currentGxact->gid) >= TMGIDSIZE)
-		elog(PANIC, "Distribute transaction identifier too long (%d)",
-			 (int) strlen(currentGxact->gid));
+	Assert(strlen(currentGxact->gid) < TMGIDSIZE);
+
 	memcpy(&gxact_log.gid, currentGxact->gid, TMGIDSIZE);
 	gxact_log.gxid = currentGxact->gxid;
 
@@ -546,10 +535,7 @@ doNotifyingCommitPrepared(void)
 
 	Assert(currentGxact->state == DTX_STATE_INSERTED_COMMITTED);
 	setCurrentGxactState(DTX_STATE_NOTIFYING_COMMIT_PREPARED);
-
-	if (strlen(currentGxact->gid) >= TMGIDSIZE)
-		elog(PANIC, "Distribute transaction identifier too long (%d)",
-			 (int) strlen(currentGxact->gid));
+	Assert(strlen(currentGxact->gid) < TMGIDSIZE);
 
 	SIMPLE_FAULT_INJECTOR(DtmBroadcastCommitPrepared);
 	savedInterruptHoldoffCount = InterruptHoldoffCount;
@@ -1377,12 +1363,7 @@ activeCurrentGxact(void)
 		Assert(gxid != InvalidDistributedTransactionId);
 	}
 
-	Assert(*shmDistribTimeStamp != 0);
-	sprintf(currentGxact->gid, "%u-%.10u", *shmDistribTimeStamp, gxid);
-	if (strlen(currentGxact->gid) >= TMGIDSIZE)
-		elog(PANIC, "Distribute transaction identifier too long (%d)",
-				(int) strlen(currentGxact->gid));
-
+	dtxFormGID(currentGxact->gid, getDtxStartTime(), gxid);
 	setCurrentGxactState(DTX_STATE_ACTIVE_DISTRIBUTED);
 
 	currentGxact->gxid = gxid;

--- a/src/backend/cdb/cdbtmutils.c
+++ b/src/backend/cdb/cdbtmutils.c
@@ -39,6 +39,14 @@ dtxCrackOpenGid(
 		elog(ERROR, "Bad distributed transaction identifier \"%s\"", gid);
 }
 
+void
+dtxFormGID(char *gid, DistributedTransactionTimeStamp tstamp, DistributedTransactionId gxid)
+{
+	sprintf(gid, "%u-%.10u", tstamp, gxid);
+	/* gxid is unsigned int32 and its max string length is 10 */
+	Assert(strlen(gid) < TMGIDSIZE);
+}
+
 char *
 DtxStateToString(DtxState state)
 {

--- a/src/backend/cdb/test/cdbdistributedsnapshot_test.c
+++ b/src/backend/cdb/test/cdbdistributedsnapshot_test.c
@@ -26,11 +26,9 @@ test__DistributedSnapshotWithLocalMapping_CommittedTest(void **state)
 
 		dslm.inProgressMappedLocalXids =
 			(TransactionId*)malloc(5 * sizeof(TransactionId));
-		dslm.maxLocalXidsCount = 5;
 
 		ds->inProgressXidArray =
 			(DistributedTransactionId*)malloc(SIZE_OF_IN_PROGRESS_ARRAY);
-		ds->maxCount = 10;
 		ds->distribSnapshotId = 12345;
 		ds->distribTransactionTimeStamp = timeStamp;
 	}

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1971,16 +1971,6 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 		globalXminDistributedSnapshots = xmin;
 
 	/*
-	 * Sort the entry {distribXid} to support the QEs doing culls on their
-	 * DisribToLocalXact sorted lists.
-	 */
-	qsort(
-		  ds->inProgressXidArray,
-		  count,
-		  sizeof(DistributedTransactionId),
-		  DistributedSnapshotMappedEntry_Compare);
-
-	/*
 	 * Copy the information we just captured under lock and then sorted into
 	 * the distributed snapshot.
 	 */
@@ -2444,6 +2434,16 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	snapshot->active_count = 0;
 	snapshot->regd_count = 0;
 	snapshot->copied = false;
+
+	/*
+	 * Sort the entry {distribXid} to support the QEs doing culls on their
+	 * DisribToLocalXact sorted lists.
+	 */
+	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE &&
+		snapshot->haveDistribSnapshot &&
+		ds->count > 1)
+		qsort(ds->inProgressXidArray, ds->count,
+			  sizeof(DistributedTransactionId), DistributedSnapshotMappedEntry_Compare);
 
 	/*
 	 * MPP Addition. If we are the chief then we'll save our local snapshot

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1485,7 +1485,7 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 	/* combocid stuff */
 	combocidSize = ((usedComboCids < MaxComboCids) ? usedComboCids : MaxComboCids );
 
-	SharedLocalSnapshotSlot->combocidcnt = combocidSize;	
+	SharedLocalSnapshotSlot->combocidcnt = combocidSize;
 	memcpy((void *)SharedLocalSnapshotSlot->combocids, comboCids,
 		   combocidSize * sizeof(ComboCidKeyData));
 
@@ -1499,7 +1499,7 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 	
 	SharedLocalSnapshotSlot->QDcid = dtxContextInfo->curcid;
 	SharedLocalSnapshotSlot->QDxid = dtxContextInfo->distributedXid;
-		
+
 	SharedLocalSnapshotSlot->ready = true;
 
 	SharedLocalSnapshotSlot->segmateSync = dtxContextInfo->segmateSync;
@@ -1527,140 +1527,197 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 	LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 }
 
-static int
-GetDistributedSnapshotMaxCount(DtxContext distributedTransactionContext)
+static void
+SnapshotResetDslm(Snapshot snapshot)
 {
-	switch (distributedTransactionContext)
+	DistributedSnapshotWithLocalMapping *dslm;
+
+	snapshot->haveDistribSnapshot = false;
+
+	dslm = &snapshot->distribSnapshotWithLocalMapping;
+	dslm->currentLocalXidsCount = 0;
+	dslm->minCachedLocalXid = InvalidTransactionId;
+	dslm->maxCachedLocalXid = InvalidTransactionId;
+	if (dslm->inProgressMappedLocalXids == NULL)
 	{
-	case DTX_CONTEXT_LOCAL_ONLY:
-	case DTX_CONTEXT_QD_RETRY_PHASE_2:
-	case DTX_CONTEXT_QE_FINISH_PREPARED:
-		return 0;
-
-	case DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE:
-		return max_prepared_xacts;
-
-	case DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER:
-	case DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER:
-	case DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT:
-	case DTX_CONTEXT_QE_ENTRY_DB_SINGLETON:
-	case DTX_CONTEXT_QE_READER:
-		if (QEDtxContextInfo.distributedSnapshot.distribSnapshotId != 0)
-			return QEDtxContextInfo.distributedSnapshot.maxCount;
-		else
-			return max_prepared_xacts;		/* UNDONE: For now? */
-	
-	case DTX_CONTEXT_QE_PREPARED:
-		elog(FATAL, "Unexpected segment distribute transaction context: '%s'",
-			 DtxContextToString(distributedTransactionContext));
-		break;
-	
-	default:
-		elog(FATAL, "Unrecognized DTX transaction context: %d",
-			(int) distributedTransactionContext);
-		break;
+		dslm->inProgressMappedLocalXids =
+			(TransactionId*) malloc(GetMaxSnapshotXidCount() * sizeof(TransactionId));
+		if (dslm->inProgressMappedLocalXids == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_OUT_OF_MEMORY),
+					 errmsg("out of memory")));
 	}
 
-	return 0;
+	DistributedSnapshot_Reset(&dslm->ds);
 }
 
-/*
- * Fill in the array of in-progress distributed XIDS in 'snapshot' from the
- * information that the QE sent us (if any).
- */
 static void
-FillInDistributedSnapshot(Snapshot snapshot, DtxContext distributedTransactionContext)
+copyLocalSnapshot(Snapshot snapshot)
 {
-	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("FillInDistributedSnapshot DTX Context = '%s'",
-					DtxContextToString(distributedTransactionContext))));
+	/*
+	 * YAY we found it.  set the contents of the
+	 * SharedLocalSnapshot to this and move on.
+	 */
+	snapshot->xmin = SharedLocalSnapshotSlot->snapshot.xmin;
+	snapshot->xmax = SharedLocalSnapshotSlot->snapshot.xmax;
+	snapshot->xcnt = SharedLocalSnapshotSlot->snapshot.xcnt;
 
-	switch (distributedTransactionContext)
+	/* We now capture our current view of the xip/combocid arrays */
+	memcpy(snapshot->xip, SharedLocalSnapshotSlot->snapshot.xip, snapshot->xcnt * sizeof(TransactionId));
+
+	snapshot->curcid = SharedLocalSnapshotSlot->snapshot.curcid;
+	snapshot->subxcnt = -1;
+
+	/* combocid */
+	usedComboCids = SharedLocalSnapshotSlot->combocidcnt;
+	Assert(usedComboCids <= MaxComboCids);
+	if (usedComboCids > 0)
 	{
-	case DTX_CONTEXT_LOCAL_ONLY:
-	case DTX_CONTEXT_QD_RETRY_PHASE_2:
-	case DTX_CONTEXT_QE_FINISH_PREPARED:
-		/*
-		 * No distributed snapshot.
-		 */
-		snapshot->haveDistribSnapshot = false;
-		snapshot->distribSnapshotWithLocalMapping.ds.count = 0;
-		break;
+		if (comboCids == NULL)
+			comboCids = MemoryContextAlloc(TopTransactionContext, MaxComboCids * sizeof(ComboCidKeyData));
 
-	case DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE:
-		/*
-		 * GetSnapshotData() should've acquired the distributed snapshot
-		 * while holding ProcArrayLock, not here.
-		 */
-		elog(ERROR, "FillInDistributedSnapshot called in context '%s'",
-			 DtxContextToString(distributedTransactionContext));
-		break;
-
-	case DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER:
-	case DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER:
-	case DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT:
-	case DTX_CONTEXT_QE_ENTRY_DB_SINGLETON:
-	case DTX_CONTEXT_QE_READER:
-		/*
-		 * Copy distributed snapshot from the one sent by the QD.
-		 */
-		{
-			DistributedSnapshot *ds = &QEDtxContextInfo.distributedSnapshot;
-
-			if (ds->distribSnapshotId != 0)
-			{
-				snapshot->haveDistribSnapshot = true;
-
-				Assert(ds->xminAllDistributedSnapshots);
-				Assert(ds->xminAllDistributedSnapshots <= ds->xmin);
-
-				DistributedSnapshot_Copy(&snapshot->distribSnapshotWithLocalMapping.ds, ds);
-			}
-			else
-			{
-				snapshot->haveDistribSnapshot = false;
-				snapshot->distribSnapshotWithLocalMapping.ds.count = 0;
-			}
-		}
-		break;
-
-	case DTX_CONTEXT_QE_PREPARED:
-		elog(FATAL, "Unexpected segment distribute transaction context: '%s'",
-			 DtxContextToString(distributedTransactionContext));
-		break;
-
-	default:
-		elog(FATAL, "Unrecognized DTX transaction context: %d",
-			(int) distributedTransactionContext);
-		break;
+		memcpy(comboCids, (char *)SharedLocalSnapshotSlot->combocids, usedComboCids * sizeof(ComboCidKeyData));
 	}
+
+	if (TransactionIdPrecedes(snapshot->xmin, TransactionXmin))
+		TransactionXmin = snapshot->xmin;
+
+	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+			(errmsg("Reader qExec setting shared local snapshot to: xmin: %d xmax: %d curcid: %d",
+					snapshot->xmin, snapshot->xmax, snapshot->curcid)));
+
+	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+			(errmsg("GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
+					GetCurrentCommandId(false), snapshot->curcid, SharedLocalSnapshotSlot->segmateSync)));
+}
+
+static void
+readerFillLocalSnapshot(Snapshot snapshot, DtxContext distributedTransactionContext)
+{
+	/* We must be a reader. */
+	Assert(distributedTransactionContext == DTX_CONTEXT_QE_READER ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON);
+
+	uint64 segmate_timeout_us = (3 * (uint64)Max(interconnect_setup_timeout, 1) * 1000* 1000) / 4;;
+	uint64 sleep_per_check_us = 1 * 1000;
+	uint64 total_sleep_time_us = 0;
+	uint64 warning_sleep_time_us = 0;
 
 	/*
-	 * Nice that we may have collected it, but turn it off...
+	 * If we're a cursor-reader, we get out snapshot from the
+	 * writer via a tempfile in the filesystem. Otherwise it is
+	 * too easy for the writer to race ahead of cursor readers.
 	 */
-	if (Debug_disable_distributed_snapshot)
-		snapshot->haveDistribSnapshot = false;
-}
+	if (QEDtxContextInfo.cursorContext)
+	{
+		readSharedLocalSnapshot_forCursor(snapshot, distributedTransactionContext);
+		return;
+	}
 
-/*
- * QEDtxContextInfo and SharedLocalSnapshotSlot are both global.
- */
-static bool
-QEwriterSnapshotUpToDate(void)
-{
-	Assert(!Gp_is_writer);
+	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+			(errmsg("[Distributed Snapshot #%u] *Start Reader Match* gxid = %u and currcid %d (%s)",
+					QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+					QEDtxContextInfo.distributedXid,
+					QEDtxContextInfo.curcid,
+					DtxContextToString(distributedTransactionContext))));
 
-	if (SharedLocalSnapshotSlot == NULL)
-		elog(ERROR, "SharedLocalSnapshotSlot is NULL");
+	/*
+	 * This is the second phase of the handshake we started in
+	 * StartTransaction().  Here we get a "good" snapshot from our
+	 * writer. In the process it is possible that we will change
+	 * our transaction's xid (see phase-one in StartTransaction()).
+	 *
+	 * Here we depend on the absolute correctness of our
+	 * writer-gang's info. We need the segmateSync to match *as
+	 * well* as the distributed-xid since the QD may send multiple
+	 * statements with the same distributed-xid/cid but
+	 * *different* local-xids (MPP-3228). The dispatcher will
+	 * distinguish such statements by the segmateSync.
+	 *
+	 * I believe that we still want the older sync mechanism ("ready" flag).
+	 * since it tells the code in TransactionIdIsCurrentTransactionId() that the
+	 * writer may be changing the local-xid (otherwise it would be possible for
+	 * cursor reader gangs to get confused).
+	 */
+	for (;;)
+	{
+		LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
 
-	LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
-	bool result = QEDtxContextInfo.distributedXid == SharedLocalSnapshotSlot->QDxid &&
-		QEDtxContextInfo.curcid == SharedLocalSnapshotSlot->QDcid &&
-		QEDtxContextInfo.segmateSync == SharedLocalSnapshotSlot->segmateSync &&
-		SharedLocalSnapshotSlot->ready;
-	LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+		if (QEDtxContextInfo.distributedXid == SharedLocalSnapshotSlot->QDxid &&
+			QEDtxContextInfo.curcid == SharedLocalSnapshotSlot->QDcid &&
+			QEDtxContextInfo.segmateSync == SharedLocalSnapshotSlot->segmateSync &&
+			SharedLocalSnapshotSlot->ready)
+		{
+			copyLocalSnapshot(snapshot);
+			SetSharedTransactionId_reader(SharedLocalSnapshotSlot->xid, snapshot->curcid, distributedTransactionContext);
+			LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+			return;
+		}
 
-	return result;
+		if (total_sleep_time_us >= segmate_timeout_us)
+		{
+			LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+					 errmsg("GetSnapshotData timed out waiting for Writer to set the shared snapshot."),
+					 errdetail("We are waiting for the shared snapshot to have XID: %d but the value "
+							   "is currently: %d."
+							   " waiting for cid to be %d but is currently %d.  ready=%d."
+							   "DistributedTransactionContext = %s. "
+							   " Our slotindex is: %d \n"
+							   "Dump of all sharedsnapshots in shmem: %s",
+							   QEDtxContextInfo.distributedXid, SharedLocalSnapshotSlot->QDxid,
+							   QEDtxContextInfo.curcid,
+							   SharedLocalSnapshotSlot->QDcid, SharedLocalSnapshotSlot->ready,
+							   DtxContextToString(distributedTransactionContext),
+							   SharedLocalSnapshotSlot->slotindex, SharedSnapshotDump())));
+		}
+
+		if (warning_sleep_time_us > 1000 * 1000)
+		{
+			/*
+			 * Every second issue warning.
+			 */
+			ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+					(errmsg("[Distributed Snapshot #%u] *No Match* gxid %u = %u and currcid %d = %d (%s)",
+							QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+							QEDtxContextInfo.distributedXid,
+							SharedLocalSnapshotSlot->QDxid,
+							QEDtxContextInfo.curcid,
+							SharedLocalSnapshotSlot->QDcid,
+							DtxContextToString(distributedTransactionContext))));
+
+			ereport(LOG,
+					(errmsg("GetSnapshotData did not find shared local snapshot information. "
+							"We are waiting for the shared snapshot to have XID: %d/%u but the value "
+							"is currently: %d/%u."
+							" waiting for cid to be %d but is currently %d.  ready=%d."
+							" Our slotindex is: %d \n"
+							"DistributedTransactionContext = %s.",
+							QEDtxContextInfo.distributedXid, QEDtxContextInfo.segmateSync,
+							SharedLocalSnapshotSlot->QDxid, SharedLocalSnapshotSlot->segmateSync,
+							QEDtxContextInfo.curcid,
+							SharedLocalSnapshotSlot->QDcid,
+							SharedLocalSnapshotSlot->ready,
+							SharedLocalSnapshotSlot->slotindex,
+							DtxContextToString(distributedTransactionContext))));
+			warning_sleep_time_us = 0;
+		}
+
+		LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+		/* UNDONE: Back-off from checking every millisecond... */
+
+		/*
+		 * didn't find it. we'll sleep for a small amount of time and
+		 * then try again.
+		 */
+		pg_usleep(sleep_per_check_us);
+
+		CHECK_FOR_INTERRUPTS();
+
+		warning_sleep_time_us += sleep_per_check_us;
+		total_sleep_time_us += sleep_per_check_us;
+	}
 }
 
 void
@@ -1832,7 +1889,7 @@ DistributedSnapshotMappedEntry_Compare(const void *p1, const void *p2)
  * create distributed snapshot based on current visible distributed transaction
  */
 static bool
-CreateDistributedSnapshot(DistributedSnapshot *ds, DtxContext distributedTransactionContext)
+CreateDistributedSnapshot(DistributedSnapshot *ds)
 {
 	int			i;
 	int			count;
@@ -1896,9 +1953,6 @@ CreateDistributedSnapshot(DistributedSnapshot *ds, DtxContext distributedTransac
 		if (gxact_candidate == MyTmGxact)
 			continue;
 
-		if (count >= ds->maxCount)
-			elog(ERROR, "Too many distributed transactions for snapshot");
-
 		ds->inProgressXidArray[count++] = gxid;
 
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
@@ -1944,10 +1998,9 @@ CreateDistributedSnapshot(DistributedSnapshot *ds, DtxContext distributedTransac
 		 "CreateDistributedSnapshot distributed snapshot has xmin = %u, count = %u, xmax = %u.",
 		 xmin, count, xmax);
 	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-		 "[Distributed Snapshot #%u] *Create* (gxid = %u, '%s')",
+		 "[Distributed Snapshot #%u] *Create* (gxid = %u')",
 		 distribSnapshotId,
-		 MyTmGxact->gxid,
-		 DtxContextToString(distributedTransactionContext));
+		 MyTmGxact->gxid);
 
 	return true;
 }
@@ -2024,6 +2077,7 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	volatile TransactionId replication_slot_catalog_xmin = InvalidTransactionId;
 
 	Assert(snapshot != NULL);
+	DistributedSnapshot *ds = &snapshot->distribSnapshotWithLocalMapping.ds;
 
 	/*
 	 * Support for true serializable isolation is not yet implemented in
@@ -2071,253 +2125,38 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	/*
 	 * GP: Distributed snapshot.
 	 */
-	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("GetSnapshotData maxCount %d, inProgressEntryArray %p",
-					snapshot->distribSnapshotWithLocalMapping.ds.maxCount,
-					snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray)));
+	Assert(distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON ||
+		   distributedTransactionContext == DTX_CONTEXT_LOCAL_ONLY ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_FINISH_PREPARED ||
+		   distributedTransactionContext == DTX_CONTEXT_QE_READER);
 
-	if (snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray == NULL)
+	SnapshotResetDslm(snapshot);
+
+	/* executor copy distributed snapshot from QEDtxContextInfo */
+	if ((distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER ||
+		 distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
+		 distributedTransactionContext == DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT ||
+		 distributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON ||
+		 distributedTransactionContext == DTX_CONTEXT_QE_READER) &&
+		QEDtxContextInfo.haveDistributedSnapshot &&
+		!Debug_disable_distributed_snapshot)
 	{
-		int maxCount = GetDistributedSnapshotMaxCount(distributedTransactionContext);
-		if (maxCount > 0)
-		{
-			snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray =
-				(DistributedTransactionId*)malloc(maxCount * sizeof(DistributedTransactionId));
-			if (snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray == NULL)
-				ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("out of memory")));
-
-			snapshot->distribSnapshotWithLocalMapping.ds.maxCount = maxCount;
-
-			snapshot->distribSnapshotWithLocalMapping.currentLocalXidsCount = 0;
-			snapshot->distribSnapshotWithLocalMapping.minCachedLocalXid = InvalidTransactionId;
-			snapshot->distribSnapshotWithLocalMapping.maxCachedLocalXid = InvalidTransactionId;
-
-			if (!IS_QUERY_DISPATCHER())
-			{
-				/*
-				 * Allocate memory for local xid cache, currently allocating it
-				 * same size as distributed, not necessary.
-				 */
-				snapshot->distribSnapshotWithLocalMapping.inProgressMappedLocalXids =
-					(TransactionId*)malloc(maxCount * sizeof(TransactionId));
-				if (snapshot->distribSnapshotWithLocalMapping.inProgressMappedLocalXids == NULL)
-					ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("out of memory")));
-
-				snapshot->distribSnapshotWithLocalMapping.maxLocalXidsCount = maxCount;
-			}
-			else
-				snapshot->distribSnapshotWithLocalMapping.maxLocalXidsCount = 0;
-		}
+		DistributedSnapshot_Copy(&snapshot->distribSnapshotWithLocalMapping.ds, &QEDtxContextInfo.distributedSnapshot);
+		snapshot->haveDistribSnapshot = true;
 	}
 
-	/*
-	 * MPP Addition. if we are in EXECUTE mode and not the writer... then we
-	 * want to just get the shared snapshot and make it our own.
-	 *
-	 * code for the writer is at the bottom of this function.
-	 *
-	 * NOTE: we could be dispatched and get here before the WRITER can set the
-	 * shared snapshot.  if this happens we'll have to wait around, hopefully
-	 * its never for a very long time.
-	 *
-	 */
-	if (distributedTransactionContext == DTX_CONTEXT_QE_READER ||
-		distributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON)
+	/* reader gang copy local snapshot from writer gang */
+	if (SharedLocalSnapshotSlot != NULL &&
+		(distributedTransactionContext == DTX_CONTEXT_QE_READER ||
+		 distributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON))
 	{
-		/* the pg_usleep() call below is in units of us (microseconds), interconnect
-		 * timeout is in seconds.  Start with 1 millisecond. */
-		uint64		segmate_timeout_us;
-		uint64		sleep_per_check_us = 1 * 1000;
-		uint64	   	total_sleep_time_us = 0;
-		uint64		warning_sleep_time_us = 0;
-
-		segmate_timeout_us = (3 * (uint64)Max(interconnect_setup_timeout, 1) * 1000* 1000) / 4;
-
-		/*
-		 * Make a copy of the distributed snapshot information; this
-		 * doesn't use the shared-snapshot-slot stuff it is just
-		 * making copies from the QEDtxContextInfo structure sent by
-		 * the QD.
-		 */
-		FillInDistributedSnapshot(snapshot, distributedTransactionContext);
-
-		/*
-		 * If we're a cursor-reader, we get out snapshot from the
-		 * writer via a tempfile in the filesystem. Otherwise it is
-		 * too easy for the writer to race ahead of cursor readers.
-		 */
-		if (QEDtxContextInfo.cursorContext)
-		{
-			readSharedLocalSnapshot_forCursor(
-				snapshot,
-				distributedTransactionContext);
-
-			return snapshot;
-		}
-
-		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-				(errmsg("[Distributed Snapshot #%u] *Start Reader Match* gxid = %u and currcid %d (%s)",
-						QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-						QEDtxContextInfo.distributedXid,
-						QEDtxContextInfo.curcid,
-						DtxContextToString(distributedTransactionContext))));
-
-		/*
-		 * This is the second phase of the handshake we started in
-		 * StartTransaction().  Here we get a "good" snapshot from our
-		 * writer. In the process it is possible that we will change
-		 * our transaction's xid (see phase-one in StartTransaction()).
-		 *
-		 * Here we depend on the absolute correctness of our
-		 * writer-gang's info. We need the segmateSync to match *as
-		 * well* as the distributed-xid since the QD may send multiple
-		 * statements with the same distributed-xid/cid but
-		 * *different* local-xids (MPP-3228). The dispatcher will
-		 * distinguish such statements by the segmateSync.
-		 *
-		 * I believe that we still want the older sync mechanism ("ready" flag).
-		 * since it tells the code in TransactionIdIsCurrentTransactionId() that the
-		 * writer may be changing the local-xid (otherwise it would be possible for
-		 * cursor reader gangs to get confused).
-		 */
-		for (;;)
-		{
-			if (QEwriterSnapshotUpToDate())
-			{
-				LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
-
-				/*
-				 * YAY we found it.  set the contents of the
-				 * SharedLocalSnapshot to this and move on.
-				 */
-				snapshot->xmin = SharedLocalSnapshotSlot->snapshot.xmin;
-				snapshot->xmax = SharedLocalSnapshotSlot->snapshot.xmax;
-				snapshot->xcnt = SharedLocalSnapshotSlot->snapshot.xcnt;
-
-				/* We now capture our current view of the xip/combocid arrays */
-				memcpy(snapshot->xip, SharedLocalSnapshotSlot->snapshot.xip, snapshot->xcnt * sizeof(TransactionId));
-				memset(snapshot->xip + snapshot->xcnt, 0, (arrayP->maxProcs - snapshot->xcnt) * sizeof(TransactionId));
-
-				snapshot->curcid = SharedLocalSnapshotSlot->snapshot.curcid;
-
-				snapshot->subxcnt = -1;
-
-				/* combocid */
-				if (usedComboCids != SharedLocalSnapshotSlot->combocidcnt)
-				{
-					if (usedComboCids == 0)
-					{
-						MemoryContext oldCtx =  MemoryContextSwitchTo(TopTransactionContext);
-						comboCids = palloc(SharedLocalSnapshotSlot->combocidcnt * sizeof(ComboCidKeyData));
-						MemoryContextSwitchTo(oldCtx);
-					}
-					else
-						repalloc(comboCids, SharedLocalSnapshotSlot->combocidcnt * sizeof(ComboCidKeyData));
-				}
-				memcpy(comboCids, (char *)SharedLocalSnapshotSlot->combocids, SharedLocalSnapshotSlot->combocidcnt * sizeof(ComboCidKeyData));
-				usedComboCids = ((SharedLocalSnapshotSlot->combocidcnt < MaxComboCids) ? SharedLocalSnapshotSlot->combocidcnt : MaxComboCids);
-
-				uint32 segmateSync = SharedLocalSnapshotSlot->segmateSync;
-				uint32 comboCidCnt = SharedLocalSnapshotSlot->combocidcnt;
-
-				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
-
-				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-						(errmsg("Reader qExec usedComboCids: %d shared %d segmateSync %d",
-								usedComboCids, comboCidCnt, segmateSync)));
-
-				SetSharedTransactionId_reader(SharedLocalSnapshotSlot->xid,
-											  SharedLocalSnapshotSlot->snapshot.curcid,
-											  distributedTransactionContext);
-
-				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-						(errmsg("Reader qExec setting shared local snapshot to: xmin: %d xmax: %d curcid: %d",
-								snapshot->xmin, snapshot->xmax, snapshot->curcid)));
-
-				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-						(errmsg("GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
-								GetCurrentCommandId(false), snapshot->curcid, segmateSync)));
-
-				if (TransactionIdPrecedes(snapshot->xmin, TransactionXmin))
-					TransactionXmin = snapshot->xmin;
-
-				return snapshot;
-			}
-			else
-			{
-				/*
-				 * didn't find it. we'll sleep for a small amount of time and
-				 * then try again.
-				 *
-				 * TODO: is there a semaphore or something better we can do here.
-				 */
-				pg_usleep(sleep_per_check_us);
-
-				CHECK_FOR_INTERRUPTS();
-
-				warning_sleep_time_us += sleep_per_check_us;
-				total_sleep_time_us += sleep_per_check_us;
-
-				LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
-
-				if (total_sleep_time_us >= segmate_timeout_us)
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-							 errmsg("GetSnapshotData timed out waiting for Writer to set the shared snapshot."),
-							 errdetail("We are waiting for the shared snapshot to have XID: %d but the value "
-									   "is currently: %d."
-									   " waiting for cid to be %d but is currently %d.  ready=%d."
-									   "DistributedTransactionContext = %s. "
-									   " Our slotindex is: %d \n"
-									   "Dump of all sharedsnapshots in shmem: %s",
-									   QEDtxContextInfo.distributedXid, SharedLocalSnapshotSlot->QDxid,
-									   QEDtxContextInfo.curcid,
-									   SharedLocalSnapshotSlot->QDcid, SharedLocalSnapshotSlot->ready,
-									   DtxContextToString(distributedTransactionContext),
-									   SharedLocalSnapshotSlot->slotindex, SharedSnapshotDump())));
-				}
-				else if (warning_sleep_time_us > 1000 * 1000)
-				{
-					/*
-					 * Every second issue warning.
-					 */
-					ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-							(errmsg("[Distributed Snapshot #%u] *No Match* gxid %u = %u and currcid %d = %d (%s)",
-									QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-									QEDtxContextInfo.distributedXid,
-									SharedLocalSnapshotSlot->QDxid,
-									QEDtxContextInfo.curcid,
-									SharedLocalSnapshotSlot->QDcid,
-									DtxContextToString(distributedTransactionContext))));
-
-
-					ereport(LOG,
-							(errmsg("GetSnapshotData did not find shared local snapshot information. "
-									"We are waiting for the shared snapshot to have XID: %d/%u but the value "
-									"is currently: %d/%u."
-									" waiting for cid to be %d but is currently %d.  ready=%d."
-									" Our slotindex is: %d \n"
-									"DistributedTransactionContext = %s.",
-									QEDtxContextInfo.distributedXid, QEDtxContextInfo.segmateSync,
-									SharedLocalSnapshotSlot->QDxid, SharedLocalSnapshotSlot->segmateSync,
-									QEDtxContextInfo.curcid,
-									SharedLocalSnapshotSlot->QDcid,
-									SharedLocalSnapshotSlot->ready,
-									SharedLocalSnapshotSlot->slotindex,
-									DtxContextToString(distributedTransactionContext))));
-					warning_sleep_time_us = 0;
-				}
-
-				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
-				/* UNDONE: Back-off from checking every millisecond... */
-			}
-		}
+		readerFillLocalSnapshot(snapshot, distributedTransactionContext);
+		return snapshot;
 	}
-
-	/* We must not be a reader. */
-	Assert(distributedTransactionContext != DTX_CONTEXT_QE_READER);
-	Assert(distributedTransactionContext != DTX_CONTEXT_QE_ENTRY_DB_SINGLETON);
 
 	/*
 	 * It is sufficient to get shared lock on ProcArrayLock, even if we are
@@ -2373,21 +2212,6 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	 * including distributed transactions in the local snapshot via their
 	 * local xids.
 	 */
-	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE)
-	{
-		snapshot->haveDistribSnapshot = CreateDistributedSnapshot(
-			&snapshot->distribSnapshotWithLocalMapping.ds,
-			distributedTransactionContext);
-
-		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-				(errmsg("Got distributed snapshot from DistributedSnapshotWithLocalXids_Create = %s",
-						(snapshot->haveDistribSnapshot ? "true" : "false"))));
-
-		/* Nice that we may have collected it, but turn it off... */
-		if (Debug_disable_distributed_snapshot)
-			snapshot->haveDistribSnapshot = false;
-	}
-
 	snapshot->takenDuringRecovery = RecoveryInProgress();
 
 	if (!snapshot->takenDuringRecovery)
@@ -2525,7 +2349,6 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 			suboverflowed = true;
 	}
 
-
 	/* fetch into volatile var while ProcArrayLock is held */
 	replication_slot_xmin = procArray->replication_slot_xmin;
 	replication_slot_catalog_xmin = procArray->replication_slot_catalog_xmin;
@@ -2545,6 +2368,16 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 						MyProc->databaseId, MyProc->pid, MyPgXact->xid, MyPgXact->xmin)));
 	}
 
+	/* GP: QD takes a distributed snapshot */
+	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && !Debug_disable_distributed_snapshot)
+	{
+		CreateDistributedSnapshot(ds);
+		snapshot->haveDistribSnapshot = true;
+
+		ereport(Debug_print_full_dtm ? LOG : DEBUG5,
+				(errmsg("Got distributed snapshot from CreateDistributedSnapshot")));
+	}
+
 	LWLockRelease(ProcArrayLock);
 
 	/*
@@ -2555,30 +2388,16 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	if (TransactionIdPrecedes(xmin, globalxmin))
 		globalxmin = xmin;
 
+	/*
+	 * GP: In computing RecentGlobalXmin, also take distributed snapshots into
+	 * account.
+	 */
 	if (!IS_QUERY_DISPATCHER())
 	{
-		/*
-		 * Fill in the distributed snapshot information we received from the
-		 * the QD.  Unless we are the QD, in which case we already created a
-		 * new distributed snapshot above.
-		 *
-		 * (We do this after releasing ProcArrayLock, to reduce contention.)
-		 */
-		FillInDistributedSnapshot(snapshot, distributedTransactionContext);
-
-		/*
-		 * In computing RecentGlobalXmin, also take distributed snapshots into
-		 * account.
-		 */
 		if (snapshot->haveDistribSnapshot)
-		{
-			DistributedSnapshot *ds = &snapshot->distribSnapshotWithLocalMapping.ds;
-
-			globalxmin =
-				DistributedLog_AdvanceOldestXmin(globalxmin,
-												 ds->distribTransactionTimeStamp,
-												 ds->xminAllDistributedSnapshots);
-		}
+			globalxmin = DistributedLog_AdvanceOldestXmin(globalxmin,
+														  ds->distribTransactionTimeStamp,
+														  ds->xminAllDistributedSnapshots);
 		else if (!gp_maintenance_mode)
 			globalxmin = DistributedLog_GetOldestXmin(globalxmin);
 	}
@@ -2631,17 +2450,12 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	 * into the shared snapshot. Note: we need to use the shared local
 	 * snapshot for the "Local Implicit using Distributed Snapshot" case, too.
 	 */
-	
-	if ((distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER ||
-		 distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
-		 distributedTransactionContext == DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT) &&
-		SharedLocalSnapshotSlot != NULL)
+	if (distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER ||
+		distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
+		distributedTransactionContext == DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT)
 	{
-		updateSharedLocalSnapshot(
-			&QEDtxContextInfo,
-			distributedTransactionContext,
-			snapshot,
-			"GetSnapshotData");
+		Assert(SharedLocalSnapshotSlot != NULL);
+		updateSharedLocalSnapshot(&QEDtxContextInfo, distributedTransactionContext, snapshot, "GetSnapshotData");
 	}
 
 	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
@@ -2650,6 +2464,8 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 
 	return snapshot;
 }
+
+
 
 /*
  * ProcArrayInstallImportedXmin -- install imported xmin into MyPgXact->xmin

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1693,9 +1693,7 @@ getAllDistributedXactStatus(TMGALLXACTSTATUS **allDistributedXactStatus)
 			TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
 
 			all->statusArray[i].gxid = gxact->gxid;
-			if (strlen(gxact->gid) >= TMGIDSIZE)
-				elog(PANIC, "Distribute transaction identifier too long (%d)",
-						(int) strlen(gxact->gid));
+			Assert(strlen(gxact->gid) < TMGIDSIZE);
 			memcpy(all->statusArray[i].gid, gxact->gid, TMGIDSIZE);
 			all->statusArray[i].state = gxact->state;
 			all->statusArray[i].sessionId = gxact->sessionId;
@@ -1932,7 +1930,7 @@ CreateDistributedSnapshot(DistributedSnapshot *ds, DtxContext distributedTransac
 	 * Copy the information we just captured under lock and then sorted into
 	 * the distributed snapshot.
 	 */
-	ds->distribTransactionTimeStamp = *shmDistribTimeStamp;
+	ds->distribTransactionTimeStamp = getDtxStartTime();
 	ds->xminAllDistributedSnapshots = globalXminDistributedSnapshots;
 	ds->distribSnapshotId = distribSnapshotId;
 	ds->xmin = xmin;

--- a/src/backend/storage/ipc/test/procarray_test.c
+++ b/src/backend/storage/ipc/test/procarray_test.c
@@ -129,6 +129,9 @@ test__CreateDistributedSnapshot(void **state)
 
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
 	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
+	if (ds->count > 1)
+		qsort(ds->inProgressXidArray, ds->count,
+				sizeof(DistributedTransactionId), DistributedSnapshotMappedEntry_Compare);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 5);

--- a/src/backend/storage/ipc/test/procarray_test.c
+++ b/src/backend/storage/ipc/test/procarray_test.c
@@ -45,11 +45,9 @@ test__CreateDistributedSnapshot(void **state)
 
 	ds->inProgressXidArray =
 		(DistributedTransactionId*)malloc(SIZE_OF_IN_PROGRESS_ARRAY);
-	ds->maxCount = 10;
 
 	distribSnapshotWithLocalMapping.inProgressMappedLocalXids =
 		(TransactionId*) malloc(1 * sizeof(TransactionId));
-	distribSnapshotWithLocalMapping.maxLocalXidsCount = 1;
 
 	setup(&controlBlock);
 
@@ -57,6 +55,7 @@ test__CreateDistributedSnapshot(void **state)
 	expect_value_count(LWLockHeldByMe, l, ProcArrayLock, -1);
 	will_return_count(LWLockHeldByMe, true, -1);
 #endif
+	will_return_count(getDtxStartTime, 0, -1);
 
 	ShmemVariableCache->latestCompletedDxid = 24;
 
@@ -73,7 +72,7 @@ test__CreateDistributedSnapshot(void **state)
 	 * Basic case, no other in progress transaction in system
 	 */
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
-	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping, DTX_CONTEXT_LOCAL_ONLY);
+	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 20);
@@ -101,7 +100,7 @@ test__CreateDistributedSnapshot(void **state)
 	procArray->numProcs = 3;
 
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
-	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping, DTX_CONTEXT_LOCAL_ONLY);
+	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 5);
@@ -129,7 +128,7 @@ test__CreateDistributedSnapshot(void **state)
 	procArray->numProcs = 5;
 
 	memset(ds->inProgressXidArray, 0, SIZE_OF_IN_PROGRESS_ARRAY);
-	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping, DTX_CONTEXT_LOCAL_ONLY);
+	CreateDistributedSnapshot(&distribSnapshotWithLocalMapping);
 
 	/* perform all the validations */
 	assert_true(ds->xminAllDistributedSnapshots == 5);

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -219,6 +219,7 @@ SharedSnapshotShmemSize(void)
 {
 	Size		size;
 
+	/* should be the same as PROCARRAY_MAXPROCS */
 	xipEntryCount = MaxBackends + max_prepared_xacts;
 
 	slotSize = sizeof(SharedSnapshotSlot);

--- a/src/backend/utils/time/visibility_summary.c
+++ b/src/backend/utils/time/visibility_summary.c
@@ -21,6 +21,7 @@
 #include "access/distributedlog.h"
 #include "access/transam.h"
 #include "access/xact.h"
+#include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h"
 #include "lib/stringinfo.h"
 #include "utils/builtins.h"
@@ -246,8 +247,7 @@ GetTupleVisibilityDistribId(TransactionId xid,
 				char	   *distribId;
 
 				distribId = palloc(TMGIDSIZE);
-				sprintf(distribId, "%u-%.10u",
-						distribTimeStamp, distribXid);
+				dtxFormGID(distribId, distribTimeStamp, distribXid);
 				return distribId;
 			}
 			else

--- a/src/include/c.h
+++ b/src/include/c.h
@@ -517,12 +517,6 @@ typedef uint32 DistributedTransactionId;
  */
 #define TMGIDSIZE 22
 
-/*
- * Used 21 spaces + NUL for a blank 22 character TMGIDSIZE GID.
- */
-#define TmGid_Init "                     "
-//                  123456789012345678901
-
 typedef uint32 CommandId;
 
 typedef int32  gpsegmentId;        /* CDB: type of gp_segment_id system col */

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -40,8 +40,6 @@ typedef struct DistributedSnapshot
 	DistributedTransactionId xmin;	/* XID < xmin are visible to me */
 	DistributedTransactionId xmax;	/* XID >= xmax are invisible to me */
 	int32		count;		/*  # of distributed xids in inProgressXidArray */
-	int32		maxCount;	/* allocated size of inProgressXidArray, or -1
-							 * if it's not malloc'd */
 
 	/* Array of distributed transactions in progress. */
 	DistributedTransactionId        *inProgressXidArray;
@@ -62,7 +60,6 @@ typedef struct DistributedSnapshotWithLocalMapping
 	TransactionId minCachedLocalXid;
 	TransactionId maxCachedLocalXid;
 	int32 currentLocalXidsCount;
-	int32 maxLocalXidsCount;
 	TransactionId *inProgressMappedLocalXids;
 } DistributedSnapshotWithLocalMapping;
 

--- a/src/include/cdb/cdbdtxcontextinfo.h
+++ b/src/include/cdb/cdbdtxcontextinfo.h
@@ -15,7 +15,7 @@
 #define CDBDTXCONTEXTINFO_H
 #include "utils/tqual.h"
 
-#define DtxContextInfo_StaticInit {0,InvalidDistributedTransactionId,TmGid_Init,0,false,false,DistributedSnapshot_StaticInit,0,0}
+#define DtxContextInfo_StaticInit {0,InvalidDistributedTransactionId,0,false,false,DistributedSnapshot_StaticInit,0,0}
 
 typedef struct DtxContextInfo
 {
@@ -23,8 +23,6 @@ typedef struct DtxContextInfo
 	
 	DistributedTransactionId 		distributedXid;
 	
-	char					 		distributedId[TMGIDSIZE];
-
 	CommandId				 		curcid;	/* in my xact, CID < curcid are visible */
 
 	bool							haveDistributedSnapshot;

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -290,6 +290,9 @@ extern DistributedTransactionTimeStamp getDtxStartTime(void);
 extern void dtxCrackOpenGid(const char	*gid,
 							DistributedTransactionTimeStamp	*distribTimeStamp,
 							DistributedTransactionId		*distribXid);
+extern void dtxFormGID(char *gid,
+					   DistributedTransactionTimeStamp tstamp,
+					   DistributedTransactionId gxid);
 extern DistributedTransactionId getDistributedTransactionId(void);
 extern bool getDistributedTransactionIdentifier(char *id);
 


### PR DESCRIPTION
- remove the checks on the length of gid
- remove redundant member 'distributedId' in 'DtxContextInfo'
- remove 'maxCount' in 'DistributedSnapshot' and 'maxLocalXidsCount' in 'DistributedSnapshotWithLocalMapping', instead, use 'GetMaxSnapshotXidCount()' as the size of the array.
- refactor the function GetSnapshotData

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
