### PR TITLE
[5X Backport] Various PXF libchurl cleanups

### DIFF
--- a/gpAux/extensions/pxf/src/libchurl.c
+++ b/gpAux/extensions/pxf/src/libchurl.c
@@ -91,34 +91,34 @@ typedef struct
 
 
 churl_context *churl_new_context(void);
-void		create_curl_handle(churl_context *context);
-void		set_curl_option(churl_context *context, CURLoption option, const void *data);
-size_t		read_callback(void *ptr, size_t size, size_t nmemb, void *userdata);
-void		setup_multi_handle(churl_context *context);
-void		multi_perform(churl_context *context);
-bool		internal_buffer_large_enough(churl_buffer *buffer, size_t required);
-void		flush_internal_buffer(churl_context *context);
-char	   *get_dest_address(CURL * curl_handle);
-void		enlarge_internal_buffer(churl_buffer *buffer, size_t required);
-void		finish_upload(churl_context *context);
-void		cleanup_curl_handle(churl_context *context);
-void		multi_remove_handle(churl_context *context);
-void		cleanup_internal_buffer(churl_buffer *buffer);
-void		churl_cleanup_context(churl_context *context);
-size_t		write_callback(char *buffer, size_t size, size_t nitems, void *userp);
-void		fill_internal_buffer(churl_context *context, int want);
-void		churl_headers_set(churl_context *context, CHURL_HEADERS settings);
-void		check_response_status(churl_context *context);
-void		check_response_code(churl_context *context);
-void		check_response(churl_context *context);
-void		clear_error_buffer(churl_context *context);
-size_t		header_callback(char *buffer, size_t size, size_t nitems, void *userp);
-void		free_http_response(churl_context *context);
-void		compact_internal_buffer(churl_buffer *buffer);
-void		realloc_internal_buffer(churl_buffer *buffer, size_t required);
-bool		handle_special_error(long response, StringInfo err);
-char	   *get_http_error_msg(long http_ret_code, char *msg, char *curl_error_buffer);
-char	   *build_header_str(const char *format, const char *key, const char *value);
+static void		create_curl_handle(churl_context *context);
+static void		set_curl_option(churl_context *context, CURLoption option, const void *data);
+static size_t		read_callback(void *ptr, size_t size, size_t nmemb, void *userdata);
+static void		setup_multi_handle(churl_context *context);
+static void		multi_perform(churl_context *context);
+static bool		internal_buffer_large_enough(churl_buffer *buffer, size_t required);
+static void		flush_internal_buffer(churl_context *context);
+static char	   *get_dest_address(CURL * curl_handle);
+static void		enlarge_internal_buffer(churl_buffer *buffer, size_t required);
+static void		finish_upload(churl_context *context);
+static void		cleanup_curl_handle(churl_context *context);
+static void		multi_remove_handle(churl_context *context);
+static void		cleanup_internal_buffer(churl_buffer *buffer);
+static void		churl_cleanup_context(churl_context *context);
+static size_t		write_callback(char *buffer, size_t size, size_t nitems, void *userp);
+static void		fill_internal_buffer(churl_context *context, int want);
+static void		churl_headers_set(churl_context *context, CHURL_HEADERS settings);
+static void		check_response_status(churl_context *context);
+static void		check_response_code(churl_context *context);
+static void		check_response(churl_context *context);
+static void		clear_error_buffer(churl_context *context);
+static size_t		header_callback(char *buffer, size_t size, size_t nitems, void *userp);
+static void		free_http_response(churl_context *context);
+static void		compact_internal_buffer(churl_buffer *buffer);
+static void		realloc_internal_buffer(churl_buffer *buffer, size_t required);
+static bool		handle_special_error(long response, StringInfo err);
+static char	   *get_http_error_msg(long http_ret_code, char *msg, char *curl_error_buffer);
+static char	   *build_header_str(const char *format, const char *key, const char *value);
 
 
 /*
@@ -158,7 +158,7 @@ churl_headers_init(void)
  * and populate <key> and <value> in it.
  * If value is empty, return <key>.
  */
-char *
+static char *
 build_header_str(const char *format, const char *key, const char *value)
 {
 	char	   *header_option = NULL;
@@ -503,7 +503,7 @@ churl_new_context()
 	return context;
 }
 
