### PR TITLE
Rename IMemoryPool to CMemoryPool

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.45.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.46.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.45.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.46.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13982,7 +13982,7 @@ int
 main ()
 {
 
-return strncmp("3.45.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.46.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13992,7 +13992,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.45.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.46.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.45.0@gpdb/stable
+orca/v3.46.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -88,9 +88,9 @@ sync_tools: opt_write_test
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
 ifeq "$(findstring sles,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/archive/v3.45.0.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/archive/v3.46.0.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 else
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.45.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.46.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 endif
 

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -398,7 +398,7 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] =
 CBitSet *
 CConfigParamMapping::PackConfigParamInBitset
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	ULONG xform_id // number of available xforms
 	)
 {

--- a/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
+++ b/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
@@ -37,7 +37,7 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CMDProviderRelcache::CMDProviderRelcache
 	(
-	IMemoryPool *mp
+	CMemoryPool *mp
 	)
 	:
 	m_mp(mp)
@@ -56,7 +56,7 @@ CMDProviderRelcache::CMDProviderRelcache
 CWStringBase *
 CMDProviderRelcache::GetMDObjDXLStr
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *md_id
 	)

--- a/src/backend/gpopt/translate/CCTEListEntry.cpp
+++ b/src/backend/gpopt/translate/CCTEListEntry.cpp
@@ -33,7 +33,7 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CCTEListEntry::CCTEListEntry
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	ULONG query_level,
 	CommonTableExpr *cte,
 	CDXLNode *cte_producer
@@ -65,7 +65,7 @@ CCTEListEntry::CCTEListEntry
 //---------------------------------------------------------------------------
 CCTEListEntry::CCTEListEntry
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	ULONG query_level,
 	List *cte_list, 
 	CDXLNodeArray *cte_dxl_arr
@@ -156,7 +156,7 @@ CCTEListEntry::GetCTEProducerTargetList
 void
 CCTEListEntry::AddCTEProducer
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CommonTableExpr *cte,
 	const CDXLNode *cte_producer
 	)

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -39,7 +39,7 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CContextDXLToPlStmt::CContextDXLToPlStmt
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CIdGenerator *plan_id_counter,
 	CIdGenerator *motion_id_counter,
 	CIdGenerator *param_id_counter,

--- a/src/backend/gpopt/translate/CContextQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CContextQueryToDXL.cpp
@@ -23,7 +23,7 @@ using namespace gpdxl;
 
 CContextQueryToDXL::CContextQueryToDXL
 	(
-	IMemoryPool *mp
+	CMemoryPool *mp
 	)
   :
   m_mp(mp),

--- a/src/backend/gpopt/translate/CDXLTranslateContext.cpp
+++ b/src/backend/gpopt/translate/CDXLTranslateContext.cpp
@@ -28,7 +28,7 @@ using namespace gpos;
 //---------------------------------------------------------------------------
 CDXLTranslateContext::CDXLTranslateContext
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	BOOL is_child_agg_node
 	)
 	:
@@ -50,7 +50,7 @@ CDXLTranslateContext::CDXLTranslateContext
 //---------------------------------------------------------------------------
 CDXLTranslateContext::CDXLTranslateContext
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	BOOL is_child_agg_node,
 	ULongToColParamMap *original
 	)

--- a/src/backend/gpopt/translate/CDXLTranslateContextBaseTable.cpp
+++ b/src/backend/gpopt/translate/CDXLTranslateContextBaseTable.cpp
@@ -29,7 +29,7 @@ using namespace gpos;
 //---------------------------------------------------------------------------
 CDXLTranslateContextBaseTable::CDXLTranslateContextBaseTable
 	(
-	IMemoryPool *mp
+	CMemoryPool *mp
 	)
 	:
 	m_mp(mp),

--- a/src/backend/gpopt/translate/CMappingColIdVar.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVar.cpp
@@ -27,7 +27,7 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CMappingColIdVar::CMappingColIdVar
 	(
-	IMemoryPool *mp
+	CMemoryPool *mp
 	)
 	:
 	m_mp(mp)

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -43,7 +43,7 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CMappingColIdVarPlStmt::CMappingColIdVarPlStmt
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const CDXLTranslateContextBaseTable *base_table_context,
 	CDXLTranslationContextArray *child_contexts,
 	CDXLTranslateContext *output_context,

--- a/src/backend/gpopt/translate/CMappingVarColId.cpp
+++ b/src/backend/gpopt/translate/CMappingVarColId.cpp
@@ -40,7 +40,7 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CMappingVarColId::CMappingVarColId
 	(
-	IMemoryPool *mp
+	CMemoryPool *mp
 	)
 	:
 	m_mp(mp)
@@ -506,7 +506,7 @@ CMappingVarColId::CopyMapColId
 CMappingVarColId *
 CMappingVarColId::CopyMapColId
 	(
-	IMemoryPool *mp
+	CMemoryPool *mp
 	)
 	const
 {
@@ -547,7 +547,7 @@ CMappingVarColId::CopyMapColId
 CMappingVarColId *
 CMappingVarColId::CopyRemapColId
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	ULongPtrArray *old_colids,
 	ULongPtrArray *new_colids
 	)

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -155,7 +155,7 @@ CQueryMutators::ShouldFallback
 Query *
 CQueryMutators::NormalizeGroupByProjList
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	const Query *query
 	)
@@ -662,7 +662,7 @@ CQueryMutators::FixGroupingCols
 TargetEntry *
 CQueryMutators::GetTargetEntryForAggExpr
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	Node *node,
 	ULONG attno
@@ -1025,7 +1025,7 @@ CQueryMutators::IncrLevelsUpIfOuterRef
 Query *
 CQueryMutators::NormalizeHaving
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	const Query *query
 	)
@@ -1130,7 +1130,7 @@ CQueryMutators::NormalizeHaving
 Query *
 CQueryMutators::NormalizeQuery
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	const Query *query,
 	ULONG query_level
@@ -1450,7 +1450,7 @@ CQueryMutators::NeedsProjListWindowNormalization
 Query *
 CQueryMutators::NormalizeWindowProjList
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	const Query *query
 	)

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -70,7 +70,7 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	CContextDXLToPlStmt* dxl_to_plstmt_context,
 	ULONG num_of_segments

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -60,7 +60,7 @@ using namespace gpopt;
 //---------------------------------------------------------------------------
 CTranslatorDXLToScalar::CTranslatorDXLToScalar
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	ULONG num_segments
 	)

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -253,7 +253,7 @@ CTranslatorQueryToDXL::CTranslatorQueryToDXL
 CTranslatorQueryToDXL *
 CTranslatorQueryToDXL::QueryToDXLInstance
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	Query *query
 	)
@@ -4456,7 +4456,7 @@ CTranslatorQueryToDXL::ConstructCTEAnchors
 ULongPtrArray *
 CTranslatorQueryToDXL::GenerateColIds
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	ULONG size
 	)
 	const
@@ -4482,7 +4482,7 @@ CTranslatorQueryToDXL::GenerateColIds
 ULongPtrArray *
 CTranslatorQueryToDXL::ExtractColIds
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IntToUlongMap *attno_to_colid_mapping
 	)
 	const
@@ -4520,7 +4520,7 @@ CTranslatorQueryToDXL::ExtractColIds
 IntToUlongMap *
 CTranslatorQueryToDXL::RemapColIds
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IntToUlongMap *attno_to_colid_mapping,
 	ULongPtrArray *from_list_colids,
 	ULongPtrArray *to_list_colids

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -97,7 +97,7 @@ const ULONG cmp_type_mappings[][2] =
 IMDCacheObject *
 CTranslatorRelcacheToDXL::RetrieveObject
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid
 	)
@@ -155,7 +155,7 @@ CTranslatorRelcacheToDXL::RetrieveObject
 IMDCacheObject *
 CTranslatorRelcacheToDXL::RetrieveObjectGPDB
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid
 	)
@@ -224,7 +224,7 @@ CTranslatorRelcacheToDXL::RetrieveObjectGPDB
 CMDName *
 CTranslatorRelcacheToDXL::GetRelName
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	Relation rel
 	)
 {
@@ -247,7 +247,7 @@ CTranslatorRelcacheToDXL::GetRelName
 CMDIndexInfoArray *
 CTranslatorRelcacheToDXL::RetrieveRelIndexInfo
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	Relation rel
 	)
 {
@@ -273,7 +273,7 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfo
 CMDIndexInfoArray *
 CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForPartTable
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	Relation root_rel
 	)
 {
@@ -329,7 +329,7 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForPartTable
 CMDIndexInfoArray *
 CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForNonPartTable
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	Relation rel
 	)
 {
@@ -429,7 +429,7 @@ CTranslatorRelcacheToDXL::RetrievePartTableIndexInfo
 IMdIdArray *
 CTranslatorRelcacheToDXL::RetrieveRelTriggers
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	Relation rel
 	)
 {
@@ -471,7 +471,7 @@ CTranslatorRelcacheToDXL::RetrieveRelTriggers
 IMdIdArray *
 CTranslatorRelcacheToDXL::RetrieveRelCheckConstraints
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	OID oid
 	)
 {
@@ -542,7 +542,7 @@ CTranslatorRelcacheToDXL::CheckUnsupportedRelation
 IMDRelation *
 CTranslatorRelcacheToDXL::RetrieveRel
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid
 	)
@@ -735,7 +735,7 @@ CTranslatorRelcacheToDXL::RetrieveRel
 CMDColumnArray *
 CTranslatorRelcacheToDXL::RetrieveRelColumns
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	Relation rel,
 	IMDRelation::Erelstoragetype rel_storage_type
