### PR TITLE
Fix a bug in check_ao_record_present

### DIFF
--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -459,7 +459,10 @@ check_ao_record_present(unsigned char type, char *buf, Size len,
 			if (hdr->xlp_info & XLP_FIRST_IS_CONTRECORD)
 			{
 				elog(DEBUG1, "remaining length of record = %u", hdr->xlp_rem_len);
-				i += MAXALIGN(XLogPageHeaderSize(hdr) + hdr->xlp_rem_len);
+				if (hdr->xlp_rem_len > XLOG_BLCKSZ - XLogPageHeaderSize(hdr))
+					i += XLOG_BLCKSZ;
+				else
+					i += MAXALIGN(XLogPageHeaderSize(hdr) + hdr->xlp_rem_len);
 			}
 			else
 			{


### PR DESCRIPTION
This bug cause the test 'generate_ao_xlog' hang sometimes.
If the current page cannot hold the remaining content (xlp_rem_len) of the
record, find the next record in the next page.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
