### PR TITLE
docs - updates for changes to resgroup MAX_SPILL_RATIO/MEMORY_LIMIT

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -497,7 +497,7 @@ SET statement_mem='10 MB';</codeblock></p>
       </topic>
     </topic>
     <topic id="topic833fvs" xml:lang="en">
-      <title>About Reserving Resource Group Memory vs. Using Resource Group Global Shared Memory</title>
+      <title>About Using Reserved Resource Group Memory vs. Using Resource Group Global Shared Memory</title>
       <body>
         <p>When you do not reserve memory for a resource group (<codeph>MEMORY_LIMIT</codeph>
           and <codeph>MEMORY_SPILL_RATIO</codeph> are set to 0):</p><ul>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -477,7 +477,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
            is 0.</p>
           <p>When <codeph>MEMORY_SPILL_RATIO</codeph> is 0, Greenplum Database uses the
             <xref href="../ref_guide/config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
-            server configuration parameter value to control operator memory.</p>
+            server configuration parameter value to control initial query operator memory.</p>
           <note>When you set <codeph>MEMORY_LIMIT</codeph> to 0,
             <codeph>MEMORY_SPILL_RATIO</codeph> must also be set to 0.</note>
           <p>You can selectively set the <codeph>MEMORY_SPILL_RATIO</codeph> on a per-query basis

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -496,6 +496,31 @@ SET statement_mem='10 MB';</codeblock></p>
         </body>
       </topic>
     </topic>
+    <topic id="topic833fvs" xml:lang="en">
+      <title>About Reserving Resource Group Memory vs. Using Resource Group Global Shared Memory</title>
+      <body>
+        <p>When you do not reserve memory for a resource group (<codeph>MEMORY_LIMIT</codeph>
+          and <codeph>MEMORY_SPILL_RATIO</codeph> are set to 0):</p><ul>
+          <li>It increases the size of the resource group global shared memory pool.</li>
+          <li>The resource group functions similarly to a resource queue, using the
+            <xref href="../ref_guide/config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+            server configuration parameter value to control initial query operator memory.</li>
+          <li>Any query submitted in the resource group competes for resource group global
+            shared memory on a first-come, first-served basis with queries running in other
+            groups.</li>
+          <li>There is no guarantee that Greenplum Database will be able to allocate memory
+            for a query running in the resource group. The risk of a query in the group
+            encountering an out of memory (OOM) condition increases when there are many
+            concurrent queries consuming memory from the resource group global shared
+            memory pool at the same time.</li>
+        </ul>
+        <p>To reduce the risk of OOM for a query running in an important resource group,
+          consider reserving some fixed memory for the group. While reserving fixed memory
+          for a group reduces the size of the resource group global shared memory pool,
+          this may be a fair tradeoff to reduce the risk of encountering an OOM condition
+          in a query running in a critical resource group.</p>
+      </body>
+    </topic>
     <topic id="topic833cons" xml:lang="en">
       <title>Other Memory Considerations</title>
       <body>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -150,12 +150,12 @@
             </row>
             <row>
               <entry colname="col1">MEMORY_LIMIT</entry>
-              <entry colname="col2">The percentage of memory resources available to this resource
-                group.</entry>
+              <entry colname="col2">The percentage of reserved memory resources available to
+                this resource group.</entry>
             </row>
             <row>
               <entry colname="col1">MEMORY_SHARED_QUOTA</entry>
-              <entry colname="col2">The percentage of memory to share across transactions submitted
+              <entry colname="col2">The percentage of reserved memory to share across transactions submitted
                 in this resource group.</entry>
             </row>
             <row>
@@ -380,28 +380,34 @@
         <codeblock>
 rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments</codeblock>
       </p>
-      <p>Each resource group reserves a percentage of the segment memory for resource management.
+      <p>Each resource group may reserve a percentage of the segment memory for resource management.
         You identify this percentage via the <codeph>MEMORY_LIMIT</codeph> value that you specify
         when you create the resource group. The minimum <codeph>MEMORY_LIMIT</codeph> percentage you
-        can specify for a resource group is 1, the maximum is 100.</p>
+        can specify for a resource group is 0, the maximum is 100. When <codeph>MEMORY_LIMIT</codeph>
+        is 0, Greenplum Database reserves no memory for the resource group, and uses resource
+        group global shared memory to fulfill all memory requests in the group. Refer to
+        <xref href="#topic833glob" type="topic" format="dita"/>
+        for more information about resource group global shared memory.</p>
       <p>The sum of <codeph>MEMORY_LIMIT</codeph>s specified for all resource groups that you define
         in your Greenplum Database cluster must not exceed 100.</p>
     </body>
     <topic id="mem_roles" xml:lang="en">
       <title>Additional Memory Limits for Role-based Resource Groups</title>
       <body>
-        <p>The memory reserved by a resource group for roles is further divided into fixed and
+        <p>If memory is reserved for a resource group for roles (non-zero
+          <codeph>MEMORY_LIMIT</codeph>), the memory is further divided into fixed and
           shared components. The <codeph>MEMORY_SHARED_QUOTA</codeph> value that you specify when
           you create the resource group identifies the percentage of reserved resource group memory
           that may be shared among the currently running transactions. This memory is allotted on a
           first-come, first-served basis. A running transaction may use none, some, or all of the
             <codeph>MEMORY_SHARED_QUOTA</codeph>.</p>
         <p>The minimum <codeph>MEMORY_SHARED_QUOTA</codeph> that you can specify is 0, the maximum
-          is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> is 20.</p>
+          is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> is 80.</p>
         <p>As mentioned previously, <codeph>CONCURRENCY</codeph> identifies the maximum number of
-          concurrently running transactions permitted in a resource group for roles. The fixed
-          memory reserved by a resource group is divided into <codeph>CONCURRENCY</codeph> number of
-          transaction slots. Each slot is allocated a fixed, equal amount of resource group memory.
+          concurrently running transactions permitted in a resource group for roles. If fixed
+          memory is reserved by a resource group (non-zero <codeph>MEMORY_LIMIT</codeph>),
+          it is divided into <codeph>CONCURRENCY</codeph> number of
+          transaction slots. Each slot is allocated a fixed, equal amount of the resource group memory.
           Greenplum Database guarantees this fixed memory to each transaction. <fig
             id="fig_py5_1sl_wlrg">
             <title>Resource Group Memory Allotments</title>
