### PR TITLE
Optimize hash table lookups in ORCA algebrization

### DIFF
--- a/src/backend/gpopt/translate/CMappingVarColId.cpp
+++ b/src/backend/gpopt/translate/CMappingVarColId.cpp
@@ -45,7 +45,9 @@ CMappingVarColId::CMappingVarColId
 	:
 	m_mp(mp)
 {
-	m_gpdb_att_opt_col_mapping = GPOS_NEW(m_mp) GPDBAttOptColHashMap(m_mp);
+	// This map can have many entries if there are many tables with many columns
+	// in the query, so use a larger hash map to minimize collisions
+	m_gpdb_att_opt_col_mapping = GPOS_NEW(m_mp) GPDBAttOptColHashMap(m_mp, 2047);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
For queries containing joins of tables with many columns, algebrization
in ORCA can be slow due to hash table collisions. For example, a 10-way
join of tables with 1500 cols each will generate a hash table with 80k+
colrefs. By minimizing these collisions, the total optimization time was reduced for
some queries by ~20%, and the algebrization time was reduced by 50%.

We're planning to make hash maps grow as they reach some load
factor. However, this is a hot spot that we'd like to fix sooner.

Authored-by: Chris Hajas <chajas@pivotal.io>