### PR TITLE
remove references to gp_enable_adaptive_nestloop GUC

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -455,9 +455,6 @@
                   <codeph>enable_tidscan</codeph>
                 </p>
                 <p>
-                  <codeph>gp_enable_adaptive_nestloop</codeph>
-                </p>
-                <p>
                   <codeph>gp_enable_agg_distinct</codeph>
                 </p>
               </stentry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -193,9 +193,6 @@
               <xref href="#gp_dynamic_partition_pruning"/>
             </li>
             <li>
-              <xref href="#gp_enable_adaptive_nestloop"/>
-            </li>
-            <li>
               <xref href="#gp_enable_agg_distinct"/>
             </li>
             <li>
@@ -2790,37 +2787,6 @@
           <tbody>
             <row>
               <entry colname="col1">on/off</entry>
-              <entry colname="col2">on</entry>
-              <entry colname="col3">master<p>session</p><p>reload</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="gp_enable_adaptive_nestloop">
-    <title>gp_enable_adaptive_nestloop</title>
-    <body>
-      <p>Enables the use a new type of join node called "Adaptive Nestloop" at query execution time
-        by the Postgres query optimizer (planner). This causes the Postgres optimizer to favor a
-        hash-join over a nested-loop join if the number of rows on the outer side of the join
-        exceeds a precalculated threshold. This parameter improves performance of index operations,
-        which previously favored slower nested-loop joins. </p>
-      <table id="gp_enable_adaptive_nestloop_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">Boolean</entry>
               <entry colname="col2">on</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -410,10 +410,6 @@
                 <xref href="guc-list.xml#enable_tidscan" type="section">enable_tidscan</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_enable_adaptive_nestloop" type="section"
-                  >gp_enable_adaptive_nestloop</xref>
-              </p>
-              <p>
                 <xref href="guc-list.xml#gp_enable_agg_distinct" type="section"
                   >gp_enable_agg_distinct</xref>
               </p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -87,7 +87,6 @@
             <topicref href="guc-list.xml#gp_debug_linger"/>
             <topicref href="guc-list.xml#gp_default_storage_options"/>
             <topicref href="guc-list.xml#gp_dynamic_partition_pruning"/>
-            <topicref href="guc-list.xml#gp_enable_adaptive_nestloop"/>
             <topicref href="guc-list.xml#gp_enable_agg_distinct"/>
             <topicref href="guc-list.xml#gp_enable_agg_distinct_pruning"/>
             <topicref href="guc-list.xml#gp_enable_direct_dispatch"/>


### PR DESCRIPTION
remove references to the gp_enable_adaptive_nestloop GUC.  hasn't been around for a while, this will be backported to 6X_STABLE and 5X_STABLE.
