### PR TITLE
Add missing test to the regress greenplum schedule

### DIFF
--- a/src/test/regress/expected/distributed_transaction_recovery_after_restart.out
+++ b/src/test/regress/expected/distributed_transaction_recovery_after_restart.out
@@ -1,3 +1,7 @@
+-- start_matchignore
+-- m/waiting for server to shut down.* done/
+-- m/waiting for server to start.* done/
+-- end_matchignore
 -- Given no superusers exist with a null rolvaliduntil value
 set allow_system_table_mods to dml;
 create table stored_superusers (role_name text, role_valid_until timestamp);

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -23,6 +23,7 @@ test: bitmap_index gp_dump_query_oids analyze gp_owner_permission incremental_an
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules
 # dispatch should always run seperately from other cases.
 test: dispatch
+test: distributed_transaction_recovery_after_restart
 
 # enable query metrics cluster GUC
 test: instr_in_shmem_setup

--- a/src/test/regress/sql/distributed_transaction_recovery_after_restart.sql
+++ b/src/test/regress/sql/distributed_transaction_recovery_after_restart.sql
@@ -1,3 +1,7 @@
+-- start_matchignore
+-- m/waiting for server to shut down.* done/
+-- m/waiting for server to start.* done/
+-- end_matchignore
 -- Given no superusers exist with a null rolvaliduntil value
 set allow_system_table_mods to dml;
 create table stored_superusers (role_name text, role_valid_until timestamp);


### PR DESCRIPTION
- ignore the output of pg_ctl, as it has a progress meter that varies
  by duration

Note: this commit belongs in 830062cc52872c1f450e9a47bc138c6871a429cd,
but was introduced at a later time. If applying the above commit,
this commit should be applied too.
