### PR TITLE
Validate symlink target before adding symlink to basebackup TAR.

### DIFF
--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -90,6 +90,7 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
+#include "utils/tarrable.h"
 #include "utils/tqual.h"
 
 #include "catalog/heap.h"
@@ -98,9 +99,6 @@
 #include "cdb/cdbvars.h"
 #include "cdb/cdbutil.h"
 #include "miscadmin.h"
-
-
-#define MAX_TARABLE_SYMLINK_PATH_LENGTH 100
 
 
 /* GUC variables */

--- a/src/include/utils/tarrable.h
+++ b/src/include/utils/tarrable.h
@@ -1,0 +1,20 @@
+/*-------------------------------------------------------------------------
+ *
+ * tarrable.h
+ *
+ *
+ * Copyright (c) 2019-Present Pivotal Software, Inc.
+ *
+ *
+ * IDENTIFICATION
+ *	    src/include/utils/tarrable.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef TARRABLE_H
+#define TARRABLE_H
+
+#define MAX_TARABLE_SYMLINK_PATH_LENGTH 100
+
+#endif /* TARRABLE_H */
+

--- a/src/test/perl/TestLib.pm
+++ b/src/test/perl/TestLib.pm
@@ -42,6 +42,8 @@ our @EXPORT = qw(
   program_version_ok
   program_options_handling_ok
   command_like
+  command_warns_like
+  command_fails_like
   issues_sql_like
 
   $tmp_check
@@ -387,14 +389,26 @@ sub command_like
 	like($stdout, $expected_stdout, "$test_name: matches");
 }
 
+sub command_warns_like
+{
+	my ($cmd, $expected_stderr, $test_name) = @_;
+	my ($stdout, $stderr);
+	print("# Running: " . join(" ", @{$cmd}) . "\n");
+	my $result = run $cmd, '>', \$stdout, '2>', \$stderr;
+	ok($result, "@$cmd exit code 0");
+	like($stderr, $expected_stderr, "$test_name: matches.");
+}
+
 sub command_fails_like
 {
-	my ($cmd, $expected_sql, $test_name) = @_;
-	truncate $test_server_logfile, 0;
-	my $result = run_log($cmd);
-	ok($result, "@$cmd exit code 0");
-	my $log = slurp_file($test_server_logfile);
-	like($log, $expected_sql, "$test_name: SQL found in server log");
+	my ($cmd, $expected_stderr, $test_name) = @_;
+	my ($stdout, $stderr);
+
+	print("# Running: " . join(" ", @{$cmd}) . "\n");
+	my $result = run $cmd, '>', \$stdout, '2>', \$stderr;
+
+	ok(!$result, "expected failure: got @$cmd exit code 0");
+	like($stderr, $expected_stderr, "$test_name: not match expected stderr");
 }
 
 1;


### PR DESCRIPTION
Symlink targets are only allowed to be 100 characters long according
to the TAR format we use to send base backups.

Send a warning to the user that the symlink target path is too long,
and that the symlink directory will not be included in the backup.

Note: the perl tests now include a function styled similarly to `command_like` and `command_fails_like` called `command_warns_like` that checks stderr against an expected expression, but also checks to see that the command succeeds.