### PR TITLE
Changes needed for removal of CDXLDatum::IsPassByValue().

### DIFF
--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -19,4 +19,4 @@ params:
   BLD_TARGETS:
   OUTPUT_ARTIFACT_DIR: gpdb_artifacts
   CONFIGURE_FLAGS:
-  ORCA_TAG: v3.69.0
+  ORCA_TAG: v3.70.0

--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.69.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.70.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.69.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.70.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -14131,7 +14131,7 @@ int
 main ()
 {
 
-return strncmp("3.69.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.70.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -14141,7 +14141,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.69.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.70.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.69.0@gpdb/stable
+orca/v3.70.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -1501,9 +1501,9 @@ CTranslatorDXLToScalar::ConvertDXLDatumToConstOid
 	constant->consttype = CMDIdGPDB::CastMdid(oid_datum_dxl->MDId())->Oid();
 	constant->consttypmod = -1;
 	constant->constcollid = InvalidOid;
-	constant->constbyval = oid_datum_dxl->IsPassedByValue();
+	constant->constbyval = true;
 	constant->constisnull = oid_datum_dxl->IsNull();
-	constant->constlen = oid_datum_dxl->Length();
+	constant->constlen = sizeof(Oid);
 
 	if (constant->constisnull)
 	{
@@ -1538,9 +1538,9 @@ CTranslatorDXLToScalar::ConvertDXLDatumToConstInt2
 	constant->consttype = CMDIdGPDB::CastMdid(datum_int2_dxl->MDId())->Oid();
 	constant->consttypmod = -1;
 	constant->constcollid = InvalidOid;
-	constant->constbyval = datum_int2_dxl->IsPassedByValue();
+	constant->constbyval = true;
 	constant->constisnull = datum_int2_dxl->IsNull();
-	constant->constlen = datum_int2_dxl->Length();
+	constant->constlen = sizeof(int16);
 
 	if (constant->constisnull)
 	{
@@ -1575,9 +1575,9 @@ CTranslatorDXLToScalar::ConvertDXLDatumToConstInt4
 	constant->consttype = CMDIdGPDB::CastMdid(datum_int4_dxl->MDId())->Oid();
 	constant->consttypmod = -1;
 	constant->constcollid = InvalidOid;
-	constant->constbyval = datum_int4_dxl->IsPassedByValue();
+	constant->constbyval = true;
 	constant->constisnull = datum_int4_dxl->IsNull();
-	constant->constlen = datum_int4_dxl->Length();
+	constant->constlen = sizeof(int32);
 
 	if (constant->constisnull)
 	{
@@ -1611,9 +1611,9 @@ CTranslatorDXLToScalar::ConvertDXLDatumToConstInt8
 	constant->consttype = CMDIdGPDB::CastMdid(datum_int8_dxl->MDId())->Oid();
 	constant->consttypmod = -1;
 	constant->constcollid = InvalidOid;
-	constant->constbyval = datum_int8_dxl->IsPassedByValue();
+	constant->constbyval = FLOAT8PASSBYVAL;
 	constant->constisnull = datum_int8_dxl->IsNull();
-	constant->constlen = datum_int8_dxl->Length();
+	constant->constlen = sizeof(int64);
 
 	if (constant->constisnull)
 	{
@@ -1647,9 +1647,9 @@ CTranslatorDXLToScalar::ConvertDXLDatumToConstBool
 	constant->consttype = CMDIdGPDB::CastMdid(datum_bool_dxl->MDId())->Oid();
 	constant->consttypmod = -1;
 	constant->constcollid = InvalidOid;
-	constant->constbyval = datum_bool_dxl->IsPassedByValue();
+	constant->constbyval = true;
 	constant->constisnull = datum_bool_dxl->IsNull();
-	constant->constlen = datum_bool_dxl->Length();
+	constant->constlen = sizeof(bool);
 
 	if (constant->constisnull)
 	{
@@ -1679,16 +1679,17 @@ CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar
 	)
 {
 	CDXLDatumGeneric *datum_generic_dxl = CDXLDatumGeneric::Cast(datum_dxl);
+	const IMDType *type = m_md_accessor->RetrieveType(datum_generic_dxl->MDId());
 
 	Const *constant = MakeNode(Const);
 	constant->consttype = CMDIdGPDB::CastMdid(datum_generic_dxl->MDId())->Oid();
 	constant->consttypmod = datum_generic_dxl->TypeModifier();
 	// GPDB_91_MERGE_FIXME: collation
 	constant->constcollid = gpdb::TypeCollation(constant->consttype);
-	constant->constbyval = datum_generic_dxl->IsPassedByValue();
-	constant->constisnull = datum_generic_dxl->IsNull();
-	constant->constlen = datum_generic_dxl->Length();
+	constant->constbyval = type->IsPassedByValue();
+	constant->constlen = type->Length();
 
+	constant->constisnull = datum_generic_dxl->IsNull();
 	if (constant->constisnull)
 	{
 		constant->constvalue = (Datum) 0;

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -2155,7 +2155,6 @@ CTranslatorScalarToDXL::TranslateGenericDatumToDXL
 	CMDIdGPDB *mdid_old = CMDIdGPDB::CastMdid(md_type->MDId());
 	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(*mdid_old);
 
-	BOOL is_const_by_val = md_type->IsPassedByValue();
 	BYTE *bytes = ExtractByteArrayFromDatum(mp, md_type, is_null, len, datum);
 	ULONG length = 0;
 	if (!is_null)
@@ -2175,7 +2174,7 @@ CTranslatorScalarToDXL::TranslateGenericDatumToDXL
 		lint_value = ExtractLintValueFromDatum(mdid, is_null, bytes, length);
 	}
 
-	return CMDTypeGenericGPDB::CreateDXLDatumVal(mp, mdid, type_modifier, is_const_by_val, is_null, bytes, length, lint_value, double_value);
+	return CMDTypeGenericGPDB::CreateDXLDatumVal(mp, mdid, type_modifier, is_null, bytes, length, lint_value, double_value);
 }
 
 

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2180,8 +2180,6 @@ CTranslatorUtils::CreateDXLProjElemConstNULL
 	CHAR *alias_name
 	)
 {
-	BOOL is_passed_by_value = md_accessor->RetrieveType(mdid)->IsPassedByValue();
-
 	// get the id and alias for the proj elem
 	CMDName *alias_mdname = NULL;
 
@@ -2226,7 +2224,6 @@ CTranslatorUtils::CreateDXLProjElemConstNULL
 										mp,
 										mdid,
 										default_type_modifier,
-										is_passed_by_value /*fConstByVal*/,
 										true /*fConstNull*/,
 										NULL, /*pba */
 										0 /*length*/,


### PR DESCRIPTION
GPORCA PR https://github.com/greenplum-db/gporca/pull/475 will remove
CDXLDatum::IsPassByValue() method and related code, because it's not
really needed and bloats DXL files unnecessarily. This commit makes the
corresponding changes to the GPORCA translator code.
