### PR TITLE
Docs: correcting statement about mirror port location

### DIFF
--- a/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
+++ b/gpdb-doc/dita/security-guide/topics/ports_and_protocols.xml
@@ -87,16 +87,18 @@ MIRROR_REPLICATION_PORT_BASE = 9000</codeblock></note>
             <entry>The SQL client connection port for a segment instance. Each primary and mirror
               segment on a host must have a unique port. Ports are assigned when the Greenplum
               system is initialized or expanded. The <codeph>gp_segment_configuration</codeph>
-              system catalog records port numbers for each segment in the <codeph>port</codeph>
-              column. Run <codeph>gpstate -p</codeph> to view the ports in use.</entry>
+              system catalog records port numbers for each primary (p) or mirror (m) segment in the
+                <codeph>port</codeph> column. Run <codeph>gpstate -p</codeph> to view the ports in
+              use.</entry>
           </row>
           <row>
             <entry>Segment mirroring port</entry>
             <entry>varies, libpq</entry>
             <entry>The port where a segment receives mirrored blocks from its primary. The port is
-              assigned when the mirror is set up. The port number is stored in the
-                <codeph>gp_segment_configuration</codeph> system catalog in the
-                <codeph>mirror_port</codeph> column.</entry>
+              assigned when the mirror is set up. The <codeph>gp_segment_configuration</codeph>
+              system catalog records port numbers for each primary (p) or mirror (m) segment in the
+                <codeph>port</codeph> column. Run <codeph>gpstate -p</codeph> to view the ports in
+              use.</entry>
           </row>
           <row>
             <entry>Greenplum Database Interconnect</entry>


### PR DESCRIPTION
`gp_segment_configuration` doesn't have a `mirror_ports` column, just `port`.