@@ -832,7 +832,7 @@ CTranslatorRelcacheToDXL::RetrieveRelColumns
 CDXLNode *
 CTranslatorRelcacheToDXL::GetDefaultColumnValue
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	TupleDesc rd_att,
 	AttrNumber attno
@@ -932,7 +932,7 @@ CTranslatorRelcacheToDXL::GetRelDistribution
 ULongPtrArray *
 CTranslatorRelcacheToDXL::RetrieveRelDistributionCols
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	GpPolicy *gp_policy,
 	CMDColumnArray *mdcol_array,
 	ULONG size
@@ -973,7 +973,7 @@ CTranslatorRelcacheToDXL::RetrieveRelDistributionCols
 void
 CTranslatorRelcacheToDXL::AddSystemColumns
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDColumnArray *mdcol_array,
 	Relation rel,
 	BOOL is_ao_table
@@ -1051,7 +1051,7 @@ CTranslatorRelcacheToDXL::IsTransactionVisibilityAttribute
 IMDIndex *
 CTranslatorRelcacheToDXL::RetrieveIndex
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid_index
 	)
@@ -1193,7 +1193,7 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 IMDIndex *
 CTranslatorRelcacheToDXL::RetrievePartTableIndex
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid_index,
 	const IMDRelation *md_rel,
@@ -1257,7 +1257,7 @@ CTranslatorRelcacheToDXL::LookupLogicalIndexById
 IMDIndex *
 CTranslatorRelcacheToDXL::RetrievePartTableIndex
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	LogicalIndexInfo *index_info,
 	IMDId *mdid_index,
@@ -1461,7 +1461,7 @@ CTranslatorRelcacheToDXL::LevelHasDefaultPartition
 ULongPtrArray *
 CTranslatorRelcacheToDXL::ComputeIncludedCols
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDRelation *md_rel
 	)
 {
@@ -1515,7 +1515,7 @@ CTranslatorRelcacheToDXL::GetAttributePosition
 ULONG *
 CTranslatorRelcacheToDXL::PopulateAttnoPositionMap
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDRelation *md_rel,
 	ULONG size
 	)
@@ -1557,7 +1557,7 @@ CTranslatorRelcacheToDXL::PopulateAttnoPositionMap
 IMDType *
 CTranslatorRelcacheToDXL::RetrieveType
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -1678,7 +1678,7 @@ CTranslatorRelcacheToDXL::RetrieveType
 CMDScalarOpGPDB *
 CTranslatorRelcacheToDXL::RetrieveScOp
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -1818,7 +1818,7 @@ CTranslatorRelcacheToDXL::LookupFuncProps
 CMDFunctionGPDB *
 CTranslatorRelcacheToDXL::RetrieveFunc
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -1902,7 +1902,7 @@ CTranslatorRelcacheToDXL::RetrieveFunc
 CMDAggregateGPDB *
 CTranslatorRelcacheToDXL::RetrieveAgg
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -1970,7 +1970,7 @@ CTranslatorRelcacheToDXL::RetrieveAgg
 CMDTriggerGPDB *
 CTranslatorRelcacheToDXL::RetrieveTrigger
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -2031,7 +2031,7 @@ CTranslatorRelcacheToDXL::RetrieveTrigger
 CMDCheckConstraintGPDB *
 CTranslatorRelcacheToDXL::RetrieveCheckConstraints
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid
 	)
@@ -2115,7 +2115,7 @@ CTranslatorRelcacheToDXL::RetrieveCheckConstraints
 CMDName *
 CTranslatorRelcacheToDXL::GetTypeName
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -2218,7 +2218,7 @@ CTranslatorRelcacheToDXL::GetEFuncDataAccess
 IMDId *
 CTranslatorRelcacheToDXL::RetrieveAggIntermediateResultType
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -2252,7 +2252,7 @@ CTranslatorRelcacheToDXL::RetrieveAggIntermediateResultType
 IMDCacheObject *
 CTranslatorRelcacheToDXL::RetrieveRelStats
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -2317,7 +2317,7 @@ CTranslatorRelcacheToDXL::RetrieveRelStats
 IMDCacheObject *
 CTranslatorRelcacheToDXL::RetrieveColStats
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid
 	)
@@ -2586,7 +2586,7 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 CDXLColStats *
 CTranslatorRelcacheToDXL::GenerateStatsForSystemCols
        (
-       IMemoryPool *mp,
+       CMemoryPool *mp,
        OID rel_oid,
        CMDIdColStats *mdid_col_stats,
        CMDName *md_colname,
@@ -2710,7 +2710,7 @@ CTranslatorRelcacheToDXL::RetrieveNumChildPartitions
 IMDCacheObject *
 CTranslatorRelcacheToDXL::RetrieveCast
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -2784,7 +2784,7 @@ CTranslatorRelcacheToDXL::RetrieveCast
 IMDCacheObject *
 CTranslatorRelcacheToDXL::RetrieveScCmp
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid
 	)
 {
@@ -2832,7 +2832,7 @@ CTranslatorRelcacheToDXL::RetrieveScCmp
 CDXLBucketArray *
 CTranslatorRelcacheToDXL::TransformStatsToDXLBucketArray
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	OID att_type,
 	CDouble num_distinct,
 	CDouble null_freq,
@@ -2943,7 +2943,7 @@ CTranslatorRelcacheToDXL::TransformStatsToDXLBucketArray
 CHistogram *
 CTranslatorRelcacheToDXL::TransformMcvToOrcaHistogram
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	const Datum *mcv_values,
 	const float4 *mcv_frequencies,
@@ -2995,7 +2995,7 @@ CTranslatorRelcacheToDXL::TransformMcvToOrcaHistogram
 CHistogram *
 CTranslatorRelcacheToDXL::TransformHistToOrcaHistogram
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	const Datum *hist_values,
 	ULONG num_hist_values,
@@ -3087,7 +3087,7 @@ CTranslatorRelcacheToDXL::TransformHistToOrcaHistogram
 CDXLBucketArray *
 CTranslatorRelcacheToDXL::TransformHistogramToDXLBucketArray
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	const CHistogram *hist
 	)
@@ -3168,7 +3168,7 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType
 void
 CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	Relation rel,
 	OID oid,
 	ULongPtrArray **part_keys,
@@ -3228,7 +3228,7 @@ CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes
 ULONG *
 CTranslatorRelcacheToDXL::ConstructAttnoMapping
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDColumnArray *mdcol_array,
 	ULONG max_cols
 	)
@@ -3270,7 +3270,7 @@ CTranslatorRelcacheToDXL::ConstructAttnoMapping
 ULongPtr2dArray *
 CTranslatorRelcacheToDXL::RetrieveRelKeysets
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	OID oid,
 	BOOL should_add_default_keys,
 	BOOL is_partitioned,
@@ -3406,7 +3406,7 @@ CTranslatorRelcacheToDXL::IsIndexSupported
 CMDPartConstraintGPDB *
 CTranslatorRelcacheToDXL::RetrievePartConstraintForIndex
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	const IMDRelation *md_rel,
 	Node *part_constraint,
@@ -3456,7 +3456,7 @@ CTranslatorRelcacheToDXL::RetrievePartConstraintForIndex
 CMDPartConstraintGPDB *
 CTranslatorRelcacheToDXL::RetrievePartConstraintForRel
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	OID rel_oid,
 	CMDColumnArray *mdcol_array,
@@ -3548,7 +3548,7 @@ CTranslatorRelcacheToDXL::RetrievePartConstraintForRel
 CMDPartConstraintGPDB *
 CTranslatorRelcacheToDXL::RetrievePartConstraintFromNode
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	CDXLColDescrArray *dxl_col_descr_array,
 	Node *part_constraints,
@@ -3661,7 +3661,7 @@ CTranslatorRelcacheToDXL::GetComparisonType
 IMdIdArray *
 CTranslatorRelcacheToDXL::RetrieveIndexOpFamilies
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid_index
 	)
 {
@@ -3690,7 +3690,7 @@ CTranslatorRelcacheToDXL::RetrieveIndexOpFamilies
 IMdIdArray *
 CTranslatorRelcacheToDXL::RetrieveScOpOpFamilies
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMDId *mdid_scalar_op
 	)
 {

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -89,7 +89,7 @@ CTranslatorScalarToDXL::CTranslatorScalarToDXL
 //---------------------------------------------------------------------------
 CTranslatorScalarToDXL::CTranslatorScalarToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *mda
 	)
 	:
@@ -139,7 +139,7 @@ CTranslatorScalarToDXL::CreateSubqueryTranslator
 CDXLNode *
 CTranslatorScalarToDXL::TranslateStandaloneExprToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *mda,
 	const CMappingVarColId* var_colid_mapping,
 	const Expr *expr
@@ -642,7 +642,7 @@ CTranslatorScalarToDXL::TranslateConstToDXL
 CDXLDatum *
 CTranslatorScalarToDXL::TranslateConstToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *mda,
 	const Const *constant
 	)
@@ -2092,7 +2092,7 @@ CTranslatorScalarToDXL::CreateExistSubqueryFromSublink
 CDXLDatum *
 CTranslatorScalarToDXL::TranslateDatumToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	INT type_modifier,
 	BOOL is_null,
@@ -2143,7 +2143,7 @@ CTranslatorScalarToDXL::TranslateDatumToDXL
 CDXLDatum *
 CTranslatorScalarToDXL::TranslateGenericDatumToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	INT type_modifier,
 	BOOL is_null,
@@ -2188,7 +2188,7 @@ CTranslatorScalarToDXL::TranslateGenericDatumToDXL
 CDXLDatum *
 CTranslatorScalarToDXL::TranslateBoolDatumToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	BOOL is_null,
 	ULONG , //len,
