### PR TITLE
Back port 6X: Control operator memory by absolute values in resource group mode (#7…

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1790,14 +1790,10 @@ CREATE VIEW gp_toolkit.gp_resgroup_config AS
     SELECT G.oid       AS groupid
          , G.rsgname   AS groupname
          , T1.value    AS concurrency
-         , T1.proposed AS proposed_concurrency
          , T2.value    AS cpu_rate_limit
          , T3.value    AS memory_limit
-         , T3.proposed AS proposed_memory_limit
          , T4.value    AS memory_shared_quota
-         , T4.proposed AS proposed_memory_shared_quota
          , T5.value    AS memory_spill_ratio
-         , T5.proposed AS proposed_memory_spill_ratio
          , CASE WHEN T6.value IS NULL THEN 'vmtracker'
                 WHEN T6.value='0'     THEN 'vmtracker'
                 WHEN T6.value='1'     THEN 'cgroup'

--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1857,11 +1857,8 @@ CREATE VIEW gp_toolkit.gp_resgroup_status_per_host AS
       , sum((s.memory->'available'       )::text::integer) AS memory_available
       , sum((s.memory->'quota_used'      )::text::integer) AS memory_quota_used
       , sum((s.memory->'quota_available' )::text::integer) AS memory_quota_available
-      , sum((s.memory->'quota_proposed'  )::text::integer) AS memory_quota_proposed
       , sum((s.memory->'shared_used'     )::text::integer) AS memory_shared_used
       , sum((s.memory->'shared_available')::text::integer) AS memory_shared_available
-      , sum((s.memory->'shared_granted'  )::text::integer) AS memory_shared_granted
-      , sum((s.memory->'shared_proposed' )::text::integer) AS memory_shared_proposed
     FROM s
     INNER JOIN pg_catalog.gp_segment_configuration AS c
         ON s.segment_id = c.content
@@ -1903,11 +1900,8 @@ CREATE VIEW gp_toolkit.gp_resgroup_status_per_segment AS
       , sum((s.memory->'available'       )::text::integer) AS memory_available
       , sum((s.memory->'quota_used'      )::text::integer) AS memory_quota_used
       , sum((s.memory->'quota_available' )::text::integer) AS memory_quota_available
-      , sum((s.memory->'quota_proposed'  )::text::integer) AS memory_quota_proposed
       , sum((s.memory->'shared_used'     )::text::integer) AS memory_shared_used
       , sum((s.memory->'shared_available')::text::integer) AS memory_shared_available
-      , sum((s.memory->'shared_granted'  )::text::integer) AS memory_shared_granted
-      , sum((s.memory->'shared_proposed' )::text::integer) AS memory_shared_proposed
     FROM s
     INNER JOIN pg_catalog.gp_segment_configuration AS c
         ON s.segment_id = c.content

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -33,6 +33,7 @@
 #include "libpq/libpq-be.h"
 #include "postmaster/backoff.h"
 #include "utils/resource_manager.h"
+#include "utils/resgroup.h"
 #include "utils/resgroup-ops.h"
 #include "storage/proc.h"
 #include "storage/procarray.h"

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -33,16 +33,24 @@
 #include "utils/builtins.h"
 #include "utils/datetime.h"
 #include "utils/fmgroids.h"
+#include "utils/guc.h"
 #include "utils/resgroup.h"
 #include "utils/resgroup-ops.h"
 #include "utils/resource_manager.h"
 #include "utils/resowner.h"
 #include "utils/syscache.h"
 #include "utils/faultinjector.h"
+#include "utils/vmem_tracker.h"
 
 #define RESGROUP_DEFAULT_CONCURRENCY (20)
-#define RESGROUP_DEFAULT_MEM_SHARED_QUOTA (20)
-#define RESGROUP_DEFAULT_MEM_SPILL_RATIO (20)
+#define RESGROUP_DEFAULT_MEMORY_LIMIT (0)
+#define RESGROUP_DEFAULT_MEM_SHARED_QUOTA (80)
+/*
+ * The default memory_spill_ratio value is 128MB, it is in absolute value
+ * format, so it is represented as a negative value, and as its unit is chunk,
+ * so need a conversion.
+ */
+#define RESGROUP_DEFAULT_MEM_SPILL_RATIO (-VmemTracker_ConvertVmemMBToChunks(128))
 
 #define RESGROUP_DEFAULT_MEM_AUDITOR (RESGROUP_MEMORY_AUDITOR_VMTRACKER)
 #define RESGROUP_INVALID_MEM_AUDITOR (-1)
@@ -53,7 +61,7 @@
 #define RESGROUP_MIN_CPU_RATE_LIMIT	(1)
 #define RESGROUP_MAX_CPU_RATE_LIMIT	(100)
 
-#define RESGROUP_MIN_MEMORY_LIMIT	(1)
+#define RESGROUP_MIN_MEMORY_LIMIT	(0)
 #define RESGROUP_MAX_MEMORY_LIMIT	(100)
 
 #define RESGROUP_MIN_MEMORY_SHARED_QUOTA	(0)
@@ -76,7 +84,7 @@ static ResGroupLimitType getResgroupOptionType(const char* defname);
 static ResGroupCap getResgroupOptionValue(DefElem *defel, int type);
 static const char *getResgroupOptionName(ResGroupLimitType type);
 static void checkResgroupCapLimit(ResGroupLimitType type, ResGroupCap value);
-static void checkResgroupMemAuditor(ResGroupCaps *caps);
+static void checkResgroupCapConflicts(ResGroupCaps *caps);
 static void parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps);
 static void validateCapabilities(Relation rel, Oid groupid, ResGroupCaps *caps, bool newGroup);
 static void insertResgroupCapabilityEntry(Relation rel, Oid groupid, uint16 type, const char *value);
@@ -466,7 +474,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 			break;
 	}
 
-	checkResgroupMemAuditor(&caps);
+	checkResgroupCapConflicts(&caps);
 
 	validateCapabilities(pg_resgroupcapability_rel, groupid, &caps, false);
 
@@ -564,8 +572,8 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 	{
 		Datum				typeDatum;
 		ResGroupLimitType	type;
-		Datum				proposedDatum;
-		char				*proposed;
+		Datum				valueDatum;
+		char				*value;
 
 		typeDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_reslimittype,
 								 rel->rd_att, &isNull);
@@ -579,37 +587,36 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 
 		mask |= 1 << type;
 
-		proposedDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_proposed,
+		valueDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_value,
 									 rel->rd_att, &isNull);
-		proposed = TextDatumGetCString(proposedDatum);
+		value = TextDatumGetCString(valueDatum);
 		switch (type)
 		{
 			case RESGROUP_LIMIT_TYPE_CONCURRENCY:
-				resgroupCaps->concurrency = str2Int(proposed, 
+				resgroupCaps->concurrency = str2Int(value,
 													getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_CPU:
-				resgroupCaps->cpuRateLimit = str2Int(proposed, 
+				resgroupCaps->cpuRateLimit = str2Int(value,
 													 getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_MEMORY:
-				resgroupCaps->memLimit = str2Int(proposed, 
+				resgroupCaps->memLimit = str2Int(value,
 												 getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_MEMORY_SHARED_QUOTA:
-				resgroupCaps->memSharedQuota = str2Int(proposed, 
+				resgroupCaps->memSharedQuota = str2Int(value,
 													   getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO:
-				resgroupCaps->memSpillRatio = str2Int(proposed,
-													  getResgroupOptionName(type));
+				resgroupCaps->memSpillRatio = ResGroupMemorySpillFromStr(value);
 				break;
 			case RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR:
-				resgroupCaps->memAuditor = str2Int(proposed,
+				resgroupCaps->memAuditor = str2Int(value,
 												   getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_CPUSET:
-				StrNCpy(resgroupCaps->cpuset, proposed, sizeof(resgroupCaps->cpuset));
+				StrNCpy(resgroupCaps->cpuset, value, sizeof(resgroupCaps->cpuset));
 				break;
 			default:
 				break;
@@ -831,6 +838,10 @@ getResgroupOptionValue(DefElem *defel, int type)
 		char *auditor_name = defGetString(defel);
 		value = getResGroupMemAuditor(auditor_name);
 	}
+	else if (type == RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO)
+	{
+		value = ResGroupMemorySpillFromStr(defGetString(defel));
+	}
 	else
 	{
 		value = defGetInt64(defel);
@@ -922,13 +933,12 @@ checkResgroupCapLimit(ResGroupLimitType type, int value)
 				break;
 
 			case RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO:
-				if (value < RESGROUP_MIN_MEMORY_SPILL_RATIO ||
-					value > RESGROUP_MAX_MEMORY_SPILL_RATIO)
-					ereport(ERROR,
-							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							errmsg("memory_spill_ratio range is [%d, %d]",
-								   RESGROUP_MIN_MEMORY_SPILL_RATIO,
-								   RESGROUP_MAX_MEMORY_SPILL_RATIO)));
+				/*
+				 * memory_spill_ratio is already checked when parsing it.
+				 *
+				 * On the other hand negative value is used as absolute value,
+				 * there is no chance to check the range now, so nothing to do.
+				 */
 				break;
 
 			case RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR:
@@ -948,12 +958,23 @@ checkResgroupCapLimit(ResGroupLimitType type, int value)
 }
 
 /*
- * Check to see if concurrency is not zero for resource group
- * with cgroup memory auditor.
+ * Check conflict settings in caps.
  */
 static void
-checkResgroupMemAuditor(ResGroupCaps *caps)
+checkResgroupCapConflicts(ResGroupCaps *caps)
 {
+	/*
+	 * When memory_limit is unlimited the memory_spill_ratio must be set in
+	 * absolute value format.
+	 */
+	if (caps->memLimit == 0 && caps->memSpillRatio > 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("when memory_limit is unlimited memory_spill_ratio must be set in absolute value format")));
+
+	/*
+	 * When memory_auditor is cgroup the concurrency must be 0.
+	 */
 	if (caps->memAuditor == RESGROUP_MEMORY_AUDITOR_CGROUP &&
 		caps->concurrency != 0)
 		ereport(ERROR,
@@ -961,22 +982,13 @@ checkResgroupMemAuditor(ResGroupCaps *caps)
 				errmsg("resource group concurrency must be 0 when group memory_auditor is %s",
 					ResGroupMemAuditorName[RESGROUP_MEMORY_AUDITOR_CGROUP])));
 
+	/*
+	 * The cgroup memory_auditor should not be used without a properly
+	 * configured cgroup memory directory.
+	 */
 	if (caps->memAuditor == RESGROUP_MEMORY_AUDITOR_CGROUP &&
 		!gp_resource_group_enable_cgroup_memory)
 	{
-		/*
-		 * Suppose the user has reconfigured the cgroup dirs by following
-		 * the gpdb documents, could it take effect at runtime (e.g. create
-		 * the resgroup again) without restart the cluster?
-		 *
-		 * It's possible but might not be reliable, as the user might
-		 * introduced unwanted changes to other cgroup dirs during the
-		 * reconfiguration (e.g. changed the permissions, moved processes
-		 * in/out).
-		 *
-		 * So we do not recheck the permissions here.
-		 */
-
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_FEATURE_NOT_CONFIGURED),
 				 errmsg("cgroup is not properly configured for the 'cgroup' memory auditor"),
@@ -1058,11 +1070,6 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 	if ((mask & (1 << RESGROUP_LIMIT_TYPE_CPUSET)))
 		EnsureCpusetIsAvailable(ERROR);
 
-	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_MEMORY)))
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				errmsg("must specify memory_limit")));
-
 	if ((mask & (1 << RESGROUP_LIMIT_TYPE_CPU)) &&
 		(mask & (1 << RESGROUP_LIMIT_TYPE_CPUSET)))
 		ereport(ERROR,
@@ -1074,6 +1081,9 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("must specify cpu_rate_limit or cpuset")));
+
+	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_MEMORY)))
+		caps->memLimit = RESGROUP_DEFAULT_MEMORY_LIMIT;
 
 	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_CONCURRENCY)))
 		caps->concurrency = RESGROUP_DEFAULT_CONCURRENCY;
