### PR TITLE
Default tablespace for index creation and temporary table tests.

### DIFF
--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -172,7 +172,8 @@ tablespace-setup:
 	./testtablespace_existing_version_dir/8/GPDB_99_399999991/ \
         ./testtablespace_1111111111222222222233333333334444444444555555555566666666667777777777888888888899999999990000000000/ \
 	./testtablespace_default_tablespace \
-	./testtablespace_temp_tablespace
+	./testtablespace_temp_tablespace \
+	./testtablespace_database_tablespace
 
 # Check for include files that are not being shipped
 .PHONY: includecheck

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -31,6 +31,7 @@ test: spi_processed64bit
 test: python_processed64bit
 
 test: temp_tablespaces
+test: default_tablespace
 
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp replication_slots create_table_like_gp
 

--- a/src/test/regress/input/default_tablespace.source
+++ b/src/test/regress/input/default_tablespace.source
@@ -1,5 +1,13 @@
 create tablespace some_default_tablespace location '@testtablespace@_default_tablespace';
+create tablespace some_database_tablespace location '@testtablespace@_database_tablespace';
+
+create database database_for_default_tablespace;
+\c database_for_default_tablespace;
+
+
 set default_tablespace to some_default_tablespace;
+
+
 create table some_table_in_default_tablespace (a int);
 
 -- expect this to be one
@@ -8,6 +16,64 @@ select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace
 -- expect this to be the number of segments
 select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_table_in_default_tablespace' and spcname = 'some_default_tablespace';
 
-drop table some_table_in_default_tablespace;
-drop tablespace some_default_tablespace;
+
+-- When I create an index with the a default tablespace set
+create index some_table_in_default_tablespace_index on some_table_in_default_tablespace(a);
+
+-- Then it should be created in the default tablespace
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_table_in_default_tablespace_index';
+
+-- And it should be created in the default tablespace on the segments
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_table_in_default_tablespace_index' and spcname = 'some_default_tablespace';
+
+-- When I create a temporary table
+create temporary table some_temporary_table_for_default_tablespace_test (a int);
+
+-- Then it should not be affected by the default_tablespace GUC
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_temporary_table_for_default_tablespace_test';
+
+-- And is should not be affected on the segments either
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_temporary_table_for_default_tablespace_test' and spcname = 'some_default_tablespace';
+
+-- When I create an index on a temporary table
+create index some_temporary_table_for_default_tablespace_test_index on some_temporary_table_for_default_tablespace_test(a);
+
+-- Then it should not be affected by the default_tablespace GUC
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_temporary_table_for_default_tablespace_test_index';
+
+-- And is should not be affected on the segments either
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_temporary_table_for_default_tablespace_test_index' and spcname = 'some_default_tablespace';
+
+
+-- When I set a tablespace for a database
 reset default_tablespace;
+create database database_with_tablespace;
+alter database database_with_tablespace set tablespace some_database_tablespace;
+\c database_with_tablespace;
+
+-- And I set a default tablespace
+set default_tablespace to some_default_tablespace;
+
+-- Then tables and indexes that I create should be in the default tablespace
+create table table_under_database_with_default_tablespace (a int);
+create index table_under_database_with_default_tablespace_index on table_under_database_with_default_tablespace(a);
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'table_under_database_with_default_tablespace';
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'table_under_database_with_default_tablespace' and spcname = 'some_default_tablespace';
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'table_under_database_with_default_tablespace_index';
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'table_under_database_with_default_tablespace_index' and spcname = 'some_default_tablespace';
+
+-- cleanup
+\c database_for_default_tablespace
+drop table some_table_in_default_tablespace;
+
+\c database_with_tablespace
+drop table table_under_database_with_default_tablespace;
+
+\c regression;
+reset default_tablespace;
+
+drop database database_for_default_tablespace;
+drop database database_with_tablespace;
+
+drop tablespace some_default_tablespace;
+drop tablespace some_database_tablespace;

--- a/src/test/regress/output/default_tablespace.source
+++ b/src/test/regress/output/default_tablespace.source
@@ -1,4 +1,7 @@
 create tablespace some_default_tablespace location '@testtablespace@_default_tablespace';
+create tablespace some_database_tablespace location '@testtablespace@_database_tablespace';
+create database database_for_default_tablespace;
+\c database_for_default_tablespace;
 set default_tablespace to some_default_tablespace;
 create table some_table_in_default_tablespace (a int);
 -- expect this to be one
@@ -15,6 +18,96 @@ select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_t
      3
 (1 row)
 
-drop table some_table_in_default_tablespace;
-drop tablespace some_default_tablespace;
+-- When I create an index with the a default tablespace set
+create index some_table_in_default_tablespace_index on some_table_in_default_tablespace(a);
+-- Then it should be created in the default tablespace
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_table_in_default_tablespace_index';
+ count 
+-------
+     1
+(1 row)
+
+-- And it should be created in the default tablespace on the segments
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_table_in_default_tablespace_index' and spcname = 'some_default_tablespace';
+ count 
+-------
+     3
+(1 row)
+
+-- When I create a temporary table
+create temporary table some_temporary_table_for_default_tablespace_test (a int);
+-- Then it should not be affected by the default_tablespace GUC
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_temporary_table_for_default_tablespace_test';
+ count 
+-------
+     0
+(1 row)
+
+-- And is should not be affected on the segments either
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_temporary_table_for_default_tablespace_test' and spcname = 'some_default_tablespace';
+ count 
+-------
+     0
+(1 row)
+
+-- When I create an index on a temporary table
+create index some_temporary_table_for_default_tablespace_test_index on some_temporary_table_for_default_tablespace_test(a);
+-- Then it should not be affected by the default_tablespace GUC
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_temporary_table_for_default_tablespace_test_index';
+ count 
+-------
+     0
+(1 row)
+
+-- And is should not be affected on the segments either
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_temporary_table_for_default_tablespace_test_index' and spcname = 'some_default_tablespace';
+ count 
+-------
+     0
+(1 row)
+
+-- When I set a tablespace for a database
 reset default_tablespace;
+create database database_with_tablespace;
+alter database database_with_tablespace set tablespace some_database_tablespace;
+\c database_with_tablespace;
+-- And I set a default tablespace
+set default_tablespace to some_default_tablespace;
+-- Then tables and indexes that I create should be in the default tablespace
+create table table_under_database_with_default_tablespace (a int);
+create index table_under_database_with_default_tablespace_index on table_under_database_with_default_tablespace(a);
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'table_under_database_with_default_tablespace';
+ count 
+-------
+     1
+(1 row)
+
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'table_under_database_with_default_tablespace' and spcname = 'some_default_tablespace';
+ count 
+-------
+     3
+(1 row)
+
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'table_under_database_with_default_tablespace_index';
+ count 
+-------
+     1
+(1 row)
+
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'table_under_database_with_default_tablespace_index' and spcname = 'some_default_tablespace';
+ count 
+-------
+     3
+(1 row)
+
+-- cleanup
+\c database_for_default_tablespace
+drop table some_table_in_default_tablespace;
+\c database_with_tablespace
+drop table table_under_database_with_default_tablespace;
+\c regression;
+reset default_tablespace;
+drop database database_for_default_tablespace;
+drop database database_with_tablespace;
+drop tablespace some_default_tablespace;
+drop tablespace some_database_tablespace;


### PR DESCRIPTION
Ensure that indexes are placed into the default tablespace on the master and segments.

These tests are very similar to the tests for table creation that live in the same file.

Includes tests for index creation and the (lack of) impact of `default_tablespace` on temporary tables / indexes on temporary tables.