### PR TITLE
Test to perform backup when master goes through XLOG switch

### DIFF
--- a/src/test/isolation2/expected/create_memory_accounting_tables.out
+++ b/src/test/isolation2/expected/create_memory_accounting_tables.out
@@ -175,10 +175,10 @@ INSERT INTO orders VALUES (39,818,'O',326565.37,'1996-09-20','3-MEDIUM','Clerk#0
 INSERT 1
 INSERT INTO orders VALUES (64,322,'F',35831.73,'1994-07-16','3-MEDIUM','Clerk#000000661',0,'wake fluffily. sometimes ironic pinto beans about the dolphin');
 INSERT 1
-INSERT INTO orders VALUES (65,163,'P',95469.44,'1995-03-18','1-URGENT','Clerk#000000632',0,'ular requests are blithely pending orbits-- even requests against the deposit'); INSERT INTO orders VALUES (66,1292,'F',104190.66,'1994-01-20','5-LOW','Clerk#000000743',0,'y pending requests integrate');
-ERROR:  syntax error at or near "F"
-LINE 1: ...nding orbits  INSERT INTO orders VALUES (66,1292,'F',104190....
-                                                             ^
+INSERT INTO orders VALUES (65,163,'P',95469.44,'1995-03-18','1-URGENT','Clerk#000000632',0,'ular requests are blithely pending orbits-- even requests against the deposit');
+INSERT 1
+INSERT INTO orders VALUES (66,1292,'F',104190.66,'1994-01-20','5-LOW','Clerk#000000743',0,'y pending requests integrate');
+INSERT 1
 INSERT INTO orders VALUES (67,568,'O',182481.16,'1996-12-19','4-NOT SPECIFIED','Clerk#000000547',0,'symptotes haggle slyly around the furiously iron');
 INSERT 1
 INSERT INTO orders VALUES (68,286,'O',301968.79,'1998-04-18','3-MEDIUM','Clerk#000000440',0,'pinto beans sleep carefully. blithely ironic deposits haggle furiously acro');
@@ -263,10 +263,10 @@ INSERT INTO customer VALUES (18,'Customer#000000018','3txGO AiuFux3zT0Z9NYaFRnZt
 INSERT 1
 INSERT INTO customer VALUES (19,'Customer#000000019','uc,3bHIx84H,wdrmLOjVsiqXCq2tr',18,'28-396-526-5053',8914.71,'HOUSEHOLD','nag. furiously careful packages are slyly at the accounts. furiously regular in');
 INSERT 1
-INSERT INTO customer VALUES (20,'Customer#000000020','JrPk8Pqplj4Ne',22,'32-957-234-8742',7603.40,'FURNITURE','g alongside of the special excuses-- fluffily enticing packages wake'); INSERT INTO customer VALUES (21,'Customer#000000021','XYmVpr9yAHDEn',8,'18-902-614-8344',1428.25,'MACHINERY','quickly final accounts integrate blithely furiously u');
-ERROR:  syntax error at or near "Customer"
-LINE 1: ...special excuses  INSERT INTO customer VALUES (21,'Customer#0...
-                                                             ^
+INSERT INTO customer VALUES (20,'Customer#000000020','JrPk8Pqplj4Ne',22,'32-957-234-8742',7603.40,'FURNITURE','g alongside of the special excuses-- fluffily enticing packages wake');
+INSERT 1
+INSERT INTO customer VALUES (21,'Customer#000000021','XYmVpr9yAHDEn',8,'18-902-614-8344',1428.25,'MACHINERY','quickly final accounts integrate blithely furiously u');
+INSERT 1
 INSERT INTO customer VALUES (22,'Customer#000000022','QI6p41,FNs5k7RZoCCVPUTkUdYpB',3,'13-806-545-9701',591.98,'MACHINERY','s nod furiously above the furiously ironic ideas.');
 INSERT 1
 INSERT INTO customer VALUES (23,'Customer#000000023','OdY W13N7Be3OC5MpgfmcYss0Wn6TKT',3,'13-312-472-8245',3332.02,'HOUSEHOLD','deposits. special deposits cajole slyly. fluffily special deposits about the furiously');
@@ -387,10 +387,10 @@ INSERT INTO partsupp VALUES (4,5,1339,113.97,'carefully unusual ideas. packages 
 INSERT 1
 INSERT INTO partsupp VALUES (4,30,6377,591.18,'ly final courts haggle carefully regular accounts. carefully regular accounts could integrate slyly. slyly express packages about the accounts wake slyly');
 INSERT 1
-INSERT INTO partsupp VALUES (4,55,2694,51.37,'g, regular deposits: quick instructions run across the carefully ironic theodolites-- final dependencies haggle into the dependencies. f'); INSERT INTO partsupp VALUES (4,80,2480,444.37,'requests sleep quickly regular accounts. theodolites detect. carefully final depths w');
-ERROR:  syntax error at or near "requests"
-LINE 1: ...s  INSERT INTO partsupp VALUES (4,80,2480,444.37,'requests s...
-                                                             ^
+INSERT INTO partsupp VALUES (4,55,2694,51.37,'g, regular deposits: quick instructions run across the carefully ironic theodolites-- final dependencies haggle into the dependencies. f');
+INSERT 1
+INSERT INTO partsupp VALUES (4,80,2480,444.37,'requests sleep quickly regular accounts. theodolites detect. carefully final depths w');
+INSERT 1
 INSERT INTO partsupp VALUES (5,6,3735,255.88,'arefully even requests. ironic requests cajole carefully even dolphin');
 INSERT 1
 INSERT INTO partsupp VALUES (5,31,9653,50.52,'y stealthy deposits. furiously final pinto beans wake furiou');
@@ -405,9 +405,9 @@ INSERT INTO partsupp VALUES (6,32,1627,424.25,'quick packages. ironic deposits p
 INSERT 1
 INSERT INTO partsupp VALUES (6,57,3336,642.13,'final instructions. courts wake packages. blithely unusual realms along the multipliers nag');
 INSERT 1
-INSERT INTO partsupp VALUES (6,82,6451,175.32,'accounts alongside of the slyly even accounts wake carefully final instructions-- ruthless platelets wake carefully ideas. even deposits are quickly final,'); INSERT INTO partsupp VALUES (7,8,7454,763.98,'y express tithes haggle furiously even foxes. furiously ironic deposits sleep toward the furiously unusual');
-ERROR:  syntax error at or near "y"
-LINE 1: ...ns  INSERT INTO partsupp VALUES (7,8,7454,763.98,'y express ...
-                                                             ^
+INSERT INTO partsupp VALUES (6,82,6451,175.32,'accounts alongside of the slyly even accounts wake carefully final instructions-- ruthless platelets wake carefully ideas. even deposits are quickly final,');
+INSERT 1
+INSERT INTO partsupp VALUES (7,8,7454,763.98,'y express tithes haggle furiously even foxes. furiously ironic deposits sleep toward the furiously unusual');
+INSERT 1
 INSERT INTO partsupp VALUES (7,33,2770,149.66,'hould have to nag after the blithely final asymptotes. fluffily spe');
 INSERT 1

--- a/src/test/isolation2/expected/oom_mixed_1.out
+++ b/src/test/isolation2/expected/oom_mixed_1.out
@@ -18,7 +18,7 @@ DETAIL:  Per-query VM protect limit reached: current limit is 2048 kB, requested
 select count(*) from orders;
  count 
 -------
- 38    
+ 40    
 (1 row)
 select pg_sleep(10);
  pg_sleep 

--- a/src/test/isolation2/expected/oom_mixed_1_optimizer.out
+++ b/src/test/isolation2/expected/oom_mixed_1_optimizer.out
@@ -18,7 +18,7 @@ DETAIL:  Per-query VM protect limit reached: current limit is 2048 kB, requested
 select count(*) from orders;
  count 
 -------
- 38    
+ 40    
 (1 row)
 select pg_sleep(10);
  pg_sleep 

--- a/src/test/isolation2/expected/oom_mixed_2.out
+++ b/src/test/isolation2/expected/oom_mixed_2.out
@@ -1,7 +1,7 @@
 select count(*) from orders;
  count 
 -------
- 38    
+ 40    
 (1 row)
 select pg_sleep(10);
  pg_sleep 

--- a/src/test/isolation2/expected/oom_mixed_2_optimizer.out
+++ b/src/test/isolation2/expected/oom_mixed_2_optimizer.out
@@ -1,7 +1,7 @@
 select count(*) from orders;
  count 
 -------
- 38    
+ 40    
 (1 row)
 select pg_sleep(10);
  pg_sleep 

--- a/src/test/isolation2/expected/oom_simple.out
+++ b/src/test/isolation2/expected/oom_simple.out
@@ -1,7 +1,7 @@
 select count(*) from partsupp;
  count 
 -------
- 22    
+ 26    
 (1 row)
 select pg_sleep(20);
  pg_sleep 

--- a/src/test/isolation2/expected/segwalrep/master_xlog_switch.out
+++ b/src/test/isolation2/expected/segwalrep/master_xlog_switch.out
@@ -1,0 +1,79 @@
+-- Test for verifying if xlog seg created while basebackup
+-- dumps out data does not get cleaned
+
+include: helpers/gp_management_utils_helpers.sql;
+CREATE
+
+-- Inject fault after checkpoint creation in basebackup
+SELECT gp_inject_fault('base_backup_post_create_checkpoint', 'suspend', dbid) FROM gp_segment_configuration WHERE content=-1 and role='p';
+ gp_inject_fault 
+-----------------
+ t               
+(1 row)
+
+-- Run pg_basebackup which should trigger and suspend at the fault
+1&: SELECT pg_basebackup(hostname, 100, port, NULL, '/tmp/master_xlog_switch_test', true, 'fetch') from gp_segment_configuration where content=-1 and role='p';  <waiting ...>
+
+-- Wait until fault has been triggered
+SELECT gp_wait_until_triggered_fault('base_backup_post_create_checkpoint', 1, dbid) FROM gp_segment_configuration WHERE content=-1 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t                             
+(1 row)
+
+-- See that pg_basebackup is still running
+SELECT application_name, state FROM pg_stat_replication;
+ application_name | state     
+------------------+-----------
+ gp_walreceiver   | streaming 
+ pg_basebackup    | backup    
+(2 rows)
+
+-- Switch to a new WAL segment file.  Two pg_switch_xlog() invocations
+-- with a command that generates WAL in between the invocations are
+-- suffice to generate new WAL file.
+CREATE TEMP TABLE xlogfile(fname text) DISTRIBUTED BY (fname);
+CREATE
+INSERT INTO xlogfile SELECT pg_xlogfile_name(pg_switch_xlog());
+INSERT 1
+CREATE TABLE master_xlog_dummy();
+CREATE
+-- This should return false, indicating current WAL segment is
+-- different than what was previously recorded xlogfile table.
+SELECT fname = pg_xlogfile_name(pg_switch_xlog()) FROM xlogfile;
+ ?column? 
+----------
+ f        
+(1 row)
+
+-- Checkpoint should retain WAL that is still needed by basebackup.
+CHECKPOINT;
+CHECKPOINT
+
+-- Resume basebackup
+SELECT gp_inject_fault('base_backup_post_create_checkpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=-1 and role='p';
+ gp_inject_fault 
+-----------------
+ t               
+(1 row)
+
+-- Wait until basebackup finishes
+1<:  <... completed>
+ pg_basebackup 
+---------------
+               
+(1 row)
+
+-- Verify if basebackup completed successfully
+-- See if recovery.conf exists (Yes - Pass)
+SELECT application_name, state FROM pg_stat_replication;
+ application_name | state     
+------------------+-----------
+ gp_walreceiver   | streaming 
+(1 row)
+!\retcode ls /tmp/master_xlog_switch_test/recovery.conf;
+-- start_ignore
+/tmp/master_xlog_switch_test/recovery.conf
+
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/helpers/gp_management_utils_helpers.sql
+++ b/src/test/isolation2/helpers/gp_management_utils_helpers.sql
@@ -7,13 +7,14 @@ create or replace language plpythonu;
 --   slotname: desired slot name to create and associate with backup
 --   datadir: destination data directory of the backup
 --   forceoverwrite: overwrite the destination directory if it exists already
---
+--   xlog_method: (stream/fetch) how to obtain XLOG segment files from source
 --
 -- usage: `select pg_basebackup('somehost', 12345, 'some_slot_name', '/some/destination/data/directory')`
 --
-create or replace function pg_basebackup(host text, dbid int, port int, slotname text, datadir text, force_overwrite boolean) returns text as $$
+create or replace function pg_basebackup(host text, dbid int, port int, slotname text, datadir text, force_overwrite boolean, xlog_method text) returns text as $$
     import subprocess
-    cmd = 'pg_basebackup -h %s -p %d --xlog-method stream -R -D %s --target-gp-dbid %d' % (host, port, datadir, dbid)
+    import os
+    cmd = 'pg_basebackup -h %s -p %d -R -D %s --target-gp-dbid %d' % (host, port, datadir, dbid)
 
     if slotname is not None:
         cmd += ' --slot %s' % (slotname)
@@ -21,7 +22,17 @@ create or replace function pg_basebackup(host text, dbid int, port int, slotname
     if force_overwrite:
         cmd += ' --force-overwrite'
 
+    if xlog_method == 'stream':
+        cmd += ' --xlog-method stream'
+    elif xlog_method == 'fetch':
+        cmd += ' --xlog-method fetch'
+    else:
+        plpy.error('invalid xlog method')
+
     try:
+        # Unset PGAPPNAME so that the pg_stat_replication.application_name is not affected
+        if os.getenv('PGAPPNAME') is not None:
+            os.environ.pop('PGAPPNAME')
         results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
     except subprocess.CalledProcessError as e:
         results = str(e) + "\ncommand output: " + e.output

--- a/src/test/isolation2/input/pg_basebackup.source
+++ b/src/test/isolation2/input/pg_basebackup.source
@@ -2,7 +2,7 @@ include: helpers/gp_management_utils_helpers.sql;
 
 
 -- When pg_basebackup runs with --slot and stream as xlog-method
-select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then a replication slot gets created on that segment with the slot
 -- name and the slot's restart_lsn is not NULL, indicating that the
@@ -11,7 +11,7 @@ select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablesp
 0U: select slot_name, slot_type, active, restart_lsn is not NULL as slot_was_used from pg_get_replication_slots() where slot_name = 'some_replication_slot';
 
 -- When another basebackup is run with the same slot name
-select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablespace@/some_other_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablespace@/some_other_isolation2_pg_basebackup', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then the backup should exist on the filesystem, ready for mirroring
 !\retcode cat @testtablespace@/some_other_isolation2_pg_basebackup/recovery.conf;
@@ -25,7 +25,7 @@ select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablesp
 !\retcode rm -rf @testtablespace@/some_other_isolation2_pg_basebackup;
 
 -- When pg_basebackup runs without --slot
-select pg_basebackup(address, dbid, port, null, '@testtablespace@/some_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, dbid, port, null, '@testtablespace@/some_isolation2_pg_basebackup', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then there should NOT be a replication slot
 0U: select count(1) from pg_get_replication_slots() where slot_name = 'some_replication_slot';

--- a/src/test/isolation2/input/pg_basebackup_with_tablespaces.source
+++ b/src/test/isolation2/input/pg_basebackup_with_tablespaces.source
@@ -23,7 +23,7 @@ create database some_database_without_tablespace;
 1q:
 
 -- When we create a full backup
-select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
 select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/');
@@ -35,7 +35,7 @@ select count_of_items_in_database_directory('@testtablespace@/some_basebackup_ta
 select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '@testtablespace@/some_basebackup_tablespace', 100, oid) from pg_tablespace where spcname='some_basebackup_tablespace';
 
 -- When we create a full backup again for the same target using force overwrite
-select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', true) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', true, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then we should have two directories in newly created target tablespace, some_database_with_tablespace and some_database_without_tablespace
 select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace/100/GPDB_*/');
@@ -76,7 +76,7 @@ create database some_database_without_tablespace;
 1q:
 
 -- When we create a full backup
-select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Then we should have one directory in the newly created target tablespace, some_database_without_tablespace
 select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace_c0/100/GPDB_*/');

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -63,7 +63,7 @@ test: uao/cursor_withhold2_row
 test: uao/delete_while_vacuum_row
 test: uao/insert_policy_row
 test: uao/insert_while_vacuum_row
-test: uao/max_concurrency_row
+test: uao/max_concurrency_row segwalrep/master_xlog_switch
 test: uao/max_concurrency2_row
 test: uao/modcount_row
 test: uao/modcount_vacuum_row

--- a/src/test/isolation2/output/pg_basebackup.source
+++ b/src/test/isolation2/output/pg_basebackup.source
@@ -3,7 +3,7 @@ CREATE
 
 
 -- When pg_basebackup runs with --slot and stream as xlog-method
-select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
  pg_basebackup 
 ---------------
                
@@ -20,7 +20,7 @@ select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablesp
 (1 row)
 
 -- When another basebackup is run with the same slot name
-select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablespace@/some_other_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, dbid, port, 'some_replication_slot', '@testtablespace@/some_other_isolation2_pg_basebackup', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
  pg_basebackup 
 ---------------
                
@@ -61,7 +61,7 @@ primary_slot_name = 'some_replication_slot'
 (exited with code 0)
 
 -- When pg_basebackup runs without --slot
-select pg_basebackup(address, dbid, port, null, '@testtablespace@/some_isolation2_pg_basebackup', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, dbid, port, null, '@testtablespace@/some_isolation2_pg_basebackup', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
  pg_basebackup 
 ---------------
                

--- a/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
+++ b/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
@@ -38,7 +38,7 @@ CREATE
 1q: ... <quitting>
 
 -- When we create a full backup
-select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
  pg_basebackup 
 ---------------
                
@@ -66,7 +66,7 @@ select validate_tablespace_symlink('@testtablespace@/some_basebackup_datadir', '
 (1 row)
 
 -- When we create a full backup again for the same target using force overwrite
-select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', true) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', true, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
  pg_basebackup 
 ---------------
                
@@ -157,7 +157,7 @@ CREATE
 1q: ... <quitting>
 
 -- When we create a full backup
-select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false) from gp_segment_configuration where content = 0 and role = 'p';
+select pg_basebackup(address, 100, port, 'some_replication_slot', '@testtablespace@/some_basebackup_datadir', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
  pg_basebackup 
 ---------------
                

--- a/src/test/isolation2/sql/segwalrep/master_xlog_switch.sql
+++ b/src/test/isolation2/sql/segwalrep/master_xlog_switch.sql
@@ -1,0 +1,45 @@
+-- Test for verifying if xlog seg created while basebackup
+-- dumps out data does not get cleaned
+
+include: helpers/gp_management_utils_helpers.sql;
+
+-- Inject fault after checkpoint creation in basebackup
+SELECT gp_inject_fault('base_backup_post_create_checkpoint', 'suspend', dbid)
+FROM gp_segment_configuration WHERE content=-1 and role='p';
+
+-- Run pg_basebackup which should trigger and suspend at the fault
+1&: SELECT pg_basebackup(hostname, 100, port, NULL,
+        '/tmp/master_xlog_switch_test', true, 'fetch')
+    from gp_segment_configuration where content=-1 and role='p';
+
+-- Wait until fault has been triggered
+SELECT gp_wait_until_triggered_fault('base_backup_post_create_checkpoint', 1, dbid)
+FROM gp_segment_configuration WHERE content=-1 and role='p';
+
+-- See that pg_basebackup is still running
+SELECT application_name, state FROM pg_stat_replication;
+
+-- Switch to a new WAL segment file.  Two pg_switch_xlog() invocations
+-- with a command that generates WAL in between the invocations are
+-- suffice to generate new WAL file.
+CREATE TEMP TABLE xlogfile(fname text) DISTRIBUTED BY (fname);
+INSERT INTO xlogfile SELECT pg_xlogfile_name(pg_switch_xlog());
+CREATE TABLE master_xlog_dummy();
+-- This should return false, indicating current WAL segment is
+-- different than what was previously recorded xlogfile table.
+SELECT fname = pg_xlogfile_name(pg_switch_xlog()) FROM xlogfile;
+
+-- Checkpoint should retain WAL that is still needed by basebackup.
+CHECKPOINT;
+
+-- Resume basebackup
+SELECT gp_inject_fault('base_backup_post_create_checkpoint', 'reset', dbid)
+FROM gp_segment_configuration WHERE content=-1 and role='p';
+
+-- Wait until basebackup finishes
+1<:
+
+-- Verify if basebackup completed successfully
+-- See if recovery.conf exists (Yes - Pass)
+SELECT application_name, state FROM pg_stat_replication;
+!\retcode ls /tmp/master_xlog_switch_test/recovery.conf;

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -464,8 +464,10 @@ class SQLIsolationExecutor(object):
                 print >>output_file, line.strip(),
                 if line[0] == "!":
                     command_part = line # shell commands can use -- for multichar options like --include
-                else:
+                elif re.match(r";.*--", line) or re.match(r"^--", line):
                     command_part = line.partition("--")[0] # remove comment from line
+                else:
+                    command_part = line
                 if command_part == "" or command_part == "\n":
                     print >>output_file 
                 elif command_part.endswith(";\n") or re.match(r"^\d+[q\\<]:$", line) or re.match(r"^-?\d+[SU][q\\<]:$", line):


### PR DESCRIPTION
This scenario used to be covered by an old, now deleted TINC test.  The test switches WAL on master to a new segment while basebackup is in progress.

The test was originally written by @jimmyyih here: https://github.com/jimmyyih/gpdb/commit/3e8a438a9c74c3ce04d73bf21f6b25af8053b6e0  I've edited it a bit.

The PR also contains a fix for comment identification in isolation2 spec parser.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
