### PR TITLE
Conditionally install dependencies for Ubuntu 16

### DIFF
--- a/src/tools/docker/README.md
+++ b/src/tools/docker/README.md
@@ -10,8 +10,8 @@ docker build -t local/gpdb-dev:centos6 centos6
 docker build -t local/gpdb-dev:centos7 centos7
 
 # Ubuntu (includes dependencies for building GPDB)
-docker build -t --build-arg local/gpdb-dev:ubuntu16 ubuntu
-docker build -t --build-arg BASE_IMAGE=ubuntu:18.04 local/gpdb-dev:ubuntu18 ubuntu
+docker build --build-arg BASE_IMAGE=ubuntu:16.04 -t local/gpdb-dev:ubuntu16 ubuntu
+docker build --build-arg BASE_IMAGE=ubuntu:18.04 -t local/gpdb-dev:ubuntu18 ubuntu
 ```
 
 OR

--- a/src/tools/docker/ubuntu/Dockerfile
+++ b/src/tools/docker/ubuntu/Dockerfile
@@ -1,14 +1,13 @@
 ARG BASE_IMAGE=ubuntu:18.04
 
-FROM ${BASE_IMAGE}
+FROM $BASE_IMAGE
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG BASE_IMAGE
 
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends apt-utils software-properties-common && \
-    apt-get install -y --no-install-recommends openjdk-8-jdk && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get update -y && \
+    apt-get install -y --no-install-recommends apt-utils openjdk-8-jdk software-properties-common && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get update -y && \
     apt-get install -y --no-install-recommends gcc-6 g++-6 cmake && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6 && \
     update-alternatives --config gcc && \
@@ -33,6 +32,7 @@ RUN apt-get update -y && \
     libperl-dev \
     libreadline-dev \
     libssl-dev \
+    $([ "$BASE_IMAGE" = ubuntu:16.04 ] && echo libxerces-c-dev) \
     libxml2-dev \
     libyaml-dev \
     libzstd1-dev \


### PR DESCRIPTION
Previously, Ubuntu 16 installed libxerces-c-dev and
python-software-properties. The removal of these dependencies caused
failures in the creation of demo cluster. Adding back these dependencies
for Ubuntu 16 only. Also, updated the README.md to fix the command to
create Ubuntu images.
