### PR TITLE
Add unique index: distribution keys must be prefix of unique indexes

### DIFF
--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -495,7 +495,7 @@ drop table atacc1;
 create table atacc1 (test int, test2 int, unique(test)) distributed by (test);
 NOTICE:  CREATE TABLE / UNIQUE will create implicit index "atacc1_test_key" for table "atacc1"
 alter table atacc1 add unique (test2);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "atacc1"
+ERROR:  The existing distribution key of "atacc1" must be equal to or a left-subset of the UNIQUE index
 -- should fail for @@ second one @@
 insert into atacc1 (test2, test) values (3, 3);
 insert into atacc1 (test2, test) values (2, 3);

--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -129,3 +129,27 @@ SELECT * FROM altable ORDER BY 1;
 -- (There used to be a quoting bug in the internal query this issues.)
 create table "foo'bar" (id int4, t text);
 alter table "foo'bar" alter column t type integer using length(t);
+-- Test add unique index constraint. If the unique index is not compatible with
+-- the existing distribution policy, update the policy if table is empty and
+-- does not have a primary key or unique index, otherwise error out.
+CREATE TABLE policy_match_unique_index(a int, b int)
+DISTRIBUTED BY (a, b)
+PARTITION BY RANGE(a) (START (1) END (2) EVERY (1));
+NOTICE:  CREATE TABLE will create partition "policy_match_unique_index_1_prt_1" for table "policy_match_unique_index"
+-- The distribution policy should by updated
+ALTER TABLE policy_match_unique_index ADD CONSTRAINT ba_pkey PRIMARY KEY (b, a);
+NOTICE:  updating distribution policy to match new primary key
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "policy_match_unique_index_pkey" for table "policy_match_unique_index"
+NOTICE:  updating distribution policy to match new primary key
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "policy_match_unique_index_1_prt_1_pkey" for table "policy_match_unique_index_1_prt_1"
+-- Add partition should still work
+ALTER TABLE policy_match_unique_index ADD PARTITION part2 START (2) END (3);
+NOTICE:  CREATE TABLE will create partition "policy_match_unique_index_1_prt_part2" for table "policy_match_unique_index"
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "policy_match_unique_index_1_prt_part2_pkey" for table "policy_match_unique_index_1_prt_part2"
+-- Should not update the distribution policy because the table already has primary key
+CREATE UNIQUE INDEX a_idx ON policy_match_unique_index (a);
+NOTICE:  building index for child partition "policy_match_unique_index_1_prt_1"
+NOTICE:  building index for child partition "policy_match_unique_index_1_prt_part2"
+ERROR:  The existing distribution key of "policy_match_unique_index" must be equal to or a left-subset of the UNIQUE index
+-- cleanup
+drop table policy_match_unique_index;

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -449,7 +449,7 @@ DROP TABLE concur_heap;
 --
 CREATE TABLE onek_with_null AS SELECT unique1, unique2 FROM onek DISTRIBUTED BY (unique1);
 INSERT INTO onek_with_null (unique1,unique2) VALUES (NULL, -1), (NULL, NULL);
-CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2,unique1);
+CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique1,unique2);
 SET enable_seqscan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = ON;
@@ -466,7 +466,7 @@ SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL AND unique2 IS NULL;
 (1 row)
 
 DROP INDEX onek_nulltest;
-CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2 desc,unique1);
+CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique1,unique2 desc);
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL;
  count 
 -------
@@ -480,7 +480,7 @@ SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL AND unique2 IS NULL;
 (1 row)
 
 DROP INDEX onek_nulltest;
-CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2 desc nulls last,unique1);
+CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique1, unique2 desc nulls last);
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL;
  count 
 -------
@@ -494,7 +494,7 @@ SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL AND unique2 IS NULL;
 (1 row)
 
 DROP INDEX onek_nulltest;
-CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2  nulls first,unique1);
+CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique1,unique2 nulls first);
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL;
  count 
 -------

