### PR TITLE
5X: resgroup: retire the memory_spill_ratio absolute value format

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -32,24 +32,16 @@
 #include "utils/builtins.h"
 #include "utils/datetime.h"
 #include "utils/fmgroids.h"
-#include "utils/guc_tables.h"
 #include "utils/resgroup.h"
 #include "utils/resgroup-ops.h"
 #include "utils/resource_manager.h"
 #include "utils/resowner.h"
 #include "utils/syscache.h"
 #include "utils/faultinjector.h"
-#include "utils/vmem_tracker.h"
 
 #define RESGROUP_DEFAULT_CONCURRENCY (20)
-#define RESGROUP_DEFAULT_MEMORY_LIMIT (0)
-#define RESGROUP_DEFAULT_MEM_SHARED_QUOTA (80)
-/*
- * The default memory_spill_ratio value is 128MB, it is in absolute value
- * format, so it is represented as a negative value, and as its unit is chunk,
- * so need a conversion.
- */
-#define RESGROUP_DEFAULT_MEM_SPILL_RATIO (-VmemTracker_ConvertVmemMBToChunks(128))
+#define RESGROUP_DEFAULT_MEM_SHARED_QUOTA (20)
+#define RESGROUP_DEFAULT_MEM_SPILL_RATIO (20)
 
 #define RESGROUP_DEFAULT_MEM_AUDITOR (RESGROUP_MEMORY_AUDITOR_VMTRACKER)
 #define RESGROUP_INVALID_MEM_AUDITOR (-1)
@@ -608,7 +600,8 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 													   getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO:
-				resgroupCaps->memSpillRatio = ResGroupMemorySpillFromStr(proposed);
+				resgroupCaps->memSpillRatio = str2Int(proposed,
+													  getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR:
 				resgroupCaps->memAuditor = str2Int(proposed,
@@ -836,10 +829,6 @@ getResgroupOptionValue(DefElem *defel, int type)
 		char *auditor_name = defGetString(defel);
 		value = getResGroupMemAuditor(auditor_name);
 	}
-	else if (type == RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO)
-	{
-		value = ResGroupMemorySpillFromStr(defGetString(defel));
-	}
 	else
 	{
 		value = defGetInt64(defel);
@@ -931,12 +920,13 @@ checkResgroupCapLimit(ResGroupLimitType type, int value)
 				break;
 
 			case RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO:
-				/*
-				 * memory_spill_ratio is already checked when parsing it.
-				 *
-				 * On the other hand negative value is used as absolute value,
-				 * there is no chance to check the range now, so nothing to do.
-				 */
+				if (value < RESGROUP_MIN_MEMORY_SPILL_RATIO ||
+					value > RESGROUP_MAX_MEMORY_SPILL_RATIO)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							errmsg("memory_spill_ratio range is [%d, %d]",
+								   RESGROUP_MIN_MEMORY_SPILL_RATIO,
+								   RESGROUP_MAX_MEMORY_SPILL_RATIO)));
 				break;
 
 			case RESGROUP_LIMIT_TYPE_MEMORY_AUDITOR:
