### PR TITLE
5X: Control operator memory by absolute values in resource group mode

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -1359,6 +1359,10 @@ OptResourceGroupElem:
 				{
 					$$ = makeDefElem("memory_spill_ratio", (Node *)$2);
 				}
+			| MEMORY_SPILL_RATIO Sconst
+				{
+					$$ = makeDefElem("memory_spill_ratio", (Node *) makeString($2));
+				}
 		;
 
 /*****************************************************************************

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1258,6 +1258,8 @@ ResourceGroupGetQueryMemoryLimit(void)
 		return 0;
 
 	memSpill = slotGetMemSpill(&slot->caps);
+	/* memSpill is already converted to chunks */
+	Assert(memSpill >= 0);
 
 	return memSpill << VmemTracker_GetChunkSizeInBits();
 }
@@ -2043,7 +2045,12 @@ groupGetMemSharedExpected(const ResGroupCaps *caps)
 static int32
 groupGetMemSpillTotal(const ResGroupCaps *caps)
 {
-	return groupGetMemExpected(caps) * memory_spill_ratio / 100;
+	if (memory_spill_ratio >= 0)
+		/* memSpill is in percentage format */
+		return groupGetMemExpected(caps) * memory_spill_ratio / 100;
+	else
+		/* memSpill is in absolute value format */
+		return -memory_spill_ratio;
 }
 
 /*
@@ -2084,8 +2091,15 @@ slotGetMemQuotaOnQE(const ResGroupCaps *caps, ResGroupData *group)
 static int32
 slotGetMemSpill(const ResGroupCaps *caps)
 {
-	Assert(caps->concurrency != 0);
-	return groupGetMemSpillTotal(caps) / caps->concurrency;
+	if (memory_spill_ratio >= 0)
+	{
+		/* memSpill is in percentage format */
+		Assert(caps->concurrency != 0);
+		return groupGetMemSpillTotal(caps) / caps->concurrency;
+	}
+	else
+		/* memSpill is in absolute value format */
+		return groupGetMemSpillTotal(caps);
 }
 
 /*
@@ -2996,9 +3010,9 @@ groupSetMemorySpillRatio(const ResGroupCaps *caps)
 {
 	char value[64];
 
-	snprintf(value, sizeof(value), "%d", caps->memSpillRatio);
+	ResGroupMemorySpillToStr(caps->memSpillRatio, value, sizeof(value));
 	set_config_option("memory_spill_ratio", value, PGC_USERSET, PGC_S_RESGROUP,
-			GUC_ACTION_SET, true);
+					  GUC_ACTION_SET, true);
 }
 
 void

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -186,6 +186,9 @@ extern void ResGroupDumpInfo(StringInfo str);
 
 extern int ResGroupGetSegmentNum(void);
 
+extern int32 ResGroupMemorySpillFromStr(const char *str);
+extern void ResGroupMemorySpillToStr(int32 value, char *buf, int bufsize);
+
 extern Bitmapset *CpusetToBitset(const char *cpuset,
 								 int len);
 extern void BitsetToCpuset(const Bitmapset *bms,

--- a/src/test/isolation2/expected/resgroup/resgroup_alter_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_alter_memory_spill_ratio.out
@@ -60,7 +60,7 @@ rg_spill_test|20                 |20                          |81               
 
 -- negative: memory_spill_ratio is negative
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO -1;
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 SELECT * FROM rg_spill_status;
 groupname    |memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------------+-------------------+----------------------------+------------------+---------------------------

--- a/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
@@ -63,8 +63,8 @@ SET
 select value from pg_resgroup_get_status_kv('dump');
 ERROR:  Only superusers can call this function.
 
-SET ROLE gpadmin;
-SET
+RESET ROLE;
+RESET
 
 DROP ROLE role_dumpinfo_test;
 DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
@@ -62,7 +62,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
 (1 row)
 RESET role;
 RESET
@@ -74,7 +74,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
 (1 row)
 RESET role;
 RESET
@@ -130,7 +130,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
 (1 row)
 RESET role;
 RESET
@@ -142,7 +142,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
 (1 row)
 RESET role;
 RESET
@@ -169,7 +169,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
 (1 row)
 RESET role;
 RESET
@@ -181,7 +181,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
 (1 row)
 RESET role;
 RESET
@@ -200,7 +200,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
 (1 row)
 SELECT f1_opmem_test();
 f1_opmem_test
@@ -217,7 +217,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
 (1 row)
 SELECT f1_opmem_test();
 f1_opmem_test

--- a/src/test/isolation2/expected/resgroup/resgroup_set_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_set_memory_spill_ratio.out
@@ -5,7 +5,7 @@
 SHOW memory_spill_ratio;
 memory_spill_ratio
 ------------------
-10                
+100 MB            
 (1 row)
 
 --start_ignore
@@ -58,7 +58,7 @@ SELECT 1;
 1       
 (1 row)
 
--- positive set to session level
+-- positive set to session level use work_mem
 SET MEMORY_SPILL_RATIO TO 0;
 SET
 SHOW MEMORY_SPILL_RATIO;
@@ -74,7 +74,7 @@ SELECT 1;
 
 -- negative set to session level
 SET MEMORY_SPILL_RATIO TO -1;
-ERROR:  -1 is outside the valid range for parameter "memory_spill_ratio" (0 .. 100)
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 SHOW MEMORY_SPILL_RATIO;
 memory_spill_ratio
 ------------------
@@ -112,6 +112,121 @@ SELECT 1;
 ?column?
 --------
 1       
+(1 row)
+
+-- positive set to session level
+SET MEMORY_SPILL_RATIO TO '20MB';
+SET
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+20 MB             
+(1 row)
+SELECT 1;
+?column?
+--------
+1       
+(1 row)
+
+-- positive set to session level
+SET MEMORY_SPILL_RATIO TO '20000kB';
+SET
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+19 MB             
+(1 row)
+SELECT 1;
+?column?
+--------
+1       
+(1 row)
+
+-- positive set to session level? can run?
+SET MEMORY_SPILL_RATIO TO '20GB';
+SET
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+20 GB             
+(1 row)
+SELECT 1;
+?column?
+--------
+1       
+(1 row)
+
+-- positive set to session level? can run?
+SET MEMORY_SPILL_RATIO TO '20  MB  ';
+SET
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+20 MB             
+(1 row)
+SELECT 1;
+?column?
+--------
+1       
+(1 row)
+
+-- negative oom when oprator memory is too large
+SET MEMORY_SPILL_RATIO TO '100GB';
+SET
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+100 GB             
+(1 row)
+SELECT * FROM gp_toolkit.gp_resgroup_config ;
+ERROR:  Out of memory
+DETAIL:  Resource group memory limit reached
+RESET MEMORY_SPILL_RATIO;
+RESET
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '10 %';
+ERROR:  syntax error on capability memory_spill_ratio
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+30                
+(1 row)
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '10.M';
+ERROR:  syntax error on capability memory_spill_ratio
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+30                
+(1 row)
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '-10M';
+ERROR:  syntax error on capability memory_spill_ratio
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+30                
+(1 row)
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '-10';
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+30                
+(1 row)
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '0x10M';
+ERROR:  syntax error on capability memory_spill_ratio
+SHOW MEMORY_SPILL_RATIO;
+memory_spill_ratio
+------------------
+30                
 (1 row)
 
 -- reset to resource group level

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -82,8 +82,8 @@ ERROR:  resource group "rg_test_group" does not exist
 SELECT * FROM gp_toolkit.gp_resgroup_config;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
-6438   |admin_group  |2          |2                   |10            |10          |10                   |50                 |50                          |10                |10                         
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
+6438   |admin_group  |2          |2                   |10            |10          |10                   |80                 |80                          |100 MB            |100 MB                     
 (2 rows)
 
 -- negative
@@ -102,13 +102,9 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 ERROR:  resource group "rg_test_group" already exists
 DROP RESOURCE GROUP rg_test_group;
 DROP
--- must specify both memory_limit and (cpu_rate_limit or cpuset)
+-- must specify cpu_rate_limit or cpuset
 CREATE RESOURCE GROUP rg_test_group WITH (memory_limit=10);
 ERROR:  must specify cpu_rate_limit or cpuset
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
-ERROR:  must specify memory_limit
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
-ERROR:  must specify memory_limit
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
 ERROR:  Find duplicate resource group resource type: concurrency
@@ -192,7 +188,7 @@ CREATE
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
 -------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
-rg_test_group|20         |20                  |10            |10          |10                   |20                 |20                
+rg_test_group|20         |20                  |10            |10          |10                   |80                 |128 MB            
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
@@ -202,6 +198,24 @@ SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,pr
 groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
 -------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
 rg_test_group|1          |1                   |-1            |10          |10                   |70                 |30                
+(1 row)
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
+CREATE
+SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
+rg_test_group|20         |20                  |10            |0           |0                    |80                 |128 MB            
+(1 row)
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
+CREATE
+SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
+rg_test_group|20         |20                  |-1            |0           |0                    |80                 |128 MB            
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
@@ -224,12 +238,12 @@ DROP RESOURCE GROUP rg_test_group2;
 DROP
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=61, memory_limit=10);
 ERROR:  total cpu_rate_limit exceeded the limit of 100
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=61);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=91);
 ERROR:  total memory_limit exceeded the limit of 100
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=0, memory_limit=10);
 ERROR:  cpu_rate_limit range is [1, 100]
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
-ERROR:  memory_limit range is [1, 100]
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=-1);
+ERROR:  memory_limit range is [0, 100]
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0.9);
 ERROR:  invalid input syntax for integer: "0.9"
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=1.9);
@@ -264,7 +278,7 @@ CREATE
 DROP RESOURCE GROUP rg_test_group;
 DROP
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=10, memory_spill_ratio=-1);
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=-1, memory_spill_ratio=10);
 ERROR:  memory_shared_quota range is [0, 100]
 
@@ -344,6 +358,91 @@ DROP RESOURCE GROUP rg_test_group;
 DROP
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=99, memory_spill_ratio=1);
 CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+
+-- negative: absolute value format of memory_spill_ratio is
+-- '^[1-9][0-9]*[MmGg]$'
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 %');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10%');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 M');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.MB');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.0MB');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M ');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10B');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10K');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10X');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10MB');
+ERROR:  memory_spill_ratio in absolute value format must be > 0
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='0 MB');
+ERROR:  memory_spill_ratio in absolute value format must be > 0
+DROP RESOURCE GROUP rg_test_group;
+ERROR:  resource group "rg_test_group" does not exist
+-- negative: memory_spill_ratio does not accept out of range percentage values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10');
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='101');
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+-- negative: when memory_limit is unlimited memory_spill_ratio must be set in
+-- absolute value format
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=10);
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='10%');
+ERROR:  syntax error on capability memory_spill_ratio
+
+-- positive
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100kB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100GB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=' 100 MB ');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='0x10 MB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='010 MB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='+10 MB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+
+-- positive: memory_spill_ratio in absolute value format will be ensured to be >= 1 chunk
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='1kB');
+CREATE
+SELECT memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+memory_spill_ratio
+------------------
+1 MB              
+(1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
 
@@ -491,4 +590,90 @@ ERROR:  resource group concurrency must be 0 when group memory_auditor is cgroup
 CREATE ROLE cgroup_audited_role RESOURCE GROUP cgroup_audited_group;
 ERROR:  You cannot assign a role to this resource group because the memory_auditor property for this group is not the default.
 DROP RESOURCE GROUP cgroup_audited_group;
+DROP
+
+-- positive: memory_spill_ratio accepts both integer and string values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ALTER
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+ALTER
+DROP RESOURCE GROUP rg_test_group;
+DROP
+
+-- negative: memory_spill_ratio only accepts string value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10%;
+ERROR:  syntax error at or near "%"
+LINE 1: ...TER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10%;
+                                                                     ^
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10M;
+ERROR:  syntax error at or near "M"
+LINE 1: ...TER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10M;
+                                                                     ^
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10MB;
+ERROR:  syntax error at or near "MB"
+LINE 1: ...ER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10MB;
+                                                                    ^
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- negative: memory_spill_ratio does not accept out of range percentage values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1';
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '101';
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1MB';
+ERROR:  memory_spill_ratio in absolute value format must be > 0
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '0MB';
+ERROR:  memory_spill_ratio in absolute value format must be > 0
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- positive: memory_limit can be altered to unlimited if memory_spill_ratio has
+-- an absolute value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+ALTER
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- negative: memory_spill_ratio only accepts an absolute value if memory_limit
+-- is unlimited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- positive: memory_spill_ratio accepts a percentage value only if
+-- memory_limit is limited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ALTER
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- negative: memory_limit must be limited if memory_spill_ratio has a
+-- percentage value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- positive: memory_spill_ratio accepts a absolute value anytime
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '50MB';
+ALTER
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+ALTER
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10MB';
+ALTER
+DROP RESOURCE GROUP rg_test_group;
 DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_unlimit_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_unlimit_memory_spill_ratio.out
@@ -20,7 +20,7 @@ DROP RESOURCE GROUP rg_spill_test;
 DROP
 
 CREATE RESOURCE GROUP rg_spill_test WITH (concurrency=10, cpu_rate_limit=20, memory_limit=20, memory_shared_quota=50, memory_spill_ratio=-1);
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 DROP RESOURCE GROUP rg_spill_test;
 ERROR:  resource group "rg_spill_test" does not exist
 
@@ -35,9 +35,9 @@ ALTER
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 100;
 ALTER
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO -1;
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 10000;
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 
 DROP RESOURCE GROUP rg_spill_test;
 DROP
@@ -86,7 +86,7 @@ SELECT 1;
 (1 row)
 
 SET MEMORY_SPILL_RATIO TO -1;
-ERROR:  -1 is outside the valid range for parameter "memory_spill_ratio" (0 .. 100)
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 SHOW MEMORY_SPILL_RATIO;
 memory_spill_ratio
 ------------------
@@ -99,7 +99,7 @@ SELECT 1;
 (1 row)
 
 SET MEMORY_SPILL_RATIO TO 10000;
-ERROR:  10000 is outside the valid range for parameter "memory_spill_ratio" (0 .. 100)
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 SHOW MEMORY_SPILL_RATIO;
 memory_spill_ratio
 ------------------
@@ -140,8 +140,8 @@ count
 (1 row)
 
 --clean env
-SET ROLE to gpadmin;
-SET
+RESET ROLE;
+RESET
 DROP TABLE test_zero_workmem;
 DROP
 DROP ROLE role_zero_workmem;

--- a/src/test/isolation2/input/resgroup/disable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/disable_resgroup.source
@@ -11,5 +11,12 @@
 
 SHOW gp_resource_manager;
 
--- reset admin_group concurrency setting
+-- reset settings
 ALTER RESOURCE GROUP admin_group SET concurrency 10;
+ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 20;
+ALTER RESOURCE GROUP admin_group SET memory_limit 10;
+ALTER RESOURCE GROUP admin_group SET memory_shared_quota 50;
+ALTER RESOURCE GROUP default_group SET concurrency 20;
+ALTER RESOURCE GROUP default_group SET memory_spill_ratio 20;
+ALTER RESOURCE GROUP default_group SET memory_limit 30;
+ALTER RESOURCE GROUP default_group SET memory_shared_quota 50;

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -58,9 +58,19 @@ DROP FUNCTION adjust_memory_limit(bigint);
 0: SELECT * FROM gp_toolkit.gp_resqueue_status;
 0: SELECT * FROM gp_toolkit.gp_resq_priority_backend;
 
+-- verify the default settings
+0: SELECT * from gp_toolkit.gp_resgroup_config;
+
 -- by default admin_group has concurrency set to -1 which leads to
 -- very small memory quota for each resgroup slot, correct it.
 0: ALTER RESOURCE GROUP admin_group SET concurrency 2;
+
+-- explicitly set memory settings
+0: ALTER RESOURCE GROUP admin_group SET memory_limit 10;
+0: ALTER RESOURCE GROUP default_group SET memory_limit 30;
+0: ALTER RESOURCE GROUP admin_group SET memory_shared_quota 80;
+0: ALTER RESOURCE GROUP default_group SET memory_shared_quota 80;
 -- in later cases we will SHOW memory_spill_ratio as first command
 -- to verify that it can be correctly loaded even for bypassed commands
-0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
+0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio '100 MB';
+0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio '100 MB';

--- a/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
@@ -503,4 +503,3 @@ DROP ROLE role1_memory_test;
 DROP ROLE role2_memory_test;
 DROP RESOURCE GROUP rg1_memory_test;
 DROP RESOURCE GROUP rg2_memory_test;
-

--- a/src/test/isolation2/output/resgroup/disable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/disable_resgroup.source
@@ -21,6 +21,20 @@ gp_resource_manager
 queue              
 (1 row)
 
--- reset admin_group concurrency setting
+-- reset settings
 ALTER RESOURCE GROUP admin_group SET concurrency 10;
+ALTER
+ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 20;
+ALTER
+ALTER RESOURCE GROUP admin_group SET memory_limit 10;
+ALTER
+ALTER RESOURCE GROUP admin_group SET memory_shared_quota 50;
+ALTER
+ALTER RESOURCE GROUP default_group SET concurrency 20;
+ALTER
+ALTER RESOURCE GROUP default_group SET memory_spill_ratio 20;
+ALTER
+ALTER RESOURCE GROUP default_group SET memory_limit 30;
+ALTER
+ALTER RESOURCE GROUP default_group SET memory_shared_quota 50;
 ALTER

--- a/src/test/isolation2/output/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup.source
@@ -77,11 +77,31 @@ rqpsession|rqpcommand|rqppriority|rqpweight
 ----------+----------+-----------+---------
 (0 rows)
 
+-- verify the default settings
+0: SELECT * from gp_toolkit.gp_resgroup_config;
+groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
+-------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
+6437   |default_group|20         |20                  |30            |30          |30                   |50                 |50                          |20                |20                         
+6438   |admin_group  |10         |10                  |10            |10          |10                   |50                 |50                          |20                |20                         
+(2 rows)
+
 -- by default admin_group has concurrency set to -1 which leads to
 -- very small memory quota for each resgroup slot, correct it.
 0: ALTER RESOURCE GROUP admin_group SET concurrency 2;
 ALTER
+
+-- explicitly set memory settings
+0: ALTER RESOURCE GROUP admin_group SET memory_limit 10;
+ALTER
+0: ALTER RESOURCE GROUP default_group SET memory_limit 30;
+ALTER
+0: ALTER RESOURCE GROUP admin_group SET memory_shared_quota 80;
+ALTER
+0: ALTER RESOURCE GROUP default_group SET memory_shared_quota 80;
+ALTER
 -- in later cases we will SHOW memory_spill_ratio as first command
 -- to verify that it can be correctly loaded even for bypassed commands
-0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
+0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio '100 MB';
+ALTER
+0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio '100 MB';
 ALTER

--- a/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
@@ -931,4 +931,3 @@ DROP RESOURCE GROUP rg1_memory_test;
 DROP
 DROP RESOURCE GROUP rg2_memory_test;
 DROP
-

--- a/src/test/isolation2/sql/resgroup/resgroup_dumpinfo.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_dumpinfo.sql
@@ -84,7 +84,7 @@ CREATE ROLE role_permission;
 SET ROLE role_permission;
 select value from pg_resgroup_get_status_kv('dump');
 
-SET ROLE gpadmin;
+RESET ROLE;
 
 DROP ROLE role_dumpinfo_test;
 DROP ROLE role_permission;

--- a/src/test/isolation2/sql/resgroup/resgroup_set_memory_spill_ratio.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_set_memory_spill_ratio.sql
@@ -30,7 +30,7 @@ SET MEMORY_SPILL_RATIO TO 70;
 SHOW MEMORY_SPILL_RATIO;
 SELECT 1;
 
--- positive set to session level
+-- positive set to session level use work_mem
 SET MEMORY_SPILL_RATIO TO 0;
 SHOW MEMORY_SPILL_RATIO;
 SELECT 1;
@@ -49,6 +49,52 @@ SELECT 1;
 SET MEMORY_SPILL_RATIO TO 20;
 SHOW MEMORY_SPILL_RATIO;
 SELECT 1;
+
+-- positive set to session level
+SET MEMORY_SPILL_RATIO TO '20MB';
+SHOW MEMORY_SPILL_RATIO;
+SELECT 1;
+
+-- positive set to session level
+SET MEMORY_SPILL_RATIO TO '20000kB';
+SHOW MEMORY_SPILL_RATIO;
+SELECT 1;
+
+-- positive set to session level? can run?
+SET MEMORY_SPILL_RATIO TO '20GB';
+SHOW MEMORY_SPILL_RATIO;
+SELECT 1;
+
+-- positive set to session level? can run?
+SET MEMORY_SPILL_RATIO TO '20  MB  ';
+SHOW MEMORY_SPILL_RATIO;
+SELECT 1;
+
+-- negative oom when oprator memory is too large
+SET MEMORY_SPILL_RATIO TO '100GB';
+SHOW MEMORY_SPILL_RATIO;
+SELECT * FROM gp_toolkit.gp_resgroup_config ;
+RESET MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '10 %';
+SHOW MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '10.M';
+SHOW MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '-10M';
+SHOW MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '-10';
+SHOW MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '0x10M';
+SHOW MEMORY_SPILL_RATIO;
 
 -- reset to resource group level
 RESET MEMORY_SPILL_RATIO;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -53,10 +53,8 @@ CREATE RESOURCE GROUP none WITH (cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 DROP RESOURCE GROUP rg_test_group;
--- must specify both memory_limit and (cpu_rate_limit or cpuset)
+-- must specify cpu_rate_limit or cpuset
 CREATE RESOURCE GROUP rg_test_group WITH (memory_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, cpu_rate_limit=5);
@@ -107,6 +105,12 @@ DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpuset='0', memory_limit=10, memory_shared_quota=70, memory_spill_ratio=30);
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
+SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
+SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+DROP RESOURCE GROUP rg_test_group;
 
 -- ----------------------------------------------------------------------
 -- Test: boundary check in create resource group syntax
@@ -120,9 +124,9 @@ CREATE RESOURCE GROUP rg_test_group3 WITH (cpu_rate_limit=1, memory_limit=10);
 DROP RESOURCE GROUP rg_test_group1;
 DROP RESOURCE GROUP rg_test_group2;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=61, memory_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=61);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=91);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=0, memory_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=-1);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0.9);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=1.9);
 -- negative: concurrency should be in [1, max_connections]
@@ -187,6 +191,52 @@ DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=0, memory_spill_ratio=100);
 DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=99, memory_spill_ratio=1);
+DROP RESOURCE GROUP rg_test_group;
+
+-- negative: absolute value format of memory_spill_ratio is
+-- '^[1-9][0-9]*[MmGg]$'
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 %');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10%');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 M');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.MB');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.0MB');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M ');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10B');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10K');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10X');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10MB');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='0 MB');
+DROP RESOURCE GROUP rg_test_group;
+-- negative: memory_spill_ratio does not accept out of range percentage values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='101');
+-- negative: when memory_limit is unlimited memory_spill_ratio must be set in
+-- absolute value format
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=10);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='10%');
+
+-- positive
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100kB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100GB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=' 100 MB ');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='0x10 MB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='010 MB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='+10 MB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
+DROP RESOURCE GROUP rg_test_group;
+
+-- positive: memory_spill_ratio in absolute value format will be ensured to be >= 1 chunk
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='1kB');
+SELECT memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
 
 -- ----------------------------------------------------------------------
@@ -255,3 +305,50 @@ ALTER RESOURCE GROUP cgroup_audited_group SET CONCURRENCY 10;
 -- negative: role should not be assigned to a cgroup audited resource group
 CREATE ROLE cgroup_audited_role RESOURCE GROUP cgroup_audited_group;
 DROP RESOURCE GROUP cgroup_audited_group;
+
+-- positive: memory_spill_ratio accepts both integer and string values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+DROP RESOURCE GROUP rg_test_group;
+
+-- negative: memory_spill_ratio only accepts string value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10%;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10M;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10MB;
+DROP RESOURCE GROUP rg_test_group;
+-- negative: memory_spill_ratio does not accept out of range percentage values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1';
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '101';
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1MB';
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '0MB';
+DROP RESOURCE GROUP rg_test_group;
+-- positive: memory_limit can be altered to unlimited if memory_spill_ratio has
+-- an absolute value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+DROP RESOURCE GROUP rg_test_group;
+-- negative: memory_spill_ratio only accepts an absolute value if memory_limit
+-- is unlimited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+DROP RESOURCE GROUP rg_test_group;
+-- positive: memory_spill_ratio accepts a percentage value only if
+-- memory_limit is limited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+DROP RESOURCE GROUP rg_test_group;
+-- negative: memory_limit must be limited if memory_spill_ratio has a
+-- percentage value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+DROP RESOURCE GROUP rg_test_group;
+-- positive: memory_spill_ratio accepts a absolute value anytime
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '50MB';
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10MB';
+DROP RESOURCE GROUP rg_test_group;

--- a/src/test/isolation2/sql/resgroup/resgroup_unlimit_memory_spill_ratio.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_unlimit_memory_spill_ratio.sql
@@ -75,7 +75,7 @@ ANALYZE test_zero_workmem;
 SELECT count(*) FROM test_zero_workmem;
 
 --clean env
-SET ROLE to gpadmin;
+RESET ROLE;
 DROP TABLE test_zero_workmem;
 DROP ROLE role_zero_workmem;
 DROP RESOURCE GROUP rg_zero_workmem;


### PR DESCRIPTION
Old memory_spill_ratio only supports percentage format,
which is hard for user to config the operator(join, sort etc.)
memory. We add absolute value format to make memory_spill_ratio
have the similar behavior like GUC statement_mem in resource
queue mode.

Also change the default values of resource group, e.g. use 128MB
as memory_spill_ratio to make the migration from resource queue
to resource group more smoothly.

Co-authored-by: Ning Yu <nyu@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
- [x] Greenlight from PM team
