### PR TITLE
Backport: Fix read pg_distributedlog bug (#7764)

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -295,32 +295,6 @@ ReadNewTransactionId(void)
 }
 
 /*
- * Get the last safe XID, i.e. the oldest XID that might exist in any
- * database of our cluster.
- */
-TransactionId
-GetTransactionIdLimit(void)
-{
-	TransactionId xid;
-
-	LWLockAcquire(XidGenLock, LW_SHARED);
-	xid = ShmemVariableCache->oldestXid;
-	LWLockRelease(XidGenLock);
-
-	if (!TransactionIdIsNormal(xid))
-	{
-		/*
-		 * shouldn't happen, but since this value is used in the computation
-		 * of oldest xmin, which determines which tuples be safely vacuumed
-		 * away, let's be paranoid.
-		 */
-		elog(ERROR, "invalid oldestXid limit: %u", xid);
-	}
-
-	return xid;
-}
-
-/*
  * Determine the last safe XID to allocate given the currently oldest
  * datfrozenxid (ie, the oldest XID that might exist in any database
  * of our cluster), and the OID of the (or a) database with that value.

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -60,7 +60,6 @@ extern bool DistributedLog_ScanForPrevCommitted(
 extern TransactionId DistributedLog_AdvanceOldestXmin(TransactionId oldestInProgressLocalXid,
 								 DistributedTransactionTimeStamp distribTimeStamp,
 								 DistributedTransactionId oldestDistribXid);
-extern void DistributedLog_AdvanceOldestXminOnQD(TransactionId oldestLocalXmin);
 extern TransactionId DistributedLog_GetOldestXmin(TransactionId oldestLocalXmin);
 
 extern Size DistributedLog_ShmemSize(void);
@@ -75,6 +74,7 @@ extern void DistributedLog_CheckPoint(void);
 extern void DistributedLog_Extend(TransactionId newestXid);
 extern bool DistributedLog_GetLowWaterXid(
 							  TransactionId *lowWaterXid);
+extern void DistributedLog_InitOldestXmin(void);
 
 /* XLOG stuff */
 #define DISTRIBUTEDLOG_ZEROPAGE		0x00

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -153,7 +153,6 @@ extern XLogRecPtr TransactionIdGetCommitLSN(TransactionId xid);
 /* in transam/varsup.c */
 extern TransactionId GetNewTransactionId(bool isSubXact);
 extern TransactionId ReadNewTransactionId(void);
-extern TransactionId GetTransactionIdLimit(void);
 extern void SetTransactionIdLimit(TransactionId oldest_datfrozenxid,
 					  Oid oldest_datoid);
 extern bool ForceTransactionIdLimitUpdate(void);

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -139,7 +139,8 @@ extern PGDLLIMPORT LWLockPadded *MainLWLockArray;
 #define SessionStateLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 7].lock)
 #define RelfilenodeGenLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 8].lock)
 #define WorkFileManagerLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 9].lock)
-#define GP_NUM_INDIVIDUAL_LWLOCKS		9
+#define DistributedLogTruncateLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 10].lock)
+#define GP_NUM_INDIVIDUAL_LWLOCKS		10
 
 /*
  * It would probably be better to allocate separate LWLock tranches


### PR DESCRIPTION
* Fix read pg_distributedlog bug

In the function 'DistributedLog_AdvanceOldestXmin', it reads pg_distributedlog,
updates 'DistributedLogShared->oldestXmin' and truncates the logs whose xid is
smaller than 'DistributedLogShared->oldestXmin'. This looks good because it's
serialized under the lock DistributedLogControlLock. The problem is the read
function 'SimpleLruReadPage' may release and re-acquire the lock, and another
caller of DistributedLog_AdvanceOldestXmin may truncate the logs concurrently
and 'SimpleLruReadPage' will error out. DistributedLog_CommittedCheck may
read LRU page in a similar way, also need to be protected.

The number of pg_distributedlog files is about 32 times of pg_clog, truncate
pg_distributedlog based on the frozenxid might left too many files on the disk.
So we introduce a new LWLock to prevent truncating a file while someone else is
reading it.

Co-authored-by: Gang Xiong <gxiong@pivotal.io>
Co-authored-by: Hubert Zhang <hzhang@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