@@ -962,13 +952,15 @@ static void
 checkResgroupCapConflicts(ResGroupCaps *caps)
 {
 	/*
-	 * When memory_limit is unlimited the memory_spill_ratio must be set in
-	 * absolute value format.
+	 * When memory_limit is unlimited the memory_spill_ratio must be set to
+	 * 'fallback' mode to use the statement_mem.
 	 */
-	if (caps->memLimit == 0 && caps->memSpillRatio > 0)
+	if (caps->memLimit == RESGROUP_UNLIMITED_MEMORY_LIMIT &&
+		caps->memSpillRatio != RESGROUP_FALLBACK_MEMORY_SPILL_RATIO)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("when memory_limit is unlimited memory_spill_ratio must be set in absolute value format")));
+				 errmsg("when memory_limit is unlimited memory_spill_ratio must be set to %d",
+						RESGROUP_FALLBACK_MEMORY_SPILL_RATIO)));
 
 	/*
 	 * When memory_auditor is cgroup the concurrency must be 0.
@@ -1068,6 +1060,11 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 	if ((mask & (1 << RESGROUP_LIMIT_TYPE_CPUSET)))
 		EnsureCpusetIsAvailable(ERROR);
 
+	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_MEMORY)))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("must specify memory_limit")));
+
 	if ((mask & (1 << RESGROUP_LIMIT_TYPE_CPU)) &&
 		(mask & (1 << RESGROUP_LIMIT_TYPE_CPUSET)))
 		ereport(ERROR,
@@ -1079,9 +1076,6 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("must specify cpu_rate_limit or cpuset")));
-
-	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_MEMORY)))
-		caps->memLimit = RESGROUP_DEFAULT_MEMORY_LIMIT;
 
 	if (!(mask & (1 << RESGROUP_LIMIT_TYPE_CONCURRENCY)))
 		caps->concurrency = RESGROUP_DEFAULT_CONCURRENCY;
@@ -1183,7 +1177,7 @@ insertResgroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *caps)
 	insertResgroupCapabilityEntry(rel, groupId,
 								  RESGROUP_LIMIT_TYPE_MEMORY_SHARED_QUOTA, value);
 
-	ResGroupMemorySpillToStr(caps->memSpillRatio, value, sizeof(value));
+	sprintf(value, "%d", caps->memSpillRatio);
 	insertResgroupCapabilityEntry(rel, groupId,
 								  RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO, value);
 
@@ -1253,10 +1247,6 @@ updateResgroupCapabilityEntry(Relation rel,
 	if (limitType == RESGROUP_LIMIT_TYPE_CPUSET)
 	{
 		StrNCpy(stringBuffer, strValue, sizeof(stringBuffer));
-	}
-	else if (limitType == RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO)
-	{
-		ResGroupMemorySpillToStr((int32) value, stringBuffer, sizeof(stringBuffer));
 	}
 	else
 	{
@@ -1598,102 +1588,4 @@ checkCpusetSyntax(const char *cpuset)
 		return false;
 	}
 	return true;
-}
-
-/*
- * Parse memory_spill_ratio from string.
- *
- * It has two input formats:
- * - the percentage format is an integer value within [0, 100], return the
- *   percentage;
- * - the absolute value format is in "number unit" format, where "unit" can be
- *   "kB", "MB", "GB" or "TB", the "number" must be > 0, it is converted to
- *   chunks, return (-1 * chunks);
- */
-int32
-ResGroupMemorySpillFromStr(const char *str)
-{
-	const char *prop = "memory_spill_ratio";
-	int32		value;
-
-	/* if memory spill ratio is percentile value */
-	if (parse_int(str, &value, 0, NULL))
-	{
-		if (value < RESGROUP_MIN_MEMORY_SPILL_RATIO ||
-			value > RESGROUP_MAX_MEMORY_SPILL_RATIO)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("%s in percentage format must be in the range [%d, %d]",
-							prop,
-							RESGROUP_MIN_MEMORY_SPILL_RATIO,
-							RESGROUP_MAX_MEMORY_SPILL_RATIO)));
-		return value;
-	}
-	/* for absolute value, all int value are allowed */
-	else if (parse_int(str, &value, GUC_UNIT_KB, NULL))
-	{
-		if (value <= 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("%s in absolute value format must be > 0", prop)));
-
-		return -Max(1,
-					VmemTracker_ConvertVmemMBToChunks(value >> 10));
-	}
-	else
-		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("syntax error on capability %s", prop)));
-}
-
-/*
- * Convert memory_spill_ratio to a string.
- *
- * Refer to ResGroupMemorySpillFromStr() for details of the string format.
- */
-void
-ResGroupMemorySpillToStr(int32 value, char *buf, int bufsize)
-{
-	if (value >= 0)
-	{
-		/* The value is in the percentage format */
-		snprintf(buf, bufsize, "%d", value);
-	}
-	else
-	{
-		/* The value is in the absolute value format */
-
-		/* Below logic is derived from _ShowOption() */
-
-#define KB_PER_MB (1024)
-#define KB_PER_GB (1024*1024)
-#define KB_PER_TB (1024*1024*1024)
-
-		int64		result;
-		const char *unit;
-
-		result = -(VmemTracker_ConvertVmemChunksToMB(value) << 10);
-		if (result % KB_PER_TB == 0)
-		{
-			result /= KB_PER_TB;
-			unit = "TB";
-		}
-		else if (result % KB_PER_GB == 0)
-		{
-			result /= KB_PER_GB;
-			unit = "GB";
-		}
-		else if (result % KB_PER_MB == 0)
-		{
-			result /= KB_PER_MB;
-			unit = "MB";
-		}
-		else
-		{
-			unit = "kB";
-		}
-
-		snprintf(buf, bufsize, INT64_FORMAT " %s",
-				 result, unit);
-	}
 }

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -1359,10 +1359,6 @@ OptResourceGroupElem:
 				{
 					$$ = makeDefElem("memory_spill_ratio", (Node *)$2);
 				}
-			| MEMORY_SPILL_RATIO Sconst
-				{
-					$$ = makeDefElem("memory_spill_ratio", (Node *) makeString($2));
-				}
 		;
 
 /*****************************************************************************

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -124,10 +124,6 @@ static const char *assign_gp_default_storage_options(
 static bool assign_pljava_classpath_insecure(bool newval, bool doit, GucSource source);
 static bool assign_gp_resource_group_bypass(bool newval, bool doit, GucSource source);
 
-static const char *assign_memory_spill_ratio(const char *newval, bool doit,
-											 GucSource source pg_attribute_unused());
-static const char *show_memory_spill_ratio(void);
-
 extern struct config_generic *find_option(const char *name, bool create_placeholders, int elevel);
 
 extern bool enable_partition_rules;
@@ -360,7 +356,6 @@ static char *gp_workfile_caching_loglevel_str;
 static char *gp_sessionstate_loglevel_str;
 static char *explain_memory_verbosity_str;
 static char *optimizer_join_order_str;
-static char *memory_spill_ratio_str;
 
 /* Backoff-related GUCs */
 bool		gp_enable_resqueue_priority;
