### PR TITLE
Fix a permission denied issue

### DIFF
--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -132,18 +132,6 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 		return InvalidOid;
 	}
 
-	/*
-	 * If the requested authorization is different from the current user,
-	 * temporarily set the current user so that the object(s) will be created
-	 * with the correct ownership.
-	 *
-	 * (The setting will be restored at the end of this routine, or in case of
-	 * error, transaction abort will clean things up.)
-	 */
-	if (saved_uid != owner_uid)
-		SetUserIdAndSecContext(owner_uid,
-							save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
-
 	/* Create the schema's namespace */
 	if (shouldDispatch || Gp_role != GP_ROLE_EXECUTE)
 	{
@@ -178,6 +166,18 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 	{
 		namespaceId = NamespaceCreate(schemaName, owner_uid, false);
 	}
+
+	/*
+	 * If the requested authorization is different from the current user,
+	 * temporarily set the current user so that the object(s) will be created
+	 * with the correct ownership.
+	 *
+	 * (The setting will be restored at the end of this routine, or in case of
+	 * error, transaction abort will clean things up.)
+	 */
+	if (saved_uid != owner_uid)
+		SetUserIdAndSecContext(owner_uid,
+							save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
 
 	/* Advance cmd counter to make the namespace visible */
 	CommandCounterIncrement();

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1752,6 +1752,9 @@ DROP GROUP regressgroup2;
 -- these are needed to clean up permissions
 REVOKE USAGE ON LANGUAGE sql FROM regressuser1;
 DROP OWNED BY regressuser1;
+-- regression test: superuser create a schema and authorize it to a non-superuser
+CREATE ROLE "non_superuser_schema";
+CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
 DROP USER regressuser1;
 DROP USER regressuser2;
 DROP USER regressuser3;

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -1060,6 +1060,10 @@ DROP GROUP regressgroup2;
 REVOKE USAGE ON LANGUAGE sql FROM regressuser1;
 DROP OWNED BY regressuser1;
 
+-- regression test: superuser create a schema and authorize it to a non-superuser
+CREATE ROLE "non_superuser_schema";
+CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
+
 DROP USER regressuser1;
 DROP USER regressuser2;
 DROP USER regressuser3;


### PR DESCRIPTION
Assume user1 has the privilege to database db1 and user2 has not, when
user1 try to create a schema in db1 and authorize it to user2, a
permission denied error is reported in QE. The RCA is QD set current
user to user2 before dispatching the query to QEs, so QE will also
set current user to user2, however, user2 has no provilege to create
schema in database db1.

To fix this, we delay setting the current user to user2 until the query
is dispatched to QEs.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
