### PR TITLE
gen_pipeline: Remove gpdb_ prefix from ?X_STABLE pipeline names

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -249,9 +249,10 @@ def print_fly_commands(args):
     print header(args)
     if args.pipeline_target == 'prod':
         print 'NOTE: You can set the production pipelines with the following:\n'
-        print gen_pipeline(args, "gpdb_%s" % BASE_BRANCH, ["gpdb_%s-ci-secrets.prod.yml" % BASE_BRANCH],
+        pipeline_name = "gpdb_%s" % BASE_BRANCH if BASE_BRANCH == "master" else BASE_BRANCH
+        print gen_pipeline(args, pipeline_name, ["gpdb_%s-ci-secrets.prod.yml" % BASE_BRANCH],
                            "https://github.com/greenplum-db/gpdb.git", BASE_BRANCH)
-        print gen_pipeline(args, "gpdb_%s_without_asserts" % BASE_BRANCH, ["gpdb_%s_without_asserts-ci-secrets.prod.yml" % BASE_BRANCH],
+        print gen_pipeline(args, "%s_without_asserts" % pipeline_name, ["gpdb_%s_without_asserts-ci-secrets.prod.yml" % BASE_BRANCH],
                            "https://github.com/greenplum-db/gpdb.git", BASE_BRANCH)
         return
 


### PR DESCRIPTION
This is a forward-merge of https://github.com/greenplum-db/gpdb/commit/f2dd588a8ea3efc3864f440ed1bade1f22590474 so that when we branch for 7X_STABLE etc., the pipeline name will not have the `gpdb_` prefix.

The gen_pipeline utiltiy generates pipelines with the gpdb_ prefix
including for the master pipeline. However, for 7X_STABLE, 6X_STABLE
etc., we want the pipelines to be named with the production branch
name only. This commit addresses this issue.

Authored-by: Shoaib Lari <slari@pivotal.io>
(cherry picked from commit f2dd588a8ea3efc3864f440ed1bade1f22590474)