@@ -3522,6 +3517,15 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"memory_spill_ratio", PGC_USERSET, RESOURCES_MEM,
+			gettext_noop("Sets the memory_spill_ratio for resource group."),
+			NULL
+		},
+		&memory_spill_ratio,
+		20, 0, 100, NULL, NULL
+	},
+
+	{
 		{"gp_resource_group_cpu_priority", PGC_POSTMASTER, RESOURCES,
 			gettext_noop("Sets the cpu priority for postgres processes when resource group is enabled."),
 			NULL
@@ -5446,20 +5450,6 @@ struct config_string ConfigureNamesString_gp[] =
 		"eager_free", gpvars_assign_gp_resgroup_memory_policy, gpvars_show_gp_resgroup_memory_policy
 	},
 
-	/*
-	 * Default value of the memory_spill_ratio GUC will be ignored.
-	 * Refer to ResGroupMemorySpillFromStr() for details of the string format.
-	 */
-	{
-		{"memory_spill_ratio", PGC_USERSET, RESOURCES_MEM,
-			gettext_noop("Sets the memory_spill_ratio for resource group.")
-		},
-		&memory_spill_ratio_str,
-		"0",
-		assign_memory_spill_ratio,
-		show_memory_spill_ratio
-	},
-
 	{
 		{"gp_test_time_slice_report_level", PGC_USERSET, LOGGING_WHEN,
 			gettext_noop("Sets the message level for time slice violation reports."),
@@ -5948,30 +5938,6 @@ assign_gp_resource_group_bypass(bool newval, bool doit, GucSource source)
 
 	elog(ERROR, "SET gp_resource_group_bypass cannot run inside a transaction block");
 	return false;
-}
-
-static const char *
-assign_memory_spill_ratio(const char *newval, bool doit,
-						  GucSource source pg_attribute_unused())
-{
-	int32		value;
-
-	value = ResGroupMemorySpillFromStr(newval);
-
-	if (doit)
-		memory_spill_ratio = value;
-
-	return newval;
-}
-
-static const char *
-show_memory_spill_ratio(void)
-{
-	static char buf[16];
-
-	ResGroupMemorySpillToStr(memory_spill_ratio, buf, sizeof(buf));
-
-	return buf;
 }
 
 static const char *

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2045,12 +2045,12 @@ groupGetMemSharedExpected(const ResGroupCaps *caps)
 static int32
 groupGetMemSpillTotal(const ResGroupCaps *caps)
 {
-	if (memory_spill_ratio >= 0)
-		/* memSpill is in percentage format */
+	if (memory_spill_ratio != RESGROUP_FALLBACK_MEMORY_SPILL_RATIO)
+		/* memSpill is in percentage mode */
 		return groupGetMemExpected(caps) * memory_spill_ratio / 100;
 	else
-		/* memSpill is in absolute value format */
-		return -memory_spill_ratio;
+		/* memSpill is in fallback mode, return statement_mem instead */
+		return VmemTracker_ConvertVmemMBToChunks(statement_mem >> 10);
 }
 
 /*
@@ -2091,15 +2091,20 @@ slotGetMemQuotaOnQE(const ResGroupCaps *caps, ResGroupData *group)
 static int32
 slotGetMemSpill(const ResGroupCaps *caps)
 {
-	if (memory_spill_ratio >= 0)
+	if (memory_spill_ratio != RESGROUP_FALLBACK_MEMORY_SPILL_RATIO)
 	{
-		/* memSpill is in percentage format */
+		/* memSpill is in percentage mode */
 		Assert(caps->concurrency != 0);
 		return groupGetMemSpillTotal(caps) / caps->concurrency;
 	}
 	else
-		/* memSpill is in absolute value format */
+	{
+		/*
+		 * memSpill is in fallback mode, it is an absolute value, no need to
+		 * divide by concurrency.
+		 */
 		return groupGetMemSpillTotal(caps);
+	}
 }
 
 /*
@@ -3010,7 +3015,7 @@ groupSetMemorySpillRatio(const ResGroupCaps *caps)
 {
 	char value[64];
 
-	ResGroupMemorySpillToStr(caps->memSpillRatio, value, sizeof(value));
+	snprintf(value, sizeof(value), "%d", caps->memSpillRatio);
 	set_config_option("memory_spill_ratio", value, PGC_USERSET, PGC_S_RESGROUP,
 					  GUC_ACTION_SET, true);
 }

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -35,6 +35,20 @@
 #define DefaultCpuset "-1"
 
 /*
+ * When setting memory_limit to 0 the group will has no reserved quota, all the
+ * memory need to be acquired from the global shared memory.
+ */
+#define RESGROUP_UNLIMITED_MEMORY_LIMIT		(0)
+
+/*
+ * When setting memory_spill_ratio to 0 the statement_mem will be used to
+ * decide the operator memory, this is called the fallback mode, the benefit is
+ * statement_mem can be set in absolute values such as "128 MB" which is easier
+ * to understand.
+ */
+#define RESGROUP_FALLBACK_MEMORY_SPILL_RATIO		(0)
+
+/*
  * Resource group capability.
  */
 typedef int32 ResGroupCap;
