### PR TITLE
Add notice if analyze finds only empty pages for table

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1531,7 +1531,9 @@ acquire_sample_rows_by_query(Relation onerel, int nattrs, VacAttrStats **attrsta
 		 * NOTICE user when all sampled pages are empty
 		 */
 		ereport(NOTICE,
-			(errmsg("ANALYZE detected all empty sample pages for table %s, please run VACUUM FULL %s for accurate estimation.", RelationGetRelationName(onerel), RelationGetRelationName(onerel))));
+			(errmsg("ANALYZE detected all empty sample pages for relation \"%s\".",
+				RelationGetRelationName(onerel)),
+			 errhint("Run VACUUM FULL on the relation to generate more accurate statistics.")));
 	}
 	if (relTuples == 0.0)
 		return 0;

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1524,6 +1524,15 @@ acquire_sample_rows_by_query(Relation onerel, int nattrs, VacAttrStats **attrsta
 	*totalrows = relTuples;
 	*totaldeadrows = 0;
 	*totalblocks = relPages;
+
+	if ('h' == onerel->rd_rel->relstorage && relTuples == 0 && relPages > 0)
+	{
+		/*
+		 * NOTICE user when all sampled pages are empty
+		 */
+		ereport(NOTICE,
+			(errmsg("ANALYZE detected all empty sample pages for table %s, please run VACUUM FULL for accurate estimation.", RelationGetRelationName(onerel))));
+	}
 	if (relTuples == 0.0)
 		return 0;
 

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1525,7 +1525,7 @@ acquire_sample_rows_by_query(Relation onerel, int nattrs, VacAttrStats **attrsta
 	*totaldeadrows = 0;
 	*totalblocks = relPages;
 
-	if ('h' == onerel->rd_rel->relstorage && relTuples == 0 && relPages > 0)
+	if (RelationIsHeap(onerel) && relTuples == 0 && relPages > 0)
 	{
 		/*
 		 * NOTICE user when all sampled pages are empty

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1531,7 +1531,7 @@ acquire_sample_rows_by_query(Relation onerel, int nattrs, VacAttrStats **attrsta
 		 * NOTICE user when all sampled pages are empty
 		 */
 		ereport(NOTICE,
-			(errmsg("ANALYZE detected all empty sample pages for table %s, please run VACUUM FULL for accurate estimation.", RelationGetRelationName(onerel))));
+			(errmsg("ANALYZE detected all empty sample pages for table %s, please run VACUUM FULL %s for accurate estimation.", RelationGetRelationName(onerel), RelationGetRelationName(onerel))));
 	}
 	if (relTuples == 0.0)
 		return 0;

--- a/src/test/regress/expected/gp_toolkit.out
+++ b/src/test/regress/expected/gp_toolkit.out
@@ -232,7 +232,8 @@ select * from gp_toolkit.gp_bloat_diag where bdirelid = 'toolkit_skew'::regclass
 -- Create bloat by deleting all rows
 delete from toolkit_skew;
 analyze toolkit_skew;
-NOTICE:  ANALYZE detected all empty sample pages for table toolkit_skew, please run VACUUM FULL toolkit_skew for accurate estimation.
+NOTICE:  ANALYZE detected all empty sample pages for relation "toolkit_skew".
+HINT:  Run VACUUM FULL on the relation to generate more accurate statistics.
 select btdrelpages > 40 as btdrelpages_over_40,
        btdrelpages < 80 as btdrelpages_below_80,
        btdexppages > 0 as btdexppages_over_0,

--- a/src/test/regress/expected/gp_toolkit.out
+++ b/src/test/regress/expected/gp_toolkit.out
@@ -232,7 +232,7 @@ select * from gp_toolkit.gp_bloat_diag where bdirelid = 'toolkit_skew'::regclass
 -- Create bloat by deleting all rows
 delete from toolkit_skew;
 analyze toolkit_skew;
-NOTICE:  ANALYZE detected all empty sample pages for table toolkit_skew, please run VACUUM FULL for accurate estimation.
+NOTICE:  ANALYZE detected all empty sample pages for table toolkit_skew, please run VACUUM FULL toolkit_skew for accurate estimation.
 select btdrelpages > 40 as btdrelpages_over_40,
        btdrelpages < 80 as btdrelpages_below_80,
        btdexppages > 0 as btdexppages_over_0,

--- a/src/test/regress/expected/metadata_track.out
+++ b/src/test/regress/expected/metadata_track.out
@@ -1202,7 +1202,7 @@ NOTICE:  CREATE TABLE will create partition "mdt_supplier_hybrid_part_1_prt_p1_2
 NOTICE:  CREATE TABLE will create partition "mdt_supplier_hybrid_part_1_prt_p1_2_prt_4" for table "mdt_supplier_hybrid_part_1_prt_p1"
 NOTICE:  CREATE TABLE will create partition "mdt_supplier_hybrid_part_1_prt_p1_2_prt_5" for table "mdt_supplier_hybrid_part_1_prt_p1"
 Vacuum analyse myschema.mdt_supplier_hybrid_part;
-NOTICE:  ANALYZE detected all empty sample pages for table mdt_supplier_hybrid_part, please run VACUUM FULL for accurate estimation.
+NOTICE:  ANALYZE detected all empty sample pages for table mdt_supplier_hybrid_part, please run VACUUM FULL mdt_supplier_hybrid_part for accurate estimation.
 ALTER TABLE myschema.mdt_supplier_hybrid_part SET SCHEMA myschema_new;
 Vacuum myschema_new.mdt_supplier_hybrid_part;
 ALTER TABLE myschema.mdt_supplier_hybrid_part_1_prt_p1 SET SCHEMA myschema_new;

--- a/src/test/regress/expected/metadata_track.out
+++ b/src/test/regress/expected/metadata_track.out
@@ -1202,7 +1202,8 @@ NOTICE:  CREATE TABLE will create partition "mdt_supplier_hybrid_part_1_prt_p1_2
 NOTICE:  CREATE TABLE will create partition "mdt_supplier_hybrid_part_1_prt_p1_2_prt_4" for table "mdt_supplier_hybrid_part_1_prt_p1"
 NOTICE:  CREATE TABLE will create partition "mdt_supplier_hybrid_part_1_prt_p1_2_prt_5" for table "mdt_supplier_hybrid_part_1_prt_p1"
 Vacuum analyse myschema.mdt_supplier_hybrid_part;
-NOTICE:  ANALYZE detected all empty sample pages for table mdt_supplier_hybrid_part, please run VACUUM FULL mdt_supplier_hybrid_part for accurate estimation.
+NOTICE:  ANALYZE detected all empty sample pages for relation "mdt_supplier_hybrid_part".
+HINT:  Run VACUUM FULL on the relation to generate more accurate statistics.
 ALTER TABLE myschema.mdt_supplier_hybrid_part SET SCHEMA myschema_new;
 Vacuum myschema_new.mdt_supplier_hybrid_part;
 ALTER TABLE myschema.mdt_supplier_hybrid_part_1_prt_p1 SET SCHEMA myschema_new;

--- a/src/test/regress/expected/workfile/spilltodisk.out
+++ b/src/test/regress/expected/workfile/spilltodisk.out
@@ -32,7 +32,8 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into spilltest select a, a%25 from generate_series(1,8000) a;
 analyze;
-NOTICE:  ANALYZE detected all empty sample pages for table pg_auth_members, please run VACUUM FULL pg_auth_members for accurate estimation.
+NOTICE:  ANALYZE detected all empty sample pages for relation "pg_auth_members".
+HINT:  Run VACUUM FULL on the relation to generate more accurate statistics.
 set enable_hashagg=on;
 set enable_groupagg=off;
 set statement_mem=10000;
@@ -103,7 +104,8 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into spilltest select a, a%25 from generate_series(1,800000) a;
 analyze; -- We have to do an analyze to force a hash join
-NOTICE:  ANALYZE detected all empty sample pages for table pg_auth_members, please run VACUUM FULL pg_auth_members for accurate estimation.
+NOTICE:  ANALYZE detected all empty sample pages for relation "pg_auth_members".
+HINT:  Run VACUUM FULL on the relation to generate more accurate statistics.
 set enable_mergejoin=off;
 set enable_nestloop=off;
 set enable_hashjoin=on;

--- a/src/test/regress/expected/workfile/spilltodisk.out
+++ b/src/test/regress/expected/workfile/spilltodisk.out
@@ -32,7 +32,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into spilltest select a, a%25 from generate_series(1,8000) a;
 analyze;
-NOTICE:  ANALYZE detected all empty sample pages for table pg_auth_members, please run VACUUM FULL for accurate estimation.
+NOTICE:  ANALYZE detected all empty sample pages for table pg_auth_members, please run VACUUM FULL pg_auth_members for accurate estimation.
 set enable_hashagg=on;
 set enable_groupagg=off;
 set statement_mem=10000;
@@ -103,7 +103,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into spilltest select a, a%25 from generate_series(1,800000) a;
 analyze; -- We have to do an analyze to force a hash join
-NOTICE:  ANALYZE detected all empty sample pages for table pg_auth_members, please run VACUUM FULL for accurate estimation.
+NOTICE:  ANALYZE detected all empty sample pages for table pg_auth_members, please run VACUUM FULL pg_auth_members for accurate estimation.
 set enable_mergejoin=off;
 set enable_nestloop=off;
 set enable_hashjoin=on;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -70,7 +70,8 @@ m/^NOTICE:.*Table has no attributes to distribute on./
 # the NOTICE for different tables and different number of tables. For E.g in one
 # test run it produced the following NOTICE for pg_auth and in other it
 # produced a NOTICE for pg_auth and pg_auth_constraints.
-m/^NOTICE:.*ANALYZE detected all empty sample pages for table .*, please run VACUUM FULL .* for accurate estimation/
+m/^NOTICE:.*ANALYZE detected all empty sample pages for relation .*./
+m/^HINT:.*Run VACUUM FULL on the relation to generate more accurate statistics./
 
 m/^WARNING:  could not close temporary file .*: No such file or directory/
 

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -70,7 +70,7 @@ m/^NOTICE:.*Table has no attributes to distribute on./
 # the NOTICE for different tables and different number of tables. For E.g in one
 # test run it produced the following NOTICE for pg_auth and in other it
 # produced a NOTICE for pg_auth and pg_auth_constraints.
-m/^NOTICE:.*ANALYZE detected all empty sample pages for table .*, please run VACUUM FULL for accurate estimation/
+m/^NOTICE:.*ANALYZE detected all empty sample pages for table .*, please run VACUUM FULL .* for accurate estimation/
 
 m/^WARNING:  could not close temporary file .*: No such file or directory/
 


### PR DESCRIPTION
If a table has significant bloat, it may have many empty pages. Due to
the sampling method of analyze in 5X, this may result in estimating 0
rows when in fact many rows exist in a table, causing poor
query performance. This commit emits a NOTICE when analyze happens to
select only empty pages so the user can take appropriate action.

```
NOTICE:  ANALYZE detected all empty sample pages for table pg_namespace, please run VACUUM FULL for accurate estimation.
```

This is not an issue in 6X_STABLE/master, thus this commit is specifically for
5X_STABLE.

Authored-by: Chris Hajas <chajas@pivotal.io>