### PR TITLE
Fix read pg_distributedlog bug

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -416,6 +416,7 @@ DistributedLog_CommittedCheck(
 	DistributedLogEntry *ptr;
 	TransactionId oldestXmin;
 
+	LWLockAcquire(DistributedLogTruncateLock, LW_SHARED);
 	LWLockAcquire(DistributedLogControlLock, LW_EXCLUSIVE);
 
 	oldestXmin = DistributedLogShared->oldestXmin;
@@ -425,6 +426,7 @@ DistributedLog_CommittedCheck(
 	if (TransactionIdPrecedes(localXid, oldestXmin))
 	{
 		LWLockRelease(DistributedLogControlLock);
+		LWLockRelease(DistributedLogTruncateLock);
 
 		*distribTimeStamp = 0;	// Set it to something.
 		*distribXid = 0;
@@ -438,6 +440,7 @@ DistributedLog_CommittedCheck(
 	*distribXid = ptr->distribXid;
 	ptr = NULL;
 	LWLockRelease(DistributedLogControlLock);
+	LWLockRelease(DistributedLogTruncateLock);
 
 	if (*distribTimeStamp != 0 && *distribXid != 0)
 	{

--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -52,6 +52,7 @@
 
 #define TransactionIdToPage(localXid) ((localXid) / (TransactionId) ENTRIES_PER_PAGE)
 #define TransactionIdToEntry(localXid) ((localXid) % (TransactionId) ENTRIES_PER_PAGE)
+#define TransactionIdToSegment(localXid) ((localXid) / (ENTRIES_PER_PAGE * SLRU_PAGES_PER_SEGMENT))
 
 static TransactionId
 AdvanceTransactionIdToNextPage(TransactionId xid)
@@ -94,10 +95,10 @@ typedef struct DistributedLogShmem
 static DistributedLogShmem *DistributedLogShared = NULL;
 
 static int	DistributedLog_ZeroPage(int page, bool writeXlog);
-static void DistributedLog_Truncate(TransactionId oldestXmin);
 static bool DistributedLog_PagePrecedes(int page1, int page2);
 static void DistributedLog_WriteZeroPageXlogRec(int page);
 static void DistributedLog_WriteTruncateXlogRec(int page);
+static void DistributedLog_Truncate(TransactionId oldestXmin);
 
 /*
  * Initialize the value for oldest local XID that might still be visible
@@ -109,22 +110,16 @@ static void DistributedLog_WriteTruncateXlogRec(int page);
  *
  * The caller is expected to hold DistributedLogControlLock on entry.
  */
-static void
-DistributedLog_InitOldestXmin(TransactionId oldestLocalXmin)
+void
+DistributedLog_InitOldestXmin(void)
 {
-	TransactionId oldestXmin;
-
-	if (DistributedLogShared->oldestXmin != InvalidTransactionId)
-	{
-		/* Already initialized. */
-		return;
-	}
+	TransactionId oldestXmin = ShmemVariableCache->oldestXid;
+	TransactionId latestXid = ShmemVariableCache->latestCompletedXid;
 
 	/*
 	 * Start scanning from oldest datfrozenxid, until we find a
 	 * valid page.
 	 */
-	oldestXmin = GetTransactionIdLimit();
 	for (;;)
 	{
 		int			page = TransactionIdToPage(oldestXmin);
@@ -140,21 +135,17 @@ DistributedLog_InitOldestXmin(TransactionId oldestLocalXmin)
 		xid = AdvanceTransactionIdToNextPage(oldestXmin);
 
 		/* but don't go past oldestLocalXmin */
-		if (TransactionIdFollows(xid, oldestLocalXmin))
+		if (TransactionIdFollows(xid, latestXid))
 		{
-			oldestXmin = oldestLocalXmin;
+			oldestXmin = latestXid;
 			break;
 		}
 
 		oldestXmin = xid;
 	}
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "Initialized oldestxmin to %u", oldestXmin);
-
 	DistributedLogShared->oldestXmin = oldestXmin;
 }
-
 /*
  * Advance the "oldest xmin" among distributed snapshots.
  *
@@ -183,15 +174,13 @@ DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
 								 DistributedTransactionId xminAllDistributedSnapshots)
 {
 	TransactionId oldestXmin;
+	TransactionId oldOldestXmin;
 	int			currPage;
 	int			slotno;
 	DistributedLogEntry *entries = NULL;
-	TransactionId oldOldestXmin;
 
 	Assert(!IS_QUERY_DISPATCHER());
-
-	if (!TransactionIdIsNormal(oldestLocalXmin))
-		elog(ERROR, "invalid oldest xmin: %u", oldestLocalXmin);
+	Assert(TransactionIdIsNormal(oldestLocalXmin));
 
 #ifdef FAULT_INJECTOR
 	const char *dbname = NULL;
@@ -202,25 +191,10 @@ DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
 								   dbname?dbname: "", "");
 #endif
 
+	LWLockAcquire(DistributedLogTruncateLock, LW_SHARED);
 	LWLockAcquire(DistributedLogControlLock, LW_EXCLUSIVE);
-
 	oldestXmin = oldOldestXmin = DistributedLogShared->oldestXmin;
-
-	if (oldestXmin == InvalidTransactionId)
-	{
-		/*
-		 * If we haven't seen any distributed snapshots from the QD yet,
-		 * initialize oldest xmin to the oldest datfrozenxid in this segment.
-		 *
-		 * This might be quite far behind the actual value, so on the first
-		 * call, the loop below can wind through millions of XIDs.
-		 * Fortunately, that only happens on the first call. But if that
-		 * ever becomes a problem, we could persist the value across
-		 * server restarts e.g. in the checkpoint record.
-		 */
-		DistributedLog_InitOldestXmin(oldestLocalXmin);
-		oldestXmin = DistributedLogShared->oldestXmin;
-	}
+	Assert(oldestXmin != InvalidTransactionId);
 
 	/*
 	 * oldestXmin (DistributedLogShared->oldestXmin) can be higher than
@@ -231,44 +205,41 @@ DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
 	 * return oldestXmin, as some other process already checked the
 	 * distributed log for us.
 	 */
-	if (TransactionIdPrecedes(oldestXmin, oldestLocalXmin))
+	currPage = -1;
+	while (TransactionIdPrecedes(oldestXmin, oldestLocalXmin))
 	{
-		currPage = -1;
-		while (!TransactionIdEquals(oldestXmin, oldestLocalXmin))
+		int			page = TransactionIdToPage(oldestXmin);
+		int			entryno = TransactionIdToEntry(oldestXmin);
+		DistributedLogEntry *ptr;
+
+		if (page != currPage)
 		{
-			int			page = TransactionIdToPage(oldestXmin);
-			int			entryno = TransactionIdToEntry(oldestXmin);
-			DistributedLogEntry *ptr;
-
-			if (page != currPage)
-			{
-				slotno = SimpleLruReadPage(DistributedLogCtl, page, true, oldestXmin);
-				currPage = page;
-				entries = (DistributedLogEntry *) DistributedLogCtl->shared->page_buffer[slotno];
-			}
-
-			ptr = &entries[entryno];
-
-			/*
-			 * If this XID is already visible to all distributed snapshots, we can
-			 * advance past it. Otherwise stop here. (Local-only transactions will
-			 * have zeros in distribXid and distribTimeStamp; this test will also
-			 * skip over those.)
-			 */
-			if (ptr->distribTimeStamp != distribTransactionTimeStamp ||
-				TransactionIdPrecedes(ptr->distribXid, xminAllDistributedSnapshots))
-			{
-				TransactionIdAdvance(oldestXmin);
-			}
-			else
-				break;
+			slotno = SimpleLruReadPage(DistributedLogCtl, page, true, oldestXmin);
+			currPage = page;
+			entries = (DistributedLogEntry *) DistributedLogCtl->shared->page_buffer[slotno];
 		}
 
-		DistributedLog_Truncate(oldestXmin);
-		DistributedLogShared->oldestXmin = oldestXmin;
+		ptr = &entries[entryno];
+
+		/*
+		 * If this XID is already visible to all distributed snapshots, we can
+		 * advance past it. Otherwise stop here. (Local-only transactions will
+		 * have zeros in distribXid and distribTimeStamp; this test will also
+		 * skip over those.)
+		 */
+		if (ptr->distribTimeStamp == distribTransactionTimeStamp &&
+			!TransactionIdPrecedes(ptr->distribXid, xminAllDistributedSnapshots))
+			break;
+
+		TransactionIdAdvance(oldestXmin);
 	}
 
+	DistributedLogShared->oldestXmin = oldestXmin;
 	LWLockRelease(DistributedLogControlLock);
+	LWLockRelease(DistributedLogTruncateLock);
+
+	if (TransactionIdToSegment(oldOldestXmin) < TransactionIdToSegment(oldestXmin))
+		DistributedLog_Truncate(oldestXmin);
 
 	return oldestXmin;
 }
@@ -281,30 +252,13 @@ DistributedLog_GetOldestXmin(TransactionId oldestLocalXmin)
 {
 	TransactionId result;
 
-	Assert(!IS_QUERY_DISPATCHER());
-
-	LWLockAcquire(DistributedLogControlLock, LW_EXCLUSIVE);
 	result = DistributedLogShared->oldestXmin;
 
-	if (result == InvalidTransactionId)
-	{
-		/*
-		 * If we haven't "seen" any distributed snapshots from the QD yet, initialize
-		 * oldest xmin based on how far back the distributed log reaches.
-		 */
-		DistributedLog_InitOldestXmin(oldestLocalXmin);
-		result = DistributedLogShared->oldestXmin;
-	}
-	LWLockRelease(DistributedLogControlLock);
+	Assert(!IS_QUERY_DISPATCHER());
+	Assert (result != InvalidTransactionId);
+	Assert (!TransactionIdFollows(result, oldestLocalXmin));
 
 	elogif(Debug_print_full_dtm, LOG, "oldestXmin is '%u'", result);
-
-	/*
-	 * Like in DistributedLog_AdvanceOldestXmin(), the shared oldestXmin
-	 * might already have been advanced past oldestLocalXmin.
-	 */
-	if (TransactionIdFollows(result, oldestLocalXmin))
-		result = oldestLocalXmin;
 
 	return result;
 }
@@ -803,6 +757,8 @@ DistributedLog_Startup(TransactionId oldestActiveXid,
 		DistributedLogCtl->shared->page_dirty[slotno] = true;
 	}
 
+	DistributedLog_InitOldestXmin();
+
 	LWLockRelease(DistributedLogControlLock);
 }
 
@@ -904,33 +860,15 @@ DistributedLog_Extend(TransactionId newestXact)
  * best not to do the XLOG flush unless we have confirmed that there is
  * a removable segment.
  *
- * NOTE: The caller should hold DistributedLogControlLock in exclusive mode.
  */
 static void
 DistributedLog_Truncate(TransactionId oldestXmin)
 {
 	int			cutoffPage;
-	TransactionId oldOldestXmin = DistributedLogShared->oldestXmin;
 
-	Assert(LWLockHeldByMe(DistributedLogControlLock));
 	Assert(!IS_QUERY_DISPATCHER());
 
-	if (oldOldestXmin == InvalidTransactionId)
-	{
-		/* not initialized yet */
-		return;
-	}
-
-	if (oldOldestXmin % (ENTRIES_PER_PAGE * SLRU_PAGES_PER_SEGMENT) ==
-		oldestXmin % (ENTRIES_PER_PAGE * SLRU_PAGES_PER_SEGMENT))
-	{
-		/*
-		 * If newly computed oldestXmin falls on the same SLRU segment, we
-		 * cannot truncate anything.
-		 */
-		return;
-	}
-
+	LWLockAcquire(DistributedLogTruncateLock, LW_EXCLUSIVE);
 	/*
 	 * The cutoff point is the start of the segment containing oldestXact. We
 	 * pass the *page* containing oldestXact to SimpleLruTruncate.
@@ -943,13 +881,17 @@ DistributedLog_Truncate(TransactionId oldestXmin)
 
 	/* Check to see if there's any files that could be removed */
 	if (!SlruScanDirectory(DistributedLogCtl, SlruScanDirCbReportPresence, &cutoffPage))
+	{
+		LWLockRelease(DistributedLogTruncateLock);
 		return;					/* nothing to remove */
+	}
 
 	/* Write XLOG record and flush XLOG to disk */
 	DistributedLog_WriteTruncateXlogRec(cutoffPage);
 
 	/* Now we can remove the old DistributedLog segment(s) */
-	SimpleLruTruncateWithLock(DistributedLogCtl, cutoffPage); /* we already hold the lock */
+	SimpleLruTruncate(DistributedLogCtl, cutoffPage);
+	LWLockRelease(DistributedLogTruncateLock);
 }
 
 

--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -295,32 +295,6 @@ ReadNewTransactionId(void)
 }
 
 /*
- * Get the last safe XID, i.e. the oldest XID that might exist in any
- * database of our cluster.
- */
-TransactionId
-GetTransactionIdLimit(void)
-{
-	TransactionId xid;
-
-	LWLockAcquire(XidGenLock, LW_SHARED);
-	xid = ShmemVariableCache->oldestXid;
-	LWLockRelease(XidGenLock);
-
-	if (!TransactionIdIsNormal(xid))
-	{
-		/*
-		 * shouldn't happen, but since this value is used in the computation
-		 * of oldest xmin, which determines which tuples be safely vacuumed
-		 * away, let's be paranoid.
-		 */
-		elog(ERROR, "invalid oldestXid limit: %u", xid);
-	}
-
-	return xid;
-}
-
-/*
  * Determine the last safe XID to allocate given the currently oldest
  * datfrozenxid (ie, the oldest XID that might exist in any database
  * of our cluster), and the OID of the (or a) database with that value.

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -60,7 +60,6 @@ extern bool DistributedLog_ScanForPrevCommitted(
 extern TransactionId DistributedLog_AdvanceOldestXmin(TransactionId oldestInProgressLocalXid,
 								 DistributedTransactionTimeStamp distribTimeStamp,
 								 DistributedTransactionId oldestDistribXid);
-extern void DistributedLog_AdvanceOldestXminOnQD(TransactionId oldestLocalXmin);
 extern TransactionId DistributedLog_GetOldestXmin(TransactionId oldestLocalXmin);
 
 extern Size DistributedLog_ShmemSize(void);
@@ -75,6 +74,7 @@ extern void DistributedLog_CheckPoint(void);
 extern void DistributedLog_Extend(TransactionId newestXid);
 extern bool DistributedLog_GetLowWaterXid(
 							  TransactionId *lowWaterXid);
+extern void DistributedLog_InitOldestXmin(void);
 
 /* XLOG stuff */
 #define DISTRIBUTEDLOG_ZEROPAGE		0x00

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -153,7 +153,6 @@ extern XLogRecPtr TransactionIdGetCommitLSN(TransactionId xid);
 /* in transam/varsup.c */
 extern TransactionId GetNewTransactionId(bool isSubXact);
 extern TransactionId ReadNewTransactionId(void);