@@ -185,9 +199,6 @@ extern int64 ResourceGroupGetQueryMemoryLimit(void);
 extern void ResGroupDumpInfo(StringInfo str);
 
 extern int ResGroupGetSegmentNum(void);
-
-extern int32 ResGroupMemorySpillFromStr(const char *str);
-extern void ResGroupMemorySpillToStr(int32 value, char *buf, int bufsize);
 
 extern Bitmapset *CpusetToBitset(const char *cpuset,
 								 int len);

--- a/src/test/isolation2/expected/resgroup/resgroup_alter_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_alter_memory_spill_ratio.out
@@ -60,7 +60,7 @@ rg_spill_test|20                 |20                          |81               
 
 -- negative: memory_spill_ratio is negative
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO -1;
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ERROR:  memory_spill_ratio range is [0, 100]
 SELECT * FROM rg_spill_status;
 groupname    |memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------------+-------------------+----------------------------+------------------+---------------------------

--- a/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_operator_memory.out
@@ -10,10 +10,8 @@ DROP VIEW IF EXISTS many_ops;
 DROP ROLE r1_opmem_test;
 DROP RESOURCE GROUP rg1_opmem_test;
 DROP RESOURCE GROUP rg2_opmem_test;
---end_ignore
-
 CREATE LANGUAGE plpythonu;
-CREATE
+--end_ignore
 
 -- a helper function to run query via SPI
 CREATE OR REPLACE FUNCTION f1_opmem_test() RETURNS void AS $$ plpy.execute("""select * from gp_dist_random('gp_id')""") $$ LANGUAGE plpythonu;
@@ -62,7 +60,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |10                |10                         
 (1 row)
 RESET role;
 RESET
@@ -74,7 +72,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |10                |10                         
 (1 row)
 RESET role;
 RESET
@@ -130,7 +128,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |10                |10                         
 (1 row)
 RESET role;
 RESET
@@ -142,7 +140,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |10                |10                         
 (1 row)
 RESET role;
 RESET
@@ -169,7 +167,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |10                |10                         
 (1 row)
 RESET role;
 RESET
@@ -181,7 +179,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |10                |10                         
 (1 row)
 RESET role;
 RESET
@@ -200,7 +198,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |10                |10                         
 (1 row)
 SELECT f1_opmem_test();
 f1_opmem_test
@@ -217,7 +215,7 @@ SET
 SELECT * FROM many_ops;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |10                |10                         
 (1 row)
 SELECT f1_opmem_test();
 f1_opmem_test

--- a/src/test/isolation2/expected/resgroup/resgroup_set_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_set_memory_spill_ratio.out
@@ -5,7 +5,7 @@
 SHOW memory_spill_ratio;
 memory_spill_ratio
 ------------------
-100 MB            
+10                
 (1 row)
 
 --start_ignore
@@ -58,7 +58,7 @@ SELECT 1;
 1       
 (1 row)
 
--- positive set to session level use work_mem
+-- positive fallback to statement_mem at session level
 SET MEMORY_SPILL_RATIO TO 0;
 SET
 SHOW MEMORY_SPILL_RATIO;
@@ -74,7 +74,7 @@ SELECT 1;
 
 -- negative set to session level
 SET MEMORY_SPILL_RATIO TO -1;
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ERROR:  -1 is outside the valid range for parameter "memory_spill_ratio" (0 .. 100)
 SHOW MEMORY_SPILL_RATIO;
 memory_spill_ratio
 ------------------
@@ -112,121 +112,6 @@ SELECT 1;
 ?column?
 --------
 1       
