### PR TITLE
docs - restore the --skip-root-stats option to the analyzedb utility

### DIFF
--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -371,24 +371,25 @@
           partitioned table is similar to the time to analyze a non-partitioned table with the same
           data since <codeph>ANALYZE ROOTPARTITION</codeph> does not collect statistics on the leaf
           partitions (the data is only sampled). The <codeph>analyzedb</codeph> utility updates root
-          partition statistics by default. </p>The Greenplum Database server configuration parameter
-            <codeph><xref
-            href="../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
-            >optimizer_analyze_root_partition</xref></codeph> affects when statistics are collected
-        on the root partition of a partitioned table. If the parameter is <codeph>on</codeph> (the
-        default), the <codeph>ROOTPARTITION</codeph> keyword is not required to collect statistics
-        on the root partition when you run <codeph>ANALYZE</codeph>. Root partition statistics are
-        collected when you run <codeph>ANALYZE</codeph> on the root partition, or when you run
-          <codeph>ANALYZE</codeph> on a child leaf partition of the partitioned table and the other
-        child leaf partitions have statistics. If the parameter is <codeph>off</codeph>, you must
-        run <codeph>ANALYZE ROOTPARTITION</codeph> to collect root partition statistics.<p>If you do
+          partition statistics by default but you can add the <codeph>--skip_root_stats</codeph>
+          option to leave root partition statistics empty if you do not use GPORCA. </p><p>The Greenplum Database server configuration parameter <codeph><xref
+              href="../../ref_guide/config_params/guc-list.xml#optimizer_analyze_root_partition"
+              >optimizer_analyze_root_partition</xref></codeph> affects when statistics are
+          collected on the root partition of a partitioned table. If the parameter is
+            <codeph>on</codeph> (the default), the <codeph>ROOTPARTITION</codeph> keyword is not
+          required to collect statistics on the root partition when you run
+          <codeph>ANALYZE</codeph>. Root partition statistics are collected when you run
+            <codeph>ANALYZE</codeph> on the root partition, or when you run <codeph>ANALYZE</codeph>
+          on a child leaf partition of the partitioned table and the other child leaf partitions
+          have statistics. If the parameter is <codeph>off</codeph>, you must run <codeph>ANALYZE
+            ROOTPARTITION</codeph> to collect root partition statistics.</p><p>If you do
           not intend to execute queries on partitioned tables with GPORCA (setting the server
           configuration parameter <codeph><xref
-              href="../../ref_guide/config_params/guc-list.xml#optimizer">optimizer</xref></codeph>
-          to <codeph>off</codeph>), you can also set the server configuration parameter
-            <codeph>optimizer_analyze_root_partition</codeph> to <codeph>off</codeph> to limit when
-            <codeph>ANALYZE</codeph> updates the root partition statistics. </p></section>
-      <section> </section>
+              href="../../ref_guide/config_params/guc-list.xml#optimizer"
+              >optimizer</xref></codeph> to <codeph>off</codeph>), you can also set the server
+          configuration parameter <codeph>optimizer_analyze_root_partition</codeph> to
+            <codeph>off</codeph> to limit when <codeph>ANALYZE</codeph> updates the root partition
+          statistics. </p></section>
     </body>
   </topic>
   <topic id="topic_gyb_qrd_2t">

--- a/gpdb-doc/dita/utility_guide/admin_utilities/analyzedb.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/analyzedb.xml
@@ -19,6 +19,7 @@
    [ <b>--gen_profile_only</b> ]   
    [ <b>-p</b> <varname>parallel-level</varname> ]
    [ <b>--full</b> ]
+   [ <b>--skip_root_stats</b> ]
    [ <b>-v</b> | <b>--verbose</b> ]
    [ <b>--debug</b> ]
    [ <b>-a</b> ]
@@ -166,6 +167,17 @@ public.lineitem -i l_shipdate, l_receiptdate </codeblock></pd>
           <pt>-p <varname>parallel-level</varname></pt>
           <pd>The number of tables that are analyzed in parallel. <varname>parallel level</varname>
             can be an integer between 1 and 10, inclusive. Default value is 5. </pd>
+        </plentry>
+        <plentry>
+          <pt>--skip_root_stats</pt>
+          <pd>For a partitioned table, skip refreshing root partition statistics if only some of the
+            leaf partitions statistics require updating. </pd>
+          <pd>When updating statistics for a partitioned table and you know which leaf partition
+            statistics require updating, you can specify those partitions and this option to improve
+            performance.</pd>
+          <pd>For information about how statistics are collected for partitioned tables, see
+                <codeph><xref href="../../ref_guide/sql_commands/ANALYZE.xml"
+              >ANALYZE</xref></codeph>.</pd>
         </plentry>
         <plentry>
           <pt>-s <varname>schema</varname></pt>


### PR DESCRIPTION
Reverts commit 1aef6434a3aa4f19a3b2da13985fba12e1161386 and fixes
a couple typos.

This PR is for master and 6X_STABLE.



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
