### PR TITLE
Port to 5X: Create an ArrayExpr from an array of constants

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.46.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.47.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.46.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.47.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.46.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.47.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.46.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.47.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.46.0@gpdb/stable
+orca/v3.47.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.46.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.47.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -1831,13 +1831,12 @@ fold_constants(PlannerGlobal *glob, Query *q, ParamListInfo boundParams, Size ma
  * the ArrayExpr into its disjunctive normal form and then deriving constraints
  * based on the elements in the ArrayExpr. It doesn't currently know how to
  * extract elements from an Array const, however, so to enable those
- * optimizations in ORCA, we convert small Array Consts into corresponding
+ * optimizations in ORCA,  we convert Array Consts into corresponding
  * ArrayExprs.
  *
- * If the argument is not an array constant or the number of elements in the
- * array is greater than optimizer_array_expansion_threshold, returns the
- * original Const unmodified since it is expensive to derive constraints for
- * large arrays.
+ * If the argument is not an array constant return the original Const unmodified.
+ * We convert an array const of any size to ArrayExpr. ORCA can use it to derive
+ * statistics.
  */
 Expr *
 transform_array_Const_to_ArrayExpr(Const *c)
@@ -1870,9 +1869,6 @@ transform_array_Const_to_ArrayExpr(Const *c)
 	get_typlenbyvalalign(elemtype, &elemlen, &elembyval, &elemalign);
 	deconstruct_array(ac, elemtype, elemlen, elembyval, elemalign,
 					  &elems, &nulls, &nelems);
-
-	if (nelems > optimizer_array_expansion_threshold)
-		return (Expr *) c;	/* too many elements */
 
 	aexpr = makeNode(ArrayExpr);
 	aexpr->array_typeid = c->consttype;


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

Earlier we didn't bother converting an in list of constants into an ArrayExpr
when then number of elements was larger than array_expansion_threshold.

We still should create an ArrayExpr because it can be useful in deriving stats
on filters even if we are not deriving constraints on it.

Corresponding ORCA PR: greenplum-db/gporca#487


