### PR TITLE
Hold AccessShareLock in pg_get_expr()

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -1742,7 +1742,9 @@ pg_get_expr(PG_FUNCTION_ARGS)
 	text	   *expr = PG_GETARG_TEXT_P(0);
 	Oid			relid = PG_GETARG_OID(1);
 	int			prettyFlags;
-	char	   *relname;
+	char		*relname;
+	text		*result;
+	Relation	rel;
 
 	prettyFlags = PRETTYFLAG_INDENT;
 
@@ -1763,7 +1765,27 @@ pg_get_expr(PG_FUNCTION_ARGS)
 	else
 		relname = NULL;
 
-	PG_RETURN_TEXT_P(pg_get_expr_worker(expr, relid, relname, prettyFlags));
+	/* 
+	 * CDB: hold the AccessShareLock in case some transactions drop it concurrently.
+	 *
+	 * Since here, if the table that the relid tells is dropped, an error will raise
+	 * later when opening the relation to get column names.
+	 *
+	 * pg_get_expr() is used by GPDB add-on view 'pg_partitions' which is widely
+	 * used by regression tests for partition tables. Lots of parallel test cases
+	 * issue view pg_partitions and drop partitions concurrently, so those cases
+	 * are very flaky. Serialize test cases will cost more testing time and be
+	 * fragile, so GPDB holds a AccessShareLock here to make tests stable.
+	 */
+	rel = try_relation_open(relid, AccessShareLock, false);
+
+	if (!rel)
+		PG_RETURN_NULL();
+
+	result = pg_get_expr_worker(expr, relid, relname, prettyFlags);
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_TEXT_P(result);
 }
 
 Datum
@@ -1773,7 +1795,9 @@ pg_get_expr_ext(PG_FUNCTION_ARGS)
 	Oid			relid = PG_GETARG_OID(1);
 	bool		pretty = PG_GETARG_BOOL(2);
 	int			prettyFlags;
-	char	   *relname;
+	char		*relname;
+	text		*result;
+	Relation	rel;
 
 	prettyFlags = pretty ? (PRETTYFLAG_PAREN | PRETTYFLAG_INDENT | PRETTYFLAG_SCHEMA) : PRETTYFLAG_INDENT;
 
@@ -1788,7 +1812,27 @@ pg_get_expr_ext(PG_FUNCTION_ARGS)
 	else
 		relname = NULL;
 
-	PG_RETURN_TEXT_P(pg_get_expr_worker(expr, relid, relname, prettyFlags));
+	/* 
+	 * CDB: hold the AccessShareLock in case some transactions drop it concurrently.
+	 *
+	 * Since here, if the table that the relid tells is dropped, an error will raise
+	 * later when opening the relation to get column names.
+	 *
+	 * pg_get_expr() is used by GPDB add-on view 'pg_partitions' which is widely
+	 * used by regression tests for partition tables. Lots of parallel test cases
+	 * issue view pg_partitions and drop partitions concurrently, so those cases
+	 * are very flaky. Serialize test cases will cost more testing time and be
+	 * fragile, so GPDB holds a AccessShareLock here to make tests stable.
+	 */
+	rel = try_relation_open(relid, AccessShareLock, false);
+
+	if (!rel)
+		PG_RETURN_NULL();
+
+	result = pg_get_expr_worker(expr, relid, relname, prettyFlags);
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_TEXT_P(result);
 }
 
 static text *


### PR DESCRIPTION
In pg_get_expr(), after getting the relname, if the table that the relid tells
is dropped, an error will raise later when opening the relation to get column
names.

pg_get_expr() is used by GPDB add-on view 'pg_partitions' which is widely used
by regression tests for partition tables. Lots of parallel test cases issue view
pg_partitions and drop partition tables concurrently, so those cases are very
flaky. Serialize test cases will cost more testing time and be fragile, so GPDB
holds a AccessShareLock here to make tests stable.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
