### PR TITLE
docs - add to pxf upgrade procedure (v5.0.1 to v5.3.2)

### DIFF
--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -78,7 +78,7 @@ After you upgrade to the new version of Greenplum Database, perform the followin
 
     1. PXF now bundles Hadoop version 2.9.2 dependent JAR files. If you registered additional Hadoop-related JAR files in `$PXF_CONF/lib`, ensure that these libraries are compabitible with Hadoop version 2.9.2.
 
-    2. The PXF JDBC connector now supports file-based server configuration. If you choose to utilize this new feature with existing external tables that reference an external SQL database, refer to to the configuration instructions in [Configuring the JDBC Connector](jdbc_cfg.xml) for additional information.
+    2. The PXF JDBC connector now supports file-based server configuration. If you choose to utilize this new feature with existing external tables that reference an external SQL database, refer to the configuration instructions in [Configuring the JDBC Connector](jdbc_cfg.xml) for additional information.
 
     3. If you plan to use Hive partition filtering with integral types, you must set the `hive.metastore.integral.jdo.pushdown` Hive property in your Hadoop cluster's `hive-site.xml` and in your PXF user configuration `$PXF_CONF/servers/default/hive-site.xml` file. See [Updating Hadoop Configuration](client_instcfg.html#client-cfg-update).
 

--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -74,6 +74,14 @@ After you upgrade to the new version of Greenplum Database, perform the followin
     5. Starting in Greenplum Database version 5.15, PXF requires that the Hadoop configuration files reside in the `$PXF_CONF/servers/default` directory. If you configured PXF Hadoop connectors in your *PXF.from* installation, copy the Hadoop configuration files in `/etc/<hadoop_service>/conf` to `$PXF_CONF/servers/default` on the Greenplum Database master host.
     5. Starting in Greenplum Database version 5.15, the default Kerberos keytab file location for PXF is `$PXF_CONF/keytabs`. If you previously configured PXF for secure HDFS and the PXF keytab file is located in a *PXF.from* installation directory (for example, `$GPHOME/pxf/conf`), consider relocating the keytab file to `$PXF_CONF/keytabs`. Alternatively, update the `PXF_KEYTAB` property setting in the `$PXF_CONF/conf/pxf-env.sh` file to reference your keytab file.
 
+5. **If you are upgrading to Greenplum Database version 5.19**:
+
+    1. PXF now bundles Hadoop version 2.9.2 dependent JAR files. If you registered additional Hadoop-related JAR files in `$PXF_CONF/lib`, ensure that these libraries are compabitible with Hadoop version 2.9.2.
+
+    2. The PXF JDBC connector now supports file-based server configuration. If you choose to utilize this new feature with existing external tables that reference an external SQL database, refer to to the configuration instructions in [Configuring the JDBC Connector](jdbc_cfg.xml) for additional information.
+
+    3. If you plan to use Hive partition filtering with integral types, you must set the `hive.metastore.integral.jdo.pushdown` Hive property in your Hadoop cluster's `hive-site.xml` and in your PXF user configuration `$PXF_CONF/servers/default/hive-site.xml` file. See [Updating Hadoop Configuration](client_instcfg.html#client-cfg-update).
+
 5. Synchronize the PXF configuration from the master host to the standby master and each Greenplum Database segment host. For example:
 
     ``` shell


### PR DESCRIPTION
add content to the pxf upgrade procedure.  last pxf release was v.5.0.1.  in this PR:
- mention new version of hadoop libraries
- mention new jdbc file-based server config
- mention new hive property for integral pushdown

upgrade involves an existing $PXF_CONF.  "pxf init" for v5.3.2 will copy over templates only.  a few questions related to conf/* file updates:
1.  azure template property names were changed from `dfs` -> `fs`.  do we need to instruct the user to manually update these if they configured related server(s)?
2. looks like pxf-log4j.properties was updated to include WARN level settings for some hadoop/objstore classes.  do we instruct the user to add these new settings to their $PXF_CONF/conf/pxf-log4j.properties file?

any other upgrade considerations/steps to add?