@@ -1087,7 +1097,7 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR)))
 		caps->memAuditor = RESGROUP_DEFAULT_MEM_AUDITOR;
 
-	checkResgroupMemAuditor(caps);
+	checkResgroupCapConflicts(caps);
 }
 
 /*
@@ -1175,7 +1185,7 @@ insertResgroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *caps)
 	insertResgroupCapabilityEntry(rel, groupId,
 								  RESGROUP_LIMIT_TYPE_MEMORY_SHARED_QUOTA, value);
 
-	sprintf(value, "%d", caps->memSpillRatio);
+	ResGroupMemorySpillToStr(caps->memSpillRatio, value, sizeof(value));
 	insertResgroupCapabilityEntry(rel, groupId,
 								  RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO, value);
 
@@ -1246,6 +1256,10 @@ updateResgroupCapabilityEntry(Relation rel,
 	{
 		StrNCpy(stringBuffer, strValue, sizeof(stringBuffer));
 	}
+	else if (limitType == RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO)
+	{
+		ResGroupMemorySpillToStr((int32) value, stringBuffer, sizeof(stringBuffer));
+	}
 	else
 	{
 		snprintf(stringBuffer, sizeof(stringBuffer), "%d", value);
@@ -1254,10 +1268,6 @@ updateResgroupCapabilityEntry(Relation rel,
 	values[Anum_pg_resgroupcapability_value - 1] = CStringGetTextDatum(stringBuffer);
 	isnull[Anum_pg_resgroupcapability_value - 1] = false;
 	repl[Anum_pg_resgroupcapability_value - 1]  = true;
-
-	values[Anum_pg_resgroupcapability_proposed - 1] = CStringGetTextDatum(stringBuffer);
-	isnull[Anum_pg_resgroupcapability_proposed - 1] = false;
-	repl[Anum_pg_resgroupcapability_proposed - 1]  = true;
 
 	newTuple = heap_modify_tuple(oldTuple, RelationGetDescr(rel),
 								 values, isnull, repl);
@@ -1341,11 +1351,11 @@ validateCapabilities(Relation rel,
 	{
 		Datum				groupIdDatum;
 		Datum				typeDatum;
-		Datum				proposedDatum;
+		Datum				valueDatum;
 		ResGroupLimitType	reslimittype;
 		Oid					resgroupid;
-		char				*proposedStr;
-		int					proposed;
+		char				*valueStr;
+		int					value;
 		bool				isNull;
 
 		groupIdDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_resgroupid,
@@ -1367,16 +1377,16 @@ validateCapabilities(Relation rel,
 								 rel->rd_att, &isNull);
 		reslimittype = (ResGroupLimitType) DatumGetInt16(typeDatum);
 
-		proposedDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_proposed,
+		valueDatum = heap_getattr(tuple, Anum_pg_resgroupcapability_value,
 									 rel->rd_att, &isNull);
 
 		if (reslimittype == RESGROUP_LIMIT_TYPE_CPU)
 		{
-			proposedStr = TextDatumGetCString(proposedDatum);
-			proposed = str2Int(proposedStr, getResgroupOptionName(reslimittype));
-			if (proposed != CPU_RATE_LIMIT_DISABLED)
+			valueStr = TextDatumGetCString(valueDatum);
+			value = str2Int(valueStr, getResgroupOptionName(reslimittype));
+			if (value != CPU_RATE_LIMIT_DISABLED)
 			{
-				totalCpu += proposed;
+				totalCpu += value;
 				if (totalCpu > RESGROUP_MAX_CPU_RATE_LIMIT)
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -1386,9 +1396,9 @@ validateCapabilities(Relation rel,
 		}
 		else if (reslimittype == RESGROUP_LIMIT_TYPE_MEMORY)
 		{
-			proposedStr = TextDatumGetCString(proposedDatum);
-			proposed = str2Int(proposedStr, getResgroupOptionName(reslimittype));
-			totalMem += proposed;
+			valueStr = TextDatumGetCString(valueDatum);
+			value = str2Int(valueStr, getResgroupOptionName(reslimittype));
+			totalMem += value;
 			if (totalMem > RESGROUP_MAX_MEMORY_LIMIT)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -1402,8 +1412,8 @@ validateCapabilities(Relation rel,
 			 */
 			if (IsResGroupActivated() && !CpusetIsEmpty(caps->cpuset))
 			{
-				proposedStr = TextDatumGetCString(proposedDatum);
-				if (!CpusetIsEmpty(proposedStr))
+				valueStr = TextDatumGetCString(valueDatum);
+				if (!CpusetIsEmpty(valueStr))
 				{
 					Bitmapset *bmsOther = NULL;
 
@@ -1411,7 +1421,7 @@ validateCapabilities(Relation rel,
 
 					Assert(!bms_is_empty(bmsCurrent));
 
-					bmsOther = CpusetToBitset(proposedStr, MaxCpuSetLength);
+					bmsOther = CpusetToBitset(valueStr, MaxCpuSetLength);
 					bmsCommon = bms_intersect(bmsCurrent, bmsOther);
 
 					if (!bms_is_empty(bmsCommon))
@@ -1435,9 +1445,6 @@ validateCapabilities(Relation rel,
 /*
  * Insert one capability to the capability table.
  *
- * 'value' and 'proposed' are both used to describe a resource,
- * in this routine we assume 'proposed' has the same value as 'value'.
- *
  * @param rel      the relation
  * @param groupid  oid of the resource group
  * @param type     the resource limit type
@@ -1460,7 +1467,6 @@ insertResgroupCapabilityEntry(Relation rel,
 	new_record[Anum_pg_resgroupcapability_resgroupid - 1] = ObjectIdGetDatum(groupid);
 	new_record[Anum_pg_resgroupcapability_reslimittype - 1] = UInt16GetDatum(type);
 	new_record[Anum_pg_resgroupcapability_value - 1] = CStringGetTextDatum(value);
-	new_record[Anum_pg_resgroupcapability_proposed - 1] = CStringGetTextDatum(value);
 
 	tuple = heap_form_tuple(tupleDesc, new_record, new_record_nulls);
 	simple_heap_insert(rel, tuple);
@@ -1587,4 +1593,103 @@ checkCpusetSyntax(const char *cpuset)
 		return false;
 	}
 	return true;
+}
+
+/*
+ * Parse memory_spill_ratio from string.
+ *
+ * It has two input formats:
+ * - the percentage format is an integer value within [0, 100], return the
+ *   percentage;
+ * - the absolute value format is in "number unit" format, where "unit" can be
+ *   "kB", "MB", "GB" or "TB", the "number" must be > 0, it is converted to
+ *   chunks, return (-1 * chunks);
+ */
+int32
+ResGroupMemorySpillFromStr(const char *str)
+{
+
+	int32			value;
+	const char	   *prop = "memory_spill_ratio";
+
+	/* if memory spill ratio is percentile value */
+	if (parse_int(str, &value, 0, NULL))
+	{
+		if (value < RESGROUP_MIN_MEMORY_SPILL_RATIO ||
+			value > RESGROUP_MAX_MEMORY_SPILL_RATIO)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("memory_spill_ratio in percentage format must be "
+							"in the range [%d, %d]",
+							RESGROUP_MIN_MEMORY_SPILL_RATIO,
+							RESGROUP_MAX_MEMORY_SPILL_RATIO)));
+		return value;
+	}
+	/* for absolute value, all int value are allowed */
+	else if (parse_int(str, &value, GUC_UNIT_KB, NULL))
+	{
+		if (value <= 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("memory_spill_ratio in absolute value format must "
+							"be > 0")));
+
+		return -Max(1,
+					VmemTracker_ConvertVmemMBToChunks(value >> 10));
+	}
+	else
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("syntax error on capability %s", prop)));
+}
+
+/*
+ * Convert memory_spill_ratio to a string.
+ *
+ * Refer to ResGroupMemorySpillFromStr() for details of the string format.
+ */
+void
+ResGroupMemorySpillToStr(int32 value, char *buf, int bufsize)
+{
+	if (value >= 0)
+	{
+		/* The value is in the percentage format */
+		snprintf(buf, bufsize, "%d", value);
+	}
+	else
+	{
+		/* The value is in the absolute value format */
+
+		/* Below logic is derived from _ShowOption() */
+#define KB_PER_MB (1024)
+#define KB_PER_GB (1024*1024)
+#define KB_PER_TB (1024*1024*1024)
+
+		int64			result;
+		const char	   *unit;
+		
+		result = -(VmemTracker_ConvertVmemChunksToMB(value) << 10);
+		if (result % KB_PER_TB == 0)
+		{
+			result /= KB_PER_TB;
+			unit = "TB";
+		}
+		else if (result % KB_PER_GB == 0)
+		{
+			result /= KB_PER_GB;
+			unit = "GB";
+		}
+		else if (result % KB_PER_MB == 0)
+		{
+			result /= KB_PER_MB;
+			unit = "MB";
+		}
+		else
+		{
+			unit = "kB";
+		}
+
+		snprintf(buf, bufsize, INT64_FORMAT " %s",
+				 result, unit);
+	}
 }

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -1501,6 +1501,10 @@ OptResourceGroupElem:
 				{
 					$$ = makeDefElem("memory_spill_ratio", (Node *) makeInteger($2));
 				}
+			| MEMORY_SPILL_RATIO Sconst
+				{
+					$$ = makeDefElem("memory_spill_ratio", (Node *) makeString($2));
+				}
 		;
 
 /*****************************************************************************

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -91,7 +91,7 @@ static bool check_pljava_classpath_insecure(bool *newval, void **extra, GucSourc
 static void assign_pljava_classpath_insecure(bool newval, void *extra);
 static bool check_gp_resource_group_bypass(bool *newval, void **extra, GucSource source);
 
-static bool check_memory_spill_ratio(const char **newval, void **extra, GucSource source);
+static bool check_memory_spill_ratio(char **newval, void **extra, GucSource source);
 static void assign_memory_spill_ratio(const char *newval, void *extra);
 static const char *show_memory_spill_ratio(void);
 
@@ -5056,15 +5056,15 @@ check_gp_workfile_compression(bool *newval, void **extra, GucSource source)
 }
 
 
-bool
-check_memory_spill_ratio(const char **newval, void **extra, GucSource source)
+static bool
+check_memory_spill_ratio(char **newval, void **extra, GucSource source)
 {
-	ResGroupMemorySpillFromStr(*newval);
+	ResGroupMemorySpillFromStr((const char *)*newval);
 
 	return true;
 }
 
-void
+static void
 assign_memory_spill_ratio(const char *newval, void *extra)
 {
 	int32		value = ResGroupMemorySpillFromStr(newval);
@@ -5072,7 +5072,7 @@ assign_memory_spill_ratio(const char *newval, void *extra)
 	memory_spill_ratio = value;
 }
 
-const char *
+static const char *
 show_memory_spill_ratio(void)
 {
 	static char buf[16];

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301905101
+#define CATALOG_VERSION_NO	301905231
 
 #endif

--- a/src/include/catalog/pg_resgroupcapability.h
+++ b/src/include/catalog/pg_resgroupcapability.h
@@ -23,10 +23,6 @@ CATALOG(pg_resgroupcapability,6439) BKI_SHARED_RELATION
 	int16		reslimittype;	/* resource limit type id (RESGROUP_LIMIT_TYPE_XXX) */
 
 	text		value;		/* resource limit (opaque type)  */
