### PR TITLE
Report name of the index that conficts with proposed distribution key

### DIFF
--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1345,7 +1345,7 @@ CREATE TABLE t_dist1(col1 INTEGER, col2 INTEGER, CONSTRAINT pk_t_dist1 PRIMARY K
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "t_dist1_pkey" for table "t_dist1"
 ALTER TABLE t_dist1 SET DISTRIBUTED BY(col1); 
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  The DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX "t_dist1_pkey" columns.
 -- case 2
 CREATE TABLE t_dist2(col1 INTEGER, col2 INTEGER, col3 INTEGER, col4 INTEGER) DISTRIBUTED BY(col1);
 CREATE UNIQUE INDEX idx1_t_dist2 ON t_dist2(col1, col2);
@@ -1357,16 +1357,16 @@ HINT:  Use ALTER TABLE "t_dist2" SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (col1
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col1, col2); 
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col1, col2, col3); 
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  The DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX "idx1_t_dist2" columns.
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col3); 
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  The DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX "idx1_t_dist2" columns.
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col4); 
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  The DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX "idx1_t_dist2" columns.
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col2);
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  The DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX "idx1_t_dist2" columns.
 ALTER TABLE t_dist2 SET DISTRIBUTED BY(col2, col1);
 ERROR:  UNIQUE INDEX and DISTRIBUTED BY definitions incompatible
-HINT:  the DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX columns.
+HINT:  The DISTRIBUTED BY columns must be equal to or a left-subset of the UNIQUE INDEX "idx1_t_dist2" columns.


### PR DESCRIPTION
It seems useful to report the name of the first index whose key
conflicts with proposed distribution policy in the warning message.
