### PR TITLE
6X_BACKPORT: Remove downloading out of gpAux/releng/releng.mk (#7838)

### DIFF
--- a/concourse/scripts/sync_tools.bash
+++ b/concourse/scripts/sync_tools.bash
@@ -13,8 +13,12 @@ function make_sync_tools() {
   popd
   case "${TARGET_OS}" in
     centos|ubuntu)
+      wget -q -O - https://github.com/greenplum-db/gporca/archive/v3.47.0.tar.gz | tar zxf - -C ${GPDB_SRC_PATH}/gpAux/ext/${BLD_ARCH}
       mkdir -p orca_src
       mv ${GPDB_SRC_PATH}/gpAux/ext/${BLD_ARCH}/gporca*/* orca_src/
+      ;;
+    sles)
+      wget -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.47.0/bin_orca_centos5_release.tar.gz | tar zxf - -C ${GPDB_SRC_PATH}/gpAux/ext/${BLD_ARCH}
       ;;
   esac
 }

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -86,14 +86,6 @@ sync_tools: opt_write_test
 	-Divyrepo.host=$(IVYREPO_HOST) -Divyrepo.realm="$(IVYREPO_REALM)" \
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
-ifeq "$(findstring aix,$(BLD_ARCH))" ""
-ifeq "$(findstring sles,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/archive/v3.47.0.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
-else
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.47.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
-endif
-endif
-
 clean_tools: opt_write_test
 	@cd releng/make/dependencies; \
 	/opt/releng/apache-ant/bin/ant clean; \


### PR DESCRIPTION
This a the same PR 7838 as to master, backport to 6X_STABLE
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