-
-	text		proposed; 	/* most of the capabilities cannot be updated immediately, we
-					 * do it in an asynchronous way to merge the proposed value 
-					 * with the working one */
 } FormData_pg_resgroupcapability;
 
 
@@ -44,38 +40,37 @@ typedef FormData_pg_resgroupcapability *Form_pg_resgroupcapability;
  *	compiler constants for pg_resgroupcapability
  * ----------------
  */
-#define Natts_pg_resgroupcapability		4
+#define Natts_pg_resgroupcapability		3
 #define Anum_pg_resgroupcapability_resgroupid	1
 #define Anum_pg_resgroupcapability_reslimittype 2
 #define Anum_pg_resgroupcapability_value	3
-#define Anum_pg_resgroupcapability_proposed	4
 
-DATA(insert ( 6437, 1, 20, 20 ));
+DATA(insert ( 6437, 1, 20));
 
-DATA(insert ( 6437, 2, 30, 30 ));
+DATA(insert ( 6437, 2, 30));
 
-DATA(insert ( 6437, 3, 30, 30 ));
+DATA(insert ( 6437, 3, 0));
 
-DATA(insert ( 6437, 4, 50, 50 ));
+DATA(insert ( 6437, 4, 80));
 
-DATA(insert ( 6437, 5, 20, 20 ));
+DATA(insert ( 6437, 5, "128 MB"));
 
-DATA(insert ( 6437, 6, 0, 0 ));
+DATA(insert ( 6437, 6, 0));
 
-DATA(insert ( 6437, 7, "-1", "-1" ));
+DATA(insert ( 6437, 7, "-1"));
 
-DATA(insert ( 6438, 1, 10, 10 ));
+DATA(insert ( 6438, 1, 10));
 
-DATA(insert ( 6438, 2, 10, 10 ));
+DATA(insert ( 6438, 2, 10));
 
-DATA(insert ( 6438, 3, 10, 10 ));
+DATA(insert ( 6438, 3, 10));
 
-DATA(insert ( 6438, 4, 50, 50 ));
+DATA(insert ( 6438, 4, 80));
 
-DATA(insert ( 6438, 5, 20, 20 ));
+DATA(insert ( 6438, 5, "128 MB"));
 
-DATA(insert ( 6438, 6, 0, 0 ));
+DATA(insert ( 6438, 6, 0));
 
-DATA(insert ( 6438, 7, "-1", "-1" ));
+DATA(insert ( 6438, 7, "-1"));
 
 #endif   /* PG_RESGROUPCAPABILITY_H */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -770,4 +770,8 @@ extern bool gpvars_check_gp_gpperfmon_send_interval(int *newval, void **extra, G
 
 extern StdRdOptions *defaultStdRdOptions(char relkind);
 
+extern bool gpvars_check_memory_spill_ratio(const char **newval, void **extra, GucSource source);
+extern void gpvars_assign_memory_spill_ratio(const char *newval, void *extra);
+extern const char *gpvars_show_memory_spill_ratio(void);
+
 #endif   /* GUC_H */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -770,8 +770,4 @@ extern bool gpvars_check_gp_gpperfmon_send_interval(int *newval, void **extra, G
 
 extern StdRdOptions *defaultStdRdOptions(char relkind);
 
-extern bool gpvars_check_memory_spill_ratio(const char **newval, void **extra, GucSource source);
-extern void gpvars_assign_memory_spill_ratio(const char *newval, void *extra);
-extern const char *gpvars_show_memory_spill_ratio(void);
-
 #endif   /* GUC_H */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -190,6 +190,9 @@ extern void ResGroupDumpInfo(StringInfo str);
 
 extern int ResGroupGetSegmentNum(void);
 