@@ -425,7 +431,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
           <p>Resource group global shared memory is available only to resource groups that you
             configure with the <codeph>vmtracker</codeph> memory auditor.</p>
           <p>When available, Greenplum Database allocates global shared memory to a transaction
-            after first allocating slot and resource group shared memory. Greenplum Database
+            after first allocating slot and resource group shared memory (if applicable). Greenplum Database
             allocates resource group global shared memory to transactions on a first-come
             first-served basis.</p>
           <note>Greenplum Database tracks, but does not actively monitor, transaction memory usage
@@ -466,20 +472,26 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
             transaction spills to disk. Greenplum Database uses the
               <codeph>MEMORY_SPILL_RATIO</codeph> to determine the initial memory to allocate to a
             transaction.</p>
-          <p> The minimum <codeph>MEMORY_SPILL_RATIO</codeph> percentage that you can specify for a
-            resource group is 0. The maximum is 100. The default <codeph>MEMORY_SPILL_RATIO</codeph>
-            is 20.</p>
-          <p>You define the <codeph>MEMORY_SPILL_RATIO</codeph> when you create a resource group for
-            roles. You can selectively set this limit on a per-query basis at the session level with
-            the <codeph><xref href="../ref_guide/config_params/guc-list.xml#memory_spill_ratio"
+          <p>You can specify an integer percentage value from 0 to 100 inclusive for
+            <codeph>MEMORY_SPILL_RATIO</codeph>. The default <codeph>MEMORY_SPILL_RATIO</codeph>
+           is 0.</p>
+          <p>When <codeph>MEMORY_SPILL_RATIO</codeph> is 0, Greenplum Database uses the
+            <xref href="../ref_guide/config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+            server configuration parameter value to control operator memory.</p>
+          <note>When you set <codeph>MEMORY_LIMIT</codeph> to 0,
+            <codeph>MEMORY_SPILL_RATIO</codeph> must also be set to 0.</note>
+          <p>You can selectively set the <codeph>MEMORY_SPILL_RATIO</codeph> on a per-query basis
+            at the session level with the
+            <codeph><xref href="../ref_guide/config_params/guc-list.xml#memory_spill_ratio"
                 type="topic"/></codeph> server configuration parameter.</p>
           <section id="topic833low" xml:lang="en">
             <title>memory_spill_ratio and Low Memory Queries </title>
-            <p>A low <codeph>memory_spill_ratio</codeph> setting (for example, in the 0-2% range)
+            <p>A low <codeph>statement_mem</codeph> setting (for example, in the 10MB range)
               has been shown to increase the performance of queries with low memory requirements.
-              Use the <codeph>memory_spill_ratio</codeph> server configuration parameter to override
-              the setting on a per-query basis. For example:
-              <codeblock>SET memory_spill_ratio=0;</codeblock></p>
+              Use the <codeph>memory_spill_ratio</codeph> and <codeph>statement_mem</codeph> server
+              configuration parameters to override the setting on a per-query basis. For example:
+              <codeblock>SET memory_spill_ratio=0;
+SET statement_mem='10 MB';</codeblock></p>
           </section>
         </body>
       </topic>
@@ -702,17 +714,17 @@ gpstart
             <row>
               <entry colname="col1">MEMORY_LIMIT</entry>
               <entry colname="col2">10</entry>
-              <entry colname="col3">30</entry>
+              <entry colname="col3">0</entry>
             </row>
             <row>
               <entry colname="col1">MEMORY_SHARED_QUOTA</entry>
-              <entry colname="col2">50</entry>
-              <entry colname="col3">50</entry>
+              <entry colname="col2">80</entry>
+              <entry colname="col3">80</entry>
             </row>
             <row>
               <entry colname="col1">MEMORY_SPILL_RATIO</entry>
-              <entry colname="col2">20</entry>
-              <entry colname="col3">20</entry>
+              <entry colname="col2">0</entry>
+              <entry colname="col3">0</entry>
             </row>
             <row>
               <entry colname="col1">MEMORY_AUDITOR</entry>
@@ -733,18 +745,23 @@ gpstart
   <topic id="topic10" xml:lang="en">
     <title id="iz139857">Creating Resource Groups</title>
     <body>
-      <p><i>When you create a resource group for a role</i>, you provide a name, a CPU resource
-        allocation mode, and memory limit. You can optionally provide a concurrent transaction limit
-        and memory shared quota and spill ratio. Use the <codeph><xref
+      <p><i>When you create a resource group for a role</i>, you provide a name and a CPU resource
+        allocation mode. You can optionally provide a concurrent transaction limit and 
+        memory limit, shared quota, and spill ratio values. Use the <codeph><xref
             href="../ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml#topic1" type="topic"
             format="dita"/></codeph> command to create a new resource group. </p>
-      <p id="iz152723">When you create a resource group for a role, you must provide
-          <codeph>CPU_RATE_LIMIT</codeph> or <codeph>CPUSET</codeph> and
-          <codeph>MEMORY_LIMIT</codeph> limit values. These limits identify the percentage of
-        Greenplum Database resources to allocate to this resource group. For example, to create a
-        resource group named <i>rgroup1</i> with a CPU limit of 20 and a memory limit of 25:</p>
+      <p id="iz152723">When you create a resource group for a role, you must provide a
+         <codeph>CPU_RATE_LIMIT</codeph> or <codeph>CPUSET</codeph> limit value. These
+         limits identify the percentage of Greenplum Database CPU resources to allocate
+         to this resource group. You may specify a <codeph>MEMORY_LIMIT</codeph> to
+         reserve a fixed amount of memory for the resource group. If you specify
+         a <codeph>MEMORY_LIMIT</codeph> of 0, Greenplum Database uses global shared memory
+         to fulfill all memory requirements for the resource group.</p>
+      <p>For example, to create
+        a resource group named <i>rgroup1</i> with a CPU limit of 20, a memory limit of 25,
+        and a memory spill ratio of 20:</p>
       <p>
-        <codeblock>=# CREATE RESOURCE GROUP <i>rgroup1</i> WITH (CPU_RATE_LIMIT=20, MEMORY_LIMIT=25);
+        <codeblock>=# CREATE RESOURCE GROUP <i>rgroup1</i> WITH (CPU_RATE_LIMIT=20, MEMORY_LIMIT=25, MEMORY_SPILL_RATIO=20);
 </codeblock>
       </p>
       <p>The CPU limit of 20 is shared by every role to which <codeph>rgroup1</codeph> is assigned.
