### PR TITLE
5X: Restore default settings for new resource groups

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -42,14 +42,8 @@
 #include "utils/vmem_tracker.h"
 
 #define RESGROUP_DEFAULT_CONCURRENCY (20)
-#define RESGROUP_DEFAULT_MEMORY_LIMIT (0)
-#define RESGROUP_DEFAULT_MEM_SHARED_QUOTA (80)
-/*
- * The default memory_spill_ratio value is 128MB, it is in absolute value
- * format, so it is represented as a negative value, and as its unit is chunk,
- * so need a conversion.
- */
-#define RESGROUP_DEFAULT_MEM_SPILL_RATIO (-VmemTracker_ConvertVmemMBToChunks(128))
+#define RESGROUP_DEFAULT_MEM_SHARED_QUOTA (20)
+#define RESGROUP_DEFAULT_MEM_SPILL_RATIO (20)
 
 #define RESGROUP_DEFAULT_MEM_AUDITOR (RESGROUP_MEMORY_AUDITOR_VMTRACKER)
 #define RESGROUP_INVALID_MEM_AUDITOR (-1)
@@ -1081,7 +1075,9 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 				errmsg("must specify cpu_rate_limit or cpuset")));
 
 	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_MEMORY)))
-		caps->memLimit = RESGROUP_DEFAULT_MEMORY_LIMIT;
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("must specify memory_limit")));
 
 	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_CONCURRENCY)))
 		caps->concurrency = RESGROUP_DEFAULT_CONCURRENCY;

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -102,9 +102,13 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 ERROR:  resource group "rg_test_group" already exists
 DROP RESOURCE GROUP rg_test_group;
 DROP
--- must specify cpu_rate_limit or cpuset
+-- must specify both memory_limit and (cpu_rate_limit or cpuset)
 CREATE RESOURCE GROUP rg_test_group WITH (memory_limit=10);
 ERROR:  must specify cpu_rate_limit or cpuset
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
+ERROR:  must specify memory_limit
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
+ERROR:  must specify memory_limit
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
 ERROR:  Find duplicate resource group resource type: concurrency
@@ -188,7 +192,7 @@ CREATE
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
 -------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
-rg_test_group|20         |20                  |10            |10          |10                   |80                 |128 MB            
+rg_test_group|20         |20                  |10            |10          |10                   |20                 |20                
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
@@ -198,24 +202,6 @@ SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,pr
 groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
 -------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
 rg_test_group|1          |1                   |-1            |10          |10                   |70                 |30                
-(1 row)
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
-CREATE
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
-groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
--------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
-rg_test_group|20         |20                  |10            |0           |0                    |80                 |128 MB            
-(1 row)
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
-CREATE
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
-groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
--------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
-rg_test_group|20         |20                  |-1            |0           |0                    |80                 |128 MB            
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
@@ -427,10 +413,6 @@ CREATE
 DROP RESOURCE GROUP rg_test_group;
 DROP
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='+10 MB');
-CREATE
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
 CREATE
 DROP RESOURCE GROUP rg_test_group;
 DROP

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -53,8 +53,10 @@ CREATE RESOURCE GROUP none WITH (cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 DROP RESOURCE GROUP rg_test_group;
--- must specify cpu_rate_limit or cpuset
+-- must specify both memory_limit and (cpu_rate_limit or cpuset)
 CREATE RESOURCE GROUP rg_test_group WITH (memory_limit=10);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, cpu_rate_limit=5);
@@ -103,12 +105,6 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpuset='0', memory_limit=10, memory_shared_quota=70, memory_spill_ratio=30);
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
 
@@ -230,8 +226,6 @@ DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='010 MB');
 DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='+10 MB');
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
 DROP RESOURCE GROUP rg_test_group;
 
 -- positive: memory_spill_ratio in absolute value format will be ensured to be >= 1 chunk


### PR DESCRIPTION
Previous commit changed the default resource group settings for newly created
groups, which might break backward compatibility, so restore the default
settings.

Co-authored-by: Ning Yu <nyu@pivotal.io>

-------------



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
- [ ] Greenlight from PM team