### PR TITLE
Docs - undeprecate analyzedb --skip_root_stats option

### DIFF
--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -311,8 +311,10 @@
           The legacy optimizer does not use these statistics. </p><p>The time to analyze a
           partitioned table is similar to the time to analyze a non-partitioned table with the same
           data since <codeph>ANALYZE ROOTPARTITION</codeph> does not collect statistics on the leaf
-          partitions (the data is only sampled). </p><p>The Greenplum Database server configuration
-        parameter <codeph><xref
+          partitions (the data is only sampled). The <codeph>analyzedb</codeph> utility updates root
+          partition statistics by default but you can add the <codeph>--skip_root_stats</codeph>
+          option to leave root partition statistics empty if you do not use GPORCA. </p><p>The
+        Greenplum Database server configuration parameter <codeph><xref
             href="../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
             >optimizer_analyze_root_partition</xref></codeph> affects when statistics are collected
         on the root partition of a partitioned table. If the parameter is <codeph>on</codeph> (the

--- a/gpdb-doc/dita/utility_guide/admin_utilities/analyzedb.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/analyzedb.xml
@@ -61,7 +61,9 @@
           utility collects statistics on the root partition of a partitioned table if the statistics
           do not exist. If any of the leaf partitions have stale statistics,
             <cmdname>analyzedb</cmdname> also refreshes the root partition statistics. The cost of
-          refreshing the root level statistics is comparable to analyzing one leaf partition. </p>
+          refreshing the root level statistics is comparable to analyzing one leaf partition.
+          You can specify the option <codeph>--skip_root_stats</codeph> to disable
+          collection of statistics on the root partition of a partitioned table.</p>
       </sectiondiv>
     </section>
     <section><title>Notes</title><p>The <cmdname>analyzedb</cmdname> utility updates append
@@ -169,9 +171,10 @@ public.lineitem -i l_shipdate, l_receiptdate </codeblock></pd>
         <plentry>
           <pt>--skip_root_stats</pt>
           <pd>For a partitioned table, skip refreshing root partition statistics if only some of the
-            leaf partitions statistics require updating. This is the default behavior. This option
-            is deprecated<ph otherprops="pivotal"> and is removed in Greenplum Database
-            6.0</ph>.</pd>
+            leaf partitions statistics require updating. </pd>
+          <pd>When updating statistics for a partitioned table and you know which leaf partition
+            statistics require updating, you can specify those partitions and this option to improve
+            performance.</pd>
           <pd>For information about how statistics are collected for partitioned tables, see
                 <codeph><xref href="../../ref_guide/sql_commands/ANALYZE.xml"
               >ANALYZE</xref></codeph>.</pd>


### PR DESCRIPTION
This commit restores text that described the --skip_root_stats option before it was deprecated. 

This text should be added back in for upcoming 5.x and 6.0x releases. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
