### PR TITLE
Fix plan for select-statement with locking clause

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3814,6 +3814,13 @@ checkCanOptSelectLockingClause(SelectStmt *stmt)
 	if (!IsA(linitial(stmt->fromClause), RangeVar))
 		return false;
 
+	/*
+	 * In Greenplum, the results of limit can only be known on QD,
+	 * so we cannot lock correct tuples on QEs.
+	 */
+	if (stmt->limitCount != NULL || stmt->limitOffset != NULL)
+		return false;
+
 	if (!stmt->lockingClause)
 		return false;
 

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1086,6 +1086,7 @@ addRangeTableEntry(ParseState *pstate,
 			elog(ERROR, "open relation(%u) fail", relid);
 
 		if (rel->rd_rel->relkind != RELKIND_RELATION ||
+			GpPolicyIsReplicated(rel->rd_cdbpolicy) ||
 			RelationIsAppendOptimized(rel))
 			pstate->p_canOptSelectLockingClause = false;
 

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -885,6 +885,37 @@ BEGIN
 1: abort;
 ABORT
 
+-- 1.5 test order-by's plan
+1: begin;
+BEGIN
+1: explain select * from t_lockmods order by c for update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.11..2.12 rows=5 width=10) 
+   Merge Key: c                                                              
+   ->  Sort  (cost=2.11..2.12 rows=2 width=10)                               
+         Sort Key: c                                                         
+         ->  Seq Scan on t_lockmods  (cost=0.00..2.05 rows=2 width=10)       
+ Optimizer: Postgres query optimizer                                         
+(6 rows)
+1: select * from t_lockmods order by c for update;
+ c 
+---
+ 1 
+ 2 
+ 3 
+ 4 
+ 5 
+(5 rows)
+1: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | ExclusiveLock   | t       | t_lockmods 
+(2 rows)
+1: abort;
+ABORT
+
 1q: ... <quitting>
 2q: ... <quitting>
 
@@ -1797,6 +1828,38 @@ BEGIN
 ----------+-----------------+---------+----------------
  relation | AccessShareLock | t       | t_lockmods_rep 
  relation | ExclusiveLock   | t       | t_lockmods_rep 
+(2 rows)
+1: abort;
+ABORT
+
+-- 2.5 test order-by's plan
+1: begin;
+BEGIN
+1: explain select * from t_lockmods order by c for update;
+ QUERY PLAN                                                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.16..2.17 rows=5 width=10) 
+   Merge Key: c                                                              
+   ->  Sort  (cost=2.16..2.17 rows=2 width=10)                               
+         Sort Key: c                                                         
+         ->  LockRows  (cost=0.00..2.10 rows=2 width=10)                     
+               ->  Seq Scan on t_lockmods  (cost=0.00..2.05 rows=2 width=10) 
+ Optimizer: Postgres query optimizer                                         
+(7 rows)
+1: select * from t_lockmods order by c for update;
+ c 
+---
+ 1 
+ 2 
+ 3 
+ 4 
+ 5 
+(5 rows)
+1: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | RowShareLock    | t       | t_lockmods 
 (2 rows)
 1: abort;
 ABORT

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -23,6 +23,9 @@ INSERT 5
 create table t_lockmods1 (c int) distributed randomly;
 CREATE
 
+create table t_lockmods_rep(c int) distributed replicated;
+CREATE
+
 -- 1.1.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
@@ -826,6 +829,59 @@ EXECUTE 5
 ----------+------------------+---------+---------------
  relation | RowExclusiveLock | t       | t_lockmods_ao 
 (1 row)
