### PR TITLE
Reduce SelectForUpdate locklevel for some simple cases

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3151,6 +3151,7 @@ _copyQuery(const Query *from)
 	COPY_SCALAR_FIELD(hasRecursive);
 	COPY_SCALAR_FIELD(hasModifyingCTE);
 	COPY_SCALAR_FIELD(hasForUpdate);
+	COPY_SCALAR_FIELD(canOptForUpdate);
 	COPY_NODE_FIELD(cteList);
 	COPY_NODE_FIELD(rtable);
 	COPY_NODE_FIELD(jointree);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -3122,8 +3122,9 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			{
 				RelOptInfo *brel = root->simple_rel_array[rc->rti];
 
-				if (GpPolicyIsPartitioned(brel->cdbpolicy) ||
-					GpPolicyIsReplicated(brel->cdbpolicy))
+				if (!parse->canOptForUpdate &&
+					(GpPolicyIsPartitioned(brel->cdbpolicy) ||
+					 GpPolicyIsReplicated(brel->cdbpolicy)))
 				{
 					if (rc->markType == ROW_MARK_EXCLUSIVE)
 						rc->markType = ROW_MARK_TABLE_EXCLUSIVE;

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -1630,8 +1630,14 @@ ScanQueryForLocks(Query *parsetree, bool acquire)
 					rc = get_parse_rowmark(parsetree, rt_index);
 					if (rc != NULL)
 					{
-						lockmode = rc->strength >= LCS_FORNOKEYUPDATE ?
-							ExclusiveLock : RowShareLock;
+						if (parsetree->canOptForUpdate &&
+							rc->strength >= LCS_FORNOKEYUPDATE)
+							lockmode = RowShareLock;
+						else
+						{
+							lockmode = rc->strength >= LCS_FORNOKEYUPDATE ?
+								ExclusiveLock : RowShareLock;
+						}
 					}
 					else
 						lockmode = AccessShareLock;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -152,6 +152,7 @@ typedef struct Query
 	bool		hasRecursive;	/* WITH RECURSIVE was specified */
 	bool		hasModifyingCTE;	/* has INSERT/UPDATE/DELETE in WITH */
 	bool		hasForUpdate;	/* FOR [KEY] UPDATE/SHARE was specified */
+	bool        canOptForUpdate;
 
 	List	   *cteList;		/* WITH list (of CommonTableExpr's) */
 

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -157,6 +157,7 @@ struct ParseState
 	bool		p_hasModifyingCTE;
 	bool		p_is_insert;
 	bool		p_is_update;
+	bool        p_canOptForUpdate;
 	LockingClause *p_lockclause_from_parent;
 	Relation	p_target_relation;
 	RangeTblEntry *p_target_rangetblentry;

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -34,10 +34,11 @@ BEGIN
 (5 rows)
 
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | ExclusiveLock   | t       | t_lockmods 
+(2 rows)
 
 1: abort;
 ABORT
@@ -183,10 +184,11 @@ BEGIN
 (8 rows)
 
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
 
 1: abort;
 ABORT
@@ -380,10 +382,11 @@ BEGIN
 (5 rows)
 
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | RowShareLock    | t       | t_lockmods 
+(2 rows)
 
 1: abort;
 ABORT
@@ -456,9 +459,9 @@ BEGIN
 (5 rows)
 
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
+ locktype | mode         | granted | relation   
+----------+--------------+---------+------------
+ relation | RowShareLock | t       | t_lockmods 
 (1 row)
 
 1: abort;
@@ -525,10 +528,11 @@ BEGIN
 (8 rows)
 
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
 
 1: abort;
 ABORT


### PR DESCRIPTION
In OLTP scenario, select-for-update statement appears frequently.
It is not easy to keep the same behavior as Postgres in Greenplum
, which is MPP database. The pain points are:
  * tuples may be motioned here, and it is not easy to lock them
  * cursor is executed in readerGang, which cannot lock tuples

But for the very simple case that only involves one table, we can
just behave as upstream when global deadlock detector is enabled.
And almost each select-for-update query in OLTP scenario is a
simple case. For such cases, we could behave just like Postgres:
holds RowShareLock on the rangetable, and locks the tuple when
executing. This will improve OLTP concurrence performance by not
locking the table in Exclusive mode.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