+extern int32 ResGroupMemorySpillFromStr(const char *str);
+extern void ResGroupMemorySpillToStr(int32 value, char *buf, int bufsize);
+
 extern Bitmapset *CpusetToBitset(const char *cpuset,
 								 int len);
 extern void BitsetToCpuset(const Bitmapset *bms,

--- a/src/test/isolation2/expected/resgroup/resgroup_alter_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_alter_memory_spill_ratio.out
@@ -5,42 +5,42 @@ ERROR:  resource group "rg_spill_test" does not exist
 CREATE RESOURCE GROUP rg_spill_test WITH (concurrency=10, cpu_rate_limit=20, memory_limit=20, memory_shared_quota=20, memory_spill_ratio=10);
 CREATE
 
-CREATE OR REPLACE VIEW rg_spill_status AS SELECT groupname, memory_shared_quota, proposed_memory_shared_quota, memory_spill_ratio, proposed_memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_spill_test';
+CREATE OR REPLACE VIEW rg_spill_status AS SELECT groupname, memory_shared_quota, memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_spill_test';
 CREATE
 
 -- ALTER MEMORY_SPILL_RATIO
 
 SELECT * FROM rg_spill_status;
- groupname     | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio 
----------------+---------------------+------------------------------+--------------------+-----------------------------
- rg_spill_test | 20                  | 20                           | 10                 | 10                          
+ groupname     | memory_shared_quota | memory_spill_ratio 
+---------------+---------------------+--------------------
+ rg_spill_test | 20                  | 10                 
 (1 row)
 
 -- positive
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 20;
 ALTER
 SELECT * FROM rg_spill_status;
- groupname     | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio 
----------------+---------------------+------------------------------+--------------------+-----------------------------
- rg_spill_test | 20                  | 20                           | 20                 | 20                          
+ groupname     | memory_shared_quota | memory_spill_ratio 
+---------------+---------------------+--------------------
+ rg_spill_test | 20                  | 20                 
 (1 row)
 
 -- positive, memory_spill_ratio range is [0, 100]
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 0;
 ALTER
 SELECT * FROM rg_spill_status;
- groupname     | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio 
----------------+---------------------+------------------------------+--------------------+-----------------------------
- rg_spill_test | 20                  | 20                           | 0                  | 0                           
+ groupname     | memory_shared_quota | memory_spill_ratio 
+---------------+---------------------+--------------------
+ rg_spill_test | 20                  | 0                  
 (1 row)
 
 -- positive: no limit on the sum of shared and spill
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 81;
 ALTER
 SELECT * FROM rg_spill_status;
- groupname     | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio 
----------------+---------------------+------------------------------+--------------------+-----------------------------
- rg_spill_test | 20                  | 20                           | 81                 | 81                          
+ groupname     | memory_shared_quota | memory_spill_ratio 
+---------------+---------------------+--------------------
+ rg_spill_test | 20                  | 81                 
 (1 row)
 
 -- negative: memory_spill_ratio is invalid
@@ -53,18 +53,18 @@ ERROR:  syntax error at or near "a"
 LINE 1: ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO a;
                                                                   ^
 SELECT * FROM rg_spill_status;
- groupname     | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio 
----------------+---------------------+------------------------------+--------------------+-----------------------------
- rg_spill_test | 20                  | 20                           | 81                 | 81                          
+ groupname     | memory_shared_quota | memory_spill_ratio 
+---------------+---------------------+--------------------
+ rg_spill_test | 20                  | 81                 
 (1 row)
 
 -- negative: memory_spill_ratio is larger than RESGROUP_MAX_MEMORY_SPILL_RATIO
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 101;
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 SELECT * FROM rg_spill_status;
- groupname     | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio 
----------------+---------------------+------------------------------+--------------------+-----------------------------
- rg_spill_test | 20                  | 20                           | 81                 | 81                          
+ groupname     | memory_shared_quota | memory_spill_ratio 
+---------------+---------------------+--------------------
+ rg_spill_test | 20                  | 81                 
 (1 row)
 
 -- cleanup

--- a/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
@@ -64,7 +64,7 @@ DROP
 
 -- test2: test alter concurrency
 -- Create a resource group with concurrency=2. Prepare 2 running transactions and 1 queueing transactions.
--- Alter concurrency 2->3, the queueing transaction will be woken up, the 'value' and 'proposed' of pg_resgroupcapability will be set to 3.
+-- Alter concurrency 2->3, the queueing transaction will be woken up, the 'value' of pg_resgroupcapability will be set to 3.
 DROP ROLE IF EXISTS role_concurrency_test;
 DROP
 -- start_ignore
@@ -91,10 +91,10 @@ SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_to
 ---------------------+-------------+--------------+------------+--------------
  rg_concurrency_test | 2           | 1            | 1          | 2            
 (1 row)
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
- concurrency | proposed_concurrency 
--------------+----------------------
- 2           | 2                    
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+ concurrency 
+-------------
+ 2           
 (1 row)
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 3;
 ALTER
@@ -103,10 +103,10 @@ SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_to
 ---------------------+-------------+--------------+------------+--------------
  rg_concurrency_test | 2           | 1            | 1          | 2            
 (1 row)
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
- concurrency | proposed_concurrency 
--------------+----------------------
- 3           | 3                    
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+ concurrency 
+-------------
+ 3           
 (1 row)
 12:END;
 END
@@ -156,18 +156,18 @@ SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_to
 ---------------------+-------------+--------------+------------+--------------
  rg_concurrency_test | 3           | 1            | 1          | 3            
 (1 row)
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
- concurrency | proposed_concurrency 
--------------+----------------------
- 3           | 3                    
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+ concurrency 
+-------------
+ 3           
 (1 row)
--- Alter concurrency 3->2, the 'proposed' of pg_resgroupcapability will be set to 2.
+-- Alter concurrency 3->2, the 'value' of pg_resgroupcapability will be set to 2.
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
 ALTER
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
- concurrency | proposed_concurrency 
--------------+----------------------
- 2           | 2                    
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+ concurrency 
+-------------
+ 2           
 (1 row)
 -- When one transaction is finished, queueing transaction won't be woken up. There're 2 running transactions and 1 queueing transaction.
 24:END;
@@ -192,13 +192,13 @@ SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_to
 ---------------------+-------------+--------------+------------+--------------
  rg_concurrency_test | 2           | 1            | 2          | 4            
 (1 row)
--- Alter concurrency 2->2, the 'value' and 'proposed' of pg_resgroupcapability will be set to 2.
+-- Alter concurrency 2->2, the 'value' of pg_resgroupcapability will be set to 2.
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
 ALTER
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
- concurrency | proposed_concurrency 
--------------+----------------------
- 2           | 2                    
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+ concurrency 
+-------------
+ 2           
 (1 row)
 -- Finish another transaction, one queueing transaction will be woken up, there're 2 running transactions and 0 queueing transaction.
 23:END;

--- a/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
@@ -63,8 +63,8 @@ SET
 select value from pg_resgroup_get_status_kv('dump');
 ERROR:  only superusers can call this function
 
-SET ROLE gpadmin;
-SET
+RESET ROLE;
+RESET
 
 DROP ROLE role_dumpinfo_test;
 DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
@@ -7,9 +7,13 @@ SET
 
 --start_ignore
 DROP VIEW IF EXISTS many_ops;
+DROP
 DROP ROLE r1_opmem_test;
+ERROR:  role "r1_opmem_test" does not exist
 DROP RESOURCE GROUP rg1_opmem_test;
+ERROR:  resource group "rg1_opmem_test" does not exist
 DROP RESOURCE GROUP rg2_opmem_test;
+ERROR:  resource group "rg2_opmem_test" does not exist
 --end_ignore
 
 CREATE LANGUAGE plpythonu;
@@ -60,9 +64,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 RESET role;
 RESET
@@ -72,9 +76,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 RESET role;
 RESET
@@ -84,9 +88,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 RESET role;
 RESET
@@ -150,9 +154,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 RESET role;
 RESET
@@ -162,9 +166,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 RESET role;
 RESET
@@ -174,9 +178,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 RESET role;
 RESET
@@ -201,9 +205,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 RESET role;
 RESET
@@ -213,9 +217,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 RESET role;
 RESET
@@ -225,9 +229,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 RESET role;
 RESET
@@ -244,9 +248,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 SELECT f1_opmem_test();
  f1_opmem_test 
@@ -261,9 +265,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 SELECT f1_opmem_test();
  f1_opmem_test 
@@ -278,9 +282,9 @@ SET
 SET ROLE TO r1_opmem_test;
 SET
 SELECT * FROM many_ops;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 SELECT f1_opmem_test();
  f1_opmem_test 

--- a/src/test/isolation2/expected/resgroup/resgroup_set_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_set_memory_spill_ratio.out
@@ -5,7 +5,7 @@
 SHOW memory_spill_ratio;
  memory_spill_ratio 
 --------------------
- 10                 
+ 100 MB             
 (1 row)
 
 --start_ignore
@@ -58,7 +58,7 @@ SELECT 1;
  1        
 (1 row)
 
--- positive set to session level
+-- positive set to session level use work_mem
 SET MEMORY_SPILL_RATIO TO 0;
 SET
 SHOW MEMORY_SPILL_RATIO;
@@ -74,7 +74,7 @@ SELECT 1;
 
 -- negative set to session level
 SET MEMORY_SPILL_RATIO TO 101;
-ERROR:  101 is outside the valid range for parameter "memory_spill_ratio" (0 .. 100)
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 SHOW MEMORY_SPILL_RATIO;
  memory_spill_ratio 
 --------------------
@@ -112,6 +112,121 @@ SELECT 1;
  ?column? 
 ----------
  1        
+(1 row)
+
+-- positive set to session level
+SET MEMORY_SPILL_RATIO TO '20MB';
+SET
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 20 MB              
+(1 row)
+SELECT 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+-- positive set to session level
+SET MEMORY_SPILL_RATIO TO '20000kB';
+SET
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 19 MB              
+(1 row)
+SELECT 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+-- positive set to session level? can run?
+SET MEMORY_SPILL_RATIO TO '20GB';
+SET
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 20 GB              
+(1 row)
+SELECT 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+-- positive set to session level? can run?
+SET MEMORY_SPILL_RATIO TO '20  MB  ';
+SET
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 20 MB              
+(1 row)
+SELECT 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+-- negative oom when oprator memory is too large
+SET MEMORY_SPILL_RATIO TO '1TB';
+SET
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 1 TB               
+(1 row)
+SELECT * FROM gp_toolkit.gp_resgroup_config ;
+ERROR:  Out of memory
+DETAIL:  Resource group memory limit reached
+RESET MEMORY_SPILL_RATIO;
+RESET
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '10 %';
+ERROR:  syntax error on capability memory_spill_ratio
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 30                 
+(1 row)
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '10.M';
+ERROR:  syntax error on capability memory_spill_ratio
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 30                 
+(1 row)
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '-10M';
+ERROR:  syntax error on capability memory_spill_ratio
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 30                 
+(1 row)
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '-10';
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 30                 
+(1 row)
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '0x10M';
+ERROR:  syntax error on capability memory_spill_ratio
+SHOW MEMORY_SPILL_RATIO;
+ memory_spill_ratio 
+--------------------
+ 30                 
 (1 row)
 
 -- reset to resource group level

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -80,10 +80,10 @@ ERROR:  resource group "rg_test_group" does not exist
 --end_ignore
 
 SELECT * FROM gp_toolkit.gp_resgroup_config;
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
- 6438    | admin_group   | 2           | 2                    | 10             | 10           | 10                    | 50                  | 50                           | 10                 | 10                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
+ 6438    | admin_group   | 2           | 10             | 10           | 80                  | 100 MB             | vmtracker      | -1     
 (2 rows)
 
 -- negative
@@ -102,13 +102,9 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 ERROR:  resource group "rg_test_group" already exists
 DROP RESOURCE GROUP rg_test_group;
 DROP
--- must specify both memory_limit and (cpu_rate_limit or cpuset)
+-- must specify cpu_rate_limit or cpuset
 CREATE RESOURCE GROUP rg_test_group WITH (memory_limit=10);
 ERROR:  must specify cpu_rate_limit or cpuset
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
-ERROR:  must specify memory_limit
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
-ERROR:  must specify memory_limit
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
 ERROR:  found duplicate resource group resource type: concurrency
@@ -189,19 +185,37 @@ ERROR:  resource group "none" does not exist
 -- positive
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 CREATE
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | memory_spill_ratio 
----------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+--------------------
- rg_test_group | 20          | 20                   | 10             | 10           | 10                    | 20                  | 20                 
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio 
+---------------+-------------+----------------+--------------+---------------------+--------------------
+ rg_test_group | 20          | 10             | 10           | 80                  | 128 MB             
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpuset='0', memory_limit=10, memory_shared_quota=70, memory_spill_ratio=30);
 CREATE
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | memory_spill_ratio 
----------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+--------------------
- rg_test_group | 1           | 1                    | -1             | 10           | 10                    | 70                  | 30                 
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio 
+---------------+-------------+----------------+--------------+---------------------+--------------------
+ rg_test_group | 1           | -1             | 10           | 70                  | 30                 
+(1 row)
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
+CREATE
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio 
+---------------+-------------+----------------+--------------+---------------------+--------------------
+ rg_test_group | 20          | 10             | 0            | 80                  | 128 MB             
+(1 row)
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
+CREATE
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio 
+---------------+-------------+----------------+--------------+---------------------+--------------------
+ rg_test_group | 20          | -1             | 0            | 80                  | 128 MB             
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
@@ -224,12 +238,12 @@ DROP RESOURCE GROUP rg_test_group2;
 DROP
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=61, memory_limit=10);
 ERROR:  total cpu_rate_limit exceeded the limit of 100
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=61);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=91);
 ERROR:  total memory_limit exceeded the limit of 100
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=0, memory_limit=10);
 ERROR:  cpu_rate_limit range is [1, 100]
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
-ERROR:  memory_limit range is [1, 100]
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=-1);
+ERROR:  memory_limit range is [0, 100]
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0.9);
 ERROR:  invalid input syntax for integer: "0.9"
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=1.9);
@@ -264,7 +278,7 @@ CREATE
 DROP RESOURCE GROUP rg_test_group;
 DROP
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=10, memory_spill_ratio=-1);
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=-1, memory_spill_ratio=10);
 ERROR:  memory_shared_quota range is [0, 100]
 
@@ -344,6 +358,95 @@ DROP RESOURCE GROUP rg_test_group;
 DROP
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=99, memory_spill_ratio=1);
 CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+
