### PR TITLE
Fix error that master and standby are never synchronized

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -142,7 +142,6 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 
 			SpinLockAcquire(&walsnd->mutex);
 			syncStandbyPresent = (walsnd->pid != 0)
-				&& (walsnd->synchronous)
 				&& ((walsnd->state == WALSNDSTATE_STREAMING)
 					|| (walsnd->state == WALSNDSTATE_CATCHUP &&
 						walsnd->caughtup_within_range));

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -2069,7 +2069,6 @@ InitWalSenderSlot(void)
 			walsnd->apply = InvalidXLogRecPtr;
 			walsnd->state = WALSNDSTATE_STARTUP;
 			/* Will be decided in hand-shake */
-			walsnd->synchronous = false;
 			walsnd->xlogCleanUpTo = InvalidXLogRecPtr;
 			walsnd->caughtup_within_range = false;
 			SpinLockRelease(&walsnd->mutex);
@@ -2117,8 +2116,6 @@ WalSndKill(int code, Datum arg)
 			SyncRepWakeQueue(true, SYNC_REP_WAIT_FLUSH);
 
 			SpinLockAcquire(&MyWalSnd->mutex);
-
-			MyWalSnd->synchronous = false;
 
 			/* xlog can get freed without the WAL sender worry */
 			MyWalSnd->xlogCleanUpTo = InvalidXLogRecPtr;

--- a/src/include/replication/walsender_private.h
+++ b/src/include/replication/walsender_private.h
@@ -90,8 +90,6 @@ typedef struct WalSnd
 	 */
 	int			sync_standby_priority;
 
-	bool		synchronous;
-
 	/*
 	 * Indicates whether the WalSnd represents a connection with a Greenplum
 	 * mirror in streaming mode


### PR DESCRIPTION
GPDB used to allow command like "START_REPLICATION %X/%X [SYNC]" to
start a replication, user can specify SYNC option to skip waiting
synchronous in replications. Now start replication command is made
similar to upstream, the SYNC option is not supported, however, the
internal flag "synchronous" is still used and always be false which
make master and standby never synchronized.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
