### PR TITLE
Verify rsync during autoconf

### DIFF
--- a/config/programs.m4
+++ b/config/programs.m4
@@ -307,3 +307,21 @@ else
   AC_MSG_ERROR([apu-1-config is required for gpperfmon, unable to find binary])
 fi
 ]) # GPAC_PATH_APU_1_CONFIG
+
+# GPAC_PATH_RSYNC
+# ---------------
+# Check for rsync, which is used by Management utilities
+AC_DEFUN([GPAC_PATH_RSYNC],
+[
+AC_PATH_PROGS(RSYNC, rsync)
+
+if test -n "$RSYNC"; then
+  rsync_version=`$RSYNC --version 2>/dev/null | sed q`
+  if test -z "$rsync_version"; then
+    AC_MSG_ERROR([rsync is required for Greenplum utilities, unable to identify version])
+  fi
+  AC_MSG_NOTICE([using rsync $rsync_version])
+else
+  AC_MSG_ERROR([rsync is required for Greenplum utilities, unable to find binary])
+fi
+]) # GPAC_PATH_RSYNC

--- a/configure
+++ b/configure
@@ -663,6 +663,7 @@ acx_pthread_config
 have_win32_dbghelp
 HAVE_IPV6
 LIBOBJS
+RSYNC
 CXXCPP
 UUID_LIBS
 CURL_LIBS
@@ -14040,6 +14041,71 @@ fi
 done
 
 fi
+
+
+##
+## Programs
+##
+
+# Check for rsync
+
+for ac_prog in rsync
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_RSYNC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $RSYNC in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_RSYNC="$RSYNC" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_RSYNC="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+RSYNC=$ac_cv_path_RSYNC
+if test -n "$RSYNC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $RSYNC" >&5
+$as_echo "$RSYNC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$RSYNC" && break
+done
+
+
+if test -n "$RSYNC"; then
+  rsync_version=`$RSYNC --version 2>/dev/null | sed q`
+  if test -z "$rsync_version"; then
+    as_fn_error $? "rsync is required for Greenplum utilities, unable to identify version" "$LINENO" 5
+  fi
+  { $as_echo "$as_me:${as_lineno-$LINENO}: using rsync $rsync_version" >&5
+$as_echo "$as_me: using rsync $rsync_version" >&6;}
+else
+  as_fn_error $? "rsync is required for Greenplum utilities, unable to find binary" "$LINENO" 5
+fi
+
 
 ##
 ## Types, structures, compiler characteristics

--- a/configure.in
+++ b/configure.in
@@ -1719,6 +1719,14 @@ if test "$PORTNAME" = "openbsd"; then
   AC_CHECK_HEADERS([execinfo.h], [], [AC_MSG_ERROR([header file <execinfo.h> is required for backtrace support])])
 fi
 
+
+##
+## Programs
+##
+
+# Check for rsync
+GPAC_PATH_RSYNC
+
 ##
 ## Types, structures, compiler characteristics
 ##


### PR DESCRIPTION
rsync is used in library functions used by the python Management utilities, but the presence of it in PATH was never verified in autoconf. Add a verification step to ensure rsync is installed, as there have been cases in CI where it was missing which caused subtle errors.
