### PR TITLE
Add gpdb github release pipeline

### DIFF
--- a/concourse/pipelines/gpdb_github_release.yml
+++ b/concourse/pipelines/gpdb_github_release.yml
@@ -1,0 +1,43 @@
+---
+
+# 1. Resources
+resources:
+- name: gpdb_src
+  type: git
+  source:
+    branch: ((gpdb-git-branch))
+    uri: ((gpdb-git-remote))
+    tag_filter: 6.*
+
+- name: gpdb_release
+  type: github-release
+  source:
+    owner: ((gpdb-release-owner))
+    repository: ((gpdb-release-repository))
+    access_token: ((gpdb-release-access-token))
+
+- name: gpdb6-centos7-build
+  type: docker-image
+  source:
+    repository: pivotaldata/gpdb6-centos7-build
+    tag: 'latest'
+
+# 2. Jobs
+jobs:
+- name: publish_gpdb_github_release
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      trigger: true
+    - get: gpdb6-centos7-build
+  - task: gpdb_github_release
+    image: gpdb6-centos7-build
+    file: gpdb_src/concourse/tasks/gpdb_github_release.yml
+  - put: gpdb_release
+    params:
+      name: release_artifacts/name
+      tag: release_artifacts/tag
+      body: release_artifacts/body
+      globs:
+        - release_artifacts/*.tar.gz
+        - release_artifacts/*.zip

--- a/concourse/scripts/gpdb_github_release.bash
+++ b/concourse/scripts/gpdb_github_release.bash
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BASE_DIR="$(pwd)"
+
+GPDB_RELEASE_TAG="$(./gpdb_src/getversion  --short)"
+
+function build_gpdb_binaries_tarball(){
+    pushd "${BASE_DIR}/gpdb_src"
+        git --no-pager show --summary refs/tags/"${GPDB_RELEASE_TAG}"
+
+        # TODO: adding the gpdb_bin_${PLATFORM} tar.gz here
+        # The tar.gz and .zip files are the github release attachements.
+        # here, I just want to test the uploading attachments function for github release concourse resource.
+        # later, we can upload the binaries of gpdb instead of them.
+        # eg. bin_gpdb_centos6.tar.gz, bin_gpdb_unbuntu18.04.tar.gz ...
+
+        git archive -o "${BASE_DIR}/release_artifacts/${GPDB_RELEASE_TAG}.tar.gz" --prefix="gpdb-${GPDB_RELEASE_TAG}/"  --format=tar.gz  refs/tags/"${GPDB_RELEASE_TAG}"
+        git archive -o "${BASE_DIR}/release_artifacts/${GPDB_RELEASE_TAG}.zip" --prefix="gpdb-${GPDB_RELEASE_TAG}/" --format=zip  -9 refs/tags/"${GPDB_RELEASE_TAG}"
+    popd
+
+    # Prepare for the gpdb github release
+    echo "${GPDB_RELEASE_TAG}" > "release_artifacts/name"
+    echo "${GPDB_RELEASE_TAG}" > "release_artifacts/tag"
+    echo "Greenplum-db version: ${GPDB_RELEASE_TAG}" > "release_artifacts/body"
+
+
+}
+
+function _main(){
+    echo "Current Released Tag: ${GPDB_RELEASE_TAG}"
+
+    build_gpdb_binaries_tarball
+    echo "Created the release binaries successfully! [tar.gz, zip]"
+}
+
+_main

--- a/concourse/tasks/gpdb_github_release.yml
+++ b/concourse/tasks/gpdb_github_release.yml
@@ -1,0 +1,18 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+
+inputs:
+- name: gpdb_src
+
+outputs:
+- name: release_artifacts
+
+run:
+  path: gpdb_src/concourse/scripts/gpdb_github_release.bash
+
+params:
+  GPDB_SRC_DEPLOY_KEY:


### PR DESCRIPTION
Automatic creation of Github Releases

When a new gpdb release published on the pivnet, it will create a new tag on the greenplum-db/gpdb automatically.

The github release pipeline will create a new github automatically release based on new tag.

Note: merged this PR to the 6X_STABLE branch and after that point generate new tag, the git release pipeline will work well.

Authored-by: Tingfang Bao <bbao@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
