### PR TITLE
Fix incorrect results from syscache for function arg types

### DIFF
--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -2046,6 +2046,9 @@ List *
 get_func_arg_types(Oid funcid)
 {
 	HeapTuple	tp;
+	Form_pg_proc procstruct;
+	oidvector *args;
+	List *result = NIL;
 
 	tp = SearchSysCache(PROCOID,
 						ObjectIdGetDatum(funcid),
@@ -2053,11 +2056,11 @@ get_func_arg_types(Oid funcid)
 	if (!HeapTupleIsValid(tp))
 		elog(ERROR, "cache lookup failed for function %u", funcid);
 
-	oidvector args = ((Form_pg_proc) GETSTRUCT(tp))->proargtypes;
-	List *result = NIL;
-	for (int i = 0; i < args.dim1; i++)
+	procstruct = (Form_pg_proc) GETSTRUCT(tp);
+	args = &procstruct->proargtypes;
+	for (int i = 0; i < args->dim1; i++)
 	{
-		result = lappend_oid(result, args.values[i]);
+		result = lappend_oid(result, args->values[i]);
 	}
 
 	ReleaseSysCache(tp);

--- a/src/backend/utils/cache/test/Makefile
+++ b/src/backend/utils/cache/test/Makefile
@@ -1,0 +1,10 @@
+subdir=src/backend/utils/cache
+top_builddir=../../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=lsyscache
+
+include $(top_builddir)/src/backend/mock.mk
+
+lsyscache.t: \
+	$(MOCK_DIR)/backend/utils/cache/syscache_mock.o \

--- a/src/backend/utils/cache/test/lsyscache_test.c
+++ b/src/backend/utils/cache/test/lsyscache_test.c
@@ -1,0 +1,60 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "postgres.h"
+#include "access/htup_details.h"
+#include "utils/memutils.h"
+#include "catalog/pg_proc.h"
+
+#include "../lsyscache.c"
+
+void
+test_get_func_arg_types_can_correctly_return_more_than_one_argtype(void **state)
+{
+	HeapTuple	tp;
+	tp = malloc(sizeof(struct HeapTupleData));
+	struct HeapTupleHeaderData *data;
+
+	/* allocate enough space to hold 2 oids in proargtypes oidvector */
+	data = malloc(sizeof(struct HeapTupleHeaderData) + sizeof(struct FormData_pg_proc) + sizeof(Oid) * 2);
+	tp->t_data = data;
+
+	/* setup tuple offset to data */
+	data->t_hoff = (uint8)sizeof(struct HeapTupleHeaderData);
+	Form_pg_proc pgproc = (Form_pg_proc)((char *)data + sizeof(struct HeapTupleHeaderData));
+
+	/* setup oidvector with 2 oids */
+	pgproc->proargtypes.dim1 = 2;
+	pgproc->proargtypes.values[0] = 11;
+	pgproc->proargtypes.values[1] = 22;
+
+	will_return(SearchSysCache, tp);
+	expect_value(SearchSysCache, cacheId, PROCOID);
+	expect_value(SearchSysCache, key1, 123);
+	expect_any(SearchSysCache, key2);
+	expect_any(SearchSysCache, key3);
+	expect_any(SearchSysCache, key4);
+
+	will_be_called(ReleaseSysCache);
+	expect_value(ReleaseSysCache, tuple, tp);
+
+	List *result = get_func_arg_types(123);
+	assert_int_equal(2, result->length);
+
+	assert_int_equal(11, lfirst_oid(list_head(result)));
+	assert_int_equal(22, lfirst_oid(lnext(list_head(result))));
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_get_func_arg_types_can_correctly_return_more_than_one_argtype)
+	};
+	MemoryContextInit();
+	return run_tests(tests);
+}


### PR DESCRIPTION
Postgres 9.5 commit 09d8d11 introduced a FLEXIBLE_ARRAY_NUMBER that is used in
oidvector. This means that `values` now has a flexible length rather than
hardcoded length of 1. However, when retrieving these args from the struct, we
were assuming no deep copy was necessary -- we simply assigned the results into
another oidvector. This meant that values were not properly copied and we got
invalid oids, which errored out on 9.5 merge branch with `Unrecognized type
name`.

In GPDB 6X, we would retrieve one value, which was enough to make
`ResolvePolymorphicTypes` not error out, but the values retrieved from
pgproctypes were still inaccurate (though it doesn't seem to cause any issues)

Now, we populate the correct arg values. This function was only used by
ORCA, which is why it only errored when ORCA was used.

We were not able to create a failing testcase on 6X and master, but the
wrong results retrieved from get_func_arg_types() seem risky enough that
they could cause issues.

Co-authored-by: Chris Hajas <chajas@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
