### PR TITLE
Remove aix5 support

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -146,9 +146,6 @@ function export_gpdb_extensions() {
       chmod 755 greenplum-*zip*
       cp greenplum-*zip* "${GPDB_ARTIFACTS_DIR}/"
     fi
-    if ls "$GPDB_ARTIFACTS_DIR"/*.gppkg 1>/dev/null 2>&1; then
-      chmod 755 "$GPDB_ARTIFACTS_DIR"/*.gppkg
-    fi
   popd
 }
 

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -141,7 +141,7 @@ ifneq "$(findstring $(BLD_ARCH),suse11_x86_64 sles11_x86_64)" ""
 APU_CONFIG=--with-apu-config=$(BLD_THIRDPARTY_BIN_DIR)/apu-1-config
 endif
 
-ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_64 aix5_ppc_32)" ""
+ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
 APR_CONFIG=--with-apr-config=$(BLD_THIRDPARTY_BIN_DIR)/apr-1-config
 endif
 
@@ -162,7 +162,7 @@ CONFIGFLAGS+= $(CONFIGURE_FLAGS)
 endif
 
 # PL/Python does not compile on Tiger, skipping it on AIX
-ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_64 aix5_ppc_32)" ""
+ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
 PG_LANG=false
 endif
 
@@ -181,8 +181,6 @@ endif
 endif
 
 # Configure in the extra path AIX requires for pthread support
-aix5_ppc_64_PTHREADS_LIB_DIR=/usr/lib/threads
-aix5_ppc_32_PTHREADS_LIB_DIR=/usr/lib/threads
 aix7_ppc_64_PTHREADS_LIB_DIR=/usr/lib/threads
 BLD_PTHREADS_LIB_DIR=$($(BLD_ARCH)_PTHREADS_LIB_DIR)
 
@@ -193,22 +191,20 @@ CONFIGFLAGS+= --with-includes="$(CONFIG_INCLUDES)" --with-libraries="$(CONFIG_LI
 
 # Configure in "authlibs"...
 # ...without an ext/ dir copy of curl-config on Tiger or AIX
-ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_64 aix5_ppc_32 rhel6_x86_64 rhel7_x86_64)" ""
+ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 rhel6_x86_64 rhel7_x86_64)" ""
 BLD_CURL_CONFIG=CURL_CONFIG=$(BLD_THIRDPARTY_BIN_DIR)/curl-config
 endif
 # ...and do not include the authlibs on Windows or AIX
-ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_64 win32 win64)" ""
+ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 win32 win64)" ""
 CONFIGFLAGS+= --with-openssl --with-pam --with-ldap $(BLD_CURL_CONFIG) $(APR_CONFIG)
 endif
 
 # ...but do include some of the authlibs on AIX
-ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64 aix5_ppc_32 aix5_ppc_64)" ""
+ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
 CONFIGFLAGS+= --with-openssl --with-pam --without-krb5 --with-ldap $(BLD_CURL_CONFIG)
 endif
 
 # Platform-specific config flags
-aix5_ppc_64_CONFIG_ADDITIONS=LDFLAGS="-Wl,-bbigtoc -L/usr/lib/threads"
-aix5_ppc_32_CONFIG_ADDITIONS=LDFLAGS="-L/usr/lib/threads"
 aix7_ppc_64_CONFIG_ADDITIONS=LDFLAGS="-Wl,-bbigtoc -L/usr/lib/threads"
 
 win32_GPFDIST_LDFLAGS += -L/usr/i686-pc-mingw32/sys-root/mingw/lib -L$(GPPGDIR)/src/bin/gpfdist/ext/lib
@@ -229,8 +225,6 @@ RECONFIG :
 	rm -f $(GPPGDIR)/GNUmakefile
 
 # avoid AIX's restricted shell
-aix5_ppc_64_CONFIG_SHELL=/usr/bin/bash
-aix5_ppc_32_CONFIG_SHELL=/usr/bin/bash
 aix7_ppc_64_CONFIG_SHELL=/usr/bin/bash
 BLD_CONFIG_SHELL=$($(BLD_ARCH)_CONFIG_SHELL)
 $(GPPGDIR)/GNUmakefile : $(GPPGDIR)/configure  env.sh
@@ -288,8 +282,6 @@ BLD_LD_LIBRARY_PATH:=$($(BLD_ARCH)_LD_LIBRARY_PATH):$($(BLD_WHERE_THE_LIBRARY_TH
 export $(BLD_WHERE_THE_LIBRARY_THINGS_ARE)=$(BLD_LD_LIBRARY_PATH)
 
 # how much of GPDB to build by platform (default is "full")
-aix5_ppc_64_GPDB_BUILDSET=partial
-aix5_ppc_32_GPDB_BUILDSET=partial
 aix7_ppc_64_GPDB_BUILDSET=aix_subset
 win64_GPDB_BUILDSET=partial
 win32_GPDB_BUILDSET=partial
@@ -502,8 +494,6 @@ CLIENTS_FILESET_BINEXT = $(strip $(tmpCLIENTS_FILESET_BINEXT))
 
 # define python file subset to ship by platform, as desired
 BLD_PYTHON_FILESET=.
-aix5_ppc_32_PYTHON_FILESET=bin/python* lib/python* include/python*
-aix5_ppc_64_PYTHON_FILESET=bin/python* lib/python* include/python*
 aix7_ppc_64_PYTHON_FILESET=bin/python* lib/*python* lib64/*python* include/python*
 ifneq "$($(BLD_ARCH)_PYTHON_FILESET)" ""
 BLD_PYTHON_FILESET=$($(BLD_ARCH)_PYTHON_FILESET)
@@ -528,12 +518,8 @@ aix7_ppc_64_CLIENTS_LIBS_GCC_LOC=/opt/freeware/lib/gcc/powerpc-ibm-aix7.1.0.0/4.
 FILESET_LIB_GCC=$($(BLD_ARCH)_CLIENTS_LIBS_GCC)
 FILESET_LIB_GCC_LOC=$($(BLD_ARCH)_CLIENTS_LIBS_GCC_LOC)
 
-aix5_ppc_32_CLIENTS_LIBS_PERZL=libz.a
-aix5_ppc_64_CLIENTS_LIBS_PERZL=libz.so libz.so.1 libz.so.1.2.4 libcrypto.so libcrypto.so.0.9.8 libssl.so libssl.so.0.9.8
 aix7_ppc_64_CLIENTS_LIBS_PERZL=libcrypto.a libssl.a
 
-aix5_ppc_32_CLIENTS_LIBS_PERZL_LOC=/opt/freeware/lib
-aix5_ppc_64_CLIENTS_LIBS_PERZL_LOC=/opt/pware64/lib
 aix7_ppc_64_CLIENTS_LIBS_PERZL_LOC=$(BLD_TOP)/ext/aix7_ppc_64/lib
 
 CLIENTS_FILESET_LIB_PERZL=$($(BLD_ARCH)_CLIENTS_LIBS_PERZL)

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -13,8 +13,6 @@ endif
 
 # include thirdparty infrastructure which depends on WHERE_THE...
 BLD_WHERE_THE_LIBRARY_THINGS_ARE=LD_LIBRARY_PATH
-aix5_ppc_64_WHERE_THE_LIBRARY_THINGS_ARE=LIBPATH
-aix5_ppc_32_WHERE_THE_LIBRARY_THINGS_ARE=LIBPATH
 aix7_ppc_64_WHERE_THE_LIBRARY_THINGS_ARE=LIBPATH
 ifneq "$($(BLD_ARCH)_WHERE_THE_LIBRARY_THINGS_ARE)" ""
 BLD_WHERE_THE_LIBRARY_THINGS_ARE=$($(BLD_ARCH)_WHERE_THE_LIBRARY_THINGS_ARE)
@@ -46,8 +44,6 @@ endif
 
 # take over the path
 ifneq "$(BLD_PATH_FIXED)" "true"
-aix5_ppc_64_PATH_PREPEND=/opt/freeware/bin
-aix5_ppc_32_PATH_PREPEND=/opt/freeware/bin
 aix7_ppc_64_PATH_PREPEND=/opt/freeware/bin
 BLD_PATH_PREPEND=$($(BLD_ARCH)_PATH_PREPEND)
 ifneq "$(BLD_PATH_PREPEND)" ""
@@ -57,8 +53,6 @@ export BLD_PATH_FIXED=true
 endif
 
 # take over the library search path
-aix5_ppc_64_LD_LIBRARY_PATH_PREPEND=/opt/freeware/lib
-aix5_ppc_32_LD_LIBRARY_PATH_PREPEND=/opt/freeware/lib
 aix7_ppc_64_LD_LIBRARY_PATH_PREPEND=/opt/freeware/lib
 BLD_LD_LIBRARY_PATH_PREPEND=$($(BLD_ARCH)_LD_LIBRARY_PATH_PREPEND)
 ifneq "$(BLD_LD_LIBRARY_PATH_PREPEND)" ""
@@ -67,8 +61,6 @@ endif
 export BLD_LD_LIBRARY_PATH_FIXED=true
 
 # specify python version to use for build-time and run-time
-aix5_ppc_32_PYTHONHOME=/opt/pware
-aix5_ppc_64_PYTHONHOME=/opt/pware64
 aix7_ppc_64_PYTHONHOME=/opt/freeware
 rhel6_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
 rhel7_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
@@ -82,8 +74,6 @@ endif
 export PYTHON=python
 ifneq "$(PYTHONHOME)" ""
 export PYTHON=$(PYTHONHOME)/bin/python
-aix5_ppc_32_PYTHON=$(PYTHONHOME)/bin/python2.7
-aix5_ppc_64_PYTHON=$(PYTHONHOME)/bin/python2.7_64
 aix7_ppc_64_PYTHON=$(PYTHONHOME)/bin/python2.7_64
 ifneq "$($(BLD_ARCH)_PYTHON)" ""
 export PYTHON=$($(BLD_ARCH)_PYTHON)
@@ -92,7 +82,7 @@ endif
 
 # if PYTHONHOME was specified above, use it for the build
 ifneq "$(PYTHONHOME)" ""
-ifeq "$(findstring $(BLD_ARCH),aix5_ppc_32 aix5_ppc_64 aix7_ppc_64)" ""
+ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
 tmpPATH=$(PYTHONHOME)/bin:$(PATH)
 export PATH:=$(tmpPATH)
 tmpLD_LIBRARY_PATH=$(PYTHONHOME)/lib:$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))
@@ -120,29 +110,20 @@ suse11_x86_64_BLD_CFLAGS=-m64
 sles11_x86_64_BLD_CFLAGS=-m64
 win64_BLD_CFLAGS=-m64
 win32_BLD_CFLAGS=-m32
-aix5_ppc_64_BLD_CFLAGS=-maix64
 aix7_ppc_64_BLD_CFLAGS=-maix64
-aix5_ppc_32_BLD_CFLAGS=
 BLD_CFLAGS=$($(BLD_ARCH)_BLD_CFLAGS)
 
-aix5_ppc_64_BLD_LDFLAGS=-maix64 -Wl,-bbigtoc
 aix7_ppc_64_BLD_LDFLAGS=-maix64 -Wl,-bbigtoc
 BLD_LDFLAGS=$($(BLD_ARCH)_BLD_LDFLAGS)
 
 # See http://www.postgresql.org/docs/faqs.FAQ_AIX.html for an explanation of this
-ifneq "$(findstring $(BLD_ARCH), aix5_ppc_64 aix7_ppc_64)" ""
+ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
 export OBJECT_MODE=64
-export CONFIG_SHELL=/usr/bin/bash
-endif
-ifeq "$(BLD_ARCH)" "aix5_ppc_32"
-export OBJECT_MODE=32
 export CONFIG_SHELL=/usr/bin/bash
 endif
 
 BLD_BITS:=$(strip $(findstring 32,$(BLD_ARCH)) $(findstring 64,$(BLD_ARCH)))
 ifeq "$(BLD_BITS)" ""
-aix5_ppc_64_BLD_BITS=64
-aix5_ppc_32_BLD_BITS=32
 aix7_ppc_64_BLD_BITS=64
 BLD_BITS=$($(BLD_ARCH)_BLD_BITS)
 endif
@@ -157,8 +138,6 @@ endif
 
 # grep by platform
 GREP=grep
-aix5_ppc_64_GREP=/opt/freeware/bin/grep
-aix5_ppc_32_GREP=/opt/freeware/bin/grep
 aix7_ppc_64_GREP=/opt/freeware/bin/grep
 ifneq "$($(BLD_ARCH)_GREP)" ""
 GREP=$($(BLD_ARCH)_GREP)
@@ -166,16 +145,12 @@ endif
 
 # tar by platform
 TAR=tar
-aix5_ppc_32_TAR=gtar
-aix5_ppc_64_TAR=gtar
 aix7_ppc_64_TAR=gtar
 ifneq "$($(BLD_ARCH)_TAR)" ""
 TAR=$($(BLD_ARCH)_TAR)
 endif
 
 # awk by platform
-aix5_ppc_32_AWK=gawk
-aix5_ppc_64_AWK=gawk
 aix7_ppc_64_AWK=gawk
 ifneq "$($(BLD_ARCH)_AWK)" ""
 AWK=$($(BLD_ARCH)_AWK)

--- a/gpAux/Makefile.thirdparty
+++ b/gpAux/Makefile.thirdparty
@@ -20,8 +20,6 @@ ifeq "$(BLD_ARCH)" ""
 BLD_ARCH:=$(shell $(BLD_TOP)/releng/set_bld_arch.sh)
 endif
 
-aix5_ppc_64_BLD_BITS=64
-aix5_ppc_32_BLD_BITS=32
 aix7_ppc_64_BLD_BITS=64
 rhel6_x86_64_BLD_BITS=64
 rhel7_x86_64_BLD_BITS=64


### PR DESCRIPTION
Remove supporting architectures for AIX, because aix5_ppc_64, aix5_ppc_32 is no longer in use, so remove them
Refer: https://groups.google.com/a/pivotal.io/forum/#!searchin/gp-releng/sync_tools%7Csort:date/gp-releng/-uu_bR3Sx2s/bk1nebiu

Another tiny clean up in gppkg, this is a follow up clean up for https://github.com/greenplum-db/gpdb/pull/7727