-(1 row)
-
--- positive set to session level
-SET MEMORY_SPILL_RATIO TO '20MB';
-SET
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-20 MB             
-(1 row)
-SELECT 1;
-?column?
---------
-1       
-(1 row)
-
--- positive set to session level
-SET MEMORY_SPILL_RATIO TO '20000kB';
-SET
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-19 MB             
-(1 row)
-SELECT 1;
-?column?
---------
-1       
-(1 row)
-
--- positive set to session level? can run?
-SET MEMORY_SPILL_RATIO TO '20GB';
-SET
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-20 GB             
-(1 row)
-SELECT 1;
-?column?
---------
-1       
-(1 row)
-
--- positive set to session level? can run?
-SET MEMORY_SPILL_RATIO TO '20  MB  ';
-SET
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-20 MB             
-(1 row)
-SELECT 1;
-?column?
---------
-1       
-(1 row)
-
--- negative oom when oprator memory is too large
-SET MEMORY_SPILL_RATIO TO '100GB';
-SET
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-100 GB             
-(1 row)
-SELECT * FROM gp_toolkit.gp_resgroup_config ;
-ERROR:  Out of memory
-DETAIL:  Resource group memory limit reached
-RESET MEMORY_SPILL_RATIO;
-RESET
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '10 %';
-ERROR:  syntax error on capability memory_spill_ratio
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-30                
-(1 row)
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '10.M';
-ERROR:  syntax error on capability memory_spill_ratio
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-30                
-(1 row)
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '-10M';
-ERROR:  syntax error on capability memory_spill_ratio
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-30                
-(1 row)
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '-10';
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-30                
-(1 row)
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '0x10M';
-ERROR:  syntax error on capability memory_spill_ratio
-SHOW MEMORY_SPILL_RATIO;
-memory_spill_ratio
-------------------
-30                
 (1 row)
 
 -- reset to resource group level

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -82,8 +82,8 @@ ERROR:  resource group "rg_test_group" does not exist
 SELECT * FROM gp_toolkit.gp_resgroup_config;
 groupid|groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|proposed_memory_shared_quota|memory_spill_ratio|proposed_memory_spill_ratio
 -------+-------------+-----------+--------------------+--------------+------------+---------------------+-------------------+----------------------------+------------------+---------------------------
-6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |100 MB            |100 MB                     
-6438   |admin_group  |2          |2                   |10            |10          |10                   |80                 |80                          |100 MB            |100 MB                     
+6437   |default_group|20         |20                  |30            |30          |30                   |80                 |80                          |10                |10                         
+6438   |admin_group  |2          |2                   |10            |10          |10                   |80                 |80                          |10                |10                         
 (2 rows)
 
 -- negative
@@ -102,9 +102,13 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 ERROR:  resource group "rg_test_group" already exists
 DROP RESOURCE GROUP rg_test_group;
 DROP
--- must specify cpu_rate_limit or cpuset
+-- must specify both memory_limit and (cpu_rate_limit or cpuset)
 CREATE RESOURCE GROUP rg_test_group WITH (memory_limit=10);
 ERROR:  must specify cpu_rate_limit or cpuset
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
+ERROR:  must specify memory_limit
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
+ERROR:  must specify memory_limit
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
 ERROR:  Find duplicate resource group resource type: concurrency
@@ -188,7 +192,7 @@ CREATE
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
 -------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
-rg_test_group|20         |20                  |10            |10          |10                   |80                 |128 MB            
+rg_test_group|20         |20                  |10            |10          |10                   |20                 |20                
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
@@ -198,24 +202,6 @@ SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,pr
 groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
 -------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
 rg_test_group|1          |1                   |-1            |10          |10                   |70                 |30                
-(1 row)
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
-CREATE
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
-groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
--------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
-rg_test_group|20         |20                  |10            |0           |0                    |80                 |128 MB            
-(1 row)
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
-CREATE
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
-groupname    |concurrency|proposed_concurrency|cpu_rate_limit|memory_limit|proposed_memory_limit|memory_shared_quota|memory_spill_ratio
--------------+-----------+--------------------+--------------+------------+---------------------+-------------------+------------------
-rg_test_group|20         |20                  |-1            |0           |0                    |80                 |128 MB            
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
@@ -278,7 +264,7 @@ CREATE
 DROP RESOURCE GROUP rg_test_group;
 DROP
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=10, memory_spill_ratio=-1);
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ERROR:  memory_spill_ratio range is [0, 100]
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=-1, memory_spill_ratio=10);
 ERROR:  memory_shared_quota range is [0, 100]
 
@@ -361,88 +347,29 @@ CREATE
 DROP RESOURCE GROUP rg_test_group;
 DROP
 
