### PR TITLE
Libs are vendored multiple times in gpdb6

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -130,7 +130,7 @@ function include_zstd() {
       ubuntu) libdir=/usr/lib ;;
     esac
     cp ${libdir}/pkgconfig/libzstd.pc lib/pkgconfig
-    cp ${libdir}/libzstd.so* lib
+    cp -d ${libdir}/libzstd.so* lib
     cp /usr/include/zstd*.h include
   popd
 }
@@ -142,7 +142,7 @@ function include_quicklz() {
       centos) libdir=/usr/lib64 ;;
       ubuntu) libdir=/usr/local/lib ;;
     esac
-    cp ${libdir}/libquicklz.so* lib
+    cp -d ${libdir}/libquicklz.so* lib
   popd
 }
 
@@ -154,7 +154,7 @@ function include_libstdcxx() {
           *.py)
             ;; # we don't vendor libstdc++.so.*-gdb.py
           *)
-            cp "$libfile" ${GREENPLUM_INSTALL_DIR}/lib
+            cp -d "$libfile" ${GREENPLUM_INSTALL_DIR}/lib
             ;; # vendor everything else
         esac
       done


### PR DESCRIPTION
gp-releng build the libs artifacts for gpdb6, and
copy them into gpdb libs when compile the gpdb binary.
We found that the libs copied multiple times. eg.

```
[root@a5e93b7cdc29 lib]# ls /usr/local/greenplum-db/lib -l | grep
libquicklz
-rwxr-xr-x  1 root root     8648 May  8 15:26 libquicklz.so
-rwxr-xr-x  1 root root     8648 May  8 15:26 libquicklz.so.1
-rwxr-xr-x  1 root root     8648 May  8 15:26 libquicklz.so.1.5.0
```

stories:

https://www.pivotaltracker.com/story/show/166200423
https://www.pivotaltracker.com/story/show/166200398
https://www.pivotaltracker.com/story/show/166200397

Authored-by: Bob Bao <bbao@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
