### PR TITLE
 Do not eager free Material over Motions

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.43.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.44.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.43.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.44.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.43.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.44.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.43.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.44.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.43.1@gpdb/stable
+orca/v3.44.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.43.1/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.44.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -733,7 +733,9 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar
 	{
 		// test expression is expected to be a comparison between an outer expression 
 		// and a scalar identifier from subplan child
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,  GPOS_WSZ_LIT("Unexpected subplan test expression"));
+		// ORCA currently only supports PARAMs on the inner side of the form id or cast(id)
+		// The outer side may be any non-param thing.
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,  GPOS_WSZ_LIT("Unsupported subplan test expression"));
 	}
 
 	// extract type of inner column

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -419,6 +419,35 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
  -1
 (10 rows)
 
+explain select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..34.51 rows=1 width=8)
+   ->  Seq Scan on a  (cost=0.00..34.51 rows=1 width=8)
+         Filter: j = ((subplan))
+         SubPlan 1
+           ->  Hash EXISTS Join  (cost=3.14..6.29 rows=2 width=4)
+                 Hash Cond: c.i = b.i
+                 ->  Result  (cost=3.11..3.13 rows=1 width=8)
+                       Filter: c.j = $0
+                       ->  Materialize  (cost=3.11..3.13 rows=1 width=8)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.11 rows=1 width=8)
+                                   ->  Seq Scan on c  (cost=0.00..3.11 rows=1 width=8)
+                 ->  Hash  (cost=3.08..3.08 rows=2 width=4)
+                       ->  Result  (cost=3.08..3.13 rows=2 width=4)
+                             ->  Materialize  (cost=3.08..3.13 rows=2 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.08 rows=2 width=4)
+                                         ->  Seq Scan on b  (cost=0.00..3.08 rows=2 width=4)
+                                               Filter: (i <> 10)
+ Optimizer: legacy query optimizer
+(18 rows)
+
+select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
+ i  
+----
+ 99
+(1 row)
+
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_any.sql - Correlated Subquery: CSQ using ANY clause (Heap)
 -- ----------------------------------------------------------------------
@@ -508,26 +537,25 @@ ERROR:  correlated subquery with skip-level correlations is not supported
 explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
                                                                        QUERY PLAN                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=46.02..46.25 rows=10 width=12)
-   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=46.02..46.25 rows=10 width=12)
+ Limit  (cost=45.91..46.14 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=45.91..46.14 rows=10 width=12)
          Merge Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-         ->  Limit  (cost=46.02..46.05 rows=4 width=12)
-               ->  Sort  (cost=46.02..46.16 rows=18 width=12)
+         ->  Limit  (cost=45.91..45.94 rows=4 width=12)
+               ->  Sort  (cost=45.91..46.05 rows=18 width=12)
                      Sort Key: a.i, qp_correlated_query.b.i, qp_correlated_query.c.j
-                     ->  Nested Loop  (cost=6.42..44.86 rows=18 width=12)
-                           ->  Nested Loop  (cost=3.10..38.30 rows=3 width=8)
-                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..34.66 rows=1 width=8)
-                                       ->  Seq Scan on a  (cost=0.00..34.62 rows=1 width=8)
+                     ->  Nested Loop  (cost=6.42..44.74 rows=18 width=12)
+                           ->  Nested Loop  (cost=3.10..38.19 rows=3 width=8)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..34.55 rows=1 width=8)
+                                       ->  Seq Scan on a  (cost=0.00..34.51 rows=1 width=8)
                                              Filter: j = ((subplan))
                                              SubPlan 1
-                                               ->  Hash EXISTS Join  (cost=3.14..6.31 rows=2 width=4)
+                                               ->  Hash EXISTS Join  (cost=3.14..6.29 rows=2 width=4)
                                                      Hash Cond: qp_correlated_query.c.i = qp_correlated_query.b.i
-                                                     ->  Result  (cost=3.14..3.15 rows=1 width=8)
+                                                     ->  Result  (cost=3.11..3.13 rows=1 width=8)
                                                            Filter: qp_correlated_query.c.j = $0
