### PR TITLE
Fix locking clause issue

### DIFF
--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -76,11 +76,6 @@ lnext:
 		HTSU_Result test;
 		HeapTuple	copyTuple;
 
-		/* CDB: CTIDs were not fetched for distributed relation. */
-		if (erm->markType == ROW_MARK_TABLE_EXCLUSIVE ||
-			erm->markType == ROW_MARK_TABLE_SHARE)
-			continue;
-
 		/* clear any leftover test tuple for this rel */
 		if (node->lr_epqstate.estate != NULL)
 			EvalPlanQualSetTuple(&node->lr_epqstate, erm->rti, NULL);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1259,6 +1259,7 @@ _copyPlanRowMark(const PlanRowMark *from)
 	COPY_SCALAR_FIELD(markType);
 	COPY_SCALAR_FIELD(noWait);
 	COPY_SCALAR_FIELD(isParent);
+	COPY_SCALAR_FIELD(canOptSelectLockingClause);
 
 	return newnode;
 }
@@ -3151,6 +3152,7 @@ _copyQuery(const Query *from)
 	COPY_SCALAR_FIELD(hasRecursive);
 	COPY_SCALAR_FIELD(hasModifyingCTE);
 	COPY_SCALAR_FIELD(hasForUpdate);
+	COPY_SCALAR_FIELD(canOptSelectLockingClause);
 	COPY_NODE_FIELD(cteList);
 	COPY_NODE_FIELD(rtable);
 	COPY_NODE_FIELD(jointree);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -905,6 +905,7 @@ _equalQuery(const Query *a, const Query *b)
 	COMPARE_SCALAR_FIELD(hasRecursive);
 	COMPARE_SCALAR_FIELD(hasModifyingCTE);
 	COMPARE_SCALAR_FIELD(hasForUpdate);
+	COMPARE_SCALAR_FIELD(canOptSelectLockingClause);
 	COMPARE_NODE_FIELD(cteList);
 	COMPARE_NODE_FIELD(rtable);
 	COMPARE_NODE_FIELD(jointree);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -869,6 +869,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_BOOL_FIELD(hasRecursive);
 	WRITE_BOOL_FIELD(hasModifyingCTE);
 	WRITE_BOOL_FIELD(hasForUpdate);
+	WRITE_BOOL_FIELD(canOptSelectLockingClause);
 	WRITE_NODE_FIELD(cteList);
 	WRITE_NODE_FIELD(rtable);
 	WRITE_NODE_FIELD(jointree);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1139,6 +1139,7 @@ _outPlanRowMark(StringInfo str, const PlanRowMark *node)
 	WRITE_ENUM_FIELD(markType, RowMarkType);
 	WRITE_BOOL_FIELD(noWait);
 	WRITE_BOOL_FIELD(isParent);
+	WRITE_BOOL_FIELD(canOptSelectLockingClause);
 }
 
 #ifndef COMPILING_BINARY_FUNCS

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3779,6 +3779,7 @@ _outQuery(StringInfo str, const Query *node)
 	WRITE_BOOL_FIELD(hasRecursive);
 	WRITE_BOOL_FIELD(hasModifyingCTE);
 	WRITE_BOOL_FIELD(hasForUpdate);
+	WRITE_BOOL_FIELD(canOptSelectLockingClause);
 	WRITE_NODE_FIELD(cteList);
 	WRITE_NODE_FIELD(rtable);
 	WRITE_NODE_FIELD(jointree);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2185,6 +2185,7 @@ _readPlanRowMark(void)
 	READ_ENUM_FIELD(markType, RowMarkType);
 	READ_BOOL_FIELD(noWait);
 	READ_BOOL_FIELD(isParent);
+	READ_BOOL_FIELD(canOptSelectLockingClause);
 
 	READ_DONE();
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -242,6 +242,7 @@ _readQuery(void)
 	READ_BOOL_FIELD(hasRecursive);
 	READ_BOOL_FIELD(hasModifyingCTE);
 	READ_BOOL_FIELD(hasForUpdate);
+	READ_BOOL_FIELD(canOptSelectLockingClause);
 	READ_NODE_FIELD(cteList);
 	READ_NODE_FIELD(rtable);
 	READ_NODE_FIELD(jointree);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -384,6 +384,7 @@ _readQuery(void)
 	READ_BOOL_FIELD(hasRecursive);
 	READ_BOOL_FIELD(hasModifyingCTE);
 	READ_BOOL_FIELD(hasForUpdate);
+	READ_BOOL_FIELD(canOptSelectLockingClause);
 	READ_NODE_FIELD(cteList);
 	READ_NODE_FIELD(rtable);
 	READ_NODE_FIELD(jointree);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -3096,62 +3096,19 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	}
 
 	/*
-	 * If there is a FOR [KEY] UPDATE/SHARE clause, add the LockRows node.
-	 * (Note: we intentionally test parse->rowMarks not root->rowMarks here.
-	 * If there are only non-locking rowmarks, they should be handled by the
-	 * ModifyTable node instead.)
+	 * Greenplum specific behavior:
+	 * The implementation of select statement with locking clause
+	 * (for update | no key update | share | key share) in postgres
+	 * is to hold RowShareLock on tables during parsing stage, and
+	 * generate a LockRows plan node for executor to lock the tuples.
+	 * It is not easy to lock tuples in Greenplum database, since
+	 * tuples may be fetched through motion nodes.
+	 *
+	 * So, in Greenplum, it should not emit LockRows node in plan.
+	 *
+	 * The conflict with UPDATE|DELETE is implemented by locking the entire
+	 * table in ExclusiveMode. More details please refer docs.
 	 */
-	if (parse->rowMarks)
-	{
-		ListCell   *lc;
-		List	   *newmarks = NIL;
-
-		/*
-		 * select for update will lock the whole table, we do it at addRangeTableEntry.
-		 * The reason is that gpdb is an MPP database, the result tuples may not be on
-		 * the same segment. And for cursor statement, reader gang cannot get Xid to lock
-		 * the tuples. (More details: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/p-6_dNjnRMQ)
-		 * Upgrading the lock mode (see below) for distributed table is probably
-		 * not needed for all the cases and we may want to enhance this later.
-		 */
-		foreach(lc, root->rowMarks)
-		{
-			PlanRowMark *rc = (PlanRowMark *) lfirst(lc);
-
-			if (rc->markType == ROW_MARK_EXCLUSIVE || rc->markType == ROW_MARK_SHARE)
-			{
-				RelOptInfo *brel = root->simple_rel_array[rc->rti];
-
-				if (GpPolicyIsPartitioned(brel->cdbpolicy) ||
-					GpPolicyIsReplicated(brel->cdbpolicy))
-				{
-					if (rc->markType == ROW_MARK_EXCLUSIVE)
-						rc->markType = ROW_MARK_TABLE_EXCLUSIVE;
-					else
-						rc->markType = ROW_MARK_TABLE_SHARE;
-				}
-			}
-
-			/* We only need LockRows for the tuple-level locks */
-			if (rc->markType != ROW_MARK_TABLE_EXCLUSIVE &&
-				rc->markType != ROW_MARK_TABLE_SHARE)
-				newmarks = lappend(newmarks, rc);
-		}
-
-		if (newmarks)
-		{
-			result_plan = (Plan *) make_lockrows(result_plan,
-												 newmarks,
-												 SS_assign_special_param(root));
-			result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
-
-			/*
-			 * The result can no longer be assumed sorted, since locking might
-			 * cause the sort key columns to be replaced with new values.
-			 */
-			current_pathkeys = NIL;
-		}
-	}
 
 	/*
 	 * Finally, if there is a LIMIT/OFFSET clause, add the LIMIT node.

--- a/src/backend/optimizer/prep/prepsecurity.c
+++ b/src/backend/optimizer/prep/prepsecurity.c
@@ -263,15 +263,8 @@ expand_security_qual(PlannerInfo *root, List *tlist, int rt_index,
 					case ROW_MARK_COPY:
 						/* No locking needed */
 						break;
-
-					/*
-					 * Additional modes in GPDB. These are only created
-					 * later in the planning, so we should not see these.
-					 */
-					case ROW_MARK_TABLE_SHARE:
-						elog(ERROR, "unexpected ROW_MARK_TABLE_SHARE locking mode encountered while expanding security barrier view");
-					case ROW_MARK_TABLE_EXCLUSIVE:
-						elog(ERROR, "unexpected ROW_MARK_TABLE_EXCLUSIVE locking mode encountered while expanding security barrier view");
+					default:
+						elog(ERROR, "unknown rowmark type encountered while expanding security barrier view");
 				}
 				root->rowMarks = list_delete(root->rowMarks, rc);
 			}

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -1393,9 +1393,12 @@ expand_inherited_rtentry(PlannerInfo *root, RangeTblEntry *rte, Index rti)
 		 * It is not easy to lock tuples in Greenplum database, since
 		 * tuples may be fetched through motion nodes.
 		 *
-		 * So in Greenplum, ExclusiveLock is held for tables in rowMarks.
+		 * But when Global Deadlock Detector is enabled, and the select
+		 * statement with locking clause contains only one table, we are
+		 * sure that there are no motions. For such simple cases, we could
+		 * make the behavior just the same as Postgres.
 		 */
-		lockmode = ExclusiveLock;
+		lockmode = oldrc->canOptSelectLockingClause ? RowShareLock : ExclusiveLock;
 	}
 	else
 		lockmode = AccessShareLock;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -47,6 +47,7 @@
 #include "parser/parse_target.h"
 #include "parser/parsetree.h"
 #include "rewrite/rewriteManip.h"
+#include "utils/guc.h"
 #include "utils/rel.h"
 
 #include "cdb/cdbhash.h"
@@ -90,6 +91,11 @@ typedef struct
 	int			ncols;
 	List	  **leafinfos;
 } setop_types_ctx;
+
+typedef struct QueryNodeSearchContext
+{
+	bool       found;
+} QueryNodeSearchContext;
 
 /* Hook for plugins to get control at end of parse analysis */
 post_parse_analyze_hook_type post_parse_analyze_hook = NULL;
@@ -135,6 +141,8 @@ static Node *grouped_window_mutator(Node *node, void *context);
 static Alias *make_replacement_alias(Query *qry, const char *aname);
 static char *generate_positional_name(AttrNumber attrno);
 static List*generate_alternate_vars(Var *var, grouped_window_ctx *ctx);
