### PR TITLE
Bump ORCA version to 3.45.0, added new value to guc

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.44.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.45.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.44.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.45.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13982,7 +13982,7 @@ int
 main ()
 {
 
-return strncmp("3.44.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.45.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13992,7 +13992,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.44.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.45.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.44.0@gpdb/stable
+orca/v3.45.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -88,9 +88,9 @@ sync_tools: opt_write_test
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
 ifeq "$(findstring sles,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/archive/v3.44.0.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/archive/v3.45.0.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 else
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.44.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.45.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 endif
 

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -525,7 +525,10 @@ CConfigParamMapping::PackConfigParamInBitset
 			join_heuristic_bitset = CXform::PbsJoinOrderOnGreedyXforms(mp);
 			break;
 		case JOIN_ORDER_EXHAUSTIVE_SEARCH:
-			join_heuristic_bitset = GPOS_NEW(mp) CBitSet(mp, EopttraceSentinel);
+			join_heuristic_bitset = CXform::PbsJoinOrderOnExhaustiveXforms(mp);
+			break;
+		case JOIN_ORDER_EXHAUSTIVE2_SEARCH:
+			join_heuristic_bitset = CXform::PbsJoinOrderOnExhaustive2Xforms(mp);
 			break;
 		default:
 			elog(ERROR, "Invalid value for optimizer_join_order, must \

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -562,6 +562,7 @@ static const struct config_enum_entry optimizer_join_order_options[] = {
 	{"query", JOIN_ORDER_IN_QUERY},
 	{"greedy", JOIN_ORDER_GREEDY_SEARCH},
 	{"exhaustive", JOIN_ORDER_EXHAUSTIVE_SEARCH},
+	{"exhaustive2", JOIN_ORDER_EXHAUSTIVE2_SEARCH},
 	{NULL, 0}
 };
 
@@ -4726,7 +4727,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 	{
 		{"optimizer_join_order", PGC_USERSET, QUERY_TUNING_OTHER,
 			gettext_noop("Set optimizer join heuristic model."),
-			gettext_noop("Valid values are query, greedy and exhaustive"),
+			gettext_noop("Valid values are query, greedy, exhaustive and exhaustive2"),
 			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_join_order,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -541,6 +541,7 @@ extern bool	optimizer_partition_selection_log;
 #define JOIN_ORDER_IN_QUERY                 0
 #define JOIN_ORDER_GREEDY_SEARCH            1
 #define JOIN_ORDER_EXHAUSTIVE_SEARCH        2
+#define JOIN_ORDER_EXHAUSTIVE2_SEARCH       3
 
 /* Time based authentication GUC */
 extern char  *gp_auth_time_override_str;

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -757,6 +757,47 @@ select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t
    2 |   2 |   2 |   2 | 1 | 2 | 3 |   2 |   2 |   2 |   2 | 1 | 2 | 3
 (4 rows)
 
+-- test different join order enumeration methods
+set optimizer_join_order = query;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+(2 rows)
+
+set optimizer_join_order = greedy;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+(2 rows)
+
+set optimizer_join_order = exhaustive;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+(2 rows)
+
+set optimizer_join_order = exhaustive2;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+(2 rows)
+
+reset optimizer_join_order;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+(2 rows)
+
 drop table t1, t2, t3;
 --
 -- Test a bug that nestloop path previously can not generate motion above

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -772,6 +772,47 @@ select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t
    2 |   2 |   2 |   2 | 1 | 2 | 3 |   2 |   2 |   2 |   2 |   | 2 | 2
 (4 rows)
 
+-- test different join order enumeration methods
+set optimizer_join_order = query;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+(2 rows)
+
+set optimizer_join_order = greedy;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+(2 rows)
+
+set optimizer_join_order = exhaustive;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+(2 rows)
+
+set optimizer_join_order = exhaustive2;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+(2 rows)
+
+reset optimizer_join_order;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+ a | b | c | a | b | c | a | b | c 
+---+---+---+---+---+---+---+---+---
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+(2 rows)
+
 drop table t1, t2, t3;
 --
 -- Test a bug that nestloop path previously can not generate motion above

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -399,6 +399,18 @@ select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t
   join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b 
   join t3 t3_1 on tt1.t1b = t3_1.b and (tt1.t2a is NULL OR tt1.t1b = t3.b);
 
+-- test different join order enumeration methods
+set optimizer_join_order = query;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+set optimizer_join_order = greedy;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+set optimizer_join_order = exhaustive;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+set optimizer_join_order = exhaustive2;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+reset optimizer_join_order;
+select * from t1 join t2 on t1.a = t2.a join t3 on t1.b = t3.b;
+
 drop table t1, t2, t3;
 
 --


### PR DESCRIPTION
Add exhaustive2 option to optimizer_join_order guc.
The corresponding ORCA PR is
https://github.com/greenplum-db/gporca/pull/467.

The same change will go into 6X_STABLE. In 5X_STABLE, the new guc
option will not be available.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
