### PR TITLE
Add logic to handle ModifyTableState in slice dependency

### DIFF
--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -899,6 +899,14 @@ ExecSliceDependencyNode(PlanState *node)
 		for (; i < ss->numSubplans; ++i)
 			ExecSliceDependencyNode(ss->subplans[i]);
 	}
+	else if (nodeTag(node) == T_ModifyTableState)
+	{
+		int			i = 0;
+		ModifyTableState *mt = (ModifyTableState *) node;
+
+		for (; i < mt->mt_nplans; ++i)
+			ExecSliceDependencyNode(mt->mt_plans[i]);
+	}
 
 	ExecSliceDependencyNode(outerPlanState(node));
 	ExecSliceDependencyNode(innerPlanState(node));


### PR DESCRIPTION
This was caught in the 9.5 merge iteration where reader/writer slices
were blocking each other because the ModifyTableState node type was
not being handled in the recursion. In master, this issue is somehow
being masked by planner by running an unneeded redistribute motion.

For example, on master:
```
                                                  QUERY PLAN
--------------------------------------------------------------------------------------------------------------
 Insert on public.newfoo  (cost=0.85..4.62 rows=4 width=8)
   ->  Hash Join  (cost=0.85..4.53 rows=4 width=8)
         Output: subfoo.c, share0_ref1.a
         Hash Cond: (subfoo.c = share0_ref1.b)
         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.33..3.86 rows=4 width=4)
               Output: subfoo.c, subfoo.a
               Hash Key: subfoo.c
               ->  Subquery Scan on subfoo  (cost=0.33..3.66 rows=4 width=4)
                     Output: subfoo.c, subfoo.a
                     ->  Hash Join  (cost=0.33..3.56 rows=4 width=8)
                           Output: cte.a, bar.c
                           Hash Cond: (bar.c = cte.a)
                           ->  Seq Scan on public.bar  (cost=0.00..3.10 rows=4 width=4)
                                 Output: bar.c
                       ->  Hash  (cost=0.20..0.20 rows=4 width=4)
                                 Output: cte.a
                                 ->  Subquery Scan on cte  (cost=0.00..0.20 rows=4 width=4)
                                       Output: cte.a
                                       ->  Shared Scan (share slice:id 1:0)  (cost=3.15..3.36 rows=4 width=8)
                                             Output: share0_ref2.a, share0_ref2.b
         ->  Hash  (cost=0.40..0.40 rows=4 width=8)
               Output: share0_ref1.a, share0_ref1.b
               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..0.40 rows=4 width=8)
                     Output: share0_ref1.a, share0_ref1.b
                     Hash Key: share0_ref1.b
                     ->  Shared Scan (share slice:id 2:0)  (cost=3.15..3.36 rows=4 width=8)
                           Output: share0_ref1.a, share0_ref1.b
                           ->  Materialize  (cost=0.00..3.15 rows=4 width=8)
                                 Output: foo.a, foo.b
                                 ->  Seq Scan on public.foo  (cost=0.00..3.10 rows=4 width=8)
                                       Output: foo.a, foo.b
 Optimizer: Postgres query optimizer
 Settings: gp_cte_sharing=on
(33 rows)
```

vs. on 9.5 merge branch:
```
                                               QUERY PLAN
--------------------------------------------------------------------------------------------------------
 Insert on public.newfoo  (cost=0.85..4.43 rows=4 width=8)
   ->  Hash Join  (cost=0.85..4.33 rows=4 width=8)
         Output: subfoo.c, share0_ref1.a
         Hash Cond: (subfoo.c = share0_ref1.b)
         ->  Subquery Scan on subfoo  (cost=0.33..3.66 rows=4 width=4)
               Output: subfoo.c
               ->  Hash Join  (cost=0.33..3.56 rows=4 width=4)
                     Output: NULL::integer, bar.c
                     Hash Cond: (bar.c = cte.a)
                     ->  Seq Scan on public.bar  (cost=0.00..3.10 rows=4 width=4)
                           Output: bar.c
                     ->  Hash  (cost=0.20..0.20 rows=4 width=4)
                       Output: cte.a
                           ->  Subquery Scan on cte  (cost=0.00..0.20 rows=4 width=4)
                                 Output: cte.a
                                 ->  Shared Scan (share slice:id 0:0)  (cost=3.15..3.36 rows=4 width=8)
                                       Output: share0_ref2.a, share0_ref2.b
         ->  Hash  (cost=0.40..0.40 rows=4 width=8)
               Output: share0_ref1.a, share0_ref1.b
               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..0.40 rows=4 width=8)
                     Output: share0_ref1.a, share0_ref1.b
                     Hash Key: share0_ref1.b
                     ->  Shared Scan (share slice:id 1:0)  (cost=3.15..3.36 rows=4 width=8)
                           Output: share0_ref1.a, share0_ref1.b
                           ->  Materialize  (cost=0.00..3.15 rows=4 width=8)
                                 Output: foo.a, foo.b
                                 ->  Seq Scan on public.foo  (cost=0.00..3.10 rows=4 width=8)
                                       Output: foo.a, foo.b
 Optimizer: Postgres query optimizer
 Settings: gp_cte_sharing=on
(30 rows)
```

However, this issue could manifest depending on the plan costing so we
should fix this on master and 6X_STABLE.

Not sure how to write a query to generate the plan needed to test this but existing tests will be sufficient when the 9.5 merge branch (with the new planner optimizations) is merged into master.

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>