### PR TITLE
Make GUCs visible and rename optimizer_enable_full_join

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -542,7 +542,7 @@ CConfigParamMapping::PackConfigParamInBitset
 		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfJoinAssociativity));
 	}
 
-	if (!optimizer_enable_full_join)
+	if (!optimizer_expand_fulljoin)
 	{
 		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfExpandFullOuterJoin));
 	}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -346,7 +346,7 @@ bool		optimizer_enable_indexscan;
 bool		optimizer_enable_tablescan;
 bool		optimizer_enable_hashagg;
 bool		optimizer_enable_groupagg;
-bool		optimizer_enable_full_join;
+bool		optimizer_expand_fulljoin;
 
 /* Optimizer plan enumeration related GUCs */
 bool		optimizer_enumerate_plans;
@@ -2388,8 +2388,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"optimizer_enable_hashagg", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enables Pivotal Optimizer (GPORCA) to use hash aggregates."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			NULL
 		},
 		&optimizer_enable_hashagg,
 		true,
@@ -2399,8 +2398,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"optimizer_enable_groupagg", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enables Pivotal Optimizer (GPORCA) to use group aggregates."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			NULL
 		},
 		&optimizer_enable_groupagg,
 		true,
@@ -2516,12 +2514,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_full_join", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_expand_fulljoin", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enables the optimizer's support of full outer joins."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&optimizer_enable_full_join,
+			NULL		},
+		&optimizer_expand_fulljoin,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -470,7 +470,7 @@ extern bool optimizer_enable_dynamictablescan;
 extern bool optimizer_enable_indexscan;
 extern bool optimizer_enable_tablescan;
 extern bool optimizer_enable_eageragg;
-extern bool optimizer_enable_full_join;
+extern bool optimizer_expand_fulljoin;
 extern bool optimizer_enable_hashagg;
 extern bool optimizer_enable_groupagg;
 


### PR DESCRIPTION
This commit achieves two things:
- Rename optimizer_enable_full_join to optimizer_expand_fulljoin.
- Make optimizer_expand_fulljoin, optimizer_enable_hashagg,
  optimizer_enable_groupagg visible.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
