### PR TITLE
docs - add content for new pxf read file as row feature

### DIFF
--- a/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
@@ -18,7 +18,7 @@ Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_
 
 You can read single- and multi-line files into a single table row, including files with embedded linefeeds. If you are reading multiple JSON files, each file must be a complete record, and each file should contain the same record type.
 
-PXF reads the complete file data into a single column. When you create the external table to read multiple files, you must ensure that all of the files that you want to read are of the same (text or JSON) type. You must also specify a single `text` or `json` column, depending upon the file type.
+PXF reads the complete file data into a single row and column. When you create the external table to read multiple files, you must ensure that all of the files that you want to read are of the same (text or JSON) type. You must also specify a single `text` or `json` column, depending upon the file type.
 
 The following syntax creates a Greenplum Database readable external table that references one or more text or JSON files on HDFS:
 
@@ -143,7 +143,7 @@ Beijing,Jul,411,11600.67' > /tmp/file2.txt
 
 7. Log in to a Greenplum Database system and start the `psql` subsystem.
 
-8. Use the `hdfs:text:multi` profile to create an external table that references the `fileasrow` HDFS directory. For example:
+8. Use the `hdfs:text:multi` profile to create an external table that references the `tdir` HDFS directory. For example:
 
     ``` sql
     CREATE EXTERNAL TABLE pxf_readfileasrow(c1 text)

--- a/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
@@ -1,8 +1,8 @@
 ---
-title: Reading a Multi-Line Text or JSON File into a Single Table Row
+title: Reading a Multi-Line Text File into a Single Table Row
 ---
 
-You can use the PXF HDFS connector to read one or more multi-line files in HDFS each as a single table row. This may be useful when you want to read multiple files into the same Greenplum Database external table, for example when individual JSON files each contain a separate record.
+You can use the PXF HDFS connector to read one or more multi-line text files in HDFS each as a single table row. This may be useful when you want to read multiple files into the same Greenplum Database external table, for example when individual JSON files each contain a separate record.
 
 PXF supports reading only text and JSON files in this manner.
 

--- a/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
@@ -16,7 +16,7 @@ Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_
 
 ## <a id="fileasrow"></a>Reading Multi-Line Text and JSON Files
 
-You can read single- and multi-line files into a single table row, including files with embedded linefeeds. If you are reading multiple JSON files, each file must be a complete record, and each file should contain the same record type.
+You can read single- and multi-line files into a single table row, including files with embedded linefeeds. If you are reading multiple JSON files, each file must be a complete record, and each file must contain the same record type.
 
 PXF reads the complete file data into a single row and column. When you create the external table to read multiple files, you must ensure that all of the files that you want to read are of the same (text or JSON) type. You must also specify a single `text` or `json` column, depending upon the file type.
 
@@ -114,19 +114,19 @@ Beijing,Jul,411,11600.67' > /tmp/file2.txt
 
     This file has multiple lines.
 
-4. Create a third text file. Open a file named `/tmp/file3.txt` in a text editor and copy/paste the following data into the file:
+4. Create a third text file named `/tmp/file3.txt`:
 
-    ``` pre
-    "4627 Star Rd.
-    San Francisco, CA  94107":Sept:2017
-    "113 Moon St.
-    San Diego, CA  92093":Jan:2018
-    "51 Belt Ct.
-    Denver, CO  90123":Dec:2016
-    "93114 Radial Rd.
-    Chicago, IL  60605":Jul:2017
-    "7301 Brookview Ave.
-    Columbus, OH  43213":Dec:2018
+    ``` shell
+    $ echo '"4627 Star Rd.
+San Francisco, CA  94107":Sept:2017
+"113 Moon St.
+San Diego, CA  92093":Jan:2018
+"51 Belt Ct.
+Denver, CO  90123":Dec:2016
+"93114 Radial Rd.
+Chicago, IL  60605":Jul:2017
+"7301 Brookview Ave.
+Columbus, OH  43213":Dec:2018' > /tmp/file3.txt
     ```
 
     This file includes embedded line feeds.

