### PR TITLE
Fix test fts_recovery_in_progress

### DIFF
--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -41,6 +41,8 @@ select gp_request_fts_probe_scan();
 select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
 -- The remaining steps are to bring back the cluster to original state.
 -- start_ignore
+-- run a DDL query to make sure the mirror has finished the promotion
+1: create temp table tmp_fts_recovery(a int);
 \! gprecoverseg -av --no-progress
 -- end_ignore
 


### PR DESCRIPTION
fts_recovery_in_progress execute 'select gp_request_fts_probe_scan()' to
promote the mirror and then run 'gprecoverseg', it fails sometimes because the
mirror promotion hasn't finished yet.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
