### PR TITLE
docs - add missing ']' to gpconfig synopsis

### DIFF
--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
@@ -8,7 +8,8 @@
     <section id="section2">
       <title>Synopsis</title>
       <codeblock><b>gpconfig</b> <b>-c</b> <varname>param_name</varname> <b>-v</b> <varname>value</varname> [<b>-m</b> <varname>master_value</varname> | <b>--masteronly</b>]
-       | <b>-r</b> <varname>param_name</varname> [<b>--masteronly</b> | <b>-l</b>
+       | <b>-r</b> <varname>param_name</varname> [<b>--masteronly</b> ]
+       | <b>-l</b>
        [<b>--skipvalidation</b>] [<b>--verbose</b>] [<b>--debug</b>]
 
 <b>gpconfig</b> <b>-s</b> <varname>param_name</varname> [<b>--file</b> | <b>--file-compare</b>] [<b>--verbose</b>] [<b>--debug</b>]

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
@@ -8,7 +8,7 @@
     <section id="section2">
       <title>Synopsis</title>
       <codeblock><b>gpconfig</b> <b>-c</b> <varname>param_name</varname> <b>-v</b> <varname>value</varname> [<b>-m</b> <varname>master_value</varname> | <b>--masteronly</b>]
-       | <b>-r</b> <varname>param_name</varname> [<b>--masteronly</b> ]
+       | <b>-r</b> <varname>param_name</varname> [<b>--masteronly</b>]
        | <b>-l</b>
        [<b>--skipvalidation</b>] [<b>--verbose</b>] [<b>--debug</b>]
 


### PR DESCRIPTION
Observed in 6X_STABLE

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