@@ -2213,7 +2213,7 @@ CTranslatorScalarToDXL::TranslateBoolDatumToDXL
 CDXLDatum *
 CTranslatorScalarToDXL::TranslateOidDatumToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	BOOL is_null,
 	ULONG , //len,
@@ -2238,7 +2238,7 @@ CTranslatorScalarToDXL::TranslateOidDatumToDXL
 CDXLDatum *
 CTranslatorScalarToDXL::TranslateInt2DatumToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	BOOL is_null,
 	ULONG , //len,
@@ -2263,7 +2263,7 @@ CTranslatorScalarToDXL::TranslateInt2DatumToDXL
 CDXLDatum *
 CTranslatorScalarToDXL::TranslateInt4DatumToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	BOOL is_null,
 	ULONG , //len,
@@ -2288,7 +2288,7 @@ CTranslatorScalarToDXL::TranslateInt4DatumToDXL
 CDXLDatum *
 CTranslatorScalarToDXL::TranslateInt8DatumToDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	BOOL is_null,
 	ULONG , //len,
@@ -2385,7 +2385,7 @@ CTranslatorScalarToDXL::ExtractDoubleValueFromDatum
 BYTE *
 CTranslatorScalarToDXL::ExtractByteArrayFromDatum
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	BOOL is_null,
 	ULONG len,
@@ -2489,7 +2489,7 @@ CTranslatorScalarToDXL::ExtractLintValueFromDatum
 IDatum *
 CTranslatorScalarToDXL::CreateIDatumFromGpdbDatum
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	const IMDType *md_type,
 	BOOL is_null,
 	Datum gpdb_datum

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -94,7 +94,7 @@ extern bool optimizer_multilevel_partitioning;
 CDXLIndexDescr *
 CTranslatorUtils::GetIndexDescr
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid
 	)
@@ -117,7 +117,7 @@ CTranslatorUtils::GetIndexDescr
 CDXLTableDescr *
 CTranslatorUtils::GetTableDescr
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	CIdGenerator *id_generator,
 	const RangeTblEntry *rte,
@@ -208,7 +208,7 @@ CTranslatorUtils::GetTableDescr
 BOOL
 CTranslatorUtils::IsSirvFunc
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	OID func_oid
 	)
@@ -265,7 +265,7 @@ CTranslatorUtils::HasSubquery
 CDXLLogicalTVF *
 CTranslatorUtils::ConvertToCDXLLogicalTVF
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	CIdGenerator *id_generator,
 	const RangeTblEntry *rte
@@ -368,7 +368,7 @@ CTranslatorUtils::ConvertToCDXLLogicalTVF
 IMdIdArray *
 CTranslatorUtils::ResolvePolymorphicTypes
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	IMdIdArray *mdid_array,
 	List *arg_types_list,
 	FuncExpr *funcexpr
@@ -466,7 +466,7 @@ CTranslatorUtils::ContainsPolymorphicTypes
 CDXLColDescrArray *
 CTranslatorUtils::GetColumnDescriptorsFromRecord
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CIdGenerator *id_generator,
 	List *col_names,
 	List *col_types,
@@ -523,7 +523,7 @@ CTranslatorUtils::GetColumnDescriptorsFromRecord
 CDXLColDescrArray *
 CTranslatorUtils::GetColumnDescriptorsFromRecord
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CIdGenerator *id_generator,
 	List *col_names,
 	IMdIdArray *out_arg_types
@@ -577,7 +577,7 @@ CTranslatorUtils::GetColumnDescriptorsFromRecord
 CDXLColDescrArray *
 CTranslatorUtils::GetColumnDescriptorsFromBase
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CIdGenerator *id_generator,
 	IMDId *mdid_return_type,
 	INT type_modifier,
@@ -616,7 +616,7 @@ CTranslatorUtils::GetColumnDescriptorsFromBase
 CDXLColDescrArray *
 CTranslatorUtils::GetColumnDescriptorsFromComposite
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	CIdGenerator *id_generator,
 	const IMDType *type
@@ -663,7 +663,7 @@ CTranslatorUtils::GetColumnDescriptorsFromComposite
 CMDColumnArray *
 CTranslatorUtils::ExpandCompositeType
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	const IMDType *type
 	)
@@ -870,7 +870,7 @@ CTranslatorUtils::GetSystemColName
 CMDIdGPDB *
 CTranslatorUtils::GetSystemColType
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	AttrNumber attno
 	)
 {
@@ -1107,7 +1107,7 @@ CTranslatorUtils::GetSetOpType
 ULongPtrArray *
 CTranslatorUtils::GetGroupingColidArray
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CBitSet *group_by_cols,
 	IntToUlongMap *sort_group_cols_to_colid_map
 	)
@@ -1140,7 +1140,7 @@ CTranslatorUtils::GetGroupingColidArray
 CBitSetArray *
 CTranslatorUtils::GetColumnAttnosForGroupBy
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	List *group_clause_list,
 	ULONG num_cols,
 	UlongToUlongMap *group_col_pos,	// mapping of grouping col positions to SortGroupRef ids
@@ -1232,7 +1232,7 @@ CTranslatorUtils::GetColumnAttnosForGroupBy
 CBitSetArray *
 CTranslatorUtils::CreateGroupingSetsForRollup
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	GroupingClause *grouping_clause,
 	ULONG num_cols,
 	UlongToUlongMap *group_col_pos,	// mapping of grouping col positions to SortGroupRef ids,
@@ -1317,7 +1317,7 @@ CTranslatorUtils::CreateGroupingSetsForRollup
 CBitSet *
 CTranslatorUtils::CreateAttnoSetForGroupingSet
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	List *group_elems,
 	ULONG num_cols,
 	UlongToUlongMap *group_col_pos,	// mapping of grouping col positions to SortGroupRef ids,
@@ -1364,7 +1364,7 @@ CTranslatorUtils::CreateAttnoSetForGroupingSet
 ULongPtrArray *
 CTranslatorUtils::GenerateColIds
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	List *target_list,
 	IMdIdArray *input_mdid_arr,
 	ULongPtrArray *input_colids,
@@ -1537,7 +1537,7 @@ CTranslatorUtils::GetTargetListReturnTypeOid
 CDXLColDescrArray *
 CTranslatorUtils::GetDXLColumnDescrArray
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	List *target_list,
 	ULongPtrArray *colids,
 	BOOL keep_res_junked
@@ -1580,7 +1580,7 @@ CTranslatorUtils::GetDXLColumnDescrArray
 ULongPtrArray *
 CTranslatorUtils::GetPosInTargetList
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	List *target_list,
 	BOOL keep_res_junked
 	)
@@ -1617,7 +1617,7 @@ CTranslatorUtils::GetPosInTargetList
 CDXLColDescr *
 CTranslatorUtils::GetColumnDescrAt
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	TargetEntry *target_entry,
 	ULONG colid,
 	ULONG pos
@@ -1668,7 +1668,7 @@ CTranslatorUtils::GetColumnDescrAt
 CDXLNode *
 CTranslatorUtils::CreateDummyProjectElem
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	ULONG colid_input,
 	ULONG colid_output,
 	CDXLColDescr *dxl_col_descr
@@ -1708,7 +1708,7 @@ CTranslatorUtils::CreateDummyProjectElem
 ULongPtrArray *
 CTranslatorUtils::GetOutputColIdsArray
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	List *target_list,
 	IntToUlongMap *attno_to_colid_map
 	)
@@ -1890,7 +1890,7 @@ CTranslatorUtils::IsWindowSpec
 CDXLNode *
 CTranslatorUtils::CreateDXLProjElemFromInt8Const
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	INT val
 	)
@@ -2179,7 +2179,7 @@ CTranslatorUtils::CreateMultiByteCharStringFromWCString
 UlongToUlongMap *
 CTranslatorUtils::MakeNewToOldColMapping
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	ULongPtrArray *old_colids,
 	ULongPtrArray *new_colids
 	)
@@ -2282,7 +2282,7 @@ CTranslatorUtils::HasProjElem
 CDXLNode *
 CTranslatorUtils::CreateDXLProjElemConstNULL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	CIdGenerator *pidgtorCol,
 	const IMDColumn *md_col
@@ -2308,7 +2308,7 @@ CTranslatorUtils::CreateDXLProjElemConstNULL
 CDXLNode *
 CTranslatorUtils::CreateDXLProjElemConstNULL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid,
 	ULONG colid,
@@ -2333,7 +2333,7 @@ CTranslatorUtils::CreateDXLProjElemConstNULL
 CDXLNode *
 CTranslatorUtils::CreateDXLProjElemConstNULL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMDId *mdid,
 	ULONG colid,
@@ -2430,7 +2430,7 @@ CTranslatorUtils::CheckRTEPermissions
 void
 CTranslatorUtils::UpdateGrpColMapping
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	UlongToUlongMap *group_col_pos, 
 	CBitSet *group_cols,
 	ULONG sort_group_ref
@@ -2586,7 +2586,7 @@ CTranslatorUtils::MapSublinkTypeToDXLSubplan
 BOOL
 CTranslatorUtils::RelHasTriggers
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	const IMDRelation *rel,
 	const EdxlDmlType dml_type_dxl

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -339,7 +339,7 @@ COptTasks::LogExceptionMessageAndDelete(CHAR* err_buf, ULONG severity_level)
 PlannedStmt *
 COptTasks::ConvertToPlanStmtFromDXL
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	const CDXLNode *dxlnode,
 	bool can_set_tag,