+-- negative: absolute value format of memory_spill_ratio is
+-- '^[1-9][0-9]*[MmGg]$'
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 %');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10%');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 M');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.MB');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.0MB');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M ');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10B');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10K');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10X');
+ERROR:  syntax error on capability memory_spill_ratio
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10MB');
+ERROR:  memory_spill_ratio in absolute value format must be > 0
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='0 MB');
+ERROR:  memory_spill_ratio in absolute value format must be > 0
+DROP RESOURCE GROUP rg_test_group;
+ERROR:  resource group "rg_test_group" does not exist
+-- negative: memory_spill_ratio does not accept out of range percentage values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10');
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='101');
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+-- negative: when memory_limit is unlimited memory_spill_ratio must be set in
+-- absolute value format
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=10);
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='10%');
+ERROR:  syntax error on capability memory_spill_ratio
+
+-- positive
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100kB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100GB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='1TB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=' 100 MB ');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='0x10 MB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='010 MB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='+10 MB');
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
+CREATE
+DROP RESOURCE GROUP rg_test_group;
+DROP
+
+-- positive: memory_spill_ratio in absolute value format will be ensured to be >= 1 chunk
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='1kB');
+CREATE
+SELECT memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ memory_spill_ratio 
+--------------------
+ 1 MB               
+(1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
 
@@ -492,4 +595,90 @@ CREATE ROLE cgroup_audited_role RESOURCE GROUP cgroup_audited_group;
 ERROR:  you cannot assign a role to this resource group
 DETAIL:  The memory_auditor property for this group is not the default.
 DROP RESOURCE GROUP cgroup_audited_group;
+DROP
+
+-- positive: memory_spill_ratio accepts both integer and string values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ALTER
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+ALTER
+DROP RESOURCE GROUP rg_test_group;
+DROP
+
+-- negative: memory_spill_ratio only accepts string value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10%;
+ERROR:  syntax error at or near "%"
+LINE 1: ...TER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10%;
+                                                                     ^
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10M;
+ERROR:  syntax error at or near "M"
+LINE 1: ...TER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10M;
+                                                                     ^
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10MB;
+ERROR:  syntax error at or near "MB"
+LINE 1: ...ER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10MB;
+                                                                    ^
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- negative: memory_spill_ratio does not accept out of range percentage values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1';
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '101';
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1MB';
+ERROR:  memory_spill_ratio in absolute value format must be > 0
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '0MB';
+ERROR:  memory_spill_ratio in absolute value format must be > 0
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- positive: memory_limit can be altered to unlimited if memory_spill_ratio has
+-- an absolute value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+ALTER
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- negative: memory_spill_ratio only accepts an absolute value if memory_limit
+-- is unlimited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- positive: memory_spill_ratio accepts a percentage value only if
+-- memory_limit is limited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ALTER
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- negative: memory_limit must be limited if memory_spill_ratio has a
+-- percentage value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
+DROP RESOURCE GROUP rg_test_group;
+DROP
+-- positive: memory_spill_ratio accepts a absolute value anytime
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10MB');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '50MB';
+ALTER
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+ALTER
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10MB';
+ALTER
+DROP RESOURCE GROUP rg_test_group;
 DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_transaction.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_transaction.out
@@ -8,7 +8,7 @@ ERROR:  resource group "rg_test_group" does not exist
 --end_ignore
 
 -- helper view to check the resgroup status
-CREATE OR REPLACE VIEW rg_test_monitor AS SELECT groupname, concurrency, proposed_concurrency, cpu_rate_limit FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+CREATE OR REPLACE VIEW rg_test_monitor AS SELECT groupname, concurrency, cpu_rate_limit FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 CREATE
 
 -- ----------------------------------------------------------------------
@@ -23,8 +23,8 @@ ERROR:  CREATE RESOURCE GROUP cannot run inside a transaction block
 END;
 END
 SELECT * FROM rg_test_monitor;
- groupname | concurrency | proposed_concurrency | cpu_rate_limit 
------------+-------------+----------------------+----------------
+ groupname | concurrency | cpu_rate_limit 
+-----------+-------------+----------------
 (0 rows)
 
 -- ALTER RESOURCE GROUP cannot run inside a transaction block
@@ -37,9 +37,9 @@ ERROR:  ALTER RESOURCE GROUP cannot run inside a transaction block
 END;
 END
 SELECT * FROM rg_test_monitor;
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit 
----------------+-------------+----------------------+----------------
- rg_test_group | 20          | 20                   | 5              
+ groupname     | concurrency | cpu_rate_limit 
+---------------+-------------+----------------
+ rg_test_group | 20          | 5              
 (1 row)
 
 -- DROP RESOURCE GROUP cannot run inside a transaction block
@@ -50,9 +50,9 @@ ERROR:  DROP RESOURCE GROUP cannot run inside a transaction block
 END;
 END
 SELECT * FROM rg_test_monitor;
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit 
----------------+-------------+----------------------+----------------
- rg_test_group | 20          | 20                   | 5              
+ groupname     | concurrency | cpu_rate_limit 
+---------------+-------------+----------------
+ rg_test_group | 20          | 5              
 (1 row)
 
 DROP RESOURCE GROUP rg_test_group;
@@ -76,8 +76,8 @@ ERROR:  CREATE RESOURCE GROUP cannot run inside a transaction block
 END;
 END
 SELECT * FROM rg_test_monitor;
- groupname | concurrency | proposed_concurrency | cpu_rate_limit 
------------+-------------+----------------------+----------------
+ groupname | concurrency | cpu_rate_limit 
+-----------+-------------+----------------
 (0 rows)
 
 -- ALTER RESOURCE GROUP cannot run inside a transaction block
@@ -95,9 +95,9 @@ ERROR:  ALTER RESOURCE GROUP cannot run inside a transaction block
 END;
 END
 SELECT * FROM rg_test_monitor;
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit 
----------------+-------------+----------------------+----------------
- rg_test_group | 20          | 20                   | 5              
+ groupname     | concurrency | cpu_rate_limit 
+---------------+-------------+----------------
+ rg_test_group | 20          | 5              
 (1 row)
 
 -- DROP RESOURCE GROUP cannot run inside a transaction block
@@ -113,9 +113,9 @@ ERROR:  DROP RESOURCE GROUP cannot run inside a transaction block
 END;
 END
 SELECT * FROM rg_test_monitor;
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit 
----------------+-------------+----------------------+----------------
- rg_test_group | 20          | 20                   | 5              
+ groupname     | concurrency | cpu_rate_limit 
+---------------+-------------+----------------
+ rg_test_group | 20          | 5              
 (1 row)
 
 DROP RESOURCE GROUP rg_test_group;
@@ -138,8 +138,8 @@ ROLLBACK
 ABORT;
 ABORT
 SELECT * FROM rg_test_monitor;
- groupname | concurrency | proposed_concurrency | cpu_rate_limit 
------------+-------------+----------------------+----------------
+ groupname | concurrency | cpu_rate_limit 
+-----------+-------------+----------------
 (0 rows)
 
 -- ALTER RESOURCE GROUP cannot run inside a subtransaction
@@ -156,9 +156,9 @@ ROLLBACK
 ABORT;
 ABORT
 SELECT * FROM rg_test_monitor;
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit 
----------------+-------------+----------------------+----------------
- rg_test_group | 20          | 20                   | 5              
+ groupname     | concurrency | cpu_rate_limit 
+---------------+-------------+----------------
+ rg_test_group | 20          | 5              
 (1 row)
 
 -- DROP RESOURCE GROUP cannot run inside a subtransaction
@@ -173,9 +173,9 @@ ROLLBACK
 ABORT;
 ABORT
 SELECT * FROM rg_test_monitor;
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit 
----------------+-------------+----------------------+----------------
- rg_test_group | 20          | 20                   | 5              
+ groupname     | concurrency | cpu_rate_limit 
+---------------+-------------+----------------
+ rg_test_group | 20          | 5              
 (1 row)
 
 DROP RESOURCE GROUP rg_test_group;
@@ -199,8 +199,8 @@ SELECT * FROM rg_create_func();
 ERROR:  CREATE RESOURCE GROUP cannot be executed from a function or multi-command string
 CONTEXT:  SQL function "rg_create_func" statement 1
 SELECT * FROM rg_test_monitor;
- groupname | concurrency | proposed_concurrency | cpu_rate_limit 
------------+-------------+----------------------+----------------
+ groupname | concurrency | cpu_rate_limit 
+-----------+-------------+----------------
 (0 rows)
 
 -- ALTER RESOURCE GROUP cannot run inside a function call
@@ -210,9 +210,9 @@ SELECT * FROM rg_alter_func();
 ERROR:  ALTER RESOURCE GROUP cannot be executed from a function or multi-command string
 CONTEXT:  SQL function "rg_alter_func" statement 1
 SELECT * FROM rg_test_monitor;
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit 
----------------+-------------+----------------------+----------------
- rg_test_group | 20          | 20                   | 5              
+ groupname     | concurrency | cpu_rate_limit 
+---------------+-------------+----------------
+ rg_test_group | 20          | 5              
 (1 row)
 
 -- DROP RESOURCE GROUP cannot run inside a function call
@@ -220,9 +220,9 @@ SELECT * FROM rg_drop_func();
 ERROR:  DROP RESOURCE GROUP cannot be executed from a function or multi-command string
 CONTEXT:  SQL function "rg_drop_func" statement 1
 SELECT * FROM rg_test_monitor;
- groupname     | concurrency | proposed_concurrency | cpu_rate_limit 
----------------+-------------+----------------------+----------------
- rg_test_group | 20          | 20                   | 5              
+ groupname     | concurrency | cpu_rate_limit 
+---------------+-------------+----------------
+ rg_test_group | 20          | 5              
 (1 row)
 
 DROP RESOURCE GROUP rg_test_group;

--- a/src/test/isolation2/expected/resgroup/resgroup_unlimit_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_unlimit_memory_spill_ratio.out
@@ -20,12 +20,12 @@ DROP RESOURCE GROUP rg_spill_test;
 DROP
 
 CREATE RESOURCE GROUP rg_spill_test WITH (concurrency=10, cpu_rate_limit=20, memory_limit=20, memory_shared_quota=50, memory_spill_ratio=-1);
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 DROP RESOURCE GROUP rg_spill_test;
 ERROR:  resource group "rg_spill_test" does not exist
 
 CREATE RESOURCE GROUP rg_spill_test WITH (concurrency=10, cpu_rate_limit=20, memory_limit=20, memory_shared_quota=50, memory_spill_ratio=101);
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 DROP RESOURCE GROUP rg_spill_test;
 ERROR:  resource group "rg_spill_test" does not exist
 
@@ -40,9 +40,9 @@ ALTER
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 100;
 ALTER
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO -1;
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 101;
-ERROR:  memory_spill_ratio range is [0, 100]
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 
 DROP RESOURCE GROUP rg_spill_test;
 DROP
@@ -91,7 +91,7 @@ SELECT 1;
 (1 row)
 
 SET MEMORY_SPILL_RATIO TO -1;
-ERROR:  -1 is outside the valid range for parameter "memory_spill_ratio" (0 .. 100)
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 SHOW MEMORY_SPILL_RATIO;
  memory_spill_ratio 
 --------------------
@@ -104,7 +104,7 @@ SELECT 1;
 (1 row)
 
 SET MEMORY_SPILL_RATIO TO 101;
-ERROR:  101 is outside the valid range for parameter "memory_spill_ratio" (0 .. 100)
+ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
 SHOW MEMORY_SPILL_RATIO;
  memory_spill_ratio 
 --------------------
@@ -145,8 +145,8 @@ SELECT count(*) FROM test_zero_workmem;
 (1 row)
 
 --clean env
-SET ROLE to gpadmin;
-SET
+RESET ROLE;
+RESET
 DROP TABLE test_zero_workmem;
 DROP
 DROP ROLE role_zero_workmem;

--- a/src/test/isolation2/expected/resgroup/resgroup_views.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views.out
@@ -1,7 +1,7 @@
 select * from gp_toolkit.gp_resgroup_config where groupname='default_group';
- groupid | groupname     | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota | memory_spill_ratio | proposed_memory_spill_ratio | memory_auditor | cpuset 
----------+---------------+-------------+----------------------+----------------+--------------+-----------------------+---------------------+------------------------------+--------------------+-----------------------------+----------------+--------
- 6437    | default_group | 20          | 20                   | 30             | 30           | 30                    | 50                  | 50                           | 20                 | 20                          | vmtracker      | -1     
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
 (1 row)
 
 select rsgname , groupid , num_running , num_queueing , num_queued , num_executed , cpu_usage->'-1' as qd_cpu_usage , memory_usage->'-1'->'used' as qd_memory_used , memory_usage->'-1'->'shared_used' as qd_memory_shared_used from gp_toolkit.gp_resgroup_status where rsgname='default_group';
@@ -10,7 +10,7 @@ select rsgname , groupid , num_running , num_queueing , num_queued , num_execute
  default_group | 6437    | 0           | 0            | 0          | 0            | 0.00         | 0              | 0                     
 (1 row)
 
-select rsgname , groupid , cpu , memory_used , memory_shared_used from gp_toolkit.gp_resgroup_status_per_host s join gp_segment_configuration c on s.hostname=c.hostname and c.content=-1 where rsgname='default_group';
+select rsgname , groupid , cpu , memory_used , memory_shared_used from gp_toolkit.gp_resgroup_status_per_host s join gp_segment_configuration c on s.hostname=c.hostname and c.content=-1 and c.role='p' where rsgname='default_group';
  rsgname       | groupid | cpu  | memory_used | memory_shared_used 
 ---------------+---------+------+-------------+--------------------
  default_group | 6437    | 0.00 | 0           | 0                  
@@ -27,7 +27,33 @@ select rsgname , groupid , segment_id , cpu , memory_used , memory_shared_used f
 
 -- start_ignore
 select * from gp_toolkit.gp_resgroup_config;
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 30           | 80                  | 100 MB             | vmtracker      | -1     
+ 6438    | admin_group   | 2           | 10             | 10           | 80                  | 100 MB             | vmtracker      | -1     
+(2 rows)
 select * from gp_toolkit.gp_resgroup_status;
+ rsgname       | groupid | num_running | num_queueing | num_queued | num_executed | total_queue_duration | cpu_usage                                 | memory_usage                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+---------------+---------+-------------+--------------+------------+--------------+----------------------+-------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ default_group | 6437    | 0           | 0            | 0          | 0            | @ 0                  | {"-1":0.00, "0":0.00, "1":0.00, "2":0.00} | {"-1":{"used":0, "available":0, "quota_used":0, "quota_available":0, "quota_granted":0, "quota_proposed":0, "shared_used":0, "shared_available":0, "shared_granted":0, "shared_proposed":0}, "0":{"used":0, "available":0, "quota_used":0, "quota_available":0, "quota_granted":0, "quota_proposed":0, "shared_used":0, "shared_available":0, "shared_granted":0, "shared_proposed":0}, "1":{"used":0, "available":0, "quota_used":0, "quota_available":0, "quota_granted":0, "quota_proposed":0, "shared_used":0, "shared_available":0, "shared_granted":0, "shared_proposed":0}, "2":{"used":0, "available":0, "quota_used":0, "quota_available":0, "quota_granted":0, "quota_proposed":0, "shared_used":0, "shared_available":0, "shared_granted":0, "shared_proposed":0}}                         
+ admin_group   | 6438    | 1           | 0            | 0          | 12           | @ 0                  | {"-1":0.23, "0":0.07, "1":0.09, "2":0.09} | {"-1":{"used":0, "available":68, "quota_used":6, "quota_available":6, "quota_granted":12, "quota_proposed":12, "shared_used":0, "shared_available":56, "shared_granted":56, "shared_proposed":56}, "0":{"used":0, "available":68, "quota_used":6, "quota_available":6, "quota_granted":12, "quota_proposed":12, "shared_used":0, "shared_available":56, "shared_granted":56, "shared_proposed":56}, "1":{"used":0, "available":68, "quota_used":6, "quota_available":6, "quota_granted":12, "quota_proposed":12, "shared_used":0, "shared_available":56, "shared_granted":56, "shared_proposed":56}, "2":{"used":0, "available":68, "quota_used":6, "quota_available":6, "quota_granted":12, "quota_proposed":12, "shared_used":0, "shared_available":56, "shared_granted":56, "shared_proposed":56}} 
+(2 rows)
 select * from gp_toolkit.gp_resgroup_status_per_host;
+ rsgname       | groupid | hostname   | cpu  | memory_used | memory_available | memory_quota_used | memory_quota_available | memory_quota_proposed | memory_shared_used | memory_shared_available | memory_shared_granted | memory_shared_proposed 
+---------------+---------+------------+------+-------------+------------------+-------------------+------------------------+-----------------------+--------------------+-------------------------+-----------------------+------------------------
+ admin_group   | 6438    | instance-1 | 0.46 | 2           | 270              | 24                | 24                     | 48                    | 0                  | 224                     | 224                   | 224                    
+ default_group | 6437    | instance-1 | 0.00 | 0           | 0                | 0                 | 0                      | 0                     | 0                  | 0                       | 0                     | 0                      
+(2 rows)
 select * from gp_toolkit.gp_resgroup_status_per_segment;
+ rsgname       | groupid | hostname   | segment_id | cpu  | memory_used | memory_available | memory_quota_used | memory_quota_available | memory_quota_proposed | memory_shared_used | memory_shared_available | memory_shared_granted | memory_shared_proposed 
+---------------+---------+------------+------------+------+-------------+------------------+-------------------+------------------------+-----------------------+--------------------+-------------------------+-----------------------+------------------------
+ admin_group   | 6438    | instance-1 | 2          | 0.05 | 0           | 68               | 6                 | 6                      | 12                    | 0                  | 56                      | 56                    | 56                     
+ default_group | 6437    | instance-1 | 1          | 0.00 | 0           | 0                | 0                 | 0                      | 0                     | 0                  | 0                       | 0                     | 0                      
+ default_group | 6437    | instance-1 | 0          | 0.00 | 0           | 0                | 0                 | 0                      | 0                     | 0                  | 0                       | 0                     | 0                      
+ default_group | 6437    | instance-1 | -1         | 0.00 | 0           | 0                | 0                 | 0                      | 0                     | 0                  | 0                       | 0                     | 0                      
+ admin_group   | 6438    | instance-1 | 0          | 0.05 | 0           | 68               | 6                 | 6                      | 12                    | 0                  | 56                      | 56                    | 56                     
+ default_group | 6437    | instance-1 | 2          | 0.00 | 0           | 0                | 0                 | 0                      | 0                     | 0                  | 0                       | 0                     | 0                      
+ admin_group   | 6438    | instance-1 | -1         | 0.23 | 2           | 66               | 6                 | 6                      | 12                    | 0                  | 56                      | 56                    | 56                     
+ admin_group   | 6438    | instance-1 | 1          | 0.05 | 0           | 68               | 6                 | 6                      | 12                    | 0                  | 56                      | 56                    | 56                     
+(8 rows)
 -- end_ignore

--- a/src/test/isolation2/input/resgroup/disable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/disable_resgroup.source
@@ -13,3 +13,9 @@ SHOW gp_resource_manager;
 
 -- reset admin_group concurrency setting
 ALTER RESOURCE GROUP admin_group SET concurrency 10;
+ALTER RESOURCE GROUP admin_group SET memory_limit 10;
+ALTER RESOURCE GROUP default_group SET memory_limit 0;
+ALTER RESOURCE GROUP admin_group SET memory_shared_quota 80;
+ALTER RESOURCE GROUP default_group SET memory_shared_quota 80;
+ALTER RESOURCE GROUP admin_group SET memory_spill_ratio '128 MB';
+ALTER RESOURCE GROUP default_group SET memory_spill_ratio '128 MB';

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -58,9 +58,19 @@ DROP FUNCTION adjust_memory_limit(bigint);
 0: SELECT * FROM gp_toolkit.gp_resqueue_status;
 0: SELECT * FROM gp_toolkit.gp_resq_priority_backend;
 
+-- verify the default settings
+0: SELECT * from gp_toolkit.gp_resgroup_config;
+
 -- by default admin_group has concurrency set to -1 which leads to
 -- very small memory quota for each resgroup slot, correct it.
 0: ALTER RESOURCE GROUP admin_group SET concurrency 2;
+
+-- explicitly set memory settings
+0: ALTER RESOURCE GROUP admin_group SET memory_limit 10;
+0: ALTER RESOURCE GROUP default_group SET memory_limit 30;
+0: ALTER RESOURCE GROUP admin_group SET memory_shared_quota 80;
+0: ALTER RESOURCE GROUP default_group SET memory_shared_quota 80;
 -- in later cases we will SHOW memory_spill_ratio as first command
 -- to verify that it can be correctly loaded even for bypassed commands
-0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
+0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio '100 MB';
+0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio '100 MB';

--- a/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/input/resgroup/resgroup_alter_memory.source
@@ -29,8 +29,8 @@ CREATE OR REPLACE VIEW rg_activity_status AS
 	ORDER BY sess_id;
 
 CREATE OR REPLACE VIEW rg_mem_status AS
-	SELECT groupname, memory_limit, proposed_memory_limit,
-		   memory_shared_quota, proposed_memory_shared_quota
+	SELECT groupname, memory_limit,
+		   memory_shared_quota
 	FROM gp_toolkit.gp_resgroup_config
 	WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test'
 	ORDER BY groupid;

--- a/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
@@ -13,8 +13,8 @@ CREATE OR REPLACE FUNCTION hold_memory_by_percent(float) RETURNS int AS $$
 $$ LANGUAGE sql;
 
 CREATE OR REPLACE VIEW rg_mem_status AS
-	SELECT groupname, memory_limit, proposed_memory_limit,
-		   memory_shared_quota, proposed_memory_shared_quota
+	SELECT groupname, memory_limit,
+		   memory_shared_quota
 	FROM gp_toolkit.gp_resgroup_config
 	WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test'
 	ORDER BY groupid;

--- a/src/test/isolation2/output/resgroup/disable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/disable_resgroup.source
@@ -24,3 +24,15 @@ SHOW gp_resource_manager;
 -- reset admin_group concurrency setting
 ALTER RESOURCE GROUP admin_group SET concurrency 10;
 ALTER
+ALTER RESOURCE GROUP admin_group SET memory_limit 10;
+ALTER
+ALTER RESOURCE GROUP default_group SET memory_limit 0;
+ALTER
+ALTER RESOURCE GROUP admin_group SET memory_shared_quota 80;
+ALTER
+ALTER RESOURCE GROUP default_group SET memory_shared_quota 80;
+ALTER
+ALTER RESOURCE GROUP admin_group SET memory_spill_ratio '128 MB';
+ALTER
+ALTER RESOURCE GROUP default_group SET memory_spill_ratio '128 MB';
+ALTER

--- a/src/test/isolation2/output/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup.source
@@ -44,13 +44,10 @@ DROP
 -- enable resource group and restart cluster.
 -- start_ignore
 ! gpconfig -c gp_resource_manager -v group;
-20170502:01:28:13:000367 gpconfig:sdw6:gpadmin-[INFO]:-completed successfully
 
 ! gpconfig -c gp_resource_group_cpu_limit -v 0.9;
-20170731:09:42:33:021079 gpconfig:sdw8:nyu-[INFO]:-completed successfully
 
 ! gpconfig -c max_connections -v 250 -m 25;
-20170731:09:42:34:021163 gpconfig:sdw8:nyu-[INFO]:-completed successfully
 
 ! gpstop -rai;
 -- end_ignore
@@ -77,11 +74,31 @@ DROP
 ------------+------------+-------------+-----------
 (0 rows)
 
+-- verify the default settings
+0: SELECT * from gp_toolkit.gp_resgroup_config;
+ groupid | groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio | memory_auditor | cpuset 
+---------+---------------+-------------+----------------+--------------+---------------------+--------------------+----------------+--------
+ 6437    | default_group | 20          | 30             | 0            | 80                  | 128 MB             | vmtracker      | -1     
+ 6438    | admin_group   | 10          | 10             | 10           | 80                  | 128 MB             | vmtracker      | -1     
+(2 rows)
+
 -- by default admin_group has concurrency set to -1 which leads to
 -- very small memory quota for each resgroup slot, correct it.
 0: ALTER RESOURCE GROUP admin_group SET concurrency 2;
 ALTER
+
+-- explicitly set memory settings
+0: ALTER RESOURCE GROUP admin_group SET memory_limit 10;
+ALTER
+0: ALTER RESOURCE GROUP default_group SET memory_limit 30;
+ALTER
+0: ALTER RESOURCE GROUP admin_group SET memory_shared_quota 80;
+ALTER
+0: ALTER RESOURCE GROUP default_group SET memory_shared_quota 80;
+ALTER
 -- in later cases we will SHOW memory_spill_ratio as first command
 -- to verify that it can be correctly loaded even for bypassed commands
-0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
+0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio '100 MB';
+ALTER
+0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio '100 MB';
 ALTER

--- a/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
+++ b/src/test/isolation2/output/resgroup/resgroup_alter_memory.source
@@ -25,7 +25,7 @@ CREATE
 CREATE OR REPLACE VIEW rg_activity_status AS SELECT rsgname, waiting_reason, state, query FROM pg_stat_activity WHERE rsgname in ('rg1_memory_test', 'rg2_memory_test') AND query <> '<IDLE>' ORDER BY sess_id;
 CREATE
 
-CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, proposed_memory_limit, memory_shared_quota, proposed_memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test' ORDER BY groupid;
+CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test' ORDER BY groupid;
 CREATE
 
 CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=60, memory_shared_quota=0, memory_spill_ratio=5);
