### PR TITLE
Ignore pg_regress tablespace symlink path length warnings.

### DIFF
--- a/src/bin/pg_rewind/Makefile
+++ b/src/bin/pg_rewind/Makefile
@@ -31,7 +31,7 @@ REGRESS = basictest extrafiles databases pg_xlog_symlink unclean_shutdown \
 	tablespaces_objects_created_before_promotion \
 	tablespaces_objects_created_after_promotion \
 	tablespaces_objects_removed_after_promotion
-REGRESS_OPTS=--use-existing --launcher=./launcher
+REGRESS_OPTS=--init-file=./regress_init_file --use-existing --launcher=./launcher
 
 all: pg_rewind
 

--- a/src/bin/pg_rewind/regress_init_file
+++ b/src/bin/pg_rewind/regress_init_file
@@ -1,0 +1,9 @@
+--
+-- We cannot ensure that these warnings will appear for all users because they
+-- depend on where their greenplum source directory is located. Therefore, ignore
+-- these errors. They are tested in the main regress suite also.
+--
+-- start_matchignore
+m/WARNING:  tablespace location ".*" is too long for TAR/
+m/DETAIL:  The location is used to create a symlink target from pg_tblspc. Symlink targets are truncated to 100 characters when sending a TAR \(e.g the BASE_BACKUP protocol response\)./
+-- end_matchignore


### PR DESCRIPTION
We cannot ensure that these warnings will appear for all users because they
depend on where their greenplum source directory is located. Therefore, ignore
these errors. They are tested in the main regress suite also.