--- a/src/test/regress/expected/gp_create_table.out
+++ b/src/test/regress/expected/gp_create_table.out
@@ -64,7 +64,7 @@ select attrnums from gp_distribution_policy where
 
 -- make sure we can't overwrite it
 create unique index distpol_uidx on distpol(k);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "distpol"
+ERROR:  The existing distribution key of "distpol" must be equal to or a left-subset of the UNIQUE index
 -- should be able to now
 alter table distpol drop constraint distpol_pkey;
 create unique index distpol_uidx on distpol(k);
@@ -79,15 +79,15 @@ select attrnums from gp_distribution_policy where
 drop index distpol_uidx;
 -- expressions shouldn't be able to update the distribution key
 create unique index distpol_uidx on distpol(ln(k));
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "distpol"
+ERROR:  The existing distribution key of "distpol" must be equal to or a left-subset of the UNIQUE index
 drop index distpol_uidx;
 ERROR:  index "distpol_uidx" does not exist
 -- lets make sure we don't change the policy when the table is full
 insert into distpol values(1, 2, 3);
 create unique index distpol_uidx on distpol(i);
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "distpol"
+ERROR:  The existing distribution key of "distpol" must be equal to or a left-subset of the UNIQUE index
 alter table distpol add primary key (i);
-ERROR:  PRIMARY KEY must contain all columns in the distribution key of relation "distpol"
+ERROR:  The existing distribution key of "distpol" must be equal to or a left-subset of the PRIMARY KEY
 drop table distpol;
 -- Make sure that distribution policy is derived correctly from PRIMARY KEY
 -- or UNIQUE index. Even with gp_create_table_random_default_distribution=on

