### PR TITLE
Remove unused memtuple function

### DIFF
--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -546,11 +546,6 @@ static inline unsigned char *memtuple_get_nullp(MemTuple mtup, MemTupleBinding *
 {
 	return mtup->PRIVATE_mt_bits + (mtbind_has_oid(pbind) ? sizeof(Oid) : 0);
 }
-static inline int memtuple_get_nullp_len(MemTupleBinding *pbind)
-{
-	return (pbind->tupdesc->natts + 7) >> 3;
-}
-
 
 /* form a memtuple from values and isnull, to a prespecified buffer */
 MemTuple memtuple_form_to(


### PR DESCRIPTION
Commit 0b6f15b8a247b48e72690f5593ff4daf29d4ae57 removed the only callsite of `memtuple_get_nullp_len()`, so remove the function too to avoid a compiler warning (and reduce cruft).