### PR TITLE
6X Backport: Declare a whitelist in gpstop for bgworker

### DIFF
--- a/gpMgmt/bin/gppylib/db/catalog.py
+++ b/gpMgmt/bin/gppylib/db/catalog.py
@@ -9,6 +9,7 @@ import copy
 
 import dbconn
 from  gppylib import gplog
+from  pygresql import pg
 
 logger=gplog.get_default_logger()
 
@@ -36,9 +37,13 @@ def getDatabaseList(conn):
     sql = "SELECT datname FROM pg_catalog.pg_database"
     return basicSQLExec(conn,sql)
 
-def getUserPIDs(conn):
+def getUserPIDs(conn, ignoreList):
     """dont count ourselves"""
     sql = """SELECT pid FROM pg_stat_activity WHERE pid != pg_backend_pid()"""
+    if ignoreList:
+        ignoreStr = ', '.join("'"+ pg.escape_string(i) +"'" for i in ignoreList)
+        sql = sql + ' and application_name not in (' + ignoreStr +')'
+
     return basicSQLExec(conn,sql)
 
 def doesSchemaExist(conn,schemaname):

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -37,6 +37,16 @@ try:
 except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
+"""
+GpstopCheckIgnoreList is a whitelist to ignore when checking active database connections
+
+In smart mode, we check the `pg_stat_activity` table for active sessions before calling
+the cluster stop routine. However, we need to ignore those that are part of the database
+implementation itself. For this purpose, we maintain a whitelist using its `application_name`
+field.
+"""
+GpstopCheckIgnoreList = ['gp_reserved_gpdiskquota']
+
 DEFAULT_NUM_WORKERS = 64
 logger = get_default_logger()
 
@@ -463,7 +473,7 @@ class GpStop:
 
     ######
     def _stop_master_checks(self):
-        total_connections = len(catalog.getUserPIDs(self.conn))
+        total_connections = len(catalog.getUserPIDs(self.conn, GpstopCheckIgnoreList))
         logger.info("There are %d connections to the database" % total_connections)
 
         if total_connections > 0 and self.mode == 'smart':


### PR DESCRIPTION
This is a clean backport of #7455 .At present, `gpstop` check `pg_stat_activity` table before stop cluster in smart model. However, we need to ignore those background workers that are part of the database implementation itself. For this purpose, we maintain a whitelist using its `application_name` field.
