### PR TITLE
WIP: pg_dumpall: dump resgroup memory_spill_ratio as strings

### DIFF
--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -693,11 +693,11 @@ buildWithClause(const char *resname, const char *ressetting, PQExpBuffer buf)
  * return false otherwise.
  */
 static bool
-strIsInt(const char *str)
+strInPercentageFormat(const char *str)
 {
 	char *end = NULL;
 
-	strtod(str, &end);
+	strtol(str, &end, 10);
 	if (end == NULL || end == str || *end != 0)
 		return false;
 
@@ -789,7 +789,7 @@ dumpResGroups(PGconn *conn)
 		memory_auditor = PQgetvalue(res, i, i_memory_auditor);
 		cpuset = PQgetvalue(res, i, i_cpuset);
 
-		if (strIsInt(memory_spill_ratio))
+		if (strInPercentageFormat(memory_spill_ratio))
 		{
 			/*
 			 * memory_spill_ratio is in percentage format, set it as an integer


### PR DESCRIPTION
The resource group memory_spill_ratio property used to accept only
integer values, but recently we introduced a new absolute-value syntax
to it, such as '1 MB', so we have to dump this property as a string.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