--- a/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
@@ -1,0 +1,181 @@
+---
+title: Reading a Multi-Line Text or JSON File into a Single Table Row
+---
+
+You can use the PXF HDFS connector to read one or more multi-line files in HDFS each as a single table row. This may be useful when you want to read multiple files into the same Greenplum Database external table, for example when individual JSON files each contain a separate record.
+
+PXF supports reading only text and JSON files in this manner.
+
+**Note**: Refer to the [Reading JSON Data from HDFS](hdfs_json.html) topic if you want to use PXF to read JSON files that include more than one record.
+
+
+## <a id="prereq"></a>Prerequisites
+
+Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq) before you attempt to read files from HDFS.
+
+
+## <a id="fileasrow"></a>Reading Multi-Line Text and JSON Files
+
+You can read single- and multi-line files into a single table row, including files with embedded linefeeds. If you are reading multiple JSON files, each file must be a complete record, and each file should contain the same record type.
+
+PXF reads the complete file data into a single column. When you create the external table to read multiple files, you must ensure that all of the files that you want to read are of the same (text or JSON) type. You must also specify a single `text` or `json` column, depending upon the file type.
+
+The following syntax creates a Greenplum Database readable external table that references one or more text or JSON files on HDFS:
+
+``` sql
+CREATE EXTERNAL TABLE <table_name>
+    ( <column_name> text|json | LIKE <other_table> )
+  LOCATION ('pxf://<path-to-files>?PROFILE=hdfs:text:multi[&SERVER=<server_name>]&FILE_AS_ROW=true')
+FORMAT 'CSV');
+```
+
+The keywords and values used in this [CREATE EXTERNAL TABLE](../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<path&#8209;to&#8209;files\>    | The absolute path to the directory or files in the HDFS data store. |
+| PROFILE    | The `PROFILE` keyword must specify `hdfs:text:multi`. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| FILE\_AS\_ROW=true    | The required option that instructs PXF to read each file into a single table row. |
+| FORMAT | The `FORMAT` must specify `'CSV'`.  |
+
+**Note**: The `hdfs:text:multi` profile does not support additional format options when you specify the `FILE_AS_ROW=true` option.
+
+For example, if `/data/pxf_examples/jdir` identifies an HDFS directory that contains a number of JSON files, the following statement creates a Greenplum Database external table that references all of the files in that directory:
+
+``` sql
+CREATE EXTERNAL TABLE pxf_readjfiles(j1 json)
+  LOCATION ('pxf://data/pxf_examples/jdir?PROFILE=hdfs:text:multi&FILE_AS_ROW=true')
+FORMAT 'CSV';
+```
+
+When you query the `pxf_readjfiles` table with a `SELECT` statement, PXF returns the contents of each JSON file in `jdir/` as a separate row in the external table.
+
+When you read JSON files, you can use the JSON functions provided in Greenplum Database to access individual data fields in the JSON record. For example, if the `pxf_readjfiles` external table above reads a JSON file that contains this JSON record:
+
+``` json
+{
+  "root":[
+    {
+      "record_obj":{
+        "created_at":"MonSep3004:04:53+00002013",
+        "id_str":"384529256681725952",
+        "user":{
+          "id":31424214,
+          "location":"COLUMBUS"
+        },
+        "coordinates":null
+      }
+    }
+  ]
+}
+```
+
+You can use the `json_array_elements()` function to extract specific JSON fields from the table row. For example, the following command displays the `user->id` field:
+
+``` sql
+SELECT json_array_elements(j1->'root')->'record_obj'->'user'->'id'
+  AS userid FROM pxf_readjfiles;
+
+  userid  
+----------
+ 31424214
+(1 rows)
+```
+
+Refer to [Working with JSON Data](../admin_guide/query/topics/json-data.html) for specific information on manipulating JSON data with Greenplum Database.
+
+
+### <a id="example_fileasrow"></a>Example: Reading an HDFS Text File into a Single Table Row
+
+Perform the following procedure to create 3 sample text files in an HDFS directory, and use the PXF `hdfs:text:multi` profile and the default PXF server to read all of these text files in a single external table query.
+
+
+1. Create an HDFS directory for the text files. For example:
+
+    ``` shell
+    $ hdfs dfs -mkdir -p /data/pxf_examples/tdir
+    ```
+
+2. Create a text data file named `file1.txt`:
+
+    ``` shell
+    $ echo 'text file with only one line' > /tmp/file1.txt
+    ```
+
+3. Create a second text data file named `file2.txt`:
+
+    ``` shell
+    $ echo 'Prague,Jan,101,4875.33
+Rome,Mar,87,1557.39
+Bangalore,May,317,8936.99
+Beijing,Jul,411,11600.67' > /tmp/file2.txt
+    ```
+
+    This file has multiple lines.
+
+4. Create a third text file. Open a file named `/tmp/file3.txt` in a text editor and copy/paste the following data into the file:
+
+    ``` pre
+    "4627 Star Rd.
+    San Francisco, CA  94107":Sept:2017
+    "113 Moon St.
+    San Diego, CA  92093":Jan:2018
+    "51 Belt Ct.
+    Denver, CO  90123":Dec:2016
+    "93114 Radial Rd.
+    Chicago, IL  60605":Jul:2017
+    "7301 Brookview Ave.
+    Columbus, OH  43213":Dec:2018
+    ```
+
+    This file includes embedded line feeds.
+
+5. Save the file and exit the editor.
+
+6. Copy the text files to HDFS:
+
+    ``` shell
+    $ hdfs dfs -put /tmp/file1.txt /data/pxf_examples/tdir
+    $ hdfs dfs -put /tmp/file2.txt /data/pxf_examples/tdir
+    $ hdfs dfs -put /tmp/file3.txt /data/pxf_examples/tdir
+    ```
+
+7. Log in to a Greenplum Database system and start the `psql` subsystem.
+
+8. Use the `hdfs:text:multi` profile to create an external table that references the `fileasrow` HDFS directory. For example:
+
+    ``` sql
+    CREATE EXTERNAL TABLE pxf_readfileasrow(c1 text)
+      LOCATION ('pxf://data/pxf_examples/tdir?PROFILE=hdfs:text:multi&FILE_AS_ROW=true')
+    FORMAT 'CSV';
+    ```
+    
+9. Turn on expanded display and query the `pxf_readfileasrow` table:
+
+    ``` sql
+    postgres=# \x on
+    postgres=# SELECT * FROM pxf_readfileasrow;
+    ```
+
+    ``` pre
+    -[ RECORD 1 ]---------------------------
+    c1 | Prague,Jan,101,4875.33
+       | Rome,Mar,87,1557.39
+       | Bangalore,May,317,8936.99
+       | Beijing,Jul,411,11600.67
+    -[ RECORD 2 ]---------------------------
+    c1 | text file with only one line
+    -[ RECORD 3 ]---------------------------
+    c1 | "4627 Star Rd.
+       | San Francisco, CA  94107":Sept:2017
+       | "113 Moon St.
+       | San Diego, CA  92093":Jan:2018
+       | "51 Belt Ct.
+       | Denver, CO  90123":Dec:2016
+       | "93114 Radial Rd.
+       | Chicago, IL  60605":Jul:2017
+       | "7301 Brookview Ave.
+       | Columbus, OH  43213":Dec:2018
+    ```
+

--- a/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
@@ -27,7 +27,7 @@ The following syntax creates a Greenplum Database readable external table that r
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> text|json | LIKE <other_table> )
-  LOCATION ('pxf://<path-to-hdfs-files>?PROFILE=hdfs:text:multi[&SERVER=<server_name>]&FILE_AS_ROW=true')
+  LOCATION ('pxf://<path-to-files>?PROFILE=<objstore>:text:multi[&SERVER=<server_name>]&FILE_AS_ROW=true')
   FORMAT 'CSV');
 ```
 
@@ -35,7 +35,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 
 | Keyword  | Value |
 |-------|-------------------------------------|
-| \<path&#8209;to&#8209;&#8209;files\>    | The absolute path to the directory or files in the object store. |
+| \<path&#8209;to&#8209;files\>    | The absolute path to the directory or files in the object store. |
 | PROFILE=\<objstore\>:text:multi    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text:multi`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
 | FILE\_AS\_ROW=true    | The required option that instructs PXF to read each file into a single table row. |