-                                                           ->  Materialize  (cost=3.14..3.15 rows=1 width=8)
-                                                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.13 rows=1 width=8)
-                                                                       ->  Seq Scan on c  (cost=0.00..3.13 rows=1 width=8)
-                                                                             Filter: i <> 10
+                                                           ->  Materialize  (cost=3.11..3.13 rows=1 width=8)
+                                                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.11 rows=1 width=8)
+                                                                       ->  Seq Scan on c  (cost=0.00..3.11 rows=1 width=8)
                                                      ->  Hash  (cost=3.08..3.08 rows=2 width=4)
                                                            ->  Result  (cost=3.08..3.13 rows=2 width=4)
                                                                  ->  Materialize  (cost=3.08..3.13 rows=2 width=4)
@@ -3619,6 +3647,125 @@ SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND q
  1 | 0 | 1 | -0
 (1 row)
 
+-- ----------------------------------------------------------------------
+-- Test: Various single & skip-level correlated subqueries
+-- ----------------------------------------------------------------------
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
+NOTICE:  table "supplier" does not exist, skipping
+create table t1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table supplier(city text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'city' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1 values (1, 1), (2, 2), (3, 3);
+insert into supplier values ('a'),('b'),('c'),('d'),('e');
+analyze t1;
+analyze supplier;
+set optimizer_enforce_subplans = 1;
+-- with TVF
+explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..39.57 rows=3 width=4)
+   ->  Seq Scan on t1 x1  (cost=0.00..39.57 rows=1 width=4)
+         SubPlan 1  (slice1; segments: 1)
+           ->  Aggregate  (cost=12.50..12.51 rows=1 width=8)
+                 ->  Function Scan on generate_series  (cost=0.00..10.00 rows=334 width=0)
+ Optimizer: legacy query optimizer
+(6 rows)
+
+select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+ a | ?column? 
+---+----------
+ 1 |        1
+ 2 |        2
+ 3 |        3
+(3 rows)
+
+-- with limit
+explain select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.99 rows=3 width=4)
+   ->  Seq Scan on t1  (cost=0.00..3.99 rows=1 width=4)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.64..0.65 rows=1 width=8)
+                 ->  Limit  (cost=0.00..0.63 rows=1 width=2)
+                       ->  Limit  (cost=0.00..0.61 rows=1 width=2)
+                             ->  Result  (cost=0.00..3.07 rows=2 width=2)
+                                   ->  Materialize  (cost=0.00..3.07 rows=2 width=2)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.05 rows=2 width=2)
+                                               ->  Seq Scan on supplier  (cost=0.00..3.05 rows=2 width=2)
+ Optimizer: legacy query optimizer
+(11 rows)
+
+select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+ a | ?column? 
+---+----------
+ 3 |        3
+ 1 |        1
+ 2 |        2
+(3 rows)
+
+-- with nested join
+explain select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..248.35 rows=3 width=8)
+   ->  Seq Scan on t1  (cost=0.00..248.35 rows=1 width=8)
+         SubPlan 1
+           ->  Aggregate  (cost=82.10..82.11 rows=1 width=8)
+                 ->  Nested Loop  (cost=2.09..74.59 rows=3000 width=0)
+                       ->  Function Scan on generate_series  (cost=0.00..12.50 rows=1000 width=0)
+                       ->  Materialize  (cost=2.09..2.12 rows=1 width=0)
+                             ->  Result  (cost=2.03..2.06 rows=1 width=0)
+                                   ->  Materialize  (cost=2.03..2.06 rows=1 width=0)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.03 rows=1 width=0)
+                                               ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=0)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+ a | b | ?column? 
+---+---+----------
+ 1 | 1 |        3
+ 2 | 2 |        6
+ 3 | 3 |        9
+(3 rows)
+
+explain select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..30000000533.19 rows=1 width=8)
+   ->  Seq Scan on t1  (cost=0.00..30000000533.19 rows=1 width=8)
+         Filter: (0 < (SubPlan 1))
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=10000000177.04..10000000177.05 rows=1 width=8)
+                 ->  Nested Loop  (cost=10000000000.00..10000000049.54 rows=1000 width=0)
+                       ->  Function Scan on generate_series  (cost=0.00..10.00 rows=334 width=0)
+                       ->  Materialize  (cost=0.00..2.04 rows=1 width=0)
+                             ->  Result  (cost=0.00..2.04 rows=1 width=0)
+                                   ->  Materialize  (cost=0.00..2.04 rows=1 width=0)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.03 rows=1 width=0)
+                                               ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=0)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(14 rows)
+
+select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+(3 rows)
+
+reset optimizer_enforce_subplans;
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -435,6 +435,34 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
  -1
 (10 rows)
 