--- a/src/test/regress/expected/partition_indexing.out
+++ b/src/test/regress/expected/partition_indexing.out
@@ -294,19 +294,19 @@ NOTICE:  building index for child partition "mpp3033a_1_prt_1"
 NOTICE:  building index for child partition "mpp3033a_1_prt_2"
 NOTICE:  building index for child partition "mpp3033a_1_prt_3"
 NOTICE:  building index for child partition "mpp3033a_1_prt_4"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  The existing distribution key of "mpp3033a" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033a_hundred ON mpp3033a (hundred);
 NOTICE:  building index for child partition "mpp3033a_1_prt_1"
 NOTICE:  building index for child partition "mpp3033a_1_prt_2"
 NOTICE:  building index for child partition "mpp3033a_1_prt_3"
 NOTICE:  building index for child partition "mpp3033a_1_prt_4"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  The existing distribution key of "mpp3033a" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033a_stringu1 ON mpp3033a (stringu1);
 NOTICE:  building index for child partition "mpp3033a_1_prt_1"
 NOTICE:  building index for child partition "mpp3033a_1_prt_2"
 NOTICE:  building index for child partition "mpp3033a_1_prt_3"
 NOTICE:  building index for child partition "mpp3033a_1_prt_4"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  The existing distribution key of "mpp3033a" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033b_unique1 ON mpp3033b (unique1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
@@ -321,7 +321,7 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  The existing distribution key of "mpp3033b" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033b_hundred ON mpp3033b (hundred);
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
@@ -329,7 +329,7 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  The existing distribution key of "mpp3033b" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033b_stringu1 ON mpp3033b (stringu1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
@@ -337,7 +337,7 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  The existing distribution key of "mpp3033b" must be equal to or a left-subset of the UNIQUE index
 select count(*) from mpp3033a;
  count 
 -------
@@ -746,17 +746,17 @@ CREATE UNIQUE INDEX mpp3033a_unique2 ON mpp3033a (unique2);
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  The existing distribution key of "mpp3033a" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033a_hundred ON mpp3033a (hundred);
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  The existing distribution key of "mpp3033a" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033a_stringu1 ON mpp3033a (stringu1);
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  The existing distribution key of "mpp3033a" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033b_unique1 ON mpp3033b (unique1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
@@ -771,7 +771,7 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  The existing distribution key of "mpp3033b" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033b_hundred ON mpp3033b (hundred);
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
@@ -779,7 +779,7 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  The existing distribution key of "mpp3033b" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033b_stringu1 ON mpp3033b (stringu1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
@@ -787,7 +787,7 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
 NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  The existing distribution key of "mpp3033b" must be equal to or a left-subset of the UNIQUE index
 select count(*) from mpp3033a;
  count 
 -------
@@ -1389,7 +1389,7 @@ NOTICE:  building index for child partition "mpp3033a_1_prt_aa_7"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  The existing distribution key of "mpp3033a" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033a_hundred ON mpp3033a (hundred);
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_1"
@@ -1402,7 +1402,7 @@ NOTICE:  building index for child partition "mpp3033a_1_prt_aa_7"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  The existing distribution key of "mpp3033a" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033a_stringu1 ON mpp3033a (stringu1);
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_1"
@@ -1415,7 +1415,7 @@ NOTICE:  building index for child partition "mpp3033a_1_prt_aa_7"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033a"
+ERROR:  The existing distribution key of "mpp3033a" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033b_unique1 ON mpp3033b (unique1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_4"
@@ -1454,7 +1454,7 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  The existing distribution key of "mpp3033b" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033b_hundred ON mpp3033b (hundred);
 NOTICE:  building index for child partition "mpp3033b_1_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_4"
@@ -1474,7 +1474,7 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  The existing distribution key of "mpp3033b" must be equal to or a left-subset of the UNIQUE index
 CREATE UNIQUE INDEX mpp3033b_stringu1 ON mpp3033b (stringu1);
 NOTICE:  building index for child partition "mpp3033b_1_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_4"
@@ -1494,7 +1494,7 @@ NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
 NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
-ERROR:  UNIQUE index must contain all columns in the distribution key of relation "mpp3033b"
+ERROR:  The existing distribution key of "mpp3033b" must be equal to or a left-subset of the UNIQUE index
 select count(*) from mpp3033a;
  count 
 -------

--- a/src/test/regress/sql/create_index.sql
+++ b/src/test/regress/sql/create_index.sql
@@ -275,7 +275,7 @@ DROP TABLE concur_heap;
 
 CREATE TABLE onek_with_null AS SELECT unique1, unique2 FROM onek DISTRIBUTED BY (unique1);
 INSERT INTO onek_with_null (unique1,unique2) VALUES (NULL, -1), (NULL, NULL);
-CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2,unique1);
+CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique1,unique2);
 
 SET enable_seqscan = OFF;
 SET enable_indexscan = ON;
@@ -286,21 +286,21 @@ SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL AND unique2 IS NULL;
 
 DROP INDEX onek_nulltest;
 
-CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2 desc,unique1);
+CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique1,unique2 desc);
 
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL;
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL AND unique2 IS NULL;
 
 DROP INDEX onek_nulltest;
 
-CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2 desc nulls last,unique1);
+CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique1, unique2 desc nulls last);
 
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL;
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL AND unique2 IS NULL;
 
 DROP INDEX onek_nulltest;
 
-CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2  nulls first,unique1);
+CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique1,unique2 nulls first);
 
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL;
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL AND unique2 IS NULL;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_alter_table_add_drop_constraint.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_alter_table_add_drop_constraint.ans
@@ -201,7 +201,7 @@ select count(*) from ck_sync1_heap_films7;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films2 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films2 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "sync1_heap_films2_code_key" for table "sync1_heap_films2"
 ALTER TABLE
 select count(*) from sync1_heap_films2;
@@ -210,7 +210,7 @@ select count(*) from sync1_heap_films2;
      5
 (1 row)
 
-ALTER TABLE ck_sync1_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE ck_sync1_heap_films1 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "ck_sync1_heap_films1_code_key" for table "ck_sync1_heap_films1"
 ALTER TABLE
 select count(*) from ck_sync1_heap_films1;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/sql/ck_sync1_alter_table_add_drop_constraint.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/sql/ck_sync1_alter_table_add_drop_constraint.sql
