### PR TITLE
Support 'copy (select statement) to file on segment'

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -183,7 +183,7 @@ cdbparallelize(PlannerInfo *root,
 	switch (query->commandType)
 	{
 		case CMD_SELECT:
-			if (query->intoClause)
+			if (query->intoClause || query->isCopy)
 			{
 				/* SELECT INTO always created partitioned tables. */
 				context->resultSegments = true;	

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -65,13 +65,6 @@ extern int popen_with_stderr(int *rwepipe, const char *exe, bool forwrite);
 extern int pclose_with_stderr(int pid, int *rwepipe, StringInfo sinfo);
 extern char *make_command(const char *cmd, extvar_t *ev);
 
-/* DestReceiver for COPY (SELECT) TO */
-typedef struct
-{
-	DestReceiver pub;			/* publicly-known function pointers */
-	CopyState	cstate;			/* CopyStateData for the command */
-} DR_copy;
-
 static const char BinarySignature[11] = "PGCOPY\n\377\r\n\0";
 
 
@@ -82,6 +75,8 @@ static void CopyTo(CopyState cstate);
 extern void CopyFromDispatch(CopyState cstate);
 static void CopyFrom(CopyState cstate);
 static void CopyFromProcessDataFileHeader(CopyState cstate, CdbCopy *cdbCopy, bool *pfile_has_oids);
+static uint64 CopyToQueryOnSegment(CopyState cstate);
+static void MangleCopyFileName(CopyState cstate);
 static char *CopyReadOidAttr(CopyState cstate, bool *isnull);
 static void CopyAttributeOutText(CopyState cstate, char *string);
 static void CopyAttributeOutCSV(CopyState cstate, char *string,
@@ -93,6 +88,7 @@ static Datum CopyReadBinaryAttribute(CopyState cstate,
 									 int column_no, FmgrInfo *flinfo,
 									 Oid typioparam, int32 typmod,
 									 bool *isnull, bool skip_parsing);
+static void ProcessCopyOptions(CopyState cstate, List *options);
 
 /* Low-level communications functions */
 static void SendCopyBegin(CopyState cstate);
@@ -151,6 +147,7 @@ static unsigned int
 GetTargetSeg(GpDistributionData *distData, Datum *baseValues, bool *baseNulls);
 static ProgramPipes *open_program_pipes(char *command, bool forwrite);
 static void close_program_pipes(CopyState cstate, bool ifThrow);
+CopyIntoClause* MakeCopyIntoClause(const CopyStmt *stmt);
 
 /* ==========================================================================
  * The following macros aid in major refactoring of data processing code (in
@@ -1066,60 +1063,30 @@ void ValidateControlChars(bool copy, bool load, bool csv_mode, char *delim,
 
 
 /*
- *	 DoCopy executes the SQL COPY statement
+ * Process the statement option list for COPY.
  *
- * Either unload or reload contents of table <relation>, depending on <from>.
- * (<from> = TRUE means we are inserting into the table.) In the "TO" case
- * we also support copying the output of an arbitrary SELECT query.
+ * Scan the options list (a list of DefElem) and transpose the information
+ * into cstate, applying appropriate error checking.
  *
- * If <pipe> is false, transfer is between the table and the file named
- * <filename>.	Otherwise, transfer is between the table and our regular
- * input/output stream. The latter could be either stdin/stdout or a
- * socket, depending on whether we're running under Postmaster control.
+ * cstate is assumed to be filled with zeroes initially.
  *
- * Iff <binary>, unload or reload in the binary format, as opposed to the
- * more wasteful but more robust and portable text format.
+ * This is exported so that external users of the COPY API can sanity-check
+ * a list of options.  In that usage, cstate should be passed as NULL
+ * (since external users don't know sizeof(CopyStateData)) and the collected
+ * data is just leaked until CurrentMemoryContext is reset.
  *
- * Iff <oids>, unload or reload the format that includes OID information.
- * On input, we accept OIDs whether or not the table has an OID column,
- * but silently drop them if it does not.  On output, we report an error
- * if the user asks for OIDs in a table that has none (not providing an
- * OID column might seem friendlier, but could seriously confuse programs).
- *
- * If in the text format, delimit columns with delimiter <delim> and print
- * NULL values as <null_print>.
- *
- * When loading in the text format from an input stream (as opposed to
- * a file), recognize a "\." on a line by itself as EOF. Also recognize
- * a stream EOF.  When unloading in the text format to an output stream,
- * write a "." on a line by itself at the end of the data.
- *
- * Do not allow a Postgres user without superuser privilege to read from
- * or write to a file.
- *
- * Do not allow the copy if user doesn't have proper permission to access
- * the table.
+ * Note that additional checking, such as whether column names listed in FORCE
+ * QUOTE actually exist, has to be applied later.  This just checks for
+ * self-consistency of the options list.
  */
-uint64
-DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
+static void
+ProcessCopyOptions(CopyState cstate,
+				   List *options) /* false means external table */
 {
-	bool		is_from = stmt->is_from;
-	bool		pipe = (stmt->filename == NULL || Gp_role == GP_ROLE_EXECUTE);
-	List	   *attnamelist = stmt->attlist;
-	List	   *force_quote = NIL;
-	List	   *force_notnull = NIL;
-	AclMode		required_access = (is_from ? ACL_INSERT : ACL_SELECT);
-	AclResult	aclresult;
 	ListCell   *option;
-	TupleDesc	tupDesc;
-	int			num_phys_attrs;
-	uint64		processed;
-	bool		qe_copy_from = (is_from && (Gp_role == GP_ROLE_EXECUTE));
-	/* save relationOid for auto-stats */
-	Oid			relationOid = InvalidOid;
 
 	/* Extract options from the statement node tree */
-	foreach(option, stmt->options)
+	foreach(option, options)
 	{
 		DefElem    *defel = (DefElem *) lfirst(option);
 
@@ -1198,19 +1165,19 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		}
 		else if (strcmp(defel->defname, "force_quote") == 0)
 		{
-			if (force_quote)
+			if (cstate->force_quote)
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("conflicting or redundant options")));
-			force_quote = (List *) defel->arg;
+			cstate->force_quote = (List *) defel->arg;
 		}
 		else if (strcmp(defel->defname, "force_notnull") == 0)
 		{
-			if (force_notnull)
+			if (cstate->force_notnull)
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("conflicting or redundant options")));
-			force_notnull = (List *) defel->arg;
+			cstate->force_notnull = (List *) defel->arg;
 		}
 		else if (strcmp(defel->defname, "fill_missing_fields") == 0)
 		{
@@ -1248,16 +1215,6 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("cannot specify DELIMITER in BINARY mode")));
-
-	if (stmt->is_program && stmt->filename == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("STDIN/STDOUT not allowed with PROGRAM")));
-
-	if (cstate->on_segment && stmt->filename == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("STDIN and STDOUT are not supported by 'COPY ON SEGMENT'")));
 
 	/*
 	 * In PostgreSQL, HEADER is not allowed in text mode either, but in GPDB,
@@ -1298,6 +1255,70 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 
 	if (!cstate->csv_mode && !cstate->escape)
 		cstate->escape = "\\";			/* default escape for text mode */
