### PR TITLE
Correct gpArray's attribute

### DIFF
--- a/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
@@ -161,7 +161,7 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         dbconn.execSQL(conn, "COMMIT")
         conn.close()
 
-        gpArray.setSegmentsAsLoadedFromDb([seg.copy() for seg in gpArray.getDbList()])
+        gpArray.setSegmentsAsLoadedFromDb([seg.copy() for seg in gpArray.getDbList(includeExpansionSegs=True)])
 
 
     def __updateSystemConfigRemoveMirror(self, conn, seg, textForConfigTable):


### PR DESCRIPTION
I think `update.goalsegmap == gpArray.getSegmentsAsLoadedFromDb()` should always `True` after GpConfigurationProviderUsingGpdbCatalog#updateSystemConfig() apply the differ generated by ComputeCatalogUpdate.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