+static bool checkCanOptSelectLockingClause(SelectStmt *stmt);
+static bool queryNodeSearch(Node *node, void *context);
 
 /*
  * parse_analyze
@@ -239,9 +247,27 @@ parse_sub_analyze(Node *parseTree, ParseState *parentParseState,
 Query *
 transformTopLevelStmt(ParseState *pstate, Node *parseTree)
 {
+	Query *q;
+
 	if (IsA(parseTree, SelectStmt))
 	{
 		SelectStmt *stmt = (SelectStmt *) parseTree;
+
+		/*
+		 * Greenplum specific behavior:
+		 * The implementation of select statement with locking clause
+		 * (for update | no key update | share | key share) in postgres
+		 * is to hold RowShareLock on tables during parsing stage, and
+		 * generate a LockRows plan node for executor to lock the tuples.
+		 * It is not easy to lock tuples in Greenplum database, since
+		 * tuples may be fetched through motion nodes.
+		 *
+		 * But when Global Deadlock Detector is enabled, and the select
+		 * statement with locking clause contains only one table, we are
+		 * sure that there are no motions. For such simple cases, we could
+		 * make the behavior just the same as Postgres.
+		 */
+		pstate->p_canOptSelectLockingClause = checkCanOptSelectLockingClause(stmt);
 
 		/* If it's a set-operation tree, drill down to leftmost SelectStmt */
 		while (stmt && stmt->op != SETOP_NONE)
@@ -268,7 +294,10 @@ transformTopLevelStmt(ParseState *pstate, Node *parseTree)
 		}
 	}
 
-	return transformStmt(pstate, parseTree);
+	q = transformStmt(pstate, parseTree);
+	q->canOptSelectLockingClause = pstate->p_canOptSelectLockingClause;
+
+	return q;
 }
 
 /*
@@ -3757,4 +3786,54 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 													  policyopclasses,
 													  dist->numsegments);
 	}
+}
+
+/*
+ * checkCanOptSelectLockingClause is used to test
+ * whether a select-statement containing locking clause
+ * can behave like Postgres. We have to know it before
+ * we acquire any locks on the tables.
+ */
+static bool
+checkCanOptSelectLockingClause(SelectStmt *stmt)
+{
+	QueryNodeSearchContext ctx = {false};
+
+	if (!IS_QUERY_DISPATCHER())
+		return false;
+
+	if (!gp_enable_global_deadlock_detector)
+		return false;
+
+	if (stmt->op != SETOP_NONE)
+		return false;
+
+	if (list_length(stmt->fromClause) != 1)
+		return false;
+
+	if (!IsA(linitial(stmt->fromClause), RangeVar))
+		return false;
+
+	if (!stmt->lockingClause)
+		return false;
+
+	(void) raw_expression_tree_walker(stmt->whereClause,
+									  queryNodeSearch, (void *)(&ctx));
+
+	if (ctx.found)
+		return false;
+
+	return true;
+}
+
+static bool
+queryNodeSearch(Node *node, void *context)
+{
+	if (IsA(node, Query))
+	{
+		((QueryNodeSearchContext *)context)->found = true;
+		return false;
+	}
+
+	return true;
 }

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -127,7 +127,6 @@ AcquireRewriteLocks(Query *parsetree,
 {
 	ListCell      *l;
 	int			   rt_index;
-	RowMarkClause *rc;
 	acquireLocksOnSubLinks_context context;
 
 	context.for_execute = forExecute;
@@ -182,16 +181,22 @@ AcquireRewriteLocks(Query *parsetree,
 				}
 				else if (forUpdatePushedDown ||
 						 get_parse_rowmark(parsetree, rt_index) != NULL)
-					lockmode = RowShareLock;
+				{
+					/*
+					 * Greenplum specific behavior:
+					 * The implementation of select statement with locking clause
+					 * (for update | no key update | share | key share) in postgres
+					 * is to hold RowShareLock on tables during parsing stage, and
+					 * generate a LockRows plan node for executor to lock the tuples.
+					 * It is not easy to lock tuples in Greenplum database, since
+					 * tuples may be fetched through motion nodes.
+					 *
+					 * So in Greenplum, ExclusiveLock is held for tables in rowMarks.
+					 */
+					lockmode = ExclusiveLock;
+				}
 				else
 					lockmode = AccessShareLock;
-
-				rc = get_parse_rowmark(parsetree, rt_index);
-				if (rc != NULL)
-				{
-					lockmode = rc->strength >= LCS_FORNOKEYUPDATE ?
-						ExclusiveLock : RowShareLock;
-				}
 
 				/* Take a lock either using CDB lock promotion or not */
 				if (needLockUpgrade)

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -191,9 +191,12 @@ AcquireRewriteLocks(Query *parsetree,
 					 * It is not easy to lock tuples in Greenplum database, since
 					 * tuples may be fetched through motion nodes.
 					 *
-					 * So in Greenplum, ExclusiveLock is held for tables in rowMarks.
+					 * But when Global Deadlock Detector is enabled, and the select
+					 * statement with locking clause contains only one table, we are
+					 * sure that there are no motions. For such simple cases, we could
+					 * make the behavior just the same as Postgres.
 					 */
-					lockmode = ExclusiveLock;
+					lockmode = parsetree->canOptSelectLockingClause ? RowShareLock : ExclusiveLock;
 				}
 				else
 					lockmode = AccessShareLock;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -152,7 +152,7 @@ typedef struct Query
 	bool		hasRecursive;	/* WITH RECURSIVE was specified */
 	bool		hasModifyingCTE;	/* has INSERT/UPDATE/DELETE in WITH */
 	bool		hasForUpdate;	/* FOR [KEY] UPDATE/SHARE was specified */
-	bool        canOptSelectLockingClause;
+	bool        canOptSelectLockingClause; /* Whether can do some optimization on select with locking clause */
 
 	List	   *cteList;		/* WITH list (of CommonTableExpr's) */
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -152,6 +152,7 @@ typedef struct Query
 	bool		hasRecursive;	/* WITH RECURSIVE was specified */
 	bool		hasModifyingCTE;	/* has INSERT/UPDATE/DELETE in WITH */
 	bool		hasForUpdate;	/* FOR [KEY] UPDATE/SHARE was specified */
+	bool        canOptSelectLockingClause;
 
 	List	   *cteList;		/* WITH list (of CommonTableExpr's) */
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1450,7 +1450,7 @@ typedef struct PlanRowMark
 	RowMarkType markType;		/* see enum above */
 	bool		noWait;			/* NOWAIT option */
 	bool		isParent;		/* true if this is a "dummy" parent entry */
-	bool        canOptSelectLockingClause;
+	bool        canOptSelectLockingClause; /* Whether can do some optimization on select with locking clause */
 } PlanRowMark;
 
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1402,11 +1402,7 @@ typedef enum RowMarkType
 	ROW_MARK_SHARE,				/* obtain shared tuple lock */
 	ROW_MARK_KEYSHARE,			/* obtain keyshare tuple lock */
 	ROW_MARK_REFERENCE,			/* just fetch the TID */
-	ROW_MARK_COPY,				/* physically copy the row value */
-	ROW_MARK_TABLE_SHARE,		/* (GPDB) Acquire RowShareLock on table,
-								 * but no tuple locks */
-	ROW_MARK_TABLE_EXCLUSIVE	/* (GPDB) Acquire ExclusiveLock on table,
-								 * blocking all other updates */
+	ROW_MARK_COPY				/* physically copy the row value */
 } RowMarkType;
 
 #define RowMarkRequiresRowShareLock(marktype)  ((marktype) <= ROW_MARK_KEYSHARE)

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1450,6 +1450,7 @@ typedef struct PlanRowMark
 	RowMarkType markType;		/* see enum above */
 	bool		noWait;			/* NOWAIT option */
 	bool		isParent;		/* true if this is a "dummy" parent entry */
+	bool        canOptSelectLockingClause;
 } PlanRowMark;
 
 

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -157,7 +157,7 @@ struct ParseState
 	bool		p_hasModifyingCTE;
 	bool		p_is_insert;
 	bool		p_is_update;
-	bool        p_canOptSelectLockingClause;
+	bool        p_canOptSelectLockingClause; /* Whether can do some optimization on select with locking clause */
 	LockingClause *p_lockclause_from_parent;
 	Relation	p_target_relation;
 	RangeTblEntry *p_target_rangetblentry;

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -157,6 +157,7 @@ struct ParseState
 	bool		p_hasModifyingCTE;
 	bool		p_is_insert;
 	bool		p_is_update;
+	bool        p_canOptSelectLockingClause;
 	LockingClause *p_lockclause_from_parent;
 	Relation	p_target_relation;
 	RangeTblEntry *p_target_rangetblentry;

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -4,9 +4,27 @@
 # session run in the same permutation holds ExclusiveLock that blocks the step.
 # GPDB_94_MERGE_FIXME: Since the introduction of Global Deadlock Detector, an
 # UPDATE/DELETE no longer acquires ExclusiveLock. So we could perhaps enable
-# some of these now.
-# GPDB_94_MERGE_FIXME: But SELECT FOR UPDATE still acquires a whole-table
-# ExclusiveLock. Why?
+# some of these now. 
+# A GUC gp_enable_global_deadlock_detector is introduced to control GDD.
+# When GDD is enabled, update|delete on heap tables will lock the table in
+# RowExclusiveLock mode. Otherwise, it locks the whole table in ExlusiveLock mode.
+# By default, GDD is set distabled and most the the cases are tested under this
+# condition.
+# Greeplum's logic for Select-Statement with locking clause (for update|no key update|share|key share)
+# is different from upstream:
+#   - For all kinds of select-statement with locking clause, Greenplum locks the entire table in ExclusiveLock
+#   mode, and does not generate LockRows plannode in the plan.
+#   - For very simple cases (defined below), Greenplum behaves just like Postgres:
+#     1. Hold RowShareLock on the table
+#     2. Generate LockRows plannode in the plan
+#     3. Lock tuples during executing
+
+# Simple cases should meet all the following conditions:
+#   1. GDD(global deadlock detector) is enabled
+#   2. Top level select statements with locking clause
+#   3. FromList in the parse tree contains and only contains one rangeVar
+#   4. No sublink and no subquery
+#   5. No set operations (union, intersect, …)
 
 #test: simple-write-skew
 #test: receipt-report
@@ -29,7 +47,7 @@
 test: delete-abort-savept
 #test: delete-abort-savept-2
 #test: aborted-keyrevoke
-test: multixact-no-deadlock
+#test: multixact-no-deadlock
 #test: multixact-no-forget
 #test: propagate-lock-delete
 test: drop-index-concurrently-1

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -20,41 +20,93 @@ CREATE
 insert into t_lockmods select * from generate_series(1, 5);
 INSERT 5
 
--- 1.1.1 select for update should hold ExclusiveLock on range tables
+-- 1.1.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
 1: select * from t_lockmods for update;
  c 
 ---
