### PR TITLE
Remove plain password from logs when run gpperfmon_install.

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpperfmon_install
+++ b/gpAux/gpperfmon/src/gpmon/gpperfmon_install
@@ -45,8 +45,15 @@ def run_command(cmd, verbose=False):
 
     if not options.verbose and not cmd.verbose:
         cmdstr = "%s >& /dev/null" % cmdstr
-
-    logger.info(cmdstr)
+    # hide password
+    if bool(re.search('CREATE ROLE.*ENCRYPTED PASSWORD',cmdstr)):
+        regex = re.compile('ENCRYPTED\sPASSWORD\s\'(.*)\'')
+        logger.info(regex.sub('ENCRYPTED PASSWORD \'********\'',cmdstr))
+    elif bool(re.search('echo.*:gpperfmon:gpmon:',cmdstr)):
+        regex = re.compile(':gpperfmon:gpmon:(.*)\"')
+        logger.info(regex.sub(':gpperfmon:gpmon:********',cmdstr))
+    else:
+        logger.info(cmdstr)
     p = Popen(cmdstr, shell=True, executable="/bin/bash")
     sts = os.waitpid(p.pid, 0)[1]
     if sts:

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -17,6 +17,8 @@ Feature: gpperfmon
         Given the database "gpperfmon" does not exist
         When the user runs "gpperfmon_install --port 15432 --enable --password foo"
         Then gpperfmon_install should return a return code of 0
+        Then gpperfmon_install should not print "foo" to stdout
+        Then gpperfmon_install should print "\*\*\*\*\*\*\*\*" to stdout
         Then verify that the last line of the file "postgresql.conf" in the master data directory contains the string "gpperfmon_log_alert_level='warning'"
         Then verify that the last line of the file "pg_hba.conf" in the master data directory contains the string "host     all         gpmon         ::1/128    md5"
         And verify that there is a "heap" table "database_history" in "gpperfmon"


### PR DESCRIPTION
Before this PR, when user run gpperfmon_install with a password,
it will output plain password into the log file.
In this PR, the password is replaced with ******** when printing
the output.

Backport to 5X_STABLE

Co-authored-by: Wenlin Zhang <wzhang@pivotal.io>
Co-authored-by: Renyuan Wang <rewang@pivotal.io>
