### PR TITLE
isolation2: Refactor tablespace related tests

### DIFF
--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -144,13 +144,6 @@ select content, preferred_role, role, status, mode from gp_segment_configuration
 
 -- end_ignore
 (exited with code 0)
-
--- Set GUC to force tablespace drop replay to complete on mirror before
--- removing the directory
-!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on;
--- start_ignore
--- end_ignore
-(exited with code 0)
 !\retcode gpstop -u;
 -- start_ignore
 -- end_ignore
@@ -164,7 +157,7 @@ select content, preferred_role, role, status, mode from gp_segment_configuration
 (1 row)
 
 -- create tablespace to test if it works with gprecoverseg -F (pg_basebackup)
-!\retcode mkdir /tmp/mirror_promotion_tablespace_loc;
+!\retcode mkdir -p /tmp/mirror_promotion_tablespace_loc;
 -- start_ignore
 
 -- end_ignore
@@ -184,27 +177,6 @@ drop table mirror_promotion_tblspc_heap_table;
 DROP
 drop tablespace mirror_promotion_tablespace;
 DROP
--- Force the mirror to replay the drop before moving forward with tablespace
--- directory deletion
-checkpoint;
-CHECKPOINT
-!\retcode rm -rf /tmp/mirror_promotion_tablespace_loc;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
-
--- Reset create_restartpoint_on_ckpt_record_replay guc
-!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
-!\retcode gpstop -u;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
 
 -- loop while segments come in sync
 do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select mode = 's' from gp_segment_configuration where content = 0 limit 1) then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;

--- a/src/test/isolation2/input/pg_basebackup_with_tablespaces.source
+++ b/src/test/isolation2/input/pg_basebackup_with_tablespaces.source
@@ -53,10 +53,8 @@ select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '
 drop database some_database_with_tablespace;
 drop database some_database_without_tablespace;
 drop tablespace some_basebackup_tablespace;
-!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on;
-!\retcode gpstop -u;
-checkpoint;
-!\retcode rm -rf @testtablespace@;
+!\retcode rm -rf @testtablespace@/some_basebackup_datadir/;
+!\retcode rm -rf @testtablespace@/some_basebackup_tablespace/100;
 
 -- Given a segment (content=0) with a tablespace mapped to a location different from that of other segments
 !\retcode mkdir -p @testtablespace@/some_basebackup_tablespace;
@@ -95,8 +93,6 @@ select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '
 0U: select pg_drop_replication_slot('some_replication_slot');
 drop database some_database_without_tablespace;
 drop tablespace some_basebackup_tablespace;
-checkpoint;
-!\retcode rm -rf @testtablespace@;
-!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay;
-!\retcode gpstop -u;
+!\retcode rm -rf @testtablespace@/some_basebackup_datadir/;
+!\retcode rm -rf @testtablespace@/some_basebackup_tablespace_c0/100;
 

--- a/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
+++ b/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
@@ -107,19 +107,12 @@ drop database some_database_without_tablespace;
 DROP
 drop tablespace some_basebackup_tablespace;
 DROP
-!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on;
+!\retcode rm -rf @testtablespace@/some_basebackup_datadir/;
 -- start_ignore
 
 -- end_ignore
 (exited with code 0)
-!\retcode gpstop -u;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
-checkpoint;
-CHECKPOINT
-!\retcode rm -rf @testtablespace@;
+!\retcode rm -rf @testtablespace@/some_basebackup_tablespace/100;
 -- start_ignore
 
 -- end_ignore
@@ -203,19 +196,12 @@ drop database some_database_without_tablespace;
 DROP
 drop tablespace some_basebackup_tablespace;
 DROP
-checkpoint;
-CHECKPOINT
-!\retcode rm -rf @testtablespace@;
+!\retcode rm -rf @testtablespace@/some_basebackup_datadir/;
 -- start_ignore
 
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
-!\retcode gpstop -u;
+!\retcode rm -rf @testtablespace@/some_basebackup_tablespace_c0/100;
 -- start_ignore
 
 -- end_ignore

--- a/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
@@ -83,17 +83,13 @@ where content = 0;
 -- set GUCs to speed-up the test
 !\retcode gpconfig -r gp_fts_probe_retries --masteronly;
 !\retcode gpconfig -r gp_fts_probe_timeout --masteronly;
-
--- Set GUC to force tablespace drop replay to complete on mirror before
--- removing the directory
-!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on;
 !\retcode gpstop -u;
 
 -- -- wait for content 0 (earlier mirror, now primary) to finish the promotion
 0U: select 1;
 
 -- create tablespace to test if it works with gprecoverseg -F (pg_basebackup)
-!\retcode mkdir /tmp/mirror_promotion_tablespace_loc;
+!\retcode mkdir -p /tmp/mirror_promotion_tablespace_loc;
 create tablespace mirror_promotion_tablespace location '/tmp/mirror_promotion_tablespace_loc';
 create table mirror_promotion_tblspc_heap_table (a int) tablespace mirror_promotion_tablespace;
 
@@ -102,14 +98,6 @@ create table mirror_promotion_tblspc_heap_table (a int) tablespace mirror_promot
 
 drop table mirror_promotion_tblspc_heap_table;
 drop tablespace mirror_promotion_tablespace;
--- Force the mirror to replay the drop before moving forward with tablespace
--- directory deletion
-checkpoint;
-!\retcode rm -rf /tmp/mirror_promotion_tablespace_loc;
-
--- Reset create_restartpoint_on_ckpt_record_replay guc
-!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay;
-!\retcode gpstop -u;
 
 -- loop while segments come in sync
 do $$


### PR DESCRIPTION
There is a race condition where replay of a `DROP TABLESPACE` command on a replication mirror could occur after the tests had already physically removed the directories. It should be safe if the tablespace directories continue to exist after the test is complete, so don't clean them up.