### PR TITLE
fix bug: timeout triggered session event deleting lead to crash

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -1621,6 +1621,7 @@ static int session_attach(request_t* r)
 		session->active_segids[r->segid] = 1; /* mark this segid as active */
 		session->maxsegs = r->totalsegs;
 		session->requests = apr_hash_make(pool);
+		event_set(&session->ev, 0, 0, 0, 0);
 
 		if (session->tid == 0 || session->path == 0 || session->key == 0)
 			gfatal(r, "out of memory in session_attach");


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

The crash issue is found at windows platform when building CL utility gpfdist, the root cause is that the gpfdist at windows platform depend on the latest libevent(2.1.8) which has the following behavior:
```
The ev object need to be set(event_set) at least once before deleting(event_del) in latest libevent 2.1.8, or the event_del invoking will lead to crash
```