### PR TITLE
Gpconfig quoting

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -375,8 +375,10 @@ def do_change(options):
 # the quote_literal() function in Postgres.
 def quote_string(guc, value):
     if value is not None and guc and guc.vartype == "string":
-        # Escape single quotes and backslashes
-        value = value.replace("'", "''").replace("\\", "\\\\")
+        # Escape single quotes, backslashes, and newlines
+        value = value.replace("'", "''") \
+                     .replace("\\", "\\\\") \
+                     .replace("\n", "\\n")
         # Single-quote the whole string
         value = "'" + value + "'"
     return value

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -375,13 +375,10 @@ def do_change(options):
 # the quote_literal() function in Postgres.
 def quote_string(guc, value):
     if value is not None and guc and guc.vartype == "string":
-        # Remove any existing single-quoting
-        if len(value) > 2 and value[0] == "'" and value[-1] == "'":
-            value = value[1:-1]
         # Escape single quotes and backslashes
         value = value.replace("'", "''").replace("\\", "\\\\")
         # Single-quote the whole string
-        value  = "'" + value + "'"
+        value = "'" + value + "'"
     return value
 
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -516,6 +516,12 @@ class GpConfig(GpTestCase):
         result = self.subject.quote_string(self.guc, value)
         self.assertEqual(result, expected)
 
+    def test_quote_string_with_newline(self):
+        value = "test\nstring"
+        expected = "'test\\nstring'"
+        result = self.subject.quote_string(self.guc, value)
+        self.assertEqual(result, expected)
+
     def setup_for_testing_quoting_string_values(self, vartype, value, additional_args=None):
         sys.argv = ["gpconfig", "--change", "my_property_name", "--value", value]
         if additional_args:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -492,12 +492,6 @@ class GpConfig(GpTestCase):
         result = self.subject.quote_string(self.guc, value)
         self.assertEqual(result, expected)
 
-    def test_quote_string_already_quoted(self):
-        value = "'teststring'"
-        expected = "'teststring'"
-        result = self.subject.quote_string(self.guc, value)
-        self.assertEqual(result, expected)
-
     def test_quote_string_quoted_with_double_quotes(self):
         value = "\"teststring\""
         expected = "'\"teststring\"'"
@@ -551,11 +545,11 @@ class GpConfig(GpTestCase):
         self.validation_for_testing_quoting_string_values(expected_value="'baz'")
 
     def test_change_of_master_value_with_quotes_succeeds(self):
-        already_quoted_master_value = "'baz'"
+        already_quoted_master_value = "'ba'z'"
         vartype = 'string'
-        self.setup_for_testing_quoting_string_values(vartype=vartype, value='baz', additional_args=['--mastervalue', already_quoted_master_value])
+        self.setup_for_testing_quoting_string_values(vartype=vartype, value=already_quoted_master_value, additional_args=['--mastervalue', already_quoted_master_value])
         self.subject.do_main()
-        self.validation_for_testing_quoting_string_values(expected_value="'baz'")
+        self.validation_for_testing_quoting_string_values(expected_value="'''ba''z'''")
 
     def test_change_of_master_only_quotes_succeeds(self):
         unquoted_master_value = "baz"

--- a/gpMgmt/sbin/gpconfig_helper.py
+++ b/gpMgmt/sbin/gpconfig_helper.py
@@ -111,7 +111,7 @@ def add_parameter(filename, name, value):
             outfile.write(line)
             new_lines = new_lines + 1
         outfile.write(bytes(name) + '=' +
-                      bytes(pickle.loads(base64.urlsafe_b64decode(value)).replace('"', '\\\"')) +
+                      bytes(pickle.loads(base64.urlsafe_b64decode(value))) +
                       os.linesep)
         new_lines = new_lines + 1
 

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -11,7 +11,7 @@ Feature: gpconfig integration tests
 
     @concourse_cluster
     @demo_cluster