@@ -45,9 +45,9 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 50;
 ALTER
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 60           | 60                    | 50                  | 50                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 60           | 50                  
 (1 row)
 
 1: SET ROLE TO role1_memory_test;
@@ -69,9 +69,9 @@ ALTER
 -- now the group has 60%*80%-15%=33% free quota and 60%*20%=12% free shared quota,
 -- so memory_shared_quota shall be the new value.
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 60           | 60                    | 20                  | 20                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 60           | 20                  
 (1 row)
 
 ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 70;
@@ -80,9 +80,9 @@ ALTER
 -- now the group has 60%*30%-15%=3% free quota and 60%*70%=42% free shared quota,
 -- so memory_shared_quota shall be the new value.
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 60           | 60                    | 70                  | 70                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 60           | 70                  
 (1 row)
 
 --
@@ -95,9 +95,9 @@ ALTER
 -- now the group has 60%*20%-15%=-3% free quota and 60%*80%=48% free shared quota,
 -- so memory_shared_quota shall be the old value.
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 60           | 60                    | 80                  | 80                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 60           | 80                  
 (1 row)
 
 1q: ... <quitting>
@@ -114,9 +114,9 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 60;
 ALTER
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 40           | 40                    | 60                  | 60                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 40           | 60                  
 (1 row)
 
 1: SET ROLE TO role1_memory_test;