@@ -385,7 +385,7 @@ COptTasks::ConvertToPlanStmtFromDXL
 CSearchStageArray *
 COptTasks::LoadSearchStrategy
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	char *path
 	)
 {
@@ -432,7 +432,7 @@ COptTasks::LoadSearchStrategy
 COptimizerConfig *
 COptTasks::CreateOptimizerConfig
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	ICostModel *cost_model
 	)
 {
@@ -606,7 +606,7 @@ COptTasks::SetCostModelParams
 ICostModel *
 COptTasks::GetCostModel
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	ULONG num_segments
 	)
 {
@@ -647,7 +647,7 @@ COptTasks::OptimizeTask
 	GPOS_ASSERT(NULL == opt_ctxt->m_plan_stmt);
 
 	AUTO_MEM_POOL(amp);
-	IMemoryPool *mp = amp.Pmp();
+	CMemoryPool *mp = amp.Pmp();
 
 	// Does the metadatacache need to be reset?
 	//
@@ -822,7 +822,7 @@ COptTasks::OptimizeTask
 void
 COptTasks::PrintMissingStatsWarning
 	(
-	IMemoryPool *mp,
+	CMemoryPool *mp,
 	CMDAccessor *md_accessor,
 	IMdIdArray *col_stats,
 	MdidHashSet *rel_stats

--- a/src/include/gpopt/config/CConfigParamMapping.h
+++ b/src/include/gpopt/config/CConfigParamMapping.h
@@ -17,7 +17,7 @@
 
 #include "gpos/base.h"
 #include "gpos/common/CBitSet.h"
-#include "gpos/memory/IMemoryPool.h"
+#include "gpos/memory/CMemoryPool.h"
 
 #include "naucrates/traceflags/traceflags.h"
 
@@ -69,7 +69,7 @@ namespace gpdxl
 		public:
 			// pack enabled optimizer config params in a traceflag bitset
 			static
-			CBitSet *PackConfigParamInBitset(IMemoryPool *mp, ULONG xform_id);
+			CBitSet *PackConfigParamInBitset(CMemoryPool *mp, ULONG xform_id);
 	};
 }
 

--- a/src/include/gpopt/relcache/CMDProviderRelcache.h
+++ b/src/include/gpopt/relcache/CMDProviderRelcache.h
@@ -47,7 +47,7 @@ namespace gpmd
 	{
 		private:
 			// memory pool
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// private copy ctor
 			CMDProviderRelcache(const CMDProviderRelcache&);
@@ -55,7 +55,7 @@ namespace gpmd
 		public:
 			// ctor/dtor
 			explicit
-			CMDProviderRelcache(IMemoryPool *mp);
+			CMDProviderRelcache(CMemoryPool *mp);
 
 			~CMDProviderRelcache()
 			{
@@ -63,13 +63,13 @@ namespace gpmd
 
 			// returns the DXL string of the requested metadata object
 			virtual
-			CWStringBase *GetMDObjDXLStr(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *md_id) const;
+			CWStringBase *GetMDObjDXLStr(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *md_id) const;
 
 			// return the mdid for the requested type
 			virtual
 			IMDId *MDId
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				CSystemId sysid,
 				IMDType::ETypeInfo type_info
 				)

--- a/src/include/gpopt/translate/CCTEListEntry.h
+++ b/src/include/gpopt/translate/CCTEListEntry.h
@@ -93,10 +93,10 @@ namespace gpdxl
 
 		public:
 			// ctor: single CTE 
-			CCTEListEntry(IMemoryPool *mp, ULONG query_level, CommonTableExpr *cte, CDXLNode *cte_producer);
+			CCTEListEntry(CMemoryPool *mp, ULONG query_level, CommonTableExpr *cte, CDXLNode *cte_producer);
 			
 			// ctor: multiple CTEs
-			CCTEListEntry(IMemoryPool *mp, ULONG query_level, List *cte_list, CDXLNodeArray *dxlnodes);
+			CCTEListEntry(CMemoryPool *mp, ULONG query_level, List *cte_list, CDXLNodeArray *dxlnodes);
 
 			// dtor
 			virtual
@@ -118,7 +118,7 @@ namespace gpdxl
 			List *GetCTEProducerTargetList(const CHAR *cte_str) const;
 
 			// add a new CTE producer for this level
-			void AddCTEProducer(IMemoryPool *mp, CommonTableExpr *cte, const CDXLNode *cte_producer);
+			void AddCTEProducer(CMemoryPool *mp, CommonTableExpr *cte, const CDXLNode *cte_producer);
 	};
 
 	// hash maps mapping ULONG -> CCTEListEntry

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -95,7 +95,7 @@ namespace gpdxl
 			typedef CHashMap<ULONG, SCTEConsumerInfo, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
 			CleanupDelete<ULONG>, CleanupDelete<SCTEConsumerInfo> > HMUlCTEConsumerInfo;
 
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// counter for generating plan ids
 			CIdGenerator *m_plan_id_counter;
