### PR TITLE
Refactor gpstate Behave test regex

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -236,8 +236,8 @@ Feature: gpstate tests
             | Master port                   = [0-9]+                 |
             | Master current role           = dispatch               |
             | Greenplum initsystem version  = [0-9]+\.[0-9]+\.[0-9]+ |
-            | Greenplum current version     = PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-            | Postgres version              = [0-9]+\.[0-9]+\.[0-9]+ |
+            | Greenplum current version     = PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+            | Postgres version              = [1-9][0-9]?\.[0-9]+.*  |
             | Master standby                =                        |
             | Standby master state          = Standby host passive   |
             | Segment Instance Status Report                         |
@@ -337,14 +337,14 @@ Feature: gpstate tests
         When the user runs "gpstate -i"
         Then gpstate output looks like
 		  | Host | Datadir                        | Port   | Version                                                                           |
-		  | \S+  | .*/qddir/demoDataDir-1         | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/standby                     | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/dbfast1/demoDataDir0        | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/dbfast_mirror1/demoDataDir0 | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/dbfast2/demoDataDir1        | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/dbfast_mirror2/demoDataDir1 | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/dbfast3/demoDataDir2        | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/dbfast_mirror3/demoDataDir2 | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/qddir/demoDataDir-1         | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/standby                     | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast1/demoDataDir0        | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast_mirror1/demoDataDir0 | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast2/demoDataDir1        | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast_mirror2/demoDataDir1 | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast3/demoDataDir2        | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast_mirror3/demoDataDir2 | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
 		And gpstate should print "All segments are running the same software version" to stdout
 
     Scenario: gpstate -i warns if any mirrors are marked down
@@ -354,13 +354,13 @@ Feature: gpstate tests
         When the user runs "gpstate -i"
         Then gpstate output looks like
 		  | Host | Datadir                        | Port   | Version                                                                           |
-		  | \S+  | .*/qddir/demoDataDir-1         | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/standby                     | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/dbfast1/demoDataDir0        | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/qddir/demoDataDir-1         | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/standby                     | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast1/demoDataDir0        | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
 		  | \S+  | .*/dbfast_mirror1/demoDataDir0 | [0-9]+ | unable to retrieve version                                                        |
-		  | \S+  | .*/dbfast2/demoDataDir1        | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast2/demoDataDir1        | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
 		  | \S+  | .*/dbfast_mirror2/demoDataDir1 | [0-9]+ | unable to retrieve version                                                        |
-		  | \S+  | .*/dbfast3/demoDataDir2        | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast3/demoDataDir2        | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
 		  | \S+  | .*/dbfast_mirror3/demoDataDir2 | [0-9]+ | unable to retrieve version                                                        |
 		And gpstate should print "Unable to retrieve version data from all segments" to stdout
 
@@ -372,13 +372,13 @@ Feature: gpstate tests
         When the user runs "gpstate -i"
         Then gpstate output looks like
 		  | Host | Datadir                        | Port   | Version                                                                           |
-		  | \S+  | .*/qddir/demoDataDir-1         | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/standby                     | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
-		  | \S+  | .*/dbfast1/demoDataDir0        | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/qddir/demoDataDir-1         | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/standby                     | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast1/demoDataDir0        | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
 		  | \S+  | .*/dbfast_mirror1/demoDataDir0 | [0-9]+ | unable to retrieve version                                                        |
-		  | \S+  | .*/dbfast2/demoDataDir1        | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast2/demoDataDir1        | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
 		  | \S+  | .*/dbfast_mirror2/demoDataDir1 | [0-9]+ | unable to retrieve version                                                        |
-		  | \S+  | .*/dbfast3/demoDataDir2        | [0-9]+ | PostgreSQL [0-9]+\.[0-9]+\.[0-9]+ \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
+		  | \S+  | .*/dbfast3/demoDataDir2        | [0-9]+ | PostgreSQL [1-9][0-9]?\.[0-9]+.* \(Greenplum Database [0-9]+\.[0-9]+\.[0-9]+.*\) |
 		  | \S+  | .*/dbfast_mirror3/demoDataDir2 | [0-9]+ | unable to retrieve version                                                        |
 		And gpstate should print "Unable to retrieve version data from all segments" to stdout
 


### PR DESCRIPTION
The PostgreSQL semver regex did not account for developer versions
(e.g. 9.4.21 vs 9.5beta1). Relax the regex to make the test pass since
this was an oversight when the test was written.

This was caught in the 9.5 merge iteration.