### PR TITLE
Optimize 'fastIUD' transactions

### DIFF
--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -152,6 +152,7 @@ DtxContextInfo_SerializeSize(DtxContextInfo *dtxContextInfo)
 	size += sizeof(uint32);		/* nestingLevel */
 	size += sizeof(bool);		/* haveDistributedSnapshot */
 	size += sizeof(bool);		/* cursorContext */
+	size += sizeof(bool);		/* isFastIUD */
 
 	if (dtxContextInfo->haveDistributedSnapshot)
 	{
@@ -200,6 +201,9 @@ DtxContextInfo_Serialize(char *buffer, DtxContextInfo *dtxContextInfo)
 
 	memcpy(p, &dtxContextInfo->nestingLevel, sizeof(uint32));
 	p += sizeof(uint32);
+
+	memcpy(p, &dtxContextInfo->isFastIUD, sizeof(bool));
+	p += sizeof(bool);
 
 	memcpy(p, &dtxContextInfo->haveDistributedSnapshot, sizeof(bool));
 	p += sizeof(bool);
@@ -261,6 +265,7 @@ DtxContextInfo_Reset(DtxContextInfo *dtxContextInfo)
 	dtxContextInfo->curcid = 0;
 	dtxContextInfo->segmateSync = 0;
 	dtxContextInfo->nestingLevel = 0;
+	dtxContextInfo->isFastIUD = false;
 
 	dtxContextInfo->haveDistributedSnapshot = false;
 
@@ -280,6 +285,7 @@ DtxContextInfo_Copy(
 	target->distributedXid = source->distributedXid;
 	target->segmateSync = source->segmateSync;
 	target->nestingLevel = source->nestingLevel;
+	target->isFastIUD = source->isFastIUD;
 
 	target->curcid = source->curcid;
 
@@ -350,6 +356,8 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 		p += sizeof(uint32);
 		memcpy(&dtxContextInfo->nestingLevel, p, sizeof(uint32));
 		p += sizeof(uint32);
+		memcpy(&dtxContextInfo->isFastIUD, p, sizeof(bool));
+		p += sizeof(bool);
 		memcpy(&dtxContextInfo->haveDistributedSnapshot, p, sizeof(bool));
 		p += sizeof(bool);
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -336,6 +336,11 @@ setupTwoPhaseTransaction(void)
 		elog(ERROR, "DTM transaction state (%s) is invalid", DtxStateToString(currentGxact->state));
 }
 
+bool
+isActiveGxact(void)
+{
+	return (currentGxact != NULL);
+}
 
 /*
  * Routine to dispatch internal sub-transaction calls from UDFs to segments.
@@ -922,6 +927,9 @@ rollbackDtxTransaction(void)
 	if (currentGxact == NULL)
 	{
 		elog(DTM_DEBUG5, "rollbackDtxTransaction nothing to do (currentGxact == NULL)");
+		Assert(MyTmGxact->gxid == InvalidDistributedTransactionId);
+		Assert(MyTmGxact->state == DTX_STATE_NONE);
+		initGxact(MyTmGxact, false);
 		return;
 	}
 
@@ -1389,6 +1397,7 @@ initGxact(TMGXACT *gxact, bool resetXid)
 	gxact->writerGangLost = false;
 	gxact->twophaseSegmentsMap = NULL;
 	gxact->twophaseSegments = NIL;
+	gxact->isFastIUD = false;
 }
 
 bool

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -28,6 +28,7 @@
 #include "cdb/cdbgang.h"
 
 #include "storage/procarray.h"	/* updateSharedLocalSnapshot */
+#include "storage/proc.h"
 #include "utils/snapmgr.h"
 
 /*
@@ -188,6 +189,7 @@ qdSerializeDtxContextInfo(int *size, bool wantSnapshot, bool inCursor,
 										  txnOptions, snapshot);
 
 			TempQDDtxContextInfo.cursorContext = inCursor;
+			TempQDDtxContextInfo.isFastIUD = MyTmGxact->isFastIUD;
 
 			if (DistributedTransactionContext ==
 				DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && snapshot != NULL)

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -27,6 +27,7 @@
 #include "cdb/cdbsrlz.h"
 #include "cdb/tupleremap.h"
 #include "nodes/execnodes.h"
+#include "storage/proc.h"
 #include "tcop/tcopprot.h"
 #include "utils/datum.h"
 #include "utils/guc.h"

--- a/src/include/cdb/cdbdtxcontextinfo.h
+++ b/src/include/cdb/cdbdtxcontextinfo.h
@@ -15,7 +15,7 @@
 #define CDBDTXCONTEXTINFO_H
 #include "utils/tqual.h"
 
-#define DtxContextInfo_StaticInit {0,InvalidDistributedTransactionId,0,false,false,DistributedSnapshot_StaticInit,0,0}
+#define DtxContextInfo_StaticInit {0,InvalidDistributedTransactionId,0,false,false,DistributedSnapshot_StaticInit,0,0,false}
 
 typedef struct DtxContextInfo
 {
@@ -34,6 +34,7 @@ typedef struct DtxContextInfo
 
 	uint32							segmateSync;
 	uint32							nestingLevel;
+	bool							isFastIUD;
 } DtxContextInfo;
 
 extern DtxContextInfo QEDtxContextInfo;	

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -231,6 +231,7 @@ typedef struct TMGXACT
 
 	Bitmapset					*twophaseSegmentsMap;
 	List						*twophaseSegments;
+	bool						isFastIUD;
 }	TMGXACT;
 
 typedef struct TMGXACTSTATUS
@@ -315,6 +316,7 @@ extern void redoDistributedCommitRecord(TMGXACT_LOG *gxact_log);
 extern void redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log);
 
 extern void setupTwoPhaseTransaction(void);
+extern bool isActiveGxact(void);
 extern bool isCurrentDtxTwoPhase(void);
 extern DtxState getCurrentDtxState(void);
 

--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -19,7 +19,7 @@ CREATE
 --------------------------
  t                        
 (1 row)
-2&:insert into crash_test_table values (1);  <waiting ...>
+2&:insert into crash_test_table select generate_series(1,10);  <waiting ...>
 3&:create table crash_test_ddl(c1 int);  <waiting ...>
 
 -- wait session 2 and session 3 hit inject point
@@ -32,7 +32,7 @@ CREATE
 CHECKPOINT
 
 -- transaction of session 4 inserted 'COMMIT' record after checkpoint
-4&:insert into crash_test_table values (2);  <waiting ...>
+4&:insert into crash_test_table select generate_series(1,10);  <waiting ...>
 
 -- wait session 4 hit inject point
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 3, 1);
@@ -47,7 +47,7 @@ CHECKPOINT
 --------------------------
  t                        
 (1 row)
-5&:INSERT INTO crash_test_table VALUES (3);  <waiting ...>
+5&:INSERT INTO crash_test_table select generate_series(1,10);  <waiting ...>
 
 -- wait session 5 hit inject point
 1:select gp_wait_until_triggered_fault('transaction_abort_after_distributed_prepared', 1, 1);
@@ -105,8 +105,26 @@ server closed the connection unexpectedly
  c1 
 ----
  1  
+ 1  
  2  
-(2 rows)
+ 2  
+ 3  
+ 3  
+ 4  
+ 4  
+ 5  
+ 5  
+ 6  
+ 6  
+ 7  
+ 7  
+ 8  
+ 8  
+ 9  
+ 9  
+ 10 
+ 10 
+(20 rows)
 6:select * from crash_test_ddl order by 1;
  c1 
 ----

--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -34,7 +34,7 @@ CREATE
  t                             
 (1 row)
 -- the 'COMMIT' record is logically after REDO pointer
-2&:insert into crash_test_redundant values (1);  <waiting ...>
+2&:insert into crash_test_redundant select generate_series(1,10);  <waiting ...>
 
 -- resume checkpoint
 3:select gp_inject_fault('checkpoint_dtx_info', 'reset', 1);
@@ -73,8 +73,17 @@ server closed the connection unexpectedly
 	before or while processing the request.
 
 -- transaction of session 2 should be recovered properly
-4:select * from crash_test_redundant;
+4:select * from crash_test_redundant order by c1;
  c1 
 ----
  1  
-(1 row)
+ 2  
+ 3  
+ 4  
+ 5  
+ 6  
+ 7  
+ 8  
+ 9  
+ 10 
+(10 rows)

--- a/src/test/isolation2/expected/distributed_snapshot.out
+++ b/src/test/isolation2/expected/distributed_snapshot.out
@@ -74,10 +74,10 @@ BEGIN
 2: INSERT INTO distributed_snapshot_test2 VALUES(1);
 INSERT 1
 -- here, take distributed snapshot
-1: SELECT 123 AS "establish snapshot";
- establish snapshot 
---------------------
- 123                
+1: SELECT * FROM distributed_snapshot_test2;
+ a 
+---
+ 1 
 (1 row)
 2: INSERT INTO distributed_snapshot_test2 VALUES(2);
 INSERT 1

--- a/src/test/isolation2/sql/crash_recovery.sql
+++ b/src/test/isolation2/sql/crash_recovery.sql
@@ -3,7 +3,7 @@
 1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 -- transaction of session 2 and session 3 inserted 'COMMIT' record before checkpoint
 1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
-2&:insert into crash_test_table values (1);
+2&:insert into crash_test_table select generate_series(1,10);
 3&:create table crash_test_ddl(c1 int);
 
 -- wait session 2 and session 3 hit inject point
@@ -11,14 +11,14 @@
 1:CHECKPOINT;
 
 -- transaction of session 4 inserted 'COMMIT' record after checkpoint
-4&:insert into crash_test_table values (2);
+4&:insert into crash_test_table select generate_series(1,10);
 
 -- wait session 4 hit inject point
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 3, 1);
 
 -- transaction of session 5 didn't insert 'COMMIT' record
 1:select gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'suspend', 1);
-5&:INSERT INTO crash_test_table VALUES (3);
+5&:INSERT INTO crash_test_table select generate_series(1,10);
 
 -- wait session 5 hit inject point
 1:select gp_wait_until_triggered_fault('transaction_abort_after_distributed_prepared', 1, 1);

--- a/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
+++ b/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
@@ -10,7 +10,7 @@
 -- wait till checkpoint reaches intended point
 2:select gp_wait_until_triggered_fault('checkpoint_dtx_info', 1, 1);
 -- the 'COMMIT' record is logically after REDO pointer
-2&:insert into crash_test_redundant values (1);
+2&:insert into crash_test_redundant select generate_series(1,10);
 
 -- resume checkpoint
 3:select gp_inject_fault('checkpoint_dtx_info', 'reset', 1);
@@ -29,4 +29,4 @@
 2<:
 
 -- transaction of session 2 should be recovered properly
-4:select * from crash_test_redundant;
+4:select * from crash_test_redundant order by c1;

--- a/src/test/isolation2/sql/distributed_snapshot.sql
+++ b/src/test/isolation2/sql/distributed_snapshot.sql
@@ -48,7 +48,7 @@ CREATE TABLE distributed_snapshot_test2 (a int);
 -- this sets latestCompletedXid
 2: INSERT INTO distributed_snapshot_test2 VALUES(1);
 -- here, take distributed snapshot
-1: SELECT 123 AS "establish snapshot";
+1: SELECT * FROM distributed_snapshot_test2;
 2: INSERT INTO distributed_snapshot_test2 VALUES(2);
 -- expected to see just VALUES(1)
 1: SELECT * FROM distributed_snapshot_test2;

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -17,8 +17,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_1 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_1;
 -- ctas tests
 create table dd_ctas_1 as select * from dd_singlecol_1 where a=1 distributed by (a);
@@ -181,8 +179,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_part_singlecol values (NULL, NULL);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- disjunction with partitioned tables
 select * from dd_part_singlecol where a in (10,11,12);
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 2 1
@@ -311,8 +307,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 create table dd_singlecol_idx2(a int, b int, c int) distributed by (a);
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -326,8 +320,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_idx;
 analyze dd_singlecol_idx2;
 -- disjunction with index scans
@@ -376,8 +368,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_bitmap_idx;
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b<2;
@@ -465,8 +455,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_part_bitmap_idx;
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
@@ -511,8 +499,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_multicol_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_multicol_idx;
 select count(*) from dd_multicol_idx;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -631,8 +617,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 create table dd_singlecol_part_idx2(a int, b int, c int) 
 distributed by (a)
 partition by range (b) 
@@ -661,8 +645,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_part_idx;
 analyze dd_singlecol_part_idx2;
 -- indexes on partitioned tables

--- a/src/test/regress/expected/bfv_dd_multicolumn.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn.out
@@ -20,16 +20,10 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_multicol_1 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into dd_multicol_1 values(1, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into dd_multicol_1 values(null, 1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_multicol_1;
 insert into dd_multicol_2 select g, g%2 from generate_series(1, 100) g;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -38,16 +32,10 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_multicol_2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into dd_multicol_2 values(1, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into dd_multicol_2 values(null, 1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- composite distr key
 select * from dd_multicol_1 where a in (1,3) and b in (1,2);
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2

--- a/src/test/regress/expected/bfv_dd_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_optimizer.out
@@ -16,8 +16,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_1 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_1;
 -- ctas tests
 create table dd_ctas_1 as select * from dd_singlecol_1 where a=1 distributed by (a);
@@ -178,8 +176,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_part_singlecol values (NULL, NULL);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- disjunction with partitioned tables
 select * from dd_part_singlecol where a in (10,11,12);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -305,8 +301,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 create table dd_singlecol_idx2(a int, b int, c int) distributed by (a);
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -319,8 +313,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_idx;
 analyze dd_singlecol_idx2;
 -- disjunction with index scans
@@ -368,8 +360,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_bitmap_idx;
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b<2;
@@ -456,8 +446,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_part_bitmap_idx;
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
@@ -619,8 +607,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 create table dd_singlecol_part_idx2(a int, b int, c int) 
 distributed by (a)
 partition by range (b) 
@@ -648,8 +634,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_part_idx;
 analyze dd_singlecol_part_idx2;
 -- indexes on partitioned tables

--- a/src/test/regress/expected/bfv_dd_types.out
+++ b/src/test/regress/expected/bfv_dd_types.out
@@ -58,68 +58,36 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 INSERT INTO direct_test_type_int2 VALUES (1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO direct_test_type_int4 VALUES (1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO direct_test_type_int8 VALUES (1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_real values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_smallint values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_boolean2 values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_double values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_date values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_numeric values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_bit values('1');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_bpchar values('abs');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_bytea values('greenplum');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_cidr values('68.44.55.111');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_inet values('68.44.55.111');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_macaddr values('12:34:56:78:90:ab');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_varbit values('0101010');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- @author antovl
 -- @created 2014-11-07 12:00:00 
 -- @modified 2014-11-07 12:00:00

--- a/src/test/regress/expected/bfv_dd_types_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_types_optimizer.out
@@ -58,68 +58,36 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 INSERT INTO direct_test_type_int2 VALUES (1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO direct_test_type_int4 VALUES (1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO direct_test_type_int8 VALUES (1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_real values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_smallint values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_boolean2 values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_double values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_date values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_numeric values (8,8,true,8,8,'2008-08-08',8.8);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_bit values('1');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_bpchar values('abs');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_bytea values('greenplum');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_cidr values('68.44.55.111');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_inet values('68.44.55.111');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_macaddr values('12:34:56:78:90:ab');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test_type_varbit values('0101010');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- @author antovl
 -- @created 2014-11-07 12:00:00 
 -- @modified 2014-11-07 12:00:00

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -70,8 +70,6 @@ set test_print_direct_dispatch_info=on;
 -- DO direct dispatch
 insert into direct_test values (100, 'cow');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test order by key, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -85,8 +83,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- Known_opt_diff: MPP-21346
 update direct_test set value = 'horse' where key = 100;
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test order by key, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -100,8 +96,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- Known_opt_diff: MPP-21346
 delete from direct_test where key = 100;
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test order by key, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -113,8 +107,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- DO direct dispatch
 insert into direct_test values (NULL, 'cow');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test order by key, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -127,14 +119,10 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- DO direct dispatch
 delete from direct_test where key is null;
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- Same single-row insert as above, but with DEFAULT instead of an explicit values.
 -- DO direct dispatch
 insert into direct_test values (default, 'cow');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test order by key, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -148,8 +136,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- Known_opt_diff: MPP-21346
 insert into direct_test_two_column values (100, 101, 'cow');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test_two_column order by key1, key2, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -163,8 +149,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- Known_opt_diff: MPP-21346
 update direct_test_two_column set value = 'horse' where key1 = 100 and key2 = 101;
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test_two_column order by key1, key2, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -177,8 +161,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- DO direct dispatch
 delete from direct_test_two_column where key1 = 100 and key2 = 101;
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test_two_column order by key1, key2, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -190,12 +172,8 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- DO direct dispatch
 insert into direct_test (key, value) values ('123',123123);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test (key, value) values (sqrt(100*10*10),123123);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 --
 -- should get 100 and 123 as the values
 --
@@ -275,8 +253,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 --
 insert into direct_test_partition values (1,'2008-01-02',1,'usa');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from direct_test_partition where trans_id =1;
 INFO:  (slice 1) Dispatch command to SINGLE content
  trans_id |    date    | amount | region 
@@ -301,12 +277,8 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 prepare test_insert (int) as insert into direct_test values ($1,100);
 execute test_insert(1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 execute test_insert(2);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from direct_test;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  key | value 
@@ -320,8 +292,6 @@ prepare test_update (int) as update direct_test set value = 'boo' where key = $1
 -- Known_opt_diff: MPP-21346
 execute test_update(2);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from direct_test;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  key | value 
@@ -471,8 +441,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into ddtesttab values (1, 1, 5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into ddtesttab values (1, 1, 5 + random()); -- volatile expression as distribution key
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
@@ -501,8 +469,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into ddtesttab values (1, 1, 5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into ddtesttab values (1, 1, 5 + random()); -- volatile expression as distribution key
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
@@ -524,8 +490,6 @@ ERROR:  can't set the distribution policy of "ddtesttab_1_prt_2"
 HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
 insert into ddtesttab values (1, 1, 5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into ddtesttab values (1, 1, 5 + random()); -- volatile expression as distribution key
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -70,8 +70,6 @@ set test_print_direct_dispatch_info=on;
 -- DO direct dispatch
 insert into direct_test values (100, 'cow');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test order by key, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -113,8 +111,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- DO direct dispatch
 insert into direct_test values (NULL, 'cow');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test order by key, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -133,8 +129,6 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 -- DO direct dispatch
 insert into direct_test values (default, 'cow');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 -- verify
 select * from direct_test order by key, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -190,12 +184,8 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- DO direct dispatch
 insert into direct_test (key, value) values ('123',123123);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into direct_test (key, value) values (sqrt(100*10*10),123123);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 --
 -- should get 100 and 123 as the values
 --
@@ -275,8 +265,6 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 --
 insert into direct_test_partition values (1,'2008-01-02',1,'usa');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from direct_test_partition where trans_id =1;
 INFO:  (slice 1) Dispatch command to SINGLE content
  trans_id |    date    | amount | region 
@@ -301,12 +289,8 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 prepare test_insert (int) as insert into direct_test values ($1,100);
 execute test_insert(1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 execute test_insert(2);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from direct_test;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  key | value 
@@ -479,8 +463,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into ddtesttab values (1, 1, 5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into ddtesttab values (1, 1, 5 + random()); -- volatile expression as distribution key
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
@@ -509,8 +491,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into ddtesttab values (1, 1, 5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into ddtesttab values (1, 1, 5 + random()); -- volatile expression as distribution key
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
@@ -532,8 +512,6 @@ ERROR:  can't set the distribution policy of "ddtesttab_1_prt_2"
 HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
 insert into ddtesttab values (1, 1, 5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into ddtesttab values (1, 1, 5 + random()); -- volatile expression as distribution key
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -364,7 +364,7 @@ DROP TABLE
 \! ./twophase_pqexecparams dbname=regression
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
 NOTICE:  Releasing segworker group to retry broadcast.
-result: INSERT 0 1
+result: INSERT 0 3
 --
 -- Subtransactions with partition table DDLs.
 --

--- a/src/test/regress/expected/qp_targeted_dispatch.out
+++ b/src/test/regress/expected/qp_targeted_dispatch.out
@@ -173,8 +173,6 @@ insert into boolean values ('f', 1);
 set test_print_direct_dispatch_info=on;
 insert into boolean values ('t', 2);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table boolean set distributed by (b);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -182,8 +180,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into boolean values ('t', 1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table boolean set distributed randomly;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -216,8 +212,6 @@ insert into date values ('2001-11-11',234.23234);
 set test_print_direct_dispatch_info=on;
 insert into date values ('2001-11-12',234.2323);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table date set distributed by (dp1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -225,12 +219,8 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into date values ('2001-11-13',234.23234);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into date values ('2001-11-14',234.2323);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table date set distributed by (date1, dp1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -255,8 +245,6 @@ insert into interval values ('23',2345);
 set test_print_direct_dispatch_info=on;
 insert into interval values ('2',234);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table interval set distributed by (num);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -264,12 +252,8 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into interval values ('24',234);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into interval values ('26',2343);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table interval set distributed by (num,interval1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -292,8 +276,6 @@ insert into real values (23, 4);
 set test_print_direct_dispatch_info=on;
 insert into real values (23, 4);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 Alter table real set distributed by (si1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -301,12 +283,8 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into real values (21, 3);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into real values (21, 2);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from real where real.si1=3;
 INFO:  (slice 1) Dispatch command to SINGLE content
  real1 | si1 
@@ -336,8 +314,6 @@ insert into bytea values ('d','0.0.0.0');
 set test_print_direct_dispatch_info=on;
 insert into bytea values ('d','0.0.0.1');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table bytea set distributed by (cidr1,bytea1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -345,8 +321,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into bytea values ('e','0.0.1.0');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from bytea where bytea1='d' and cidr1='0.0.0.1';
 INFO:  (slice 1) Dispatch command to SINGLE content
  bytea1 |   cidr1    
@@ -364,8 +338,6 @@ insert into inetmac values ('0.0.0.0','AA:AA:AA:AA:AA:AA');
 set test_print_direct_dispatch_info=on;
 insert into inetmac values ('0.0.0.0','AC:AA:AA:AA:AA:AA');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table inetmac set distributed by (macaddr1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -373,8 +345,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into inetmac values ('0.0.0.2','AA:AA:AA:AA:AA:AC');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table inetmac set distributed by (macaddr1,inet1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -382,8 +352,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into inetmac values ('0.0.0.2','AA:AA:AA:AA:AA:AC');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from inetmac where inet1='0.0.0.0' and macaddr1 ='AA:AA:AA:AA:AA:AA';
 INFO:  (slice 1) Dispatch command to SINGLE content
   inet1  |     macaddr1      
@@ -402,8 +370,6 @@ insert into time2 values ('00:00:00+1359', 'abcg');
 set test_print_direct_dispatch_info=on;
 insert into time2 values ('00:00:00+1359', 'abcf');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table time2 set distributed by (text1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -411,8 +377,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into time2 values ('00:00:00+1352', 'abce');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table time2 set distributed by (text1,time2);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -420,8 +384,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into time2 values ('00:00:00+1352', 'abcd');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from time2 where time2='00:00:00+1359' and text1='abcg';
 INFO:  (slice 1) Dispatch command to SINGLE content
      time2      | text1 
@@ -440,8 +402,6 @@ insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
 set test_print_direct_dispatch_info=on;
 insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table timestamp set distributed by (time2);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -449,8 +409,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into timestamp values ('2004-12-13 01:51:25','2004-12-12 01:51:15+1359');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table timestamp set distributed by (time2, timestamp1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -458,8 +416,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into timestamp values ('2004-12-13 01:51:25','2004-12-12 01:51:15+1359');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from timestamp where timestamp1='2004-12-13 01:51:25' and time2 ='2004-12-12 01:51:15+1359';
 INFO:  (slice 1) Dispatch command to SINGLE content
         timestamp1        |            time2             
@@ -477,8 +433,6 @@ insert into bit1 values ('0', 23);
 set test_print_direct_dispatch_info=on;
 insert into bit1 values ('1', 23);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table bit1 set distributed by (b);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -486,8 +440,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into bit1 values ('0', 24);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table bit1 set distributed by (b,a);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -495,8 +447,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into bit1 values ('0', 24);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from bit1 where a='0' and b =24;
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | b  
@@ -619,8 +569,6 @@ NOTICE:  building index for child partition "range_table_1_prt_2"
 set test_print_direct_dispatch_info=on;
 INSERT INTO range_table(id) VALUES (1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 DROP INDEX id3;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -631,24 +579,14 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 INSERT INTO range_table(id) VALUES (2);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO range_table(id) VALUES (3);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO range_table(id) VALUES (4);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO range_table(id) VALUES (5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO range_table(id) VALUES (5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from range_table where id =1;
 INFO:  (slice 1) Dispatch command to SINGLE content
  id 
@@ -709,8 +647,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into mpp7620 values (200, 200);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into zoompp7620 select * from mpp7620 where key=200;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -173,8 +173,6 @@ insert into boolean values ('f', 1);
 set test_print_direct_dispatch_info=on;
 insert into boolean values ('t', 2);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table boolean set distributed by (b);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -182,8 +180,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into boolean values ('t', 1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table boolean set distributed randomly;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -216,8 +212,6 @@ insert into date values ('2001-11-11',234.23234);
 set test_print_direct_dispatch_info=on;
 insert into date values ('2001-11-12',234.2323);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table date set distributed by (dp1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -225,12 +219,8 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into date values ('2001-11-13',234.23234);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into date values ('2001-11-14',234.2323);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table date set distributed by (date1, dp1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -255,8 +245,6 @@ insert into interval values ('23',2345);
 set test_print_direct_dispatch_info=on;
 insert into interval values ('2',234);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table interval set distributed by (num);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -264,12 +252,8 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into interval values ('24',234);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into interval values ('26',2343);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table interval set distributed by (num,interval1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -292,8 +276,6 @@ insert into real values (23, 4);
 set test_print_direct_dispatch_info=on;
 insert into real values (23, 4);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 Alter table real set distributed by (si1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -301,12 +283,8 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into real values (21, 3);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into real values (21, 2);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from real where real.si1=3;
 INFO:  (slice 1) Dispatch command to SINGLE content
  real1 | si1 
@@ -336,8 +314,6 @@ insert into bytea values ('d','0.0.0.0');
 set test_print_direct_dispatch_info=on;
 insert into bytea values ('d','0.0.0.1');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table bytea set distributed by (cidr1,bytea1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -364,8 +340,6 @@ insert into inetmac values ('0.0.0.0','AA:AA:AA:AA:AA:AA');
 set test_print_direct_dispatch_info=on;
 insert into inetmac values ('0.0.0.0','AC:AA:AA:AA:AA:AA');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table inetmac set distributed by (macaddr1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -373,8 +347,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into inetmac values ('0.0.0.2','AA:AA:AA:AA:AA:AC');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table inetmac set distributed by (macaddr1,inet1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -402,8 +374,6 @@ insert into time2 values ('00:00:00+1359', 'abcg');
 set test_print_direct_dispatch_info=on;
 insert into time2 values ('00:00:00+1359', 'abcf');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table time2 set distributed by (text1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -411,8 +381,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into time2 values ('00:00:00+1352', 'abce');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table time2 set distributed by (text1,time2);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -440,8 +408,6 @@ insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
 set test_print_direct_dispatch_info=on;
 insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table timestamp set distributed by (time2);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -449,8 +415,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into timestamp values ('2004-12-13 01:51:25','2004-12-12 01:51:15+1359');
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table timestamp set distributed by (time2, timestamp1);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -477,8 +441,6 @@ insert into bit1 values ('0', 23);
 set test_print_direct_dispatch_info=on;
 insert into bit1 values ('1', 23);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table bit1 set distributed by (b);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -486,8 +448,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into bit1 values ('0', 24);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 alter table bit1 set distributed by (b,a);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -605,8 +565,6 @@ NOTICE:  building index for child partition "range_table_1_prt_2"
 set test_print_direct_dispatch_info=on;
 INSERT INTO range_table(id) VALUES (1);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 DROP INDEX id3;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
@@ -617,24 +575,14 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 INSERT INTO range_table(id) VALUES (2);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO range_table(id) VALUES (3);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO range_table(id) VALUES (4);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO range_table(id) VALUES (5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 INSERT INTO range_table(id) VALUES (5);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from range_table where id =1;
 INFO:  (slice 1) Dispatch command to SINGLE content
  id 
@@ -695,8 +643,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into mpp7620 values (200, 200);
 INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 insert into zoompp7620 select * from mpp7620 where key=200;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2

--- a/src/test/regress/twophase_pqexecparams.c
+++ b/src/test/regress/twophase_pqexecparams.c
@@ -31,7 +31,7 @@ main(int argc, char **argv)
 	const char *conninfo;
 	PGconn	   *conn;
 	PGresult   *res;
-	const char *paramValues[1];
+	const char *paramValues[3];
 
 	/*
 	 * If the user supplies a parameter on the command line, use it as the
@@ -69,7 +69,9 @@ main(int argc, char **argv)
 	PQexec(conn, "SET debug_dtm_action_segment = 0");
 	PQexec(conn, "SET debug_dtm_action = \"fail_begin_command\"");
 
-	paramValues[0] = "joe's place";
+	paramValues[0] = "0";
+	paramValues[1] = "1";
+	paramValues[2] = "2";
 
 	/* Upone receving the INSERT below, the segment will error out due to the
 	 * fault-injector GUCs set earlier.  However, the master will retry and we
@@ -77,8 +79,8 @@ main(int argc, char **argv)
 	 */
 
 	res = PQexecParams(conn,
-					   "INSERT INTO test1(t) VALUES($1)",
-					   1,		/* one param */
+					   "INSERT INTO test1(i) VALUES($1), ($2), ($3)",
+					   3,		/* one param */
 					   NULL,	/* let the backend deduce param type */
 					   paramValues,
 					   NULL,	/* don't need param lengths since text */


### PR DESCRIPTION
A 'fastIUD' transaction refers to an implicit transaction that does
INSERT/UPDATE/DELETE and only affects rows in one segment. We can simplify the
two-phase commit by treating it as a local transaction on the segment, which
is, QD does the planning and dispatch the plan to QE, QE execute the plan in a
local transaction context. The modification to the tuples is visible once the
transaction is committed locally. As the QD doesn't start a distributed
transaction, it's not appeared in the distributed snapshot of any other
transactions. Other transactions will check the visibility of the affected
tuples use local snapshot on the QE.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
