### PR TITLE
5X Only - gpcheck: update net.ipv4.ip_local_port_range values

### DIFF
--- a/concourse/scripts/behave_gpdb.bash
+++ b/concourse/scripts/behave_gpdb.bash
@@ -48,7 +48,7 @@ function gpcheck_setup() {
         net.ipv4.tcp_tw_recycle = 1
         net.ipv4.tcp_max_syn_backlog = 4096
         net.ipv4.conf.all.arp_filter = 1
-        net.ipv4.ip_local_port_range = 1025 65535
+        net.ipv4.ip_local_port_range = 10000 65535
         net.core.netdev_max_backlog = 10000
         vm.overcommit_memory = 2" >> /etc/sysctl.conf
 

--- a/gpMgmt/bin/gpcheck
+++ b/gpMgmt/bin/gpcheck
@@ -846,60 +846,68 @@ def checkUser():
         gpcheck_info.is_root = False
 
 
-logger = get_default_logger()
-setup_tool_logging(EXECNAME,getLocalHostname(),getUserName())
+def main():
+    global logger
+    logger = get_default_logger()
+    setup_tool_logging(EXECNAME,getLocalHostname(),getUserName())
 
-if (parseargs()):
-    sys.exit(0)
-
-pool = WorkerPool()
-
-## COLLECT INPUT SECTION ###
-
-if (createTmpDir()):
-    earlyExit(True)
-
-if options.zipin:
-
-    if (readZip()):
-        earlyExit(True)
-
-else:
-    gpcheck_info = GpCheckInfo()
-
-    if (checkPlatform()):
+    if (parseargs()):
         sys.exit(0)
 
-    checkUser()
+    global pool
+    pool = WorkerPool()
 
-    if (createHostList()):
+    ## COLLECT INPUT SECTION ###
+
+    if (createTmpDir()):
         earlyExit(True)
 
-    logger.info("Detected platform: %s" % hosttype_str(gpcheck_info.host_type))
+    if options.zipin:
 
-    if (runCollections()):
+        if (readZip()):
+            earlyExit(True)
+
+    else:
+        global gpcheck_info
+        gpcheck_info = GpCheckInfo()
+
+        if (checkPlatform()):
+            sys.exit(0)
+
+        checkUser()
+
+        if (createHostList()):
+            earlyExit(True)
+
+        logger.info("Detected platform: %s" % hosttype_str(gpcheck_info.host_type))
+
+        if (runCollections()):
+            earlyExit(True)
+
+        if (readDataFiles()):
+            earlyExit(True)
+
+
+    ## GENERATE OUTPUT SECTION ###
+
+    if options.zipout:
+        filename = "./gpcheck_%s" % time.time()
+        doZip(filename)
+        cleanZip(filename)
+        earlyExit(False)
+
+    if options.stdout:
+        doPrint()
+        earlyExit(False)
+
+    if (runTests()):
         earlyExit(True)
 
-    if (readDataFiles()):
-        earlyExit(True)
+    if not found_errors:
+        logger.info("GPCHECK_NORMAL")
 
-
-## GENERATE OUTPUT SECTION ###
-
-if options.zipout:
-    filename = "./gpcheck_%s" % time.time()
-    doZip(filename)
-    cleanZip(filename)
     earlyExit(False)
 
-if options.stdout:
-    doPrint()
-    earlyExit(False)
 
-if (runTests()):
-    earlyExit(True)
-
-if not found_errors:
-    logger.info("GPCHECK_NORMAL")
-
-earlyExit(False)
+if __name__ == "__main__":
+    main()

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_gpcheck.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_gpcheck.py
@@ -1,10 +1,24 @@
+import imp
+import logging
+import mock
+import os
+
 from gppylib.commands.base import Command, REMOTE
 from gppylib.operations.gpcheck import get_host_for_command, get_command, get_copy_command
-
 from test.unit.gp_unittest import GpTestCase, run_tests
 
+gpcheck_file = os.path.abspath(os.path.dirname(__file__) + "/../../../../gpcheck")
 
 class GpCheckTestCase(GpTestCase):
+    def setUp(self):
+        # Because gpcheck does not have a .py extension, we have to use imp to
+        # import it. If we had a gpcheck.py, this is equivalent to:
+        #   import gpcheck
+        #   self.subject = gpcheck
+        self.gpcheck = imp.load_source('gpcheck', gpcheck_file)
+        self.gpcheck.logger = mock.MagicMock(logging.Logger)
+        self.gpcheck.gpcheck_config = self.gpcheck.GpCheckConfig()
+
     def test_get_host_for_command_uses_supplied_remote_host(self):
         cmd = Command('name', 'hostname', ctxt=REMOTE, remoteHost='foo') 
         result = get_host_for_command(False, cmd)
@@ -52,6 +66,46 @@ class GpCheckTestCase(GpTestCase):
         expected_result = Command(host, 'mv -f %s %s/%s.data' % (datafile, tmpdir, host))
         self.assertEqual(result.name, expected_result.name)
         self.assertEqual(result.cmdStr, expected_result.cmdStr)
+
+    def test_sysctl_succeeds_when_config_values_match(self):
+        self.gpcheck.printError = mock.MagicMock()
+
+        localhost = mock.MagicMock()
+        localhost.hostname = "localhost"
+        localhost.data.sysctl.variables = {'sysctl.net.ipv4.tcp_syncookies': '1'}
+
+        self.gpcheck.gpcheck_config.expectedSysctlValues = {'sysctl.net.ipv4.tcp_syncookies': '1'}
+
+        self.gpcheck.testSysctl(localhost)
+        self.gpcheck.printError.assert_not_called()
+        self.assertFalse(self.gpcheck.found_errors)
+
+    def test_sysctl_prints_error_when_config_values_dont_match(self):
+        localhost = mock.MagicMock()
+        localhost.hostname = "localhost"
+        localhost.data.sysctl.variables = {'sysctl.net.ipv4.ip_local_port_range': '10000 65535'}
+
+        self.gpcheck.gpcheck_config.expectedSysctlValues = {'sysctl.net.ipv4.ip_local_port_range': '1 60000'}
+
+        self.gpcheck.testSysctl(localhost)
+        self.assertTrue(self.gpcheck.found_errors)
+        self.gpcheck.logger.error.assert_called_once_with("GPCHECK_ERROR host(%s): %s",
+                                                          "localhost",
+                                                          "/etc/sysctl.conf value for key 'sysctl.net.ipv4.ip_local_port_range' has value '10000 65535' and expects '1 60000'")
+
+    def test_sysctl_prints_error_when_config_is_missing(self):
+        localhost = mock.MagicMock()
+        localhost.hostname = "localhost"
+        localhost.data.sysctl.variables = {'sysctl.non.existent.setting': '10000 65535'}
+
+        self.gpcheck.gpcheck_config.expectedSysctlValues = {'sysctl.net.ipv4.ip_local_port_range': '1 60000'}
+
+        self.gpcheck.testSysctl(localhost)
+        self.assertTrue(self.gpcheck.found_errors)
+        self.gpcheck.logger.error.assert_called_once_with("GPCHECK_ERROR host(%s): %s",
+                                                          "localhost",
+                                                          "variable not detected in /etc/sysctl.conf: 'sysctl.net.ipv4.ip_local_port_range'")
+
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/doc/gpconfigs/gpcheck.cnf
+++ b/gpMgmt/doc/gpconfigs/gpcheck.cnf
@@ -18,6 +18,6 @@ sysctl.net.ipv4.conf.default.accept_source_route = 0
 sysctl.net.ipv4.tcp_tw_recycle = 1
 sysctl.net.ipv4.tcp_max_syn_backlog = 4096
 sysctl.net.ipv4.conf.all.arp_filter = 1
-sysctl.net.ipv4.ip_local_port_range = 1025 65535
+sysctl.net.ipv4.ip_local_port_range = 10000 65535
 sysctl.net.core.netdev_max_backlog = 10000
 sysctl.vm.overcommit_memory = 2


### PR DESCRIPTION
Update net.ipv4.ip_local_port_range values to match those in the Greenplum documentation.

Allow gpcheck to be correctly imported for unit testing. And add a unit test for checking sysctl settings.

A 5X CLI only pipeline has passed and a full pipeline is running.