### PR TITLE
5X: Fix add/remove mirror deadlock

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -127,7 +127,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 	component_databases->entry_db_info =
 		(CdbComponentDatabaseInfo *) palloc0(sizeof(CdbComponentDatabaseInfo) * entry_array_size);
 
-	gp_seg_config_rel = heap_open(GpSegmentConfigRelationId, AccessShareLock);
+	gp_seg_config_rel = heap_open(GpSegmentConfigRelationId, RowShareLock);
 
 	gp_seg_config_scan = heap_beginscan(gp_seg_config_rel, SnapshotNow, 0, NULL);
 
@@ -287,7 +287,7 @@ getCdbComponentInfo(bool DNSLookupAsError)
 	 * all the relations we opened.
 	 */
 	heap_endscan(gp_seg_config_scan);
-	heap_close(gp_seg_config_rel, AccessShareLock);
+	heap_close(gp_seg_config_rel, NoLock);
 
 	/*
 	 * Validate that there exists at least one entry and one segment

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -454,6 +454,14 @@ checkDispatchResult(CdbDispatcherState *ds,
 		else
 			timeout = DISPATCH_WAIT_CANCEL_TIMEOUT_MSEC;
 
+#ifdef FAULT_INJECTOR
+		if (SIMPLE_FAULT_INJECTOR(DispatchResultPoll) == FaultInjectorTypeSkip)
+		{
+			timeoutCounter = 500;
+			n = 0;
+		}
+		else
+#endif
 		n = poll(fds, nfds, timeout);
 
 		/* poll returns with an error, including one due to an interrupted call */

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -267,6 +267,51 @@ UnlockRelation(Relation relation, LOCKMODE lockmode)
 }
 
 /*
+ *		CheckRelationLockedByMe
+ *
+ * Returns true if current transaction holds a lock on 'relation' of mode
+ * 'lockmode'.  If 'orstronger' is true, a stronger lockmode is also OK.
+ * ("Stronger" is defined as "numerically higher", which is a bit
+ * semantically dubious but is OK for the purposes we use this for.)
+ */
+bool
+CheckRelationLockedByMe(Relation relation, LOCKMODE lockmode, bool orstronger)
+{
+	LOCKTAG		tag;
+
+	SET_LOCKTAG_RELATION(tag,
+						 relation->rd_lockInfo.lockRelId.dbId,
+						 relation->rd_lockInfo.lockRelId.relId);
+
+	if (LockHeldByMe(&tag, lockmode))
+		return true;
+
+	if (orstronger)
+	{
+		LOCKMODE	slockmode;
+
+		for (slockmode = lockmode + 1;
+			 slockmode <= MaxLockMode;
+			 slockmode++)
+		{
+			if (LockHeldByMe(&tag, slockmode))
+			{
+#ifdef NOT_USED
+				/* Sometimes this might be useful for debugging purposes */
+				elog(WARNING, "lock mode %s substituted for %s on relation %s",
+					 GetLockmodeName(tag.locktag_lockmethodid, slockmode),
+					 GetLockmodeName(tag.locktag_lockmethodid, lockmode),
+					 RelationGetRelationName(relation));
+#endif
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/*
  *		LockRelationIdForSession
  *
  * This routine grabs a session-level lock on the target relation.	The

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -451,6 +451,29 @@ proclock_hash(const void *key, Size keysize)
 	return lockhash;
 }
 
+/*
+ * LockHeldByMe -- test whether lock 'locktag' is held with mode 'lockmode'
+ *		by the current transaction
+ */
+bool
+LockHeldByMe(const LOCKTAG *locktag, LOCKMODE lockmode)
+{
+	LOCALLOCKTAG localtag;
+	LOCALLOCK  *locallock;
+
+	/*
+	 * See if there is a LOCALLOCK entry for this lock and lockmode
+	 */
+	MemSet(&localtag, 0, sizeof(localtag)); /* must clear padding */
+	localtag.lock = *locktag;
+	localtag.mode = lockmode;
+
+	locallock = (LOCALLOCK *) hash_search(LockMethodLocalHash,
+										  (void *) &localtag,
+										  HASH_FIND, NULL);
+
+	return (locallock && locallock->nLocks > 0);
+}
 
 
 

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -864,7 +864,7 @@ gp_add_segment_mirror(PG_FUNCTION_ARGS)
 	mirroring_sanity_check(MASTER_ONLY | SUPERUSER, "gp_add_segment_mirror");
 
 	/* avoid races */
-	rel = heap_open(GpSegmentConfigRelationId, AccessExclusiveLock);
+	rel = heap_open(GpSegmentConfigRelationId, ExclusiveLock);
 
 	pridbid = contentid_get_dbid(contentid, SEGMENT_ROLE_PRIMARY, false /* false == current, not preferred, role */);
 	if (!pridbid)
@@ -923,7 +923,7 @@ gp_remove_segment_mirror(PG_FUNCTION_ARGS)
 	mirroring_sanity_check(MASTER_ONLY | SUPERUSER, "gp_remove_segment_mirror");
 
 	/* avoid races */
-	rel = heap_open(GpSegmentConfigRelationId, AccessExclusiveLock);
+	rel = heap_open(GpSegmentConfigRelationId, ExclusiveLock);
 
 	pridbid = contentid_get_dbid(contentid, SEGMENT_ROLE_PRIMARY, false /* false == current, not preferred, role */);
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -281,6 +281,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault after compaction, but before the drop of the
 		 * segment file */
 	_("compaction_before_cleanup_phase"),
+	    /* inject fault before polling for dispatch results */
+	_("dispatch_result_poll"),
 		/* inject fault after compaction and drop, but before
 		 * the cleanup phase for a relation */
 	_("appendonly_insert"),
@@ -1069,6 +1071,8 @@ FaultInjector_NewHashEntry(
 			case CreateResourceGroupFail:
 			case CreateGangInProgress:
 			case GangCreated:
+
+			case DispatchResultPoll:
 
 			case DecreaseToastMaxChunkSize:
 			case ProcessStartupPacketFault:

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -35,6 +35,7 @@ extern LockAcquireResult LockRelationNoWait(Relation relation, LOCKMODE lockmode
 
 extern bool ConditionalLockRelation(Relation relation, LOCKMODE lockmode);
 extern void UnlockRelation(Relation relation, LOCKMODE lockmode);
+extern bool CheckRelationLockedByMe(Relation relation, LOCKMODE lockmode, bool orstronger);
 
 extern void LockRelationIdForSession(LockRelId *relid, LOCKMODE lockmode);
 extern void UnlockRelationIdForSession(LockRelId *relid, LOCKMODE lockmode);

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -155,6 +155,8 @@ typedef uint16 LOCKMETHODID;
 #define AccessExclusiveLock		8		/* ALTER TABLE, DROP TABLE, VACUUM
 										 * FULL, and unqualified LOCK TABLE */
 
+#define MaxLockMode				8
+
 /*
  * Map from lock methods to lock table data structures.
  */
@@ -552,6 +554,7 @@ extern void LockReleaseAll(LOCKMETHODID lockmethodid, bool allLocks);
 // TODO why are we missing extern void LockReleaseSession(LOCKMETHODID lockmethodid); ?
 extern void LockReleaseCurrentOwner(LOCALLOCK **locallocks, int nlocks);
 extern void LockReassignCurrentOwner(LOCALLOCK **locallocks, int nlocks);
+extern bool LockHeldByMe(const LOCKTAG *locktag, LOCKMODE lockmode);
 extern VirtualTransactionId *GetLockConflicts(const LOCKTAG *locktag,
 				 LOCKMODE lockmode);
 extern void AtPrepare_Locks(void);

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -184,6 +184,8 @@ typedef enum FaultInjectorIdentifier_e {
 	CompactionBeforeSegmentFileDropPhase,
 	CompactionBeforeCleanupPhase,
 
+	DispatchResultPoll,
+
 	AppendOnlyInsert,
 	AppendOnlyDelete,
 	AppendOnlyUpdate,

--- a/src/test/regress/expected/recoverseg_dispatch_deadlock.out
+++ b/src/test/regress/expected/recoverseg_dispatch_deadlock.out
@@ -1,0 +1,188 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+create language plpythonu;
+-- Helper function
+CREATE or REPLACE FUNCTION wait_for_segment_status_update(db_id smallint, state text, m text)
+RETURNS bool AS
+$$
+declare
+retries int; /* in func */
+begin /* in func */
+  retries := 1200; /* in func */
+  loop /* in func */
+    if (select count(*) = 1 from gp_segment_configuration where dbid = db_id and status = state and mode = m) then /* in func */
+      return true; /* in func */
+    end if; /* in func */
+    if retries <= 0 then /* in func */
+      return false; /* in func */
+    end if; /* in func */
+    perform pg_sleep(0.1); /* in func */
+    retries := retries - 1; /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$ language plpgsql;
+--
+-- pg_ctl:
+--   datadir: data directory of process to target with `pg_ctl`
+--   command: commands valid for `pg_ctl`
+--   command_mode: modes valid for `pg_ctl -m`
+--
+create or replace function pg_ctl(datadir text, command text, command_mode text default 'immediate')
+returns text as $$
+    import subprocess
+    if command == 'promote':
+        cmd = 'pg_ctl promote -D %s' % datadir
+    elif command in ('stop', 'restart'):
+        cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir
+        cmd = cmd + '-w -m %s %s' % (command_mode, command)
+    else:
+        return 'Invalid command input'
+
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+$$ language plpythonu;
+CREATE or REPLACE FUNCTION gp_add_segment_mirror_for_content0()
+RETURNS int AS
+$$
+declare
+content_id int2;
+db_id int2;
+host_name text;
+addr text;
+p int4;
+rp int4;
+fs_name text;
+datadir text;
+fsmap text[][];
+result int2;
+begin
+  select contentid, dbid, hostname, address, port, rep_port, fsname, fselocation into content_id, db_id, host_name, addr, p, rp, fs_name, datadir from add_mirror_args;
+  fsmap := array[array[fs_name, datadir]::text[]];
+  -- Timeout when the dispatcher polls results from QEs
+  perform gp_inject_fault_new('dispatch_result_poll', 'skip', 1);
+  -- Add mirror back
+  select into result gp_add_segment_mirror(content_id, host_name, addr, p, rp, fsmap);
+  -- Mark the mirror as down as gprecoverseg would do, without this the fts probe process will fail
+  set allow_system_table_mods='dml';
+  update pg_catalog.gp_segment_configuration set mode = 'r', status = 'd' where dbid = db_id;
+  reset allow_system_table_mods;
+  return result;
+end;
+$$ language plpgsql;
+-- No segment down
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+     0
+(1 row)
+
+-- Record args for add mirror before removing the mirror
+create temp table add_mirror_args (contentid int2, dbid int2, hostname text, address text, port int4, rep_port int4, fsname text, fselocation text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'contentid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into add_mirror_args(contentid, dbid, hostname, address, port, rep_port, fsname, fselocation)
+select content, dbid, hostname, address, port, replication_port, fsname, fselocation
+from gp_segment_configuration
+join pg_filespace on dbid = 5 -- content 0
+join pg_filespace_entry on fsedbid = dbid;
+-- Take down a mirror
+SELECT pg_ctl(fselocation, 'stop') from pg_filespace_entry where fsedbid = 5;
+                pg_ctl                
+--------------------------------------
+ waiting for server to shut down done 
+ server stopped                       
+ 
+(1 row)
+
+select wait_for_segment_status_update(5::smallint, 'd'::text, 's'::text);
+ wait_for_segment_status_update 
+--------------------------------
+ t
+(1 row)
+
+select dbid, content, role, preferred_role, mode, status from gp_segment_configuration;
+ dbid | content | role | preferred_role | mode | status 
+------+---------+------+----------------+------+--------
+    1 |      -1 | p    | p              | s    | u
+    3 |       1 | p    | p              | s    | u
+    4 |       2 | p    | p              | s    | u
+    6 |       1 | m    | m              | s    | u
+    7 |       2 | m    | m              | s    | u
+    2 |       0 | p    | p              | c    | u
+    5 |       0 | m    | m              | s    | d
+(7 rows)
+
+-- Timeout when the dispatcher polls results from QEs
+select gp_inject_fault_new('dispatch_result_poll', 'skip', 1);
+WARNING:  could not insert fault injection entry into table, entry already exists, fault name:'dispatch_result_poll' fault type:'skip'
+ERROR:  Failure: could not insert fault injection, entry already exists (gp_inject_fault.c:68)
+-- Remove segment mirror should work and deadlock should not happen
+select gp_remove_segment_mirror(0::int2);
+ gp_remove_segment_mirror 
+--------------------------
+ t
+(1 row)
+
+-- The mirror should be removed
+select dbid, content, role, preferred_role, mode, status from gp_segment_configuration;
+ dbid | content | role | preferred_role | mode | status 
+------+---------+------+----------------+------+--------
+    1 |      -1 | p    | p              | s    | u
+    3 |       1 | p    | p              | s    | u
+    4 |       2 | p    | p              | s    | u
+    6 |       1 | m    | m              | s    | u
+    7 |       2 | m    | m              | s    | u
+    2 |       0 | p    | p              | c    | u
+(6 rows)
+
+-- Reset the fault
+SELECT gp_inject_fault('dispatch_result_poll', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- Add segment mirror should also work and deadlock should not happen
+select gp_add_segment_mirror_for_content0();
+NOTICE:  Success:
+CONTEXT:  SQL statement "SELECT  gp_inject_fault_new('dispatch_result_poll', 'skip', 1)"
+PL/pgSQL function "gp_add_segment_mirror_for_content0" line 16 at PERFORM
+ gp_add_segment_mirror_for_content0 
+------------------------------------
+                                  5
+(1 row)
+
+-- Mirror should be added back
+select dbid, content, role, preferred_role, mode, status from gp_segment_configuration;
+ dbid | content | role | preferred_role | mode | status 
+------+---------+------+----------------+------+--------
+    1 |      -1 | p    | p              | s    | u
+    3 |       1 | p    | p              | s    | u
+    4 |       2 | p    | p              | s    | u
+    6 |       1 | m    | m              | s    | u
+    7 |       2 | m    | m              | s    | u
+    2 |       0 | p    | p              | c    | u
+    5 |       0 | m    | m              | r    | d
+(7 rows)
+
+-- post test cleanup
+-- start_ignore
+\! gprecoverseg -aF
+-- end_ignore
+select wait_for_segment_status_update(5::smallint, 'u'::text, 's'::text);
+ wait_for_segment_status_update 
+--------------------------------
+ t
+(1 row)
+
+select dbid, content, role, preferred_role, mode, status from gp_segment_configuration;
+ dbid | content | role | preferred_role | mode | status 
+------+---------+------+----------------+------+--------
+    1 |      -1 | p    | p              | s    | u
+    3 |       1 | p    | p              | s    | u
+    4 |       2 | p    | p              | s    | u
+    6 |       1 | m    | m              | s    | u
+    7 |       2 | m    | m              | s    | u
+    2 |       0 | p    | p              | s    | u
+    5 |       0 | m    | m              | s    | u
+(7 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -222,4 +222,6 @@ test: oid_wraparound
 
 test: autovacuum-template0
 
+test: recoverseg_dispatch_deadlock
+
 # end of tests

--- a/src/test/regress/sql/recoverseg_dispatch_deadlock.sql
+++ b/src/test/regress/sql/recoverseg_dispatch_deadlock.sql
@@ -1,0 +1,114 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+create language plpythonu;
+
+-- Helper function
+CREATE or REPLACE FUNCTION wait_for_segment_status_update(db_id smallint, state text, m text)
+RETURNS bool AS
+$$
+declare
+retries int; /* in func */
+begin /* in func */
+  retries := 1200; /* in func */
+  loop /* in func */
+    if (select count(*) = 1 from gp_segment_configuration where dbid = db_id and status = state and mode = m) then /* in func */
+      return true; /* in func */
+    end if; /* in func */
+    if retries <= 0 then /* in func */
+      return false; /* in func */
+    end if; /* in func */
+    perform pg_sleep(0.1); /* in func */
+    retries := retries - 1; /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
+--
+-- pg_ctl:
+--   datadir: data directory of process to target with `pg_ctl`
+--   command: commands valid for `pg_ctl`
+--   command_mode: modes valid for `pg_ctl -m`
+--
+create or replace function pg_ctl(datadir text, command text, command_mode text default 'immediate')
+returns text as $$
+    import subprocess
+    if command == 'promote':
+        cmd = 'pg_ctl promote -D %s' % datadir
+    elif command in ('stop', 'restart'):
+        cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir
+        cmd = cmd + '-w -m %s %s' % (command_mode, command)
+    else:
+        return 'Invalid command input'
+
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+$$ language plpythonu;
+
+CREATE or REPLACE FUNCTION gp_add_segment_mirror_for_content0()
+RETURNS int AS
+$$
+declare
+content_id int2;
+db_id int2;
+host_name text;
+addr text;
+p int4;
+rp int4;
+fs_name text;
+datadir text;
+fsmap text[][];
+result int2;
+begin
+  select contentid, dbid, hostname, address, port, rep_port, fsname, fselocation into content_id, db_id, host_name, addr, p, rp, fs_name, datadir from add_mirror_args;
+  fsmap := array[array[fs_name, datadir]::text[]];
+  -- Timeout when the dispatcher polls results from QEs
+  perform gp_inject_fault_new('dispatch_result_poll', 'skip', 1);
+  -- Add mirror back
+  select into result gp_add_segment_mirror(content_id, host_name, addr, p, rp, fsmap);
+  -- Mark the mirror as down as gprecoverseg would do, without this the fts probe process will fail
+  set allow_system_table_mods='dml';
+  update pg_catalog.gp_segment_configuration set mode = 'r', status = 'd' where dbid = db_id;
+  reset allow_system_table_mods;
+  return result;
+end;
+$$ language plpgsql;
+
+-- No segment down
+select count(*) from gp_segment_configuration where status = 'd';
+
+-- Record args for add mirror before removing the mirror
+create temp table add_mirror_args (contentid int2, dbid int2, hostname text, address text, port int4, rep_port int4, fsname text, fselocation text);
+insert into add_mirror_args(contentid, dbid, hostname, address, port, rep_port, fsname, fselocation)
+select content, dbid, hostname, address, port, replication_port, fsname, fselocation
+from gp_segment_configuration
+join pg_filespace on dbid = 5 -- content 0
+join pg_filespace_entry on fsedbid = dbid;
+
+-- Take down a mirror
+SELECT pg_ctl(fselocation, 'stop') from pg_filespace_entry where fsedbid = 5;
+select wait_for_segment_status_update(5::smallint, 'd'::text, 's'::text);
+select dbid, content, role, preferred_role, mode, status from gp_segment_configuration;
+
+-- Timeout when the dispatcher polls results from QEs
+select gp_inject_fault_new('dispatch_result_poll', 'skip', 1);
+
+-- Remove segment mirror should work and deadlock should not happen
+select gp_remove_segment_mirror(0::int2);
+
+-- The mirror should be removed
+select dbid, content, role, preferred_role, mode, status from gp_segment_configuration;
+
+-- Reset the fault
+SELECT gp_inject_fault('dispatch_result_poll', 'reset', 1);
+
+-- Add segment mirror should also work and deadlock should not happen
+select gp_add_segment_mirror_for_content0();
+
+-- Mirror should be added back
+select dbid, content, role, preferred_role, mode, status from gp_segment_configuration;
+
+-- post test cleanup
+-- start_ignore
+\! gprecoverseg -aF
+-- end_ignore
+
+select wait_for_segment_status_update(5::smallint, 'u'::text, 's'::text);
+select dbid, content, role, preferred_role, mode, status from gp_segment_configuration;


### PR DESCRIPTION
WIP: Fix deadlock between gprecoverseg and FTS probe

The deadlock happens when gprecoverseg invokes
gp_{add,remove}_segment_mirror(). Current sequence of opterations for
those two functions are:

1. Lock gp_segment_configuration table with `AccessExclusiveLock`
2. Read the dbid of the mirror and its primary from the table
3. Acquire `RowExclusiveLock` on gp_segment_configuration
4. Add/Remove the mirror entry from gp_segment_configuration
5. Close gp_segment_configuration but keep the locks
6. Add/Remove entries in the psersistent tables that refers to the
mirror on master, and dispatch this operation to all the segments
7. Commit and release the locks on gp_segment_configuration

In step 6, the dispatcher process polls results from the QEs, and if it
encounters internal error or timeouts during the poll(), it notifies the
FTS process to probe the segments. This is where deadlock happens. After
being notified, the FTS process, specifically in getCdbComponentInfo(),
needs to accquire a `AccessShareLock`, but it is blocked by the
`AccessExclusiveLock` the dispacther accquired in step 1, so FTS cannot
probe, hence step 6 hangs.

This patch makes three changes to the dispatcher and FTS:

1. Downgrade the lock in step 1 to `ExclusiveLock`.

The reason why we chose AccessExclusiveLock is not clear from the commit
history, but we think the rationale is to prevent any writes to
gp_segment_configuration from the time it reads the dbid of the primary
and the mirror until the end of the transaction. Note that
RowExclusiveLock doesn't conflict with itself.

2. Upgrade the lock in FTS getCdbComponentInfo() to `RowShareLock` and
hold the lock for the entire FTS probe.

What FTS does is essentially select for update, in the sense that it
first reads from gp_segment_configuration into cdb_component_dbs in
memory, probe each segment by open connections to them, and finally
update gp_segment_configuration with `RowExclusiveLock`. We want
`RowShareLock` because we don't want the table to be modified during one
probe.

3. Don't request FTS probe if the dispatcher already held
`ExclusiveLock` or stronger

If we just do 1 and 2 to make things right, we would still have the
deadlock problem, as `ExclusiveLock` and `RowShareLock` doesn't conflict
with each other. Hence adding the check to prevent FTS probe if the
process that requested the probe already held a `ExclusiveLock` or
stronger.

Partial cherry-picked upstream commit b04aeb0a for LockHeldByMe() and
CheckRelationLockedByMe().


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