+explain select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1765379.74 rows=5 width=4)
+   ->  Result  (cost=0.00..1765379.74 rows=2 width=4)
+         ->  Table Scan on a  (cost=0.00..1765379.74 rows=2 width=4)
+               Filter: j = ((subplan))
+               SubPlan 1
+                 ->  Result  (cost=0.00..862.00 rows=1 width=4)
+                       Filter: c.j = $0
+                       ->  Materialize  (cost=0.00..862.00 rows=6 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=6 width=4)
+                                   ->  Hash EXISTS Join  (cost=0.00..862.00 rows=2 width=4)
+                                         Hash Cond: c.i = b.i AND c.i = b.i
+                                         ->  Table Scan on c  (cost=0.00..431.00 rows=3 width=8)
+                                         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                                               ->  Table Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                     Filter: i <> 10
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.44.0
+(17 rows)
+
+select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
+ i  
+----
+ 99
+(1 row)
+
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_any.sql - Correlated Subquery: CSQ using ANY clause (Heap)
 -- ----------------------------------------------------------------------
@@ -759,7 +787,6 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                                                                                        Filter: (subplan)
                                                                                        SubPlan 1
                                                                                          ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                               Filter: (CASE WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
                                                                                                ->  Result  (cost=0.00..431.00 rows=1 width=1)
                                                                                                      Filter: (CASE WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN qp_correlated_query.b.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> qp_correlated_query.b.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
                                                                                                      ->  Result  (cost=0.00..431.00 rows=1 width=1)
@@ -3706,6 +3733,129 @@ SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND q
  1 | 0 | 1 | -0
 (1 row)
 
+-- ----------------------------------------------------------------------
+-- Test: Various single & skip-level correlated subqueries
+-- ----------------------------------------------------------------------
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
+NOTICE:  table "supplier" does not exist, skipping
+create table t1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table supplier(city text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'city' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1 values (1, 1), (2, 2), (3, 3);
+insert into supplier values ('a'),('b'),('c'),('d'),('e');
+analyze t1;
+analyze supplier;
+set optimizer_enforce_subplans = 1;
+-- with TVF
+explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Result  (cost=0.00..882747.36 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+   SubPlan 1
+     ->  Aggregate  (cost=0.00..0.00 rows=1 width=8)
+           ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=1)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.44.0
+(8 rows)
+
+select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
+ a | ?column? 
+---+----------
+ 1 |        1
+ 2 |        2
+ 3 |        3
+(3 rows)
+
+-- with limit
+explain select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324051.59 rows=3 width=12)
+   ->  Result  (cost=0.00..1324051.59 rows=1 width=12)
+         ->  Table Scan on t1  (cost=0.00..1324051.59 rows=334 width=12)
+         SubPlan 1
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Limit  (cost=0.00..431.00 rows=5 width=1)
+                       ->  Materialize  (cost=0.00..431.00 rows=5 width=1)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=1)
+                                   ->  Table Scan on supplier  (cost=0.00..431.00 rows=2 width=1)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.44.0
+(11 rows)
+
+select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
+ a | ?column? 
+---+----------
+ 3 |        3
+ 1 |        1
+ 2 |        2
+(3 rows)
+
+-- with nested join
+explain select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1808685700.13 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=8)
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+   SubPlan 1
+     ->  Aggregate  (cost=0.00..1765432.56 rows=1 width=8)
+           ->  Nested Loop  (cost=0.00..1765432.56 rows=1000 width=1)
+                 Join Filter: true
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=1)
+                             ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=1)
+                 ->  Materialize  (cost=0.00..0.00 rows=334 width=1)
+                       ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=1)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.44.0
+(14 rows)
+
+select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
+ a | b | ?column? 
+---+---+----------
+ 1 | 1 |        3
+ 2 | 2 |        6
+ 3 | 3 |        9
+(3 rows)
+
+explain select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1808685700.16 rows=1 width=8)
+   Filter: 0 < ((subplan))
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=8)
+         ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+   SubPlan 1
+     ->  Aggregate  (cost=0.00..1765432.56 rows=1 width=8)
+           ->  Nested Loop  (cost=0.00..1765432.56 rows=1000 width=1)
+                 Join Filter: true
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=1)
+                             ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=1)
+                 ->  Materialize  (cost=0.00..0.00 rows=334 width=1)
+                       ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=1)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.44.0
+(15 rows)
+
+select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+(3 rows)
+
+reset optimizer_enforce_subplans;
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS supplier;
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
Please review this PR commit by commit
Commit #1 is a revert commit.
Commit #2 is additional fixes.

