### PR TITLE
PXF: Fix repository path

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ make distclean
 ### Building GPDB with PXF
 
 PXF is an extension framework for GPDB to enable fast access to external hadoop datasets.
-Refer to [PXF extension](gpAux/extensions/pxf/README.md) for more information.
+Refer to [PXF extension](gpcontrib/pxf/README.md) for more information.
 
 Currently, GPDB is built with PXF by default (--enable-pxf is on).
 In order to build GPDB without pxf, simply invoke `./configure` with additional option `--disable-pxf`.

--- a/gpcontrib/pxf/test/Makefile
+++ b/gpcontrib/pxf/test/Makefile
@@ -1,4 +1,4 @@
-subdir=gpAux/extensions/pxf/test
+subdir=gpcontrib/pxf/test
 top_builddir=../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/gpdb-doc/markdown/pxf/sdk/dev_overview.html.md.erb
+++ b/gpdb-doc/markdown/pxf/sdk/dev_overview.html.md.erb
@@ -3,7 +3,7 @@ title: Using the PXF Java SDK
 ---
 The Greenplum Platform Extension Framework (PXF) SDK provides the Java classes and interfaces that you use to create connectors to new external data sources, data formats, and data access APIs from Greenplum Database. You can extend PXF functionality *without changing Greenplum Database* when you use the PXF Java SDK.
 
-PXF in Greenplum Database has its roots in the Apache HAWQ project. You can contribute to Greenplum PXF development via the open source github repositories for [PXF Server Plugins](https://github.com/greenplum-db/pxf) and the [Greenplum PXF Extension/Client](https://github.com/greenplum-db/gpdb/tree/master/gpAux/extensions/pxf).
+PXF in Greenplum Database has its roots in the Apache HAWQ project. You can contribute to Greenplum PXF development via the open source github repositories for [PXF Server Plugins](https://github.com/greenplum-db/pxf) and the [Greenplum PXF Extension/Client](https://github.com/greenplum-db/gpdb/tree/master/gpcontrib/pxf).
 
 ## <a id="prereqs"></a>Topic Overview
 


### PR DESCRIPTION
Fix remnant PXF paths that were pointing to the old repository path.

gpAux/extensions/pxf -> gpcontrib/pxf
