### PR TITLE
Make set_subqueryscan_references find the right rel.

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1386,6 +1386,7 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 	}
 
 	rel->subroot = subroot;
+	rel->subplan->rel = rel;
 
 	/* Isolate the params needed by this specific subplan */
 	rel->subplan_params = root->plan_params;

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1290,7 +1290,9 @@ set_subqueryscan_references(PlannerInfo *root,
 	Plan	   *result;
 
 	/* Need to look up the subquery's RelOptInfo, since we need its subroot */
-	rel = find_base_rel(root, plan->scan.scanrelid);
+	rel = plan->subplan->rel;
+	if (!rel)
+		rel = find_base_rel(root, plan->scan.scanrelid);
 	/*
 	 * The Assert() on RelOptInfo's subplan being same as the
 	 * subqueryscan's subplan, is valid in Upstream but not for GPDB,

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -281,6 +281,7 @@ typedef struct Plan
 	 * The parent motion node of a plan node.
 	 */
 	struct Plan *motionNode;
+	struct RelOptInfo *rel;
 } Plan;
 
 /* ----------------

--- a/src/test/regress/expected/multistage_aggregate_with_subquery_scan.out
+++ b/src/test/regress/expected/multistage_aggregate_with_subquery_scan.out
@@ -1,0 +1,15 @@
+-- Given a table with a few columns
+create table a (i int, j int, k int) distributed by (i);
+-- When I try to query the table with multiple stage aggregate and a subquery
+-- Then it should succeed instead of crashing
+select count(distinct j), count(distinct k)
+from (
+     select j, k
+     from a
+     group by j,k
+) some_subquery
+group by j;
+ count | count 
+-------+-------
+(0 rows)
+

--- a/src/test/regress/sql/multistage_aggregate_with_subquery_scan.sql
+++ b/src/test/regress/sql/multistage_aggregate_with_subquery_scan.sql
@@ -1,0 +1,11 @@
+-- Given a table with a few columns
+create table a (i int, j int, k int) distributed by (i);
+-- When I try to query the table with multiple stage aggregate and a subquery
+-- Then it should succeed instead of crashing
+select count(distinct j), count(distinct k)
+from (
+     select j, k
+     from a
+     group by j,k
+) some_subquery
+group by j;


### PR DESCRIPTION
When making two/three stage aggregate, GPDB needs to rebuild arrays
for RelOptInfo and RangeTblEntry for the PlannerInfo when the
underlying range tables are transformed. To do that,
rebuild_simple_rel_and_rte() just allocates a new memory area for the
arrays, without retaining the original RelOptInfos. It turns out the
original RelOptinfos are needed later in
set_subqueryscan_references(). So currently, for some SubqueryScan,
when it retrieves RelOptInfo with scanrelid from
root->simple_rel_array, it gets a wrong one, because the correct one
has been lost.

- adds test to ensure crash doesn't regress.

Co-authored-by: Adam Berlin <aberlin@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