@@ -768,7 +785,7 @@ gpstart
         For example:</p>
       <p>
         <codeblock>=# ALTER RESOURCE GROUP <i>rg_role_light</i> SET CONCURRENCY 7;
-=# ALTER RESOURCE GROUP <i>exec</i> SET MEMORY_LIMIT 25;
+=# ALTER RESOURCE GROUP <i>exec</i> SET MEMORY_SPILL_RATIO 25;
 =# ALTER RESOURCE GROUP <i>rgroup1</i> SET CPUSET '2,4';
 </codeblock>
       </p>
@@ -848,10 +865,8 @@ gpstart
       <body>
         <p>The <codeph><xref href="../ref_guide/system_catalogs/gp_resgroup_config.xml" type="topic"
               format="dita"/></codeph>
-          <codeph>gp_toolkit</codeph> system view displays the current and proposed limits for a
-          resource group. The proposed limit differs from the current limit when you alter the limit
-          but the new value can not be immediately applied. To view the limits of all resource
-          groups:</p>
+          <codeph>gp_toolkit</codeph> system view displays the current limits for a
+          resource group. To view the limits of all resource groups:</p>
         <p>
           <codeblock>=# SELECT * FROM gp_toolkit.gp_resgroup_config;
 </codeblock>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -384,7 +384,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
         You identify this percentage via the <codeph>MEMORY_LIMIT</codeph> value that you specify
         when you create the resource group. The minimum <codeph>MEMORY_LIMIT</codeph> percentage you
         can specify for a resource group is 0, the maximum is 100. When <codeph>MEMORY_LIMIT</codeph>
-        is 0, Greenplum Database reserves no memory for the resource group, and uses resource
+        is 0, Greenplum Database reserves no memory for the resource group, but uses resource
         group global shared memory to fulfill all memory requests in the group. Refer to
         <xref href="#topic833glob" type="topic" format="dita"/>
         for more information about resource group global shared memory.</p>
@@ -394,7 +394,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
     <topic id="mem_roles" xml:lang="en">
       <title>Additional Memory Limits for Role-based Resource Groups</title>
       <body>
