### PR TITLE
Fix GUC name for workload pipeline

### DIFF
--- a/concourse/scripts/builds/GpBuild.py
+++ b/concourse/scripts/builds/GpBuild.py
@@ -101,8 +101,9 @@ class GpBuild(GpdbBuildBase):
         for fsql in sql_files:
             if fsql.endswith('.sql') and fsql not in ['stats.sql', 'schema.sql']:
                 output_fname = 'out/{}'.format(fsql.replace('.sql', '.out'))
+                # GUC name should match with name in gpdb 5X_STABLE branch
                 with open(output_fname, 'w') as fout:
-                    current_status = self._run_gpdb_command("env PGOPTIONS='-c optimizer_expand_fulljoin=on' psql -a -f sql/{}".format(fsql), stdout=fout, stderr=fout, source_env_cmd=source_env_cmd)
+                    current_status = self._run_gpdb_command("env PGOPTIONS='-c optimizer_enable_full_join=on' psql -a -f sql/{}".format(fsql), stdout=fout, stderr=fout, source_env_cmd=source_env_cmd)
                     print "status: {0}".format(current_status)
                     status = status if status != 0 else current_status
 


### PR DESCRIPTION
workload pipeline runs on 5X_STABLE where the GUC name is
`optimizer_enable_full_join`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