@@ -148,11 +148,11 @@ select count(*) from ck_sync1_heap_films7;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films2 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films2 ADD UNIQUE(date_prod, code);
 select count(*) from sync1_heap_films2;
 
 
-ALTER TABLE ck_sync1_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE ck_sync1_heap_films1 ADD UNIQUE(date_prod, code);
 select count(*) from ck_sync1_heap_films1;
 
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_alter_table_add_drop_constraint.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_alter_table_add_drop_constraint.ans
@@ -147,7 +147,7 @@ select count(*) from ct_heap_films5;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films4 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films4 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "sync1_heap_films4_code_key" for table "sync1_heap_films4"
 ALTER TABLE
 select count(*) from sync1_heap_films4;
@@ -156,7 +156,7 @@ select count(*) from sync1_heap_films4;
      5
 (1 row)
 
-ALTER TABLE ck_sync1_heap_films3 ADD UNIQUE(code, date_prod);
+ALTER TABLE ck_sync1_heap_films3 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "ck_sync1_heap_films3_code_key" for table "ck_sync1_heap_films3"
 ALTER TABLE
 select count(*) from ck_sync1_heap_films3;
@@ -165,7 +165,7 @@ select count(*) from ck_sync1_heap_films3;
      5
 (1 row)
 
-ALTER TABLE ct_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE ct_heap_films1 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "ct_heap_films1_code_key" for table "ct_heap_films1"
 ALTER TABLE
 select count(*) from ct_heap_films1;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/sql/ct_alter_table_add_drop_constraint.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/sql/ct_alter_table_add_drop_constraint.sql
@@ -110,13 +110,13 @@ select count(*) from ct_heap_films5;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films4 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films4 ADD UNIQUE(date_prod, code);
 select count(*) from sync1_heap_films4;
 
-ALTER TABLE ck_sync1_heap_films3 ADD UNIQUE(code, date_prod);
+ALTER TABLE ck_sync1_heap_films3 ADD UNIQUE(date_prod, code);
 select count(*) from ck_sync1_heap_films3;
 
-ALTER TABLE ct_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE ct_heap_films1 ADD UNIQUE(date_prod, code);
 select count(*) from ct_heap_films1;
 
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_alter_table_add_drop_constraint.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_alter_table_add_drop_constraint.ans
@@ -93,7 +93,7 @@ select count(*) from resync_heap_films3;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films6 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films6 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "sync1_heap_films6_code_key" for table "sync1_heap_films6"
 ALTER TABLE
 select count(*) from sync1_heap_films6;
@@ -102,7 +102,7 @@ select count(*) from sync1_heap_films6;
      5
 (1 row)
 
-ALTER TABLE ck_sync1_heap_films5 ADD UNIQUE(code, date_prod);
+ALTER TABLE ck_sync1_heap_films5 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "ck_sync1_heap_films5_code_key" for table "ck_sync1_heap_films5"
 ALTER TABLE
 select count(*) from ck_sync1_heap_films5;
@@ -111,7 +111,7 @@ select count(*) from ck_sync1_heap_films5;
      5
 (1 row)
 
-ALTER TABLE ct_heap_films3 ADD UNIQUE(code, date_prod);
+ALTER TABLE ct_heap_films3 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "ct_heap_films3_code_key" for table "ct_heap_films3"
 ALTER TABLE
 select count(*) from ct_heap_films3;
@@ -120,7 +120,7 @@ select count(*) from ct_heap_films3;
      5
 (1 row)
 
-ALTER TABLE resync_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE resync_heap_films1 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "resync_heap_films1_code_key" for table "resync_heap_films1"
 ALTER TABLE
 select count(*) from resync_heap_films1;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/sql/resync_alter_table_add_drop_constraint.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/sql/resync_alter_table_add_drop_constraint.sql
@@ -74,16 +74,16 @@ select count(*) from resync_heap_films3;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films6 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films6 ADD UNIQUE(date_prod,code);
 select count(*) from sync1_heap_films6;
 