+}
+
+
+/*
+ *	 DoCopy executes the SQL COPY statement
+ *
+ * Either unload or reload contents of table <relation>, depending on <from>.
+ * (<from> = TRUE means we are inserting into the table.) In the "TO" case
+ * we also support copying the output of an arbitrary SELECT query.
+ *
+ * If <pipe> is false, transfer is between the table and the file named
+ * <filename>.	Otherwise, transfer is between the table and our regular
+ * input/output stream. The latter could be either stdin/stdout or a
+ * socket, depending on whether we're running under Postmaster control.
+ *
+ * Iff <binary>, unload or reload in the binary format, as opposed to the
+ * more wasteful but more robust and portable text format.
+ *
+ * Iff <oids>, unload or reload the format that includes OID information.
+ * On input, we accept OIDs whether or not the table has an OID column,
+ * but silently drop them if it does not.  On output, we report an error
+ * if the user asks for OIDs in a table that has none (not providing an
+ * OID column might seem friendlier, but could seriously confuse programs).
+ *
+ * If in the text format, delimit columns with delimiter <delim> and print
+ * NULL values as <null_print>.
+ *
+ * When loading in the text format from an input stream (as opposed to
+ * a file), recognize a "\." on a line by itself as EOF. Also recognize
+ * a stream EOF.  When unloading in the text format to an output stream,
+ * write a "." on a line by itself at the end of the data.
+ *
+ * Do not allow a Postgres user without superuser privilege to read from
+ * or write to a file.
+ *
+ * Do not allow the copy if user doesn't have proper permission to access
+ * the table.
+ */
+uint64
+DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
+{
+	bool		is_from = stmt->is_from;
+	bool		pipe = (stmt->filename == NULL || Gp_role == GP_ROLE_EXECUTE);
+	List	   *attnamelist = stmt->attlist;
+	AclMode		required_access = (is_from ? ACL_INSERT : ACL_SELECT);
+	AclResult	aclresult;
+	TupleDesc	tupDesc;
+	int			num_phys_attrs;
+	uint64		processed;
+	bool		qe_copy_from = (is_from && (Gp_role == GP_ROLE_EXECUTE));
+	/* save relationOid for auto-stats */
+	Oid			relationOid = InvalidOid;
+
+	ProcessCopyOptions(cstate, stmt->options);
+
+	if (stmt->is_program && stmt->filename == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+						errmsg("STDIN/STDOUT not allowed with PROGRAM")));
+
+	if (cstate->on_segment && stmt->filename == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+						errmsg("STDIN and STDOUT are not supported by 'COPY ON SEGMENT'")));
 
 	/*
 	 * Error handling setup
@@ -1356,8 +1377,8 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 						 cstate->null_print,
 						 cstate->quote,
 						 cstate->escape,
-						 force_quote,
-						 force_notnull,
+						 cstate->force_quote,
+						 cstate->force_notnull,
 						 cstate->header_line,
 						 cstate->fill_missing,
 						 cstate->eol_str,
@@ -1390,31 +1411,10 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 	cstate->copy_dest = COPY_FILE;		/* default */
 	if (Gp_role == GP_ROLE_EXECUTE)
 	{
-		if (cstate->on_segment) /* Save data to a local file */
+		if (cstate->on_segment)
 		{
-			StringInfoData filepath;
-			initStringInfo(&filepath);
-			appendStringInfoString(&filepath, stmt->filename);
-
-			replaceStringInfoString(&filepath, "<SEG_DATA_DIR>", DataDir);
-
-			if (strstr(stmt->filename, "<SEGID>") == NULL)
-				ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("<SEGID> is required for file name")));
-
-			char segid_buf[8];
-			snprintf(segid_buf, 8, "%d", GpIdentity.segindex);
-			replaceStringInfoString(&filepath, "<SEGID>", segid_buf);
-
-			cstate->filename = filepath.data;
-			/* Rename filename if error log needed */
-			if (NULL != cstate->cdbsreh)
-			{
-				snprintf(cstate->cdbsreh->filename,
-						 sizeof(cstate->cdbsreh->filename), "%s",
-						 filepath.data);
-			}
+			cstate->filename = stmt->filename;
+			MangleCopyFileName(cstate);
 
 			pipe = false;
 		}
@@ -1580,6 +1580,11 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		Assert(query->commandType == CMD_SELECT);
 		Assert(query->utilityStmt == NULL);
 
+		if (cstate->on_segment && IsA(query, Query))
+		{
+			query->isCopy = true;
+		}
+
 		/* Query mustn't use INTO, either */
 		if (query->intoClause)
 			ereport(ERROR,
@@ -1607,6 +1612,9 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 											ActiveSnapshot, InvalidSnapshot,
 											dest, NULL,
 											GP_INSTRUMENT_OPTS);
+		if (cstate->on_segment)
+			cstate->queryDesc->plannedstmt->copyIntoClause =
+					MakeCopyIntoClause(stmt);
 
 		if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
 		{
@@ -1641,12 +1649,12 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 
 	/* Convert FORCE QUOTE name list to per-column flags, check validity */
 	cstate->force_quote_flags = (bool *) palloc0(num_phys_attrs * sizeof(bool));
-	if (force_quote)
+	if (cstate->force_quote)
 	{
 		List	   *attnums;
 		ListCell   *cur;
 
-		attnums = CopyGetAttnums(tupDesc, cstate->rel, force_quote);
+		attnums = CopyGetAttnums(tupDesc, cstate->rel, cstate->force_quote);
 
 		foreach(cur, attnums)
 		{
@@ -1663,12 +1671,12 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 
 	/* Convert FORCE NOT NULL name list to per-column flags, check validity */
 	cstate->force_notnull_flags = (bool *) palloc0(num_phys_attrs * sizeof(bool));
-	if (force_notnull)
+	if (cstate->force_notnull)
 	{
 		List	   *attnums;
 		ListCell   *cur;
 
-		attnums = CopyGetAttnums(tupDesc, cstate->rel, force_notnull);
+		attnums = CopyGetAttnums(tupDesc, cstate->rel, cstate->force_notnull);
 
 		foreach(cur, attnums)
 		{
@@ -1681,9 +1689,6 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 					   NameStr(tupDesc->attrs[attnum - 1]->attname))));
 			cstate->force_notnull_flags[attnum - 1] = true;
 		}
-
-		/* keep the raw version too, we will need it later */
-		cstate->force_notnull = force_notnull;
 	}
 
 	/* Set up variables to avoid per-attribute overhead. */
@@ -1912,7 +1917,10 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 		}
 	}
 	else
-		DoCopyTo(cstate);		/* copy from database to file */
+		if(Gp_role == GP_ROLE_DISPATCH && cstate->on_segment && !cstate->rel)
+			CopyToQueryOnSegment(cstate);
+		else
+			DoCopyTo(cstate);		/* copy from database to file */
 
 	/*
 	 * Close the relation or query.  If reading, we can release the
@@ -1926,6 +1934,8 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 	{
 		/* Close down the query and free resources. */
 		ExecutorEnd(cstate->queryDesc);
+		if (Gp_role == GP_ROLE_DISPATCH && cstate->on_segment && !cstate->rel)
+			cstate->processed = cstate->queryDesc->es_processed;
 		FreeQueryDesc(cstate->queryDesc);
 		cstate->queryDesc = NULL;
 	}
@@ -1934,7 +1944,6 @@ DoCopyInternal(const CopyStmt *stmt, const char *queryString, CopyState cstate)
 	if(cstate->cdbsreh)
 		destroyCdbSreh(cstate->cdbsreh);
 
-	/* Clean up storage (probably not really necessary) */
 	processed = cstate->processed;
 
     /* MPP-4407. Logging number of tuples copied */
@@ -6969,6 +6978,331 @@ CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist)
 	return attnums;
 }
 
