### PR TITLE
Mark default_tablespace GUC to be included in dispatch

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2818,7 +2818,7 @@ static struct config_string ConfigureNamesString[] =
 		{"default_tablespace", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Sets the default tablespace to create tables and indexes in."),
 			gettext_noop("An empty string selects the database's default tablespace."),
-			GUC_IS_NAME
+			GUC_IS_NAME | GUC_GPDB_ADDOPT
 		},
 		&default_tablespace,
 		"",

--- a/src/test/regress/input/tablespace.source
+++ b/src/test/regress/input/tablespace.source
@@ -114,6 +114,25 @@ RESET ROLE;
 
 ALTER TABLESPACE testspace RENAME TO testspace_renamed;
 
+-- Test that default_tablespace GUC is honored even after gang reset.
+CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL
+AS '@abs_builddir@/regress@DLSUFFIX@', 'cleanupAllGangs' LANGUAGE C;
+
+SET default_tablespace TO testspace_renamed;
+
+-- Destroy the QD-QE libpq connections.
+select cleanupAllGangs();
+
+-- New gang will be setup to dispatch this DDL and default_tablespace
+-- should be set to testspace_renamed on QEs.
+CREATE TABLE tablespace_table1(a int, b int) DISTRIBUTED BY (a);
+
+SELECT spcname FROM pg_class c, pg_tablespace t
+WHERE c.reltablespace = t.oid and c.relname = 'tablespace_table1';
+
+SELECT spcname FROM gp_dist_random('pg_class') c, pg_tablespace t
+WHERE c.reltablespace = t.oid and c.relname = 'tablespace_table1';
+
 ALTER TABLE ALL IN TABLESPACE testspace_renamed SET TABLESPACE pg_default;
 ALTER INDEX ALL IN TABLESPACE testspace_renamed SET TABLESPACE pg_default;
 

--- a/src/test/regress/output/tablespace.source
+++ b/src/test/regress/output/tablespace.source
@@ -214,6 +214,36 @@ ERROR:  cannot alter indexed column
 HINT:  DROP the index first, and recreate it after the ALTER
 RESET ROLE;
 ALTER TABLESPACE testspace RENAME TO testspace_renamed;
+-- Test that default_tablespace GUC is honored even after gang reset.
+CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL
+AS '@abs_builddir@/regress@DLSUFFIX@', 'cleanupAllGangs' LANGUAGE C;
+SET default_tablespace TO testspace_renamed;
+-- Destroy the QD-QE libpq connections.
+select cleanupAllGangs();
+ cleanupallgangs 
+-----------------
+ t
+(1 row)
+
+-- New gang will be setup to dispatch this DDL and default_tablespace
+-- should be set to testspace_renamed on QEs.
+CREATE TABLE tablespace_table1(a int, b int) DISTRIBUTED BY (a);
+SELECT spcname FROM pg_class c, pg_tablespace t
+WHERE c.reltablespace = t.oid and c.relname = 'tablespace_table1';
+      spcname      
+-------------------
+ testspace_renamed
+(1 row)
+
+SELECT spcname FROM gp_dist_random('pg_class') c, pg_tablespace t
+WHERE c.reltablespace = t.oid and c.relname = 'tablespace_table1';
+      spcname      
+-------------------
+ testspace_renamed
+ testspace_renamed
+ testspace_renamed
+(3 rows)
+
 ALTER TABLE ALL IN TABLESPACE testspace_renamed SET TABLESPACE pg_default;
 ALTER INDEX ALL IN TABLESPACE testspace_renamed SET TABLESPACE pg_default;
 -- Should show notice that nothing was done


### PR DESCRIPTION
Without this, `default_tablespace` GUC is only dispatched to QEs during explicit SET command.  However, if the gang resets and a new gang is created, the GUC is omitted and any tables / indexes created thereafter in that session will not be created by QEs in the right tablespace.

This was pointed out by @ashwinstar in a PR comment: https://github.com/greenplum-db/gpdb/pull/7771#issuecomment-498759730
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