-    Scenario Outline: run each gpconfig command for guc type: <type>
+    Scenario Outline: running gpconfig test case: <test_case>, for guc type: <type>
       Given the user runs "gpstop -u"
         And gpstop should return a return code of 0
         And the gpconfig context is setup
@@ -64,21 +64,25 @@ Feature: gpconfig integration tests
         And gpconfig should print "Master  value: <live_value_master>" escaped to stdout
         And gpconfig should print "Segment value: <live_value>" escaped to stdout
 
-    # test for each type documented for gpconfig
     Examples:
-        | guc                          | type     | seed_value | value    | file_value | live_value | value_master_only | file_value_master_only | value_master | file_value_master | live_value_master |
-        | log_connections              |  bool    | off        | on       | on         | on         | off               | off                    | off          | off               | off               |
-        | gp_resgroup_memory_policy    |  enum    | eager_free | auto     | auto       | auto       | eager_free        | eager_free             | eager_free   | eager_free        | eager_free        |
-        | vacuum_cost_limit            |  integer | 300        | 400      | 400        | 400        | 555               | 555                    | 500          | 500               | 500               |
-        | checkpoint_completion_target |  real    | 0.4        | 0.5      | 0.5        | 0.5        | 0.33              | 0.33                   | 0.7          | 0.7               | 0.7               |
-        | application_name             |  string  | xxxxxx     | bodhi    | 'bodhi'    | bodhi      | lucy              | 'lucy'                 | bengie       | 'bengie'          | bengie            |
-        | application_name             |  string  | yyyyyy     | 'bod hi' | 'bod hi'   | bod hi     | 'lu cy'           | 'lu cy'                | 'ben gie'    | 'ben gie'         | ben gie           |
-        | application_name             |  string  | zzzzzz     | ''       | ''         |            | ''                | ''                     | ''           | ''                |                   |
-        | application_name             |  string  | zzzzzz     | '"hi"'   | '"hi"'     | "hi"       | '"hi"'            | '"hi"'                 | '"hi"'       | '"hi"'            | "hi"              |
-        | application_name             |  string  | zzzzzz     | "'hi'"   | '''hi'''   | 'hi'       | "'hi'"            | '''hi'''               | "'hi'"       | '''hi'''          | 'hi'              |
-        | application_name             |  string  | boo        | "\'"     | '\\'''     | \'         | "\'"              | '\\'''                 | "\'"         | '\\'''            | \'                |
-        | application_name             |  string  | boo        | "''''"   | '''''''''' | ''''       | "''"              | ''''''                 | "'"          | ''''              | '                 |
-        | search_path                  |  string  | boo        | Ομήρου   | 'Ομήρου'   | Ομήρου     | Ομήρου            | 'Ομήρου'               | Ομήρου       | 'Ομήρου'          | Ομήρου            |
+        | test_case                              | guc                          | type       | seed_value | value     | file_value | live_value | value_master_only | file_value_master_only | value_master | file_value_master | live_value_master |
+        | bool                                   | log_connections              | bool       | off        | on        | on         | on         | off               | off                    | off          | off               | off               |
+        | enum                                   | gp_resgroup_memory_policy    | enum       | eager_free | auto      | auto       | auto       | eager_free        | eager_free             | eager_free   | eager_free        | eager_free        |
+        | integer                                | vacuum_cost_limit            | integer    | 300        | 400       | 400        | 400        | 555               | 555                    | 500          | 500               | 500               |
+        | integer with memory unit               | statement_mem                | int w/unit | 123MB      | 500MB     | 500MB      | 500MB      | 500MB             | 500MB                  | 500MB        | 500MB             | 500MB             |
+        | integer with time unit                 | statement_timeout            | int w/unit | 1min       | 5min      | 5min       | 5min       | 5min              | 5min                   | 5min         | 5min              | 5min              |
+        | float                                  | checkpoint_completion_target | float      | 0.4        | 0.5       | 0.5        | 0.5        | 0.33              | 0.33                   | 0.7          | 0.7               | 0.7               |
+        | basic string                           | application_name             | string     | xxxxxx     | bodhi     | 'bodhi'    | bodhi      | lucy              | 'lucy'                 | bengie       | 'bengie'          | bengie            |
+        | string with spaces                     | application_name             | string     | yyyyyy     | 'bod hi'  | 'bod hi'   | bod hi     | 'bod hi'          | 'bod hi'               | 'bod hi'     | 'bod hi'          | bod hi            |
+        | different value on master and segments | application_name             | string     | yyyyyy     | 'bod hi'  | 'bod hi'   | bod hi     | 'lu cy'           | 'lu cy'                | 'ben gie'    | 'ben gie'         | ben gie           |
+        | empty string                           | application_name             | string     | zzzzzz     | ''        | ''         |            | ''                | ''                     | ''           | ''                |                   |
+        | quoted double quotes                   | application_name             | string     | zzzzzz     | '"hi"'    | '"hi"'     | "hi"       | '"hi"'            | '"hi"'                 | '"hi"'       | '"hi"'            | "hi"              |
+        | quoted single quotes                   | application_name             | string     | zzzzzz     | "'hi'"    | '''hi'''   | 'hi'       | "'hi'"            | '''hi'''               | "'hi'"       | '''hi'''          | 'hi'              |
+        | escaped single quote                   | application_name             | string     | boo        | "\'"      | '\\'''     | \'         | "\'"              | '\\'''                 | "\'"         | '\\'''            | \'                |
+        | multiple quoted single quotes          | application_name             | string     | boo        | "''''"    | '''''''''' | ''''       | "''"              | ''''''                 | "'"          | ''''              | '                 |
+        | utf-8 works                            | search_path                  | string     | boo        | Ομήρου    | 'Ομήρου'   | Ομήρου     | Ομήρου            | 'Ομήρου'               | Ομήρου       | 'Ομήρου'          | Ομήρου            |
+#       | integer with time unit with spaces     | statement_timeout            | int w/unit | 2min       | "'7 min'" | '7 min'    | 7min       | "'7 min'"         | '7 min'                | "'7 min'"    | '7 min'           | 7min              |
+# 'Integer with time unit with spaces' fails because the live server parses '7 min' as 7min, and our comparison logic does not handle this correctly.
 
     @concourse_cluster
     @demo_cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -76,7 +76,8 @@ Feature: gpconfig integration tests
         | application_name             |  string  | xxxxxx     | bodhi    | 'bodhi'    | bodhi      | lucy              | 'lucy'                 | bengie       | 'bengie'          | bengie            |
         | application_name             |  string  | yyyyyy     | 'bod hi' | 'bod hi'   | bod hi     | 'lu cy'           | 'lu cy'                | 'ben gie'    | 'ben gie'         | ben gie           |
         | application_name             |  string  | zzzzzz     | ''       | ''         |            | ''                | ''                     | ''           | ''                |                   |