@@ -151,9 +151,9 @@ SET
 -- proc4 shall be pending
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 40           | 40                    | 70                  | 70                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 40           | 70                  
 (1 row)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -173,9 +173,9 @@ ALTER
 4<:  <... completed>
 BEGIN
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 40           | 40                    | 40                  | 40                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 40           | 40                  
 (1 row)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -203,9 +203,9 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 60;
 ALTER
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 50           | 50                    | 60                  | 60                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 50           | 60                  
 (1 row)
 
 1: SET ROLE TO role1_memory_test;
@@ -228,9 +228,9 @@ ALTER
 -- so memory_limit can be the new value, however at the moment we don't update
 -- value when increasing memory_limit, so it's still the old value.
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 60           | 60                    | 60                  | 60                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 60           | 60                  
 (1 row)
 
 ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 40;
@@ -239,9 +239,9 @@ ALTER
 -- now the group has 40%*40%-10%=6% free quota and 40%*60%=24% free shared quota,
 -- so memory_limit shall be the new value.
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 40           | 40                    | 60                  | 60                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 40           | 60                  
 (1 row)
 
 --
@@ -254,9 +254,9 @@ ALTER
 -- now the group has 10%*40%-10%=-6% free quota and 10%*60%=6% free shared quota,
 -- so memory_limit shall be the old value.
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 10           | 10                    | 60                  | 60                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 10           | 60                  
 (1 row)
 
 --
@@ -272,9 +272,9 @@ ALTER
 
 -- now the group has 40%*40%-10%=6% free quota and 40%*60%=24% free shared quota,
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 40           | 40                    | 60                  | 60                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 40           | 60                  
 (1 row)
 
 1: SELECT hold_memory_by_percent(1,0.5);
@@ -292,9 +292,9 @@ ALTER
 -- now the group has 40%*80%-10%=22% free quota and 40%*20%-20%=-12% free shared quota,
 -- so memory_shared_quota shall be the old value.
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 40           | 40                    | 20                  | 20                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 40           | 20                  
 (1 row)
 
 ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 30;
@@ -303,9 +303,9 @@ ALTER
 -- now the group has 30%*80%-10%=14% free quota and 30%*20%-20%=-14% free shared quota,
 -- so memory_limit shall be the old value.
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 30           | 30                    | 20                  | 20                           
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 30           | 20                  
 (1 row)
 
 1q: ... <quitting>
@@ -333,10 +333,10 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 31;
 ERROR:  total memory_limit exceeded the limit of 100
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 30           | 30                    | 0                   | 0                            
- rg2_memory_test | 30           | 30                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 30           | 0                   
+ rg2_memory_test | 30           | 0                   
 (2 rows)
 
 -- but increase could succeed if another rg is first decreased.
@@ -346,10 +346,10 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 40;
 ALTER
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 40           | 40                    | 0                   | 0                            
- rg2_memory_test | 20           | 20                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 40           | 0                   
+ rg2_memory_test | 20           | 0                   
 (2 rows)
 
 --
@@ -371,10 +371,10 @@ ALTER RESOURCE GROUP rg2_memory_test SET MEMORY_SHARED_QUOTA 0;
 ALTER
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 30           | 30                    | 0                   | 0                            
- rg2_memory_test | 30           | 30                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 30           | 0                   
+ rg2_memory_test | 30           | 0                   
 (2 rows)
 
 11: SET ROLE TO role1_memory_test;
@@ -411,10 +411,10 @@ BEGIN
 -- proc21 gets a quota of 40%/2=20% from rg2
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 15           | 15                    | 0                   | 0                            
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 15           | 0                   
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -432,10 +432,10 @@ SELECT * FROM rg_activity_status;
 -- proc12 ends, 10%-5%=5% quota is returned to sys
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 15           | 15                    | 0                   | 0                            
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 15           | 0                   
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -452,10 +452,10 @@ BEGIN
 -- proc22 gets a quota of 40%/2=20% from rg2
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 15           | 15                    | 0                   | 0                            
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 15           | 0                   
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -490,10 +490,10 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 0;
 ALTER
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 30           | 30                    | 0                   | 0                            
- rg2_memory_test | 30           | 30                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 30           | 0                   
+ rg2_memory_test | 30           | 0                   
 (2 rows)
 
 11: SET ROLE TO role1_memory_test;
@@ -537,10 +537,10 @@ SET
 -- but as rg2 only has 30%-20%=10% free quota now,
 -- it shall be pending.
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 15           | 15                    | 0                   | 0                            
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 15           | 0                   
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -558,10 +558,10 @@ END
 -- proc11 ends, 10%-5%=5% quota is returned to sys
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 15           | 15                    | 0                   | 0                            
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 15           | 0                   
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -582,10 +582,10 @@ END
 22<:  <... completed>
 BEGIN
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 15           | 15                    | 0                   | 0                            
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 15           | 0                   
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -620,10 +620,10 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 60;
 ALTER
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 30           | 30                    | 60                  | 60                           
- rg2_memory_test | 30           | 30                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 30           | 60                  
+ rg2_memory_test | 30           | 0                   
 (2 rows)
 
 11: SET ROLE TO role1_memory_test;
@@ -667,10 +667,10 @@ SET
 -- proc24 shall be pending.
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 20           | 20                    | 60                  | 60                           
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 20           | 60                  
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -693,10 +693,10 @@ ALTER
 24<:  <... completed>
 BEGIN
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 20           | 20                    | 30                  | 30                           
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 20           | 30                  
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -735,10 +735,10 @@ ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_SHARED_QUOTA 90;
 ALTER
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 30           | 30                    | 90                  | 90                           
- rg2_memory_test | 30           | 30                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 30           | 90                  
+ rg2_memory_test | 30           | 0                   
 (2 rows)
 
 11: SET ROLE TO role1_memory_test;
@@ -791,10 +791,10 @@ SET
 -- proc24 shall be pending.
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 20           | 20                    | 90                  | 90                           
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 20           | 90                  
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query                                  
@@ -811,10 +811,10 @@ ALTER
 -- rg1 can't free any shared quota as all of them are in use by proc11
 
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 20           | 20                    | 30                  | 30                           
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 20           | 30                  
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query                                  
@@ -835,10 +835,10 @@ SELECT * FROM rg_activity_status;
 24<:  <... completed>
 BEGIN
 SELECT * FROM rg_mem_status;
- groupname       | memory_limit | proposed_memory_limit | memory_shared_quota | proposed_memory_shared_quota 
------------------+--------------+-----------------------+---------------------+------------------------------
- rg1_memory_test | 20           | 20                    | 30                  | 30                           
- rg2_memory_test | 40           | 40                    | 0                   | 0                            
+ groupname       | memory_limit | memory_shared_quota 
+-----------------+--------------+---------------------
+ rg1_memory_test | 20           | 30                  
+ rg2_memory_test | 40           | 0                   
 (2 rows)
 SELECT * FROM rg_activity_status;
  rsgname         | waiting_reason | state               | query  
@@ -886,7 +886,7 @@ SET
 -- ALTER should fail and the memory_limit in both catalog and share memory are
 -- still 5%
 ALTER RESOURCE GROUP rg_test_group set memory_limit 1;
-ERROR:  Raise ERROR for debug_dtm_action = 2, debug_dtm_action_protocol = Distributed Prepare
+ERROR:  Raise ERROR for debug_dtm_action = 2, debug_dtm_action_protocol = Distributed Prepare  (seg0 10.146.0.5:25432 pid=13067)
 
 RESET debug_dtm_action;
 RESET

--- a/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
@@ -13,7 +13,7 @@ CREATE
 CREATE OR REPLACE FUNCTION hold_memory_by_percent(float) RETURNS int AS $$ SELECT * FROM resGroupPalloc($1) $$ LANGUAGE sql;
 CREATE
 
-CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, proposed_memory_limit, memory_shared_quota, proposed_memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test' ORDER BY groupid;
+CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test' ORDER BY groupid;
 CREATE
 
 CREATE OR REPLACE VIEW memory_result AS SELECT rsgname, memory_usage from gp_toolkit.gp_resgroup_status;
@@ -98,7 +98,7 @@ SET
  0     
 (1 row)
 1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.14 / 0.52)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=18610)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=12550)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
@@ -106,7 +106,7 @@ CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1: SET ROLE TO role1_memory_test;
 SET
 1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.42 / 0.52)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=18619)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=12562)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
@@ -211,7 +211,7 @@ SET
  0     
 (1 row)
 1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.12 / 0.52)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=19259)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=12602)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
@@ -219,7 +219,7 @@ CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1: SET ROLE TO role1_memory_test;
 SET
 1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.48 / 0.52)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=19269)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=12614)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
@@ -308,7 +308,7 @@ SET
  0     
 (1 row)
 1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.25 / 0.52)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=19875)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=12653)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
@@ -316,7 +316,7 @@ CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1: SET ROLE TO role1_memory_test;
 SET
 1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.75 / 0.52)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=19884)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=12662)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
@@ -454,7 +454,7 @@ BEGIN
  0     
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.32 / 0.52)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=21102)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=12755)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
@@ -624,7 +624,7 @@ BEGIN
  0     
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.39 / 0.52)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=21783)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=12866)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
@@ -795,7 +795,7 @@ BEGIN
  0     
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3 / 0.2)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=22464)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=12989)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
@@ -892,7 +892,7 @@ ALTER
 1: SET ROLE TO role1_memory_test;
 SET
 1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.2 / 0.3)=0;
-ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=23131)
+ERROR:  Out of memory  (seg0 slice1 10.146.0.5:25432 pid=13040)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>

