### PR TITLE
Fix: always return error when gpscp fails

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_dump.c
+++ b/src/bin/pg_dump/cdb/cdb_dump.c
@@ -452,7 +452,7 @@ copyFilesToSegments(InputOptions *pInputOpts, SegmentDatabaseArray *segDBAr)
 	unlink(hostfile_name);
 	free(cmdLine);
 
-	if (result == -1)
+	if (result != 0)
 	{
 		mpp_err_msg_cache(logError, progname, "failed to send table files to segments (%d, %d)",
 						  result, errno);


### PR DESCRIPTION
Improve logging: exit when the shelled-out command fails with any non-zero error code, not just -1 error code

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Larry Hamel <lhamel@pivotal.io>
