### PR TITLE
Docs -  gpmfr utility correction

### DIFF
--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpmfr.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpmfr.xml
@@ -40,7 +40,7 @@
          <title>Prerequisites</title>
          <p>The Data Domain systems that are used as local and remote backup systems for managed
             file replication must have Data Domain Boost and Replicator enabled. </p>
-         <p>The Greenplum Database master host segment hosts must be able to connect to both the
+         <p>The Greenplum Database master host must be able to connect to both the
             local Data Domain system and the remote Data Domain system.</p>
          <p>The login credentials for the local and remote Data Domain systems must be configured on
             the Greenplum master host with the <codeph>gpcrondump</codeph> utility. See "Backing Up


### PR DESCRIPTION
The gpmfr utility doesn't require segment hosts to be able to connect to the remote Data Domain system - only the master host. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
