### PR TITLE
BACKPORT 6X: GUC with PGC_BACKEND context should also be dispatched to QE (#7741)

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -339,7 +339,9 @@ makeOptions(void)
 		struct config_generic *guc = gucs[i];
 
 		if ((guc->flags & GUC_GPDB_ADDOPT) &&
-			(guc->context == PGC_USERSET || IsAuthenticatedUserSuperUser()))
+			(guc->context == PGC_USERSET ||
+			 guc->context == PGC_BACKEND ||
+			 IsAuthenticatedUserSuperUser()))
 			addOneOption(&string, guc);
 	}
 


### PR DESCRIPTION
PGC_BACKEND means GUC could be set through PGOPTIONS in libpq
which is the same as how we pass GUC from QD to QE.

Reviewed-by: Asim R P <apraveen@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