-        | application_name             |  string  | boo        | "'\''"   | '\\'''     | \'         | "'\''"            | '\\'''                 | "'\''"       | '\\'''            | \'                |
+        | application_name             |  string  | boo        | "\'"     | '\\'''     | \'         | "\'"              | '\\'''                 | "\'"         | '\\'''            | \'                |
+        | application_name             |  string  | boo        | "''''"   | '''''''''' | ''''       | "''"              | ''''''                 | "'"          | ''''              | '                 |
 
     @concourse_cluster
     @demo_cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -78,6 +78,7 @@ Feature: gpconfig integration tests
         | application_name             |  string  | zzzzzz     | ''       | ''         |            | ''                | ''                     | ''           | ''                |                   |
         | application_name             |  string  | boo        | "\'"     | '\\'''     | \'         | "\'"              | '\\'''                 | "\'"         | '\\'''            | \'                |
         | application_name             |  string  | boo        | "''''"   | '''''''''' | ''''       | "''"              | ''''''                 | "'"          | ''''              | '                 |
+        | search_path                  |  string  | boo        | Ομήρου   | 'Ομήρου'   | Ομήρου     | Ομήρου            | 'Ομήρου'               | Ομήρου       | 'Ομήρου'          | Ομήρου            |
 
     @concourse_cluster
     @demo_cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -21,32 +21,32 @@ Feature: gpconfig integration tests
        # set same value on master and segments
        When the user runs "gpconfig -c <guc> -v <value>"
        Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value>"