+/*
+ * Modify the filename in cstate->filename, and cstate->cdbsreh if any,
+ * for COPY ON SEGMENT.
+ *
+ * Replaces the "<SEGID>" token in the filename with this segment's ID.
+ */
+static void
+MangleCopyFileName(CopyState cstate)
+{
+	char	   *filename = cstate->filename;
+	StringInfoData filepath;
+
+	initStringInfo(&filepath);
+	appendStringInfoString(&filepath, filename);
+
+	replaceStringInfoString(&filepath, "<SEG_DATA_DIR>", DataDir);
+
+	if (strstr(filename, "<SEGID>") == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("<SEGID> is required for file name")));
+
+	char segid_buf[8];
+	snprintf(segid_buf, 8, "%d", GpIdentity.segindex);
+	replaceStringInfoString(&filepath, "<SEGID>", segid_buf);
+
+	cstate->filename = filepath.data;
+	/* Rename filename if error log needed */
+	if (NULL != cstate->cdbsreh)
+	{
+		snprintf(cstate->cdbsreh->filename,
+				 sizeof(cstate->cdbsreh->filename), "%s",
+				 filepath.data);
+	}
+}
+
+
+static CopyState
+BeginCopyOnSegment(bool is_from,
+				   Relation rel,
+				   Node *raw_query,
+				   const char *queryString,
+				   const Oid queryRelId,
+				   List *attnamelist,
+				   List *options,
+				   TupleDesc tupDesc)
+{
+	CopyState	cstate;
+	int			num_phys_attrs;
+
+	/* Allocate workspace and zero all fields */
+	cstate = (CopyStateData *) palloc0(sizeof(CopyStateData));
+
+	cstate->attnamelist = attnamelist;
+	/* Generate or convert list of attributes to process */
+	cstate->attnumlist = CopyGetAttnums(tupDesc, cstate->rel, attnamelist);
+
+	ProcessCopyOptions(cstate, options);
+
+	num_phys_attrs = tupDesc->natts;
+
+	/* Convert FORCE QUOTE name list to per-column flags, check validity */
+	cstate->force_quote_flags = (bool *) palloc0(num_phys_attrs * sizeof(bool));
+	if (cstate->force_quote)
+	{
+		List	   *attnums;
+		ListCell   *cur;
+
+		attnums = CopyGetAttnums(tupDesc, cstate->rel, cstate->force_quote);
+
+		foreach(cur, attnums)
+		{
+			int			attnum = lfirst_int(cur);
+
+			if (!list_member_int(cstate->attnumlist, attnum))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+								errmsg("FORCE QUOTE column \"%s\" not referenced by COPY",
+									   NameStr(tupDesc->attrs[attnum - 1]->attname))));
+			cstate->force_quote_flags[attnum - 1] = true;
+		}
+	}
+
+	/* Convert FORCE NOT NULL name list to per-column flags, check validity */
+	cstate->force_notnull_flags = (bool *) palloc0(num_phys_attrs * sizeof(bool));
+	if (cstate->force_notnull)
+	{
+		List	   *attnums;
+		ListCell   *cur;
+
+		attnums = CopyGetAttnums(tupDesc, cstate->rel, cstate->force_notnull);
+
+		foreach(cur, attnums)
+		{
+			int			attnum = lfirst_int(cur);
+
+			if (!list_member_int(cstate->attnumlist, attnum))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+								errmsg("FORCE NOT NULL column \"%s\" not referenced by COPY",
+									   NameStr(tupDesc->attrs[attnum - 1]->attname))));
+			cstate->force_notnull_flags[attnum - 1] = true;
+		}
+	}
+
+	cstate->copy_dest = COPY_FILE;		/* default */
+
+	return cstate;
+}
+
+CopyIntoClause*
+MakeCopyIntoClause(const CopyStmt *stmt)
+{
+	CopyIntoClause *copyIntoClause;
+	copyIntoClause = makeNode(CopyIntoClause);
+
+	copyIntoClause->is_program = stmt->is_program;
+	copyIntoClause->ao_segnos = stmt->ao_segnos;
+	copyIntoClause->filename = stmt->filename;
+	copyIntoClause->options = stmt->options;
+	copyIntoClause->attlist = stmt->attlist;
+
+	return copyIntoClause;
+}
+
+CopyState
+BeginCopyToOnSegment(QueryDesc *queryDesc)
+{
+	CopyState	cstate;
+	ListCell   *cur;
+
+	TupleDesc	tupDesc;
+	int			num_phys_attrs;
+	Form_pg_attribute *attr;
+	char	   *filename;
+	CopyIntoClause *copyIntoClause;
+
+	Assert(Gp_role == GP_ROLE_EXECUTE);
+
+	copyIntoClause = queryDesc->plannedstmt->copyIntoClause;
+	tupDesc = queryDesc->tupDesc;
+
+
+	cstate = BeginCopyOnSegment(false, NULL, NULL, NULL, InvalidOid,
+								copyIntoClause->attlist,copyIntoClause->options,
+								tupDesc);
+
+	cstate->null_print_client = cstate->null_print;		/* default */
+
+	/* We use fe_msgbuf as a per-row buffer regardless of copy_dest */
+	cstate->fe_msgbuf = makeStringInfo();
+
+	cstate->filename = pstrdup(copyIntoClause->filename);
+	cstate->is_program = copyIntoClause->is_program;
+
+	if (cstate->on_segment)
+		MangleCopyFileName(cstate);
+	filename = cstate->filename;
+
+	if (cstate->is_program)
+	{
+		cstate->program_pipes = open_program_pipes(cstate->filename, true);
+		cstate->copy_file = fdopen(cstate->program_pipes->pipes[0], PG_BINARY_W);
+
+		if (cstate->copy_file == NULL)
+			ereport(ERROR,
+					(errmsg("could not execute command \"%s\": %m",
+							cstate->filename)));
+	}
+	else
+	{
+		mode_t oumask; /* Pre-existing umask value */
+		struct stat st;
+
+		/*
+		 * Prevent write to relative path ... too easy to shoot oneself in
+		 * the foot by overwriting a database file ...
+		 */
+		if (!is_absolute_path(filename))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_NAME),
+							errmsg("relative path not allowed for COPY to file")));
+
+		oumask = umask(S_IWGRP | S_IWOTH);
+		cstate->copy_file = AllocateFile(filename, PG_BINARY_W);
+		umask(oumask);
+		if (cstate->copy_file == NULL)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+							errmsg("could not open file \"%s\" for writing: %m", filename)));
+
+		// Increase buffer size to improve performance  (cmcdevitt)
+		setvbuf(cstate->copy_file, NULL, _IOFBF, 393216); // 384 Kbytes
+
+		fstat(fileno(cstate->copy_file), &st);
+		if (S_ISDIR(st.st_mode))
+			ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+							errmsg("\"%s\" is a directory", filename)));
+	}
+
+	attr = tupDesc->attrs;
+	num_phys_attrs = tupDesc->natts;
+	/* Get info about the columns we need to process. */
+	cstate->out_functions = (FmgrInfo *) palloc(num_phys_attrs * sizeof(FmgrInfo));
+	foreach(cur, cstate->attnumlist)
+	{
+		int			attnum = lfirst_int(cur);
+		Oid			out_func_oid;
+		bool		isvarlena;
+
+		if (cstate->binary)
+			getTypeBinaryOutputInfo(attr[attnum - 1]->atttypid,
+									&out_func_oid,
+									&isvarlena);
+		else
+			getTypeOutputInfo(attr[attnum - 1]->atttypid,
+							  &out_func_oid,
+							  &isvarlena);
+		fmgr_info(out_func_oid, &cstate->out_functions[attnum - 1]);
+	}
+
+	/*
+	 * Create a temporary memory context that we can reset once per row to
+	 * recover palloc'd memory.  This avoids any problems with leaks inside
+	 * datatype output routines, and should be faster than retail pfree's
+	 * anyway.  (We don't need a whole econtext as CopyFrom does.)
+	 */
+	cstate->rowcontext = AllocSetContextCreate(CurrentMemoryContext,
+											   "COPY TO",
+											   ALLOCSET_DEFAULT_MINSIZE,
+											   ALLOCSET_DEFAULT_INITSIZE,
+											   ALLOCSET_DEFAULT_MAXSIZE);
+
+	if (cstate->binary)
+	{
+		/* Generate header for a binary copy */
+		int32		tmp;
+
+		/* Signature */
+		CopySendData(cstate, BinarySignature, 11);
+		/* Flags field */
+		tmp = 0;
+		if (cstate->oids)
+			tmp |= (1 << 16);
+		CopySendInt32(cstate, tmp);
+		/* No header extension */
+		tmp = 0;
+		CopySendInt32(cstate, tmp);
+	}
+	else
+	{
+		/* if a header has been requested send the line */
+		if (cstate->header_line)
+		{
+			bool		hdr_delim = false;
+
+			foreach(cur, cstate->attnumlist)
+			{
+				int			attnum = lfirst_int(cur);
+				char	   *colname;
+
+				if (hdr_delim)
+					CopySendChar(cstate, cstate->delim[0]);
+				hdr_delim = true;
+
+				colname = NameStr(attr[attnum - 1]->attname);
+
+				CopyAttributeOutCSV(cstate, colname, false,
+									list_length(cstate->attnumlist) == 1);
+			}
+
+			CopySendEndOfRow(cstate);
+		}
+	}
+
+	return cstate;
+}
+
+void EndCopyToOnSegment(CopyState cstate)
+{
+	Assert(Gp_role == GP_ROLE_EXECUTE);
+
+	if (cstate->binary)
+	{
+		/* Generate trailer for a binary copy */
+		CopySendInt16(cstate, -1);
+
+		/* Need to flush out the trailer */
+		CopySendEndOfRow(cstate);
+	}
+
+	MemoryContextDelete(cstate->rowcontext);
+
+	if (cstate->is_program)
+	{
+		close_program_pipes(cstate, true);
+	}
+	else
+	{
+		if (cstate->filename != NULL && FreeFile(cstate->copy_file))
+			ereport(ERROR,
+					(errcode_for_file_access(),
+							errmsg("could not close file \"%s\": %m",
+								   cstate->filename)));
+	}
+
+	/* Clean up single row error handling related memory */
+	if (cstate->cdbsreh)
+		destroyCdbSreh(cstate->cdbsreh);
+
+	pfree(cstate);
+}
+
+static uint64
+CopyToQueryOnSegment(CopyState cstate)
+{
+	Assert(Gp_role != GP_ROLE_EXECUTE);
+
+	/* run the plan --- the dest receiver will send tuples */
+	ExecutorRun(cstate->queryDesc, ForwardScanDirection, 0L);
+	return 0;
+}
+
+
 #define COPY_FIND_MD_DELIM \
 md_delim = memchr(line_start, COPY_METADATA_DELIM, Min(32, cstate->line_buf.len)); \
 if(md_delim && (md_delim != line_start)) \
