### PR TITLE
Fix create table ... as (...) with no data error

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -188,7 +188,7 @@ create_ctas_internal(List *attrList, IntoClause *into, QueryDesc *queryDesc, boo
 									relkind,
 									InvalidOid,
 									relstorage,
-									dispatch,
+									false,
 									queryDesc->ddesc ? queryDesc->ddesc->useChangedAOOpts : true,
 									queryDesc->plannedstmt->intoPolicy);
 
@@ -222,7 +222,13 @@ create_ctas_internal(List *attrList, IntoClause *into, QueryDesc *queryDesc, boo
 		StoreViewQuery(intoRelationId, query, false);
 		CommandCounterIncrement();
 	}
-
+	if (Gp_role == GP_ROLE_DISPATCH && dispatch)
+		CdbDispatchUtilityStatement((Node *) create,
+									DF_CANCEL_ON_ERROR |
+									DF_NEED_TWO_PHASE |
+									DF_WITH_SNAPSHOT,
+									GetAssignedOidsForDispatch(),
+									NULL);
 	return intoRelationId;
 }
 

--- a/src/test/regress/expected/select_into.out
+++ b/src/test/regress/expected/select_into.out
@@ -88,6 +88,17 @@ DROP TABLE ctas_nodata;
 DROP TABLE ctas_nodata_2;
 DROP TABLE ctas_nodata_3;
 DROP TABLE ctas_nodata_4;
+-- Test for WITH NO DATA on toast column
+CREATE TABLE ctas_base (i text);
+INSERT INTO ctas_base VALUES ('a');
+CREATE TABLE ctas_nodata AS SELECT i FROM ctas_base  WITH NO DATA; -- OK
+SELECT * FROM ctas_nodata;
+ i 
+---
+(0 rows)
+
+DROP TABLE ctas_base;
+DROP TABLE ctas_nodata;
 --
 -- CREATE TABLE AS/SELECT INTO as last command in a SQL function
 -- have been known to cause problems

--- a/src/test/regress/sql/select_into.sql
+++ b/src/test/regress/sql/select_into.sql
@@ -71,6 +71,13 @@ DROP TABLE ctas_nodata;
 DROP TABLE ctas_nodata_2;
 DROP TABLE ctas_nodata_3;
 DROP TABLE ctas_nodata_4;
+-- Test for WITH NO DATA on toast column
+CREATE TABLE ctas_base (i text);
+INSERT INTO ctas_base VALUES ('a');
+CREATE TABLE ctas_nodata AS SELECT i FROM ctas_base  WITH NO DATA; -- OK
+SELECT * FROM ctas_nodata;
+DROP TABLE ctas_base;
+DROP TABLE ctas_nodata;
 
 --
 -- CREATE TABLE AS/SELECT INTO as last command in a SQL function


### PR DESCRIPTION
We dispatch the create table utility before create toast table, so
we will get a "no pre-assigned OID" error. Fix it by call dispatch
function after create toast table.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