--- negative: absolute value format of memory_spill_ratio is
--- '^[1-9][0-9]*[MmGg]$'
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 %');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10%');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 M');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.MB');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.0MB');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M ');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10B');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10K');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10X');
-ERROR:  syntax error on capability memory_spill_ratio
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10MB');
-ERROR:  memory_spill_ratio in absolute value format must be > 0
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='0 MB');
-ERROR:  memory_spill_ratio in absolute value format must be > 0
-DROP RESOURCE GROUP rg_test_group;
-ERROR:  resource group "rg_test_group" does not exist
 -- negative: memory_spill_ratio does not accept out of range percentage values
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10');
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='101');
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
--- negative: when memory_limit is unlimited memory_spill_ratio must be set in
--- absolute value format
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=-1);
+ERROR:  memory_spill_ratio range is [0, 100]
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=101);
+ERROR:  memory_spill_ratio range is [0, 100]
+
+-- negative: memory_spill_ratio does not accept string values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='0');
+ERROR:  memory_spill_ratio requires a numeric value
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10');
+ERROR:  memory_spill_ratio requires a numeric value
+
+-- negative: memory_spill_ratio does not accept float values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10.5);
+ERROR:  invalid input syntax for integer: "10.5"
+
+-- negative: when memory_limit is unlimited memory_spill_ratio must be set to 0
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=10);
-ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='10%');
-ERROR:  syntax error on capability memory_spill_ratio
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set to 0
 
 -- positive
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100kB');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=0);
 CREATE
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
-CREATE
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100GB');
-CREATE
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=' 100 MB ');
-CREATE
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='0x10 MB');
-CREATE
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='010 MB');
-CREATE
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='+10 MB');
-CREATE
-DROP RESOURCE GROUP rg_test_group;
-DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
-CREATE
-DROP RESOURCE GROUP rg_test_group;
-DROP
-
--- positive: memory_spill_ratio in absolute value format will be ensured to be >= 1 chunk
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='1kB');
-CREATE
-SELECT memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
-memory_spill_ratio
-------------------
-1 MB              
-(1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
 
@@ -592,88 +519,67 @@ ERROR:  You cannot assign a role to this resource group because the memory_audit
 DROP RESOURCE GROUP cgroup_audited_group;
 DROP
 
--- positive: memory_spill_ratio accepts both integer and string values
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+-- positive: memory_spill_ratio accepts integer values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=20);
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
-ALTER
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
 ALTER
 DROP RESOURCE GROUP rg_test_group;
 DROP
 
--- negative: memory_spill_ratio only accepts string value
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+-- negative: memory_spill_ratio only accepts integer values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=20);
 CREATE
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10%;
-ERROR:  syntax error at or near "%"
-LINE 1: ...TER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10%;
-                                                                     ^
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10M;
-ERROR:  syntax error at or near "M"
-LINE 1: ...TER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10M;
-                                                                     ^
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10MB;
-ERROR:  syntax error at or near "MB"
-LINE 1: ...ER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10MB;
-                                                                    ^
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+ERROR:  syntax error at or near "'10'"
+LINE 1: ...ER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+                                                                  ^
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10.5;
+ERROR:  syntax error at or near "10.5"
+LINE 1: ...ER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10.5;
+                                                                  ^
 DROP RESOURCE GROUP rg_test_group;
 DROP
--- negative: memory_spill_ratio does not accept out of range percentage values
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+
+-- negative: memory_spill_ratio does not accept out of range values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=20);
 CREATE
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1';
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '101';
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1MB';
-ERROR:  memory_spill_ratio in absolute value format must be > 0
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '0MB';
-ERROR:  memory_spill_ratio in absolute value format must be > 0
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio -1;
+ERROR:  memory_spill_ratio range is [0, 100]
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 101;
+ERROR:  memory_spill_ratio range is [0, 100]
 DROP RESOURCE GROUP rg_test_group;
 DROP
--- positive: memory_limit can be altered to unlimited if memory_spill_ratio has
--- an absolute value
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+
+-- positive: memory_limit can be altered to unlimited if memory_spill_ratio is 0
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=0);
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
 ALTER
 DROP RESOURCE GROUP rg_test_group;
 DROP
--- negative: memory_spill_ratio only accepts an absolute value if memory_limit
--- is unlimited
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+
+-- negative: memory_spill_ratio can only be set to 0 if memory_limit is unlimited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=0);
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
-ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
-ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set to 0
 DROP RESOURCE GROUP rg_test_group;
 DROP
+
 -- positive: memory_spill_ratio accepts a percentage value only if
 -- memory_limit is limited
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=0);
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
 ALTER
 DROP RESOURCE GROUP rg_test_group;
 DROP
--- negative: memory_limit must be limited if memory_spill_ratio has a
--- percentage value
+
+-- negative: memory_limit must be limited if memory_spill_ratio > 0
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
-ERROR:  when memory_limit is unlimited memory_spill_ratio must be set in absolute value format
-DROP RESOURCE GROUP rg_test_group;
-DROP
--- positive: memory_spill_ratio accepts a absolute value anytime
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10MB');
-CREATE
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '50MB';
-ALTER
-ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
-ALTER
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10MB';
-ALTER
+ERROR:  when memory_limit is unlimited memory_spill_ratio must be set to 0
 DROP RESOURCE GROUP rg_test_group;
 DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_unlimit_memory_spill_ratio.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_unlimit_memory_spill_ratio.out
@@ -20,7 +20,7 @@ DROP RESOURCE GROUP rg_spill_test;
 DROP
 
 CREATE RESOURCE GROUP rg_spill_test WITH (concurrency=10, cpu_rate_limit=20, memory_limit=20, memory_shared_quota=50, memory_spill_ratio=-1);
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ERROR:  memory_spill_ratio range is [0, 100]
 DROP RESOURCE GROUP rg_spill_test;
 ERROR:  resource group "rg_spill_test" does not exist
 
