### PR TITLE
Remove references to paramiko, ecdsa, and pycrypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ install:
   - pip install --user --upgrade pip
   - pip install --user --pre psutil
   - pip install --user lockfile
-  - pip install --user paramiko
   - pip install --user setuptools
 
 env:

--- a/README.amazon_linux
+++ b/README.amazon_linux
@@ -38,7 +38,7 @@ cat /sys/kernel/mm/transparent_hugepage/enabled
 
 # pip packages
 curl https://bootstrap.pypa.io/get-pip.py | sudo python
-sudo pip install --upgrade setuptools wheel paramiko pip lockfile psutil
+sudo pip install --upgrade setuptools wheel pip lockfile psutil
 
 # configure and build
 git clone https://github.com/greenplum-db/gpdb.git

--- a/README.ubuntu.bash
+++ b/README.ubuntu.bash
@@ -34,7 +34,6 @@ apt-get install -y \
   openssl \
   python-dev \
   python-lockfile \
-  python-paramiko \
   python-pip \
   python-psutil \
   python-yaml \

--- a/concourse/server_pipeline/docker/Dockerfile
+++ b/concourse/server_pipeline/docker/Dockerfile
@@ -46,7 +46,6 @@ RUN apt update && apt install -y \
     openssl \
     python-dev \
     python-lockfile \
-    python-paramiko \
     python-pip \
     python-psutil \
     python-yaml \

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -68,20 +68,11 @@ install: generate_greenplum_path_file
 
 	# Setup /lib/python contents
 	cp -rp bin/gppylib $(DESTDIR)$(prefix)/lib/python
-	if [ -e bin/ext/Crypto ]; then \
-	    cp -rp bin/ext/Crypto $(DESTDIR)$(prefix)/lib/python ; \
-	fi
 	if [ -e bin/ext/__init__.py ]; then \
 	    cp -rp bin/ext/__init__.py $(DESTDIR)$(prefix)/lib/python ; \
 	fi
 	if [ -e bin/ext/lockfile ]; then \
 	    cp -rp bin/ext/lockfile $(DESTDIR)$(prefix)/lib/python ; \
-	fi
-	if [ -e bin/ext/paramiko ]; then \
-	    cp -rp bin/ext/paramiko $(DESTDIR)$(prefix)/lib/python ; \
-	fi
-	if [ -e bin/ext/ecdsa ]; then \
-	    cp -rp bin/ext/ecdsa $(DESTDIR)$(prefix)/lib/python ; \
 	fi
 	if [ -e bin/ext/psutil ]; then \
 	    cp -rp bin/ext/psutil $(DESTDIR)$(prefix)/lib/python ; \

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -32,7 +32,7 @@ core: pygresql subprocess32
 	python gpconfig_modules/parse_guc_metadata.py $(prefix)
 
 ifneq "$(wildcard $(CURDIR)/pythonSrc/ext/*.tar.gz)" ""
-install: core lockfile paramiko ecdsa pycrypto stream psutil
+install: core lockfile stream psutil
 else
 install: core stream
 endif
@@ -79,28 +79,6 @@ pygresql:
 	touch $(PYLIB_DIR)/__init__.py
 
 #
-# PARAMIKO
-#
-PARAMIKO_VERSION=1.18.4
-PARAMIKO_DIR=paramiko-$(PARAMIKO_VERSION)
-paramiko:
-	@echo "--- paramiko"
-	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(PARAMIKO_DIR).tar.gz
-	cd $(PYLIB_SRC_EXT)/$(PARAMIKO_DIR)/ && python setup.py build
-	cp -r $(PYLIB_SRC_EXT)/$(PARAMIKO_DIR)/build/lib*/paramiko $(PYLIB_DIR)/
-
-#
-# ecdsa
-#
-ECDSA_VERSION=0.13
-ECDSA_DIR=ecdsa-$(ECDSA_VERSION)
-ecdsa:
-	@echo "--- ecdsa"
-	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(ECDSA_DIR).tar.gz
-	cd $(PYLIB_SRC_EXT)/$(ECDSA_DIR)/ && python setup.py build
-	cp -r $(PYLIB_SRC_EXT)/$(ECDSA_DIR)/build/lib*/ecdsa $(PYLIB_DIR)/
-
-#
 # LOCKFILE
 #
 # note the awk commands are used to eliminate references to code in __init__.py
@@ -125,20 +103,6 @@ subprocess32:
 		  cd $(PYLIB_SRC)/subprocess32 && CC="$(CC)" python setup.py build; \
 		  cp -f $(PYLIB_SRC)/subprocess32/build/lib.*/* $(PYLIB_DIR)/;  \
 	  fi
-
-#
-# PYCRYPTO
-#
-PYCRYPTO_VERSION=2.0.1
-PYCRYPTO_DIR=pycrypto-$(PYCRYPTO_VERSION)
-
-pycrypto:
-	@echo "--- pycrypto"
-ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 )" ""
-	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(PYCRYPTO_DIR).tar.gz
-	cd $(PYLIB_SRC_EXT)/$(PYCRYPTO_DIR)/ && CC="$(CC)" python setup.py build
-	cp -r $(PYLIB_SRC_EXT)/$(PYCRYPTO_DIR)/build/lib.*/Crypto $(PYLIB_DIR)
-endif
 
 #
 # PSI
