### PR TITLE
Add tests for default tablespace and alter database set tablespace

### DIFF
--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -171,7 +171,8 @@ tablespace-setup:
 	./testtablespace_existing_version_dir/7/GPDB_99_399999991/ \
 	./testtablespace_existing_version_dir/8/GPDB_99_399999991/ \
         ./testtablespace_1111111111222222222233333333334444444444555555555566666666667777777777888888888899999999990000000000/ \
-	./testtablespace_default_tablespace
+	./testtablespace_default_tablespace \
+	./testtablespace_database_tablespace
 
 # Check for include files that are not being shipped
 .PHONY: includecheck

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -30,6 +30,8 @@ test: gp_tablespace gp_aggregates gp_metadata variadic_parameters default_parame
 test: spi_processed64bit
 test: python_processed64bit
 
+test: default_tablespace
+
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp replication_slots create_table_like_gp
 
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format

--- a/src/test/regress/input/default_tablespace.source
+++ b/src/test/regress/input/default_tablespace.source
@@ -18,6 +18,23 @@ select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace
 -- And it should be created in the default tablespace on the segments
 select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_table_in_default_tablespace_index' and spcname = 'some_default_tablespace';
 
+-- When I create a temporary table
+create temporary table some_temporary_table_for_default_tablespace_test (a int);
+
+-- Then it should not be affected by the default_tablespace GUC
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_temporary_table_for_default_tablespace_test';
+
+-- And is should not be affected on the segments either
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_temporary_table_for_default_tablespace_test' and spcname = 'some_default_tablespace';
+
+-- When I create an index on a temporary table
+create index some_temporary_table_for_default_tablespace_test_index on some_temporary_table_for_default_tablespace_test(a);
+
+-- Then it should not be affected by the default_tablespace GUC
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_temporary_table_for_default_tablespace_test_index';
+
+-- And is should not be affected on the segments either
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_temporary_table_for_default_tablespace_test_index' and spcname = 'some_default_tablespace';
 
 drop table some_table_in_default_tablespace;
 drop tablespace some_default_tablespace;

--- a/src/test/regress/input/default_tablespace.source
+++ b/src/test/regress/input/default_tablespace.source
@@ -8,6 +8,17 @@ select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace
 -- expect this to be the number of segments
 select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_table_in_default_tablespace' and spcname = 'some_default_tablespace';
 
+
+-- When I create an index with the a default tablespace set
+create index some_table_in_default_tablespace_index on some_table_in_default_tablespace(a);
+
+-- Then it should be created in the default tablespace
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_table_in_default_tablespace_index';
+
+-- And it should be created in the default tablespace on the segments
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_table_in_default_tablespace_index' and spcname = 'some_default_tablespace';
+
+
 drop table some_table_in_default_tablespace;
 drop tablespace some_default_tablespace;
 reset default_tablespace;

--- a/src/test/regress/input/default_tablespace.source
+++ b/src/test/regress/input/default_tablespace.source
@@ -1,4 +1,5 @@
 create tablespace some_default_tablespace location '@testtablespace@_default_tablespace';
+create tablespace some_database_tablespace location '@testtablespace@_database_tablespace';
 set default_tablespace to some_default_tablespace;
 create table some_table_in_default_tablespace (a int);
 
@@ -36,6 +37,31 @@ select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace
 -- And is should not be affected on the segments either
 select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_temporary_table_for_default_tablespace_test_index' and spcname = 'some_default_tablespace';
 
+
+-- When I set a tablespace for a database
+reset default_tablespace;
+create database database_with_tablespace;
+alter database database_with_tablespace set tablespace some_database_tablespace;
+\c database_with_tablespace;
+
+-- And I set a default tablespace
+set default_tablespace to some_default_tablespace;
+
+-- Then tables and indexes that I create should be in the default tablespace
+create table table_under_database_with_default_tablespace (a int);
+create index table_under_database_with_default_tablespace_index on table_under_database_with_default_tablespace(a); 
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'table_under_database_with_default_tablespace';
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'table_under_database_with_default_tablespace' and spcname = 'some_default_tablespace';
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'table_under_database_with_default_tablespace_index';
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'table_under_database_with_default_tablespace_index' and spcname = 'some_default_tablespace';
+
+-- cleanup
+\c regression
 drop table some_table_in_default_tablespace;
 drop tablespace some_default_tablespace;
 reset default_tablespace;
+\c database_with_tablespace
+drop table table_under_database_with_default_tablespace;
+\c regression
+drop database database_with_tablespace;
+drop tablespace some_database_tablespace;