--- a/src/test/isolation2/sql/resgroup/resgroup_alter_memory_spill_ratio.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_alter_memory_spill_ratio.sql
@@ -5,7 +5,7 @@ CREATE RESOURCE GROUP rg_spill_test WITH
 (concurrency=10, cpu_rate_limit=20, memory_limit=20, memory_shared_quota=20, memory_spill_ratio=10);
 
 CREATE OR REPLACE VIEW rg_spill_status AS
-	SELECT groupname, memory_shared_quota, proposed_memory_shared_quota, memory_spill_ratio, proposed_memory_spill_ratio
+	SELECT groupname, memory_shared_quota, memory_spill_ratio
 	FROM gp_toolkit.gp_resgroup_config
 	WHERE groupname='rg_spill_test';
 

--- a/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
@@ -33,7 +33,7 @@ DROP RESOURCE GROUP rg_concurrency_test;
 
 -- test2: test alter concurrency
 -- Create a resource group with concurrency=2. Prepare 2 running transactions and 1 queueing transactions.
--- Alter concurrency 2->3, the queueing transaction will be woken up, the 'value' and 'proposed' of pg_resgroupcapability will be set to 3.
+-- Alter concurrency 2->3, the queueing transaction will be woken up, the 'value' of pg_resgroupcapability will be set to 3.
 DROP ROLE IF EXISTS role_concurrency_test;
 -- start_ignore
 DROP RESOURCE GROUP rg_concurrency_test;
@@ -47,10 +47,10 @@ CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
 14:SET ROLE role_concurrency_test;
 14&:BEGIN;
 SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 3;
 SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 12:END;
 13:END;
 14<:
@@ -78,10 +78,10 @@ CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
 25:SET ROLE role_concurrency_test;
 25&:BEGIN;
 SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
--- Alter concurrency 3->2, the 'proposed' of pg_resgroupcapability will be set to 2.
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+-- Alter concurrency 3->2, the 'value' of pg_resgroupcapability will be set to 2.
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 -- When one transaction is finished, queueing transaction won't be woken up. There're 2 running transactions and 1 queueing transaction.
 24:END;
 SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
@@ -91,9 +91,9 @@ SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_to
 -- Finish another transaction, one queueing transaction will be woken up, there're 2 running transactions and 1 queueing transaction.
 22:END;
 SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
--- Alter concurrency 2->2, the 'value' and 'proposed' of pg_resgroupcapability will be set to 2.
+-- Alter concurrency 2->2, the 'value' of pg_resgroupcapability will be set to 2.
 ALTER RESOURCE GROUP rg_concurrency_test SET CONCURRENCY 2;
-SELECT concurrency,proposed_concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
+SELECT concurrency FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_concurrency_test';
 -- Finish another transaction, one queueing transaction will be woken up, there're 2 running transactions and 0 queueing transaction.
 23:END;
 SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';

--- a/src/test/isolation2/sql/resgroup/resgroup_dumpinfo.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_dumpinfo.sql
@@ -84,7 +84,7 @@ CREATE ROLE role_permission;
 SET ROLE role_permission;
 select value from pg_resgroup_get_status_kv('dump');
 
-SET ROLE gpadmin;
+RESET ROLE;
 
 DROP ROLE role_dumpinfo_test;
 DROP ROLE role_permission;

--- a/src/test/isolation2/sql/resgroup/resgroup_set_memory_spill_ratio.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_set_memory_spill_ratio.sql
@@ -30,7 +30,7 @@ SET MEMORY_SPILL_RATIO TO 70;
 SHOW MEMORY_SPILL_RATIO;
 SELECT 1;
 
--- positive set to session level
+-- positive set to session level use work_mem
 SET MEMORY_SPILL_RATIO TO 0;
 SHOW MEMORY_SPILL_RATIO;
 SELECT 1;
@@ -49,6 +49,52 @@ SELECT 1;
 SET MEMORY_SPILL_RATIO TO 20;
 SHOW MEMORY_SPILL_RATIO;
 SELECT 1;
+
+-- positive set to session level
+SET MEMORY_SPILL_RATIO TO '20MB';
+SHOW MEMORY_SPILL_RATIO;
+SELECT 1;
+
+-- positive set to session level
+SET MEMORY_SPILL_RATIO TO '20000kB';
+SHOW MEMORY_SPILL_RATIO;
+SELECT 1;
+
+-- positive set to session level? can run?
+SET MEMORY_SPILL_RATIO TO '20GB';
+SHOW MEMORY_SPILL_RATIO;
+SELECT 1;
+
+-- positive set to session level? can run?
+SET MEMORY_SPILL_RATIO TO '20  MB  ';
+SHOW MEMORY_SPILL_RATIO;
+SELECT 1;
+
+-- negative oom when oprator memory is too large
+SET MEMORY_SPILL_RATIO TO '1TB';
+SHOW MEMORY_SPILL_RATIO;
+SELECT * FROM gp_toolkit.gp_resgroup_config ;
+RESET MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '10 %';
+SHOW MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '10.M';
+SHOW MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '-10M';
+SHOW MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '-10';
+SHOW MEMORY_SPILL_RATIO;
+
+-- negative set to session level
+SET MEMORY_SPILL_RATIO TO '0x10M';
+SHOW MEMORY_SPILL_RATIO;
 
 -- reset to resource group level
 RESET MEMORY_SPILL_RATIO;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -53,10 +53,8 @@ CREATE RESOURCE GROUP none WITH (cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 DROP RESOURCE GROUP rg_test_group;
--- must specify both memory_limit and (cpu_rate_limit or cpuset)
+-- must specify cpu_rate_limit or cpuset
 CREATE RESOURCE GROUP rg_test_group WITH (memory_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, cpu_rate_limit=5);
@@ -102,10 +100,16 @@ DROP RESOURCE GROUP none;
 
 -- positive
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpuset='0', memory_limit=10, memory_shared_quota=70, memory_spill_ratio=30);
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
 
 -- ----------------------------------------------------------------------
@@ -120,9 +124,9 @@ CREATE RESOURCE GROUP rg_test_group3 WITH (cpu_rate_limit=1, memory_limit=10);
 DROP RESOURCE GROUP rg_test_group1;
 DROP RESOURCE GROUP rg_test_group2;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=61, memory_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=61);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=91);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=0, memory_limit=10);
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=-1);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0.9);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=1.9);
 -- negative: concurrency should be in [1, max_connections]
@@ -187,6 +191,54 @@ DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=0, memory_spill_ratio=100);
 DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=99, memory_spill_ratio=1);
+DROP RESOURCE GROUP rg_test_group;
+
+-- negative: absolute value format of memory_spill_ratio is
+-- '^[1-9][0-9]*[MmGg]$'
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 %');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10%');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 M');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.MB');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.0MB');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M ');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10B');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10K');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10X');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10MB');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='0 MB');
+DROP RESOURCE GROUP rg_test_group;
+-- negative: memory_spill_ratio does not accept out of range percentage values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='101');
+-- negative: when memory_limit is unlimited memory_spill_ratio must be set in
+-- absolute value format
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=10);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='10%');
+
+-- positive
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100kB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100GB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='1TB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=' 100 MB ');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='0x10 MB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='010 MB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='+10 MB');
+DROP RESOURCE GROUP rg_test_group;
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
+DROP RESOURCE GROUP rg_test_group;
+
+-- positive: memory_spill_ratio in absolute value format will be ensured to be >= 1 chunk
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='1kB');
+SELECT memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
 
 -- ----------------------------------------------------------------------
@@ -255,3 +307,50 @@ ALTER RESOURCE GROUP cgroup_audited_group SET CONCURRENCY 10;
 -- negative: role should not be assigned to a cgroup audited resource group
 CREATE ROLE cgroup_audited_role RESOURCE GROUP cgroup_audited_group;
 DROP RESOURCE GROUP cgroup_audited_group;
+
+-- positive: memory_spill_ratio accepts both integer and string values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+DROP RESOURCE GROUP rg_test_group;
+
+-- negative: memory_spill_ratio only accepts string value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10%;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10M;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10MB;
+DROP RESOURCE GROUP rg_test_group;
+-- negative: memory_spill_ratio does not accept out of range percentage values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1';
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '101';
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1MB';
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '0MB';
+DROP RESOURCE GROUP rg_test_group;
+-- positive: memory_limit can be altered to unlimited if memory_spill_ratio has
+-- an absolute value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+DROP RESOURCE GROUP rg_test_group;
+-- negative: memory_spill_ratio only accepts an absolute value if memory_limit
+-- is unlimited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+DROP RESOURCE GROUP rg_test_group;
+-- positive: memory_spill_ratio accepts a percentage value only if
+-- memory_limit is limited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
+DROP RESOURCE GROUP rg_test_group;
+-- negative: memory_limit must be limited if memory_spill_ratio has a
+-- percentage value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+DROP RESOURCE GROUP rg_test_group;
+-- positive: memory_spill_ratio accepts a absolute value anytime
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10MB');
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '50MB';
+ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10MB';
+DROP RESOURCE GROUP rg_test_group;

--- a/src/test/isolation2/sql/resgroup/resgroup_transaction.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_transaction.sql
@@ -8,7 +8,7 @@ DROP RESOURCE GROUP rg_test_group;
 
 -- helper view to check the resgroup status
 CREATE OR REPLACE VIEW rg_test_monitor AS
-	SELECT groupname, concurrency, proposed_concurrency, cpu_rate_limit
+	SELECT groupname, concurrency, cpu_rate_limit
 	FROM gp_toolkit.gp_resgroup_config
 	WHERE groupname='rg_test_group';
 

--- a/src/test/isolation2/sql/resgroup/resgroup_unlimit_memory_spill_ratio.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_unlimit_memory_spill_ratio.sql
@@ -79,7 +79,7 @@ ANALYZE test_zero_workmem;
 SELECT count(*) FROM test_zero_workmem;
 
 --clean env
-SET ROLE to gpadmin;
+RESET ROLE;
 DROP TABLE test_zero_workmem;
 DROP ROLE role_zero_workmem;
 DROP RESOURCE GROUP rg_zero_workmem;

--- a/src/test/isolation2/sql/resgroup/resgroup_views.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_views.sql
@@ -21,7 +21,7 @@ select rsgname
      , memory_shared_used
   from gp_toolkit.gp_resgroup_status_per_host s
   join gp_segment_configuration c
-    on s.hostname=c.hostname and c.content=-1
+    on s.hostname=c.hostname and c.content=-1 and c.role='p'
  where rsgname='default_group';
 
 select rsgname


### PR DESCRIPTION
…743)

Old memory_spill_ratio only supports percentage format,
which is hard for user to config the operator(join, sort etc.)
memory. We add absolute value format to make memory_spill_ratio
have the similar behavior like GUC statement_mem in resource
queue mode.

Also change the default values of resource group, e.g. use 128MB
as memory_spill_ratio to make the migration from resource queue
to resource group more smoothly.

Also remove proposed column in pg_resgroupcapability.

Co-authored-by: Ning Yu <nyu@pivotal.io>
Co-authored-by: Hubert Zhang <hzhang@pivotal.io>
Reviewed-by: Zhenghua Lyu <kainwen@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
