### PR TITLE
Back Port 6X: Support internal communications when re-initialize connection. (#7697)

### DIFF
--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -414,7 +414,8 @@ is_internal_gpdb_conn(Port *port)
 	 * This is an internal connection if major version is three and we've set
 	 * the upper bits to 7.
 	 */
-	if (PG_PROTOCOL_MAJOR(port->proto) == 3 && port->proto >> 28 == 7)
+	if (PG_PROTOCOL_MAJOR(port->proto) == 3 &&
+			IS_GPDB_INTERNAL_PROTOCOL(port->proto))
 		return true;
 	else
 		return false;

--- a/src/include/libpq/pqcomm.h
+++ b/src/include/libpq/pqcomm.h
@@ -105,6 +105,10 @@ typedef struct
 #define PG_PROTOCOL_MINOR(v)	((v) & 0x0000ffff)
 #define PG_PROTOCOL(m,n)	(((m) << 16) | (n))
 
+/* GPDB specific */
+#define GPDB_INTERNAL_PROTOCOL(m, n)    PG_PROTOCOL((m) | 0x7000, (n))
+#define IS_GPDB_INTERNAL_PROTOCOL(v)    (((v) >> 28) == 7)
+
 /* The earliest and latest frontend/backend protocol version supported. */
 
 #define PG_PROTOCOL_EARLIEST	PG_PROTOCOL(1,0)

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -1649,7 +1649,7 @@ connectDBStart(PGconn *conn)
 	conn->addrlist_family = hint.ai_family;
 #ifndef FRONTEND
 	// GPDB uses the high bits of the major version to indicate special internal communications
-	conn->pversion = PG_PROTOCOL(3 + 0x7000, 0);
+	conn->pversion = GPDB_INTERNAL_PROTOCOL(3, 0);
 #else
 	conn->pversion = PG_PROTOCOL(3, 0);
 #endif
@@ -1884,7 +1884,12 @@ keep_going:						/* We will come back to here until there is
 		 * reset them when we start to consider a new address (since it might
 		 * not be the same server).
 		 */
+#ifndef FRONTEND
+		// GPDB uses the high bits of the major version to indicate special internal communications
+		conn->pversion = GPDB_INTERNAL_PROTOCOL(3, 0);
+#else
 		conn->pversion = PG_PROTOCOL(3, 0);
+#endif	
 		conn->send_appname = true;
 #ifdef USE_SSL
 		/* initialize these values based on SSL mode */

--- a/src/test/regress/expected/internal_connection.out
+++ b/src/test/regress/expected/internal_connection.out
@@ -1,0 +1,36 @@
+-- create a new user
+drop user if exists user_disallowed_via_local;
+create user user_disallowed_via_local with login;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+-- cleanup previous settings if any
+\! sed -i '/user_disallowed_via_local/d' $MASTER_DATA_DIRECTORY/pg_hba.conf;
+-- allow it to login via the [tcp] protocol
+\! echo 'host all user_disallowed_via_local samenet trust' | tee -a $MASTER_DATA_DIRECTORY/pg_hba.conf;
+host all user_disallowed_via_local samenet trust
+-- disallow it to login via the [local] protocol
+\! echo 'local all user_disallowed_via_local reject' | tee -a $MASTER_DATA_DIRECTORY/pg_hba.conf;
+local all user_disallowed_via_local reject
+-- inform the cluster to reload the settings
+\! gpstop -qu;
+-- the reloading might not happen immediately, wait for a while
+select pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- login via a network address is allowed
+\c postgres user_disallowed_via_local localhost
+-- now we are the new user
+create temp table t1_of_user_disallowed_via_local(c1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- below query will fork an entry db on master, it will connect via [local],
+-- but as it is an internal connection it should still be allowed
+select * from t1_of_user_disallowed_via_local, pg_sleep(0);
+ c1 | pg_sleep 
+----+----------
+(0 rows)
+
+-- cleanup settings if any
+\! sed -i '/user_disallowed_via_local/d' $MASTER_DATA_DIRECTORY/pg_hba.conf;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -34,6 +34,9 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
 
+# test gpdb internal connection
+test: internal_connection
+
 # bitmap_index triggers recovery, run it seperately
 test: bitmap_index
 test: gp_dump_query_oids analyze gp_owner_permission incremental_analyze

--- a/src/test/regress/sql/internal_connection.sql
+++ b/src/test/regress/sql/internal_connection.sql
@@ -1,0 +1,28 @@
+-- create a new user
+drop user if exists user_disallowed_via_local;
+create user user_disallowed_via_local with login;
+
+-- cleanup previous settings if any
+\! sed -i '/user_disallowed_via_local/d' $MASTER_DATA_DIRECTORY/pg_hba.conf;
+-- allow it to login via the [tcp] protocol
+\! echo 'host all user_disallowed_via_local samenet trust' | tee -a $MASTER_DATA_DIRECTORY/pg_hba.conf;
+-- disallow it to login via the [local] protocol
+\! echo 'local all user_disallowed_via_local reject' | tee -a $MASTER_DATA_DIRECTORY/pg_hba.conf;
+
+-- inform the cluster to reload the settings
+\! gpstop -qu;
+-- the reloading might not happen immediately, wait for a while
+select pg_sleep(2);
+
+-- login via a network address is allowed
+\c postgres user_disallowed_via_local localhost
+
+-- now we are the new user
+create temp table t1_of_user_disallowed_via_local(c1 int);
+
+-- below query will fork an entry db on master, it will connect via [local],
+-- but as it is an internal connection it should still be allowed
+select * from t1_of_user_disallowed_via_local, pg_sleep(0);
+
+-- cleanup settings if any
+\! sed -i '/user_disallowed_via_local/d' $MASTER_DATA_DIRECTORY/pg_hba.conf;


### PR DESCRIPTION
GPDB uses the high three bits of protocol version to indicate this is internal
communication. Previous merge forgets to set these three bits when
re-initialize connection.

Co-authored-by: Ning Yu <nyu@pivotal.io>
Reviewed-by: Zhenghua Lyu <zlv@pivotal.io>
Reviewed-by: Asim R P <apraveen@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
- [ ] Greenlight from PM team