--- a/src/test/regress/output/default_tablespace.source
+++ b/src/test/regress/output/default_tablespace.source
@@ -15,6 +15,22 @@ select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_t
      3
 (1 row)
 
+-- When I create an index with the a default tablespace set
+create index some_table_in_default_tablespace_index on some_table_in_default_tablespace(a);
+-- Then it should be created in the default tablespace
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_table_in_default_tablespace_index';
+ count 
+-------
+     1
+(1 row)
+
+-- And it should be created in the default tablespace on the segments
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_table_in_default_tablespace_index' and spcname = 'some_default_tablespace';
+ count 
+-------
+     3
+(1 row)
+
 drop table some_table_in_default_tablespace;
 drop tablespace some_default_tablespace;
 reset default_tablespace;

--- a/src/test/regress/output/default_tablespace.source
+++ b/src/test/regress/output/default_tablespace.source
@@ -1,4 +1,5 @@
 create tablespace some_default_tablespace location '@testtablespace@_default_tablespace';
+create tablespace some_database_tablespace location '/Users/adamberlin/workspace/gpdb7/src/test/regress/testtablespace_database_tablespace';
 set default_tablespace to some_default_tablespace;
 create table some_table_in_default_tablespace (a int);
 -- expect this to be one
@@ -63,6 +64,47 @@ select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_t
      0
 (1 row)
 
+-- When I set a tablespace for a database
+reset default_tablespace;
+create database database_with_tablespace;
+alter database database_with_tablespace set tablespace some_database_tablespace;
+\c database_with_tablespace;
+-- And I set a default tablespace
+set default_tablespace to some_default_tablespace;
+-- Then tables and indexes that I create should be in the default tablespace
+create table table_under_database_with_default_tablespace (a int);
+create index table_under_database_with_default_tablespace_index on table_under_database_with_default_tablespace(a);
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'table_under_database_with_default_tablespace';
+ count 
+-------
+     1
+(1 row)
+
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'table_under_database_with_default_tablespace' and spcname = 'some_default_tablespace';
+ count 
+-------
+     3
+(1 row)
+
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'table_under_database_with_default_tablespace_index';
+ count 
+-------
+     1
+(1 row)
+
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'table_under_database_with_default_tablespace_index' and spcname = 'some_default_tablespace';
+ count 
+-------
+     3
+(1 row)
+
+-- cleanup
+\c regression
 drop table some_table_in_default_tablespace;
 drop tablespace some_default_tablespace;
 reset default_tablespace;
+\c database_with_tablespace
+drop table table_under_database_with_default_tablespace;
+\c regression
+drop database database_with_tablespace;
+drop tablespace some_database_tablespace;

--- a/src/test/regress/output/default_tablespace.source
+++ b/src/test/regress/output/default_tablespace.source
@@ -31,6 +31,38 @@ select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_t
      3
 (1 row)
 
+-- When I create a temporary table
+create temporary table some_temporary_table_for_default_tablespace_test (a int);
+-- Then it should not be affected by the default_tablespace GUC
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_temporary_table_for_default_tablespace_test';
+ count 
+-------
+     0
+(1 row)
+
+-- And is should not be affected on the segments either
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_temporary_table_for_default_tablespace_test' and spcname = 'some_default_tablespace';
+ count 
+-------
+     0
+(1 row)
+
+-- When I create an index on a temporary table
+create index some_temporary_table_for_default_tablespace_test_index on some_temporary_table_for_default_tablespace_test(a);
+-- Then it should not be affected by the default_tablespace GUC
+select count(1) from pg_class inner join pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid where spcname = 'some_default_tablespace' AND relname = 'some_temporary_table_for_default_tablespace_test_index';
+ count 
+-------
+     0
+(1 row)
+
+-- And is should not be affected on the segments either
+select count(1) from gp_dist_random('pg_class') segment_pg_class inner join pg_tablespace on pg_tablespace.oid = segment_pg_class.reltablespace where relname = 'some_temporary_table_for_default_tablespace_test_index' and spcname = 'some_default_tablespace';
+ count 
+-------
+     0
+(1 row)
+
 drop table some_table_in_default_tablespace;
 drop tablespace some_default_tablespace;
 reset default_tablespace;


### PR DESCRIPTION
This builds upon #7884. I'll rebase master after it has been merged.

It also depends on the work being done to make ALTER DATABASE SET TABLESPACE remove the dboid directory from the original tablespace. The tests currently fail because the test is unable to remove the `some_default_tablespace` tablespace. 

After the two dependent PRs are merged, this should be ready to go.