-ALTER TABLE ck_sync1_heap_films5 ADD UNIQUE(code, date_prod);
+ALTER TABLE ck_sync1_heap_films5 ADD UNIQUE(date_prod,code);
 select count(*) from ck_sync1_heap_films5;
 
-ALTER TABLE ct_heap_films3 ADD UNIQUE(code, date_prod);
+ALTER TABLE ct_heap_films3 ADD UNIQUE(date_prod,code);
 select count(*) from ct_heap_films3;
 
-ALTER TABLE resync_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE resync_heap_films1 ADD UNIQUE(date_prod,code);
 select count(*) from resync_heap_films1;
 
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_alter_table_add_drop_constraint.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_alter_table_add_drop_constraint.ans
@@ -228,7 +228,7 @@ select count(*) from sync1_heap_films8;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films1 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "sync1_heap_films1_code_key" for table "sync1_heap_films1"
 ALTER TABLE
 select count(*) from sync1_heap_films1;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/sql/sync1_alter_table_add_drop_constraint.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/sql/sync1_alter_table_add_drop_constraint.sql
@@ -167,7 +167,7 @@ select count(*) from sync1_heap_films8;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films1 ADD UNIQUE(date_prod, code);
 select count(*) from sync1_heap_films1;
 
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_alter_table_add_drop_constraint.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_alter_table_add_drop_constraint.ans
@@ -66,7 +66,7 @@ select count(*) from sync2_heap_films2;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films7 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films7 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "sync1_heap_films7_code_key" for table "sync1_heap_films7"
 ALTER TABLE
 select count(*) from sync1_heap_films7;
@@ -75,7 +75,7 @@ select count(*) from sync1_heap_films7;
      5
 (1 row)
 
-ALTER TABLE ck_sync1_heap_films6 ADD UNIQUE(code, date_prod);
+ALTER TABLE ck_sync1_heap_films6 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "ck_sync1_heap_films6_code_key" for table "ck_sync1_heap_films6"
 ALTER TABLE
 select count(*) from ck_sync1_heap_films6;
@@ -84,7 +84,7 @@ select count(*) from ck_sync1_heap_films6;
      5
 (1 row)
 
-ALTER TABLE ct_heap_films4 ADD UNIQUE(code, date_prod);
+ALTER TABLE ct_heap_films4 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "ct_heap_films4_code_key" for table "ct_heap_films4"
 ALTER TABLE
 select count(*) from ct_heap_films4;
@@ -93,7 +93,7 @@ select count(*) from ct_heap_films4;
      5
 (1 row)
 
-ALTER TABLE resync_heap_films2 ADD UNIQUE(code, date_prod);
+ALTER TABLE resync_heap_films2 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "resync_heap_films2_code_key" for table "resync_heap_films2"
 ALTER TABLE
 select count(*) from resync_heap_films2;
@@ -102,7 +102,7 @@ select count(*) from resync_heap_films2;
      5
 (1 row)
 
-ALTER TABLE sync2_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync2_heap_films1 ADD UNIQUE(date_prod, code);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "sync2_heap_films1_code_key" for table "sync2_heap_films1"
 ALTER TABLE
 select count(*) from sync2_heap_films1;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/sql/sync2_alter_table_add_drop_constraint.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/sql/sync2_alter_table_add_drop_constraint.sql
@@ -54,19 +54,19 @@ select count(*) from sync2_heap_films2;
 --
 --ADD table_constraint
 --
-ALTER TABLE sync1_heap_films7 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync1_heap_films7 ADD UNIQUE(date_prod, code);
 select count(*) from sync1_heap_films7;
 
-ALTER TABLE ck_sync1_heap_films6 ADD UNIQUE(code, date_prod);
+ALTER TABLE ck_sync1_heap_films6 ADD UNIQUE(date_prod, code);
 select count(*) from ck_sync1_heap_films6;
 
