### PR TITLE
Don't discard const qualifier create_target_tablespace_layout

### DIFF
--- a/src/bin/pg_rewind/file_ops.c
+++ b/src/bin/pg_rewind/file_ops.c
@@ -281,24 +281,25 @@ static void
 create_target_tablespace_layout(const char *path, const char *link)
 {
 	char		dstpath[MAXPGPATH];
+	char		*newlink;
 
 	if (dry_run)
 		return;
 
 	/* Append the target dbid to the symlink target. */
-	link = psprintf("%s/%d", link, dbid_target);
+	newlink = psprintf("%s/%d", link, dbid_target);
 
 	snprintf(dstpath, sizeof(dstpath), "%s/%s", datadir_target, path);
-	if (symlink(link, dstpath) != 0)
+	if (symlink(newlink, dstpath) != 0)
 		pg_fatal("could not create symbolic link at \"%s\": %s\n",
 				 dstpath, strerror(errno));
 
 	/* We need to create the directory at the symlink target. */
-	if (mkdir(link, S_IRWXU) != 0)
+	if (mkdir(newlink, S_IRWXU) != 0)
 		pg_fatal("could not create directory \"%s\": %s\n",
 				 dstpath, strerror(errno));
 
-	pfree(link);
+	pfree(newlink);
 }
 
 


### PR DESCRIPTION
The function create_target_tablespace_layout() correctly decorates
link as a const and also follows the pattern of the rest of the
tablespace functions. Operate on a local pointer instead and don't
mutate on the referenced argument. Also, if the intension was to
mutate the referenced argument, then it should have first be pfreed.
