### PR TITLE
5X_STABLE: Error if about to store an invalid segment number.

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -90,6 +90,8 @@ InsertInitialAOCSFileSegInfo(Relation prel, int4 segno, int4 nvp)
 	Relation segrel;
 	int16		formatVersion;
 
+	ValidateAppendonlySegmentDataBeforeStorage(segno);
+
 	/* New segments are always created in the latest format */
 	formatVersion = AORelationVersion_GetLatest();
 

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -25,6 +25,7 @@
 #include "access/aocssegfiles.h"
 #include "access/aosegfiles.h"
 #include "access/appendonlytid.h"
+#include "access/appendonlywriter.h"
 #include "catalog/pg_appendonly_fn.h"
 #include "catalog/pg_type.h"
 #include "catalog/pg_proc.h"
@@ -84,6 +85,13 @@ NewFileSegInfo(int segno)
 	return fsinfo;
 }
 
+void
+ValidateAppendonlySegmentDataBeforeStorage(int segno)
+{
+	if (segno >= MAX_AOREL_CONCURRENCY || segno < 0)
+		ereport(ERROR, (errmsg("expected segment number to be between zero and the maximum number of concurrent writers, actually %d", segno)));
+}
+
 /*
  * InsertFileSegInfo
  *
@@ -103,6 +111,8 @@ InsertInitialSegnoEntry(Relation parentrel, int segno)
 	bool	   *nulls;
 	Datum	   *values;
 	int16		formatVersion;
+
+	ValidateAppendonlySegmentDataBeforeStorage(segno);
 
 	/* New segments are always created in the latest format */
 	formatVersion = AORelationVersion_GetLatest();

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -1507,10 +1507,7 @@ get_awaiting_drop_status_from_segments(Relation parentrel)
 					value = PQgetvalue(pgresult, j, 1);
 					segno = pg_atoi(value, sizeof(int32), 0);
 
-					if (segno < 0)
-						elog(ERROR, "segno %d is negative", segno);
-					if (segno >= MAX_AOREL_CONCURRENCY)
-						elog(ERROR, "segno %d exceeds max AO concurrency", segno);
+					ValidateAppendonlySegmentDataBeforeStorage(segno);
 
 					if (qe_state == AOSEG_STATE_AWAITING_DROP)
 					{

--- a/src/backend/access/appendonly/test/Makefile
+++ b/src/backend/access/appendonly/test/Makefile
@@ -2,7 +2,7 @@ subdir=src/backend/access/appendonly
 top_builddir=../../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=aomd appendonly_visimap appendonlywriter appendonly_visimap_entry
+TARGETS=aomd appendonly_visimap appendonlywriter appendonly_visimap_entry aosegfiles
 
 include $(top_builddir)/src/backend/mock.mk
 
@@ -19,3 +19,4 @@ appendonlywriter.t: \
 
 appendonly_visimap_entry.t:
 
+aosegfiles.t: $(top_builddir)/src/backend/access/appendonly/aosegfiles.o

--- a/src/backend/access/appendonly/test/aosegfiles_test.c
+++ b/src/backend/access/appendonly/test/aosegfiles_test.c
@@ -1,0 +1,83 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "postgres.h"
+#include "access/aosegfiles.h"
+#include "utils/memutils.h"
+
+
+void
+test_validate_segno_returns_false_when_segno_less_than_zero(void **state)
+{
+	bool error_thrown = false;
+  
+	PG_TRY();
+	{
+		ValidateAppendonlySegmentDataBeforeStorage(-1);
+	}
+	PG_CATCH();
+	{
+		error_thrown = true;
+	}
+	PG_END_TRY();
+
+	assert_true(error_thrown);
+}
+
+void
+test_validate_segno_returns_true_when_segno_greater_than_or_equal_to_zero(void **state)
+{
+	bool error_thrown = false;
+  
+	PG_TRY();
+	{
+		ValidateAppendonlySegmentDataBeforeStorage(0);
+		ValidateAppendonlySegmentDataBeforeStorage(1);
+		ValidateAppendonlySegmentDataBeforeStorage(10);
+		ValidateAppendonlySegmentDataBeforeStorage(100);
+	}
+	PG_CATCH();
+	{
+		error_thrown = true;
+	}
+	PG_END_TRY();
+
+	assert_false(error_thrown);
+}
+
+void
+test_validate_segno_throws_error_when_value_is_greater_than_maximum_number_of_concurrent_writers(void **state)
+{
+	bool error_thrown = false;
+	int some_number_above_aorel_concurrency = 1234;
+  
+	PG_TRY();
+	{
+		ValidateAppendonlySegmentDataBeforeStorage(some_number_above_aorel_concurrency);
+	}
+	PG_CATCH();
+	{
+		error_thrown = true;
+	}
+	PG_END_TRY();
+
+	assert_true(error_thrown);
+}
+
+int 
+main(int argc, char* argv[]) 
+{
+	cmockery_parse_arguments(argc, argv);
+	
+	MemoryContextInit();
+
+	const UnitTest tests[] = {
+	  unit_test(test_validate_segno_returns_false_when_segno_less_than_zero),
+	  unit_test(test_validate_segno_returns_true_when_segno_greater_than_or_equal_to_zero),
+	  unit_test(test_validate_segno_throws_error_when_value_is_greater_than_maximum_number_of_concurrent_writers)
+	};
+
+	return run_tests(tests);
+}

--- a/src/include/access/aosegfiles.h
+++ b/src/include/access/aosegfiles.h
@@ -159,6 +159,9 @@ typedef enum
 extern FileSegInfo *NewFileSegInfo(int segno);
 
 extern void InsertInitialSegnoEntry(Relation parentrel, int segno);
+
+extern void ValidateAppendonlySegmentDataBeforeStorage(int segno);
+
  
  /*
   * GetFileSegInfo


### PR DESCRIPTION
A user found a scenario where they had stored a -1 for a tuple's
segno. We'd like to be notified of this type of scenario because it
should not exist and we would like to track down the root
cause. Validations that throw errors will help us track the root cause
down.

(cherry picked from commit 19a0c80011735258e4a8ffc376983f67195021d0)
