### PR TITLE
6X Backport: Fix random gp_tablespace test failure. (#7854)

### DIFF
--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -8,7 +8,7 @@
 include: helpers/server_helpers.sql;
 CREATE
 
-create or replace function wait_for_replication_replay (retries int) returns bool as $$ declare i int; /* in func */ result bool; /* in func */ begin /* in func */ i := 0; /* in func */ -- Wait until all mirrors has replayed up to flush location loop /* in func */ SELECT flush_location = replay_location INTO result from gp_stat_replication where gp_segment_id = 0; /* in func */ if result then /* in func */ return true; /* in func */ end if; /* in func */ 
+create or replace function wait_for_replication_replay (retries int) returns bool as $$ declare i int; /* in func */ result bool; /* in func */ begin /* in func */ i := 0; /* in func */ -- Wait until the mirror (content 0) has replayed up to flush location loop /* in func */ SELECT flush_location = replay_location INTO result from gp_stat_replication where gp_segment_id = 0; /* in func */ if result then /* in func */ return true; /* in func */ end if; /* in func */ 
 if i >= retries then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
 CREATE
 

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -14,7 +14,7 @@ declare
 	result bool; /* in func */
 begin /* in func */
 	i := 0; /* in func */
-	-- Wait until all mirrors has replayed up to flush location
+	-- Wait until the mirror (content 0) has replayed up to flush location
 	loop /* in func */
 		SELECT flush_location = replay_location INTO result from gp_stat_replication where gp_segment_id = 0; /* in func */
 		if result then /* in func */

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -256,8 +256,7 @@ clean distclean maintainer-clean: clean-lib
 	rm -f pg_regress_main.o pg_regress.o pg_regress$(X)
 # things created by various check targets
 	rm -f $(output_files) $(input_files)
-	rm -rf testtablespace
-	rm -rf testtablespace_otherloc
+	rm -rf ./testtablespace ./testtablespace_*
 	rm -rf $(pg_regress_clean_files)
 	rm -f data/pg_class32.data
 	rm -f gmon.out

--- a/src/test/regress/expected/mirror_replay.out
+++ b/src/test/regress/expected/mirror_replay.out
@@ -28,7 +28,7 @@ declare
   result bool;
 begin
   i := 0;
-  -- Wait until all mirrors has replayed up to flush location
+  -- Wait until the mirror (content 0) has replayed up to flush location
   loop
     SELECT flush_location = replay_location INTO result from gp_stat_replication where gp_segment_id = 0;
     if result then

--- a/src/test/regress/input/gp_tablespace.source
+++ b/src/test/regress/input/gp_tablespace.source
@@ -62,7 +62,25 @@ SELECT pg_ls_dir('./pg_tblspc/' || oid) = get_tablespace_version_directory_name(
          AS has_version_dir
 FROM pg_tablespace WHERE spcname = 'testspace';
 
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+CREATE or REPLACE FUNCTION wait_for_tablespace_create(retries integer, exp_num integer) RETURNS bool AS
+$$
+import os,time
+for x in range(retries):
+  num_str = os.popen("ls -lh @testtablespace@ | wc -l").read()
+  num = num_str.split("\n")
+  if num[0] == str(exp_num):
+    return True
+  time.sleep(0.1)
+return False
+$$ language plpythonu;
+
 -- Confirm that all the dbid directories were created under the testtablespace path
+--GPDB_96_MERGE_FIXME: Use 'set synchronous_commit=remote_apply' instead of the polling function
+-- Each dbid has one file/directory. There are 8 dbids, so expected num is 9.
+SELECT wait_for_tablespace_create(500, 9);
 \! ls @testtablespace@;
 
 -- Test moving AO/AOCO tables from one tablespace to another.
@@ -173,6 +191,22 @@ WHERE a.versiondirs = get_tablespace_version_directory_name();
 -- drop this tablespace
 DROP TABLESPACE testspace_existing_version_dir;
 
+CREATE or REPLACE FUNCTION wait_for_tablespace_drop(retries integer, exp_num integer) RETURNS bool AS
+$$
+import os,time
+for x in range(retries):
+  num_str = os.popen("find @testtablespace@_existing_version_dir | wc -l").read()
+  num = num_str.split("\n")
+  if num[0] == str(exp_num):
+    return True
+  time.sleep(0.1)
+return False
+$$ language plpythonu;
+
+-- Wait for all mirrors to drop related tablespace directories.
+--GPDB_96_MERGE_FIXME: Use 'set synchronous_commit=remote_apply' instead of the polling function
+-- Each dbid has two files/directories. There are 8 dbids, so expected num is 17.
+SELECT wait_for_tablespace_drop(500, 17);
 \! ls @testtablespace@_existing_version_dir/*;
 
 -- Test alter tablespace: PG does not seem to test these.

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -78,7 +78,29 @@ FROM pg_tablespace WHERE spcname = 'testspace';
  t
 (1 row)
 
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+CREATE or REPLACE FUNCTION wait_for_tablespace_create(retries integer, exp_num integer) RETURNS bool AS
+$$
+import os,time
+for x in range(retries):
+  num_str = os.popen("ls -lh @testtablespace@ | wc -l").read()
+  num = num_str.split("\n")
+  if num[0] == str(exp_num):
+    return True
+  time.sleep(0.1)
+return False
+$$ language plpythonu;
 -- Confirm that all the dbid directories were created under the testtablespace path
+--GPDB_96_MERGE_FIXME: Use 'set synchronous_commit=remote_apply' instead of the polling function
+-- Each dbid has one file/directory. There are 8 dbids, so expected num is 9.
+SELECT wait_for_tablespace_create(500, 9);
+ wait_for_tablespace_create 
+----------------------------
+ t
+(1 row)
+
 \! ls @testtablespace@;
 1
 2
@@ -296,6 +318,26 @@ WHERE a.versiondirs = get_tablespace_version_directory_name();
 -- Do not drop the dbid directory, nor the existing version directory if you
 -- drop this tablespace
 DROP TABLESPACE testspace_existing_version_dir;
+CREATE or REPLACE FUNCTION wait_for_tablespace_drop(retries integer, exp_num integer) RETURNS bool AS
+$$
+import os,time
+for x in range(retries):
+  num_str = os.popen("find @testtablespace@_existing_version_dir | wc -l").read()
+  num = num_str.split("\n")
+  if num[0] == str(exp_num):
+    return True
+  time.sleep(0.1)
+return False
+$$ language plpythonu;
+-- Wait for all mirrors to drop related tablespace directories.
+--GPDB_96_MERGE_FIXME: Use 'set synchronous_commit=remote_apply' instead of the polling function
+-- Each dbid has two files/directories. There are 8 dbids, so expected num is 17.
+SELECT wait_for_tablespace_drop(500, 17);
+ wait_for_tablespace_drop 
+--------------------------
+ t
+(1 row)
+
 \! ls @testtablespace@_existing_version_dir/*;
 @testtablespace@_existing_version_dir/1:
 GPDB_99_399999991

--- a/src/test/regress/sql/mirror_replay.sql
+++ b/src/test/regress/sql/mirror_replay.sql
@@ -31,7 +31,7 @@ declare
   result bool;
 begin
   i := 0;
-  -- Wait until all mirrors has replayed up to flush location
+  -- Wait until the mirror (content 0) has replayed up to flush location
   loop
     SELECT flush_location = replay_location INTO result from gp_stat_replication where gp_segment_id = 0;
     if result then


### PR DESCRIPTION
It is possible that mirror/standby might not flush or not finish flushing the
related xlog soon after the tablespace drop/create command finishes, so using
'ls' or 'find' to check tablespace related directories in the test might fail.

gp_tablespace test failure was observed several times recently, due to this.
Adding UDFs to poll the status until timeout.

This patch does some minor cleanup for other files also.

Reviewed-by: Asim Praveen