@@ -7499,7 +7833,10 @@ escape_quotes(const char *src)
 static void
 copy_dest_startup(DestReceiver *self __attribute__((unused)), int operation __attribute__((unused)), TupleDesc typeinfo __attribute__((unused)))
 {
-	/* no-op */
+	if (Gp_role == GP_ROLE_DISPATCH)
+		return;
+	DR_copy    *myState = (DR_copy *) self;
+	myState->cstate = BeginCopyToOnSegment(myState->queryDesc);
 }
 
 /*
@@ -7524,7 +7861,10 @@ copy_dest_receive(TupleTableSlot *slot, DestReceiver *self)
 static void
 copy_dest_shutdown(DestReceiver *self __attribute__((unused)))
 {
-	/* no-op */
+	if (Gp_role == GP_ROLE_DISPATCH)
+		return;
+	DR_copy    *myState = (DR_copy *) self;
+	EndCopyToOnSegment(myState->cstate);
 }
 
 /*

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1565,7 +1565,8 @@ InitRootSlices(QueryDesc *queryDesc)
 			{
 				case CMD_SELECT:
 					Assert(slice->gangType == GANGTYPE_UNALLOCATED && slice->gangSize == 0);
-					if (queryDesc->plannedstmt->intoClause != NULL)
+					if (queryDesc->plannedstmt->intoClause != NULL ||
+						queryDesc->plannedstmt->copyIntoClause != NULL)
 					{
 						slice->gangType = GANGTYPE_PRIMARY_WRITER;
 						slice->gangSize = getgpsegmentCount();
@@ -2155,7 +2156,7 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 	 * Wait for them to finish and clean up the dispatching structures.
 	 * Replace current error info with QE error info if more interesting.
 	 */
-	if (estate->dispatcherState && estate->dispatcherState->primaryResults)
+	if (estate && estate->dispatcherState && estate->dispatcherState->primaryResults)
 	{
 		/*
 		 * If we are finishing a query before all the tuples of the query
@@ -2170,7 +2171,7 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 	}
 
 	/* Clean up the interconnect. */
-	if (estate->es_interconnect_is_setup)
+	if (estate && estate->es_interconnect_is_setup)
 	{
 		TeardownInterconnect(estate->interconnect_context, estate->motionlayer_context, true /* force EOS */, true);
 		estate->es_interconnect_is_setup = false;

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -1314,6 +1314,8 @@ CQueryMutators::ConvertToDerivedTable
     new_query->rtable = gpdb::LAppend(new_query->rtable, rte);
     new_query->intoClause = origIntoClause;
     new_query->intoPolicy = into_policy;
+	new_query->isCopy = derived_table_query->isCopy;
+	derived_table_query->isCopy = false;
 
 	FromExpr *fromexpr = MakeNode(FromExpr);
 	fromexpr->quals = NULL;

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -406,9 +406,13 @@ CTranslatorQueryToDXL::CheckSupportedCmdType
 
 	if (CMD_SELECT == query->commandType)
 	{
-		if (!optimizer_enable_ctas && NULL != query->intoClause)
+		if (!optimizer_enable_ctas && (NULL != query->intoClause || query->isCopy))
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA"));
+		}
+		if (query->isCopy)
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("COPY. Copy select statement to file on segment is not supported with GPORCA"));
 		}
 		
 		// supported: regular select or CTAS when it is enabled
@@ -626,7 +630,7 @@ CTranslatorQueryToDXL::TranslateQueryToDXL()
 	switch (m_query->commandType)
 	{
 		case CMD_SELECT:
-			if (NULL == m_query->intoClause)
+			if (NULL == m_query->intoClause && !m_query->isCopy)
 			{
 				return TranslateSelectQueryToDXL();
 			}

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -133,6 +133,8 @@ _copyPlannedStmt(PlannedStmt *from)
 	COPY_SCALAR_FIELD(query_mem);
 	COPY_SCALAR_FIELD(metricsQueryType);
 
+	COPY_NODE_FIELD(copyIntoClause);
+
 	return newnode;
 }
 
@@ -1341,6 +1343,23 @@ _copyIntoClause(IntoClause *from)
 	COPY_NODE_FIELD(options);
 	COPY_SCALAR_FIELD(onCommit);
 	COPY_STRING_FIELD(tableSpaceName);
+
+	return newnode;
+}
+
+/*
+ * _copyIntoClause
+ */
+static CopyIntoClause *
+_copyCopyIntoClause(const CopyIntoClause *from)
+{
+	CopyIntoClause *newnode = makeNode(CopyIntoClause);
+
+	COPY_NODE_FIELD(attlist);
+	COPY_SCALAR_FIELD(is_program);
+	COPY_STRING_FIELD(filename);
+	COPY_NODE_FIELD(options);
+	COPY_NODE_FIELD(ao_segnos);
 
 	return newnode;
 }
@@ -2856,6 +2875,7 @@ _copyQuery(Query *from)
 	}
 	else
 		newnode->intoPolicy = NULL;
+	COPY_SCALAR_FIELD(isCopy);
 
 	return newnode;
 }
@@ -4719,6 +4739,9 @@ copyObject(void *from)
 			break;
 		case T_IntoClause:
 			retval = _copyIntoClause(from);
+			break;
+		case T_CopyIntoClause:
+			retval = _copyCopyIntoClause(from);
 			break;
 		case T_Var:
 			retval = _copyVar(from);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -868,6 +868,8 @@ _equalQuery(Query *a, Query *b)
 	if (!GpPolicyEqual(a->intoPolicy, b->intoPolicy))
 		return false;
 
+	COMPARE_SCALAR_FIELD(isCopy);
+
 	return true;
 }
 

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -351,6 +351,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_INT8_FIELD(metricsQueryType);
+	WRITE_NODE_FIELD(copyIntoClause);
 }
 
 static void
@@ -922,6 +923,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(limitCount);
 	WRITE_NODE_FIELD(rowMarks);
 	WRITE_NODE_FIELD(setOperations);
+	WRITE_BOOL_FIELD(isCopy);
 	/* Don't serialize policy */
 }
 
@@ -1392,6 +1394,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_IntoClause:
 				_outIntoClause(str, obj);
+				break;
+			case T_CopyIntoClause:
+				_outCopyIntoClause(str, obj);
 				break;
 			case T_Var:
 				_outVar(str, obj);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -319,6 +319,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_INT_FIELD(metricsQueryType);
+	WRITE_NODE_FIELD(copyIntoClause);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
@@ -1179,6 +1180,19 @@ _outIntoClause(StringInfo str, IntoClause *node)
 	WRITE_NODE_FIELD(options);
 	WRITE_ENUM_FIELD(onCommit, OnCommitAction);
 	WRITE_STRING_FIELD(tableSpaceName);
+}
+
+static void
+_outCopyIntoClause(StringInfo str, const CopyIntoClause *node)
+{
+WRITE_NODE_TYPE("COPYINTOCLAUSE");
+
+WRITE_NODE_FIELD(attlist);
+WRITE_BOOL_FIELD(is_program);
+WRITE_STRING_FIELD(filename);
+WRITE_NODE_FIELD(options);
+WRITE_NODE_FIELD(ao_segnos);
+
 }
 
 static void
@@ -3520,6 +3534,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(limitCount);
 	WRITE_NODE_FIELD(rowMarks);
 	WRITE_NODE_FIELD(setOperations);
+	WRITE_BOOL_FIELD(isCopy);
 	/* Don't serialize policy */
 }
 #endif /* COMPILING_BINARY_FUNCS */
@@ -4525,6 +4540,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_IntoClause:
 				_outIntoClause(str, obj);
+				break;
+			case T_CopyIntoClause:
+				_outCopyIntoClause(str, obj);
 				break;
 			case T_Var:
 				_outVar(str, obj);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -252,6 +252,7 @@ _readQuery(void)
 	READ_NODE_FIELD(limitCount);
 	READ_NODE_FIELD(rowMarks);
 	READ_NODE_FIELD(setOperations);
+	READ_BOOL_FIELD(isCopy);
 	/* policy not serialized */
 
 	READ_DONE();
@@ -1479,6 +1480,7 @@ _readPlannedStmt(void)
 
 	READ_UINT64_FIELD(query_mem);
 	READ_INT8_FIELD(metricsQueryType);
+	READ_NODE_FIELD(copyIntoClause);
 	READ_DONE();
 }
 
@@ -2942,6 +2944,9 @@ readNodeBinary(void)
 				break;
 			case T_IntoClause:
 				return_value = _readIntoClause();
+				break;
+			case T_CopyIntoClause:
+				return_value = _readCopyIntoClause();
 				break;
 			case T_Var:
 				return_value = _readVar();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -342,6 +342,7 @@ _readQuery(void)
 	READ_NODE_FIELD(limitCount);
 	READ_NODE_FIELD(rowMarks);
 	READ_NODE_FIELD(setOperations);