-ALTER TABLE ct_heap_films4 ADD UNIQUE(code, date_prod);
+ALTER TABLE ct_heap_films4 ADD UNIQUE(date_prod, code);
 select count(*) from ct_heap_films4;
 
-ALTER TABLE resync_heap_films2 ADD UNIQUE(code, date_prod);
+ALTER TABLE resync_heap_films2 ADD UNIQUE(date_prod, code);
 select count(*) from resync_heap_films2;
 
-ALTER TABLE sync2_heap_films1 ADD UNIQUE(code, date_prod);
+ALTER TABLE sync2_heap_films1 ADD UNIQUE(date_prod, code);
 select count(*) from sync2_heap_films1;
 
 --

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_pkey_4.ans
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_pkey_4.ans
@@ -5,7 +5,7 @@
 -- @tags partitionindexes
 -- @negtest True
 -- @description ALTER TABLE, Unique index with Primary Key
-ALTER TABLE pt_lt_tab ADD primary key(col2,col1);
+ALTER TABLE pt_lt_tab ADD primary key(col1,col2);
 psql:alter_tab_add_pkey_4.sql:7: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pt_lt_tab_pkey" for table "pt_lt_tab"
 psql:alter_tab_add_pkey_4.sql:7: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pt_lt_tab_1_prt_part1_pkey" for table "pt_lt_tab_1_prt_part1"
 psql:alter_tab_add_pkey_4.sql:7: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pt_lt_tab_1_prt_part2_pkey" for table "pt_lt_tab_1_prt_part2"

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_pkey_6.ans
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_pkey_6.ans
@@ -5,7 +5,7 @@
 -- @tags partitionindexes
 -- @negtest True
 -- @description ALTER TABLE, Unique index with Primary Key
-ALTER TABLE pt_lt_tab ADD primary key(col2,col1);
+ALTER TABLE pt_lt_tab ADD primary key(col1,col2);
 psql:alter_tab_add_pkey_6.sql:7: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pt_lt_tab_pkey" for table "pt_lt_tab"
 psql:alter_tab_add_pkey_6.sql:7: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pt_lt_tab_1_prt_part1_pkey" for table "pt_lt_tab_1_prt_part1"
 psql:alter_tab_add_pkey_6.sql:7: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pt_lt_tab_1_prt_part2_pkey" for table "pt_lt_tab_1_prt_part2"

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_3.ans
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_3.ans
@@ -4,7 +4,7 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1,col2);
 psql:alter_tab_add_uniquekey_3.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_col2_key" for table "pt_lt_tab"
 psql:alter_tab_add_uniquekey_3.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part1_col2_key" for table "pt_lt_tab_1_prt_part1"
 psql:alter_tab_add_uniquekey_3.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part2_col2_key" for table "pt_lt_tab_1_prt_part2"

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_4.ans
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_4.ans
@@ -4,7 +4,7 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1,col2);
 psql:alter_tab_add_uniquekey_4.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_col2_key" for table "pt_lt_tab"
 psql:alter_tab_add_uniquekey_4.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part1_col2_key" for table "pt_lt_tab_1_prt_part1"
 psql:alter_tab_add_uniquekey_4.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part2_col2_key" for table "pt_lt_tab_1_prt_part2"

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_5.ans
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_5.ans
@@ -4,7 +4,7 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1,col2);
 psql:alter_tab_add_uniquekey_5.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_col2_key" for table "pt_lt_tab"
 psql:alter_tab_add_uniquekey_5.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part1_col2_key" for table "pt_lt_tab_1_prt_part1"
 psql:alter_tab_add_uniquekey_5.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part2_col2_key" for table "pt_lt_tab_1_prt_part2"

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_7.ans
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_7.ans
@@ -4,7 +4,7 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1,col2);
 psql:alter_tab_add_uniquekey_7.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_col2_key" for table "pt_lt_tab"
 psql:alter_tab_add_uniquekey_7.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part1_col2_key" for table "pt_lt_tab_1_prt_part1"
 psql:alter_tab_add_uniquekey_7.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part2_col2_key" for table "pt_lt_tab_1_prt_part2"

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_9.ans
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/expected/alter_tab_add_uniquekey_9.ans
@@ -4,7 +4,7 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1,col2);
 psql:alter_tab_add_uniquekey_9.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_col2_key" for table "pt_lt_tab"
 psql:alter_tab_add_uniquekey_9.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part1_col2_key" for table "pt_lt_tab_1_prt_part1"
 psql:alter_tab_add_uniquekey_9.sql:7: NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "pt_lt_tab_1_prt_part2_col2_key" for table "pt_lt_tab_1_prt_part2"

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_pkey_4.sql
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_pkey_4.sql
@@ -5,5 +5,5 @@
 -- @tags partitionindexes
 -- @negtest True
 -- @description ALTER TABLE, Unique index with Primary Key