-void
+static void
 clear_error_buffer(churl_context *context)
 {
 	if (!context)
@@ -511,7 +511,7 @@ clear_error_buffer(churl_context *context)
 	context->curl_error_buffer[0] = 0;
 }
 
-void
+static void
 create_curl_handle(churl_context *context)
 {
 	context->curl_handle = curl_easy_init();
@@ -519,7 +519,7 @@ create_curl_handle(churl_context *context)
 		elog(ERROR, "internal error: curl_easy_init failed");
 }
 
-void
+static void
 set_curl_option(churl_context *context, CURLoption option, const void *data)
 {
 	int			curl_error;
@@ -534,7 +534,7 @@ set_curl_option(churl_context *context, CURLoption option, const void *data)
  * Copies data from internal buffer to libcurl's buffer.
  * Once zero is returned, libcurl knows upload is over
  */
-size_t
+static size_t
 read_callback(void *ptr, size_t size, size_t nmemb, void *userdata)
 {
 	churl_context *context = (churl_context *) userdata;
@@ -551,7 +551,7 @@ read_callback(void *ptr, size_t size, size_t nmemb, void *userdata)
 /*
  * Setups the libcurl multi API
  */
-void
+static void
 setup_multi_handle(churl_context *context)
 {
 	int			curl_error;
@@ -577,7 +577,7 @@ setup_multi_handle(churl_context *context)
  * During this functions execution,
  * callbacks are called.
  */
-void
+static void
 multi_perform(churl_context *context)
 {
 	int			curl_error;
@@ -590,13 +590,13 @@ multi_perform(churl_context *context)
 			 curl_error, curl_easy_strerror(curl_error));
 }
 
-bool
+static bool
 internal_buffer_large_enough(churl_buffer *buffer, size_t required)
 {
 	return ((buffer->top + required) <= buffer->max);
 }
 
-void
+static void
 flush_internal_buffer(churl_context *context)
 {
 	churl_buffer *context_buffer = context->upload_buffer;
@@ -630,7 +630,7 @@ flush_internal_buffer(churl_context *context)
  * If it's not available, returns an empty string.
  * The returned value should be free'd.
  */
-char *
+static char *
 get_dest_address(CURL *curl_handle)
 {
 	char	   *dest_url = NULL;
@@ -643,7 +643,7 @@ get_dest_address(CURL *curl_handle)
 	return dest_url;
 }
 
-void
+static void
 enlarge_internal_buffer(churl_buffer *buffer, size_t required)
 {
 	if (buffer->ptr != NULL)
@@ -657,7 +657,7 @@ enlarge_internal_buffer(churl_buffer *buffer, size_t required)
  * Let libcurl finish the upload by
  * calling perform repeatedly
  */
-void
+static void
 finish_upload(churl_context *context)
 {
 	if (!context->multi_handle)
@@ -675,7 +675,7 @@ finish_upload(churl_context *context)
 	check_response(context);
 }
 
-void
+static void
 cleanup_curl_handle(churl_context *context)
 {
 	if (!context->curl_handle)
@@ -688,7 +688,7 @@ cleanup_curl_handle(churl_context *context)
 	context->multi_handle = NULL;
 }
 
-void
+static void
 multi_remove_handle(churl_context *context)
 {
 	int			curl_error;
@@ -701,7 +701,7 @@ multi_remove_handle(churl_context *context)
 			 curl_error, curl_easy_strerror(curl_error));
 }
 
-void
+static void
 cleanup_internal_buffer(churl_buffer *buffer)
 {
 	if ((buffer) && (buffer->ptr))
@@ -714,7 +714,7 @@ cleanup_internal_buffer(churl_buffer *buffer)
 	}
 }
 
-void
+static void
 churl_cleanup_context(churl_context *context)
 {
 	if (context)
@@ -733,7 +733,7 @@ churl_cleanup_context(churl_context *context)
  * Stores data from libcurl's buffer into the internal buffer.
  * If internal buffer is not large enough, increases it.
  */
-size_t
+static size_t
 write_callback(char *buffer, size_t size, size_t nitems, void *userp)
 {
 	churl_context *context = (churl_context *) userp;
@@ -758,7 +758,7 @@ write_callback(char *buffer, size_t size, size_t nitems, void *userp)
  * Fills internal buffer up to want bytes.
  * returns when size reached or transfer ended
  */
-void
+static void
 fill_internal_buffer(churl_context *context, int want)
 {
 	fd_set		fdread;
@@ -814,7 +814,7 @@ fill_internal_buffer(churl_context *context, int want)
 	}
 }
 
-void
+static void
 churl_headers_set(churl_context *context, CHURL_HEADERS headers)
 {
 	churl_settings *settings = (churl_settings *) headers;
@@ -826,7 +826,7 @@ churl_headers_set(churl_context *context, CHURL_HEADERS headers)
  * Checks that the response finished successfully
  * with a valid response status and code.
  */
-void
+static void
 check_response(churl_context *context)
 {
 	check_response_code(context);
@@ -839,7 +839,7 @@ check_response(churl_context *context)
  * a message can have a response code 200 (OK), but end prematurely
  * and so have an error status.
  */
-void
+static void
 check_response_status(churl_context *context)
 {
 	CURLMsg    *msg;			/* for picking up messages with the transfer
@@ -879,7 +879,7 @@ check_response_status(churl_context *context)
  * Parses return code from libcurl operation and
  * reports if different than 200 and 100
  */
-void
+static void
 check_response_code(churl_context *context)
 {
 	long		response_code;
@@ -980,7 +980,7 @@ check_response_code(churl_context *context)
  * Our first priority is to get the paragraph <p> inside <body>, and in case we don't find it, then we try to get
  * the <title>.
  */
-char *
+static char *
 get_http_error_msg(long http_ret_code, char *msg, char *curl_error_buffer)
 {
 	char	   *start,
@@ -1101,7 +1101,7 @@ get_http_error_msg(long http_ret_code, char *msg, char *curl_error_buffer)
 	return msg;
 }
 
-void
+static void
 free_http_response(churl_context *context)
 {
 	if (!context->last_http_reponse)
@@ -1115,7 +1115,7 @@ free_http_response(churl_context *context)
  * Called during a perform by libcurl on either download or an upload.
  * Stores the first line of the header for error reporting
  */
-size_t
+static size_t
 header_callback(char *buffer, size_t size, size_t nitems, void *userp)
 {
 	const int	nbytes = size * nitems;
@@ -1133,7 +1133,7 @@ header_callback(char *buffer, size_t size, size_t nitems, void *userp)
 	return nbytes;
 }
 
-void
+static void
 compact_internal_buffer(churl_buffer *buffer)
 {
 	int			n;
@@ -1148,7 +1148,7 @@ compact_internal_buffer(churl_buffer *buffer)
 	buffer->top = n;
 }
 
-void
+static void
 realloc_internal_buffer(churl_buffer *buffer, size_t required)
 {
 	int			n;
@@ -1163,7 +1163,7 @@ realloc_internal_buffer(churl_buffer *buffer, size_t required)
 	buffer->max = n;
 }
 
-bool
+static bool
 handle_special_error(long response, StringInfo err)
 {
 	switch (response)

--- a/gpAux/extensions/pxf/src/libchurl.c
+++ b/gpAux/extensions/pxf/src/libchurl.c
@@ -864,9 +864,11 @@ check_response_status(churl_context *context)
 			appendStringInfo(&err, "transfer error (%ld): %s",
 							 status, curl_easy_strerror(status));
 
-			if (strlen(addr) != 0)
+			if (addr)
+			{
 				appendStringInfo(&err, " from %s", addr);
-			pfree(addr);
+				pfree(addr);
+			}
 			elog(ERROR, "%s", err.data);
 		}
 		elog(DEBUG2, "check_response_status: msg %d done with status OK", i++);
@@ -912,11 +914,11 @@ check_response_code(churl_context *context)
 		appendStringInfo(&err, "remote component error (%ld)", response_code);
 
 		addr = get_dest_address(context->curl_handle);
-		if (strlen(addr) != 0)
+		if (addr)
 		{
 			appendStringInfo(&err, " from %s", addr);
+			pfree(addr);
 		}
-		pfree(addr);
 
 		if (!handle_special_error(response_code, &err))
 		{


### PR DESCRIPTION
Only 2 commits cherry-picked for 5x. From @danielgustafsson:
While skimming those code due to a question I noticed a few things that could be cleaned up to simplify the code a bit and avoid a few allocations here and there. See individual commit messages for more information.