-        <p>If memory is reserved for a resource group for roles (non-zero
+        <p>If resource group memory is reserved for roles (non-zero
           <codeph>MEMORY_LIMIT</codeph>), the memory is further divided into fixed and
           shared components. The <codeph>MEMORY_SHARED_QUOTA</codeph> value that you specify when
           you create the resource group identifies the percentage of reserved resource group memory

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -73,11 +73,11 @@
           <p>
             <b>memory_spill_ratio</b>
           </p>
-          <p>Set <codeph>memory_spill_ratio</codeph> to increase or decrease the initial
-            amount of memory Greenplum Database allots to a query. When you set
+          <p>Set <codeph>memory_spill_ratio</codeph> to increase or decrease the amount
+            of query operator memory Greenplum Database allots to a query. When you set
             <codeph>memory_spill_ratio</codeph> to 0, Greenplum Database uses the
-            <codeph>statement_mem</codeph> setting to determine the query operator memory
-            amount.</p>
+            <codeph>statement_mem</codeph> setting to determine the initial query operator
+            memory amount.</p>
         </li>
         <li>
           <b>statement_mem</b>

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -74,10 +74,13 @@
             <b>memory_spill_ratio</b>
           </p>
           <p>Set <codeph>memory_spill_ratio</codeph> to increase or decrease the amount
-            of query operator memory Greenplum Database allots to a query. When you set
-            <codeph>memory_spill_ratio</codeph> to 0, Greenplum Database uses the
-            <codeph>statement_mem</codeph> setting to determine the initial query operator
-            memory amount.</p>
+            of query operator memory Greenplum Database allots to a query. When <codeph>memory_spill_ratio</codeph>
+            is larger than 0, it represents the percentage of resource group memory to
+            allot to query operators. If concurrency is high, this memory amount may be small
+            even when <codeph>memory_spill_ratio</codeph> is set to the max value of 100.
+            When you set <codeph>memory_spill_ratio</codeph> to 0, Greenplum Database uses
+            the <codeph>statement_mem</codeph> setting to determine the initial amount of
+            query operator memory to allot.</p>
         </li>
         <li>
           <b>statement_mem</b>

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -69,6 +69,22 @@
             Compressing spill files may help to avoid overloading the disk subsystem with IO
             operations. </p>
         </li>
+        <li>
+          <p>
+            <b>memory_spill_ratio</b>
+          </p>
+          <p>Set <codeph>memory_spill_ratio</codeph> to increase or decrease the initial
+            amount of memory Greenplum Database allots to a query. When you set
+            <codeph>memory_spill_ratio</codeph> to 0, Greenplum Database uses the
+            <codeph>statement_mem</codeph> setting to determine the query operator memory
+            amount.</p>
+        </li>
+        <li>
+          <b>statement_mem</b>
+          <p>When <codeph>memory_spill_ratio</codeph> is 0, Greenplum Database uses the
+            <codeph>statement_mem</codeph> setting to determine the amount of memory
+            to allocate to a query.</p>
+        </li>
       </ul>
       <p>Other considerations:</p>
       <ul id="ul_xv2_phn_2z">
@@ -96,7 +112,7 @@
         <li>Use the <codeph>CONCURRENCY</codeph> resource group parameter to limit the
             number of active queries that members of a particular resource group can run
             concurrently.</li>
-        <li>Use the <codeph>MEMORY_LIMIT</codeph> and <codeph>MEMORY_SHARED_QUOTA</codeph>
+        <li>Use the <codeph>MEMORY_LIMIT</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph>
             parameters to control the maximum amount of memory that queries running in the
            resource group can consume.</li>
         <li>Greenplum Database assigns unreserved memory (100 - (sum of all resource
@@ -104,7 +120,7 @@
           memory is available to all queries on a first-come, first-served basis.</li>
         <li>Alter resource groups dynamically to match the real requirements of the
           group for the workload and the time of day.</li>
-        <li>Use the <codeph>gptoolkit</codeph> views to examine resource group resource
+        <li>Use the <codeph>gp_toolkit</codeph> views to examine resource group resource
             usage and to monitor how the groups are working.</li>
         <li otherprops="pivotal">Consider using Pivotal Greenplum Command Center
           to create and manage resource groups, and to define the criteria under which
@@ -113,11 +129,13 @@
     </section>
     <section id="section113x" xml:lang="en">
       <title>Low Memory Queries</title>
-      <p>A low <codeph>memory_spill_ratio</codeph> setting (for example, in the 0-2% range)
+      <p>A low <codeph>statement_mem</codeph> setting (for example, in the 10MB range)
         has been shown to increase the performance of queries with low memory requirements.
-        Use the <codeph>memory_spill_ratio</codeph> server configuration parameter to override
+        Use the <codeph>memory_spill_ratio</codeph> and <codeph>statement_mem</codeph> server
+        configuration parameters to override
         the setting on a per-query basis. For example:
-        <codeblock>SET memory_spill_ratio=0;</codeblock></p>
+        <codeblock>SET memory_spill_ratio=0;
+SET statement_mem='10 MB';</codeblock></p>
     </section>
     <section id="section177x" xml:lang="en">
       <title>Administrative Utilities and admin_group Concurrency</title>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -6880,8 +6880,10 @@
         a per-query basis. For example, if you have a specific query that spills to disk and
         requires more memory, you may choose to set a larger <codeph>memory_spill_ratio</codeph> to
         increase the initial memory allocation.</p>
-      <p>When you set <codeph>memory_spill_ratio</codeph> at the session level, Greenplum Database
-        does not perform semantic validation on the new value until you next perform a query.</p>
+      <p>You can specify an integer percentage value from 0 to 100 inclusive. If you
+        specify a value of 0, Greenplum Database uses the
+            <xref href="#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+            server configuration parameter value to control operator memory.</p>
       <table id="memory_spill_ratio_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -6829,15 +6829,12 @@
   <topic id="max_statement_mem">
     <title>max_statement_mem</title>
     <body>
-      <note>The <codeph>max_statement_mem</codeph> server configuration parameter is enforced only
-        when resource queue-based resource management is active.</note>
       <p>Sets the maximum memory limit for a query. Helps avoid out-of-memory errors on a segment
         host during query processing as a result of setting <codeph><xref href="#statement_mem"
             format="dita"/>
-        </codeph>too high. When <codeph><xref href="#gp_resqueue_memory_policy" format="dita"
-          />=auto</codeph>, <codeph>statement_mem</codeph> and resource queue memory limits control
-        query memory usage. Taking into account the configuration of a single segment host,
-        calculate this setting as follows:</p>
+        </codeph>too high.</p>
+      <p>Taking into account the configuration of a single segment host,
+        calculate <codeph>max_statement_mem</codeph> as follows:</p>
       <p>
         <codeph>(seghost_physical_memory) / (average_number_concurrent_queries)</codeph>
       </p>
@@ -6883,7 +6880,8 @@
       <p>You can specify an integer percentage value from 0 to 100 inclusive. If you
         specify a value of 0, Greenplum Database uses the
             <xref href="#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
-            server configuration parameter value to control operator memory.</p>
+        server configuration parameter value to control the initial query operator memory
+        amount.</p>
       <table id="memory_spill_ratio_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -8528,23 +8526,33 @@
   <topic id="statement_mem">
     <title>statement_mem</title>
     <body>
-      <note>The <codeph>statement_mem</codeph> server configuration parameter is enforced only when
-        resource queue-based resource management is active.</note>
       <p>Allocates segment host memory per query. The amount of memory allocated with this parameter
         cannot exceed <codeph><xref href="#max_statement_mem" format="dita"/></codeph> or the memory
-        limit on the resource queue through which the query was submitted. When <codeph><xref
-            href="#gp_resqueue_memory_policy" format="dita"/> =auto</codeph>,
+        limit on the resource queue or resource group through which the query was submitted.
+        If additional memory is required for a query, temporary spill files on disk are used.</p>
+      <p><i>If you are using resource groups to control resource allocation in your Greenplum
+        Database cluster</i>:</p><ul>
+        <li>Greenplum Database uses <codeph>statement_mem</codeph> to control query memory
+          usage when the resource group <codeph>MEMORY_SPILL_RATIO</codeph> is set to 0.</li>
+        <li>You can use the following calculation to estimate a reasonable <codeph>statement_mem</codeph>
+          value:
+          <codeblock>rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments
+statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
+      </ul>
+
+      <p><i>If you are using resource queues to control resource allocation in your Greenplum
+        Database cluster</i>:</p><ul>
+        <li> When <codeph><xref href="#gp_resqueue_memory_policy" format="dita"/> =auto</codeph>,
           <codeph>statement_mem</codeph> and resource queue memory limits control query memory
-        usage. </p>
-      <p>If additional memory is required for a query, temporary spill files on disk are used.</p>
-      <p>This calculation can be used to estimate a reasonable value for a wide variety of
-        situations.</p>
-      <codeblock>( <varname>gp_vmem_protect_limit</varname>GB * .9 ) / <varname>max_expected_concurrent_queries</varname></codeblock>
-      <p>With the <varname>gp_vmem_protect_limit</varname> set to 8192MB (8GB) and assuming a
-        maximum of 40 concurrent queries with a 10% buffer </p>
-      <p>
-        <codeblock>(8GB * .9) / 40 = .18GB = 184MB</codeblock>
-      </p>
+        usage. </li>
+        <li>You can use the following calculation to estimate a reasonable <codeph>statement_mem</codeph>
+          value for a wide variety of situations:
+          <codeblock>( <varname>gp_vmem_protect_limit</varname>GB * .9 ) / <varname>max_expected_concurrent_queries</varname></codeblock>
+          <p>For example, with a <varname>gp_vmem_protect_limit</varname> set to 8192MB (8GB)
+            and assuming a maximum of 40 concurrent queries with a 10% buffer, you would use
+            the following calculation to determine the <codeph>statement_mem</codeph> value:</p>
+          <codeblock>(8GB * .9) / 40 = .18GB = 184MB</codeblock></li>
+      </ul>
       <p>When changing both <codeph>max_statement_mem</codeph> and <codeph>statement_mem</codeph>,
           <codeph>max_statement_mem</codeph> must be changed first, or listed first in the
           <systemoutput>postgresql.conf</systemoutput> file.</p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1187,6 +1187,9 @@
             <p>
               <xref href="guc-list.xml#memory_spill_ratio" type="section">memory_spill_ratio</xref>
             </p>
+            <p>
+              <xref href="guc-list.xml#statement_mem" type="section">statement_mem</xref>
+            </p>
             <p><xref href="guc-list.xml#vmem_process_interrupt" type="section"
                 >vmem_process_interrupt</xref></p>
           </stentry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1185,6 +1185,9 @@
                 >gp_vmem_protect_segworker_cache_limit</xref>
             </p>
             <p>
+              <xref href="guc-list.xml#max_statement_mem" type="section">max_statement_mem</xref>
+            </p>
+            <p>
               <xref href="guc-list.xml#memory_spill_ratio" type="section">memory_spill_ratio</xref>
             </p>
             <p>

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1567,9 +1567,7 @@
       <title id="ie193152x" class="- topic/title ">gp_resgroup_config</title>
       <body class="- topic/body ">
         <p>The <codeph>gp_resgroup_config</codeph> view allows administrators to see the current
-          CPU, memory, and concurrency limits for a resource group. The view also displays proposed
-          limit settings. A proposed limit will differ from the current limit when the limit has
-          been altered, but the new value could not be immediately applied.</p>
+          CPU, memory, and concurrency limits for a resource group.</p>
         <p>This view is accessible to all users.</p>
         <table id="ie177971x" class="- topic/table ">
           <title class="- topic/title ">gp_resgroup_config</title>
@@ -1597,11 +1595,6 @@
                     (<codeph>CONCURRENCY</codeph>) value specified for the resource group.</entry>
               </row>
               <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">proposed_concurrency</entry>
-                <entry colname="col2" class="- topic/entry ">The pending concurrency value for the
-                  resource group.</entry>
-              </row>
-              <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">cpu_rate_limit</entry>
                 <entry colname="col2" class="- topic/entry ">The CPU limit
                     (<codeph>CPU_RATE_LIMIT</codeph>) value specified for the resource group, or
@@ -1613,31 +1606,16 @@
                     (<codeph>MEMORY_LIMIT</codeph>) value specified for the resource group.</entry>
               </row>
               <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">proposed_memory_limit</entry>
-                <entry colname="col2" class="- topic/entry ">The pending memory limit value for the
-                  resource group.</entry>
-              </row>
-              <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">memory_shared_quota</entry>
                 <entry colname="col2" class="- topic/entry ">The shared memory quota
                     (<codeph>MEMORY_SHARED_QUOTA</codeph>) value specified for the resource
                   group.</entry>
               </row>
               <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">proposed_memory_shared_quota</entry>
-                <entry colname="col2" class="- topic/entry ">The pending shared memory quota value
-                  for the resource group.</entry>
-              </row>
-              <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">memory_spill_ratio</entry>
                 <entry colname="col2" class="- topic/entry ">The memory spill ratio
                     (<codeph>MEMORY_SPILL_RATIO</codeph>) value specified for the resource
                   group.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">proposed_memory_spill_ratio</entry>
-                <entry colname="col2" class="- topic/entry ">The pending memory spill ratio value
-                  for the resource group.</entry>
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">memory_auditor</entry>
@@ -1744,13 +1722,13 @@
         <p id="json_field_info2">The <codeph>memory_usage</codeph> field is also a JSON-formatted,
           key:value string. The string contents differ depending upon the type of resource group.
           For each resource group that you assign to a role (default memory auditor
-            <codeph>vmtracker</codeph>), this string identifies the used, available, granted, and
-          proposed fixed and shared memory quota allocations on each segment. The key is segment id.
+            <codeph>vmtracker</codeph>), this string identifies the used and available
+          fixed and shared memory quota allocations on each segment. The key is segment id.
           The values are memory values displayed in MB units. The following example shows
             <codeph>memory_usage</codeph> column output for a single segment for a resource group
           that you assign to a
           role:<codeblock>
-"0":{"used":0, "available":76, "quota_used":-1, "quota_available":60, "quota_granted":60, "quota_proposed":60, "shared_used":0, "shared_available":16, "shared_granted":16, "shared_proposed":16}</codeblock>
+"0":{"used":0, "available":76, "quota_used":-1, "quota_available":60, "shared_used":0, "shared_available":16}</codeblock>
           For each resource group that you assign to an external component, the
             <codeph>memory_usage</codeph> JSON-formatted string identifies the memory used and the
           memory limit on each segment. The following example shows <codeph>memory_usage</codeph>
@@ -1822,11 +1800,6 @@
                   on the host.</entry>
               </row>
               <row>
-                <entry colname="col1"> <codeph>memory_quota_proposed</codeph> </entry>
-                <entry colname="col2">The total amount of fixed memory that Greenplum
-                  Database has allotted to the resource group on the host.</entry>
-              </row>
-              <row>
                 <entry colname="col1"> <codeph>memory_shared_used</codeph> </entry>
                 <entry colname="col2">The group shared memory used by the resource
                   group on the host. If any global shared memory is used by the resource
@@ -1838,31 +1811,14 @@
                   resource group on the host. Resource group global shared memory is not
                   included in this total.</entry>
               </row>
-              <row>
-                <entry colname="col1"> <codeph>memory_shared_granted</codeph> </entry>
-                <entry colname="col2">The portion of group shared memory that Greenplum
-                  Database has allotted to the resource group on the host. Resource group
-                  global shared memory is not included in this value.</entry>
-              </row>
-              <row>
-                <entry colname="col1"> <codeph>memory_shared_proposed</codeph> </entry>
-                <entry colname="col2">The total amount of group shared memory requested
-                  by the resource group on the host.</entry>
-              </row>
             </tbody>
           </tgroup>
         </table>
-        <p>The <codeph>memory_shared_granted</codeph> value may be less than
-          <codeph>memory_shared_proposed</codeph> if the cluster does not have enough
-          memory to allot. It may be greater than <codeph>memory_shared_proposed</codeph>
-          when global shared memory is in use by the resource group.
-          <codeph>memory_shared_granted</codeph> and <codeph>memory_shared_proposed</codeph>
-          should reach the same value over time.</p>
         <p>Sample output for the <codeph>gp_resgroup_status_per_host</codeph> view:</p>
-        <codeblock> rsgname       | groupid | hostname   | cpu  | memory_used | memory_available | memory_quota_used | memory_quota_available | memory_quota_proposed | memory_shared_used | memory_shared_available | memory_shared_granted | memory_shared_proposed 
----------------+---------+------------+------+-------------+------------------+-------------------+------------------------+-----------------------+--------------------+-------------------------+-----------------------+------------------------
- admin_group   | 6438    | my-desktop | 0.84 | 1           | 271              | 68                | 68                     | 136                   | 0                  | 136                     | 136                   | 136                    
- default_group | 6437    | my-desktop | 0.00 | 0           | 816              | 0                 | 400                    | 400                   | 0                  | 416                     | 416                   | 416                    
+        <codeblock> rsgname       | groupid | hostname   | cpu  | memory_used | memory_available | memory_quota_used | memory_quota_available | memory_shared_used | memory_shared_available 
+---------------+---------+------------+------+-------------+------------------+-------------------+------------------------+---------------------+---------------------
+ admin_group   | 6438    | my-desktop | 0.84 | 1           | 271              | 68                | 68                     | 0                  | 136                     
+ default_group | 6437    | my-desktop | 0.00 | 0           | 816              | 0                 | 400                    | 0                  | 416                     
 (2 rows)</codeblock>
       </body>
     </topic>
@@ -1934,13 +1890,6 @@
                   the segment instance on the host.</entry>
               </row>
               <row>
-                <entry colname="col1"> <codeph>memory_quota_proposed</codeph> </entry>
-                <entry colname="col4">The total amount of fixed memory that Greenplum Database
-                  has allotted to the resource group for the segment on the host. This value
-                  will be the same for all resource group and segment instance combinations
-                  on a host.</entry>
-              </row>
-              <row>
                 <entry colname="col1"> <codeph>memory_shared_used</codeph> </entry>
                 <entry colname="col4">The group shared memory used by the resource
                   group for the segment instance on the host.</entry>
@@ -1950,19 +1899,6 @@
                 <entry colname="col4">The amount of group shared memory available
                   for the segment instance on the host. Resource group global shared memory
                   is not included in this total.</entry>
-              </row>
-              <row>
-                <entry colname="col1"> <codeph>memory_shared_granted</codeph> </entry>
-                <entry colname="col4">The portion of group shared memory that
-                  Greenplum Database has allotted to the resource group for the segment
-                  instance on the host. Resource group global shared memory is not
-                  included in this value.</entry>
-              </row>
-              <row>
-                <entry colname="col1"> <codeph>memory_shared_proposed</codeph> </entry>
-                <entry colname="col4">The total amount of group shared memory requested
-                  by the resource group on the host. This value will be the same for all
-                  resource group and segment instance combinations on a host.</entry>
               </row>
             </tbody>
           </tgroup>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -67,9 +67,14 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
         </plentry>
         <plentry>
           <pt>MEMORY_LIMIT <varname>integer</varname></pt>
-          <pd>The percentage of memory resources to allocate to
-            this resource group. The minimum memory percentage for a resource group is 1.
-            The maximum is 100. The sum of the
+          <pd>The percentage of Greenplum Database memory resources to reserve for 
+            this resource group. The minimum memory percentage for a resource group is 0.
+            The maximum is 100. The default value is 0.</pd>
+          <pd>When <codeph>MEMORY_LIMIT</codeph> is 0, Greenplum Database reserves no
+            memory for the resource group, and uses global shared memory to fulfill all
+            memory requests in the group. If <codeph>MEMORY_LIMIT</codeph> is 0,
+            <codeph>MEMORY_SPILL_RATIO</codeph> must also be 0.</pd>
+          <pd>The sum of the
             <codeph>MEMORY_LIMIT</codeph>s of all resource groups defined in the
             Greenplum Database cluster must not exceed 100.</pd>
         </plentry>
@@ -78,14 +83,16 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
           <pd>The percentage of memory resources to share among transactions in
             the resource group. The minimum memory shared quota percentage for a
             resource group is 0. The maximum is 100. The default
-            <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20.</pd>
+            <codeph>MEMORY_SHARED_QUOTA</codeph> value is 80.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>
-          <pd>The memory usage threshold for memory-intensive operators in a transaction
-            issued in the resource group. The minimum memory spill ratio percentage for a
-            resource group is 0. The maximum is 100. The default
-            <codeph>MEMORY_SPILL_RATIO</codeph> value is 20.</pd>
+          <pd>The memory usage threshold for memory-intensive operators in a transaction.
+            You can specify an integer percentage value from 0 to 100 inclusive. The default
+            <codeph>MEMORY_SPILL_RATIO</codeph> value is 0. When <codeph>MEMORY_SPILL_RATIO</codeph>
+            is 0, Greenplum Database uses the
+            <xref href="../config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+            server configuration parameter value to control operator memory.</pd>
         </plentry>
       </parml>
     </section>
@@ -104,7 +111,7 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
       <codeblock>ALTER RESOURCE GROUP rgroup2 SET CPU_RATE_LIMIT 45;</codeblock>
       <p>Update the memory limit for a resource group: </p>
       <codeblock>ALTER RESOURCE GROUP rgroup3 SET MEMORY_LIMIT 30;</codeblock>
-      <p>Increase the memory spill ratio for a resource group from the default: </p>
+      <p>Update the memory spill ratio for a resource group: </p>
       <codeblock>ALTER RESOURCE GROUP rgroup4 SET MEMORY_SPILL_RATIO 25;</codeblock>
       <p>Reserve CPU core 1 for a resource group: </p>
       <codeblock>ALTER RESOURCE GROUP rgroup5 SET CPUSET '1';</codeblock>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -94,7 +94,7 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
             <codeph>MEMORY_SPILL_RATIO</codeph> value is 0. When <codeph>MEMORY_SPILL_RATIO</codeph>
             is 0, Greenplum Database uses the
             <xref href="../config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
-            server configuration parameter value to control query operator memory.</pd>
+            server configuration parameter value to control initial query operator memory.</pd>
         </plentry>
       </parml>
     </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -92,7 +92,7 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
             <codeph>MEMORY_SPILL_RATIO</codeph> value is 0. When <codeph>MEMORY_SPILL_RATIO</codeph>
             is 0, Greenplum Database uses the
             <xref href="../config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
-            server configuration parameter value to control operator memory.</pd>
+            server configuration parameter value to control query operator memory.</pd>
         </plentry>
       </parml>
     </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -71,7 +71,7 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
             this resource group. The minimum memory percentage for a resource group is 0.
             The maximum is 100. The default value is 0.</pd>
           <pd>When <codeph>MEMORY_LIMIT</codeph> is 0, Greenplum Database reserves no
-            memory for the resource group, and uses global shared memory to fulfill all
+            memory for the resource group, but uses global shared memory to fulfill all
             memory requests in the group. If <codeph>MEMORY_LIMIT</codeph> is 0,
             <codeph>MEMORY_SPILL_RATIO</codeph> must also be 0.</pd>
           <pd>The sum of the

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -76,7 +76,9 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
             <codeph>MEMORY_SPILL_RATIO</codeph> must also be 0.</pd>
           <pd>The sum of the
             <codeph>MEMORY_LIMIT</codeph>s of all resource groups defined in the
-            Greenplum Database cluster must not exceed 100.</pd>
+            Greenplum Database cluster must not exceed 100. If this sum is less
+            than 100, Greenplum Database allocates any unreserved memory to a resource
+            group global shared memory pool.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -10,7 +10,7 @@
       <codeblock id="sql_command_synopsis">CREATE RESOURCE GROUP <varname>name</varname> WITH (<varname>group_attribute</varname>=<varname>value</varname> [, ... ])</codeblock>
       <p>where <varname>group_attribute</varname> is:</p>
       <codeblock>CPU_RATE_LIMIT=<varname>integer</varname> | CPUSET=<varname>tuple</varname>
-MEMORY_LIMIT=<varname>integer</varname>
+[ MEMORY_LIMIT=<varname>integer</varname> ]
 [ CONCURRENCY=<varname>integer</varname> ]
 [ MEMORY_SHARED_QUOTA=<varname>integer</varname> ]
 [ MEMORY_SPILL_RATIO=<varname>integer</varname> ]
@@ -63,15 +63,28 @@ MEMORY_LIMIT=<varname>integer</varname>
         </plentry>
         <plentry>
           <pt>MEMORY_LIMIT <varname>integer</varname></pt>
-          <pd>Required. The total percentage of Greenplum Database memory resources to allocate to this resource group. The minimum memory percentage you can specify for a resource group is 1. The maximum is 100. The sum of the <codeph>MEMORY_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.</pd>
+          <pd>The total percentage of Greenplum Database memory resources to reserve for this
+            resource group. The minimum memory percentage you can specify for a resource
+            group is 0. The maximum is 100. The default value is 0.</pd>
+          <pd>When you specify a <codeph>MEMORY_LIMIT</codeph> of 0, Greenplum Database
+            reserves no memory for the resource group, and uses global shared memory to
+            fulfill all memory requests in the group. If <codeph>MEMORY_LIMIT</codeph> is 0,
+           <codeph>MEMORY_SPILL_RATIO</codeph> must also be 0.</pd>
+          <pd>The sum of the <codeph>MEMORY_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>
-          <pd>The quota of shared memory in the resource group. Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. This shared memory is allocated on a first-come, first-served basis as available. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 20.</pd>
+          <pd>The quota of shared memory in the resource group. Resource groups with a <codeph>MEMORY_SHARED_QUOTA</codeph> threshold set aside a percentage of memory allotted to the resource group to share across transactions. This shared memory is allocated on a first-come, first-served basis as available. A transaction may use none, some, or all of this memory. The minimum memory shared quota percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> value is 80.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>
-          <pd>The memory usage threshold for memory-intensive operators in a transaction. When this threshold is reached, a transaction spills to disk. The minimum memory spill ratio percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SPILL_RATIO</codeph> value is 20.</pd>
+          <pd>The memory usage threshold for memory-intensive operators in a transaction.
+            When this threshold is reached, a transaction spills to disk. You can specify
+            an integer percentage value  from 0 to 100 inclusive. The default
+            <codeph>MEMORY_SPILL_RATIO</codeph> value is 0. When <codeph>MEMORY_SPILL_RATIO</codeph>
+            is 0, Greenplum Database uses the
+            <xref href="../config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+            server configuration parameter value to control operator memory.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_AUDITOR {vmtracker | cgroup}</pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -84,7 +84,7 @@
             <codeph>MEMORY_SPILL_RATIO</codeph> value is 0. When <codeph>MEMORY_SPILL_RATIO</codeph>
             is 0, Greenplum Database uses the
             <xref href="../config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
-            server configuration parameter value to control query operator memory.</pd>
+            server configuration parameter value to control initial query operator memory.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_AUDITOR {vmtracker | cgroup}</pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -67,7 +67,7 @@
             resource group. The minimum memory percentage you can specify for a resource
             group is 0. The maximum is 100. The default value is 0.</pd>
           <pd>When you specify a <codeph>MEMORY_LIMIT</codeph> of 0, Greenplum Database
-            reserves no memory for the resource group, and uses global shared memory to
+            reserves no memory for the resource group, but uses global shared memory to
             fulfill all memory requests in the group. If <codeph>MEMORY_LIMIT</codeph> is 0,
            <codeph>MEMORY_SPILL_RATIO</codeph> must also be 0.</pd>
           <pd>The sum of the <codeph>MEMORY_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.</pd>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -84,7 +84,7 @@
             <codeph>MEMORY_SPILL_RATIO</codeph> value is 0. When <codeph>MEMORY_SPILL_RATIO</codeph>
             is 0, Greenplum Database uses the
             <xref href="../config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
-            server configuration parameter value to control operator memory.</pd>
+            server configuration parameter value to control query operator memory.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_AUDITOR {vmtracker | cgroup}</pt>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_config.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_config.xml
@@ -5,9 +5,7 @@
   <title id="fp141670">gp_resgroup_config</title>
   <body>
     <p>The <codeph>gp_toolkit.gp_resgroup_config</codeph> view allows administrators to see the
-      current CPU, memory, and concurrency limits for a resource group. The
-      view also displays proposed limit settings. A proposed limit will differ from a current
-      limit when the limit has been altered, but the new value could not be immediately applied.</p>
+      current CPU, memory, and concurrency limits for a resource group.</p>
       <note>The <codeph>gp_resgroup_config</codeph> view is valid only when resource group-based resource management is active.</note>
     <table id="fp141982">
       <title>gp_toolkit.gp_resgroup_config</title>
@@ -51,14 +49,6 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph>proposed_concurrency</codeph>
-            </entry>
-            <entry colname="col2">text</entry>
-            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype = 1</entry>
-            <entry colname="col4">The pending concurrency value for the resource group.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
               <codeph>cpu_rate_limit</codeph>
             </entry>
             <entry colname="col2">text</entry>
@@ -75,14 +65,6 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph>proposed_memory_limit</codeph>
-            </entry>
-            <entry colname="col2">text</entry>
-            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype = 3</entry>
-            <entry colname="col4">The pending memory limit value for the resource group.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
               <codeph>memory_shared_quota</codeph>
             </entry>
             <entry colname="col2">text</entry>
@@ -91,27 +73,11 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph>proposed_memory_shared_quota</codeph>
-            </entry>
-            <entry colname="col2">text</entry>
-            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype = 4</entry>
-            <entry colname="col4">The pending shared memory quota value for the resource group.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
               <codeph>memory_spill_ratio</codeph>
             </entry>
             <entry colname="col2">text</entry>
             <entry colname="col3">pg_resgroupcapability.value for pg_resgroupcapability.reslimittype = 5</entry>
             <entry colname="col4">The memory spill ratio (<codeph>MEMORY_SPILL_RATIO</codeph>) value specified for the resource group.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
-              <codeph>proposed_memory_spill_ratio</codeph>
-            </entry>
-            <entry colname="col2">text</entry>
-            <entry colname="col3">pg_resgroupcapability.proposed for pg_resgroupcapability.reslimittype> = 5</entry>
-            <entry colname="col4">The pending memory spill ratio value for the resource group.</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_host.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_host.xml
@@ -99,15 +99,6 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph>memory_quota_proposed</codeph>
-            </entry>
-            <entry colname="col2">integer</entry>
-            <entry colname="col3"></entry>
-            <entry colname="col4">The total amount of fixed memory that Greenplum
-              Database has allotted to the resource group on the host.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
               <codeph>memory_shared_used</codeph>
             </entry>
             <entry colname="col2">integer</entry>
@@ -125,25 +116,6 @@
             <entry colname="col4">The amount of group shared memory available to the
               resource group on the host. Resource group global shared memory is not
               included in this total.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
-              <codeph>memory_shared_granted</codeph>
-            </entry>
-            <entry colname="col2">integer</entry>
-            <entry colname="col3"></entry>
-            <entry colname="col4">The portion of group shared memory that Greenplum
-              Database has allotted to the resource group on the host. Resource
-              group global shared memory is not included in this value.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
-              <codeph>memory_shared_proposed</codeph>
-            </entry>
-            <entry colname="col2">integer</entry>
-            <entry colname="col3"></entry>
-            <entry colname="col4">The total amount of group shared memory requested
-              by the resource group on the host.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_segment.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_segment.xml
@@ -108,17 +108,6 @@
           </row>
           <row>
             <entry colname="col1">
-              <codeph>memory_quota_proposed</codeph>
-            </entry>
-            <entry colname="col2">integer</entry>
-            <entry colname="col3"></entry>
-            <entry colname="col4">The total amount of fixed memory that Greenplum Database
-              has allotted to the resource group for the segment on the host. This value
-              will be the same for all resource group and segment instance combinations
-              on a host.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
               <codeph>memory_shared_used</codeph>
             </entry>
             <entry colname="col2">integer</entry>
@@ -135,27 +124,6 @@
             <entry colname="col4">The amount of group shared memory available
               for the segment instance on the host. Resource group global shared memory
               is not included in this total.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
-              <codeph>memory_shared_granted</codeph>
-            </entry>
-            <entry colname="col2">integer</entry>
-            <entry colname="col3"></entry>
-            <entry colname="col4">The portion of group shared memory that
-              Greenplum Database has allotted to the resource group for the segment
-              instance on the host. Resource group global shared memory is not
-              included in this value.</entry>
-          </row>
-          <row>
-            <entry colname="col1">
-              <codeph>memory_shared_proposed</codeph>
-            </entry>
-            <entry colname="col2">integer</entry>
-            <entry colname="col3"></entry>
-            <entry colname="col4">The total amount of group shared memory requested
-              by the resource group on the host. This value will be the same for all
-              resource group and segment instance combinations on a host.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_resgroupcapability.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_resgroupcapability.xml
@@ -60,17 +60,6 @@
               this record. This value has the fixed type <codeph>text</codeph>, and will be
               converted to a different data type depending upon the limit referenced. </entry>
           </row>
-          <row>
-            <entry colname="col1">
-              <codeph>proposed</codeph>
-            </entry>
-            <entry colname="col2">opaque type</entry>
-            <entry colname="col3"/>
-            <entry colname="col4">If you altered a resource limit and the limit cannot be
-               updated immediately, the proposed value for the limit referenced in this
-               record. Otherwise, <codeph>proposed</codeph> reflects the currently set
-               <codeph>value</codeph>.</entry>
-          </row>
         </tbody>
       </tgroup>
     </table>


### PR DESCRIPTION
document the "fallback to statement_mem" and "do not reserve memory for RGs, use global shared memory" resource group changes.

i believe that the functionality is the same in master and 6X_STABLE (please confirm MPP team).  if so, this will be backported to 6X_STABLE.  i will submit a new PR for 5X_STABLE - will be similar, but without the catalog changes.

in this PR:
- "using" page - new MEMORY_LIMIT range and default, new MEMORY_SHARED_QUOTA default, new MEMORY_SPILL_RATIO default and new meaning to MEMORY_SPILL_RATIO=0, update examples, identify new default_group and admin_group limit defaults, update "low memory queries section to also set statement_mem"
- ALTER/CREATE RESOURCE GROUP - document the limit changes
- add statement_mem to list of GUCs in resource group category
- gp_toolkit - remove *proposed* attributes and related fields, update memory output
- gp_resgroup_config* views - remove some fields
- pg_resgroupcapability - remove proposed field
- memory_spill_ratio GUC - if 0, greenplum uses statement_mem
- best practices for RGs - misc edits, include memory_spill_ratio and statement_mem in list of config params, update the "low memory queries section

QUESTION:  it wasn't clear to me how to modify the statement_mem GUC description (http://docs-lisa-review.cfapps.io/6-0/ref_guide/config_params/guc-list.html#statement_mem)- right now, it is very specific to resource queues and utilizes gp_vmem_protect_limit in the calculation.

doc review site links:
-  "using" page:  http://docs-lisa-review.cfapps.io/6-0/admin_guide/workload_mgmt_resgroups.html#topic8339717
- ALTER RESOURCE GROUP:  http://docs-lisa-review.cfapps.io/6-0/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html#topic1
- best practices:  http://docs-lisa-review.cfapps.io/6-0/best_practices/resgroups.html
- gp_toolkit:  http://docs-lisa-review.cfapps.io/6-0/ref_guide/gp_toolkit.html#topic26x