### PR TITLE
Fix compile warning in check_memory_spill_ratio

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -91,7 +91,7 @@ static bool check_pljava_classpath_insecure(bool *newval, void **extra, GucSourc
 static void assign_pljava_classpath_insecure(bool newval, void *extra);
 static bool check_gp_resource_group_bypass(bool *newval, void **extra, GucSource source);
 
-static bool check_memory_spill_ratio(const char **newval, void **extra, GucSource source);
+static bool check_memory_spill_ratio(char **newval, void **extra, GucSource source);
 static void assign_memory_spill_ratio(const char *newval, void *extra);
 static const char *show_memory_spill_ratio(void);
 
@@ -5056,15 +5056,15 @@ check_gp_workfile_compression(bool *newval, void **extra, GucSource source)
 }
 
 
-bool
-check_memory_spill_ratio(const char **newval, void **extra, GucSource source)
+static bool
+check_memory_spill_ratio(char **newval, void **extra, GucSource source)
 {
-	ResGroupMemorySpillFromStr(*newval);
+	ResGroupMemorySpillFromStr((const char *)*newval);
 
 	return true;
 }
 
-void
+static void
 assign_memory_spill_ratio(const char *newval, void *extra)
 {
 	int32		value = ResGroupMemorySpillFromStr(newval);
@@ -5072,7 +5072,7 @@ assign_memory_spill_ratio(const char *newval, void *extra)
 	memory_spill_ratio = value;
 }
 
-const char *
+static const char *
 show_memory_spill_ratio(void)
 {
 	static char buf[16];

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -770,8 +770,4 @@ extern bool gpvars_check_gp_gpperfmon_send_interval(int *newval, void **extra, G
 
 extern StdRdOptions *defaultStdRdOptions(char relkind);
 
-extern bool gpvars_check_memory_spill_ratio(const char **newval, void **extra, GucSource source);
-extern void gpvars_assign_memory_spill_ratio(const char *newval, void *extra);
-extern const char *gpvars_show_memory_spill_ratio(void);
-
 #endif   /* GUC_H */


### PR DESCRIPTION
Check hook of string GUC should use char ** instead of const char **
Also remove unused function gpvars_check_memory_spill_ratio() etc.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
