### PR TITLE
Fix the path of PXF subdir

### DIFF
--- a/gpcontrib/pxf/test/Makefile
+++ b/gpcontrib/pxf/test/Makefile
@@ -1,4 +1,4 @@
-subdir=gpcontrib/pxf/test
+subdir=gpcontrib/pxf
 top_builddir=../../..
 include $(top_builddir)/src/Makefile.global
 


### PR DESCRIPTION
The path for the PXF subdir is pointing to the incorrect location. Updating it to the correct subdir