+        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value>" escaped
         And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
 
        # set value on master only, leaving segments the same
        When the user runs "gpconfig -c <guc> -v <value_master_only> --masteronly "
        Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value_master_only>"
+        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value_master_only>" escaped
         And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
 
        # set value on master with a different value from the segments
        When the user runs "gpconfig -c <guc> -v <value> -m <value_master>"
        Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value_master>"
+        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value_master>" escaped
         And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
 
        # now make sure the last changes took full effect as seen by gpconfig
        When the user runs "gpconfig -s <guc> --file"
        Then gpconfig should return a return code of 0
-        And gpconfig should print "Master[\s]*value: <file_value_master>" to stdout
-        And gpconfig should print "Segment[\s]*value: <file_value>" to stdout
+        And gpconfig should print "Master  value: <file_value_master>" escaped to stdout
+        And gpconfig should print "Segment value: <file_value>" escaped to stdout
 
        When the user runs "gpconfig -s <guc> --file-compare"
        Then gpconfig should return a return code of 0
         And gpconfig should print "GUCS ARE OUT OF SYNC" to stdout
-        And gpconfig should print "value: <seed_value> \| file: <file_value_master>" to stdout
-        And gpconfig should print "value: <seed_value> \| file: <file_value>" to stdout
+        And gpconfig should print "value: <seed_value> | file: <file_value_master>" escaped to stdout
+        And gpconfig should print "value: <seed_value> | file: <file_value>" escaped to stdout
 
        When the user runs "gpstop -ar"
        Then gpstop should return a return code of 0
@@ -60,8 +60,8 @@ Feature: gpconfig integration tests
 
        When the user runs "gpconfig -s <guc>"
        Then gpconfig should return a return code of 0
-        And gpconfig should print "Master[\s]*value: <live_value_master>" to stdout
-        And gpconfig should print "Segment[\s]*value: <live_value>" to stdout
+        And gpconfig should print "Master  value: <live_value_master>" escaped to stdout
+        And gpconfig should print "Segment value: <live_value>" escaped to stdout
 
     # test for each type documented for gpconfig
     Examples:
@@ -73,41 +73,7 @@ Feature: gpconfig integration tests
         | application_name            |  string  | xxxxxx     | bodhi    | 'bodhi'    | bodhi      | lucy              | 'lucy'                 | bengie       | 'bengie'          | bengie            |
         | application_name            |  string  | yyyyyy     | 'bod hi' | 'bod hi'   | bod hi     | 'lu cy'           | 'lu cy'                | 'ben gie'    | 'ben gie'         | ben gie           |
         | application_name            |  string  | zzzzzz     | ''       | ''         |            | ''                | ''                     | ''           | ''                |                   |