+	READ_BOOL_FIELD(isCopy);
 
 	local_node->intoPolicy = NULL;
 
@@ -649,6 +650,20 @@ _readIntoClause(void)
 	READ_NODE_FIELD(options);
 	READ_ENUM_FIELD(onCommit, OnCommitAction);
 	READ_STRING_FIELD(tableSpaceName);
+
+	READ_DONE();
+}
+
+static CopyIntoClause *
+_readCopyIntoClause(void)
+{
+	READ_LOCALS(CopyIntoClause);
+
+	READ_NODE_FIELD(attlist);
+	READ_BOOL_FIELD(is_program);
+	READ_STRING_FIELD(filename);
+	READ_NODE_FIELD(options);
+	READ_NODE_FIELD(ao_segnos);
 
 	READ_DONE();
 }
@@ -2893,6 +2908,8 @@ parseNodeString(void)
 		return_value = _readRangeVar();
 	else if (MATCH("INTOCLAUSE", 10))
 		return_value = _readIntoClause();
+	else if (MATCH("COPYINTOCLAUSE", 10))
+		return_value = _readCopyIntoClause();
 	else if (MATCH("VAR", 3))
 		return_value = _readVar();
 	else if (MATCH("CONST", 5))

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1943,7 +1943,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		result_plan->flow = pull_up_Flow(result_plan,
 										 getAnySubplan(result_plan),
 										 (current_pathkeys != NIL));
-
 	/*
 	 * MPP: If there's a DISTINCT clause and we're not collocated on the
 	 * distinct key, we need to redistribute on that key.  In addition, we

--- a/src/backend/postmaster/autostats.c
+++ b/src/backend/postmaster/autostats.c
@@ -207,6 +207,10 @@ autostats_get_cmdtype(QueryDesc *queryDesc, AutoStatsCmdType * pcmdType, Oid *pr
 					relationOid = RelationGetRelid(queryDesc->estate->es_into_relation_descriptor);
 				cmdType = AUTOSTATS_CMDTYPE_CTAS;
 			}
+			else if (stmt->copyIntoClause != NULL)
+			{
+				cmdType = AUTOSTATS_CMDTYPE_COPY;
+			}
 			break;
 		case CMD_INSERT:
 			rte = rt_fetch(lfirst_int(list_head(stmt->resultRelations)), stmt->rtable);

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -395,7 +395,8 @@ ChoosePortalStrategy(List *stmts)
 			{
 				if (query->commandType == CMD_SELECT &&
 					query->utilityStmt == NULL &&
-					query->intoClause == NULL)
+					query->intoClause == NULL &&
+					!query->isCopy)
 					return PORTAL_ONE_SELECT;
 				if (query->commandType == CMD_UTILITY &&
 					query->utilityStmt != NULL)
@@ -415,7 +416,8 @@ ChoosePortalStrategy(List *stmts)
 			{
 				if (pstmt->commandType == CMD_SELECT &&
 					pstmt->utilityStmt == NULL &&
-					pstmt->intoClause == NULL)
+					pstmt->intoClause == NULL &&
+					pstmt->copyIntoClause == NULL)
 					return PORTAL_ONE_SELECT;
 			}
 		}
@@ -520,7 +522,8 @@ FetchStatementTargetList(Node *stmt)
 		{
 			if (query->commandType == CMD_SELECT &&
 				query->utilityStmt == NULL &&
-				query->intoClause == NULL)
+				query->intoClause == NULL &&
+				!query->isCopy)
 				return query->targetList;
 			if (query->returningList)
 				return query->returningList;
@@ -533,7 +536,8 @@ FetchStatementTargetList(Node *stmt)
 
 		if (pstmt->commandType == CMD_SELECT &&
 			pstmt->utilityStmt == NULL &&
-			pstmt->intoClause == NULL)
+			pstmt->intoClause == NULL &&
+			pstmt->copyIntoClause == NULL)
 			return pstmt->planTree->targetlist;
 		if (pstmt->returningLists)
 			return (List *) linitial(pstmt->returningLists);

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -264,6 +264,16 @@ typedef CopyStateData *CopyState;
 #define ISOCTAL(c) (((c) >= '0') && ((c) <= '7'))
 #define OCTVALUE(c) ((c) - '0')
 
+typedef struct CopyStateData *CopyState;
+
+/* DestReceiver for COPY (SELECT) TO */
+typedef struct
+{
+	DestReceiver pub;			/* publicly-known function pointers */
+	CopyState	cstate;			/* CopyStateData for the command */
+	QueryDesc  *queryDesc;		/* QueryDesc for the copy*/
+} DR_copy;
+
 /*
  * Some platforms like macOS (since Yosemite) already define 64 bit versions
  * of htonl and nhohl so we need to guard against redefinition.
@@ -281,7 +291,8 @@ extern void ValidateControlChars(bool copy, bool load, bool csv_mode, char *deli
 								 bool header_line, bool fill_missing, char *newline,
 								 int numcols);
 extern uint64 DoCopy(const CopyStmt *stmt, const char *queryString);
-
+extern CopyState BeginCopyToOnSegment(QueryDesc *queryDesc);
+extern void EndCopyToOnSegment(CopyState cstate);
 extern DestReceiver *CreateCopyDestReceiver(void);
 
 extern List *CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist);

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -172,6 +172,7 @@ typedef struct CopyStateData
 	 */
 	FmgrInfo   *out_functions;	/* lookup info for output functions */
 	MemoryContext rowcontext;	/* per-row evaluation context */
+	MemoryContext copycontext;	/* per-copy execution context */
 
 	/*
 	 * These variables are used to reduce overhead in textual COPY FROM.

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -218,6 +218,7 @@ typedef enum NodeTag
 	T_JoinExpr,
 	T_FromExpr,
 	T_IntoClause,
+	T_CopyIntoClause,
 	T_Flow,
 	T_WindowFrame,
 	T_WindowFrameEdge,

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -175,8 +175,13 @@ typedef struct Query
 	 * policy for SELECT ... INTO and set operations.
 	 */
 	struct GpPolicy *intoPolicy;
-} Query;
 
+	/*
+	 * GPDB: Used to indicate this query is COPY so that its plan
+	 * would always be dispatched in parallel.
+	 */
+	bool isCopy;
+} Query;
 
 /****************************************************************************
  *	Supporting data structures for Parse Trees

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -21,6 +21,7 @@
 #include "nodes/bitmapset.h"
 #include "nodes/primnodes.h"
 #include "storage/itemptr.h"
+#include "parsenodes.h"
 
 typedef struct DirectDispatchInfo
 {
@@ -146,6 +147,7 @@ typedef struct PlannedStmt
 
 	/* GPDB: whether the query is a spi/function inner/top-level query or for extension usage */
 	int8		metricsQueryType;
+	CopyIntoClause *copyIntoClause;
 } PlannedStmt;
 
 /*

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -97,6 +97,18 @@ typedef struct IntoClause
 	char	   *tableSpaceName; /* table space to use, or NULL */
 } IntoClause;
 
