### PR TITLE
Check presence of commit SHA in executables with readelf

### DIFF
--- a/concourse/scripts/verify_gpdb_versions.bash
+++ b/concourse/scripts/verify_gpdb_versions.bash
@@ -14,13 +14,13 @@ install_greenplum() {
 assert_postgres_version_matches() {
   local gpdb_src_sha=$1
 
-  if [[ ! "$(postgres --gp-version)" =~ "commit:$gpdb_src_sha" ]]; then
-    echo "bin_gpdb version: '$(postgres --gp-version)' does not match gpdb_src commit: '${gpdb_src_sha}'. Exiting..."
+  if ! readelf --string-dump=.rodata $(command -v postgres) | grep -c "commit:$gpdb_src_sha" > /dev/null ; then
+    echo "bin_gpdb version: gpdb_src commit '${gpdb_src_sha}' not found in binary '$(command -v postgres)'. Exiting..."
     exit 1
   fi
 }
 
-yum -d1 -y install git
+yum -d0 -y install git
 
 GPDB_SRC_SHA=$(cd gpdb_src && git rev-parse HEAD)
 for bin_gpdb in bin_gpdb_{centos{6,7},ubuntu18.04}; do


### PR DESCRIPTION
The verify_gpdb_versions task is using a base CentOS 7 image and the
version of the shared objects included are incorrect for executing the
GPDB binaries built for Ubuntu. Instead of actually executing the
binaries, we check for the presence of the commit SHA by dumping the
rodata section of `greenplum-db/bin/postgres`.

Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>
Co-authored-by: Jesse Zhang <jzhang@pivotal.io>
