### PR TITLE
Add license_finder dependency config for Windows client package.

### DIFF
--- a/gpAux/client/doc/dependency_decisions.yml
+++ b/gpAux/client/doc/dependency_decisions.yml
@@ -1,0 +1,76 @@
+---
+- - :add_package
+  - zlib
+  - 1.2.11
+  - &1
+    :who: 
+    :why: 
+    :versions: []
+    :when: 2019-05-14 09:06:17.930573000 Z
+- - :license
+  - zlib
+  - zlib
+  - *1
+- - :approve
+  - zlib
+  - *1
+- - :add_package
+  - libapr
+  - 1.6.5
+  - &2
+    :who: 
+    :why: 
+    :versions: []
+    :when: 2019-05-14 09:06:18.317282000 Z
+- - :license
+  - libapr
+  - Apache 2.0
+  - *2
+- - :approve
+  - libapr
+  - *2
+- - :add_package
+  - libevent
+  - 2.1.8
+  - &3
+    :who: 
+    :why: 
+    :versions: []
+    :when: 2019-05-14 09:06:18.662063000 Z
+- - :license
+  - libevent
+  - BSD
+  - *3
+- - :approve
+  - libevent
+  - *3
+- - :add_package
+  - openssl
+  - 1.0.2
+  - &4
+    :who: 
+    :why: 
+    :versions: []
+    :when: 2019-05-14 09:06:19.010160000 Z
+- - :license
+  - openssl
+  - Apache 2.0
+  - *4
+- - :approve
+  - openssl
+  - *4
+- - :add_package
+  - PyGreSQL
+  - '4.0'
+  - &5
+    :who: 
+    :why: 
+    :versions: []
+    :when: 2019-05-14 09:15:00.666521000 Z
+- - :license
+  - PyGreSQL
+  - BSD
+  - *5
+- - :approve
+  - PyGreSQL
+  - *5

--- a/gpAux/client/doc/dependency_decisions.yml
+++ b/gpAux/client/doc/dependency_decisions.yml
@@ -74,3 +74,15 @@
 - - :approve
   - PyGreSQL
   - *5
+- - :add_package
+  - Kerberos
+  - krb5-1.17
+  - &6
+    :who: 
+    :why: 
+    :versions: []
+    :when: 2019-05-15 02:36:14.982918000 Z
+- - :license
+  - Kerberos
+  - unknown
+  - *6


### PR DESCRIPTION
Below are the command:
`license_finder dependencies add zlib zlib 1.2.11 --approve`
`license_finder dependencies add libapr "Apache 2.0" 1.6.5 --approve`
`license_finder dependencies add libevent BSD 2.1.8 --approve`
`license_finder dependencies add openssl "Apache 2.0" 1.0.2 --approve`
`license_finder dependencies add PyGreSQL BSD 4.0 --approve`

There is no test because it doesn't affect code.  All dependency can be shown with `license_finder dependencies  list`