+typedef struct CopyIntoClause
+{
+	NodeTag		type;
+
+	List	   *attlist;		/* List of column names (as Strings), or NIL
+								 * for all columns */
+	bool		is_program;		/* is 'filename' a program to popen? */
+	char	   *filename;		/* filename, or NULL for STDIN/STDOUT */
+	List	   *options;		/* List of DefElem nodes */
+	List	   *ao_segnos;		/* AO segno map */
+} CopyIntoClause;
+
 
 /* ----------------------------------------------------------------
  *					node types for executable expressions

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -723,7 +723,7 @@ SELECT * FROM segment_reject_limit_from;
 COPY segment_reject_limit_from to STDOUT on segment log errors segment reject limit 3 rows;
 COPY segment_reject_limit_from to PROGRAM STDOUT log errors segment reject limit 3 rows;
 
--- 'COPY (SELECT ...) TO' doesn't support 'ON SEGMENT'
+-- 'COPY (SELECT ...) TO' has supported 'ON SEGMENT'
 COPY (SELECT * FROM segment_reject_limit_from) TO '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT;
 
 -- \copy from doesn't support on segment
@@ -813,6 +813,10 @@ COPY test_copy_on_segment_nocol TO '/tmp/valid_filename_nocol<SEGID>.txt' ON SEG
 COPY test_copy_on_segment_nocol FROM '/tmp/valid_filename_nocol<SEGID>.txt' ON SEGMENT;
 SELECT * FROM test_copy_on_segment_nocol;
 
+COPY (select * from test_copy_on_segment_nocol) TO '/tmp/valid_filename_nocol<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment_nocol FROM '/tmp/valid_filename_nocol<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_on_segment_nocol;
+
 CREATE TABLE test_copy_on_segment_array (a int[], b text) DISTRIBUTED BY (a);
 INSERT INTO test_copy_on_segment_array VALUES ('{1,2,3}', 'sd');
 INSERT INTO test_copy_on_segment_array VALUES ('{2,2,3}', 'fg');
@@ -826,6 +830,11 @@ CREATE TABLE test_copy_on_segment_array_1 (a int[], b text) DISTRIBUTED BY (a);
 COPY test_copy_on_segment_array_1 FROM '/tmp/valid_filename_array<SEGID>.txt' ON SEGMENT;
 SELECT * FROM test_copy_on_segment_array EXCEPT SELECT * FROM test_copy_on_segment_array_1;
 
+delete from test_copy_on_segment_array_1;
+COPY (select * from test_copy_on_segment_array) TO '/tmp/valid_filename_array_select<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment_array_1 FROM '/tmp/valid_filename_array_select<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_on_segment_array EXCEPT SELECT * FROM test_copy_on_segment_array_1;
+
 CREATE TABLE test_copy_on_segment_2dim_array (a int[][]) DISTRIBUTED BY (a);
 INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,2,3},{2,5,9}}');
 INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,8,3},{2,5,9}}');
@@ -837,6 +846,11 @@ COPY test_copy_on_segment_2dim_array TO '/tmp/valid_filename_2dim_array<SEGID>.t
 
 CREATE TABLE test_copy_on_segment_2dim_array_1 (a int[][]) DISTRIBUTED BY (a);
 COPY test_copy_on_segment_2dim_array_1 FROM '/tmp/valid_filename_2dim_array<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_on_segment_2dim_array EXCEPT SELECT * FROM test_copy_on_segment_2dim_array_1;
+
+delete from test_copy_on_segment_2dim_array_1;
+COPY (select * from test_copy_on_segment_2dim_array) TO '/tmp/valid_filename_2dim_array_select<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment_2dim_array_1 FROM '/tmp/valid_filename_2dim_array_select<SEGID>.txt' ON SEGMENT;
 SELECT * FROM test_copy_on_segment_2dim_array EXCEPT SELECT * FROM test_copy_on_segment_2dim_array_1;
 
 CREATE TABLE test_copy_on_segment (a int, b text, c text) DISTRIBUTED BY (b);
@@ -874,6 +888,29 @@ CREATE TABLE test_copy_from_on_segment_withoids (LIKE test_copy_on_segment_witho
 COPY test_copy_from_on_segment_withoids FROM '/tmp/withoids_valid_filename<SEGID>.csv' WITH ON SEGMENT OIDS CSV QUOTE '"' ESCAPE E'\\' NULL '\N' DELIMITER ',' IGNORE EXTERNAL PARTITIONS;
 SELECT * FROM test_copy_from_on_segment_withoids ORDER BY a;
 
+COPY (select * from test_copy_on_segment) TO '/tmp/invalid_filename_select.txt' ON SEGMENT;
+COPY (select * from test_copy_on_segment) TO '/tmp/valid_filename_select<SEGID>.txt' ON SEGMENT;
+COPY (select * from test_copy_on_segment) TO '/tmp/valid_filename_select<SEGID>.bin' ON SEGMENT BINARY;
+COPY test_copy_on_segment TO '/tmp/valid_filename_select<SEGID>.csv' WITH ON SEGMENT CSV QUOTE '"' FORCE QUOTE a,b,c ESCAPE E'\\' NULL '\N' DELIMITER ',' HEADER;
+COPY test_copy_on_segment_withoids TO '/tmp/withoids_valid_filename_select<SEGID>.csv' WITH ON SEGMENT OIDS CSV QUOTE '"' FORCE QUOTE a,b,c ESCAPE E'\\' NULL '\N' DELIMITER ',';
+
+delete from test_copy_from_on_segment_txt;
+COPY test_copy_from_on_segment_txt FROM '/tmp/invalid_filename_select.txt' ON SEGMENT;
+COPY test_copy_from_on_segment_txt FROM '/tmp/valid_filename_select<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_from_on_segment_txt ORDER BY a;
+
+delete from test_copy_from_on_segment_binary;
+COPY test_copy_from_on_segment_binary FROM '/tmp/valid_filename_select<SEGID>.bin' ON SEGMENT BINARY;
+SELECT * FROM test_copy_from_on_segment_binary ORDER BY a;
+
+delete from test_copy_from_on_segment_csv;
+COPY test_copy_from_on_segment_csv FROM '/tmp/valid_filename_select<SEGID>.csv' WITH ON SEGMENT CSV QUOTE '"' ESCAPE E'\\' NULL '\N' DELIMITER ',' HEADER;
+SELECT * FROM test_copy_from_on_segment_csv ORDER BY a;
+
+delete from  test_copy_from_on_segment_withoids;
+COPY test_copy_from_on_segment_withoids FROM '/tmp/withoids_valid_filename_select<SEGID>.csv' WITH ON SEGMENT OIDS CSV QUOTE '"' ESCAPE E'\\' NULL '\N' DELIMITER ',';
+SELECT * FROM test_copy_from_on_segment_withoids ORDER BY a;
+
 CREATE TABLE onek_copy_onsegment (
     unique1     int4,
     unique2     int4,
@@ -898,6 +935,13 @@ COPY onek_copy_onsegment TO '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt'
 
 CREATE TABLE onek_copy_from_onsegment (LIKE onek_copy_onsegment);
 COPY onek_copy_from_onsegment FROM '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt' ON SEGMENT;
+SELECT * FROM onek_copy_onsegment EXCEPT SELECT * FROM onek_copy_from_onsegment;
+SELECT count(*) FROM onek_copy_from_onsegment;
+
+COPY (select * from onek_copy_onsegment) TO '/tmp/valid_filename_onek_copy_onsegment_select<SEGID>.txt' ON SEGMENT;
+
+delete from onek_copy_from_onsegment;
+COPY onek_copy_from_onsegment FROM '/tmp/valid_filename_onek_copy_onsegment_select<SEGID>.txt' ON SEGMENT;
 SELECT * FROM onek_copy_onsegment EXCEPT SELECT * FROM onek_copy_from_onsegment;
 SELECT count(*) FROM onek_copy_from_onsegment;
 
@@ -929,6 +973,9 @@ DROP TABLE IF EXISTS LINEITEM_2;
 DROP TABLE IF EXISTS LINEITEM_3;
 DROP TABLE IF EXISTS LINEITEM_4;
 DROP TABLE IF EXISTS LINEITEM_5;
+DROP TABLE IF EXISTS LINEITEM_6;
+DROP TABLE IF EXISTS LINEITEM_7;
+DROP TABLE IF EXISTS LINEITEM_8;
 -- end_ignore
 CREATE TABLE LINEITEM ( L_ORDERKEY INTEGER NOT NULL,
 L_PARTKEY INTEGER NOT NULL,
@@ -956,11 +1003,15 @@ CREATE TABLE LINEITEM_2 (LIKE LINEITEM);
 CREATE TABLE LINEITEM_3 (LIKE LINEITEM);
 CREATE TABLE LINEITEM_4 (LIKE LINEITEM);
 CREATE TABLE LINEITEM_5 (LIKE LINEITEM);
+CREATE TABLE LINEITEM_6 (LIKE LINEITEM);
+CREATE TABLE LINEITEM_7 (LIKE LINEITEM);
+CREATE TABLE LINEITEM_8 (LIKE LINEITEM);
 
 COPY LINEITEM FROM '@abs_srcdir@/data/lineitem.csv' WITH DELIMITER '|' CSV;
 SELECT COUNT(*) FROM LINEITEM;
 COPY LINEITEM TO '/tmp/lineitem.csv' CSV;
 COPY LINEITEM TO '/tmp/lineitem_s<SEGID>.csv' ON SEGMENT CSV;
+COPY (select * from LINEITEM) TO '/tmp/lineitem_qs<SEGID>.csv' ON SEGMENT CSV;
 
 COPY LINEITEM_1 FROM '/tmp/lineitem.csv' CSV;
 SELECT COUNT(*) FROM LINEITEM_1;
@@ -970,20 +1021,34 @@ COPY LINEITEM_2 FROM '/tmp/lineitem_s<SEGID>.csv' ON SEGMENT CSV;
 SELECT COUNT(*) FROM LINEITEM_2;
 SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_2;
 
-COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program.csv' CSV;
-COPY LINEITEM_3 FROM PROGRAM 'cat /tmp/lineitem_program.csv' CSV;
+COPY LINEITEM_3 FROM '/tmp/lineitem_qs<SEGID>.csv' ON SEGMENT CSV;
 SELECT COUNT(*) FROM LINEITEM_3;
 SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_3;
 
-COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
-COPY LINEITEM_4 FROM PROGRAM 'cat /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program.csv' CSV;
+COPY LINEITEM_4 FROM PROGRAM 'cat /tmp/lineitem_program.csv' CSV;
 SELECT COUNT(*) FROM LINEITEM_4;
 SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_4;
 
-\COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program_client.csv' CSV;
-\COPY LINEITEM_5 FROM PROGRAM 'cat /tmp/lineitem_program_client.csv' CSV;
+COPY (select * from LINEITEM) TO PROGRAM 'cat > /tmp/lineitem_program.csv' CSV;
+COPY LINEITEM_5 FROM PROGRAM 'cat /tmp/lineitem_program.csv' CSV;
 SELECT COUNT(*) FROM LINEITEM_5;
 SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_5;
+
+COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+COPY LINEITEM_6 FROM PROGRAM 'cat /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+SELECT COUNT(*) FROM LINEITEM_6;
+SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_6;
+
+COPY (select * from LINEITEM) TO PROGRAM 'cat > /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+COPY LINEITEM_7 FROM PROGRAM 'cat /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+SELECT COUNT(*) FROM LINEITEM_7;
+SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_7;
+
+\COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program_client.csv' CSV;
+\COPY LINEITEM_8 FROM PROGRAM 'cat /tmp/lineitem_program_client.csv' CSV;
+SELECT COUNT(*) FROM LINEITEM_8;
+SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_8;
 
 --Test for `COPY FROM ON SEGMENT` checking the distribution key restriction 
 -- start_matchsubs
@@ -1103,6 +1168,7 @@ CREATE TABLE COPY_TO_PROGRAM_ERROR(dir text);
 
 COPY COPY_TO_PROGRAM_ERROR TO PROGRAM 'echo && echo "error" >&2 && exit 255';
 COPY COPY_TO_PROGRAM_ERROR TO PROGRAM 'echo <SEGID>&& echo "error" >&2 && exit 255' on segment;
+COPY (SELECT * FROM COPY_TO_PROGRAM_ERROR) TO PROGRAM 'echo <SEGID>&& echo "error" >&2 && exit 255' on segment;
 
 CREATE TABLE COPY_FROM_PROGRAM_ERROR(a int);
 

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -749,9 +749,8 @@ COPY segment_reject_limit_from to STDOUT on segment log errors segment reject li
 ERROR:  STDIN and STDOUT are not supported by 'COPY ON SEGMENT'
 COPY segment_reject_limit_from to PROGRAM STDOUT log errors segment reject limit 3 rows;
 ERROR:  STDIN/STDOUT not allowed with PROGRAM
--- 'COPY (SELECT ...) TO' doesn't support 'ON SEGMENT'
+-- 'COPY (SELECT ...) TO' has supported 'ON SEGMENT'
 COPY (SELECT * FROM segment_reject_limit_from) TO '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT;
-ERROR:  'COPY (SELECT ...) TO' doesn't support 'ON SEGMENT'.
 -- \copy from doesn't support on segment
 --on segment lower case
 \COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment;
@@ -816,6 +815,12 @@ SELECT * FROM test_copy_on_segment_nocol;
 --
 (0 rows)
 
+COPY (select * from test_copy_on_segment_nocol) TO '/tmp/valid_filename_nocol<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment_nocol FROM '/tmp/valid_filename_nocol<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_on_segment_nocol;
+--
+(0 rows)
+
 CREATE TABLE test_copy_on_segment_array (a int[], b text) DISTRIBUTED BY (a);
 INSERT INTO test_copy_on_segment_array VALUES ('{1,2,3}', 'sd');
 INSERT INTO test_copy_on_segment_array VALUES ('{2,2,3}', 'fg');
@@ -831,6 +836,14 @@ SELECT * FROM test_copy_on_segment_array EXCEPT SELECT * FROM test_copy_on_segme
 ---+---
 (0 rows)
 
+delete from test_copy_on_segment_array_1;
+COPY (select * from test_copy_on_segment_array) TO '/tmp/valid_filename_array_select<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment_array_1 FROM '/tmp/valid_filename_array_select<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_on_segment_array EXCEPT SELECT * FROM test_copy_on_segment_array_1;
+ a | b 
+---+---
+(0 rows)
+
 CREATE TABLE test_copy_on_segment_2dim_array (a int[][]) DISTRIBUTED BY (a);
 INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,2,3},{2,5,9}}');
 INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,8,3},{2,5,9}}');
@@ -841,6 +854,14 @@ INSERT INTO test_copy_on_segment_2dim_array VALUES ('{{1,666,3},{2,555,9}}');
 COPY test_copy_on_segment_2dim_array TO '/tmp/valid_filename_2dim_array<SEGID>.txt' ON SEGMENT;
 CREATE TABLE test_copy_on_segment_2dim_array_1 (a int[][]) DISTRIBUTED BY (a);
 COPY test_copy_on_segment_2dim_array_1 FROM '/tmp/valid_filename_2dim_array<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_on_segment_2dim_array EXCEPT SELECT * FROM test_copy_on_segment_2dim_array_1;
+ a 
+---
+(0 rows)
+
+delete from test_copy_on_segment_2dim_array_1;
+COPY (select * from test_copy_on_segment_2dim_array) TO '/tmp/valid_filename_2dim_array_select<SEGID>.txt' ON SEGMENT;
+COPY test_copy_on_segment_2dim_array_1 FROM '/tmp/valid_filename_2dim_array_select<SEGID>.txt' ON SEGMENT;
 SELECT * FROM test_copy_on_segment_2dim_array EXCEPT SELECT * FROM test_copy_on_segment_2dim_array_1;
  a 
 ---
@@ -912,6 +933,60 @@ SELECT * FROM test_copy_from_on_segment_withoids ORDER BY a;
  3 | h | j
 (3 rows)
 
+COPY (select * from test_copy_on_segment) TO '/tmp/invalid_filename_select.txt' ON SEGMENT;
+ERROR:  <SEGID> is required for file name  (seg0 127.0.0.1:25432 pid=22593)
+COPY (select * from test_copy_on_segment) TO '/tmp/valid_filename_select<SEGID>.txt' ON SEGMENT;
+COPY (select * from test_copy_on_segment) TO '/tmp/valid_filename_select<SEGID>.bin' ON SEGMENT BINARY;
+COPY test_copy_on_segment TO '/tmp/valid_filename_select<SEGID>.csv' WITH ON SEGMENT CSV QUOTE '"' FORCE QUOTE a,b,c ESCAPE E'\\' NULL '\N' DELIMITER ',' HEADER;
+COPY test_copy_on_segment_withoids TO '/tmp/withoids_valid_filename_select<SEGID>.csv' WITH ON SEGMENT OIDS CSV QUOTE '"' FORCE QUOTE a,b,c ESCAPE E'\\' NULL '\N' DELIMITER ',';
+delete from test_copy_from_on_segment_txt;
+COPY test_copy_from_on_segment_txt FROM '/tmp/invalid_filename_select.txt' ON SEGMENT;
+ERROR:  <SEGID> is required for file name  (seg0 127.0.0.1:25432 pid=22593)
+COPY test_copy_from_on_segment_txt FROM '/tmp/valid_filename_select<SEGID>.txt' ON SEGMENT;
+SELECT * FROM test_copy_from_on_segment_txt ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+ 4 | i | l
+ 5 | q | w
+(5 rows)
+
+delete from test_copy_from_on_segment_binary;
+COPY test_copy_from_on_segment_binary FROM '/tmp/valid_filename_select<SEGID>.bin' ON SEGMENT BINARY;
+SELECT * FROM test_copy_from_on_segment_binary ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+ 4 | i | l
+ 5 | q | w
+(5 rows)
+
+delete from test_copy_from_on_segment_csv;
+COPY test_copy_from_on_segment_csv FROM '/tmp/valid_filename_select<SEGID>.csv' WITH ON SEGMENT CSV QUOTE '"' ESCAPE E'\\' NULL '\N' DELIMITER ',' HEADER;
+SELECT * FROM test_copy_from_on_segment_csv ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+ 4 | i | l
+ 5 | q | w
+(5 rows)
+
+delete from  test_copy_from_on_segment_withoids;
+COPY test_copy_from_on_segment_withoids FROM '/tmp/withoids_valid_filename_select<SEGID>.csv' WITH ON SEGMENT OIDS CSV QUOTE '"' ESCAPE E'\\' NULL '\N' DELIMITER ',';
+SELECT * FROM test_copy_from_on_segment_withoids ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | s | d
+ 2 | f | g
+ 3 | h | j
+(3 rows)
+
 CREATE TABLE onek_copy_onsegment (
     unique1     int4,
     unique2     int4,
@@ -941,6 +1016,20 @@ COPY onek_copy_onsegment TO '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt'
 CREATE TABLE onek_copy_from_onsegment (LIKE onek_copy_onsegment);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 COPY onek_copy_from_onsegment FROM '/tmp/valid_filename_onek_copy_onsegment<SEGID>.txt' ON SEGMENT;
+SELECT * FROM onek_copy_onsegment EXCEPT SELECT * FROM onek_copy_from_onsegment;
+ unique1 | unique2 | two | four | ten | twenty | hundred | thousand | twothousand | fivethous | tenthous | odd | even | stringu1 | stringu2 | string4 
+---------+---------+-----+------+-----+--------+---------+----------+-------------+-----------+----------+-----+------+----------+----------+---------
+(0 rows)
+
+SELECT count(*) FROM onek_copy_from_onsegment;
+ count 
+-------
+  1000
+(1 row)
+
+COPY (select * from onek_copy_onsegment) TO '/tmp/valid_filename_onek_copy_onsegment_select<SEGID>.txt' ON SEGMENT;
+delete from onek_copy_from_onsegment;
+COPY onek_copy_from_onsegment FROM '/tmp/valid_filename_onek_copy_onsegment_select<SEGID>.txt' ON SEGMENT;
 SELECT * FROM onek_copy_onsegment EXCEPT SELECT * FROM onek_copy_from_onsegment;
  unique1 | unique2 | two | four | ten | twenty | hundred | thousand | twothousand | fivethous | tenthous | odd | even | stringu1 | stringu2 | string4 
 ---------+---------+-----+------+-----+--------+---------+----------+-------------+-----------+----------+-----+------+----------+----------+---------
@@ -982,6 +1071,9 @@ DROP TABLE IF EXISTS LINEITEM_2;
 DROP TABLE IF EXISTS LINEITEM_3;
 DROP TABLE IF EXISTS LINEITEM_4;
 DROP TABLE IF EXISTS LINEITEM_5;
+DROP TABLE IF EXISTS LINEITEM_6;
+DROP TABLE IF EXISTS LINEITEM_7;
+DROP TABLE IF EXISTS LINEITEM_8;
 -- end_ignore
 CREATE TABLE LINEITEM ( L_ORDERKEY INTEGER NOT NULL,
 L_PARTKEY INTEGER NOT NULL,
@@ -1009,6 +1101,9 @@ CREATE TABLE LINEITEM_2 (LIKE LINEITEM);
 CREATE TABLE LINEITEM_3 (LIKE LINEITEM);
 CREATE TABLE LINEITEM_4 (LIKE LINEITEM);
 CREATE TABLE LINEITEM_5 (LIKE LINEITEM);
+CREATE TABLE LINEITEM_6 (LIKE LINEITEM);
+CREATE TABLE LINEITEM_7 (LIKE LINEITEM);
+CREATE TABLE LINEITEM_8 (LIKE LINEITEM);
 COPY LINEITEM FROM '@abs_srcdir@/data/lineitem.csv' WITH DELIMITER '|' CSV;
 SELECT COUNT(*) FROM LINEITEM;
  count 
@@ -1018,6 +1113,7 @@ SELECT COUNT(*) FROM LINEITEM;
 
 COPY LINEITEM TO '/tmp/lineitem.csv' CSV;
 COPY LINEITEM TO '/tmp/lineitem_s<SEGID>.csv' ON SEGMENT CSV;
+COPY (select * from LINEITEM) TO '/tmp/lineitem_qs<SEGID>.csv' ON SEGMENT CSV;
 COPY LINEITEM_1 FROM '/tmp/lineitem.csv' CSV;
 SELECT COUNT(*) FROM LINEITEM_1;
  count 
@@ -1042,8 +1138,7 @@ SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_2;
 ------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+----------------+------------+-----------
 (0 rows)
 
-COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program.csv' CSV;
-COPY LINEITEM_3 FROM PROGRAM 'cat /tmp/lineitem_program.csv' CSV;
+COPY LINEITEM_3 FROM '/tmp/lineitem_qs<SEGID>.csv' ON SEGMENT CSV;
 SELECT COUNT(*) FROM LINEITEM_3;
  count 
 -------
@@ -1055,8 +1150,8 @@ SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_3;
 ------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+----------------+------------+-----------
 (0 rows)
 
-COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
-COPY LINEITEM_4 FROM PROGRAM 'cat /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program.csv' CSV;
+COPY LINEITEM_4 FROM PROGRAM 'cat /tmp/lineitem_program.csv' CSV;
 SELECT COUNT(*) FROM LINEITEM_4;
  count 
 -------
@@ -1068,8 +1163,8 @@ SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_4;
 ------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+----------------+------------+-----------
 (0 rows)
 
-\COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program_client.csv' CSV;
-\COPY LINEITEM_5 FROM PROGRAM 'cat /tmp/lineitem_program_client.csv' CSV;
+COPY (select * from LINEITEM) TO PROGRAM 'cat > /tmp/lineitem_program.csv' CSV;
+COPY LINEITEM_5 FROM PROGRAM 'cat /tmp/lineitem_program.csv' CSV;
 SELECT COUNT(*) FROM LINEITEM_5;
  count 
 -------
@@ -1077,6 +1172,45 @@ SELECT COUNT(*) FROM LINEITEM_5;
 (1 row)
 
 SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_5;
+ l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate | l_shipinstruct | l_shipmode | l_comment 
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+----------------+------------+-----------
+(0 rows)
+
+COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+COPY LINEITEM_6 FROM PROGRAM 'cat /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+SELECT COUNT(*) FROM LINEITEM_6;
+ count 
+-------
+ 57190
+(1 row)
+
+SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_6;
+ l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate | l_shipinstruct | l_shipmode | l_comment 
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+----------------+------------+-----------
+(0 rows)
+
+COPY (select * from LINEITEM) TO PROGRAM 'cat > /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+COPY LINEITEM_7 FROM PROGRAM 'cat /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+SELECT COUNT(*) FROM LINEITEM_7;
+ count 
+-------
+ 57190
+(1 row)
+
+SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_7;
+ l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate | l_shipinstruct | l_shipmode | l_comment 
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+----------------+------------+-----------
+(0 rows)
+
+\COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program_client.csv' CSV;
+\COPY LINEITEM_8 FROM PROGRAM 'cat /tmp/lineitem_program_client.csv' CSV;
+SELECT COUNT(*) FROM LINEITEM_8;
+ count 
+-------
+ 57190
+(1 row)
+
+SELECT * FROM LINEITEM EXCEPT SELECT * FROM LINEITEM_8;
  l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate | l_shipinstruct | l_shipmode | l_comment 
 ------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+----------------+------------+-----------
 (0 rows)
@@ -1269,6 +1403,8 @@ COPY COPY_TO_PROGRAM_ERROR TO PROGRAM 'echo && echo "error" >&2 && exit 255';
 ERROR:  command error message: error
 COPY COPY_TO_PROGRAM_ERROR TO PROGRAM 'echo <SEGID>&& echo "error" >&2 && exit 255' on segment;
 ERROR:  Error from segment 0: ERROR:  command error message: error
+COPY (SELECT * FROM COPY_TO_PROGRAM_ERROR) TO PROGRAM 'echo <SEGID>&& echo "error" >&2 && exit 255' on segment;
+ERROR:  command error message: error  (seg0 127.0.0.1:25432 pid=23338)
 CREATE TABLE COPY_FROM_PROGRAM_ERROR(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.


### PR DESCRIPTION
In ‘copy (select statement) to file’, we generate a query plan and set
its dest receivor to copy_dest_receive. And run the dest receivor on QD.
In 'copy (select statement) to file on segment', we modify the query plan,
delete gather mothon, and let dest receivor run on QE.

Change 'isCtas' in Query to 'parentStmtType' to be able to mark the upper
utility statement type. Add a CopyIntoClause node to store copy
informations. Add copyIntoClause to PlannedStmt.

In postgres, we don't need to make a different query plan for the
query in the utility stament. But in greenplum, we need to.
So we use a field to indicate whether the query is contained in utitily
statemnt, and the type of utitily statemnt.

Actually the behavior of 'copy (select statement) to file on segment'
is very similar to 'SELECT ... INTO ...' and 'CREATE TABLE ... AS SELECT ...'.
We use distribution policy inherent in the query result as the final data
distribution policy. If not, we use the first clomn in target list as the key,
and redistribute. The only difference is that we used 'copy_dest_receiver'
instead of 'intorel_dest_receiver'

The commit backport from "bad6cebc942ad2abc77b36b4d3a1d55236e33a18"

Co-authored-by: Wen Lin <wlin@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
