### PR TITLE
Remove warning log on gpfdist curl operation timeout

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -569,10 +569,22 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		CURLcode e = curl_easy_perform(file->curl->handle);
 		if (CURLE_OK != e)
 		{
-			elog(WARNING, "%s error (%d - %s)", file->curl_url, e, curl_easy_strerror(e));
 			if (CURLE_OPERATION_TIMEDOUT == e)
 			{
 				timeout_count++;
+				elog(LOG, "curl operation timeout, timeout_count = %d", timeout_count);
+				if (timeout_count >= 2)
+				{
+					ereport(ERROR,
+					(errcode(ERRCODE_CONNECTION_FAILURE),
+					errmsg("error when writing data to gpfdist %s, quit after %d timeout_count",
+							file->curl_url, timeout_count)));
+				}
+				continue;
+			}
+			else
+			{
+				elog(WARNING, "%s error (%d - %s)", file->curl_url, e, curl_easy_strerror(e));
 			}
 		}
 		else
@@ -586,6 +598,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 					return;
 
 				case FDIST_TIMEOUT:
+					elog(LOG, "%s timeout from gpfdist", file->curl_url);
 					break;
 
 				default:
@@ -599,7 +612,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 			response_string = NULL;
 		}
 
-		if (wait_time > MAX_TRY_WAIT_TIME || timeout_count >= 2)
+		if (wait_time > MAX_TRY_WAIT_TIME)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_CONNECTION_FAILURE),


### PR DESCRIPTION
GPDB prints warning log and retry on gpfdist curl operation timeout.
If the retry succeeds, ODBC driver API SQLExecDirectW() will return
code 1 (SQL_SUCCESS_WITH_INFO). It is considered as unexpected result
in some ODBC client implementations.
So we remove the warning log in this case, and maintain GPDB behavior.

test can be covered by gpfdist and upload cases.