-ALTER TABLE pt_lt_tab ADD primary key(col2,col1);
+ALTER TABLE pt_lt_tab ADD primary key(col1,col2);
 SELECT * FROM pt_lt_tab WHERE col2 <> 10 ORDER BY col2,col3 LIMIT 5;

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_pkey_6.sql
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_pkey_6.sql
@@ -5,5 +5,5 @@
 -- @tags partitionindexes
 -- @negtest True
 -- @description ALTER TABLE, Unique index with Primary Key
-ALTER TABLE pt_lt_tab ADD primary key(col2,col1);
+ALTER TABLE pt_lt_tab ADD primary key(col1,col2);
 SELECT * FROM pt_lt_tab  WHERE col2 > 10 OR col1 = 50 ORDER BY col2,col3 LIMIT 5;

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_3.sql
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_3.sql
@@ -4,5 +4,5 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1,col2);
 SELECT * FROM pt_lt_tab WHERE col1 < 10 ORDER BY col2,col3 LIMIT 5;

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_4.sql
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_4.sql
@@ -4,5 +4,5 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1,col2);
 SELECT * FROM pt_lt_tab WHERE col1 > 50 ORDER BY col2,col3 LIMIT 5;

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_5.sql
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_5.sql
@@ -4,5 +4,5 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1, col2);
 SELECT * FROM pt_lt_tab WHERE col2 = 25 ORDER BY col2,col3 LIMIT 5;

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_7.sql
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_7.sql
@@ -4,5 +4,5 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1,col2);
 SELECT * FROM pt_lt_tab  WHERE col2 > 10 AND col1 = 10 ORDER BY col2,col3 LIMIT 5;

--- a/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_9.sql
+++ b/src/test/tinc/tincrepo/partitioning/partitionindexes/sql/alter_tab_add_uniquekey_9.sql
@@ -4,5 +4,5 @@
 -- @db_name ptidx
 -- @tags partitionindexes
 -- @description ALTER TABLE, Unique index with Primary Key, unique index on the default partition 
-ALTER TABLE pt_lt_tab ADD unique(col2,col1);
+ALTER TABLE pt_lt_tab ADD unique(col1,col2);
 SELECT * FROM pt_lt_tab  WHERE col2 between 10 AND 50 ORDER BY col2,col3 LIMIT 5;


### PR DESCRIPTION
Previously when ALTER TABLE ADD UNIQUE INDEX, we only verify that
DISTRIBUTED BY columns must be equal to or a subset of the UNIQUE INDEX
columns. Theoretically there is nothing wrong with it, however, given
the fact that CREATE TABLE and ALTER TABLE ADD PARTITION have always
been limiting the DISTRIBUTED BY columns to be equal to or a
left-subset(prefix) of the UNIQUE INDEX columns, we have to apply the
same restriction to ADD UNIQUE INDEX. Otherwise, it is possible to
successfully add an unique index that contains all the distributed by
columns but with different order, after this new partitions can never be
added.

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>

This is to re-open PR #7298. It was reverted because it failed the filerep tests
and QP_optimizer-functional test. Now those tests are fixed.
