### PR TITLE
Adds rsync to server pipeline docker image.

### DIFF
--- a/concourse/server_pipeline/docker/Dockerfile
+++ b/concourse/server_pipeline/docker/Dockerfile
@@ -51,7 +51,8 @@ RUN apt update && apt install -y \
     python-psutil \
     python-yaml \
     zlib1g-dev \
-    cpanminus
+    cpanminus \
+    rsync
 
 #
 # Prepare debugging environment


### PR DESCRIPTION
rsync is a dependency of the management utilities and was causing the gpinitmirror tests in
isolation2 to fail.