- 4 
- 5 
  1 
  2 
+ 5 
  3 
+ 4 
 (5 rows)
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation   
 ----------+---------------+---------+------------
  relation | ExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
+1: begin;
+BEGIN
+1: select * from t_lockmods for no key update;
+ c 
+---
+ 1 
+ 2 
+ 5 
+ 3 
+ 4 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: select * from t_lockmods for share;
+ c 
+---
+ 1 
+ 2 
+ 5 
+ 3 
+ 4 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: select * from t_lockmods for key share;
+ c 
+---
+ 1 
+ 2 
+ 5 
+ 3 
+ 4 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
+1: abort;
+ABORT
 
 -- 1.1.2 update | delete should hold ExclusiveLock on result relations
 1: begin;
 BEGIN
 1: update t_lockmods set c = c + 0;
 UPDATE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation   
 ----------+---------------+---------+------------
  relation | ExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -62,13 +114,11 @@ ABORT
 BEGIN
 1: delete from t_lockmods;
 DELETE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation   
 ----------+---------------+---------+------------
  relation | ExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -77,18 +127,22 @@ ABORT
 BEGIN
 1: insert into t_lockmods select * from generate_series(1, 5);
 INSERT 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation   
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
 -- 1.1.4 use cached plan should be consistent with no cached plan
 1: prepare select_for_update as select * from t_lockmods for update;
+PREPARE
+1: prepare select_for_nokeyupdate as select * from t_lockmods for no key update;
+PREPARE
+1: prepare select_for_share as select * from t_lockmods for share;
+PREPARE
+1: prepare select_for_keyshare as select * from t_lockmods for key share;
 PREPARE
 1: prepare update_tlockmods as update t_lockmods set c = c + 0;
 PREPARE
@@ -102,19 +156,74 @@ BEGIN
 1: execute select_for_update;
  c 
 ---
- 4 
- 5 
  1 
  2 
+ 5 
+ 4 
  3 
 (5 rows)
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation   
 ----------+---------------+---------+------------
  relation | ExclusiveLock | t       | t_lockmods 
 (1 row)
+1: abort;
+ABORT
 
+1: begin;
+BEGIN
+1: execute select_for_nokeyupdate;
+ c 
+---
+ 4 
+ 1 
+ 2 
+ 5 
+ 3 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute select_for_share;
+ c 
+---
+ 4 
+ 1 
+ 2 
+ 5 
+ 3 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute select_for_keyshare;
+ c 
+---
+ 4 
+ 1 
+ 2 
+ 5 
+ 3 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
 1: abort;
 ABORT
 
@@ -122,13 +231,11 @@ ABORT
 BEGIN
 1: execute update_tlockmods;
 EXECUTE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation   
 ----------+---------------+---------+------------
  relation | ExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -136,13 +243,11 @@ ABORT
 BEGIN
 1: execute delete_tlockmods;
 EXECUTE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation   
 ----------+---------------+---------+------------
  relation | ExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -150,13 +255,11 @@ ABORT
 BEGIN
 1: execute insert_tlockmods;
 EXECUTE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation   
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -166,44 +269,105 @@ CREATE
 insert into t_lockmods_ao select * from generate_series(1, 8);
 INSERT 8
 
--- 1.2.1 select for update should hold ExclusiveLock on range tables
+-- 1.2.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
 1: select * from t_lockmods_ao for update;
  c 
 ---
- 2 
  4 
+ 7 
+ 2 
+ 6 
+ 8 
  1 
  3 
  5 
- 8 
- 6 
- 7 
 (8 rows)
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
+1: begin;
+BEGIN
+1: select * from t_lockmods_ao for no key update;
+ c 
+---
+ 4 
+ 7 
+ 2 
+ 6 
+ 8 
+ 1 
+ 3 
+ 5 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: select * from t_lockmods_ao for share;
+ c 
+---
+ 2 
+ 6 
+ 8 
+ 1 
+ 3 
+ 5 
+ 4 
+ 7 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: select * from t_lockmods_ao for key share;
+ c 
+---
+ 1 
+ 3 
+ 5 
+ 4 
+ 7 
+ 2 
+ 6 
+ 8 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
+1: abort;
+ABORT
 
 -- 1.2.2 update | delete should hold ExclusiveLock on result relations
 1: begin;
 BEGIN
 1: update t_lockmods_ao set c = c + 0;
 UPDATE 8
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -211,13 +375,11 @@ ABORT
 BEGIN
 1: delete from t_lockmods_ao;
 DELETE 8
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -226,18 +388,22 @@ ABORT
 BEGIN
 1: insert into t_lockmods_ao select * from generate_series(1, 5);
 INSERT 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation      
 ----------+------------------+---------+---------------
  relation | RowExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
 -- 1.2.4 use cached plan should be consistent with no cached plan
 1: prepare select_for_update_ao as select * from t_lockmods_ao for update;
+PREPARE
+1: prepare select_for_nokeyupdate_ao as select * from t_lockmods_ao for no key update;
+PREPARE
+1: prepare select_for_share_ao as select * from t_lockmods_ao for share;
+PREPARE
+1: prepare select_for_keyshare_ao as select * from t_lockmods_ao for key share;
 PREPARE
 1: prepare update_tlockmods_ao as update t_lockmods_ao set c = c + 0;
 PREPARE
@@ -251,22 +417,86 @@ BEGIN
 1: execute select_for_update_ao;
  c 
 ---
- 6 
- 7 
- 2 
- 4 
  1 
  3 
  5 
+ 2 
+ 6 
  8 
+ 4 
+ 7 
 (8 rows)
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
+1: abort;
+ABORT
 
+1: begin;
+BEGIN
+1: execute select_for_nokeyupdate_ao;
+ c 
+---
+ 1 
+ 3 
+ 5 
+ 2 
+ 6 
+ 8 
+ 4 
+ 7 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute select_for_share_ao;
+ c 
+---
+ 1 
+ 3 
+ 5 
+ 2 
+ 6 
+ 8 
+ 4 
+ 7 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute select_for_keyshare_ao;
+ c 
+---
+ 1 
+ 3 
+ 5 
+ 2 
+ 6 
+ 8 
+ 4 
+ 7 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
 1: abort;
 ABORT
 
@@ -274,13 +504,11 @@ ABORT
 BEGIN
 1: execute update_tlockmods_ao;
 EXECUTE 8
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -288,13 +516,11 @@ ABORT
 BEGIN
 1: execute delete_tlockmods_ao;
 EXECUTE 8
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -302,13 +528,11 @@ ABORT
 BEGIN
 1: execute insert_tlockmods_ao;
 EXECUTE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation      
 ----------+------------------+---------+---------------
  relation | RowExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -317,38 +541,42 @@ ABORT
 
 -- start_ignore
 ! gpconfig -c gp_enable_global_deadlock_detector -v on;
-20190401:16:37:37:002792 gpconfig:zlv:gpadmin-[INFO]:-completed successfully with parameters '-c gp_enable_global_deadlock_detector -v on'
+20190515:15:53:44:050050 gpconfig:zlv:gpadmin-[INFO]:-completed successfully with parameters '-c gp_enable_global_deadlock_detector -v on'
 
 ! gpstop -rai;
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Starting gpstop with args: -rai
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Gathering information and validating the environment...
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Obtaining Segment details from master...
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0-beta.3+dev.17653.g86b0b90 build dev'
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-There are 1 connections to the database
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Master host=zlv
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-No standby master host configured
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Targeting dbid [2, 3, 4] for shutdown
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
-20190401:16:37:37:002915 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-   Segments stopped successfully      = 3
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-   Segments with errors during stop   = 0
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown 3 of 3 segment instances 
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-No leftover gpmmon process found
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
-20190401:16:37:38:002915 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover shared memory
-20190401:16:37:39:002915 gpstop:zlv:gpadmin-[INFO]:-Restarting System...
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Gathering information and validating the environment...
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Obtaining Segment details from master...
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.196.g0f8a703 build dev'
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-There are 1 connections to the database
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Master host=zlv
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Stopping master standby host zlv mode=fast
+20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown standby process on zlv
+20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
+20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
+20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-No leftover gpmmon process found
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Restarting System...
 
 -- end_ignore
 
@@ -366,7 +594,7 @@ SET
 
 -- 2.1 test for heap tables
 
--- 2.1.1 select for update should hold ExclusiveLock on range tables
+-- 2.1.1 select for (update|share|no key update |key share) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
 1: select * from t_lockmods for update;
@@ -374,17 +602,72 @@ BEGIN
 ---
  1 
  2 
- 3 
- 4 
  5 
+ 4 
+ 3 
 (5 rows)
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation   
 ----------+---------------+---------+------------
  relation | ExclusiveLock | t       | t_lockmods 
 (1 row)
+1: abort;
+ABORT
 
+1: begin;
+BEGIN
+1: select * from t_lockmods for no key update;
+ c 
+---
+ 1 
+ 2 
+ 5 
+ 3 
+ 4 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: select * from t_lockmods for share;
+ c 
+---
+ 1 
+ 2 
+ 5 
+ 3 
+ 4 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: select * from t_lockmods for key share;
+ c 
+---
+ 1 
+ 2 
+ 5 
+ 3 
+ 4 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
 1: abort;
 ABORT
 
@@ -394,13 +677,11 @@ ABORT
 BEGIN
 1: update t_lockmods set c = c + 0;
 UPDATE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation   
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -408,13 +689,11 @@ ABORT
 BEGIN
 1: delete from t_lockmods;
 DELETE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation   
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -423,18 +702,22 @@ ABORT
 BEGIN
 1: insert into t_lockmods select * from generate_series(1, 5);
 INSERT 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation   
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
 -- 2.1.4 use cached plan should be consistent with no cached plan
 1: prepare select_for_update as select * from t_lockmods for update;
+PREPARE
+1: prepare select_for_nokeyupdate as select * from t_lockmods for no key update;
+PREPARE
+1: prepare select_for_share as select * from t_lockmods for share;
+PREPARE
+1: prepare select_for_keyshare as select * from t_lockmods for key share;
 PREPARE
 1: prepare update_tlockmods as update t_lockmods set c = c + 0;
 PREPARE
@@ -448,19 +731,74 @@ BEGIN
 1: execute select_for_update;
  c 
 ---
- 1 
- 2 
  3 
  4 
+ 1 
+ 2 
  5 
 (5 rows)
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation   
 ----------+---------------+---------+------------
  relation | ExclusiveLock | t       | t_lockmods 
 (1 row)
