### PR TITLE
Add gpdb github release pipeline

### DIFF
--- a/concourse/pipelines/gpdb_github_release.yml
+++ b/concourse/pipelines/gpdb_github_release.yml
@@ -1,0 +1,71 @@
+---
+
+resource_types:
+- name: pivnet
+  type: docker-image
+  source:
+    repository: pivotalcf/pivnet-resource
+    tag: latest-final
+
+# 1. Resources
+resources:
+- name: pivotal_gpdb
+  type: pivnet
+  source:
+    api_token: ((pivnet-refresh-token))
+    endpoint: ((pivnet-endpoint))
+    product_slug: ((pivnet-product-slug))
+    # product_version: 6\..*
+    # sort_by: semver
+
+- name: gpdb_src
+  type: git
+  source:
+    branch: ((gpdb-git-branch))
+    uri: ((gpdb-git-remote))
+    private_key: ((gpdb-git-deploy-key))
+
+- name: gpdb_staging
+  type: git
+  source:
+    branch: ((gpdb-staging-git-branch))
+    uri: ((gpdb-staging-git-remote))
+    private_key: ((gpdb-staging-deploy-key))
+    # tag_filter: 6.*
+
+- name: gpdb_release
+  type: github-release
+  source:
+    owner: ((gpdb-release-owner))
+    repository: ((gpdb-release-repository))
+    access_token: ((gpdb-release-access-token))
+
+- name: gpdb6-centos7-build
+  type: docker-image
+  source:
+    repository: pivotaldata/gpdb6-centos7-build
+    tag: 'latest'
+
+# 2. Jobs
+jobs:
+- name: publish_gpdb_github_release
+  plan:
+  - aggregate:
+    - get: pivotal_gpdb
+      trigger: true
+    - get: gpdb_src
+    - get: gpdb_staging
+    - get: gpdb6-centos7-build
+  - task: gpdb_github_release
+    image: gpdb6-centos7-build
+    file: gpdb_src/concourse/tasks/gpdb_github_release.yml
+    params:
+      GPDB_SRC_DEPLOY_KEY: ((gpdb-git-deploy-key))
+  - put: gpdb_release
+    params:
+      name: release_artifacts/name
+      tag: release_artifacts/tag
+      body: release_artifacts/body
+      globs:
+        - release_artifacts/*.tar.gz
+        - release_artifacts/*.zip

--- a/concourse/scripts/gpdb_github_release.bash
+++ b/concourse/scripts/gpdb_github_release.bash
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BASE_DIR=$(pwd)
+
+# Format: 6.0.0-beta.3#2019-05-08T15:35:55.252Z
+GPDB_BUILD_TAG=$(cat pivotal_gpdb/version)
+
+# Format: 6.0.0-beta.3
+GPDB_RELEASE_TAG=${GPDB_BUILD_TAG%%#*}
+
+git config --global user.email "gp-releng@pivotal.io"
+git config --global user.name "gp-releng-bot"
+
+mkdir -p ~/.ssh/
+echo "${GPDB_SRC_DEPLOY_KEY}" > ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+function get_release_commit_sha() {
+    local __release_tag
+    __release_tag=$1
+
+    git --git-dir "${BASE_DIR}/gpdb_staging/.git" log -1 --pretty=format:"%H" "${__release_tag}"
+}
+
+function tag_gpdb_src() {
+    local __commit_sha
+    local __gpdb_tag
+
+    __gpdb_tag=$1
+    __commit_sha=$2
+
+    # github-release concourse resource type: only lightweight tags are supported
+    # ref: https://github.com/concourse/github-release-resource/blob/0447360bed360a53c11b09c912decc3b2fa5abd2/in_command.go#L209
+    git --git-dir "${BASE_DIR}/gpdb_src/.git" tag "${__gpdb_tag}" "${__commit_sha}"
+}
+
+function push_gpdb_src_tags_to_remote() {
+    git --git-dir "${BASE_DIR}/gpdb_src/.git" push --tags
+}
+
+function build_gpdb_binaries_tarball(){
+    pushd "${BASE_DIR}/gpdb_src"
+        git --no-pager show --summary refs/tags/"${GPDB_RELEASE_TAG}"
+
+        # TODO: adding the gpdb_bin_${PLATFORM} tar.gz here
+        # The tar.gz and .zip files are the github release attachements.
+        # here, I just want to test the uploading attachments function for github release concourse resource.
+        # later, we can upload the binaries of gpdb instead of them.
+        # eg. bin_gpdb_centos6.tar.gz, bin_gpdb_unbuntu18.04.tar.gz ...
+
+        git archive -o "${BASE_DIR}/release_artifacts/${GPDB_RELEASE_TAG}.tar.gz" --prefix="gpdb-${GPDB_RELEASE_TAG}/"  --format=tar.gz  refs/tags/"${GPDB_RELEASE_TAG}"
+        git archive -o "${BASE_DIR}/release_artifacts/${GPDB_RELEASE_TAG}.zip" --prefix="gpdb-${GPDB_RELEASE_TAG}/" --format=zip  -9 refs/tags/"${GPDB_RELEASE_TAG}"
+    popd
+
+    # Prepare for the gpdb github release
+    echo "${GPDB_RELEASE_TAG}" > "release_artifacts/name"
+    echo "${GPDB_RELEASE_TAG}" > "release_artifacts/tag"
+    echo "Greenplum-db version: ${GPDB_RELEASE_TAG}" > "release_artifacts/body"
+
+
+}
+
+function _main(){
+    local __gpdb_release_commit_sha
+
+    echo "Current Released Tag: ${GPDB_RELEASE_TAG}"
+
+    __gpdb_release_commit_sha=$(get_release_commit_sha "${GPDB_RELEASE_TAG}")
+    echo "The commit SHA of current release: ${__gpdb_release_commit_sha}"
+
+    tag_gpdb_src "${GPDB_RELEASE_TAG}" "${__gpdb_release_commit_sha}"
+    echo "Created tag: ${GPDB_RELEASE_TAG} on gpdb_src successfully!"
+
+    build_gpdb_binaries_tarball
+    echo "Created the release binaries successfully! [tar.gz, zip]"
+
+    push_gpdb_src_tags_to_remote
+    echo "Pushed all tags of gpdb repo successfully!"
+}
+
+_main

--- a/concourse/tasks/gpdb_github_release.yml
+++ b/concourse/tasks/gpdb_github_release.yml
@@ -1,0 +1,20 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+
+inputs:
+- name: gpdb_src
+- name: gpdb_staging
+- name: pivotal_gpdb
+
+outputs:
+- name: release_artifacts
+
+run:
+  path: gpdb_src/concourse/scripts/gpdb_github_release.bash
+
+params:
+  GPDB_SRC_DEPLOY_KEY:


### PR DESCRIPTION
Automatic creation of Github Tags and Releases

When a new gpdb release published on the pivnet, it will create a new tag on the greenplum-db/gpdb automatically and create a new github release.

Authored-by: Tingfang Bao <bbao@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