--- a/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
@@ -1,8 +1,10 @@
 ---
-title: Reading a Multi-Line Text or JSON File into a Single Table Row
+title: Reading a Multi-Line Text File into a Single Table Row
 ---
 
-The PXF object store connectors support reading a multi-line file as a single table row. This section describes how to use PXF to read multi-line text and JSON data files in an object store, including how to create an external table that references multiple files in the store.
+The PXF object store connectors support reading a multi-line text file as a single table row. This section describes how to use PXF to read multi-line text and JSON data files in an object store, including how to create an external table that references multiple files in the store.
+
+PXF supports reading only text and JSON files in this manner.
 
 **Note**: Accessing multi-line files from an object store is very similar to accessing multi-line files in HDFS. This topic identifies the object store-specific information required to read these files. Refer to the [PXF HDFS documentation](hdfs_fileasrow.html) for more information.
 

--- a/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
@@ -1,0 +1,65 @@
+---
+title: Reading a Multi-Line Text or JSON File into a Single Table Row
+---
+
+The PXF object store connectors support reading a multi-line file as a single table row. This section describes how to use PXF to read multi-line text and JSON data files in an object store, including how to create an external table that references multiple files in the store.
+
+**Note**: Accessing multi-line files from an object store is very similar to accessing multi-line files in HDFS. This topic identifies the object store-specific information required to read these files. Refer to the [PXF HDFS documentation](hdfs_fileasrow.html) for more information.
+
+## <a id="prereq"></a>Prerequisites
+
+Ensure that you have met the PXF Object Store [Prerequisites](access_objstore.html#objstore_prereq) before you attempt to read data from multiple files residing in an object store.
+
+## <a id="objmulti_cet"></a>Creating the External Table
+
+Use the `<objstore>:hdfs:multi` profile to read multiple files in an object store each into a single table row. PXF supports the following `<objstore>` profile prefixes:
+
+| Object Store  | Profile Prefix |
+|-------|-------------------------------------|
+| Azure Blob Storage   | wasbs |
+| Azure Data Lake    | adl |
+| Google Cloud Storage    | gs |
+| Minio    | s3 |
+| S3    | s3 |
+
+The following syntax creates a Greenplum Database readable external table that references one or more text files in an object store:
+
+``` sql
+CREATE EXTERNAL TABLE <table_name>
+    ( <column_name> text|json | LIKE <other_table> )
+  LOCATION ('pxf://<path-to-hdfs-files>?PROFILE=hdfs:text:multi[&SERVER=<server_name>]&FILE_AS_ROW=true')
+  FORMAT 'CSV');
+```
+
+The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<path&#8209;to&#8209;&#8209;files\>    | The absolute path to the directory or files in the object store. |
+| PROFILE=\<objstore\>:text:multi    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text:multi`. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| FILE\_AS\_ROW=true    | The required option that instructs PXF to read each file into a single table row. |
+| FORMAT | The `FORMAT` must specify `'CSV'`.  |
+
+If you are accessing an S3 object store, you can provide S3 credentials directly in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration](access_objstore.html#s3_override).
+
+## <a id="example"></a>Example
+
+Refer to [Example: Reading an HDFS Text File into a Single Table Row](hdfs_fileasrow.html#example_fileasrow) in the PXF HDFS documentation for an example. Modifications that you must make to run the example with an object store include:
+
+- Copying the file to the object store instead of HDFS. For example, to copy the file to S3:
+
+    ``` shell
+    $ aws s3 cp /tmp/file1.txt s3://BUCKET/pxf_examples/tdir
+    $ aws s3 cp /tmp/file2.txt s3://BUCKET/pxf_examples/tdir
+    $ aws s3 cp /tmp/file3.txt s3://BUCKET/pxf_examples/tdir
+    ```
+
+- Using the `CREATE EXTERNAL TABLE` syntax and `LOCATION` keywords and settings described above. For example, if your server name is `s3srvcfg`:
+
+    ``` sql
+    CREATE EXTERNAL TABLE pxf_readfileasrow_s3( c1 text )
+      LOCATION('pxf://BUCKET/pxf_examples/tdir?PROFILE=s3:text:multi&SERVER=s3srvcfg&FILE_AS_ROW=true')
+    FORMAT 'CSV'
+    ```
+


### PR DESCRIPTION
pxf now supports reading one or more multi-line files where each file is a single row in the same external table.  the current pxf "using" docs are partitioned by external location: hadoop/objstore/jdbc.  within hadoop/objstore docs, we break the docs down by data format: text/avro/json/parquet...  this feature uses a previously-defined text profile (`*:text:multi`) to support text and JSON files.  adding content to the text page and JSON page doesn't make sense with this organization, so created a new page/topic for hadoop and a new page/topic for object store content.  as with the docs for other data formats, the HDFS page includes more detailed information, and the obj store page notes differences.

- the title "Reading a Multi-Line JSON or Text File into a Single Table Row" is kind of long, suggestions please.
- do we need to address quoting or escaping?

doc review site links:
- new hdfs topic:   http://docs-lisa-pxf2.cfapps.io/6-0/pxf/hdfs_fileasrow.html
- new objstore topic:  http://docs-lisa-pxf2.cfapps.io/6-0/pxf/objstore_fileasrow.html