@@ -35,9 +35,9 @@ ALTER
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 100;
 ALTER
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO -1;
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ERROR:  memory_spill_ratio range is [0, 100]
 ALTER RESOURCE GROUP rg_spill_test SET MEMORY_SPILL_RATIO 10000;
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ERROR:  memory_spill_ratio range is [0, 100]
 
 DROP RESOURCE GROUP rg_spill_test;
 DROP
@@ -86,7 +86,7 @@ SELECT 1;
 (1 row)
 
 SET MEMORY_SPILL_RATIO TO -1;
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ERROR:  -1 is outside the valid range for parameter "memory_spill_ratio" (0 .. 100)
 SHOW MEMORY_SPILL_RATIO;
 memory_spill_ratio
 ------------------
@@ -99,7 +99,7 @@ SELECT 1;
 (1 row)
 
 SET MEMORY_SPILL_RATIO TO 10000;
-ERROR:  memory_spill_ratio in percentage format must be in the range [0, 100]
+ERROR:  10000 is outside the valid range for parameter "memory_spill_ratio" (0 .. 100)
 SHOW MEMORY_SPILL_RATIO;
 memory_spill_ratio
 ------------------

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -72,5 +72,5 @@ DROP FUNCTION adjust_memory_limit(bigint);
 0: ALTER RESOURCE GROUP default_group SET memory_shared_quota 80;
 -- in later cases we will SHOW memory_spill_ratio as first command
 -- to verify that it can be correctly loaded even for bypassed commands
-0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio '100 MB';
-0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio '100 MB';
+0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
+0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio 10;

--- a/src/test/isolation2/output/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup.source
@@ -101,7 +101,7 @@ ALTER
 ALTER
 -- in later cases we will SHOW memory_spill_ratio as first command
 -- to verify that it can be correctly loaded even for bypassed commands
-0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio '100 MB';
+0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
 ALTER
-0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio '100 MB';
+0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio 10;
 ALTER

--- a/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_operator_memory.sql
@@ -9,9 +9,8 @@ DROP VIEW IF EXISTS many_ops;
 DROP ROLE r1_opmem_test;
 DROP RESOURCE GROUP rg1_opmem_test;
 DROP RESOURCE GROUP rg2_opmem_test;
---end_ignore
-
 CREATE LANGUAGE plpythonu;
+--end_ignore
 
 -- a helper function to run query via SPI
 CREATE OR REPLACE FUNCTION f1_opmem_test() RETURNS void AS $$

--- a/src/test/isolation2/sql/resgroup/resgroup_set_memory_spill_ratio.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_set_memory_spill_ratio.sql
@@ -30,7 +30,7 @@ SET MEMORY_SPILL_RATIO TO 70;
 SHOW MEMORY_SPILL_RATIO;
 SELECT 1;
 
--- positive set to session level use work_mem
+-- positive fallback to statement_mem at session level
 SET MEMORY_SPILL_RATIO TO 0;
 SHOW MEMORY_SPILL_RATIO;
 SELECT 1;
@@ -49,52 +49,6 @@ SELECT 1;
 SET MEMORY_SPILL_RATIO TO 20;
 SHOW MEMORY_SPILL_RATIO;
 SELECT 1;
-
--- positive set to session level
-SET MEMORY_SPILL_RATIO TO '20MB';
-SHOW MEMORY_SPILL_RATIO;
-SELECT 1;
-
--- positive set to session level
-SET MEMORY_SPILL_RATIO TO '20000kB';
-SHOW MEMORY_SPILL_RATIO;
-SELECT 1;
-
--- positive set to session level? can run?
-SET MEMORY_SPILL_RATIO TO '20GB';
-SHOW MEMORY_SPILL_RATIO;
-SELECT 1;
-
--- positive set to session level? can run?
-SET MEMORY_SPILL_RATIO TO '20  MB  ';
-SHOW MEMORY_SPILL_RATIO;
-SELECT 1;
-
--- negative oom when oprator memory is too large
-SET MEMORY_SPILL_RATIO TO '100GB';
-SHOW MEMORY_SPILL_RATIO;
-SELECT * FROM gp_toolkit.gp_resgroup_config ;
-RESET MEMORY_SPILL_RATIO;
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '10 %';
-SHOW MEMORY_SPILL_RATIO;
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '10.M';
-SHOW MEMORY_SPILL_RATIO;
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '-10M';
-SHOW MEMORY_SPILL_RATIO;
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '-10';
-SHOW MEMORY_SPILL_RATIO;
-
--- negative set to session level
-SET MEMORY_SPILL_RATIO TO '0x10M';
-SHOW MEMORY_SPILL_RATIO;
 
 -- reset to resource group level
 RESET MEMORY_SPILL_RATIO;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -53,8 +53,10 @@ CREATE RESOURCE GROUP none WITH (cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 DROP RESOURCE GROUP rg_test_group;
--- must specify cpu_rate_limit or cpuset
+-- must specify both memory_limit and (cpu_rate_limit or cpuset)
 CREATE RESOURCE GROUP rg_test_group WITH (memory_limit=10);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 -- can't specify the resource limit type multiple times
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=5, memory_limit=5, concurrency=1);
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=5, memory_limit=5, cpu_rate_limit=5);
@@ -103,12 +105,6 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10);
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpuset='0', memory_limit=10, memory_shared_quota=70, memory_spill_ratio=30);
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10);
-SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
 
