### PR TITLE
6X backport: Fix pipeline failure in compile_gpdb_sles11

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -124,12 +124,12 @@ function unittest_check_gpdb() {
 
 function include_zstd() {
   local libdir
+  case "${TARGET_OS}" in
+    centos) libdir=/usr/lib64 ;;
+    ubuntu) libdir=/usr/lib ;;
+    *) return ;;
+  esac
   pushd ${GREENPLUM_INSTALL_DIR}
-    case "${TARGET_OS}" in
-      centos) libdir=/usr/lib64 ;;
-      ubuntu) libdir=/usr/lib ;;
-      *) return ;;
-    esac
     cp ${libdir}/pkgconfig/libzstd.pc lib/pkgconfig
     cp -d ${libdir}/libzstd.so* lib
     cp /usr/include/zstd*.h include
@@ -138,12 +138,12 @@ function include_zstd() {
 
 function include_quicklz() {
   local libdir
+  case "${TARGET_OS}" in
+    centos) libdir=/usr/lib64 ;;
+    ubuntu) libdir=/usr/local/lib ;;
+    *) return ;;
+  esac
   pushd ${GREENPLUM_INSTALL_DIR}
-    case "${TARGET_OS}" in
-      centos) libdir=/usr/lib64 ;;
-      ubuntu) libdir=/usr/local/lib ;;
-      *) return ;;
-    esac
     cp -d ${libdir}/libquicklz.so* lib
   popd
 }


### PR DESCRIPTION
This is a 6X backport of PR https://github.com/greenplum-db/gpdb/pull/7806
When TARGET_OS is sles, it goes to case *) and return without popd, so leave a
dangled pushd, that results later pushd can not work.

Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>
Co-authored-by: Shaoqi Bai <sbai@pivotal.io>

Reviewed-by: Ning Yu <nyu@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