+1: abort;
+ABORT
 
+1: begin;
+BEGIN
+1: execute select_for_nokeyupdate;
+ c 
+---
+ 4 
+ 1 
+ 2 
+ 5 
+ 3 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute select_for_share;
+ c 
+---
+ 1 
+ 2 
+ 5 
+ 3 
+ 4 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute select_for_keyshare;
+ c 
+---
+ 1 
+ 2 
+ 5 
+ 3 
+ 4 
+(5 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation   
+----------+---------------+---------+------------
+ relation | ExclusiveLock | t       | t_lockmods 
+(1 row)
 1: abort;
 ABORT
 
@@ -468,13 +806,11 @@ ABORT
 BEGIN
 1: execute update_tlockmods;
 EXECUTE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation   
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -482,13 +818,11 @@ ABORT
 BEGIN
 1: execute delete_tlockmods;
 EXECUTE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation   
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -496,40 +830,102 @@ ABORT
 BEGIN
 1: execute insert_tlockmods;
 EXECUTE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation   
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
-
 1: abort;
 ABORT
 
 -- 2.2 test for AO table
 
--- 2.2.1 select for update should hold ExclusiveLock on range tables
+-- 2.2.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
 1: select * from t_lockmods_ao for update;
  c 
 ---
+ 2 
+ 6 
+ 8 
  1 
  3 
  5 
- 8 
- 6 
- 7 
- 2 
  4 
+ 7 
 (8 rows)
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
+1: abort;
+ABORT
 
+1: begin;
+BEGIN
+1: select * from t_lockmods_ao for no key update;
+ c 
+---
+ 1 
+ 3 
+ 5 
+ 4 
+ 7 
+ 2 
+ 6 
+ 8 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: select * from t_lockmods_ao for share;
+ c 
+---
+ 4 
+ 7 
+ 2 
+ 6 
+ 8 
+ 1 
+ 3 
+ 5 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: select * from t_lockmods_ao for key share;
+ c 
+---
+ 4 
+ 7 
+ 2 
+ 6 
+ 8 
+ 1 
+ 3 
+ 5 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
 1: abort;
 ABORT
 
@@ -539,13 +935,11 @@ ABORT
 BEGIN
 1: update t_lockmods_ao set c = c + 0;
 UPDATE 8
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -553,13 +947,11 @@ ABORT
 BEGIN
 1: delete from t_lockmods_ao;
 DELETE 8
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -568,18 +960,22 @@ ABORT
 BEGIN
 1: insert into t_lockmods_ao select * from generate_series(1, 5);
 INSERT 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation      
 ----------+------------------+---------+---------------
  relation | RowExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
 -- 2.2.4 use cached plan should be consistent with no cached plan
 1: prepare select_for_update_ao as select * from t_lockmods_ao for update;
+PREPARE
+1: prepare select_for_nokeyupdate_ao as select * from t_lockmods_ao for no key update;
+PREPARE
+1: prepare select_for_share_ao as select * from t_lockmods_ao for share;
+PREPARE
+1: prepare select_for_keyshare_ao as select * from t_lockmods_ao for key share;
 PREPARE
 1: prepare update_tlockmods_ao as update t_lockmods_ao set c = c + 0;
 PREPARE
@@ -594,21 +990,85 @@ BEGIN
  c 
 ---
  2 
- 4 
+ 6 
+ 8 
  1 
  3 
  5 
- 8 
- 6 
+ 4 
  7 
 (8 rows)
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
+1: abort;
+ABORT
 
+1: begin;
+BEGIN
+1: execute select_for_nokeyupdate_ao;
+ c 
+---
+ 2 
+ 6 
+ 8 
+ 1 
+ 3 
+ 5 
+ 4 
+ 7 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute select_for_share_ao;
+ c 
+---
+ 2 
+ 6 
+ 8 
+ 1 
+ 3 
+ 5 
+ 4 
+ 7 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute select_for_keyshare_ao;
+ c 
+---
+ 2 
+ 6 
+ 8 
+ 4 
+ 7 
+ 1 
+ 3 
+ 5 
+(8 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation      
+----------+---------------+---------+---------------
+ relation | ExclusiveLock | t       | t_lockmods_ao 
+(1 row)
 1: abort;
 ABORT
 
@@ -616,13 +1076,11 @@ ABORT
 BEGIN
 1: execute update_tlockmods_ao;
 EXECUTE 8
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -630,13 +1088,11 @@ ABORT
 BEGIN
 1: execute delete_tlockmods_ao;
 EXECUTE 8
-
 2: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation      
 ----------+---------------+---------+---------------
  relation | ExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -644,13 +1100,11 @@ ABORT
 BEGIN
 1: execute insert_tlockmods_ao;
 EXECUTE 5
-
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation      
 ----------+------------------+---------+---------------
  relation | RowExclusiveLock | t       | t_lockmods_ao 
 (1 row)
-
 1: abort;
 ABORT
 
@@ -659,38 +1113,42 @@ ABORT
 
 -- start_ignore
 ! gpconfig -c gp_enable_global_deadlock_detector -v off;
-20190401:16:37:42:003348 gpconfig:zlv:gpadmin-[INFO]:-completed successfully with parameters '-c gp_enable_global_deadlock_detector -v off'
+20190515:15:53:50:051138 gpconfig:zlv:gpadmin-[INFO]:-completed successfully with parameters '-c gp_enable_global_deadlock_detector -v off'
 
 ! gpstop -rai;
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Starting gpstop with args: -rai
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Gathering information and validating the environment...
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Obtaining Segment details from master...
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0-beta.3+dev.17653.g86b0b90 build dev'
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-There are 0 connections to the database
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Master host=zlv
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-No standby master host configured
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Targeting dbid [2, 3, 4] for shutdown
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
-20190401:16:37:42:003471 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-   Segments stopped successfully      = 3
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-   Segments with errors during stop   = 0
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown 3 of 3 segment instances 
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-No leftover gpmmon process found
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover shared memory
-20190401:16:37:43:003471 gpstop:zlv:gpadmin-[INFO]:-Restarting System...
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Gathering information and validating the environment...
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Obtaining Segment details from master...
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.196.g0f8a703 build dev'
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-There are 0 connections to the database
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Master host=zlv
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
+20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Stopping master standby host zlv mode=fast
+20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown standby process on zlv
+20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover gpmmon process
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-No leftover gpmmon process found
+20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover gpsmon processes
+20190515:15:53:53:051308 gpstop:zlv:gpadmin-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20190515:15:53:53:051308 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20190515:15:53:53:051308 gpstop:zlv:gpadmin-[INFO]:-Restarting System...
 
 -- end_ignore
 

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -20,9 +20,19 @@ CREATE
 insert into t_lockmods select * from generate_series(1, 5);
 INSERT 5
 
+create table t_lockmods1 (c int) distributed randomly;
+CREATE
+
 -- 1.1.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
+1: explain select * from t_lockmods for update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.05 rows=5 width=10) 
+   ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)             
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods for update;
  c 
 ---
@@ -33,15 +43,23 @@ BEGIN
  4 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | ExclusiveLock   | t       | t_lockmods 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods for no key update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.05 rows=5 width=10) 
+   ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)             
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods for no key update;
  c 
 ---
@@ -52,15 +70,23 @@ BEGIN
  4 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | ExclusiveLock   | t       | t_lockmods 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods for share;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.05 rows=5 width=10) 
+   ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)             
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods for share;
  c 
 ---
@@ -71,15 +97,23 @@ BEGIN
  4 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | ExclusiveLock   | t       | t_lockmods 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods for key share;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.05 rows=5 width=10) 
+   ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)             
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods for key share;
  c 
 ---
@@ -90,10 +124,123 @@ BEGIN
  4 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | ExclusiveLock   | t       | t_lockmods 
+(2 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods, t_lockmods1 for update;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000016715.06 rows=481500 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000016715.06 rows=160500 width=20)                        
+         ->  Seq Scan on t_lockmods1  (cost=0.00..1063.00 rows=32100 width=10)                        
+         ->  Materialize  (cost=0.00..3.33 rows=5 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=10)     
+                     ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)                    
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods, t_lockmods1 for update;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation    
+----------+-----------------+---------+-------------
+ relation | AccessShareLock | t       | t_lockmods1 
+ relation | ExclusiveLock   | t       | t_lockmods1 
+ relation | AccessShareLock | t       | t_lockmods  
+ relation | ExclusiveLock   | t       | t_lockmods  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods, t_lockmods1 for no key update;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000016715.06 rows=481500 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000016715.06 rows=160500 width=20)                        
+         ->  Seq Scan on t_lockmods1  (cost=0.00..1063.00 rows=32100 width=10)                        
+         ->  Materialize  (cost=0.00..3.33 rows=5 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=10)     
+                     ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)                    
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods, t_lockmods1 for no key update;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation    
+----------+-----------------+---------+-------------
+ relation | AccessShareLock | t       | t_lockmods1 
+ relation | ExclusiveLock   | t       | t_lockmods1 
+ relation | AccessShareLock | t       | t_lockmods  
+ relation | ExclusiveLock   | t       | t_lockmods  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods, t_lockmods1 for share;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000016715.06 rows=481500 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000016715.06 rows=160500 width=20)                        
+         ->  Seq Scan on t_lockmods1  (cost=0.00..1063.00 rows=32100 width=10)                        
+         ->  Materialize  (cost=0.00..3.33 rows=5 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=10)     
+                     ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)                    
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods, t_lockmods1 for share;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation    
+----------+-----------------+---------+-------------
+ relation | AccessShareLock | t       | t_lockmods1 
+ relation | ExclusiveLock   | t       | t_lockmods1 
+ relation | AccessShareLock | t       | t_lockmods  
+ relation | ExclusiveLock   | t       | t_lockmods  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods, t_lockmods1 for key share;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000016715.06 rows=481500 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000016715.06 rows=160500 width=20)                        
+         ->  Seq Scan on t_lockmods1  (cost=0.00..1063.00 rows=32100 width=10)                        
+         ->  Materialize  (cost=0.00..3.33 rows=5 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=10)     
+                     ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)                    
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods, t_lockmods1 for key share;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation    
+----------+-----------------+---------+-------------
+ relation | AccessShareLock | t       | t_lockmods1 
+ relation | ExclusiveLock   | t       | t_lockmods1 
+ relation | AccessShareLock | t       | t_lockmods  
+ relation | ExclusiveLock   | t       | t_lockmods  
+(4 rows)
 1: abort;
 ABORT
 
