### PR TITLE
Fix \dd psql command

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -1114,54 +1114,8 @@ objectDescription(const char *pattern, bool showSystem)
 		appendPQExpBufferStr(&buf, "WHERE n.nspname <> 'pg_catalog'\n"
 							 "      AND n.nspname <> 'information_schema'\n");
 
-	processSQLNamePattern(pset.db, &buf, pattern, !showSystem && !pattern, false,
-						  "n.nspname", "o.oprname", NULL,
-						  "pg_catalog.pg_operator_is_visible(o.oid)");
-
-	/* Type descriptions */
-	appendPQExpBuffer(&buf,
-					  "UNION ALL\n"
-					  "  SELECT t.oid as oid, t.tableoid as tableoid,\n"
-					  "  n.nspname as nspname,\n"
-					  "  pg_catalog.format_type(t.oid, NULL) as name,"
-					  "  CAST('%s' AS pg_catalog.text) as object\n"
-					  "  FROM pg_catalog.pg_type t\n"
-	"       LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace\n",
-					  gettext_noop("data type"));
-
-	if (!showSystem && !pattern)
-		appendPQExpBuffer(&buf, "WHERE n.nspname <> 'pg_catalog'\n"
-						  "      AND n.nspname <> 'information_schema'\n");
-
-	processSQLNamePattern(pset.db, &buf, pattern, !showSystem && !pattern, false,
-						  "n.nspname", "pg_catalog.format_type(t.oid, NULL)",
-						  NULL,
-						  "pg_catalog.pg_type_is_visible(t.oid)");
-
-	/* Relation (tables, views, indexes, sequences, external) descriptions */
-	appendPQExpBuffer(&buf,
-					  "UNION ALL\n"
-					  "  SELECT c.oid as oid, c.tableoid as tableoid,\n"
-					  "  n.nspname as nspname,\n"
-					  "  CAST(c.relname AS pg_catalog.text) as name,\n"
-					  "  CAST(\n"
-					  "    CASE c.relkind WHEN 'r' THEN '%s' WHEN 'v' THEN '%s' WHEN 'i' THEN '%s' WHEN 'S' THEN '%s' WHEN 'f' THEN '%s' END"
-					  "  AS pg_catalog.text) as object\n"
-					  "  FROM pg_catalog.pg_class c\n"
-	 "       LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace\n"
-					  "  WHERE c.relkind IN ('r', 'v', 'i', 'S', 'f')\n",
-					  gettext_noop("table"),
-					  gettext_noop("view"),
-					  gettext_noop("index"),
-					  gettext_noop("sequence"),
-					  gettext_noop("foreign table"));
-
-	if (!showSystem && !pattern)
-		appendPQExpBuffer(&buf, "      AND n.nspname <> 'pg_catalog'\n"
-						  "      AND n.nspname <> 'information_schema'\n");
-
-	processSQLNamePattern(pset.db, &buf, pattern, true, false,
-						  "n.nspname", "c.relname", NULL,
+	processSQLNamePattern(pset.db, &buf, pattern, !showSystem && !pattern,
+						  false, "n.nspname", "pgc.conname", NULL,
 						  "pg_catalog.pg_table_is_visible(c.oid)");
 
 	/*

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -222,6 +222,28 @@ ALTER EXTERNAL TABLE "dE_external_table" OWNER TO test_psql_de_role;
  test_psql_schema | dE_foreign_table  | foreign table | test_psql_de_role
 (2 rows)
 
+-- \dd should list objects having comments
+\dd
+         Object descriptions
+ Schema | Name | Object | Description 
+--------+------+--------+-------------
+(0 rows)
+
+create rule dd_notify as on update to d_heap do also notify d_heap;
+comment on rule dd_notify on d_heap is 'this is a rule';
+alter table d_heap add constraint dd_ichk check (i>20);
+comment on constraint dd_ichk on d_heap is 'this is a constraint';
+create operator family dd_opfamily using btree;
+comment on operator family dd_opfamily using btree is 'this is an operator family';
+\dd
+                              Object descriptions
+      Schema      |    Name     |     Object      |        Description         
+------------------+-------------+-----------------+----------------------------
+ test_psql_schema | dd_ichk     | constraint      | this is a constraint
+ test_psql_schema | dd_notify   | rule            | this is a rule
+ test_psql_schema | dd_opfamily | operator family | this is an operator family
+(3 rows)
+
 -- Clean up
 DROP OWNED BY test_psql_de_role;
 DROP ROLE test_psql_de_role;

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -115,6 +115,16 @@ ALTER EXTERNAL TABLE "dE_external_table" OWNER TO test_psql_de_role;
 \dE "dE"*
 \dE
 
+-- \dd should list objects having comments
+\dd
+create rule dd_notify as on update to d_heap do also notify d_heap;
+comment on rule dd_notify on d_heap is 'this is a rule';
+alter table d_heap add constraint dd_ichk check (i>20);
+comment on constraint dd_ichk on d_heap is 'this is a constraint';
+create operator family dd_opfamily using btree;
+comment on operator family dd_opfamily using btree is 'this is an operator family';
+\dd
+
 -- Clean up
 DROP OWNED BY test_psql_de_role;
 DROP ROLE test_psql_de_role;


### PR DESCRIPTION
This was most likely due to some mismerge during 9.2 cycle.  See
598f4b0ef7a00f and e0aa3ef26347623.

Fixes GitHub issue #7712.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