-
-    @concourse_cluster
-    @demo_cluster
-    Scenario Outline: gpconfig edge cases for type: <type>
-      Given the user runs "gpstop -ar"
-        And gpstop should return a return code of 0
-        And the gpconfig context is setup
-        And the user runs "gpconfig -c <guc> -v <seed_value>"
-        And gpconfig should return a return code of 0
-
-       # set same value on master and segments
-       When the user runs "gpconfig -c <guc> -v <value>"
-       Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value>" escaped
-        And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
-
-       # now make sure the last changes took full effect as seen by gpconfig
-       When the user runs "gpconfig -s <guc> --file"
-       Then gpconfig should return a return code of 0
-        And gpconfig should print "Master  value: <file_value>" escaped to stdout
-        And gpconfig should print "Segment value: <file_value>" escaped to stdout
-
-       When the user runs "gpstop -ar"
-        And gpstop should return a return code of 0
-
-       When the user runs "gpconfig -s <guc>"
-       Then gpconfig should return a return code of 0
-        And gpconfig should print "Master  value: <live_value>" escaped to stdout
-        And gpconfig should print "Segment value: <live_value>" escaped to stdout
-
-    # NOTE: <value> is a command-line value
-    Examples:
-        | guc              | type     | seed_value | value   | file_value | live_value |
-        | application_name |  string  |  boo       |  "'\''" | '\\'''     |  \'        |
-       #| application_name |  string  |  boo       |  'C:\\home\\fun'  | 'C:\\home\\fun' | 'C:\\home\\fun' |
+        | application_name            |  string  | boo        | "'\''"   | '\\'''     | \'         | "'\''"            | '\\'''                 | "'\''"       | '\\'''            | \'                |
 
     @concourse_cluster
     @demo_cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -1,21 +1,24 @@
 @gpconfig
 Feature: gpconfig integration tests
 
-    # Below, we use 2 change (-c) operations to prove that we have changed a file,
-    # because any existing postgresql.conf file could already have the first value in it a priori
-    # NOTE: since we are restarting the database with the given paramaters, do not change parameters
-    #   that will cause the database to not restart given your machine setup.
+    # Below, we use 2 change (-c) operations to prove that we have changed a
+    # file, because any existing postgresql.conf file could already have the
+    # first value in it a priori
+    #
+    # NOTE: since we are SIGHUPing the database after each change (full restarts
+    # would be too slow), you must choose parameters with a sighup or weaker
+    # context.
 
     @concourse_cluster
     @demo_cluster
     Scenario Outline: run each gpconfig command for guc type: <type>
-      Given the user runs "gpstop -ar"
+      Given the user runs "gpstop -u"
         And gpstop should return a return code of 0
         And the gpconfig context is setup
         And the user runs "gpconfig -c <guc> -v <seed_value>"
         And gpconfig should return a return code of 0
         # ensure <guc> is set to <seed_value> for the tests below
-        And the user runs "gpstop -ar"
+        And the user runs "gpstop -u"
         And gpstop should return a return code of 0
 
        # set same value on master and segments
@@ -48,7 +51,7 @@ Feature: gpconfig integration tests
         And gpconfig should print "value: <seed_value> | file: <file_value_master>" escaped to stdout
         And gpconfig should print "value: <seed_value> | file: <file_value>" escaped to stdout
 
-       When the user runs "gpstop -ar"
+       When the user runs "gpstop -u"
        Then gpstop should return a return code of 0
 
       # FIXME: a file string value of 'my_value' (quotes in file) has a live value of my_value (no quotes) and
@@ -65,26 +68,26 @@ Feature: gpconfig integration tests
 
     # test for each type documented for gpconfig
     Examples:
-        | guc                         | type     | seed_value | value    | file_value | live_value | value_master_only | file_value_master_only | value_master | file_value_master | live_value_master |
-        | log_connections             |  bool    | off        | on       | on         | on         | off               | off                    | off          | off               | off               |
-        | gp_resgroup_memory_policy   |  enum    | eager_free | auto     | auto       | auto       | eager_free        | eager_free             | eager_free   | eager_free        | eager_free        |
-        | vacuum_cost_limit           |  integer | 300        | 400      | 400        | 400        | 555               | 555                    | 500          | 500               | 500               |
-        | gp_resource_group_cpu_limit |  real    | 0.4        | 0.5      | 0.5        | 0.5        | 0.33              | 0.33                   | 0.7          | 0.7               | 0.7               |
-        | application_name            |  string  | xxxxxx     | bodhi    | 'bodhi'    | bodhi      | lucy              | 'lucy'                 | bengie       | 'bengie'          | bengie            |
-        | application_name            |  string  | yyyyyy     | 'bod hi' | 'bod hi'   | bod hi     | 'lu cy'           | 'lu cy'                | 'ben gie'    | 'ben gie'         | ben gie           |
-        | application_name            |  string  | zzzzzz     | ''       | ''         |            | ''                | ''                     | ''           | ''                |                   |
-        | application_name            |  string  | boo        | "'\''"   | '\\'''     | \'         | "'\''"            | '\\'''                 | "'\''"       | '\\'''            | \'                |
+        | guc                          | type     | seed_value | value    | file_value | live_value | value_master_only | file_value_master_only | value_master | file_value_master | live_value_master |
+        | log_connections              |  bool    | off        | on       | on         | on         | off               | off                    | off          | off               | off               |
+        | gp_resgroup_memory_policy    |  enum    | eager_free | auto     | auto       | auto       | eager_free        | eager_free             | eager_free   | eager_free        | eager_free        |
+        | vacuum_cost_limit            |  integer | 300        | 400      | 400        | 400        | 555               | 555                    | 500          | 500               | 500               |
+        | checkpoint_completion_target |  real    | 0.4        | 0.5      | 0.5        | 0.5        | 0.33              | 0.33                   | 0.7          | 0.7               | 0.7               |
+        | application_name             |  string  | xxxxxx     | bodhi    | 'bodhi'    | bodhi      | lucy              | 'lucy'                 | bengie       | 'bengie'          | bengie            |
+        | application_name             |  string  | yyyyyy     | 'bod hi' | 'bod hi'   | bod hi     | 'lu cy'           | 'lu cy'                | 'ben gie'    | 'ben gie'         | ben gie           |
+        | application_name             |  string  | zzzzzz     | ''       | ''         |            | ''                | ''                     | ''           | ''                |                   |
+        | application_name             |  string  | boo        | "'\''"   | '\\'''     | \'         | "'\''"            | '\\'''                 | "'\''"       | '\\'''            | \'                |
 
     @concourse_cluster
     @demo_cluster
     Scenario Outline: write directly to postgresql.conf file: <type>
-      Given the user runs "gpstop -ar"
+      Given the user runs "gpstop -u"
         And gpstop should return a return code of 0
         And the gpconfig context is setup
         # we do this to make sure all segment files contain this <guc>, both in file and live
         And the user runs "gpconfig -c <guc> -v <seed_value>"
         And gpconfig should return a return code of 0
-        And the user runs "gpstop -ar"
+        And the user runs "gpstop -u"
         And gpstop should return a return code of 0
 
        When the user writes "<guc>" as "<value>" to the master config file
@@ -95,7 +98,7 @@ Feature: gpconfig integration tests
        Then gpconfig should return a return code of 0
         And gpconfig should print "Master  value: <file_value>" escaped to stdout
 
-       When the user runs "gpstop -ar"
+       When the user runs "gpstop -u"
        Then gpstop should return a return code of 0
 
        When the user runs "gpconfig -s <guc>"
@@ -104,19 +107,19 @@ Feature: gpconfig integration tests
 
     # NOTE: <value> is directly entered into postgresql.conf
     Examples:
-        | guc                         | type     | seed_value | value    | file_value | live_value |
-        | log_connections             |  bool    | off        | on       | on         | on         |
-        | gp_resgroup_memory_policy   |  enum    | eager_free | auto     | auto       | auto       |
-        | vacuum_cost_limit           |  integer | 300        | 400      | 400        | 400        |
-        | gp_resource_group_cpu_limit |  real    | 0.4        | 0.5      | 0.5        | 0.5        |
-        | application_name            |  string  | xxxxxx     | bodhi    | bodhi      | bodhi      |
-        | application_name            |  string  | xxxxxx     | 'bod hi' | 'bod hi'   | bod hi     |
-        | application_name            |  string  | xxxxxx     | ''       | ''         |            |
+        | guc                          | type     | seed_value | value    | file_value | live_value |
+        | log_connections              |  bool    | off        | on       | on         | on         |
+        | gp_resgroup_memory_policy    |  enum    | eager_free | auto     | auto       | auto       |
+        | vacuum_cost_limit            |  integer | 300        | 400      | 400        | 400        |
+        | checkpoint_completion_target |  real    | 0.4        | 0.5      | 0.5        | 0.5        |
+        | application_name             |  string  | xxxxxx     | bodhi    | bodhi      | bodhi      |
+        | application_name             |  string  | xxxxxx     | 'bod hi' | 'bod hi'   | bod hi     |
+        | application_name             |  string  | xxxxxx     | ''       | ''         |            |
 
     @concourse_cluster
     @demo_cluster
     Scenario Outline: gpconfig basic removal for type: <type>
-      Given the user runs "gpstop -ar"
+      Given the user runs "gpstop -u"
         And gpstop should return a return code of 0
         And the gpconfig context is setup
         And the user runs "gpconfig -c <guc> -v <value>"
@@ -133,11 +136,11 @@ Feature: gpconfig integration tests
         And verify that the file "postgresql.conf" in each segment data directory has "some" line starting with "#<guc>="
 
     Examples:
-        | guc                         | type     | value      |
-        | log_connections             |  bool    | off        |
-        | gp_resgroup_memory_policy   |  enum    | eager_free |
-        | vacuum_cost_limit           |  integer | 300        |
-        | gp_resource_group_cpu_limit |  real    | 0.4        |
-        | application_name            |  string  | bengie     |
-        | application_name            |  string  | 'ben gie'  |
-        | application_name            |  string  | ''         |
+        | guc                          | type     | value      |
+        | log_connections              |  bool    | off        |
+        | gp_resgroup_memory_policy    |  enum    | eager_free |
+        | vacuum_cost_limit            |  integer | 300        |
+        | checkpoint_completion_target |  real    | 0.4        |
+        | application_name             |  string  | bengie     |
+        | application_name             |  string  | 'ben gie'  |
+        | application_name             |  string  | ''         |

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -54,12 +54,10 @@ Feature: gpconfig integration tests
        When the user runs "gpstop -u"
        Then gpstop should return a return code of 0
 
-      # FIXME: a file string value of 'my_value' (quotes in file) has a live value of my_value (no quotes) and
-      #   --file-compare is currently broken on that case.
-#       When the user runs "gpconfig -s <guc> --file-compare"
-#       Then gpconfig should return a return code of 0
-#        And gpconfig should print "Master[\s]*value: <live_value_master> \| file: <file_value_master>" to stdout
-#        And gpconfig should print "Segment[\s]*value: <live_value> \| file: <file_value>" to stdout
+       When the user runs "gpconfig -s <guc> --file-compare"
+       Then gpconfig should return a return code of 0
+        And gpconfig should print "Master  value: <live_value_master> | file: <file_value_master>" escaped to stdout
+        And gpconfig should print "Segment value: <live_value> | file: <file_value>" escaped to stdout
 
        When the user runs "gpconfig -s <guc>"
        Then gpconfig should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -74,6 +74,8 @@ Feature: gpconfig integration tests
         | application_name             |  string  | xxxxxx     | bodhi    | 'bodhi'    | bodhi      | lucy              | 'lucy'                 | bengie       | 'bengie'          | bengie            |
         | application_name             |  string  | yyyyyy     | 'bod hi' | 'bod hi'   | bod hi     | 'lu cy'           | 'lu cy'                | 'ben gie'    | 'ben gie'         | ben gie           |
         | application_name             |  string  | zzzzzz     | ''       | ''         |            | ''                | ''                     | ''           | ''                |                   |