-extern TransactionId GetTransactionIdLimit(void);
 extern void SetTransactionIdLimit(TransactionId oldest_datfrozenxid,
 					  Oid oldest_datoid);
 extern bool ForceTransactionIdLimitUpdate(void);

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -139,7 +139,8 @@ extern PGDLLIMPORT LWLockPadded *MainLWLockArray;
 #define SessionStateLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 7].lock)
 #define RelfilenodeGenLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 8].lock)
 #define WorkFileManagerLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 9].lock)
-#define GP_NUM_INDIVIDUAL_LWLOCKS		9
+#define DistributedLogTruncateLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 10].lock)
+#define GP_NUM_INDIVIDUAL_LWLOCKS		10
 
 /*
  * It would probably be better to allocate separate LWLock tranches


### PR DESCRIPTION
In the function 'DistributedLog_AdvanceOldestXmin', it reads pg_distributedlog,
updates 'DistributedLogShared->oldestXmin' and truncates the logs whose xid is
smaller than 'DistributedLogShared->oldestXmin'. This looks good because it's
serialized under the lock DistributedLogControlLock. The problem is the read
function 'SimpleLruReadPage' may release and re-acquire the lock, and another
caller of DistributedLog_AdvanceOldestXmin may truncate the logs concurrently
and cause 'SimpleLruReadPage' error out.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