@@ -193,50 +189,22 @@ DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_shared_quota=99, memory_spill_ratio=1);
 DROP RESOURCE GROUP rg_test_group;
 
--- negative: absolute value format of memory_spill_ratio is
--- '^[1-9][0-9]*[MmGg]$'
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 %');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10%');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10 M');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.MB');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10.0MB');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10M ');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10B');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10K');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10X');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10MB');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='0 MB');
-DROP RESOURCE GROUP rg_test_group;
 -- negative: memory_spill_ratio does not accept out of range percentage values
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='-10');
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='101');
--- negative: when memory_limit is unlimited memory_spill_ratio must be set in
--- absolute value format
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=-1);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=101);
+
+-- negative: memory_spill_ratio does not accept string values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='0');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10');
+
+-- negative: memory_spill_ratio does not accept float values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10.5);
+
+-- negative: when memory_limit is unlimited memory_spill_ratio must be set to 0
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=10);
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='10%');
 
 -- positive
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100kB');
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100GB');
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=' 100 MB ');
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='0x10 MB');
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='010 MB');
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='+10 MB');
-DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0);
-DROP RESOURCE GROUP rg_test_group;
-
--- positive: memory_spill_ratio in absolute value format will be ensured to be >= 1 chunk
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='1kB');
-SELECT memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=0);
 DROP RESOURCE GROUP rg_test_group;
 
 -- ----------------------------------------------------------------------
@@ -306,49 +274,40 @@ ALTER RESOURCE GROUP cgroup_audited_group SET CONCURRENCY 10;
 CREATE ROLE cgroup_audited_role RESOURCE GROUP cgroup_audited_group;
 DROP RESOURCE GROUP cgroup_audited_group;
 
--- positive: memory_spill_ratio accepts both integer and string values
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+-- positive: memory_spill_ratio accepts integer values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=20);
 ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
 DROP RESOURCE GROUP rg_test_group;
 
--- negative: memory_spill_ratio only accepts string value
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10%;
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10M;
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10MB;
+-- negative: memory_spill_ratio only accepts integer values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=20);
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10.5;
 DROP RESOURCE GROUP rg_test_group;
--- negative: memory_spill_ratio does not accept out of range percentage values
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1';
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '101';
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '-1MB';
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '0MB';
+
+-- negative: memory_spill_ratio does not accept out of range values
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=20);
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio -1;
+ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 101;
 DROP RESOURCE GROUP rg_test_group;
--- positive: memory_limit can be altered to unlimited if memory_spill_ratio has
--- an absolute value
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+
+-- positive: memory_limit can be altered to unlimited if memory_spill_ratio is 0
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=0);
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
 DROP RESOURCE GROUP rg_test_group;
--- negative: memory_spill_ratio only accepts an absolute value if memory_limit
--- is unlimited
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio='100MB');
+
+-- negative: memory_spill_ratio can only be set to 0 if memory_limit is unlimited
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=0, memory_spill_ratio=0);
 ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10';
 DROP RESOURCE GROUP rg_test_group;
+
 -- positive: memory_spill_ratio accepts a percentage value only if
 -- memory_limit is limited
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='100MB');
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=0);
 ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio 10;
 DROP RESOURCE GROUP rg_test_group;
--- negative: memory_limit must be limited if memory_spill_ratio has a
--- percentage value
+
+-- negative: memory_limit must be limited if memory_spill_ratio > 0
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
-DROP RESOURCE GROUP rg_test_group;
--- positive: memory_spill_ratio accepts a absolute value anytime
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio='10MB');
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '50MB';
-ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
-ALTER RESOURCE GROUP rg_test_group SET memory_spill_ratio '10MB';
 DROP RESOURCE GROUP rg_test_group;


### PR DESCRIPTION
The memory_spill_ratio absolute value format was introduced in commit
2e931eeeec1b6b93be07a9f67b1590ee65400704 to explicitly specify the
operator memory in a unit like MB or KB in resource group mode.  But now
memory_spill_ratio has two formats: absolute value and percentage on the
same property, which is confusing and a bad user experience. Now we
retire this syntax, and provide a new fallback mode by setting
memory_spill_ratio to 0, then the statement_mem will be used to
calculate the operator memory instead of memory_spill_ratio itself.

Co-authored-by: Hubert Zhang <hzhang@pivotal.io>
Co-authored-by: Ning Yu <nyu@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