+1: abort;
+ABORT
+
+-- 1.3 With limit clause, such case should
+-- acquire ExclusiveLock on the whole table and do not generate lockrows node
+1: begin;
+BEGIN
+1: explain select * from t_lockmods order by c limit 1 for update;
+ QUERY PLAN                                                                        
+-----------------------------------------------------------------------------------
+ Limit  (cost=2.07..2.10 rows=1 width=10)                                          
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.07..2.10 rows=1 width=10) 
+         Merge Key: c                                                              
+         ->  Limit  (cost=2.07..2.08 rows=1 width=10)                              
+               ->  Sort  (cost=2.07..2.09 rows=2 width=10)                         
+                     Sort Key: c                                                   
+                     ->  Seq Scan on t_lockmods  (cost=0.00..2.05 rows=2 width=10) 
+ Optimizer: Postgres query optimizer                                               
+(8 rows)
+1: select * from t_lockmods order by c limit 1 for update;
+ c 
+---
+ 1 
+(1 row)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | ExclusiveLock   | t       | t_lockmods 
+(2 rows)
+1: abort;
+ABORT
+
+-- 1.4 For replicated table, we should lock the entire table on ExclusiveLock
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_rep for update;
+ QUERY PLAN                                                                         
+------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1063.00 rows=96300 width=10) 
+   ->  Seq Scan on t_lockmods_rep  (cost=0.00..1063.00 rows=96300 width=10)         
+ Optimizer: Postgres query optimizer                                                
+(3 rows)
+1: select * from t_lockmods_rep for update;
+ c 
+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_rep 
+ relation | ExclusiveLock   | t       | t_lockmods_rep 
+(2 rows)
 1: abort;
 ABORT
 
@@ -1689,6 +1745,59 @@ EXECUTE 5
 ----------+------------------+---------+---------------
  relation | RowExclusiveLock | t       | t_lockmods_ao 
 (1 row)
+1: abort;
+ABORT
+
+-- 2.3 With limit clause, such case should
+-- acquire ExclusiveLock on the whole table and do not generate lockrows node
+1: begin;
+BEGIN
+1: explain select * from t_lockmods order by c limit 1 for update;
+ QUERY PLAN                                                                        
+-----------------------------------------------------------------------------------
+ Limit  (cost=2.07..2.10 rows=1 width=10)                                          
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.07..2.10 rows=1 width=10) 
+         Merge Key: c                                                              
+         ->  Limit  (cost=2.07..2.08 rows=1 width=10)                              
+               ->  Sort  (cost=2.07..2.09 rows=2 width=10)                         
+                     Sort Key: c                                                   
+                     ->  Seq Scan on t_lockmods  (cost=0.00..2.05 rows=2 width=10) 
+ Optimizer: Postgres query optimizer                                               
+(8 rows)
+1: select * from t_lockmods order by c limit 1 for update;
+ c 
+---
+ 1 
+(1 row)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation   
+----------+-----------------+---------+------------
+ relation | AccessShareLock | t       | t_lockmods 
+ relation | ExclusiveLock   | t       | t_lockmods 
+(2 rows)
+1: abort;
+ABORT
+
+-- 2.4 For replicated table, we should lock the entire table on ExclusiveLock
+1: begin;
+BEGIN
+1: explain select * from t_lockmods_rep for update;
+ QUERY PLAN                                                                         
+------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1063.00 rows=96300 width=10) 
+   ->  Seq Scan on t_lockmods_rep  (cost=0.00..1063.00 rows=96300 width=10)         
+ Optimizer: Postgres query optimizer                                                
+(3 rows)
+1: select * from t_lockmods_rep for update;
+ c 
+---
+(0 rows)
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation       
+----------+-----------------+---------+----------------
+ relation | AccessShareLock | t       | t_lockmods_rep 
+ relation | ExclusiveLock   | t       | t_lockmods_rep 
+(2 rows)
 1: abort;
 ABORT
 

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -20,6 +20,8 @@ insert into t_lockmods select * from generate_series(1, 5);
 
 create table t_lockmods1 (c int) distributed randomly;
 
+create table t_lockmods_rep(c int) distributed replicated;
+
 -- 1.1.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 1: explain select * from t_lockmods for update;
@@ -242,6 +244,21 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 
 1: begin;
 1: execute insert_tlockmods_ao;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+-- 1.3 With limit clause, such case should
