### PR TITLE
Error if about to store an invalid segment number.

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -93,6 +93,8 @@ InsertInitialAOCSFileSegInfo(Relation prel, int32 segno, int32 nvp)
 	Relation	segrel;
 	int16		formatVersion;
 
+	ValidateAppendonlySegmentDataBeforeStorage(segno);
+
 	/* New segments are always created in the latest format */
 	formatVersion = AORelationVersion_GetLatest();
 

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -1517,10 +1517,7 @@ get_awaiting_drop_status_from_segments(Relation parentrel)
 					value = PQgetvalue(pgresult, j, 1);
 					segno = pg_atoi(value, sizeof(int32), 0);
 
-					if (segno < 0)
-						elog(ERROR, "segno %d is negative", segno);
-					if (segno >= MAX_AOREL_CONCURRENCY)
-						elog(ERROR, "segno %d exceeds max AO concurrency", segno);
+					ValidateAppendonlySegmentDataBeforeStorage(segno);
 
 					if (qe_state == AOSEG_STATE_AWAITING_DROP)
 					{

--- a/src/backend/access/appendonly/test/Makefile
+++ b/src/backend/access/appendonly/test/Makefile
@@ -3,7 +3,7 @@ top_builddir=../../../../..
 include $(top_builddir)/src/Makefile.global
 
 TARGETS=aomd appendonly_visimap appendonlywriter appendonly_visimap_entry \
-	aomd_filehandler
+	aomd_filehandler aosegfiles
 
 include $(top_builddir)/src/backend/mock.mk
 
@@ -24,3 +24,4 @@ aomd_filehandler.t: \
 
 appendonly_visimap_entry.t:
 
+aosegfiles.t: $(top_builddir)/src/backend/access/appendonly/aosegfiles.o

--- a/src/backend/access/appendonly/test/aosegfiles_test.c
+++ b/src/backend/access/appendonly/test/aosegfiles_test.c
@@ -1,0 +1,83 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "postgres.h"
+#include "access/aosegfiles.h"
+#include "utils/memutils.h"
+
+
+void
+test_validate_segno_returns_false_when_segno_less_than_zero(void **state)
+{
+	bool error_thrown = false;
+  
+	PG_TRY();
+	{
+		ValidateAppendonlySegmentDataBeforeStorage(-1);
+	}
+	PG_CATCH();
+	{
+		error_thrown = true;
+	}
+	PG_END_TRY();
+
+	assert_true(error_thrown);
+}
+
+void
+test_validate_segno_returns_true_when_segno_greater_than_or_equal_to_zero(void **state)
+{
+	bool error_thrown = false;
+  
+	PG_TRY();
+	{
+		ValidateAppendonlySegmentDataBeforeStorage(0);
+		ValidateAppendonlySegmentDataBeforeStorage(1);
+		ValidateAppendonlySegmentDataBeforeStorage(10);
+		ValidateAppendonlySegmentDataBeforeStorage(100);
+	}
+	PG_CATCH();
+	{
+		error_thrown = true;
+	}
+	PG_END_TRY();
+
+	assert_false(error_thrown);
+}
+
+void
+test_validate_segno_throws_error_when_value_is_greater_than_maximum_number_of_concurrent_writers(void **state)
+{
+	bool error_thrown = false;
+	int some_number_above_aorel_concurrency = 1234;
+  
+	PG_TRY();
+	{
+		ValidateAppendonlySegmentDataBeforeStorage(some_number_above_aorel_concurrency);
+	}
+	PG_CATCH();
+	{
+		error_thrown = true;
+	}
+	PG_END_TRY();
+
+	assert_true(error_thrown);
+}
+
+int 
+main(int argc, char* argv[]) 
+{
+	cmockery_parse_arguments(argc, argv);
+	
+	MemoryContextInit();
+
+	const UnitTest tests[] = {
+	  unit_test(test_validate_segno_returns_false_when_segno_less_than_zero),
+	  unit_test(test_validate_segno_returns_true_when_segno_greater_than_or_equal_to_zero),
+	  unit_test(test_validate_segno_throws_error_when_value_is_greater_than_maximum_number_of_concurrent_writers)
+	};
+
+	return run_tests(tests);
+}

--- a/src/include/access/aosegfiles.h
+++ b/src/include/access/aosegfiles.h
@@ -131,6 +131,8 @@ extern FileSegInfo *NewFileSegInfo(int segno);
 
 extern void InsertInitialSegnoEntry(Relation parentrel, int segno);
 
+extern void ValidateAppendonlySegmentDataBeforeStorage(int segno);
+
  /*
   * GetFileSegInfo
   *


### PR DESCRIPTION
A user found a scenario where they had stored a -1 for a tuple's
segno. We'd like to be notified of this type of scenario because it
should not exist and we would like to track down the root
cause. Validations that throw errors will help us track the root cause
down.

This change introduces a validation step before inserting in both row and column orientation insertion.

This change should probably go back to all supported versions.