### PR TITLE
5X_STABLE: Dump persistent tables before and after resync transition

### DIFF
--- a/src/backend/cdb/cdbfilerepresyncmanager.c
+++ b/src/backend/cdb/cdbfilerepresyncmanager.c
@@ -850,8 +850,11 @@ FileRepResyncManager_InResyncTransition(void)
 		   dataState == DataStateInResync))
 	{
 		goto exit;
-	}						
-	
+	}
+
+	/* Dump the state of all persistent objects to the log before the transition */
+	PersistentFileSysObj_DebugPrintPersistentState(true);
+
 	if (isFullResync())
 	{
 		FileRep_InsertConfigLogEntry("run resync transition, mark full copy");
@@ -993,6 +996,9 @@ FileRepResyncManager_InResyncTransition(void)
 
 	ChangeTracking_MarkTransitionToResyncCompleted();
 	
+	/* Dump the state of all persistent objects to the log after the transition */
+	PersistentFileSysObj_DebugPrintPersistentState(false);
+
 	FileRepSubProcess_ProcessSignals();
 	if (! (segmentState == SegmentStateReady &&
 		   dataState == DataStateInResync))

--- a/src/include/cdb/cdbpersistentfilesysobj.h
+++ b/src/include/cdb/cdbpersistentfilesysobj.h
@@ -254,6 +254,8 @@ extern void PersistentFileSysObj_GetAppendOnlyCatchupMirrorStartEof(
 
 extern void PersistentFileSysObj_RequestResynchronizeTransition(void);
 
+extern void PersistentFileSysObj_DebugPrintPersistentState(bool is_start);
+
 extern void PersistentFileSysObj_MarkWholeMirrorFullCopy(void);
 
 extern void PersistentFileSysObj_MarkAppendOnlyCatchup(void);


### PR DESCRIPTION
I have run into several instances where a file will not be replicated during a full segment recovery. I suspect that those files were in a strange persistent state before the recovery began, but the system did not leave behind evidence to tell us what that state might be.

This commit will dump the state of all the persistent objects to the log file on a primary doing either a full or an incremental recovery. This will persist the state of the system to disk at the expense of approximately 7GB of logs for a system with 6,000,000 persistent objects.

The log messages will be enabled by default, but can be disabled by setting the debug_filerep_config_print guc to 'false'.

A bit more context: The most likely reason we aren't replicating these files would be be that relfiles are stuck in the state `PersistentFileSysState_BulkLoadCreatePending` after being created, but some of the files that failed to be replicated are AOCO, and it doesn't appear that AOCO relfiles can even go into that state under normal circumstances.