@@ -268,10 +415,19 @@ create table t_lockmods_ao (c int) with (appendonly=true) distributed randomly;
 CREATE
 insert into t_lockmods_ao select * from generate_series(1, 8);
 INSERT 8
+create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
+CREATE
 
 -- 1.2.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
+1: explain select * from t_lockmods_ao for update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=8 width=10) 
+   ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)          
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods_ao for update;
  c 
 ---
@@ -285,15 +441,23 @@ BEGIN
  5 
 (8 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods_ao for no key update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=8 width=10) 
+   ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)          
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods_ao for no key update;
  c 
 ---
@@ -307,15 +471,23 @@ BEGIN
  5 
 (8 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods_ao for share;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=8 width=10) 
+   ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)          
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods_ao for share;
  c 
 ---
@@ -329,15 +501,23 @@ BEGIN
  7 
 (8 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods_ao for key share;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=8 width=10) 
+   ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)          
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods_ao for key share;
  c 
 ---
@@ -351,10 +531,123 @@ BEGIN
  8 
 (8 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for update;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000026102.50 rows=770400 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000026102.50 rows=256800 width=20)                        
+         ->  Seq Scan on t_lockmods_ao1  (cost=0.00..1063.00 rows=32100 width=10)                     
+         ->  Materialize  (cost=0.00..1.52 rows=8 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.40 rows=8 width=10)     
+                     ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)                 
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods_ao, t_lockmods_ao1 for update;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_ao1 
+ relation | ExclusiveLock   | t       | t_lockmods_ao1 
+ relation | AccessShareLock | t       | t_lockmods_ao  
+ relation | ExclusiveLock   | t       | t_lockmods_ao  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for no key update;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000026102.50 rows=770400 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000026102.50 rows=256800 width=20)                        
+         ->  Seq Scan on t_lockmods_ao1  (cost=0.00..1063.00 rows=32100 width=10)                     
+         ->  Materialize  (cost=0.00..1.52 rows=8 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.40 rows=8 width=10)     
+                     ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)                 
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods_ao, t_lockmods_ao1 for no key update;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_ao1 
+ relation | ExclusiveLock   | t       | t_lockmods_ao1 
+ relation | AccessShareLock | t       | t_lockmods_ao  
+ relation | ExclusiveLock   | t       | t_lockmods_ao  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for share;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000026102.50 rows=770400 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000026102.50 rows=256800 width=20)                        
+         ->  Seq Scan on t_lockmods_ao1  (cost=0.00..1063.00 rows=32100 width=10)                     
+         ->  Materialize  (cost=0.00..1.52 rows=8 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.40 rows=8 width=10)     
+                     ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)                 
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods_ao, t_lockmods_ao1 for share;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_ao1 
+ relation | ExclusiveLock   | t       | t_lockmods_ao1 
+ relation | AccessShareLock | t       | t_lockmods_ao  
+ relation | ExclusiveLock   | t       | t_lockmods_ao  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for key share;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000026102.50 rows=770400 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000026102.50 rows=256800 width=20)                        
+         ->  Seq Scan on t_lockmods_ao1  (cost=0.00..1063.00 rows=32100 width=10)                     
+         ->  Materialize  (cost=0.00..1.52 rows=8 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.40 rows=8 width=10)     
+                     ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)                 
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods_ao, t_lockmods_ao1 for key share;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_ao1 
+ relation | ExclusiveLock   | t       | t_lockmods_ao1 
+ relation | AccessShareLock | t       | t_lockmods_ao  
+ relation | ExclusiveLock   | t       | t_lockmods_ao  
+(4 rows)
 1: abort;
 ABORT
 
@@ -597,6 +890,14 @@ SET
 -- 2.1.1 select for (update|share|no key update |key share) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
+1: explain select * from t_lockmods for update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=5 width=10) 
+   ->  LockRows  (cost=0.00..3.10 rows=2 width=10)                           
+         ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)       
+ Optimizer: Postgres query optimizer                                         
+(4 rows)
 1: select * from t_lockmods for update;
  c 
 ---
@@ -607,15 +908,24 @@ BEGIN
  3 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | RowShareLock    | t       | t_lockmods 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods for no key update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=5 width=10) 
+   ->  LockRows  (cost=0.00..3.10 rows=2 width=10)                           
+         ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)       
+ Optimizer: Postgres query optimizer                                         
+(4 rows)
 1: select * from t_lockmods for no key update;
  c 
 ---
@@ -626,15 +936,24 @@ BEGIN
  4 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | RowShareLock    | t       | t_lockmods 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods for share;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=5 width=10) 
+   ->  LockRows  (cost=0.00..3.10 rows=2 width=10)                           
+         ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)       
+ Optimizer: Postgres query optimizer                                         
+(4 rows)
 1: select * from t_lockmods for share;
  c 
 ---
@@ -645,15 +964,24 @@ BEGIN
  4 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | RowShareLock    | t       | t_lockmods 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods for key share;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=5 width=10) 
+   ->  LockRows  (cost=0.00..3.10 rows=2 width=10)                           
+         ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)       
+ Optimizer: Postgres query optimizer                                         
+(4 rows)
 1: select * from t_lockmods for key share;
  c 
 ---
@@ -664,10 +992,123 @@ BEGIN
  4 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
-(1 row)
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | RowShareLock    | t       | t_lockmods 
+(2 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods, t_lockmods1 for update;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000016715.06 rows=481500 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000016715.06 rows=160500 width=20)                        
+         ->  Seq Scan on t_lockmods1  (cost=0.00..1063.00 rows=32100 width=10)                        
+         ->  Materialize  (cost=0.00..3.33 rows=5 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=10)     
+                     ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)                    
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods, t_lockmods1 for update;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation    
+----------+-----------------+---------+-------------
+ relation | AccessShareLock | t       | t_lockmods1 
+ relation | ExclusiveLock   | t       | t_lockmods1 
+ relation | AccessShareLock | t       | t_lockmods  
+ relation | ExclusiveLock   | t       | t_lockmods  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods, t_lockmods1 for no key update;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000016715.06 rows=481500 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000016715.06 rows=160500 width=20)                        
+         ->  Seq Scan on t_lockmods1  (cost=0.00..1063.00 rows=32100 width=10)                        
+         ->  Materialize  (cost=0.00..3.33 rows=5 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=10)     
+                     ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)                    
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods, t_lockmods1 for no key update;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation    
+----------+-----------------+---------+-------------
+ relation | AccessShareLock | t       | t_lockmods1 
+ relation | ExclusiveLock   | t       | t_lockmods1 
+ relation | AccessShareLock | t       | t_lockmods  
+ relation | ExclusiveLock   | t       | t_lockmods  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods, t_lockmods1 for share;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000016715.06 rows=481500 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000016715.06 rows=160500 width=20)                        
+         ->  Seq Scan on t_lockmods1  (cost=0.00..1063.00 rows=32100 width=10)                        
+         ->  Materialize  (cost=0.00..3.33 rows=5 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=10)     
+                     ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)                    
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods, t_lockmods1 for share;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation    
+----------+-----------------+---------+-------------
+ relation | AccessShareLock | t       | t_lockmods1 
+ relation | ExclusiveLock   | t       | t_lockmods1 
+ relation | AccessShareLock | t       | t_lockmods  
+ relation | ExclusiveLock   | t       | t_lockmods  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods, t_lockmods1 for key share;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000016715.06 rows=481500 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000016715.06 rows=160500 width=20)                        
+         ->  Seq Scan on t_lockmods1  (cost=0.00..1063.00 rows=32100 width=10)                        
+         ->  Materialize  (cost=0.00..3.33 rows=5 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=10)     
+                     ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)                    
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods, t_lockmods1 for key share;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation    
+----------+-----------------+---------+-------------
+ relation | AccessShareLock | t       | t_lockmods1 
+ relation | ExclusiveLock   | t       | t_lockmods1 
+ relation | AccessShareLock | t       | t_lockmods  
+ relation | ExclusiveLock   | t       | t_lockmods  
+(4 rows)
 1: abort;
 ABORT
 
@@ -738,9 +1179,9 @@ BEGIN
  5 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
+ locktype | mode         | granted | relation   
+----------+--------------+---------+------------
+ relation | RowShareLock | t       | t_lockmods 
 (1 row)
 1: abort;
 ABORT
@@ -757,9 +1198,9 @@ BEGIN
  3 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
+ locktype | mode         | granted | relation   
+----------+--------------+---------+------------
+ relation | RowShareLock | t       | t_lockmods 
 (1 row)
 1: abort;
 ABORT
@@ -776,9 +1217,9 @@ BEGIN
  4 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
+ locktype | mode         | granted | relation   
+----------+--------------+---------+------------
+ relation | RowShareLock | t       | t_lockmods 
 (1 row)
 1: abort;
 ABORT
@@ -795,9 +1236,9 @@ BEGIN
  4 
 (5 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation   
-----------+---------------+---------+------------
- relation | ExclusiveLock | t       | t_lockmods 
+ locktype | mode         | granted | relation   
+----------+--------------+---------+------------
+ relation | RowShareLock | t       | t_lockmods 
 (1 row)
 1: abort;
 ABORT
@@ -843,6 +1284,13 @@ ABORT
 -- 2.2.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
+1: explain select * from t_lockmods_ao for update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=8 width=10) 
+   ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)          
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods_ao for update;
  c 
 ---
@@ -856,15 +1304,23 @@ BEGIN
  7 
 (8 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods_ao for no key update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=8 width=10) 
+   ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)          
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods_ao for no key update;
  c 
 ---
@@ -878,15 +1334,23 @@ BEGIN
  8 
 (8 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods_ao for share;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=8 width=10) 
+   ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)          
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods_ao for share;
  c 
 ---
@@ -900,15 +1364,23 @@ BEGIN
  5 
 (8 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
 1: abort;
 ABORT
 
 1: begin;
 BEGIN
+1: explain select * from t_lockmods_ao for key share;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=8 width=10) 
+   ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)          
+ Optimizer: Postgres query optimizer                                         
+(3 rows)
 1: select * from t_lockmods_ao for key share;
  c 
 ---
@@ -922,13 +1394,125 @@ BEGIN
  5 
 (8 rows)
 2: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation      
