### PR TITLE
Skip vacuuming external and foreign tables at the first place

### DIFF
--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -331,5 +331,7 @@ reset gp_autostats_mode;
 -- Check forbidden relkind for vacuum is correctly skipped
 CREATE SEQUENCE s_serial START 100;
 VACUUM (ANALYZE, VERBOSE) s_serial;
-WARNING:  skipping "s_serial" --- cannot vacuum non-tables or special system tables
+WARNING:  skipping "s_serial" --- cannot vacuum non-tables, external tables, foreign tables or special system tables
 DROP SEQUENCE s_serial;
+VACUUM gp_toolkit.__gp_log_master_ext;
+WARNING:  skipping "__gp_log_master_ext" --- cannot vacuum non-tables, external tables, foreign tables or special system tables

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -207,3 +207,4 @@ reset gp_autostats_mode;
 CREATE SEQUENCE s_serial START 100;
 VACUUM (ANALYZE, VERBOSE) s_serial;
 DROP SEQUENCE s_serial;
+VACUUM gp_toolkit.__gp_log_master_ext;


### PR DESCRIPTION
```
WARNING:  skipping "__gp_log_master_ext" --- cannot vacuum non-tables or special system tables
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
connection to server was lost
```

External or foreign tables don't support vacuum action, skip them.

The same checks in vacuum_rel() from upstream are not needed to keep
since vacuumStatement_Relation() already checked.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
