### PR TITLE
Error out on AO and EXTERNAL in pageinspect

### DIFF
--- a/contrib/pageinspect/rawpage.c
+++ b/contrib/pageinspect/rawpage.c
@@ -121,6 +121,19 @@ get_raw_page_internal(text *relname, ForkNumber forknum, BlockNumber blkno)
 				 errmsg("cannot get raw page from foreign table \"%s\"",
 						RelationGetRelationName(rel))));
 
+	/* Check that this relation has the right kind of storage */
+	if (rel->rd_rel->relstorage == RELSTORAGE_AOROWS ||
+		rel->rd_rel->relstorage == RELSTORAGE_AOCOLS)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("cannot get raw page from append-optimized relation \"%s\"",
+						RelationGetRelationName(rel))));
+	if (rel->rd_rel->relstorage == RELSTORAGE_EXTERNAL)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("cannot get raw page from external relation \"%s\"",
+						RelationGetRelationName(rel))));
+
 	/*
 	 * Reject attempts to read non-local temporary relations; we would be
 	 * likely to get wrong data since we have no visibility into the owning


### PR DESCRIPTION
The pageinspect code only knows how to handle heap relations, so make sure to error out gracefully on AO/AOCS and EXTERNAL relations.

Spotted while looking at #7407.