+        | application_name             |  string  | zzzzzz     | '"hi"'   | '"hi"'     | "hi"       | '"hi"'            | '"hi"'                 | '"hi"'       | '"hi"'            | "hi"              |
+        | application_name             |  string  | zzzzzz     | "'hi'"   | '''hi'''   | 'hi'       | "'hi'"            | '''hi'''               | "'hi'"       | '''hi'''          | 'hi'              |
         | application_name             |  string  | boo        | "\'"     | '\\'''     | \'         | "\'"              | '\\'''                 | "\'"         | '\\'''            | \'                |
         | application_name             |  string  | boo        | "''''"   | '''''''''' | ''''       | "''"              | ''''''                 | "'"          | ''''              | '                 |
         | search_path                  |  string  | boo        | Ομήρου   | 'Ομήρου'   | Ομήρου     | Ομήρου            | 'Ομήρου'               | Ομήρου       | 'Ομήρου'          | Ομήρου            |

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1,3 +1,4 @@
+import codecs
 import math
 import fnmatch
 import getpass
@@ -1325,9 +1326,11 @@ def impl(context, filename, output):
 def find_string_in_master_data_directory(context, filename, output, escapeStr=False):
     contents = ''
     file_path = os.path.join(master_data_dir, filename)
-    with open(file_path) as fr:
-        for line in fr:
+
+    with codecs.open(file_path, encoding='utf-8') as f:
+        for line in f:
             contents = line.strip()
+
     if escapeStr:
         output = re.escape(output)
     pat = re.compile(output)
@@ -1419,7 +1422,9 @@ def impl(context, filename, output):
         cmd_str = 'ssh %s "tail -n1 %s"' % (host, filepath)
         cmd = Command(name='Running remote command: %s' % cmd_str, cmdStr=cmd_str)
         cmd.run(validateAfter=True)
-        if output not in cmd.get_stdout():
+
+        actual = cmd.get_stdout().decode('utf-8')
+        if output not in actual:
             raise Exception('File %s on host %s does not contain "%s"' % (filepath, host, output))
 
 @given('the gpfdists occupying port {port} on host "{hostfile}"')

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -129,8 +129,13 @@ def check_stdout_msg(context, msg, escapeStr = False):
     if escapeStr:
         msg = re.escape(msg)
     pat = re.compile(msg)
-    if not pat.search(context.stdout_message):
-        err_str = "Expected stdout string '%s' and found: '%s'" % (msg, context.stdout_message)
+
+    actual = context.stdout_message
+    if isinstance(msg, unicode):
+        actual = actual.decode('utf-8')
+
+    if not pat.search(actual):
+        err_str = "Expected stdout string '%s' and found: '%s'" % (msg, actual)
         raise Exception(err_str)
 
 

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
@@ -78,11 +78,7 @@
           <pd>The value to use for the configuration parameter you specified with the
               <codeph>-c</codeph> option. By default, this value is applied to all segments, their
             mirrors, the master, and the standby master.</pd>
-          <pd>Parameter values that are not simple identifiers or numbers must be enclosed in single
-            quotes (<codeph>'</codeph>). For example, values that contain spaces or special
-            characters must be enclosed in single quotes. To embed a single quote in a parameter
-            value, enter either two single quotes or backslash and quote (<codeph>\'</codeph>).</pd>
-          <pd>The utility encloses the value in single quotes when adding the setting to the
+          <pd>The utility correctly quotes the value when adding the setting to the
               <codeph>postgresql.conf</codeph> files.</pd>
         </plentry>
         <plentry>


### PR DESCRIPTION
We changed the way that gpconfig writes values to postgresql.conf files to now take the user's input and properly quote it before writing it to a file.

Other fixes:
* improved the behave test performance by an order of magnitude
* added a utf-8 encoding test case
* fixed the file_GUC == db_GUC comparison logic
* escape newlines before writing to a file

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community