### PR TITLE
Enable fault_injector "extension support" feature

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -114,7 +114,7 @@ FaultInjectorTypeStringToEnum(char* faultTypeString)
 	FaultInjectorType_e	faultTypeEnum = FaultInjectorTypeMax;
 	int	ii;
 	
-	for (ii=FaultInjectorTypeNotSpecified+1; ii < FaultInjectorTypeMax; ii++)
+	for (ii=0; ii < FaultInjectorTypeMax; ii++)
 	{
 		if (strcmp(FaultInjectorTypeEnumToString[ii], faultTypeString) == 0)
 		{
@@ -131,7 +131,7 @@ FaultInjectorIdentifierStringToEnum(char* faultName)
 	FaultInjectorIdentifier_e	faultId = FaultInjectorIdMax;
 	int	ii;
 	
-	for (ii=FaultInjectorIdNotSpecified+1; ii < FaultInjectorIdMax; ii++)
+	for (ii=0; ii < FaultInjectorIdMax; ii++)
 	{
 		if (strcmp(FaultInjectorIdentifierEnumToString[ii], faultName) == 0)
 		{
@@ -1081,13 +1081,14 @@ InjectFault(char *faultName, char *type, char *ddlStatement, char *databaseName,
 
 	strlcpy(faultEntry.faultName, faultName, sizeof(faultEntry.faultName));
 	faultEntry.faultInjectorIdentifier = FaultInjectorIdentifierStringToEnum(faultName);
-	if (faultEntry.faultInjectorIdentifier == FaultInjectorIdMax)
+	if (faultEntry.faultInjectorIdentifier == FaultInjectorIdNotSpecified)
 		ereport(ERROR,
 				(errcode(ERRCODE_PROTOCOL_VIOLATION),
 				 errmsg("could not recognize fault name '%s'", faultName)));
 
 	faultEntry.faultInjectorType = FaultInjectorTypeStringToEnum(type);
-	if (faultEntry.faultInjectorType == FaultInjectorTypeMax)
+	if (faultEntry.faultInjectorType == FaultInjectorTypeMax ||
+	    faultEntry.faultInjectorType == FaultInjectorTypeNotSpecified)
 		ereport(ERROR,
 				(errcode(ERRCODE_PROTOCOL_VIOLATION),
 				 errmsg("could not recognize fault type '%s'", type)));

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -65,8 +65,6 @@ typedef struct FaultInjectorEntry_s {
 	
 	char						faultName[FAULT_NAME_MAX_LENGTH];
 
-	FaultInjectorIdentifier_e	faultInjectorIdentifier;
-	
 	FaultInjectorType_e		faultInjectorType;
 	
 	int						extraArg;


### PR DESCRIPTION
1. Extension support feature of fault_injector was add
   in PR #3249, it uses fault name instead of enum
   as the key for a fault injector. Therefore, an extension
   can also use the fault_injector without need to add a key
   in the head file. This is a very useful feature for
   extension development, but it was disabled in PR #7739 and #7739.
   This patch enables this feature again for extensions.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