@@ -137,7 +137,7 @@ namespace gpdxl
 			// ctor/dtor
 			CContextDXLToPlStmt
 						(
-						IMemoryPool *mp,
+						CMemoryPool *mp,
 						CIdGenerator *plan_id_counter,
 						CIdGenerator *motion_id_counter,
 						CIdGenerator *param_id_counter,

--- a/src/include/gpopt/translate/CContextQueryToDXL.h
+++ b/src/include/gpopt/translate/CContextQueryToDXL.h
@@ -46,7 +46,7 @@ namespace gpdxl
 
 		private:
 			// memory pool
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// counter for generating unique column ids
 			CIdGenerator *m_colid_counter;
@@ -64,7 +64,7 @@ namespace gpdxl
 			// ctor
 			CContextQueryToDXL
 				(
-				IMemoryPool *mp
+				CMemoryPool *mp
 				);
 
 			// dtor

--- a/src/include/gpopt/translate/CDXLTranslateContext.h
+++ b/src/include/gpopt/translate/CDXLTranslateContext.h
@@ -57,7 +57,7 @@ namespace gpdxl
 	{
 
 		private:
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// private copy ctor
 			CDXLTranslateContext(const CDXLTranslateContext&);
@@ -80,9 +80,9 @@ namespace gpdxl
 
 		public:
 			// ctor/dtor
-			CDXLTranslateContext(IMemoryPool *mp, BOOL is_child_agg_node);
+			CDXLTranslateContext(CMemoryPool *mp, BOOL is_child_agg_node);
 
-			CDXLTranslateContext(IMemoryPool *mp, BOOL is_child_agg_node, ULongToColParamMap *original);
+			CDXLTranslateContext(CMemoryPool *mp, BOOL is_child_agg_node, ULongToColParamMap *original);
 
 			~CDXLTranslateContext();
 

--- a/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
+++ b/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
@@ -49,7 +49,7 @@ namespace gpdxl
 
 
 		private:
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// oid of the base table
 			OID m_oid;
@@ -65,7 +65,7 @@ namespace gpdxl
 
 		public:
 			// ctor/dtor
-			explicit CDXLTranslateContextBaseTable(IMemoryPool *mp);
+			explicit CDXLTranslateContextBaseTable(CMemoryPool *mp);
 
 
 			~CDXLTranslateContextBaseTable();

--- a/src/include/gpopt/translate/CMappingColIdVar.h
+++ b/src/include/gpopt/translate/CMappingColIdVar.h
@@ -47,13 +47,13 @@ namespace gpdxl
 	{
 		protected:
 			// memory pool
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 		public:
 
 			// ctor/dtor
 			explicit
-			CMappingColIdVar(IMemoryPool *);
+			CMappingColIdVar(CMemoryPool *);
 
 			virtual
 			~CMappingColIdVar(){}

--- a/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
+++ b/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
@@ -63,7 +63,7 @@ namespace gpdxl
 
 			CMappingColIdVarPlStmt
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const CDXLTranslateContextBaseTable *base_table_context,
 				CDXLTranslationContextArray *child_contexts,
 				CDXLTranslateContext *output_context,

--- a/src/include/gpopt/translate/CMappingVarColId.h
+++ b/src/include/gpopt/translate/CMappingVarColId.h
@@ -76,7 +76,7 @@ namespace gpdxl
 	{
 		private:
 			// memory pool
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// hash map structure to store gpdb att -> opt col information
 			typedef CHashMap<CGPDBAttInfo, CGPDBAttOptCol, HashGPDBAttInfo, EqualGPDBAttInfo,
@@ -108,7 +108,7 @@ namespace gpdxl
 
 			// ctor
 			explicit
-			CMappingVarColId(IMemoryPool *);
+			CMappingVarColId(CMemoryPool *);
 
 			// dtor
 			virtual
@@ -159,7 +159,7 @@ namespace gpdxl
 			void Load(ULONG query_level, ULONG RTE_index,	CIdGenerator *id_generator, List *col_names);
 
 			// create a deep copy
-			CMappingVarColId *CopyMapColId(IMemoryPool *mp) const;
+			CMappingVarColId *CopyMapColId(CMemoryPool *mp) const;
 
 			// create a deep copy
 			CMappingVarColId *CopyMapColId(ULONG query_level) const;
@@ -167,7 +167,7 @@ namespace gpdxl
 			// create a copy of the mapping replacing old col ids with new ones
 			CMappingVarColId *CopyRemapColId
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				ULongPtrArray *old_colids,
 				ULongPtrArray *new_colids
 				)

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -60,7 +60,7 @@ namespace gpdxl
 			public:
 
 				// memory pool
-				IMemoryPool *m_mp;
+				CMemoryPool *m_mp;
 
 				// MD accessor to get the function name
 				CMDAccessor *m_mda;
@@ -83,7 +83,7 @@ namespace gpdxl
 				// ctor
 				SContextGrpbyPlMutator
 					(
-					IMemoryPool *mp,
+					CMemoryPool *mp,
 					CMDAccessor *mda,
 					Query *query,
 					List *groupby_tlist
@@ -180,7 +180,7 @@ namespace gpdxl
 
 			// normalize query
 			static
-			Query *NormalizeQuery(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query, ULONG query_level);
+			Query *NormalizeQuery(CMemoryPool *mp, CMDAccessor *md_accessor, const Query *query, ULONG query_level);
 
 			// check if the project list contains expressions on window operators thereby needing normalization
 			static
@@ -188,7 +188,7 @@ namespace gpdxl
 
 			// flatten expressions in window operation project list
 			static
-			Query *NormalizeWindowProjList(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
+			Query *NormalizeWindowProjList(CMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
 
 			// traverse the project list to extract all window functions in an arbitrarily complex project element
 			static
@@ -196,7 +196,7 @@ namespace gpdxl
 
 			// flatten expressions in project list
 			static
-			Query *NormalizeGroupByProjList(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
+			Query *NormalizeGroupByProjList(CMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
 
 			// make a copy of the aggref (minus the arguments)
 			static
@@ -216,7 +216,7 @@ namespace gpdxl
 
 			// pull up having clause into a select
 			static
-			Query *NormalizeHaving(IMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
+			Query *NormalizeHaving(CMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
 
 			// traverse the expression and fix the levels up of any outer reference
 			static
@@ -236,7 +236,7 @@ namespace gpdxl
 
 			// return a target entry for the aggregate expression
 			static
-			TargetEntry *GetTargetEntryForAggExpr(IMemoryPool *mp, CMDAccessor *md_accessor, Node *node, ULONG attno);
+			TargetEntry *GetTargetEntryForAggExpr(CMemoryPool *mp, CMDAccessor *md_accessor, Node *node, ULONG attno);
 
 			// traverse the having qual to extract all aggregate functions,
 			// fix correlated vars and return the modified having qual

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -125,7 +125,7 @@ namespace gpdxl
 			}; // SContextIndexVarAttno
 
 			// memory pool
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// meta data accessor
 			CMDAccessor *m_md_accessor;
@@ -165,7 +165,7 @@ namespace gpdxl
 
 		public:
 			// ctor
-			CTranslatorDXLToPlStmt(IMemoryPool *mp, CMDAccessor *md_accessor, CContextDXLToPlStmt *dxl_to_plstmt_context, ULONG num_of_segments);
+			CTranslatorDXLToPlStmt(CMemoryPool *mp, CMDAccessor *md_accessor, CContextDXLToPlStmt *dxl_to_plstmt_context, ULONG num_of_segments);
 
 			// dtor
 			~CTranslatorDXLToPlStmt();

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -95,7 +95,7 @@ namespace gpdxl
 				const_func_ptr translate_func;
 			};
 
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// meta data accessor
 			CMDAccessor *m_md_accessor;
@@ -338,7 +338,7 @@ namespace gpdxl
 			};
 
 			// ctor
-			CTranslatorDXLToScalar(IMemoryPool *mp, CMDAccessor *md_accessor, ULONG num_segments);
+			CTranslatorDXLToScalar(CMemoryPool *mp, CMDAccessor *md_accessor, ULONG num_segments);
 
 			// translate DXL scalar operator node into an Expr expression
 			// This function is called during the translation of DXL->Query or DXL->Query

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -98,7 +98,7 @@ namespace gpdxl
 			CContextQueryToDXL *m_context;
 
 			// memory pool
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// source system id
 			CSystemId m_sysid;
@@ -447,14 +447,14 @@ namespace gpdxl
 			void ConstructCTEAnchors(CDXLNodeArray *dxlnodes, CDXLNode **dxl_cte_anchor_top, CDXLNode **dxl_cte_anchor_bottom);
 			
 			// generate an array of new column ids of the given size
-			ULongPtrArray *GenerateColIds(IMemoryPool *mp, ULONG size) const;
+			ULongPtrArray *GenerateColIds(CMemoryPool *mp, ULONG size) const;
 
 			// extract an array of colids from the given column mapping
-			ULongPtrArray *ExtractColIds(IMemoryPool *mp, IntToUlongMap *attno_to_colid_mapping) const;
+			ULongPtrArray *ExtractColIds(CMemoryPool *mp, IntToUlongMap *attno_to_colid_mapping) const;
 			
 			// construct a new mapping based on the given one by replacing the colid in the "From" list
 			// with the colid at the same position in the "To" list
-			IntToUlongMap *RemapColIds(IMemoryPool *mp, IntToUlongMap *attno_to_colid_mapping, ULongPtrArray *from_list_colids, ULongPtrArray *to_list_colids) const;
+			IntToUlongMap *RemapColIds(CMemoryPool *mp, IntToUlongMap *attno_to_colid_mapping, ULongPtrArray *from_list_colids, ULongPtrArray *to_list_colids) const;
 
 			// true iff this query or one of its ancestors is a DML query
 			BOOL IsDMLQuery();
@@ -497,7 +497,7 @@ namespace gpdxl
 			static
 			CTranslatorQueryToDXL *QueryToDXLInstance
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				CMDAccessor *md_accessor,
 				Query *query
 				);

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -175,7 +175,7 @@ namespace gpdxl
 
 			// get type name from the relcache
 			static
-			CMDName *GetTypeName(IMemoryPool *mp, IMDId *mdid);
+			CMDName *GetTypeName(CMemoryPool *mp, IMDId *mdid);
 
 			// get function stability property from the GPDB character representation
 			static
@@ -187,33 +187,33 @@ namespace gpdxl
 
 			// get type of aggregate's intermediate result from the relcache
 			static
-			IMDId *RetrieveAggIntermediateResultType(IMemoryPool *mp, IMDId *mdid);
+			IMDId *RetrieveAggIntermediateResultType(CMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a GPDB metadata object from the relcache
 			static
-			IMDCacheObject *RetrieveObjectGPDB(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
+			IMDCacheObject *RetrieveObjectGPDB(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// retrieve relstats object from the relcache
 			static
-			IMDCacheObject *RetrieveRelStats(IMemoryPool *mp, IMDId *mdid);
+			IMDCacheObject *RetrieveRelStats(CMemoryPool *mp, IMDId *mdid);
 
 			// retrieve column stats object from the relcache
 			static
-			IMDCacheObject *RetrieveColStats(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
+			IMDCacheObject *RetrieveColStats(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// retrieve cast object from the relcache
 			static
-			IMDCacheObject *RetrieveCast(IMemoryPool *mp, IMDId *mdid);
+			IMDCacheObject *RetrieveCast(CMemoryPool *mp, IMDId *mdid);
 			
 			// retrieve scalar comparison object from the relcache
 			static
-			IMDCacheObject *RetrieveScCmp(IMemoryPool *mp, IMDId *mdid);
+			IMDCacheObject *RetrieveScCmp(CMemoryPool *mp, IMDId *mdid);
 
 			// transform GPDB's MCV information to optimizer's histogram structure
 			static
 			CHistogram *TransformMcvToOrcaHistogram
 								(
-								IMemoryPool *mp,
+								CMemoryPool *mp,
 								const IMDType *md_type,
 								const Datum *mcv_values,
 								const float4 *mcv_frequencies,
@@ -224,7 +224,7 @@ namespace gpdxl
 			static
 			CHistogram *TransformHistToOrcaHistogram
 								(
-								IMemoryPool *mp,
+								CMemoryPool *mp,
 								const IMDType *md_type,
 								const Datum *hist_values,
 								ULONG num_hist_values,
@@ -236,7 +236,7 @@ namespace gpdxl
 			static
 			CDXLBucketArray *TransformHistogramToDXLBucketArray
 								(
-								IMemoryPool *mp,
+								CMemoryPool *mp,
 								const IMDType *md_type,
 								const CHistogram *hist
 								);
@@ -245,7 +245,7 @@ namespace gpdxl
 			static
 			CDXLBucketArray *TransformStatsToDXLBucketArray
 								(
-								IMemoryPool *mp,
+								CMemoryPool *mp,
 								OID att_type,
 								CDouble num_distinct,
 								CDouble null_freq,
@@ -258,11 +258,11 @@ namespace gpdxl
 
 			// get partition keys and types for a relation
 			static
-			void RetrievePartKeysAndTypes(IMemoryPool *mp, Relation rel, OID oid, ULongPtrArray **part_keys, CharPtrArray **part_types);
+			void RetrievePartKeysAndTypes(CMemoryPool *mp, Relation rel, OID oid, ULongPtrArray **part_keys, CharPtrArray **part_types);
 
 			// get keysets for relation
 			static
-			ULongPtr2dArray *RetrieveRelKeysets(IMemoryPool *mp, OID oid, BOOL should_add_default_keys, BOOL is_partitioned, ULONG *attno_mapping);
+			ULongPtr2dArray *RetrieveRelKeysets(CMemoryPool *mp, OID oid, BOOL should_add_default_keys, BOOL is_partitioned, ULONG *attno_mapping);
 
 			// storage type for a relation
 			static
@@ -274,20 +274,20 @@ namespace gpdxl
 
 			// get the relation columns
 			static
-			CMDColumnArray *RetrieveRelColumns(IMemoryPool *mp, CMDAccessor *md_accessor, Relation rel, IMDRelation::Erelstoragetype rel_storage_type);
+			CMDColumnArray *RetrieveRelColumns(CMemoryPool *mp, CMDAccessor *md_accessor, Relation rel, IMDRelation::Erelstoragetype rel_storage_type);
 
 			// return the dxl representation of the column's default value
 			static
-			CDXLNode *GetDefaultColumnValue(IMemoryPool *mp, CMDAccessor *md_accessor, TupleDesc rd_att, AttrNumber attrno);
+			CDXLNode *GetDefaultColumnValue(CMemoryPool *mp, CMDAccessor *md_accessor, TupleDesc rd_att, AttrNumber attrno);
 
 
 			// get the distribution columns
 			static
-			ULongPtrArray *RetrieveRelDistributionCols(IMemoryPool *mp, GpPolicy *gp_policy, CMDColumnArray *mdcol_array, ULONG size);
+			ULongPtrArray *RetrieveRelDistributionCols(CMemoryPool *mp, GpPolicy *gp_policy, CMDColumnArray *mdcol_array, ULONG size);
 
 			// construct a mapping GPDB attnos -> position in the column array
 			static
-			ULONG *ConstructAttnoMapping(IMemoryPool *mp, CMDColumnArray *mdcol_array, ULONG max_cols);
+			ULONG *ConstructAttnoMapping(CMemoryPool *mp, CMDColumnArray *mdcol_array, ULONG max_cols);
 
 			// check if index is supported
 			static
@@ -299,7 +299,7 @@ namespace gpdxl
 			 
 			// compute the array of included columns
 			static
-			ULongPtrArray *ComputeIncludedCols(IMemoryPool *mp, const IMDRelation *md_rel);
+			ULongPtrArray *ComputeIncludedCols(CMemoryPool *mp, const IMDRelation *md_rel);
 			
 			// is given level included in the default partitions
 			static 
@@ -309,7 +309,7 @@ namespace gpdxl
 			static
 			CMDPartConstraintGPDB *RetrievePartConstraintForIndex
 				(
-				IMemoryPool *mp, 
+				CMemoryPool *mp, 
 				CMDAccessor *md_accessor, 
 				const IMDRelation *md_rel, 
 				Node *part_constraint,
@@ -319,13 +319,13 @@ namespace gpdxl
 
 			// retrieve part constraint for relation
 			static
-			CMDPartConstraintGPDB *RetrievePartConstraintForRel(IMemoryPool *mp, CMDAccessor *md_accessor, OID rel_oid, CMDColumnArray *mdcol_array, BOOL has_index);
+			CMDPartConstraintGPDB *RetrievePartConstraintForRel(CMemoryPool *mp, CMDAccessor *md_accessor, OID rel_oid, CMDColumnArray *mdcol_array, BOOL has_index);
 
 			// retrieve part constraint from a GPDB node
 			static
 			CMDPartConstraintGPDB *RetrievePartConstraintFromNode
 				(
-				IMemoryPool *mp, 
+				CMemoryPool *mp, 
 				CMDAccessor *md_accessor,
 				CDXLColDescrArray *dxl_col_descr_array, 
 				Node *part_constraint,
@@ -335,23 +335,23 @@ namespace gpdxl
 	
 			// return relation name
 			static
-			CMDName *GetRelName(IMemoryPool *mp, Relation rel);
+			CMDName *GetRelName(CMemoryPool *mp, Relation rel);
 
 			// return the index info list defined on the given relation
 			static
-			CMDIndexInfoArray *RetrieveRelIndexInfo(IMemoryPool *mp, Relation rel);
+			CMDIndexInfoArray *RetrieveRelIndexInfo(CMemoryPool *mp, Relation rel);
 
 			// return index info list of indexes defined on a partitoned table
 			static
-			CMDIndexInfoArray *RetrieveRelIndexInfoForPartTable(IMemoryPool *mp, Relation root_rel);
+			CMDIndexInfoArray *RetrieveRelIndexInfoForPartTable(CMemoryPool *mp, Relation root_rel);
 
 			// return index info list of indexes defined on regular, external tables or leaf partitions
 			static
-			CMDIndexInfoArray *RetrieveRelIndexInfoForNonPartTable(IMemoryPool *mp, Relation rel);
+			CMDIndexInfoArray *RetrieveRelIndexInfoForNonPartTable(CMemoryPool *mp, Relation rel);
 
 			// retrieve an index over a partitioned table from the relcache
 			static
-			IMDIndex *RetrievePartTableIndex(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid_index, const IMDRelation *md_rel, LogicalIndexes *logical_indexes);
+			IMDIndex *RetrievePartTableIndex(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid_index, const IMDRelation *md_rel, LogicalIndexes *logical_indexes);
 			
 			// lookup an index given its id from the logical indexes structure
 			static
@@ -359,15 +359,15 @@ namespace gpdxl
 			
 			// construct an MD cache index object given its logical index representation
 			static
-			IMDIndex *RetrievePartTableIndex(IMemoryPool *mp, CMDAccessor *md_accessor, LogicalIndexInfo *index_info, IMDId *mdid_index, const IMDRelation *md_rel);
+			IMDIndex *RetrievePartTableIndex(CMemoryPool *mp, CMDAccessor *md_accessor, LogicalIndexInfo *index_info, IMDId *mdid_index, const IMDRelation *md_rel);
 
 			// return the triggers defined on the given relation
 			static
-			IMdIdArray *RetrieveRelTriggers(IMemoryPool *mp, Relation rel);
+			IMdIdArray *RetrieveRelTriggers(CMemoryPool *mp, Relation rel);
 
 			// return the check constraints defined on the relation with the given oid
 			static
-			IMdIdArray *RetrieveRelCheckConstraints(IMemoryPool *mp, OID oid);
+			IMdIdArray *RetrieveRelCheckConstraints(CMemoryPool *mp, OID oid);
 
 			// does attribute number correspond to a transaction visibility attribute
 			static 
@@ -383,11 +383,11 @@ namespace gpdxl
 			
 			// retrieve the opfamilies mdids for the given scalar op
 			static
-			IMdIdArray *RetrieveScOpOpFamilies(IMemoryPool *mp, IMDId *mdid_scalar_op);
+			IMdIdArray *RetrieveScOpOpFamilies(CMemoryPool *mp, IMDId *mdid_scalar_op);
 			
 			// retrieve the opfamilies mdids for the given index
 			static
-			IMdIdArray *RetrieveIndexOpFamilies(IMemoryPool *mp, IMDId *mdid_index);
+			IMdIdArray *RetrieveIndexOpFamilies(CMemoryPool *mp, IMDId *mdid_index);
 
             // for non-leaf partition tables return the number of child partitions
             // else return 1
@@ -398,7 +398,7 @@ namespace gpdxl
             static
             CDXLColStats *GenerateStatsForSystemCols
                               (
-                              IMemoryPool *mp,
+                              CMemoryPool *mp,
                               OID rel_oid,
                               CMDIdColStats *mdid_col_stats,
                               CMDName *md_colname,
@@ -410,27 +410,27 @@ namespace gpdxl
 		public:
 			// retrieve a metadata object from the relcache
 			static
-			IMDCacheObject *RetrieveObject(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
+			IMDCacheObject *RetrieveObject(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// retrieve a relation from the relcache
 			static
-			IMDRelation *RetrieveRel(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
+			IMDRelation *RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// add system columns (oid, tid, xmin, etc) in table descriptors
 			static
-			void AddSystemColumns(IMemoryPool *mp, CMDColumnArray *mdcol_array, Relation rel, BOOL is_ao_table);
+			void AddSystemColumns(CMemoryPool *mp, CMDColumnArray *mdcol_array, Relation rel, BOOL is_ao_table);
 
 			// retrieve an index from the relcache
 			static
-			IMDIndex *RetrieveIndex(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid_index);
+			IMDIndex *RetrieveIndex(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid_index);
 
 			// retrieve a check constraint from the relcache
 			static
-			CMDCheckConstraintGPDB *RetrieveCheckConstraints(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
+			CMDCheckConstraintGPDB *RetrieveCheckConstraints(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// populate the attribute number to position mapping
 			static
-			ULONG *PopulateAttnoPositionMap(IMemoryPool *mp, const IMDRelation *md_rel, ULONG size);
+			ULONG *PopulateAttnoPositionMap(CMemoryPool *mp, const IMDRelation *md_rel, ULONG size);
 
 			// return the position of a given attribute number
 			static
@@ -438,23 +438,23 @@ namespace gpdxl
 
 			// retrieve a type from the relcache
 			static
-			IMDType *RetrieveType(IMemoryPool *mp, IMDId *mdid);
+			IMDType *RetrieveType(CMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a scalar operator from the relcache
 			static
-			CMDScalarOpGPDB *RetrieveScOp(IMemoryPool *mp, IMDId *mdid);
+			CMDScalarOpGPDB *RetrieveScOp(CMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a function from the relcache
 			static
-			CMDFunctionGPDB *RetrieveFunc(IMemoryPool *mp, IMDId *mdid);
+			CMDFunctionGPDB *RetrieveFunc(CMemoryPool *mp, IMDId *mdid);
 
 			// retrieve an aggregate from the relcache
 			static
-			CMDAggregateGPDB *RetrieveAgg(IMemoryPool *mp, IMDId *mdid);
+			CMDAggregateGPDB *RetrieveAgg(CMemoryPool *mp, IMDId *mdid);
 
 			// retrieve a trigger from the relcache
 			static
-			CMDTriggerGPDB *RetrieveTrigger(IMemoryPool *mp, IMDId *mdid);
+			CMDTriggerGPDB *RetrieveTrigger(CMemoryPool *mp, IMDId *mdid);
 			
 			// translate GPDB comparison type
 			static

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -62,13 +62,13 @@ namespace gpdxl
 		typedef CDXLNode * (CTranslatorScalarToDXL::*ExprToDXLFn)(const Expr *expr, const CMappingVarColId* var_colid_mapping);
 
 		// shorthand for functions for translating DXL nodes to GPDB expressions
-		typedef CDXLDatum * (DxlDatumFromDatum)(IMemoryPool *mp, const IMDType *md_type, BOOL is_null, ULONG len, Datum datum);
+		typedef CDXLDatum * (DxlDatumFromDatum)(CMemoryPool *mp, const IMDType *md_type, BOOL is_null, ULONG len, Datum datum);
 
 		private:
 			// private constructor for TranslateStandaloneExprToDXL
 			CTranslatorScalarToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				CMDAccessor *mda
 				);
 
@@ -84,7 +84,7 @@ namespace gpdxl
 			CContextQueryToDXL *m_context;
 
 			// memory pool
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// meta data accessor
 			CMDAccessor *m_md_accessor;
@@ -416,7 +416,7 @@ namespace gpdxl
 			static
 			CDXLNode *TranslateStandaloneExprToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				CMDAccessor *mda,
 				const CMappingVarColId* var_colid_mapping,
 				const Expr *expr
@@ -426,7 +426,7 @@ namespace gpdxl
 			static
 			CDXLDatum *TranslateConstToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				CMDAccessor *mda,
 				const Const *constant
 				);
@@ -435,7 +435,7 @@ namespace gpdxl
 			static
 			CDXLDatum *TranslateDatumToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const IMDType *md_type,
 				INT type_modifier,
 				BOOL is_null,
@@ -447,7 +447,7 @@ namespace gpdxl
 			static
 			IDatum *CreateIDatumFromGpdbDatum
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const IMDType *md_type,
 				BOOL is_null,
 				Datum datum
@@ -457,7 +457,7 @@ namespace gpdxl
 			static
 			BYTE *ExtractByteArrayFromDatum
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const IMDType *md_type,
 				BOOL is_null,
 				ULONG len,
@@ -494,7 +494,7 @@ namespace gpdxl
 			static
 			CDXLDatum *TranslateOidDatumToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const IMDType *md_type,
 				BOOL is_null,
 				ULONG len,
@@ -505,7 +505,7 @@ namespace gpdxl
 			static
 			CDXLDatum *TranslateInt2DatumToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const IMDType *md_type,
 				BOOL is_null,
 				ULONG len,
@@ -516,7 +516,7 @@ namespace gpdxl
 			static
 			CDXLDatum *TranslateInt4DatumToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const IMDType *md_type,
 				BOOL is_null,
 				ULONG len,
@@ -527,7 +527,7 @@ namespace gpdxl
 			static
 			CDXLDatum *TranslateInt8DatumToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const IMDType *md_type,
 				BOOL is_null,
 				ULONG len,
@@ -538,7 +538,7 @@ namespace gpdxl
 			static
 			CDXLDatum *TranslateBoolDatumToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const IMDType *md_type,
 				BOOL is_null,
 				ULONG len,
@@ -549,7 +549,7 @@ namespace gpdxl
 			static
 			CDXLDatum *TranslateGenericDatumToDXL
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				const IMDType *md_type,
 				INT type_modifier,
 				BOOL is_null,

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -74,11 +74,11 @@ namespace gpdxl
 
 			// construct a set of column attnos corresponding to a single grouping set
 			static
-			CBitSet *CreateAttnoSetForGroupingSet(IMemoryPool *mp, List *group_elems, ULONG num_cols, UlongToUlongMap *group_col_pos, CBitSet *group_cols);
+			CBitSet *CreateAttnoSetForGroupingSet(CMemoryPool *mp, List *group_elems, ULONG num_cols, UlongToUlongMap *group_col_pos, CBitSet *group_cols);
 
 			// create a set of grouping sets for a rollup
 			static
-			CBitSetArray *CreateGroupingSetsForRollup(IMemoryPool *mp, GroupingClause *grouping_clause, ULONG num_cols, UlongToUlongMap *grouping_col_to_pos_map, CBitSet *group_cols);
+			CBitSetArray *CreateGroupingSetsForRollup(CMemoryPool *mp, GroupingClause *grouping_clause, ULONG num_cols, UlongToUlongMap *grouping_col_to_pos_map, CBitSet *group_cols);
 
 			// check if the given mdid array contains any of the polymorphic
 			// types (ANYELEMENT, ANYARRAY)
@@ -90,7 +90,7 @@ namespace gpdxl
 			static
 			IMdIdArray *ResolvePolymorphicTypes
 						(
-						IMemoryPool *mp,
+						CMemoryPool *mp,
 						IMdIdArray *mdid_array,
 						List *arg_types,
 						FuncExpr *func_expr
@@ -98,7 +98,7 @@ namespace gpdxl
 			
 			// update grouping col position mappings
 			static
-			void UpdateGrpColMapping(IMemoryPool *mp, UlongToUlongMap *grouping_col_to_pos_map, CBitSet *group_cols, ULONG sort_group_ref);
+			void UpdateGrpColMapping(CMemoryPool *mp, UlongToUlongMap *grouping_col_to_pos_map, CBitSet *group_cols, ULONG sort_group_ref);
 
 		public:
 
@@ -123,7 +123,7 @@ namespace gpdxl
 			
 			// return the type for the system column with the given number
 			static
-			CMDIdGPDB *GetSystemColType(IMemoryPool *mp, AttrNumber attno);
+			CMDIdGPDB *GetSystemColType(CMemoryPool *mp, AttrNumber attno);
 
 			// find the n-th column descriptor in the table descriptor
 			static
@@ -147,13 +147,13 @@ namespace gpdxl
 
 			// create a DXL index descriptor from an index MD id
 			static
-			CDXLIndexDescr *GetIndexDescr(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
+			CDXLIndexDescr *GetIndexDescr(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid);
 
 			// translate a RangeTableEntry into a CDXLTableDescr
 			static
 			CDXLTableDescr *GetTableDescr
 								(
-								IMemoryPool *mp,
+								CMemoryPool *mp,
 								CMDAccessor *md_accessor,
 								CIdGenerator *id_generator,
 								const RangeTblEntry *rte,
@@ -164,7 +164,7 @@ namespace gpdxl
 			static
 			CDXLLogicalTVF *ConvertToCDXLLogicalTVF
 								(
-								IMemoryPool *mp,
+								CMemoryPool *mp,
 								CMDAccessor *md_accessor,
 								CIdGenerator *id_generator,
 								const RangeTblEntry *rte
@@ -174,7 +174,7 @@ namespace gpdxl
 			static
 			CDXLColDescrArray *GetColumnDescriptorsFromRecord
 						(
-						IMemoryPool *mp,
+						CMemoryPool *mp,
 						CIdGenerator *id_generator,
 						List *col_names,
 						List *col_types,
@@ -185,7 +185,7 @@ namespace gpdxl
 			static
 			CDXLColDescrArray *GetColumnDescriptorsFromRecord
 						(
-						IMemoryPool *mp,
+						CMemoryPool *mp,
 						CIdGenerator *id_generator,
 						List *col_names,
 						IMdIdArray *out_arg_types
@@ -195,7 +195,7 @@ namespace gpdxl
 			static
 			CDXLColDescrArray *GetColumnDescriptorsFromBase
 						(
-						IMemoryPool *mp,
+						CMemoryPool *mp,
 						CIdGenerator *id_generator,
 						IMDId *mdid_return_type,
 						INT type_modifier,
@@ -206,7 +206,7 @@ namespace gpdxl
 			static
 			CDXLColDescrArray *GetColumnDescriptorsFromComposite
 						(
-						IMemoryPool *mp,
+						CMemoryPool *mp,
 						CMDAccessor *md_accessor,
 						CIdGenerator *id_generator,
 						const IMDType *md_type
@@ -216,7 +216,7 @@ namespace gpdxl
 			static
 			CMDColumnArray *ExpandCompositeType
 						(
-						IMemoryPool *mp,
+						CMemoryPool *mp,
 						CMDAccessor *md_accessor,
 						const IMDType *md_type
 						);
@@ -228,7 +228,7 @@ namespace gpdxl
 			// construct a dynamic array of sets of column attnos corresponding
 			// to the group by clause
 			static
-			CBitSetArray *GetColumnAttnosForGroupBy(IMemoryPool *mp, List *group_clause, ULONG num_cols, UlongToUlongMap *group_col_pos, CBitSet *group_cold);
+			CBitSetArray *GetColumnAttnosForGroupBy(CMemoryPool *mp, List *group_clause, ULONG num_cols, UlongToUlongMap *group_col_pos, CBitSet *group_cold);
 
 			// return a copy of the query with constant of unknown type being coerced
 			// to the common data type of the output target list
@@ -242,7 +242,7 @@ namespace gpdxl
 			static
 			ULongPtrArray *GenerateColIds
 					(
-					IMemoryPool *mp,
+					CMemoryPool *mp,
 					List *target_list,
 					IMdIdArray *input_mdids,
 					ULongPtrArray *input_nums,
@@ -253,28 +253,28 @@ namespace gpdxl
 			// construct an array of DXL column descriptors for a target list
 			// using the column ids in the given array
 			static
-			CDXLColDescrArray *GetDXLColumnDescrArray(IMemoryPool *mp, List *target_list, ULongPtrArray *colids, BOOL keep_res_junked);
+			CDXLColDescrArray *GetDXLColumnDescrArray(CMemoryPool *mp, List *target_list, ULongPtrArray *colids, BOOL keep_res_junked);
 
 			// return the positions of the target list entries included in the output
 			static
-			ULongPtrArray *GetPosInTargetList(IMemoryPool *mp, List *target_list, BOOL keep_res_junked);
+			ULongPtrArray *GetPosInTargetList(CMemoryPool *mp, List *target_list, BOOL keep_res_junked);
 
 			// construct a column descriptor from the given target entry, column identifier and position in the output
 			static
-			CDXLColDescr *GetColumnDescrAt(IMemoryPool *mp, TargetEntry *target_entry, ULONG colid, ULONG pos);
+			CDXLColDescr *GetColumnDescrAt(CMemoryPool *mp, TargetEntry *target_entry, ULONG colid, ULONG pos);
 
 			// create a dummy project element to rename the input column identifier
 			static
-			CDXLNode *CreateDummyProjectElem(IMemoryPool *mp, ULONG colid_input, ULONG colid_output, CDXLColDescr *dxl_col_descr);
+			CDXLNode *CreateDummyProjectElem(CMemoryPool *mp, ULONG colid_input, ULONG colid_output, CDXLColDescr *dxl_col_descr);
 
 			// construct a list of colids corresponding to the given target list
 			// using the given attno->colid map
 			static
-			ULongPtrArray *GetOutputColIdsArray(IMemoryPool *mp, List *target_list, IntToUlongMap *attno_to_colid_map);
+			ULongPtrArray *GetOutputColIdsArray(CMemoryPool *mp, List *target_list, IntToUlongMap *attno_to_colid_map);
 
 			// construct an array of column ids for the given group by set
 			static
-			ULongPtrArray *GetGroupingColidArray(IMemoryPool *mp, CBitSet *group_by_cols, IntToUlongMap *sort_group_cols_to_colid_map);
+			ULongPtrArray *GetGroupingColidArray(CMemoryPool *mp, CBitSet *group_by_cols, IntToUlongMap *sort_group_cols_to_colid_map);
 
 			// return the Colid of column with given index
 			static
@@ -301,7 +301,7 @@ namespace gpdxl
 
 			// create a scalar const value expression for the given int8 value
 			static
-			CDXLNode *CreateDXLProjElemFromInt8Const(IMemoryPool *mp, CMDAccessor *md_accessor, INT val);
+			CDXLNode *CreateDXLProjElemFromInt8Const(CMemoryPool *mp, CMDAccessor *md_accessor, INT val);
 
 			// check to see if the target list entry is a grouping column
 			static
@@ -342,7 +342,7 @@ namespace gpdxl
 			CHAR *CreateMultiByteCharStringFromWCString(const WCHAR *wcstr);
 			
 			static 
-			UlongToUlongMap *MakeNewToOldColMapping(IMemoryPool *mp, ULongPtrArray *old_colids, ULongPtrArray *new_colids);
+			UlongToUlongMap *MakeNewToOldColMapping(CMemoryPool *mp, ULongPtrArray *old_colids, ULongPtrArray *new_colids);
 
 			// check if the given tree contains a subquery
 			static
@@ -351,7 +351,7 @@ namespace gpdxl
 			// check if the given function is a SIRV (single row volatile) that reads
 			// or modifies SQL data
 			static
-			BOOL IsSirvFunc(IMemoryPool *mp, CMDAccessor *md_accessor, OID func_oid);
+			BOOL IsSirvFunc(CMemoryPool *mp, CMDAccessor *md_accessor, OID func_oid);
 			
 			// is this a motion sensitive to duplicates
 			static
@@ -359,16 +359,16 @@ namespace gpdxl
 
 			// construct a project element with a const NULL expression
 			static
-			CDXLNode *CreateDXLProjElemConstNULL(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid, ULONG colid, const WCHAR *col_name);
+			CDXLNode *CreateDXLProjElemConstNULL(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid, ULONG colid, const WCHAR *col_name);
 
 			// construct a project element with a const NULL expression
 			static
-			CDXLNode *CreateDXLProjElemConstNULL(IMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid, ULONG colid, CHAR *alias_name);
+			CDXLNode *CreateDXLProjElemConstNULL(CMemoryPool *mp, CMDAccessor *md_accessor, IMDId *mdid, ULONG colid, CHAR *alias_name);
 
 			// create a DXL project element node with a Const NULL of type provided
 			// by the column descriptor
 			static
-			CDXLNode *CreateDXLProjElemConstNULL(IMemoryPool *mp, CMDAccessor *md_accessor, CIdGenerator *colid_generator, const IMDColumn *col);
+			CDXLNode *CreateDXLProjElemConstNULL(CMemoryPool *mp, CMDAccessor *md_accessor, CIdGenerator *colid_generator, const IMDColumn *col);
 
 			// check required permissions for the range table
 			static 
@@ -389,7 +389,7 @@ namespace gpdxl
 			// check whether there are triggers for the given operation on
 			// the given relation
 			static
-			BOOL RelHasTriggers(IMemoryPool *mp, CMDAccessor *md_accessor, const IMDRelation *mdrel, const EdxlDmlType dml_type_dxl);
+			BOOL RelHasTriggers(CMemoryPool *mp, CMDAccessor *md_accessor, const IMDRelation *mdrel, const EdxlDmlType dml_type_dxl);
 
 			// check whether the given trigger is applicable to the given DML operation
 			static

--- a/src/include/gpopt/utils/CConstExprEvaluatorProxy.h
+++ b/src/include/gpopt/utils/CConstExprEvaluatorProxy.h
@@ -57,7 +57,7 @@ namespace gpdxl
 					explicit
 					CEmptyMappingColIdVar
 						(
-						IMemoryPool *mp
+						CMemoryPool *mp
 						)
 						:
 						CMappingColIdVar(mp)
@@ -75,7 +75,7 @@ namespace gpdxl
 			};
 
 			// memory pool, not owned
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// empty mapping needed for the translator
 			CEmptyMappingColIdVar m_emptymapcidvar;
@@ -90,7 +90,7 @@ namespace gpdxl
 			// ctor
 			CConstExprEvaluatorProxy
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				CMDAccessor *md_accessor
 				)
 				:

--- a/src/include/gpopt/utils/COptClient.h
+++ b/src/include/gpopt/utils/COptClient.h
@@ -76,7 +76,7 @@ namespace gpoptudfs
 			const char *m_path;
 
 			// memory pool
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// communicator
 			CCommunicator *m_communicator;

--- a/src/include/gpopt/utils/COptServer.h
+++ b/src/include/gpopt/utils/COptServer.h
@@ -108,7 +108,7 @@ namespace gpoptudfs
 			const CHAR *m_socket_path;
 
 			// memory pool for connections
-			IMemoryPool *m_mp;
+			CMemoryPool *m_mp;
 
 			// hashtable of connections
 			ConnectionHT *m_connections_ht;
@@ -146,13 +146,13 @@ namespace gpoptudfs
 
 			// receive optimization request and construct query context for it
 			static
-			CQueryContext *RecvQuery(IMemoryPool *mp, CCommunicator *communicator, CMDAccessor *md_accessor);
+			CQueryContext *RecvQuery(CMemoryPool *mp, CCommunicator *communicator, CMDAccessor *md_accessor);
 
 			// extract query plan, serialize it and send it to client
 			static
 			void SendPlan
 				(
-				IMemoryPool *mp,
+				CMemoryPool *mp,
 				CCommunicator *communicator,
 				CMDAccessor *md_accessor,
 				CQueryContext *query_ctxt,

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -27,7 +27,7 @@
 // fwd decl
 namespace gpos
 {
-	class IMemoryPool;
+	class CMemoryPool;
 	class CBitSet;
 }
 
@@ -130,7 +130,7 @@ class COptTasks
 
 		// create optimizer configuration object
 		static
-		COptimizerConfig *CreateOptimizerConfig(IMemoryPool *mp, ICostModel *cost_model);
+		COptimizerConfig *CreateOptimizerConfig(CMemoryPool *mp, ICostModel *cost_model);
 
 		// optimize a query to a physical DXL
 		static
@@ -138,11 +138,11 @@ class COptTasks
 
 		// translate a DXL tree into a planned statement
 		static
-		PlannedStmt *ConvertToPlanStmtFromDXL(IMemoryPool *mp, CMDAccessor *md_accessor, const CDXLNode *dxlnode, bool can_set_tag, DistributionHashOpsKind distribution_hashops);
+		PlannedStmt *ConvertToPlanStmtFromDXL(CMemoryPool *mp, CMDAccessor *md_accessor, const CDXLNode *dxlnode, bool can_set_tag, DistributionHashOpsKind distribution_hashops);
 
 		// load search strategy from given path
 		static
-		CSearchStageArray *LoadSearchStrategy(IMemoryPool *mp, char *path);
+		CSearchStageArray *LoadSearchStrategy(CMemoryPool *mp, char *path);
 
 		// helper for converting wide character string to regular string
 		static
@@ -166,11 +166,11 @@ class COptTasks
 
 		// generate an instance of optimizer cost model
 		static
-		ICostModel *GetCostModel(IMemoryPool *mp, ULONG num_segments);
+		ICostModel *GetCostModel(CMemoryPool *mp, ULONG num_segments);
 
 		// print warning messages for columns with missing statistics
 		static
-		void PrintMissingStatsWarning(IMemoryPool *mp, CMDAccessor *md_accessor, IMdIdArray *col_stats, MdidHashSet *phsmdidRel);
+		void PrintMissingStatsWarning(CMemoryPool *mp, CMDAccessor *md_accessor, IMdIdArray *col_stats, MdidHashSet *phsmdidRel);
 
 	public:
 


### PR DESCRIPTION
The IMemoryPool interface was removed in ORCA to remove an unnecessary
abstraction layer and avoid costly casting.

ORCA PR: https://github.com/greenplum-db/gporca/pull/483

Authored-by: Chris Hajas <chajas@pivotal.io>