-----------+---------------+---------+---------------
- relation | ExclusiveLock | t       | t_lockmods_ao 
-(1 row)
+ locktype | mode            | granted | relation      
+----------+-----------------+---------+---------------
+ relation | AccessShareLock | t       | t_lockmods_ao 
+ relation | ExclusiveLock   | t       | t_lockmods_ao 
+(2 rows)
 1: abort;
 ABORT
 
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for update;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000026102.50 rows=770400 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000026102.50 rows=256800 width=20)                        
+         ->  Seq Scan on t_lockmods_ao1  (cost=0.00..1063.00 rows=32100 width=10)                     
+         ->  Materialize  (cost=0.00..1.52 rows=8 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.40 rows=8 width=10)     
+                     ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)                 
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods_ao, t_lockmods_ao1 for update;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_ao1 
+ relation | ExclusiveLock   | t       | t_lockmods_ao1 
+ relation | AccessShareLock | t       | t_lockmods_ao  
+ relation | ExclusiveLock   | t       | t_lockmods_ao  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for no key update;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000026102.50 rows=770400 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000026102.50 rows=256800 width=20)                        
+         ->  Seq Scan on t_lockmods_ao1  (cost=0.00..1063.00 rows=32100 width=10)                     
+         ->  Materialize  (cost=0.00..1.52 rows=8 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.40 rows=8 width=10)     
+                     ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)                 
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods_ao, t_lockmods_ao1 for no key update;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_ao1 
+ relation | ExclusiveLock   | t       | t_lockmods_ao1 
+ relation | AccessShareLock | t       | t_lockmods_ao  
+ relation | ExclusiveLock   | t       | t_lockmods_ao  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for share;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000026102.50 rows=770400 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000026102.50 rows=256800 width=20)                        
+         ->  Seq Scan on t_lockmods_ao1  (cost=0.00..1063.00 rows=32100 width=10)                     
+         ->  Materialize  (cost=0.00..1.52 rows=8 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.40 rows=8 width=10)     
+                     ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)                 
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods_ao, t_lockmods_ao1 for share;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_ao1 
+ relation | ExclusiveLock   | t       | t_lockmods_ao1 
+ relation | AccessShareLock | t       | t_lockmods_ao  
+ relation | ExclusiveLock   | t       | t_lockmods_ao  
+(4 rows)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for key share;
+ QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000026102.50 rows=770400 width=20) 
+   ->  Nested Loop  (cost=10000000000.00..10000026102.50 rows=256800 width=20)                        
+         ->  Seq Scan on t_lockmods_ao1  (cost=0.00..1063.00 rows=32100 width=10)                     
+         ->  Materialize  (cost=0.00..1.52 rows=8 width=10)                                           
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.40 rows=8 width=10)     
+                     ->  Seq Scan on t_lockmods_ao  (cost=0.00..1.08 rows=3 width=10)                 
+ Optimizer: Postgres query optimizer                                                                  
+(7 rows)
+1: select * from t_lockmods_ao, t_lockmods_ao1 for key share;
+ c | c 
+---+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_ao1 
+ relation | ExclusiveLock   | t       | t_lockmods_ao1 
+ relation | AccessShareLock | t       | t_lockmods_ao  
+ relation | ExclusiveLock   | t       | t_lockmods_ao  
+(4 rows)
+1: abort;
+ABORT
 
 -- 2.2.2 update | delete should hold ExclusiveLock on result relations
 1: begin;

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -18,140 +18,172 @@ show gp_enable_global_deadlock_detector;
 create table t_lockmods (c int) distributed randomly;
 insert into t_lockmods select * from generate_series(1, 5);
 
--- 1.1.1 select for update should hold ExclusiveLock on range tables
+-- 1.1.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 1: select * from t_lockmods for update;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
+1: begin;
+1: select * from t_lockmods for no key update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: select * from t_lockmods for share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: select * from t_lockmods for key share;
+2: select * from show_locks_lockmodes;
+1: abort;
 
 -- 1.1.2 update | delete should hold ExclusiveLock on result relations
 1: begin;
 1: update t_lockmods set c = c + 0;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: delete from t_lockmods;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 1.1.3 insert should hold RowExclusiveLock on result relations
 1: begin;
 1: insert into t_lockmods select * from generate_series(1, 5);
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 1.1.4 use cached plan should be consistent with no cached plan
 1: prepare select_for_update as select * from t_lockmods for update;
+1: prepare select_for_nokeyupdate as select * from t_lockmods for no key update;
+1: prepare select_for_share as select * from t_lockmods for share;
+1: prepare select_for_keyshare as select * from t_lockmods for key share;
 1: prepare update_tlockmods as update t_lockmods set c = c + 0;
 1: prepare delete_tlockmods as delete from t_lockmods;
 1: prepare insert_tlockmods as insert into t_lockmods select * from generate_series(1, 5);
 
 1: begin;
 1: execute select_for_update;
-
 2: select * from show_locks_lockmodes;
+1: abort;
 
+1: begin;
+1: execute select_for_nokeyupdate;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute select_for_share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute select_for_keyshare;
+2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
 1: execute update_tlockmods;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: execute delete_tlockmods;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: execute insert_tlockmods;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 1.2 test for AO table
 create table t_lockmods_ao (c int) with (appendonly=true) distributed randomly;
 insert into t_lockmods_ao select * from generate_series(1, 8);
 
--- 1.2.1 select for update should hold ExclusiveLock on range tables
+-- 1.2.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 1: select * from t_lockmods_ao for update;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
+1: begin;
+1: select * from t_lockmods_ao for no key update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: select * from t_lockmods_ao for share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: select * from t_lockmods_ao for key share;
+2: select * from show_locks_lockmodes;
+1: abort;
 
 -- 1.2.2 update | delete should hold ExclusiveLock on result relations
 1: begin;
 1: update t_lockmods_ao set c = c + 0;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: delete from t_lockmods_ao;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 1.2.3 insert should hold RowExclusiveLock on result relations
 1: begin;
 1: insert into t_lockmods_ao select * from generate_series(1, 5);
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 1.2.4 use cached plan should be consistent with no cached plan
 1: prepare select_for_update_ao as select * from t_lockmods_ao for update;
+1: prepare select_for_nokeyupdate_ao as select * from t_lockmods_ao for no key update;
+1: prepare select_for_share_ao as select * from t_lockmods_ao for share;
+1: prepare select_for_keyshare_ao as select * from t_lockmods_ao for key share;
 1: prepare update_tlockmods_ao as update t_lockmods_ao set c = c + 0;
 1: prepare delete_tlockmods_ao as delete from t_lockmods_ao;
 1: prepare insert_tlockmods_ao as insert into t_lockmods_ao select * from generate_series(1, 5);
 
 1: begin;
 1: execute select_for_update_ao;
-
 2: select * from show_locks_lockmodes;
+1: abort;
 
+1: begin;
+1: execute select_for_nokeyupdate_ao;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute select_for_share_ao;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute select_for_keyshare_ao;
+2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
 1: execute update_tlockmods_ao;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: execute delete_tlockmods_ao;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: execute insert_tlockmods_ao;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1q:
@@ -171,138 +203,172 @@ insert into t_lockmods_ao select * from generate_series(1, 8);
 
 -- 2.1 test for heap tables
 
--- 2.1.1 select for update should hold ExclusiveLock on range tables
+-- 2.1.1 select for (update|share|no key update |key share) should hold ExclusiveLock on range tables
 1: begin;
 1: select * from t_lockmods for update;
-
 2: select * from show_locks_lockmodes;
+1: abort;
 
+1: begin;
+1: select * from t_lockmods for no key update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: select * from t_lockmods for share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: select * from t_lockmods for key share;
+2: select * from show_locks_lockmodes;
 1: abort;
 
 
 -- 2.1.2 update | delete should hold RowExclusiveLock on result relations
 1: begin;
 1: update t_lockmods set c = c + 0;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: delete from t_lockmods;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 2.1.3 insert should hold RowExclusiveLock on result relations
 1: begin;
 1: insert into t_lockmods select * from generate_series(1, 5);
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 2.1.4 use cached plan should be consistent with no cached plan
 1: prepare select_for_update as select * from t_lockmods for update;
+1: prepare select_for_nokeyupdate as select * from t_lockmods for no key update;
+1: prepare select_for_share as select * from t_lockmods for share;
+1: prepare select_for_keyshare as select * from t_lockmods for key share;
 1: prepare update_tlockmods as update t_lockmods set c = c + 0;
 1: prepare delete_tlockmods as delete from t_lockmods;
 1: prepare insert_tlockmods as insert into t_lockmods select * from generate_series(1, 5);
 
 1: begin;
 1: execute select_for_update;
-
 2: select * from show_locks_lockmodes;
+1: abort;
 
+1: begin;
+1: execute select_for_nokeyupdate;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute select_for_share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute select_for_keyshare;
+2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
 1: execute update_tlockmods;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: execute delete_tlockmods;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: execute insert_tlockmods;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 2.2 test for AO table
 
--- 2.2.1 select for update should hold ExclusiveLock on range tables
+-- 2.2.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 1: select * from t_lockmods_ao for update;
-
 2: select * from show_locks_lockmodes;
+1: abort;
 
+1: begin;
+1: select * from t_lockmods_ao for no key update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: select * from t_lockmods_ao for share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: select * from t_lockmods_ao for key share;
+2: select * from show_locks_lockmodes;
 1: abort;
 
 
 -- 2.2.2 update | delete should hold ExclusiveLock on result relations
 1: begin;
 1: update t_lockmods_ao set c = c + 0;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: delete from t_lockmods_ao;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 2.2.3 insert should hold RowExclusiveLock on result relations
 1: begin;
 1: insert into t_lockmods_ao select * from generate_series(1, 5);
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 -- 2.2.4 use cached plan should be consistent with no cached plan
 1: prepare select_for_update_ao as select * from t_lockmods_ao for update;
+1: prepare select_for_nokeyupdate_ao as select * from t_lockmods_ao for no key update;
+1: prepare select_for_share_ao as select * from t_lockmods_ao for share;
+1: prepare select_for_keyshare_ao as select * from t_lockmods_ao for key share;
 1: prepare update_tlockmods_ao as update t_lockmods_ao set c = c + 0;
 1: prepare delete_tlockmods_ao as delete from t_lockmods_ao;
 1: prepare insert_tlockmods_ao as insert into t_lockmods_ao select * from generate_series(1, 5);
 
 1: begin;
 1: execute select_for_update_ao;
-
 2: select * from show_locks_lockmodes;
+1: abort;
 
+1: begin;
+1: execute select_for_nokeyupdate_ao;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute select_for_share_ao;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute select_for_keyshare_ao;
+2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
 1: execute update_tlockmods_ao;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: execute delete_tlockmods_ao;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1: begin;
 1: execute insert_tlockmods_ao;
-
 2: select * from show_locks_lockmodes;
-
 1: abort;
 
 1q:

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -18,24 +18,54 @@ show gp_enable_global_deadlock_detector;
 create table t_lockmods (c int) distributed randomly;
 insert into t_lockmods select * from generate_series(1, 5);
 
