### PR TITLE
Fix uninitialized variable 'need_recheck' for appendonly bitmap index…

### DIFF
--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -671,7 +671,7 @@ BitmapAppendOnlyNext(BitmapHeapScanState *node)
 	for (;;)
 	{
 		TBMIterateResult *tbmres = node->tbmres;
-		bool		need_recheck;
+		bool		need_recheck = false;
 
 		CHECK_FOR_INTERRUPTS();
 


### PR DESCRIPTION
…scan (#7657)

when appendonly row-oriented table through bitmap indexscan, variable
'need_recheck' do not Initialized in BitmapAppendOnlyNextfunction,
then the value is always 'true' for release, result to unnecessary
recheck the qual conditions at every tuple.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
