### PR TITLE
6X: Support AO/ENCODING in CREATE TABLE .. LIKE INCLUDING

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17615,7 +17615,7 @@ make_distributedby_for_rel(Relation rel)
  * Given a relation, get all column encodings for that relation as a list of
  * ColumnReferenceStorageDirective structures.
  */
-static List *
+List *
 rel_get_column_encodings(Relation rel)
 {
 	List **colencs = RelationGetUntransformedAttributeOptions(rel);

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -137,4 +137,6 @@ extern void RangeVarCallbackOwnsTable(const RangeVar *relation,
 
 extern void RangeVarCallbackOwnsRelation(const RangeVar *relation,
 							 Oid relId, Oid oldRelId, void *noCatalogs);
+
+extern List * rel_get_column_encodings(Relation rel);
 #endif   /* TABLECMDS_H */

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -1,0 +1,59 @@
+-- AO/AOCS
+CREATE TABLE t_ao (a integer, b text) WITH (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t_ao_enc (a integer, b text ENCODING (compresstype=zlib,compresslevel=1,blocksize=32768)) WITH (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t_ao_a (LIKE t_ao INCLUDING ALL);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+CREATE TABLE t_ao_b (LIKE t_ao INCLUDING STORAGE);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+CREATE TABLE t_ao_c (LIKE t_ao); -- Should create a heap table
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+CREATE TABLE t_ao_enc_a (LIKE t_ao_enc INCLUDING STORAGE);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+-- Verify gp_default_storage_options GUC doesn't get used
+SET gp_default_storage_options = "appendonly=true, orientation=row";
+CREATE TABLE t_ao_d (LIKE t_ao INCLUDING ALL);
+RESET gp_default_storage_options;
+-- Verify created tables and attributes
+SELECT
+	c.relname,
+	c.relstorage,
+	a.columnstore,
+	a.compresstype,
+	a.compresslevel
+FROM
+	pg_catalog.pg_class c
+		LEFT OUTER JOIN pg_catalog.pg_appendonly a ON (c.oid = a.relid)
+WHERE
+	c.relname LIKE 't_ao%';
+  relname   | relstorage | columnstore | compresstype | compresslevel 
+------------+------------+-------------+--------------+---------------
+ t_ao       | c          | t           |              |             0
+ t_ao_enc   | c          | t           |              |             0
+ t_ao_a     | c          | t           |              |             0
+ t_ao_b     | c          | t           |              |             0
+ t_ao_c     | h          |             |              |              
+ t_ao_d     | c          | t           |              |             0
+ t_ao_enc_a | c          | t           |              |             0
+(7 rows)
+
+SELECT
+	c.relname,
+	a.attnum,
+	a.attoptions
+FROM
+	pg_catalog.pg_class c
+		JOIN pg_catalog.pg_attribute_encoding a ON (a.attrelid = c.oid)
+WHERE
+	c.relname like 't_ao_enc%';
+  relname   | attnum |                     attoptions                      
+------------+--------+-----------------------------------------------------
+ t_ao_enc   |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ t_ao_enc   |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ t_ao_enc_a |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ t_ao_enc_a |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+(4 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -30,7 +30,7 @@ test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parame
 test: spi_processed64bit
 test: python_processed64bit
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp create_table_like_gp
 
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
 

--- a/src/test/regress/sql/create_table_like_gp.sql
+++ b/src/test/regress/sql/create_table_like_gp.sql
@@ -1,0 +1,37 @@
+-- AO/AOCS
+CREATE TABLE t_ao (a integer, b text) WITH (appendonly=true, orientation=column);
+CREATE TABLE t_ao_enc (a integer, b text ENCODING (compresstype=zlib,compresslevel=1,blocksize=32768)) WITH (appendonly=true, orientation=column);
+
+CREATE TABLE t_ao_a (LIKE t_ao INCLUDING ALL);
+CREATE TABLE t_ao_b (LIKE t_ao INCLUDING STORAGE);
+CREATE TABLE t_ao_c (LIKE t_ao); -- Should create a heap table
+
+CREATE TABLE t_ao_enc_a (LIKE t_ao_enc INCLUDING STORAGE);
+
+-- Verify gp_default_storage_options GUC doesn't get used
+SET gp_default_storage_options = "appendonly=true, orientation=row";
+CREATE TABLE t_ao_d (LIKE t_ao INCLUDING ALL);
+RESET gp_default_storage_options;
+
+-- Verify created tables and attributes
+SELECT
+	c.relname,
+	c.relstorage,
+	a.columnstore,
+	a.compresstype,
+	a.compresslevel
+FROM
+	pg_catalog.pg_class c
+		LEFT OUTER JOIN pg_catalog.pg_appendonly a ON (c.oid = a.relid)
+WHERE
+	c.relname LIKE 't_ao%';
+
+SELECT
+	c.relname,
+	a.attnum,
+	a.attoptions
+FROM
+	pg_catalog.pg_class c
+		JOIN pg_catalog.pg_attribute_encoding a ON (a.attrelid = c.oid)
+WHERE
+	c.relname like 't_ao_enc%';


### PR DESCRIPTION
INCLUDING STORAGE was introduced in PostgreSQL 9.0, but support for setting the AO/AOCS/ENCODING storage options on the created table was never supported as we merged upstream. This extends support for copying over the table storage type as well as attribute encodings when creating a table with INCLUDING STORAGE or ALL.

Backported from master commit 951065c48cc1e636ca9bf54bde440c93482a