### PR TITLE
Avoid two-phase commit if segment doesn't write WAL that includes xid

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -417,7 +417,8 @@ IsAbortedTransactionBlockState(void)
 bool
 TransactionDidWriteXLog(void)
 {
-	return (XactLastRecEnd != InvalidXLogRecPtr);
+	TransactionState s = CurrentTransactionState;
+	return s->didLogXid;
 }
 
 bool

--- a/src/test/regress/expected/freeze_aux_tables.out
+++ b/src/test/regress/expected/freeze_aux_tables.out
@@ -368,13 +368,13 @@ select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('te
 group by segid = -1, relname, classify_age(age);
  is_master |      relname       | classify_age 
 -----------+--------------------+--------------
- t         | pg_aocsseg_<oid>   | very young
- f         | pg_toast_<oid>     | very young
- f         | pg_aoblkdir_<oid>  | very young
- t         | pg_toast_<oid>     | very young
  t         | pg_aovisimap_<oid> | very young
- f         | pg_aocsseg_<oid>   | very young
  t         | pg_aoblkdir_<oid>  | very young
- f         | pg_aovisimap_<oid> | very young
+ f         | pg_aoblkdir_<oid>  | zero
+ f         | pg_aocsseg_<oid>   | zero
+ t         | pg_toast_<oid>     | very young
+ f         | pg_toast_<oid>     | zero
+ f         | pg_aovisimap_<oid> | zero
+ t         | pg_aocsseg_<oid>   | very young
 (8 rows)
 


### PR DESCRIPTION
In commit b43629, we disable two-phase commit if the transaction doesn't write
any WAL on the segment. That makes some tests flaky because a read-only
transaction may also write WALs on segment and that behavior is indeterminate.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