Consider the plan below:
```
shardikar=# explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
                                                            QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1852036426373.84 rows=1 width=12)
   ->  Nested Loop  (cost=0.00..1852036426373.84 rows=1 width=12)
         Join Filter: true
         ->  Nested Loop  (cost=0.00..1808628460.63 rows=1 width=8)
               Join Filter: true
               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1765376.73 rows=1 width=4)
                     ->  Result  (cost=0.00..1765376.73 rows=1 width=4)
                           ->  Table Scan on a  (cost=0.00..1765376.73 rows=1 width=4)
                                 Filter: j = ((subplan))
                                 SubPlan 1
                                   ->  Result  (cost=0.00..862.00 rows=1 width=4)
                                         Filter: public.c.j = $0
                                         ->  Materialize  (cost=0.00..862.00 rows=1 width=4)
                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
                                                     ->  Hash EXISTS Join  (cost=0.00..862.00 rows=1 width=4)
                                                           Hash Cond: public.c.i = public.b.i AND public.c.i = public.b.i
                                                           ->  Table Scan on c  (cost=0.00..431.00 rows=1 width=8)
                                                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                                 ->  Table Scan on b  (cost=0.00..431.00 rows=1 width=4)
                                                                       Filter: i <> 10
               ->  Table Scan on b  (cost=0.00..431.00 rows=1 width=4)
         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                     ->  Table Scan on c  (cost=0.00..431.00 rows=1 width=4)
```

The plan gives the following error on execution: `ERROR:  Illegal rescan of motion node: invalid plan.`. However the plan satisfies all the rules. The problems come from these lines in `ExecProcNode`:

```
			if (subplanAtTopNestLevel)
			{
				ExecSquelchNode(subplanState->planstate);
				ExecEagerFreeChildNodes(subplanState->planstate, subplanAtTopNestLevel);
				ExecEagerFree(subplanState->planstate);
			}
```

In `ExecProcNode` we EagerFree nodes in subplans, if the result tuple is NULL. In the case of our plan, once `Table Scan on a` returns a NULL tuple, the Materialize in the sub plan is eager free'd. But since the table scan is on the inner side of a NLJ, it is Rescan and that ultimately causes the a Rescan on the underlying Broadcast motion.

IMHO, the blind Eager free-ing of nodes in ExecProcNode is probably incorrect and should be refactored, but I wanted a fix that is very localized. This commit essentially disables Eager Free on Materials if they are directly above Motion nodes, since, more often than not, they were put there to prevent the ReScan of the Motion. Eager free too "eagerly" could cause wrong results & other issues. Thus, not eager free is safer (for correctness).

(NB: This test already exists as TINC test, converted into ICG in master)