+-- acquire ExclusiveLock on the whole table and do not generate lockrows node
+1: begin;
+1: explain select * from t_lockmods order by c limit 1 for update;
+1: select * from t_lockmods order by c limit 1 for update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+-- 1.4 For replicated table, we should lock the entire table on ExclusiveLock
+1: begin;
+1: explain select * from t_lockmods_rep for update;
+1: select * from t_lockmods_rep for update;
 2: select * from show_locks_lockmodes;
 1: abort;
 
@@ -482,6 +499,21 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 
 1: begin;
 1: execute insert_tlockmods_ao;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+-- 2.3 With limit clause, such case should
+-- acquire ExclusiveLock on the whole table and do not generate lockrows node
+1: begin;
+1: explain select * from t_lockmods order by c limit 1 for update;
+1: select * from t_lockmods order by c limit 1 for update;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+-- 2.4 For replicated table, we should lock the entire table on ExclusiveLock
+1: begin;
+1: explain select * from t_lockmods_rep for update;
+1: select * from t_lockmods_rep for update;
 2: select * from show_locks_lockmodes;
 1: abort;
 

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -262,6 +262,13 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 2: select * from show_locks_lockmodes;
 1: abort;
 
+-- 1.5 test order-by's plan
+1: begin;
+1: explain select * from t_lockmods order by c for update;
+1: select * from t_lockmods order by c for update;
+1: select * from show_locks_lockmodes;
+1: abort;
+
 1q:
 2q:
 
@@ -515,6 +522,13 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 1: explain select * from t_lockmods_rep for update;
 1: select * from t_lockmods_rep for update;
 2: select * from show_locks_lockmodes;
+1: abort;
+
+-- 2.5 test order-by's plan
+1: begin;
+1: explain select * from t_lockmods order by c for update;
+1: select * from t_lockmods order by c for update;
+1: select * from show_locks_lockmodes;
 1: abort;
 
 1q:


### PR DESCRIPTION
Commit 6ebce7333 do some optimization for select statement
with locking clause for some simple cases. It also applies
such optimization to select statement with limit.

In Greenplum, the results of limit can only be known on QD,
but we can only lock tuples on QEs. So this commit fixes this.

Also, for replicated table, select statement may only execute
on one segment, but update statement has to happen on all segments.
We should also turn off such optimization on locking clause for
replicated table.

----------

Currently, Greenplum uses two-stage sort to implement
order by, and might generate a gather motion to QD.

If the processing order is: first order-by then rowmarks,
we might put a lockrows plannode above a gather motion.
However, we cannot lock tuples on QD.

This commit changes the order. The plan for the query
`select * from t order by c for update` on a hash-distributed
table or randomly-distributed table t is:

  previous:
               QUERY PLAN
    ------------------------------------------
    LockRows
        ->Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: c
          ->  Sort
              Sort Key: c
               ->  Seq Scan on t

  after this commit:
             QUERY PLAN
    ------------------------------------------
    Gather Motion 3:1  (slice1; segments: 3)
        Merge Key: c
        ->  Sort
            Sort Key: c
             ->  LockRows
                 ->  Seq Scan on t

-----------
In Postgres, the process order is sort -> rowmarks -> limit,
 the reason I think is that we should only lock those tuples after
 limit. Based on the one tuple one time model, the following plan
     limit
        -> lockrows
            -> sort
                -> scan
 will only lock one tuple even the sort node sort all tuples.

 But for Greenplum, we might not emit lockrows plannode due to many
 limitations in MPP architecture. Greenplum can only behave like
 postgres in some simple cases (refer the function
 `parser/analyze.c:checkCanOptSelectLockingClause` for details).
 Select-statement with limit clause and locking clause  is not a
 simple case, because we can only know which tuples will be output
 on QD, but lock rows have to work on QEs. So for select-statement
 with limit clause and locking clause will not emit lockrows plannode,
 that is, in such case, it will ignore the rowmarks.

 So Greenplum changes the process order as: rowmarks(maybe) -> sort -> limit.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