+create table t_lockmods1 (c int) distributed randomly;
+
 -- 1.1.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
+1: explain select * from t_lockmods for update;
 1: select * from t_lockmods for update;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods for no key update;
 1: select * from t_lockmods for no key update;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods for share;
 1: select * from t_lockmods for share;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods for key share;
 1: select * from t_lockmods for key share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods, t_lockmods1 for update;
+1: select * from t_lockmods, t_lockmods1 for update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods, t_lockmods1 for no key update;
+1: select * from t_lockmods, t_lockmods1 for no key update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods, t_lockmods1 for share;
+1: select * from t_lockmods, t_lockmods1 for share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods, t_lockmods1 for key share;
+1: select * from t_lockmods, t_lockmods1 for key share;
 2: select * from show_locks_lockmodes;
 1: abort;
 
@@ -103,25 +133,54 @@ insert into t_lockmods select * from generate_series(1, 5);
 -- 1.2 test for AO table
 create table t_lockmods_ao (c int) with (appendonly=true) distributed randomly;
 insert into t_lockmods_ao select * from generate_series(1, 8);
+create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 
 -- 1.2.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
+1: explain select * from t_lockmods_ao for update;
 1: select * from t_lockmods_ao for update;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods_ao for no key update;
 1: select * from t_lockmods_ao for no key update;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods_ao for share;
 1: select * from t_lockmods_ao for share;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods_ao for key share;
 1: select * from t_lockmods_ao for key share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for update;
+1: select * from t_lockmods_ao, t_lockmods_ao1 for update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for no key update;
+1: select * from t_lockmods_ao, t_lockmods_ao1 for no key update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for share;
+1: select * from t_lockmods_ao, t_lockmods_ao1 for share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for key share;
+1: select * from t_lockmods_ao, t_lockmods_ao1 for key share;
 2: select * from show_locks_lockmodes;
 1: abort;
 
@@ -205,22 +264,50 @@ insert into t_lockmods_ao select * from generate_series(1, 8);
 
 -- 2.1.1 select for (update|share|no key update |key share) should hold ExclusiveLock on range tables
 1: begin;
+1: explain select * from t_lockmods for update;
 1: select * from t_lockmods for update;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods for no key update;
 1: select * from t_lockmods for no key update;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods for share;
 1: select * from t_lockmods for share;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods for key share;
 1: select * from t_lockmods for key share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods, t_lockmods1 for update;
+1: select * from t_lockmods, t_lockmods1 for update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods, t_lockmods1 for no key update;
+1: select * from t_lockmods, t_lockmods1 for no key update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods, t_lockmods1 for share;
+1: select * from t_lockmods, t_lockmods1 for share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods, t_lockmods1 for key share;
+1: select * from t_lockmods, t_lockmods1 for key share;
 2: select * from show_locks_lockmodes;
 1: abort;
 
@@ -290,25 +377,52 @@ insert into t_lockmods_ao select * from generate_series(1, 8);
 
 -- 2.2.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
+1: explain select * from t_lockmods_ao for update;
 1: select * from t_lockmods_ao for update;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods_ao for no key update;
 1: select * from t_lockmods_ao for no key update;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods_ao for share;
 1: select * from t_lockmods_ao for share;
 2: select * from show_locks_lockmodes;
 1: abort;
 
 1: begin;
+1: explain select * from t_lockmods_ao for key share;
 1: select * from t_lockmods_ao for key share;
 2: select * from show_locks_lockmodes;
 1: abort;
 
+1: begin;
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for update;
+1: select * from t_lockmods_ao, t_lockmods_ao1 for update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for no key update;
+1: select * from t_lockmods_ao, t_lockmods_ao1 for no key update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for share;
+1: select * from t_lockmods_ao, t_lockmods_ao1 for share;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: explain select * from t_lockmods_ao, t_lockmods_ao1 for key share;
+1: select * from t_lockmods_ao, t_lockmods_ao1 for key share;
+2: select * from show_locks_lockmodes;
+1: abort;
 
 -- 2.2.2 update | delete should hold ExclusiveLock on result relations
 1: begin;

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -2117,8 +2117,8 @@ SELECT * FROM t1 WHERE a=100; -- Nothing should have been changed to 100
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
-                                                                              QUERY PLAN                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.t1 t1_4
    ->  Redistribute Motion 3:3  (slice1; segments: 3)
          Output: ((t1.a + 1)), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id, (DMLAction)
@@ -2128,20 +2128,18 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                ->  Subquery Scan on t1
                      Output: (t1.a + 1), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id
                      Filter: snoop(t1.a)
-                     ->  LockRows
+                     ->  Nested Loop Semi Join
                            Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c, t1_5.ctid, t12.ctid, t12.tableoid
-                           ->  Nested Loop Semi Join
-                                 Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c, t1_5.ctid, t12.ctid, t12.tableoid
-                                 ->  Seq Scan on public.t1 t1_5
-                                       Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c
-                                       Filter: ((t1_5.a > 5) AND (t1_5.a = 8) AND leakproof(t1_5.a))
-                                 ->  Append
-                                       ->  Seq Scan on public.t12
-                                             Output: t12.ctid, t12.tableoid, t12.a
-                                             Filter: ((t12.a > 5) AND (t12.a = 8))
-                                       ->  Seq Scan on public.t111
-                                             Output: t111.ctid, t111.tableoid, t111.a
-                                             Filter: ((t111.a > 5) AND (t111.a = 8))
+                           ->  Seq Scan on public.t1 t1_5
+                                 Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c
+                                 Filter: ((t1_5.a > 5) AND (t1_5.a = 8) AND leakproof(t1_5.a))
+                           ->  Append
+                                 ->  Seq Scan on public.t12
+                                       Output: t12.ctid, t12.tableoid, t12.a
+                                       Filter: ((t12.a > 5) AND (t12.a = 8))
+                                 ->  Seq Scan on public.t111
+                                       Output: t111.ctid, t111.tableoid, t111.a
+                                       Filter: ((t111.a > 5) AND (t111.a = 8))
    ->  Redistribute Motion 3:3  (slice2; segments: 3)
          Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          Hash Key: ((t1_1.a + 1))
@@ -2150,20 +2148,18 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                ->  Subquery Scan on t1_1
                      Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id
                      Filter: snoop(t1_1.a)
-                     ->  LockRows
+                     ->  Nested Loop Semi Join
                            Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d, t11.ctid, t12_1.ctid, t12_1.tableoid
-                           ->  Nested Loop Semi Join
-                                 Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d, t11.ctid, t12_1.ctid, t12_1.tableoid
-                                 ->  Seq Scan on public.t11
-                                       Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d
-                                       Filter: ((t11.a > 5) AND (t11.a = 8) AND leakproof(t11.a))
-                                 ->  Append
-                                       ->  Seq Scan on public.t12 t12_1
-                                             Output: t12_1.ctid, t12_1.tableoid, t12_1.a
-                                             Filter: ((t12_1.a > 5) AND (t12_1.a = 8))
-                                       ->  Seq Scan on public.t111 t111_1
-                                             Output: t111_1.ctid, t111_1.tableoid, t111_1.a
-                                             Filter: ((t111_1.a > 5) AND (t111_1.a = 8))
+                           ->  Seq Scan on public.t11
+                                 Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d
+                                 Filter: ((t11.a > 5) AND (t11.a = 8) AND leakproof(t11.a))
+                           ->  Append
+                                 ->  Seq Scan on public.t12 t12_1
+                                       Output: t12_1.ctid, t12_1.tableoid, t12_1.a
+                                       Filter: ((t12_1.a > 5) AND (t12_1.a = 8))
+                                 ->  Seq Scan on public.t111 t111_1
+                                       Output: t111_1.ctid, t111_1.tableoid, t111_1.a
+                                       Filter: ((t111_1.a > 5) AND (t111_1.a = 8))
    ->  Redistribute Motion 3:3  (slice3; segments: 3)
          Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
          Hash Key: ((t1_2.a + 1))
@@ -2172,20 +2168,18 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                ->  Subquery Scan on t1_2
                      Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id
                      Filter: snoop(t1_2.a)
-                     ->  LockRows
+                     ->  Nested Loop Semi Join
                            Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e, t12_2.ctid, t12_3.ctid, t12_3.tableoid
-                           ->  Nested Loop Semi Join
-                                 Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e, t12_2.ctid, t12_3.ctid, t12_3.tableoid
-                                 ->  Seq Scan on public.t12 t12_2
-                                       Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e
-                                       Filter: ((t12_2.a > 5) AND (t12_2.a = 8) AND leakproof(t12_2.a))
-                                 ->  Append
-                                       ->  Seq Scan on public.t12 t12_3
-                                             Output: t12_3.ctid, t12_3.tableoid, t12_3.a
-                                             Filter: ((t12_3.a > 5) AND (t12_3.a = 8))
-                                       ->  Seq Scan on public.t111 t111_2
-                                             Output: t111_2.ctid, t111_2.tableoid, t111_2.a
-                                             Filter: ((t111_2.a > 5) AND (t111_2.a = 8))
+                           ->  Seq Scan on public.t12 t12_2
+                                 Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e
+                                 Filter: ((t12_2.a > 5) AND (t12_2.a = 8) AND leakproof(t12_2.a))
+                           ->  Append
+                                 ->  Seq Scan on public.t12 t12_3
+                                       Output: t12_3.ctid, t12_3.tableoid, t12_3.a
+                                       Filter: ((t12_3.a > 5) AND (t12_3.a = 8))
+                                 ->  Seq Scan on public.t111 t111_2
+                                       Output: t111_2.ctid, t111_2.tableoid, t111_2.a
+                                       Filter: ((t111_2.a > 5) AND (t111_2.a = 8))
    ->  Redistribute Motion 3:3  (slice4; segments: 3)
          Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          Hash Key: ((t1_3.a + 1))
@@ -2194,20 +2188,18 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                ->  Subquery Scan on t1_3
                      Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id
                      Filter: snoop(t1_3.a)
-                     ->  LockRows
+                     ->  Nested Loop Semi Join
                            Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e, t111_3.ctid, t12_4.ctid, t12_4.tableoid
