### PR TITLE
Add hashbang to greenplum_path.sh when generating it

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# add hashbang to greenplum_path.sh
+cat << EOF
+#!/bin/bash
+EOF
+
 if [ x$1 != x ] ; then
     GPHOME_PATH=$1
 else


### PR DESCRIPTION
In many shell scripts, they assume the default shell is bash. But
it is not always true on ubuntu. We should explicitly declare it.

- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
