### PR TITLE
5X: Avoid infinite loop in processCopyEndResults

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -473,7 +473,7 @@ processCopyEndResults(CdbCopy *c,
 		pollRead->events = POLLIN;
 		pollRead->revents = 0;
 
-		while (PQisBusy(q->conn))
+		while (PQisBusy(q->conn) && PQstatus(q->conn) == CONNECTION_OK)
 		{
 			if ((Gp_role == GP_ROLE_DISPATCH) && InterruptPending)
 			{


### PR DESCRIPTION
The command "COPY enumtest FROM stdin;" hit an infinite loop on merge
branch.  Code indicates that the issue can happen on master as well.
QD backend went into infinite loop when the connection was already
closed from QE end.  The TCP connection was in CLOSE_WAIT state.
Libpq connection status was CONNECTION_BAD and asyncStatus was
PGASYNC_BUSY.

Fix the infinite loop by checking libpq connection status in each
iteration.

(cherry picked from commit 25bc3855db2a9036582e051b18e2857582bafad0)