### PR TITLE
Add tests for basic default tablespace behavior.

### DIFF
--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -170,7 +170,8 @@ tablespace-setup:
 	./testtablespace_existing_version_dir/6/GPDB_99_399999991/ \
 	./testtablespace_existing_version_dir/7/GPDB_99_399999991/ \
 	./testtablespace_existing_version_dir/8/GPDB_99_399999991/ \
-        ./testtablespace_1111111111222222222233333333334444444444555555555566666666667777777777888888888899999999990000000000/
+        ./testtablespace_1111111111222222222233333333334444444444555555555566666666667777777777888888888899999999990000000000/ \
+	./testtablespace_default_tablespace
 
 # Check for include files that are not being shipped
 .PHONY: includecheck

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -11,6 +11,7 @@ bb_mpph.out
 /copy.out
 /create_function_1.out
 /create_function_2.out
+/default_tablespace.out
 dispatch.out
 external_table.out
 filespace.out

--- a/src/test/regress/input/default_tablespace.source
+++ b/src/test/regress/input/default_tablespace.source
@@ -1,0 +1,13 @@
+create tablespace some_default_tablespace location '@testtablespace@_default_tablespace';
+set default_tablespace to some_default_tablespace;
+create table some_table_in_default_tablespace (a int);
+
+-- expect this to be one
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_table_in_default_tablespace';
+
+-- expect this to be the number of segments
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_table_in_default_tablespace' and spcname = 'some_default_tablespace';
+
+drop table some_table_in_default_tablespace;
+drop tablespace some_default_tablespace;
+reset default_tablespace;

--- a/src/test/regress/output/default_tablespace.source
+++ b/src/test/regress/output/default_tablespace.source
@@ -1,0 +1,20 @@
+create tablespace some_default_tablespace location '@testtablespace@_default_tablespace';
+set default_tablespace to some_default_tablespace;
+create table some_table_in_default_tablespace (a int);
+-- expect this to be one
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_table_in_default_tablespace';
+ count 
+-------
+     1
+(1 row)
+
+-- expect this to be the number of segments
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_table_in_default_tablespace' and spcname = 'some_default_tablespace';
+ count 
+-------
+     3
+(1 row)
+
+drop table some_table_in_default_tablespace;
+drop tablespace some_default_tablespace;
+reset default_tablespace;

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -6,6 +6,7 @@
 /copy.sql
 /create_function_1.sql
 /create_function_2.sql
+/default_tablespace.sql
 /gp_transactions.sql
 /largeobject.sql
 /misc.sql


### PR DESCRIPTION
When the default tablespace guc is set, objects created should go into that tablespace.

This change should go back to at least 6x.