@@ -252,8 +216,6 @@ installcheck:
 
 clean distclean:
 	rm -rf $(PYLIB_SRC_EXT)/$(LOCKFILE_DIR)
-	rm -rf $(PYLIB_SRC_EXT)/$(PARAMIKO_DIR)
-	rm -rf $(PYLIB_SRC_EXT)/$(PYCRYPTO_DIR)
 	rm -rf $(PYLIB_SRC_EXT)/$(PYLINT_DIR)
 	rm -rf $(PYLIB_SRC_EXT)/$(LOGILAB_COMMON_DIR)
 	rm -rf $(PYLIB_SRC_EXT)/$(LOGILAB_ASTNG_DIR)

--- a/gpMgmt/bin/ext/.gitignore
+++ b/gpMgmt/bin/ext/.gitignore
@@ -1,3 +1,1 @@
-Crypto
-paramiko
 pygresql

--- a/gpMgmt/bin/ext/Crypto/.gitignore
+++ b/gpMgmt/bin/ext/Crypto/.gitignore
@@ -1,2 +1,0 @@
-__init__.py
-test.py

--- a/gpMgmt/bin/lib/.gitignore
+++ b/gpMgmt/bin/lib/.gitignore
@@ -1,6 +1,4 @@
 netperf
 netserver
 stream
-Crypto
-paramiko
 gp_bash_version.sh

--- a/python-dependencies.txt
+++ b/python-dependencies.txt
@@ -1,15 +1,12 @@
 argparse==1.2.1
 behave==1.2.4
-ecdsa==0.13
 epydoc==3.0.1
 lockfile==0.9.1
 logilab-astng==0.20.1
 logilab-common==0.50.1
 MarkupSafe==1.0
 mock==1.0.1
-paramiko==1.18.1
 parse==1.8.2
 psutil==4.0.0
-pycrypto==2.6.1
 setuptools==36.6.0
 unittest2==0.5.1

--- a/src/tools/docker/centos6/Dockerfile
+++ b/src/tools/docker/centos6/Dockerfile
@@ -11,7 +11,7 @@ RUN yum makecache && \
 # install all software we need
 RUN yum makecache && \
     yum -y install python-pip && \
-    yum -y install python-devel python-paramiko python-psutil python-setuptools && \
+    yum -y install python-devel python-psutil python-setuptools && \
     yum -y install apr-devel bzip2-devel expat-devel libcurl-devel && \
     yum -y install libevent-devel libuuid-devel libxml2-devel libyaml-devel libzstd-devel && \
     yum -y install openssl-devel pam-devel readline-devel snappy-devel && \

--- a/src/tools/docker/centos7/Dockerfile
+++ b/src/tools/docker/centos7/Dockerfile
@@ -11,7 +11,7 @@ RUN yum makecache && \
 # install all software we need
 RUN yum makecache && \
     yum -y install python2-pip && \
-    yum -y install python-devel python-paramiko python-psutil python-setuptools && \
+    yum -y install python-devel python-psutil python-setuptools && \
     yum -y install apr-devel bzip2-devel expat-devel libcurl-devel && \
     yum -y install libevent-devel libuuid-devel libxml2-devel libyaml-devel libzstd-devel && \
     yum -y install openssl-devel pam-devel readline-devel snappy-devel && \

--- a/src/tools/docker/ubuntu16/Dockerfile
+++ b/src/tools/docker/ubuntu16/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update -y && \
     pkg-config \
     python-dev \
     python-lockfile \
-    python-paramiko \
     python-pip \
     python-psutil \
     python-setuptools \

--- a/src/tools/vagrant/centos/vagrant-setup.sh
+++ b/src/tools/vagrant/centos/vagrant-setup.sh
@@ -38,6 +38,6 @@ yum -y install "${dependencies[@]}"
 # so we can call cmake
 ln -s /usr/bin/cmake{3,}
 
-pip install psutil lockfile paramiko setuptools
+pip install psutil lockfile setuptools
 
 chown -R vagrant:vagrant /usr/local

--- a/src/tools/vagrant/debian/vagrant-setup.sh
+++ b/src/tools/vagrant/debian/vagrant-setup.sh
@@ -58,7 +58,6 @@ dpkg-reconfigure locales -f noninteractive
 pip install setuptools --upgrade
 pip install cffi --upgrade
 pip install lockfile
-pip install paramiko --upgrade
 pip install --pre psutil
 pip install cryptography --upgrade
 


### PR DESCRIPTION
This removes paramiko and its dependencies, since it is no longer used.

## Here are some reminders before you submit the pull request
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community