-                           ->  Nested Loop Semi Join
-                                 Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e, t111_3.ctid, t12_4.ctid, t12_4.tableoid
-                                 ->  Seq Scan on public.t111 t111_3
-                                       Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e
-                                       Filter: ((t111_3.a > 5) AND (t111_3.a = 8) AND leakproof(t111_3.a))
-                                 ->  Append
-                                       ->  Seq Scan on public.t12 t12_4
-                                             Output: t12_4.ctid, t12_4.tableoid, t12_4.a
-                                             Filter: ((t12_4.a > 5) AND (t12_4.a = 8))
-                                       ->  Seq Scan on public.t111 t111_4
-                                             Output: t111_4.ctid, t111_4.tableoid, t111_4.a
-                                             Filter: ((t111_4.a > 5) AND (t111_4.a = 8))
+                           ->  Seq Scan on public.t111 t111_3
+                                 Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e
+                                 Filter: ((t111_3.a > 5) AND (t111_3.a = 8) AND leakproof(t111_3.a))
+                           ->  Append
+                                 ->  Seq Scan on public.t12 t12_4
+                                       Output: t12_4.ctid, t12_4.tableoid, t12_4.a
+                                       Filter: ((t12_4.a > 5) AND (t12_4.a = 8))
+                                 ->  Seq Scan on public.t111 t111_4
+                                       Output: t111_4.ctid, t111_4.tableoid, t111_4.a
+                                       Filter: ((t111_4.a > 5) AND (t111_4.a = 8))
  Optimizer: Postgres query optimizer
 (90 rows)
 

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -2146,8 +2146,8 @@ SELECT * FROM t1 WHERE a=100; -- Nothing should have been changed to 100
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.t1 t1_4
    ->  Redistribute Motion 3:3  (slice1; segments: 3)
          Output: ((t1.a + 1)), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id, (DMLAction)
@@ -2157,20 +2157,18 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                ->  Subquery Scan on t1
                      Output: (t1.a + 1), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id
                      Filter: snoop(t1.a)
-                     ->  LockRows
+                     ->  Nested Loop Semi Join
                            Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c, t1_5.ctid, t12.ctid, t12.tableoid
-                           ->  Nested Loop Semi Join
-                                 Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c, t1_5.ctid, t12.ctid, t12.tableoid
-                                 ->  Seq Scan on public.t1 t1_5
-                                       Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c
-                                       Filter: ((t1_5.a > 5) AND (t1_5.a = 8) AND leakproof(t1_5.a))
-                                 ->  Append
-                                       ->  Seq Scan on public.t12
-                                             Output: t12.ctid, t12.tableoid, t12.a
-                                             Filter: ((t12.a > 5) AND (t12.a = 8))
-                                       ->  Seq Scan on public.t111
-                                             Output: t111.ctid, t111.tableoid, t111.a
-                                             Filter: ((t111.a > 5) AND (t111.a = 8))
+                           ->  Seq Scan on public.t1 t1_5
+                                 Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c
+                                 Filter: ((t1_5.a > 5) AND (t1_5.a = 8) AND leakproof(t1_5.a))
+                           ->  Append
+                                 ->  Seq Scan on public.t12
+                                       Output: t12.ctid, t12.tableoid, t12.a
+                                       Filter: ((t12.a > 5) AND (t12.a = 8))
+                                 ->  Seq Scan on public.t111
+                                       Output: t111.ctid, t111.tableoid, t111.a
+                                       Filter: ((t111.a > 5) AND (t111.a = 8))
    ->  Redistribute Motion 3:3  (slice2; segments: 3)
          Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          Hash Key: ((t1_1.a + 1))
@@ -2179,20 +2177,18 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                ->  Subquery Scan on t1_1
                      Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id
                      Filter: snoop(t1_1.a)
-                     ->  LockRows
+                     ->  Nested Loop Semi Join
                            Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d, t11.ctid, t12_1.ctid, t12_1.tableoid
-                           ->  Nested Loop Semi Join
-                                 Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d, t11.ctid, t12_1.ctid, t12_1.tableoid
-                                 ->  Seq Scan on public.t11
-                                       Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d
-                                       Filter: ((t11.a > 5) AND (t11.a = 8) AND leakproof(t11.a))
-                                 ->  Append
-                                       ->  Seq Scan on public.t12 t12_1
-                                             Output: t12_1.ctid, t12_1.tableoid, t12_1.a
-                                             Filter: ((t12_1.a > 5) AND (t12_1.a = 8))
-                                       ->  Seq Scan on public.t111 t111_1
-                                             Output: t111_1.ctid, t111_1.tableoid, t111_1.a
-                                             Filter: ((t111_1.a > 5) AND (t111_1.a = 8))
+                           ->  Seq Scan on public.t11
+                                 Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d
+                                 Filter: ((t11.a > 5) AND (t11.a = 8) AND leakproof(t11.a))
+                           ->  Append
+                                 ->  Seq Scan on public.t12 t12_1
+                                       Output: t12_1.ctid, t12_1.tableoid, t12_1.a
+                                       Filter: ((t12_1.a > 5) AND (t12_1.a = 8))
+                                 ->  Seq Scan on public.t111 t111_1
+                                       Output: t111_1.ctid, t111_1.tableoid, t111_1.a
+                                       Filter: ((t111_1.a > 5) AND (t111_1.a = 8))
    ->  Redistribute Motion 3:3  (slice3; segments: 3)
          Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
          Hash Key: ((t1_2.a + 1))
@@ -2201,20 +2197,18 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                ->  Subquery Scan on t1_2
                      Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id
                      Filter: snoop(t1_2.a)
-                     ->  LockRows
+                     ->  Nested Loop Semi Join
                            Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e, t12_2.ctid, t12_3.ctid, t12_3.tableoid
-                           ->  Nested Loop Semi Join
-                                 Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e, t12_2.ctid, t12_3.ctid, t12_3.tableoid
-                                 ->  Seq Scan on public.t12 t12_2
-                                       Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e
-                                       Filter: ((t12_2.a > 5) AND (t12_2.a = 8) AND leakproof(t12_2.a))
-                                 ->  Append
-                                       ->  Seq Scan on public.t12 t12_3
-                                             Output: t12_3.ctid, t12_3.tableoid, t12_3.a
-                                             Filter: ((t12_3.a > 5) AND (t12_3.a = 8))
-                                       ->  Seq Scan on public.t111 t111_2
-                                             Output: t111_2.ctid, t111_2.tableoid, t111_2.a
-                                             Filter: ((t111_2.a > 5) AND (t111_2.a = 8))
+                           ->  Seq Scan on public.t12 t12_2
+                                 Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e
+                                 Filter: ((t12_2.a > 5) AND (t12_2.a = 8) AND leakproof(t12_2.a))
+                           ->  Append
+                                 ->  Seq Scan on public.t12 t12_3
+                                       Output: t12_3.ctid, t12_3.tableoid, t12_3.a
+                                       Filter: ((t12_3.a > 5) AND (t12_3.a = 8))
+                                 ->  Seq Scan on public.t111 t111_2
+                                       Output: t111_2.ctid, t111_2.tableoid, t111_2.a
+                                       Filter: ((t111_2.a > 5) AND (t111_2.a = 8))
    ->  Redistribute Motion 3:3  (slice4; segments: 3)
          Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          Hash Key: ((t1_3.a + 1))
@@ -2223,20 +2217,18 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                ->  Subquery Scan on t1_3
                      Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id
                      Filter: snoop(t1_3.a)
-                     ->  LockRows
+                     ->  Nested Loop Semi Join
                            Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e, t111_3.ctid, t12_4.ctid, t12_4.tableoid
-                           ->  Nested Loop Semi Join
-                                 Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e, t111_3.ctid, t12_4.ctid, t12_4.tableoid
-                                 ->  Seq Scan on public.t111 t111_3
-                                       Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e
-                                       Filter: ((t111_3.a > 5) AND (t111_3.a = 8) AND leakproof(t111_3.a))
-                                 ->  Append
-                                       ->  Seq Scan on public.t12 t12_4
-                                             Output: t12_4.ctid, t12_4.tableoid, t12_4.a
-                                             Filter: ((t12_4.a > 5) AND (t12_4.a = 8))
-                                       ->  Seq Scan on public.t111 t111_4
-                                             Output: t111_4.ctid, t111_4.tableoid, t111_4.a
-                                             Filter: ((t111_4.a > 5) AND (t111_4.a = 8))
+                           ->  Seq Scan on public.t111 t111_3
+                                 Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e
+                                 Filter: ((t111_3.a > 5) AND (t111_3.a = 8) AND leakproof(t111_3.a))
+                           ->  Append
+                                 ->  Seq Scan on public.t12 t12_4
+                                       Output: t12_4.ctid, t12_4.tableoid, t12_4.a
+                                       Filter: ((t12_4.a > 5) AND (t12_4.a = 8))
+                                 ->  Seq Scan on public.t111 t111_4
+                                       Output: t111_4.ctid, t111_4.tableoid, t111_4.a
+                                       Filter: ((t111_4.a > 5) AND (t111_4.a = 8))
  Optimizer: Postgres query optimizer
 (90 rows)
 


### PR DESCRIPTION
This PR divides into two commits for the convenience of reviewing (maybe more convenient). 
Reviewers could review this commit by commit and read details in the commit messages.

There are four kinds of locking clause:
  1. for update
  2. for no key update
  3. for share
  4. for key share

The key steps to implement the locking clause semantics in Postgres are:
   1. lock the table in RowShareLock mode during the parsing stage (this is the same
       for each type of locking clause)
   2. Generate a LockRows node in the plan
   3. During executing the node LockRows, it locks each tuple from below plan nodes

In Greenplum, things get more complicated.

If Global Deadlock Detector is disabled, we cannot simply lock tuples on segments without
holding a high-level lock on QD, because this may lead to Global DeadLocks. Even if we enable
Global Deadlock Detector, in the MPP environment, tuples may be motioned here, it is not possible
to lock remote tuples now.

But for the very simple case that only involves one table, we can just behave as upstream when
global deadlock detector is enabled. And almost each select-for-xxx query in OLTP scenario
is a simple case. For such cases, we could behave just like Postgres: holds RowShareLock on the rangetable, and locks the tuple when executing. This will improve OLTP concurrence performance
by not locking the table in Exclusive mode.

In Summary:
    * With GDD disabled, Greenplum locks the entire tables in ExclusiveLock mode for select statement
       with locking clause (for update|for no key update|for share|for key share) to conflict with DMLs
    * With GDD enabled, it keeps the same behaviour as above, except for some very simple cases 
       shown  below (these simple case, hold RowShareLock on the table, then generate lockrows plan):

Simple cases have to ensure all the following condition holds:
    1. GDD is enabled
    2. Top level select statement
    3. no set operations (union, intersect, ...)
    4. From list contains and only contains one rangeVar (and is not a view)
    5. no sublink, subquery
    6. has locking clause
    7. the table in locking clause is a heap table (AO table cannot lock tuples now)

For case examples, please review the test cases.

-------

GPDB-DEV mailling list thread: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/q8Nro2iBHRU

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
