### PR TITLE
Enable quicklz tests during ICW

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -1082,6 +1082,10 @@ jobs:
       resource: binary_swap_gpdb_centos6
       trigger: [[ test_trigger ]]
     - get: gpdb6-centos6-test
+    - get: libquicklz-installer
+      resource: libquicklz-centos6
+    - get: libquicklz-devel-installer
+      resource: libquicklz-devel-centos6
   - task: ic_gpdb
     file: gpdb_src/concourse/tasks/ic_gpdb_binary_swap.yml
     image: gpdb6-centos6-test
@@ -1101,6 +1105,10 @@ jobs:
       passed: [compile_gpdb_centos6]
       trigger: [[ test_trigger ]]
     - get: gpdb6-centos6-test
+    - get: libquicklz-installer
+      resource: libquicklz-centos6
+    - get: libquicklz-devel-installer
+      resource: libquicklz-devel-centos6
   - task: ic_gpdb
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
@@ -1123,6 +1131,10 @@ jobs:
       passed: [compile_gpdb_centos6]
       trigger: [[ test_trigger ]]
     - get: gpdb6-centos6-test
+    - get: libquicklz-installer
+      resource: libquicklz-centos6
+    - get: libquicklz-devel-installer
+      resource: libquicklz-devel-centos6
   - task: ic_gpdb
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
@@ -1142,6 +1154,10 @@ jobs:
       passed: [compile_gpdb_centos6]
       trigger: [[ test_trigger ]]
     - get: gpdb6-centos6-test
+    - get: libquicklz-installer
+      resource: libquicklz-centos6
+    - get: libquicklz-devel-installer
+      resource: libquicklz-devel-centos6
   - task: ic_gpdb
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
@@ -1161,6 +1177,10 @@ jobs:
       passed: [compile_gpdb_centos7]
       trigger: [[ test_trigger ]]
     - get: gpdb6-centos7-test
+    - get: libquicklz-installer
+      resource: libquicklz-centos7
+    - get: libquicklz-devel-installer
+      resource: libquicklz-devel-centos7
   - task: ic_gpdb
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos7-test
@@ -1179,6 +1199,10 @@ jobs:
       resource: bin_gpdb_centos7
       trigger: [[ test_trigger ]]
     - get: gpdb6-centos7-test
+    - get: libquicklz-installer
+      resource: libquicklz-centos7
+    - get: libquicklz-devel-installer
+      resource: libquicklz-devel-centos7
   - task: ic_gpdb
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos7-test
@@ -1286,6 +1310,10 @@ jobs:
       resource: bin_gpdb_centos6
       trigger: [[ test_trigger ]]
     - get: gpdb6-centos6-test
+    - get: libquicklz-installer
+      resource: libquicklz-centos6
+    - get: libquicklz-devel-installer
+      resource: libquicklz-devel-centos6
   - task: ic_gpdb
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -35,7 +35,7 @@ function configure() {
       # The full set of configure options which were used for building the
       # tree must be used here as well since the toplevel Makefile depends
       # on these options for deciding what to test. Since we don't ship
-      ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python --with-libxml --enable-mapreduce --enable-orafce --enable-tap-tests --disable-orca --with-openssl ${CONFIGURE_FLAGS}
+      ./configure --prefix=/usr/local/greenplum-db-devel --with-quicklz --with-perl --with-python --with-libxml --enable-mapreduce --enable-orafce --enable-tap-tests --disable-orca --with-openssl ${CONFIGURE_FLAGS}
 
   popd
 }

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -44,6 +44,16 @@ function setup_gpadmin_user() {
     ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash "$TEST_OS"
 }
 
+function install_quicklz() {
+  # quicklz is proprietary code that we cannot put in our public Docker images.
+  if [ -d libquicklz-installer ]; then
+    rpm -i libquicklz-installer/libquicklz-*.rpm
+  fi
+  if [ -d libquicklz-devel-installer ]; then
+    rpm -i libquicklz-devel-installer/libquicklz-*.rpm
+  fi
+}
+
 function _main() {
     if [ -z "${MAKE_TEST_COMMAND}" ]; then
         echo "FATAL: MAKE_TEST_COMMAND is not set"
@@ -64,6 +74,7 @@ function _main() {
       ;;
     esac
 
+    time install_quicklz
     time install_and_configure_gpdb
     time setup_gpadmin_user
     time make_cluster

--- a/concourse/tasks/ic_gpdb.yml
+++ b/concourse/tasks/ic_gpdb.yml
@@ -4,6 +4,8 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
+  - name: libquicklz-installer
+  - name: libquicklz-devel-installer
 outputs:
   - name: sqldump
 params:

--- a/gpcontrib/quicklz/expected/compression_quicklz.out
+++ b/gpcontrib/quicklz/expected/compression_quicklz.out
@@ -43,7 +43,7 @@ SELECT * FROM quicklztest_row ORDER BY id DESC LIMIT 4;
 SELECT get_ao_compression_ratio('quicklztest_row');
  get_ao_compression_ratio 
 --------------------------
-                      1.8
+                     1.83
 (1 row)
 
 -- Test for appendonly column oriented

--- a/gpcontrib/quicklz/expected/quicklz_column_compression.out
+++ b/gpcontrib/quicklz/expected/quicklz_column_compression.out
@@ -56,7 +56,7 @@ insert into aoco_table_compressed_type select '123456'::int42 from generate_seri
 select get_ao_compression_ratio('aoco_table_compressed_type') as quicklz_compress_ratio;
  quicklz_compress_ratio 
 ------------------------
-                   17.2
+                  17.17
 (1 row)
 
 -- Given an AO/RO table using the int42 type with quicklz compresstype


### PR DESCRIPTION
- need to install libquicklz-devel in order to run configure with
  quicklz enabled before running ICW on CentOS

Co-authored-by: Jesse Zhang <jzhang@pivotal.io>
Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>
