### PR TITLE
6X backport:  Remove statically defined faults from faultinjector framework

### DIFF
--- a/gpcontrib/quicklz/quicklz_compression.c
+++ b/gpcontrib/quicklz/quicklz_compression.c
@@ -99,7 +99,7 @@ Datum
 quicklz_constructor(PG_FUNCTION_ARGS)
 {
 #ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(MallocFailure,
+	FaultInjector_InjectFaultIfSet("malloc_failure",
 					DDLNotSpecified,
 					"", // databaseName
 					""); // tableName

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -897,7 +897,7 @@ aocs_insert_values(AOCSInsertDesc idesc, Datum *d, bool *null, AOTupleId *aoTupl
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_InjectFaultIfSet(
-								   AppendOnlyInsert,
+								   "appendonly_insert",
 								   DDLNotSpecified,
 								   "",	/* databaseName */
 								   RelationGetRelationName(idesc->aoi_rel));	/* tableName */
@@ -1598,7 +1598,7 @@ aocs_update(AOCSUpdateDesc desc, TupleTableSlot *slot,
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_InjectFaultIfSet(
-								   AppendOnlyUpdate,
+								   "appendonly_update",
 								   DDLNotSpecified,
 								   "", //databaseName
 								   RelationGetRelationName(desc->insertDesc->aoi_rel));
@@ -1699,7 +1699,7 @@ aocs_delete(AOCSDeleteDesc aoDeleteDesc,
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_InjectFaultIfSet(
-								   AppendOnlyDelete,
+								   "appendonly_delete",
 								   DDLNotSpecified,
 								   "",	/* databaseName */
 								   RelationGetRelationName(aoDeleteDesc->aod_rel)); /* tableName */

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2479,7 +2479,7 @@ appendonly_delete(AppendOnlyDeleteDesc aoDeleteDesc,
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_InjectFaultIfSet(
-								   AppendOnlyDelete,
+								   "appendonly_delete",
 								   DDLNotSpecified,
 								   "", //databaseName
 								   RelationGetRelationName(aoDeleteDesc->aod_rel));
@@ -2550,7 +2550,7 @@ appendonly_update(AppendOnlyUpdateDesc aoUpdateDesc,
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_InjectFaultIfSet(
-								   AppendOnlyUpdate,
+								   "appendonly_update",
 								   DDLNotSpecified,
 								   "", //databaseName
 								   RelationGetRelationName(aoUpdateDesc->aoInsertDesc->aoi_rel));
@@ -2821,7 +2821,7 @@ appendonly_insert(AppendOnlyInsertDesc aoInsertDesc,
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_InjectFaultIfSet(
-								   AppendOnlyInsert,
+								   "appendonly_insert",
 								   DDLNotSpecified,
 								   "", //databaseName
 								   RelationGetRelationName(aoInsertDesc->aoi_rel));

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -208,7 +208,7 @@ AORelCreateHashEntry(Oid relid)
 	 */
 	release_lightweight_lock();
 
-	SIMPLE_FAULT_INJECTOR(BeforeCreatingAnAOHashEntry);
+	SIMPLE_FAULT_INJECTOR("before_creating_an_ao_hash_entry");
 
 	/*
 	 * Now get all the segment files information for this relation from the QD

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1238,7 +1238,7 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 	}
 
 	/* inject fault after holding the lock */
-	SIMPLE_FAULT_INJECTOR(UpgradeRowLock);
+	SIMPLE_FAULT_INJECTOR("upgrade_row_lock");
 
 	return rel;
 }                                       /* CdbOpenRelation */

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -1759,7 +1759,7 @@ toast_save_datum(Relation rel, Datum value,
 	 * modified (here, we decrease it by one). The result must still fit into
 	 * TOAST_MAX_CHUNK_SIZE so that it doesn't overflow our chunk_data struct.
 	 */
-	if (FaultInjector_InjectFaultIfSet(DecreaseToastMaxChunkSize,
+	if (FaultInjector_InjectFaultIfSet("decrease_toast_max_chunk_size",
 									   DDLNotSpecified,
 									   "", /* databaseName */
 									   ""  /* tableName */) != FaultInjectorTypeNotSpecified)

--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -187,7 +187,7 @@ DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
 	if (MyProcPort)
 		dbname = MyProcPort->database_name;
 
-	FaultInjector_InjectFaultIfSet(DistributedLogAdvanceOldestXmin, DDLNotSpecified,
+	FaultInjector_InjectFaultIfSet("distributedlog_advance_oldest_xmin", DDLNotSpecified,
 								   dbname?dbname: "", "");
 #endif
 

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1193,7 +1193,7 @@ EndPrepare(GlobalTransaction gxact)
 	 */
 	MyPgXact->delayChkpt = false;
 
-	SIMPLE_FAULT_INJECTOR(EndPreparedTwoPhase);
+	SIMPLE_FAULT_INJECTOR("end_prepare_two_phase");
 
 	/*
 	 * Wait for synchronous replication, if required.
@@ -1287,7 +1287,7 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
     XLogRecPtr   tfXLogRecPtr;
     XLogRecord  *tfRecord  = NULL;
 
-	SIMPLE_FAULT_INJECTOR(FinishPreparedStartOfFunction);
+	SIMPLE_FAULT_INJECTOR("finish_prepared_start_of_function");
 
 	/*
 	 * Validate the GID, and lock the GXACT to ensure that two backends do not
@@ -1459,7 +1459,7 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
 	RemoveGXact(gxact);
 	MyLockedGxact = NULL;
 
-	SIMPLE_FAULT_INJECTOR(FinishPreparedAfterRecordCommitPrepared);
+	SIMPLE_FAULT_INJECTOR("finish_prepared_after_record_commit_prepared");
 
 	XLogReaderFree(xlogreader);
 
@@ -1964,7 +1964,7 @@ RecordTransactionCommitPrepared(TransactionId xid,
 	}
 	rdata[lastrdata].next = NULL;
 
-	SIMPLE_FAULT_INJECTOR(TwoPhaseTransactionCommitPrepared);
+	SIMPLE_FAULT_INJECTOR("twophase_transaction_commit_prepared");
 
 	recptr = XLogInsert(RM_XACT_ID, XLOG_XACT_COMMIT_PREPARED, rdata);
 
@@ -2061,7 +2061,7 @@ RecordTransactionAbortPrepared(TransactionId xid,
 	}
 	rdata[lastrdata].next = NULL;
 
-	SIMPLE_FAULT_INJECTOR(TwoPhaseTransactionAbortPrepared);
+	SIMPLE_FAULT_INJECTOR("twophase_transaction_abort_prepared");
 
 	recptr = XLogInsert(RM_XACT_ID, XLOG_XACT_ABORT_PREPARED, rdata);
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1441,7 +1441,7 @@ RecordTransactionCommit(void)
 			}
 			rdata[lastrdata].next = NULL;
 
-			SIMPLE_FAULT_INJECTOR(OnePhaseTransactionCommit);
+			SIMPLE_FAULT_INJECTOR("onephase_transaction_commit");
 
 			if (isDtxPrepared)
 			{
@@ -1518,7 +1518,7 @@ RecordTransactionCommit(void)
 		if (isDtxPrepared == 0 &&
 			CurrentTransactionState->blockState == TBLOCK_END)
 		{
-			FaultInjector_InjectFaultIfSet(LocalTmRecordTransactionCommit,
+			FaultInjector_InjectFaultIfSet("local_tm_record_transaction_commit",
 										   DDLNotSpecified,
 										   "",  // databaseName
 										   ""); // tableName
@@ -1575,7 +1575,7 @@ RecordTransactionCommit(void)
 #ifdef FAULT_INJECTOR
 	if (isDtxPrepared)
 	{
-		FaultInjector_InjectFaultIfSet(DtmXLogDistributedCommit,
+		FaultInjector_InjectFaultIfSet("dtm_xlog_distributed_commit",
 									   DDLNotSpecified,
 									   "",  // databaseName
 									   ""); // tableName
@@ -2175,7 +2175,7 @@ StartTransaction(void)
 
 	if (DistributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON)
 	{
-		SIMPLE_FAULT_INJECTOR(TransactionStartUnderEntryDbSingleton);
+		SIMPLE_FAULT_INJECTOR("transaction_start_under_entry_db_singleton");
 	}
 
 	/*
@@ -2649,7 +2649,7 @@ CommitTransaction(void)
 	if (isPreparedDtxTransaction())
 	{
 		FaultInjector_InjectFaultIfSet(
-									   TransactionAbortAfterDistributedPrepared, 
+									   "transaction_abort_after_distributed_prepared",
 									   DDLNotSpecified,
 									   "",	// databaseName
 									   ""); // tableName
@@ -2943,7 +2943,7 @@ PrepareTransaction(void)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("cannot PREPARE a transaction that has operated on temporary tables")));
 #endif
-	SIMPLE_FAULT_INJECTOR(StartPrepareTx);
+	SIMPLE_FAULT_INJECTOR("start_prepare");
 
 	/*
 	 * Likewise, don't allow PREPARE after pg_export_snapshot.  This could be
@@ -3148,7 +3148,7 @@ AbortTransaction(void)
 	TransactionState s = CurrentTransactionState;
 	TransactionId latestXid;
 
-	SIMPLE_FAULT_INJECTOR(AbortTransactionFail);
+	SIMPLE_FAULT_INJECTOR("transaction_abort_failure");
 
 	/* Prevent cancel/die interrupt while cleaning up */
 	HOLD_INTERRUPTS();

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8594,7 +8594,7 @@ CreateCheckPoint(int flags)
 
 #ifdef FAULT_INJECTOR
 	if (FaultInjector_InjectFaultIfSet(
-			Checkpoint,
+			"checkpoint",
 			DDLNotSpecified,
 			"" /* databaseName */,
 			"" /* tableName */) == FaultInjectorTypeSkip)
@@ -8894,7 +8894,7 @@ CreateCheckPoint(int flags)
 	if (!shutdown && XLogStandbyInfoActive())
 		LogStandbySnapshot();
 
-	SIMPLE_FAULT_INJECTOR(CheckpointAfterRedoCalculated);
+	SIMPLE_FAULT_INJECTOR("checkpoint_after_redo_calculated");
 
 	START_CRIT_SECTION();
 

--- a/src/backend/catalog/aoblkdir.c
+++ b/src/backend/catalog/aoblkdir.c
@@ -33,7 +33,7 @@ AlterTableCreateAoBlkdirTable(Oid relOid, bool is_part_child, bool is_part_paren
 	int16		coloptions[3];
 	List	   *indexColNames;
 
-	SIMPLE_FAULT_INJECTOR(BeforeAcquireLockDuringCreateAoBlkdirTable);
+	SIMPLE_FAULT_INJECTOR("before_acquire_lock_during_create_ao_blkdir_table");
 
 	/*
 	 * Grab an exclusive lock on the target table, which we will NOT release

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -4098,7 +4098,7 @@ reindex_relation(Oid relid, int flags)
 
 	result = (indexIds != NIL);
 
-	SIMPLE_FAULT_INJECTOR(ReindexRelation);
+	SIMPLE_FAULT_INJECTOR("reindex_relation");
 
 	/*
 	 * If the relation has a secondary toast rel, reindex that too while we

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -1173,7 +1173,7 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 #ifdef FAULT_INJECTOR
 	/* Simulate that compression is not possible if the fault is set. */
 	if (FaultInjector_InjectFaultIfSet(
-			AppendOnlySkipCompression,
+			"appendonly_skip_compression",
 			DDLNotSpecified,
 			"",
 			storageWrite->relationName) == FaultInjectorTypeSkip)

--- a/src/backend/cdb/cdbappendonlyxlog.c
+++ b/src/backend/cdb/cdbappendonlyxlog.c
@@ -58,7 +58,7 @@ xlog_ao_insert(RelFileNode relFileNode, int32 segmentFileNum,
 		rdata[1].next = NULL;
 	}
 
-	SIMPLE_FAULT_INJECTOR(XLogAoInsert);
+	SIMPLE_FAULT_INJECTOR("xlog_ao_insert");
 	XLogInsert(RM_APPEND_ONLY_ID, XLOG_APPENDONLY_INSERT, rdata);
 }
 

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -209,7 +209,7 @@ cdbCopyStart(CdbCopy *c, CopyStmt *stmt,
 
 	CdbDispatchCopyStart(c, (Node *) stmt, flags);
 
-	SIMPLE_FAULT_INJECTOR(CdbCopyStartAfterDispatch);
+	SIMPLE_FAULT_INJECTOR("cdb_copy_start_after_dispatch");
 }
 
 /*

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -511,7 +511,7 @@ doPrepareTransaction(void)
 	Assert(currentGxact->state == DTX_STATE_PREPARING);
 	setCurrentGxactState(DTX_STATE_PREPARED);
 
-	SIMPLE_FAULT_INJECTOR(DtmBroadcastPrepare);
+	SIMPLE_FAULT_INJECTOR("dtm_broadcast_prepare");
 
 	elog(DTM_DEBUG5, "doPrepareTransaction leaving in state = %s", DtxStateToString(currentGxact->state));
 }
@@ -596,7 +596,7 @@ doNotifyingCommitPrepared(void)
 		elog(PANIC, "Distribute transaction identifier too long (%d)",
 			 (int) strlen(currentGxact->gid));
 
-	SIMPLE_FAULT_INJECTOR(DtmBroadcastCommitPrepared);
+	SIMPLE_FAULT_INJECTOR("dtm_broadcast_commit_prepared");
 	savedInterruptHoldoffCount = InterruptHoldoffCount;
 
 	Assert(currentGxact->twophaseSegments != NIL);
@@ -871,7 +871,7 @@ doNotifyingAbort(void)
 		}
 	}
 
-	SIMPLE_FAULT_INJECTOR(DtmBroadcastAbortPrepared);
+	SIMPLE_FAULT_INJECTOR("dtm_broadcast_abort_prepared");
 
 	Assert(currentGxact->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED ||
 		   currentGxact->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
@@ -1277,8 +1277,6 @@ initTM(void)
 		 * back.
 		 */
 		olduser = ChangeToSuperuser();
-
-		SIMPLE_FAULT_INJECTOR(DtmInit);
 
 		oldcontext = CurrentMemoryContext;
 		succeeded = false;

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -719,7 +719,7 @@ cleanupQE(SegmentDatabaseDescriptor *segdbDesc)
 	Assert(segdbDesc != NULL);
 
 #ifdef FAULT_INJECTOR
-	if (SIMPLE_FAULT_INJECTOR(CleanupQE) == FaultInjectorTypeSkip)
+	if (SIMPLE_FAULT_INJECTOR("cleanup_qe") == FaultInjectorTypeSkip)
 		return false;
 #endif
 
@@ -1162,7 +1162,7 @@ getAddressesForDBid(CdbComponentDatabaseInfo *c, int elevel)
 
 #ifdef FAULT_INJECTOR
 	if (am_ftsprobe &&
-		SIMPLE_FAULT_INJECTOR(GetDnsCachedAddress) == FaultInjectorTypeSkip)
+		SIMPLE_FAULT_INJECTOR("get_dns_cached_address") == FaultInjectorTypeSkip)
 	{
 		/* inject a dns error for primary of segment 0 */
 		if (c->segindex == 0 &&

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1139,13 +1139,13 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 			if (InterruptPending)
 				break;
 		}
-		SIMPLE_FAULT_INJECTOR(BeforeOneSliceDispatched);
+		SIMPLE_FAULT_INJECTOR("before_one_slice_dispatched");
 
 		cdbdisp_dispatchToGang(ds, primaryGang, si);
 		if (planRequiresTxn)
 			addToGxactTwophaseSegments(primaryGang);
 
-		SIMPLE_FAULT_INJECTOR(AfterOneSliceDispatched);
+		SIMPLE_FAULT_INJECTOR("after_one_slice_dispatched");
 	}
 
 	pfree(sliceVector);

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -229,7 +229,7 @@ create_gang_retry:
 			if (nfds == 0)
 				break;
 
-			SIMPLE_FAULT_INJECTOR(CreateGangInProgress);
+			SIMPLE_FAULT_INJECTOR("create_gang_in_progress");
 
 			CHECK_FOR_INTERRUPTS();
 
@@ -305,7 +305,7 @@ create_gang_retry:
 	}
 	PG_END_TRY();
 
-	SIMPLE_FAULT_INJECTOR(GangCreated);
+	SIMPLE_FAULT_INJECTOR("gang_created");
 
 	if (retry)
 	{

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1231,7 +1231,7 @@ SetupTCPInterconnect(EState *estate)
 	ChunkTransportStateEntry *sendingChunkTransportState = NULL;
 	ChunkTransportState *interconnect_context;
 
-	SIMPLE_FAULT_INJECTOR(InterconnectSetupPalloc);
+	SIMPLE_FAULT_INJECTOR("interconnect_setup_palloc");
 	interconnect_context = palloc0(sizeof(ChunkTransportState));
 
 	/* initialize state variables */

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3068,7 +3068,7 @@ SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable)
 				conn->pkt_q_head = 0;
 				conn->pkt_q_tail = 0;
 
-				SIMPLE_FAULT_INJECTOR(InterconnectSetupPalloc);
+				SIMPLE_FAULT_INJECTOR("interconnect_setup_palloc");
 				conn->pkt_q = (uint8 **) palloc0(conn->pkt_q_capacity * sizeof(uint8 *));
 
 				/* update the max buffer count of our rx buffer pool.  */
@@ -5612,7 +5612,7 @@ doSendStopMessageUDPIFC(ChunkTransportState *transportStates, int16 motNodeID)
 
 #ifdef FAULT_INJECTOR
 				if (FaultInjector_InjectFaultIfSet(
-												   InterconnectStopAckIsLost,
+												   "interconnect_stop_ack_is_lost",
 												   DDLNotSpecified,
 												   "" /* databaseName */ ,
 												   "" /* tableName */ ) == FaultInjectorTypeSkip)

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -1430,7 +1430,7 @@ movedb(const char *dbname, const char *tblspcname)
 	 */
 	DatabaseDropStorage(db_id, src_tblspcoid);
 
-	SIMPLE_FAULT_INJECTOR(InsideMoveDbTransaction);
+	SIMPLE_FAULT_INJECTOR("inside_move_db_transaction");
 }
 
 /*

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -2234,7 +2234,7 @@ ReindexRelationList(List *relids)
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 
-	SIMPLE_FAULT_INJECTOR(ReindexDB);
+	SIMPLE_FAULT_INJECTOR("reindex_db");
 
 	foreach (lc, relids)
 	{

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -251,7 +251,7 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 			CpusetDifference(defaultGroupCpuset, caps.cpuset, MaxCpuSetLength);
 			ResGroupOps_SetCpuSet(DEFAULT_CPUSET_GROUP_ID, defaultGroupCpuset);
 		}
-		SIMPLE_FAULT_INJECTOR(CreateResourceGroupFail);
+		SIMPLE_FAULT_INJECTOR("create_resource_group_fail");
 	}
 	else if (Gp_role == GP_ROLE_DISPATCH)
 		ereport(WARNING,

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -675,7 +675,7 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 	{
 		Assert(Gp_role == GP_ROLE_EXECUTE);
 		lmode = AccessExclusiveLock;
-		SIMPLE_FAULT_INJECTOR(VacuumRelationOpenRelationDuringDropPhase);
+		SIMPLE_FAULT_INJECTOR("vacuum_relation_open_relation_during_drop_phase");
 	}
 	else if (!(vacstmt->options & VACOPT_VACUUM))
 		lmode = ShareUpdateExclusiveLock;
@@ -755,7 +755,7 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 
 		if (vacstmt->appendonly_phase == AOVAC_DROP)
 		{
-			SIMPLE_FAULT_INJECTOR(VacuumRelationOpenRelationDuringDropPhase);
+			SIMPLE_FAULT_INJECTOR("vacuum_relation_open_relation_during_drop_phase");
 		}
 
 		vacuum_rel(onerel, relid, vacstmt, lmode, for_wraparound);
@@ -851,7 +851,7 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 			 * However, we do not expect this to happen too frequently such
 			 * that all segfiles are marked.
 			 */
-			SIMPLE_FAULT_INJECTOR(VacuumRelationOpenRelationDuringDropPhase);
+			SIMPLE_FAULT_INJECTOR("vacuum_relation_open_relation_during_drop_phase");
 			onerel = try_relation_open(relid, AccessExclusiveLock, true /* dontwait */);
 
 			if (!RelationIsValid(onerel))
@@ -1947,7 +1947,7 @@ vac_update_datfrozenxid(void)
 	if (dirty)
 	{
 		heap_inplace_update(relation, tuple);
-		SIMPLE_FAULT_INJECTOR(VacuumUpdateDatFrozenXid);
+		SIMPLE_FAULT_INJECTOR("vacuum_update_dat_frozen_xid");
 	}
 
 	heap_freetuple(tuple);

--- a/src/backend/commands/vacuumlazy.c
+++ b/src/backend/commands/vacuumlazy.c
@@ -225,7 +225,7 @@ lazy_vacuum_rel(Relation onerel, VacuumStmt *vacstmt,
 	if (vacstmt->appendonly_phase == AOVAC_DROP)
 	{
 			FaultInjector_InjectFaultIfSet(
-				CompactionBeforeSegmentFileDropPhase,
+				"compaction_before_segmentfile_drop",
 				DDLNotSpecified,
 				"",	// databaseName
 				RelationGetRelationName(onerel)); // tableName
@@ -233,7 +233,7 @@ lazy_vacuum_rel(Relation onerel, VacuumStmt *vacstmt,
 	if (vacstmt->appendonly_phase == AOVAC_CLEANUP)
 	{
 			FaultInjector_InjectFaultIfSet(
-				CompactionBeforeCleanupPhase,
+				"compaction_before_cleanup_phase",
 				DDLNotSpecified,
 				"",	// databaseName
 				RelationGetRelationName(onerel)); // tableName

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -539,7 +539,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 				SetupInterconnect(estate);
 				UpdateMotionExpectedReceivers(estate->motionlayer_context, estate->es_sliceTable);
 
-				SIMPLE_FAULT_INJECTOR(QEGotSnapshotAndInterconnect);
+				SIMPLE_FAULT_INJECTOR("qe_got_snapshot_and_interconnect");
 				Assert(estate->interconnect_context);
 			}
 			PG_CATCH();
@@ -1020,7 +1020,7 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 	if (estate->es_processed >= 10000 && estate->es_processed <= 1000000)
 	//if (estate->es_processed >= 10000)
 	{
-		if (FaultInjector_InjectFaultIfSet(ExecutorRunHighProcessed,
+		if (FaultInjector_InjectFaultIfSet("executor_run_high_processed",
 										   DDLNotSpecified,
 										   "" /* databaseName */,
 										   "" /* tableName */) == FaultInjectorTypeSkip)
@@ -2993,7 +2993,7 @@ ExecutePlan(EState *estate,
 			 */
 			if (estate->es_processed >= 10000 && estate->es_processed <= 1000000)
 			{
-				if (FaultInjector_InjectFaultIfSet(ExecutorRunHighProcessed,
+				if (FaultInjector_InjectFaultIfSet("executor_run_high_processed",
 												   DDLNotSpecified,
 												   "" /* databaseName */,
 												   "" /* tableName */) == FaultInjectorTypeSkip)

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -108,7 +108,7 @@ MultiExecHash(HashState *node)
 	hashkeys = node->hashkeys;
 	econtext = node->ps.ps_ExprContext;
 
-	SIMPLE_FAULT_INJECTOR(MultiExecHashLargeVmem);
+	SIMPLE_FAULT_INJECTOR("multi_exec_hash_large_vmem");
 
 	/*
 	 * get all inner tuples and insert into the hash table (or temp files)

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -899,7 +899,7 @@ ExecHashJoinNewBatch(HashJoinState *hjstate)
 	int			nbatch;
 	int			curbatch;
 
-	SIMPLE_FAULT_INJECTOR(FaultExecHashJoinNewBatch);
+	SIMPLE_FAULT_INJECTOR("exec_hashjoin_new_batch");
 
 	HashState  *hashState = (HashState *) innerPlanState(hjstate);
 
@@ -1448,7 +1448,7 @@ ExecHashJoinReloadHashTable(HashJoinState *hjstate)
 				BufFileGetSize(hashtable->innerBatchFile[curbatch]);
 		}
 
-		SIMPLE_FAULT_INJECTOR(WorkfileHashJoinFailure);
+		SIMPLE_FAULT_INJECTOR("workfile_hashjoin_failure");
 
 		/*
 		 * If we want to re-use the hash table after a re-scan, don't

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -191,7 +191,7 @@ ExecShareInputScan(ShareInputScanState *node)
 		if(!gotOK)
 			return NULL;
 
-		SIMPLE_FAULT_INJECTOR(ExecShareInputNext);
+		SIMPLE_FAULT_INJECTOR("execshare_input_next");
 
 		return slot;
 	}

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -190,7 +190,7 @@ ExecSort(SortState *node)
 			tuplesort_puttupleslot(tuplesortstate, slot);
 		}
 
-		SIMPLE_FAULT_INJECTOR(ExecSortBeforeSorting);
+		SIMPLE_FAULT_INJECTOR("execsort_before_sorting");
 
 		/*
 		 * Complete the sort.

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2652,7 +2652,7 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, int64 tcount)
 			/*
 			 * only check number tuples if the SPI 64 bit test is NOT running
 			 */
-			if (!FaultInjector_InjectFaultIfSet(ExecutorRunHighProcessed,
+			if (!FaultInjector_InjectFaultIfSet("executor_run_high_processed",
 										   DDLNotSpecified,
 										   "" /* databaseName */,
 										   "" /* tableName */))

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -415,7 +415,7 @@ probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 		simple_heap_insert(histrel, histtuple);
 		CatalogUpdateIndexes(histrel, histtuple);
 
-		SIMPLE_FAULT_INJECTOR(FtsUpdateConfig);
+		SIMPLE_FAULT_INJECTOR("fts_update_config");
 
 		heap_close(histrel, RowExclusiveLock);
 	}
@@ -523,10 +523,8 @@ void FtsLoop()
 		probe_requested = false;
 		skipFtsProbe = false;
 
-#ifdef FAULT_INJECTOR
-		if (SIMPLE_FAULT_INJECTOR(FtsProbe) == FaultInjectorTypeSkip)
+		if (SIMPLE_FAULT_INJECTOR("fts_probe") == FaultInjectorTypeSkip)
 			skipFtsProbe = true;
-#endif
 
 		if (skipFtsProbe || !has_mirrors)
 		{

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -431,7 +431,7 @@ HandleFtsMessage(const char* query_string)
 				(errmsg("message type: %s received contentid:%d doesn't match this segments configured contentid:%d",
 						message_type, contid, GpIdentity.segindex)));
 
-	SIMPLE_FAULT_INJECTOR(FtsHandleMessage);
+	SIMPLE_FAULT_INJECTOR("fts_handle_message");
 
 	if (strncmp(query_string, FTS_MSG_PROBE,
 				strlen(FTS_MSG_PROBE)) == 0)

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -3000,17 +3000,12 @@ gpdb::RunStaticPartitionSelection
 FaultInjectorType_e
 gpdb::InjectFaultInOptTasks
 	(
-	FaultInjectorIdentifier_e identifier
+	const char *fault_name
 	)
 {
-	/*
-	 * To activate this fault injection point, use gp_inject_fault
-	 * extension with opt_task_allocate_string_buffer as the fault
-	 * name.
-	 */
 	GP_WRAP_START;
 	{
-		return FaultInjector_InjectFaultIfSet(identifier, DDLNotSpecified, "", "");
+		return FaultInjector_InjectFaultIfSet(fault_name, DDLNotSpecified, "", "");
 	}
 	GP_WRAP_END;
 	return FaultInjectorTypeNotSpecified;

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -106,7 +106,7 @@ CTranslatorRelcacheToDXL::RetrieveObject
 	GPOS_ASSERT(NULL != md_accessor);
 
 #ifdef FAULT_INJECTOR
-	gpdb::InjectFaultInOptTasks(OptRelcacheTranslatorCatalogAccess);
+	gpdb::InjectFaultInOptTasks("opt_relcache_translator_catalog_access");
 #endif // FAULT_INJECTOR
 
 	switch(mdid->MdidType())

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -1733,7 +1733,7 @@ AutoVacWorkerMain(int argc, char *argv[])
 		ereport(LOG,
 				(errmsg("autovacuum: processing database \"%s\"", dbname)));
 
-		SIMPLE_FAULT_INJECTOR(AutoVacWorkerBeforeDoAutovacuum);
+		SIMPLE_FAULT_INJECTOR("auto_vac_worker_before_do_autovacuum");
 
 		if (PostAuthDelay)
 			pg_usleep(PostAuthDelay * 1000000L);

--- a/src/backend/postmaster/bgwriter.c
+++ b/src/backend/postmaster/bgwriter.c
@@ -261,7 +261,7 @@ BackgroundWriterMain(void)
 		int			rc;
 
 #ifdef USE_ASSERT_CHECKING
-		SIMPLE_FAULT_INJECTOR(FaultInBackgroundWriterMain);
+		SIMPLE_FAULT_INJECTOR("fault_in_background_writer_main");
 #endif
 
 		/* Clear any already-pending wakeups */

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2423,7 +2423,7 @@ retry1:
 
 #ifdef FAULT_INJECTOR
 					if (FaultInjector_InjectFaultIfSet(
-							FTSConnStartupPacket,
+							"fts_conn_startup_packet",
 							DDLNotSpecified,
 							"" /* databaseName */,
 							"" /* tableName */) == FaultInjectorTypeSkip)
@@ -2434,7 +2434,7 @@ retry1:
 						 * progressing.
 						 */
 						if (FaultInjector_InjectFaultIfSet(
-							FTSRecoveryInProgress,
+							"fts_recovery_in_progress",
 							DDLNotSpecified,
 							"" /* databaseName */,
 							"" /* tableName */) == FaultInjectorTypeSkip)
@@ -2643,7 +2643,7 @@ retry1:
 
 #ifdef FAULT_INJECTOR
 	if (!am_ftshandler && !IsFaultHandler && !am_walsender &&
-		FaultInjector_InjectFaultIfSet(ProcessStartupPacketFault,
+		FaultInjector_InjectFaultIfSet("process_startup_packet",
 									   DDLNotSpecified,
 									   port->database_name /* databaseName */,
 									   "" /* tableName */) == FaultInjectorTypeSkip)

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -240,7 +240,7 @@ perform_base_backup(basebackup_options *opt, DIR *tblspcdir)
 	 */
 	WalSndSetXLogCleanUpTo(startptr);
 
-	SIMPLE_FAULT_INJECTOR(BaseBackupPostCreateCheckpoint);
+	SIMPLE_FAULT_INJECTOR("base_backup_post_create_checkpoint");
 
 	/*
 	 * Once do_pg_start_backup has been called, ensure that any failure causes

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -307,7 +307,7 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 			ereport(WARNING,
 					(errmsg("ignoring query cancel request for synchronous replication to ensure cluster consistency"),
 					 errdetail("The transaction has already changed locally, it has to be replicated to standby.")));
-			SIMPLE_FAULT_INJECTOR(SyncRepQueryCancel);
+			SIMPLE_FAULT_INJECTOR("sync_rep_query_cancel");
 		}
 
 		/*

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -1031,7 +1031,7 @@ XLogWalRcvFlush(bool dying)
 	{
 #ifdef FAULT_INJECTOR
 		/* Simulate the case that the standby / mirror is lagging behind. */
-		if (SIMPLE_FAULT_INJECTOR(WalRecvSkipFlush) == FaultInjectorTypeSkip)
+		if (SIMPLE_FAULT_INJECTOR("walrecv_skip_flush") == FaultInjectorTypeSkip)
 			return;
 #endif
 

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -253,7 +253,7 @@ InitWalSender(void)
 	/* Set up resource owner */
 	CurrentResourceOwner = ResourceOwnerCreate(NULL, "walsender top-level resource owner");
 
-	SIMPLE_FAULT_INJECTOR(InitializeWalSender);
+	SIMPLE_FAULT_INJECTOR("initialize_wal_sender");
 
 	/*
 	 * Let postmaster know that we're a WAL sender. Once we've declared us as
@@ -1898,7 +1898,7 @@ WalSndLoop(WalSndSendDataCallback send_data)
 	 */
 	for (;;)
 	{
-		SIMPLE_FAULT_INJECTOR(WalSenderLoop);
+		SIMPLE_FAULT_INJECTOR("wal_sender_loop");
 
 		/*
 		 * Emergency bailout if postmaster has died.  This is to avoid the
@@ -1956,7 +1956,7 @@ WalSndLoop(WalSndSendDataCallback send_data)
 		if (pq_flush_if_writable() != 0)
 			WalSndShutdown();
 
-		SIMPLE_FAULT_INJECTOR(WalSenderAfterCaughtupWithinRange);
+		SIMPLE_FAULT_INJECTOR("wal_sender_after_caughtup_within_range");
 
 		/* If nothing remains to be sent right now ... */
 		if (WalSndCaughtUp && !pq_is_send_pending())

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -1703,7 +1703,7 @@ BgBufferSync(void)
 
 #ifdef FAULT_INJECTOR
 	/* flush all buffers. */
-	if (SIMPLE_FAULT_INJECTOR(BgBufferSyncDefaultLogic) == FaultInjectorTypeSkip)
+	if (SIMPLE_FAULT_INJECTOR("bg_buffer_sync_default_logic") == FaultInjectorTypeSkip)
 		min_scan_buffers = NBuffers;
 #endif
 
@@ -1730,7 +1730,7 @@ BgBufferSync(void)
 
 #ifdef FAULT_INJECTOR
 	/* Flush all buffers. */
-	if (SIMPLE_FAULT_INJECTOR(BgBufferSyncDefaultLogic) == FaultInjectorTypeSkip)
+	if (SIMPLE_FAULT_INJECTOR("bg_buffer_sync_default_logic") == FaultInjectorTypeSkip)
 		num_to_scan = NBuffers;
 #endif
 
@@ -1740,7 +1740,7 @@ BgBufferSync(void)
 	skip_recently_used = true;
 
 #ifdef FAULT_INJECTOR
-		if (SIMPLE_FAULT_INJECTOR(BgBufferSyncDefaultLogic) == FaultInjectorTypeSkip)
+		if (SIMPLE_FAULT_INJECTOR("bg_buffer_sync_default_logic") == FaultInjectorTypeSkip)
 			skip_recently_used= false;
 #endif
 

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -210,7 +210,7 @@ BufFileCreateTempInSet(workfile_set *work_set, bool interXact)
 	FileSetIsWorkfile(file->file);
 	RegisterFileWithSet(file->file, work_set);
 
-	SIMPLE_FAULT_INJECTOR(WorkfileCreationFail);
+	SIMPLE_FAULT_INJECTOR("workfile_creation_failure");
 
 	return file;
 }
@@ -536,7 +536,7 @@ BufFileWrite(BufFile *file, const void *ptr, size_t size)
 	size_t		nwritten = 0;
 	size_t		nthistime;
 
-	SIMPLE_FAULT_INJECTOR(WorkfileWriteFail);
+	SIMPLE_FAULT_INJECTOR("workfile_write_failure");
 
 	switch (file->state)
 	{

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -288,7 +288,7 @@ ProcArrayAdd(PGPROC *proc)
 
 	LWLockAcquire(ProcArrayLock, LW_EXCLUSIVE);
 
-	SIMPLE_FAULT_INJECTOR(ProcArray_Add);
+	SIMPLE_FAULT_INJECTOR("procarray_add");
 
 	if (arrayP->numProcs >= arrayP->maxProcs)
 	{
@@ -1814,7 +1814,7 @@ getDtxCheckPointInfo(char **result, int *result_size)
 	for (i = 0; i < *shmNumCommittedGxacts; i++)
 		gxact_log_array[actual++] = shmCommittedGxactArray[i++];
 
-	SIMPLE_FAULT_INJECTOR(CheckPointDtxInfo);
+	SIMPLE_FAULT_INJECTOR("checkpoint_dtx_info");
 
 	/*
 	 * If a transaction inserted 'commit' record logically before the checkpoint

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -1150,7 +1150,7 @@ mdsync(void)
 				int			failures;
 
 #ifdef FAULT_INJECTOR
-		if (SIMPLE_FAULT_INJECTOR(FsyncCounter) == FaultInjectorTypeSkip)
+		if (SIMPLE_FAULT_INJECTOR("fsync_counter") == FaultInjectorTypeSkip)
 		{
 			if (MyAuxProcType == CheckpointerProcess)
 				elog(LOG, "checkpoint performing fsync for %d/%d/%d",

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -620,7 +620,7 @@ ReadCommand(StringInfo inBuf)
 {
 	int			result;
 
-	SIMPLE_FAULT_INJECTOR(BeforeReadCommand);
+	SIMPLE_FAULT_INJECTOR("before_read_command");
 
 	if (whereToSendOutput == DestRemote)
 		result = SocketBackend(inBuf);
@@ -4885,7 +4885,7 @@ PostgresMain(int argc, char *argv[],
 	if (!(am_ftshandler || IsFaultHandler) && Gp_role == GP_ROLE_EXECUTE)
 	{
 #ifdef FAULT_INJECTOR
-		if (SIMPLE_FAULT_INJECTOR(SendQEDetailsInitBackend) != FaultInjectorTypeSkip)
+		if (SIMPLE_FAULT_INJECTOR("send_qe_details_init_backend") != FaultInjectorTypeSkip)
 #endif
 			sendQEDetails();
 	}

--- a/src/backend/utils/adt/pg_locale.c
+++ b/src/backend/utils/adt/pg_locale.c
@@ -1226,7 +1226,7 @@ pg_newlocale_from_collation(Oid collid)
 	cache_entry = lookup_collation_cache(collid, false);
 
 #ifdef FAULT_INJECTOR
-	SIMPLE_FAULT_INJECTOR(CollateLocaleOsLookup);
+	SIMPLE_FAULT_INJECTOR("collate_locale_os_lookup");
 #endif
 
 	if (cache_entry->locale == 0)

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -1193,7 +1193,7 @@ datumstreamread_block_content(DatumStreamRead * acc)
 					pfree(acc->large_object_buffer);
 					acc->large_object_buffer = NULL;
 
-					SIMPLE_FAULT_INJECTOR(MallocFailure);
+					SIMPLE_FAULT_INJECTOR("malloc_failure");
 				}
 
 				acc->large_object_buffer_size = acc->getBlockInfo.contentLen;

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -395,7 +395,7 @@ GlobalDeadLockDetectorLoop(void)
 		}
 
 #ifdef FAULT_INJECTOR
-		if (SIMPLE_FAULT_INJECTOR(GddProbe) == FaultInjectorTypeSkip)
+		if (SIMPLE_FAULT_INJECTOR("gdd_probe") == FaultInjectorTypeSkip)
 			continue;
 #endif
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -79,19 +79,14 @@ static int FaultInjector_MarkEntryAsResume(
 static bool FaultInjector_RemoveHashEntry(
 								const char* faultName);
 
+static int FaultInjector_SetFaultInjection(FaultInjectorEntry_s *entry);
+
 /* Arrays to map between enum values and strings */
 const char*
 FaultInjectorTypeEnumToString[] = {
 #define FI_TYPE(id, str) str,
 #include "utils/faultinjector_lists.h"
 #undef FI_TYPE
-};
-
-const char*
-FaultInjectorIdentifierEnumToString[] = {
-#define FI_IDENT(id, str) str,
-#include "utils/faultinjector_lists.h"
-#undef FI_IDENT
 };
 
 const char*
@@ -123,23 +118,6 @@ FaultInjectorTypeStringToEnum(char* faultTypeString)
 		}
 	}
 	return faultTypeEnum;
-}
-
-FaultInjectorIdentifier_e
-FaultInjectorIdentifierStringToEnum(char* faultName)
-{
-	FaultInjectorIdentifier_e	faultId = FaultInjectorIdMax;
-	int	ii;
-	
-	for (ii=FaultInjectorIdNotSpecified+1; ii < FaultInjectorIdMax; ii++)
-	{
-		if (strcmp(FaultInjectorIdentifierEnumToString[ii], faultName) == 0)
-		{
-			faultId = ii;
-			break;
-		}
-	}
-	return faultId;
 }
 
 DDLStatement_e
@@ -241,21 +219,6 @@ FaultInjector_ShmemInit(void)
 
 FaultInjectorType_e
 FaultInjector_InjectFaultIfSet(
-							   FaultInjectorIdentifier_e identifier,
-							   DDLStatement_e			 ddlStatement,
-							   const char*					 databaseName,
-							   const char*					 tableName)
-{
-	return FaultInjector_InjectFaultNameIfSet(
-			FaultInjectorIdentifierEnumToString[identifier],
-			ddlStatement,
-			databaseName,
-			tableName);
-	
-}
-
-FaultInjectorType_e
-FaultInjector_InjectFaultNameIfSet(
 							   const char*				 faultName,
 							   DDLStatement_e			 ddlStatement,
 							   const char*				 databaseName,
@@ -589,8 +552,8 @@ FaultInjector_InsertHashEntry(
 		return entry;
 	} 
 	
-	elog(DEBUG1, "FaultInjector_InsertHashEntry() entry_key:%d", 
-		 entry->faultInjectorIdentifier);
+	elog(DEBUG1, "FaultInjector_InsertHashEntry() entry_key:%s",
+		 entry->faultName);
 	
 	if (foundPtr) {
 		*exists = TRUE;
@@ -692,7 +655,6 @@ FaultInjector_NewHashEntry(
 	}
 		
 	entryLocal->faultInjectorType = entry->faultInjectorType;
-	entryLocal->faultInjectorIdentifier = entry->faultInjectorIdentifier;
 	strlcpy(entryLocal->faultName, entry->faultName, sizeof(entryLocal->faultName));
 
 	entryLocal->extraArg = entry->extraArg;
@@ -711,8 +673,7 @@ FaultInjector_NewHashEntry(
 		
 	FiLockRelease();
 	
-	elog(DEBUG1, "FaultInjector_NewHashEntry() identifier:'%s'", 
-		 entry->faultName);
+	elog(DEBUG1, "FaultInjector_NewHashEntry(): '%s'", entry->faultName);
 	
 exit:
 		
@@ -768,9 +729,9 @@ exit:
 }
 
 /*
- * 
+ * Inject fault according to its type.
  */
-int
+static int
 FaultInjector_SetFaultInjection(
 						   FaultInjectorEntry_s	*entry)
 {
@@ -783,7 +744,7 @@ FaultInjector_SetFaultInjection(
 			HASH_SEQ_STATUS			hash_status;
 			FaultInjectorEntry_s	*entryLocal;
 			
-			if (entry->faultInjectorIdentifier == FaultInjectorIdAll) 
+			if (strcmp(entry->faultName, FaultInjectorNameAll) == 0)
 			{
 				hash_seq_init(&hash_status, faultInjectorShmem->hash);
 				
@@ -897,8 +858,8 @@ FaultInjector_SetFaultInjection(
 							FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
 						entryLocal->numTimesTriggered)));
 				
-				if (entry->faultInjectorIdentifier == entryLocal->faultInjectorIdentifier ||
-					entry->faultInjectorIdentifier == FaultInjectorIdAll)
+				if (strcmp(entry->faultName, entryLocal->faultName) == 0 ||
+					strcmp(entry->faultName, FaultInjectorNameAll) == 0)
 				{
 					length = snprintf((entry->bufOutput + length), sizeof(entry->bufOutput) - length,
 									  "fault name:'%s' "
@@ -949,70 +910,6 @@ FaultInjector_SetFaultInjection(
 			break;
 	}
 	return status;
-}
-
-/*
- * 
- */
-bool
-FaultInjector_IsFaultInjected(
-							  char* faultName)
-{
-	FaultInjectorEntry_s	*entry = NULL;
-	bool					isCompleted = FALSE;
-	bool					retval = FALSE;
-	bool					isRemoved;
-		
-	FiLockAcquire();
-		
-	entry = FaultInjector_LookupHashEntry(faultName);
-		
-	if (entry == NULL) {
-		retval = TRUE;
-		isCompleted = TRUE;
-		goto exit;
-	}
-		
-	switch (entry->faultInjectorState) {
-		case FaultInjectorStateWaiting:
-			/* No operation */
-			break;
-		case FaultInjectorStateTriggered:	
-			/* No operation */
-			break;
-		case FaultInjectorStateCompleted:
-			
-			retval = TRUE;
-			/* NO break */
-		case FaultInjectorStateFailed:
-			
-			isCompleted = TRUE;
-			isRemoved = FaultInjector_RemoveHashEntry(faultName);
-			
-			if (isRemoved == FALSE) {
-				ereport(DEBUG1,
-						(errmsg("LOG(fault injector): could not remove fault injection from hash"
-								"identifier:'%s' ",
-								faultName)));
-			} else {
-				faultInjectorShmem->faultInjectorSlots--;
-			}
-
-			break;
-		default:
-			Assert(0);
-	}
-
-exit:
-	FiLockRelease();
-	
-	if ((isCompleted == TRUE) && (retval == FALSE)) {
-		ereport(WARNING,
-				(errmsg("could not complete fault injection, fault name:'%s' fault type:'%s' ",
-						faultName,
-						FaultInjectorTypeEnumToString[entry->faultInjectorType])));
-	}
-	return isCompleted;
 }
 
 void
@@ -1080,11 +977,6 @@ InjectFault(char *faultName, char *type, char *ddlStatement, char *databaseName,
 		 startOccurrence, endOccurrence, extraArg );
 
 	strlcpy(faultEntry.faultName, faultName, sizeof(faultEntry.faultName));
-	faultEntry.faultInjectorIdentifier = FaultInjectorIdentifierStringToEnum(faultName);
-	if (faultEntry.faultInjectorIdentifier == FaultInjectorIdMax)
-		ereport(ERROR,
-				(errcode(ERRCODE_PROTOCOL_VIOLATION),
-				 errmsg("could not recognize fault name '%s'", faultName)));
 
 	faultEntry.faultInjectorType = FaultInjectorTypeStringToEnum(type);
 	if (faultEntry.faultInjectorType == FaultInjectorTypeMax)

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -81,6 +81,10 @@ static bool FaultInjector_RemoveHashEntry(
 
 static int FaultInjector_SetFaultInjection(FaultInjectorEntry_s *entry);
 
+static FaultInjectorType_e FaultInjectorTypeStringToEnum(const char *faultType);
+
+static DDLStatement_e FaultInjectorDDLStringToEnum(const char *ddlString);
+
 /* Arrays to map between enum values and strings */
 const char*
 FaultInjectorTypeEnumToString[] = {
@@ -103,8 +107,8 @@ FaultInjectorStateEnumToString[] = {
 #undef FI_STATE
 };
 
-FaultInjectorType_e
-FaultInjectorTypeStringToEnum(char* faultTypeString)
+static FaultInjectorType_e
+FaultInjectorTypeStringToEnum(const char* faultTypeString)
 {
 	FaultInjectorType_e	faultTypeEnum = FaultInjectorTypeMax;
 	int	ii;
@@ -120,8 +124,8 @@ FaultInjectorTypeStringToEnum(char* faultTypeString)
 	return faultTypeEnum;
 }
 
-DDLStatement_e
-FaultInjectorDDLStringToEnum(char* ddlString)
+static DDLStatement_e
+FaultInjectorDDLStringToEnum(const char* ddlString)
 {
 	DDLStatement_e	ddlEnum = DDLMax;
 	int	ii;
@@ -232,6 +236,15 @@ FaultInjector_InjectFaultIfSet(
 	int						ii = 0;
 	int cnt = 3600;
 	FaultInjectorType_e retvalue = FaultInjectorTypeNotSpecified;
+
+	if (strlen(faultName) >= sizeof(localEntry.faultName))
+		elog(ERROR, "fault name too long: '%s'", faultName);
+	if (strcmp(faultName, FaultInjectorNameAll) == 0)
+		elog(ERROR, "invalid fault name '%s'", faultName);
+	if (strlen(databaseName) >= NAMEDATALEN)
+		elog(ERROR, "database name too long:'%s'", databaseName);
+	if (strlen(tableName) >= NAMEDATALEN)
+		elog(ERROR, "table name too long: '%s'", tableName);
 
 	/*
 	 * Auto-vacuum worker and launcher process, may run at unpredictable times
@@ -821,75 +834,53 @@ FaultInjector_SetFaultInjection(
 
 		case FaultInjectorTypeStatus:
 		{	
-			HASH_SEQ_STATUS			hash_status;
 			FaultInjectorEntry_s	*entryLocal;
-			bool					found = FALSE;
 			int                     length;
-			
-			if (faultInjectorShmem->hash == NULL) {
+
+			if (faultInjectorShmem->hash == NULL)
+			{
 				status = STATUS_ERROR;
 				break;
 			}
 			length = snprintf(entry->bufOutput, sizeof(entry->bufOutput), "Success: ");
-			
-			hash_seq_init(&hash_status, faultInjectorShmem->hash);
 
-			while ((entryLocal = (FaultInjectorEntry_s *) hash_seq_search(&hash_status)) != NULL) {
-				ereport(LOG,
-					(errmsg("fault injector status: "
-							"fault name:'%s' "
-							"fault type:'%s' "
-							"ddl statement:'%s' "
-							"database name:'%s' "
-							"table name:'%s' "
-							"start occurrence:'%d' "
-							"end occurrence:'%d' "
-							"extra argument:'%d' "
-							"fault injection state:'%s' "
-							"num times hit:'%d' ",
-							entryLocal->faultName,
-							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType],
-							FaultInjectorDDLEnumToString[entryLocal->ddlStatement],
-							entryLocal->databaseName,
-							entryLocal->tableName,
-							entryLocal->startOccurrence,
-							entryLocal->endOccurrence,
-							entryLocal->extraArg,
-							FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
-						entryLocal->numTimesTriggered)));
-				
-				if (strcmp(entry->faultName, entryLocal->faultName) == 0 ||
-					strcmp(entry->faultName, FaultInjectorNameAll) == 0)
-				{
-					length = snprintf((entry->bufOutput + length), sizeof(entry->bufOutput) - length,
-									  "fault name:'%s' "
-									  "fault type:'%s' "
-									  "ddl statement:'%s' "
-									  "database name:'%s' "
-									  "table name:'%s' "
-									  "start occurrence:'%d' "
-									  "end occurrence:'%d' "
-									  "extra arg:'%d' "
-									  "fault injection state:'%s'  "
-									  "num times hit:'%d' \n",
-									  entryLocal->faultName,
-									  FaultInjectorTypeEnumToString[entryLocal->faultInjectorType],
-									  FaultInjectorDDLEnumToString[entryLocal->ddlStatement],
-									  entryLocal->databaseName,
-									  entryLocal->tableName,
-									  entryLocal->startOccurrence,
-									  entryLocal->endOccurrence,
-									  entryLocal->extraArg,
-									  FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
-									  entryLocal->numTimesTriggered);
-						found = TRUE;
-				}
+			entryLocal = FaultInjector_LookupHashEntry(entry->faultName);
+			if (entryLocal)
+			{
+				length = snprintf(
+					(entry->bufOutput + length),
+					sizeof(entry->bufOutput) - length,
+					"fault name:'%s' "
+					"fault type:'%s' "
+					"ddl statement:'%s' "
+					"database name:'%s' "
+					"table name:'%s' "
+					"start occurrence:'%d' "
+					"end occurrence:'%d' "
+					"extra arg:'%d' "
+					"fault injection state:'%s'  "
+					"num times hit:'%d' \n",
+					entryLocal->faultName,
+					FaultInjectorTypeEnumToString[entryLocal->faultInjectorType],
+					FaultInjectorDDLEnumToString[entryLocal->ddlStatement],
+					entryLocal->databaseName,
+					entryLocal->tableName,
+					entryLocal->startOccurrence,
+					entryLocal->endOccurrence,
+					entryLocal->extraArg,
+					FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
+					entryLocal->numTimesTriggered);
 			}
-			if (found == FALSE) {
-				snprintf(entry->bufOutput, sizeof(entry->bufOutput), "Failure: "
-						 "fault name:'%s' not set",
-						 entry->faultName);
+			else
+			{
+				length = snprintf(entry->bufOutput, sizeof(entry->bufOutput),
+								  "Failure: fault name:'%s' not set",
+								  entry->faultName);
 			}
+			elog(LOG, "%s", entry->bufOutput);
+			if (length > sizeof(entry->bufOutput))
+				elog(LOG, "fault status truncated from %d to %zu characters",
+					 length, sizeof(entry->bufOutput));
 			break;
 		}
 		case FaultInjectorTypeResume:
@@ -976,13 +967,26 @@ InjectFault(char *faultName, char *type, char *ddlStatement, char *databaseName,
 		 faultName, type, ddlStatement, databaseName, tableName,
 		 startOccurrence, endOccurrence, extraArg );
 
-	strlcpy(faultEntry.faultName, faultName, sizeof(faultEntry.faultName));
+	if (strlcpy(faultEntry.faultName, faultName, sizeof(faultEntry.faultName)) >=
+		sizeof(faultEntry.faultName))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("fault name too long: '%s'", faultName),
+				 errdetail("Fault name should be no more than %d characters.",
+						   FAULT_NAME_MAX_LENGTH-1)));
 
 	faultEntry.faultInjectorType = FaultInjectorTypeStringToEnum(type);
 	if (faultEntry.faultInjectorType == FaultInjectorTypeMax)
 		ereport(ERROR,
 				(errcode(ERRCODE_PROTOCOL_VIOLATION),
 				 errmsg("could not recognize fault type '%s'", type)));
+
+	/* Special fault name "all" is only used to reset all faults */
+	if (faultEntry.faultInjectorType != FaultInjectorTypeReset &&
+		strcmp(faultEntry.faultName, FaultInjectorNameAll) == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("invalid fault name '%s'", faultName)));
 
 	faultEntry.extraArg = extraArg;
 	if (faultEntry.faultInjectorType == FaultInjectorTypeSleep)
@@ -999,9 +1003,22 @@ InjectFault(char *faultName, char *type, char *ddlStatement, char *databaseName,
 				(errcode(ERRCODE_PROTOCOL_VIOLATION),
 				 errmsg("could not recognize DDL statement")));
 
-	snprintf(faultEntry.databaseName, sizeof(faultEntry.databaseName), "%s", databaseName);
+	if (strlcpy(faultEntry.databaseName, databaseName,
+				sizeof(faultEntry.databaseName)) >=
+		sizeof(faultEntry.databaseName))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("database name too long: '%s'", databaseName),
+				 errdetail("Database name should be no more than %d characters.",
+						   NAMEDATALEN-1)));
 
-	snprintf(faultEntry.tableName, sizeof(faultEntry.tableName), "%s", tableName);
+	if (strlcpy(faultEntry.tableName, tableName, sizeof(faultEntry.tableName)) >=
+		sizeof(faultEntry.tableName))
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("table name too long: '%s'", tableName),
+				 errdetail("Table name should be no more than %d characters.",
+						   NAMEDATALEN-1)));
 
 	if (startOccurrence < 1 || startOccurrence > 1000)
 		ereport(ERROR,

--- a/src/backend/utils/mmgr/runaway_cleaner.c
+++ b/src/backend/utils/mmgr/runaway_cleaner.c
@@ -182,7 +182,7 @@ RunawayCleaner_StartCleanup()
 
 		if (RunawayCleaner_ShouldCancelQuery())
 		{
-			SIMPLE_FAULT_INJECTOR(RunawayCleanup);
+			SIMPLE_FAULT_INJECTOR("runaway_cleanup");
 
 			ereport(ERROR, (errmsg("Canceling query because of high VMEM usage. Used: %dMB, available %dMB, red zone: %dMB",
 					VmemTracker_ConvertVmemChunksToMB(MySessionState->sessionVmem), VmemTracker_GetAvailableVmemMB(),

--- a/src/backend/utils/mmgr/test/runaway_cleaner_test.c
+++ b/src/backend/utils/mmgr/test/runaway_cleaner_test.c
@@ -150,7 +150,7 @@ test__RunawayCleaner_StartCleanup__StartsPrimaryCleanupIfPossible(void **state)
 	will_return(IsTransactionState, true);
 
 #ifdef FAULT_INJECTOR
-	expect_value(FaultInjector_InjectFaultIfSet, identifier, RunawayCleanup);
+	expect_value(FaultInjector_InjectFaultIfSet, faultName, "runaway_cleanup");
 	expect_value(FaultInjector_InjectFaultIfSet, ddlStatement, DDLNotSpecified);
 	expect_value(FaultInjector_InjectFaultIfSet, databaseName, "");
 	expect_value(FaultInjector_InjectFaultIfSet, tableName, "");
@@ -217,7 +217,7 @@ test__RunawayCleaner_StartCleanup__StartsSecondaryCleanupIfPossible(void **state
 	will_return(IsTransactionState, true);
 
 #ifdef FAULT_INJECTOR
-	expect_value(FaultInjector_InjectFaultIfSet, identifier, RunawayCleanup);
+	expect_value(FaultInjector_InjectFaultIfSet, faultName, "runaway_cleanup");
 	expect_value(FaultInjector_InjectFaultIfSet, ddlStatement, DDLNotSpecified);
 	expect_value(FaultInjector_InjectFaultIfSet, databaseName, "");
 	expect_value(FaultInjector_InjectFaultIfSet, tableName, "");

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2532,7 +2532,7 @@ AssignResGroupOnMaster(void)
 		self->caps = slot->caps;
 
 		/* Don't error out before this line in this function */
-		SIMPLE_FAULT_INJECTOR(ResGroupAssignedOnMaster);
+		SIMPLE_FAULT_INJECTOR("resgroup_assigned_on_master");
 
 		/* Add into cgroup */
 		ResGroupOps_AssignGroup(self->groupId, &(self->caps), MyProcPid);

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2030,7 +2030,7 @@ mergeruns(Tuplesortstate_mk *state)
 	 */
 	HOLD_INTERRUPTS();
 	FaultInjector_InjectFaultIfSet(
-								   ExecSortMKSortMergeRuns,
+								   "execsort_mksort_mergeruns",
 								   DDLNotSpecified,
 								   "", //databaseName
 								   "");

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -635,7 +635,7 @@ namespace gpdb {
 	SelectedParts *RunStaticPartitionSelection(PartitionSelector *ps);
 
 	// simple fault injector used by COptTasks.cpp to inject GPDB fault
-	FaultInjectorType_e InjectFaultInOptTasks(FaultInjectorIdentifier_e identifier);
+	FaultInjectorType_e InjectFaultInOptTasks(const char* fault_name);
 
 	// return the number of leaf partition for a given table oid
 	gpos::ULONG CountLeafPartTables(Oid oidRelation);

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -20,15 +20,8 @@
 #define Natts_fault_message_response 1
 #define Anum_fault_message_response_status 0
 
-/*
- *
- */
-typedef enum FaultInjectorIdentifier_e {
-#define FI_IDENT(id, str) id,
-#include "utils/faultinjector_lists.h"
-#undef FI_IDENT
-	FaultInjectorIdMax
-} FaultInjectorIdentifier_e;
+/* Fault name that matches all faults */
+#define FaultInjectorNameAll "all"
 
 typedef enum FaultInjectorType_e {
 #define FI_TYPE(id, str) id,
@@ -65,8 +58,6 @@ typedef struct FaultInjectorEntry_s {
 	
 	char						faultName[FAULT_NAME_MAX_LENGTH];
 
-	FaultInjectorIdentifier_e	faultInjectorIdentifier;
-	
 	FaultInjectorType_e		faultInjectorType;
 	
 	int						extraArg;
@@ -92,9 +83,6 @@ typedef struct FaultInjectorEntry_s {
 extern FaultInjectorType_e	FaultInjectorTypeStringToEnum(
 									char*		faultTypeString);
 
-extern	FaultInjectorIdentifier_e FaultInjectorIdentifierStringToEnum(
-									char*			faultName);
-
 extern DDLStatement_e FaultInjectorDDLStringToEnum(
 									char*	ddlString);
 
@@ -102,24 +90,11 @@ extern Size FaultInjector_ShmemSize(void);
 
 extern void FaultInjector_ShmemInit(void);
 
-extern FaultInjectorType_e FaultInjector_InjectFaultNameIfSet(
+extern FaultInjectorType_e FaultInjector_InjectFaultIfSet(
 							   const char*				 faultName,
 							   DDLStatement_e			 ddlStatement,
 							   const char*				 databaseName,
 							   const char*				 tableName);
-
-extern FaultInjectorType_e FaultInjector_InjectFaultIfSet(
-							   FaultInjectorIdentifier_e identifier,
-							   DDLStatement_e			 ddlStatement,
-							   const char*				 databaseName,
-							   const char*				 tableName);
-
-extern int FaultInjector_SetFaultInjection(
-							FaultInjectorEntry_s	*entry);
-
-
-extern bool FaultInjector_IsFaultInjected(
-							char* faultName);
 
 extern char *InjectFault(
 	char *faultName, char *type, char *ddlStatement, char *databaseName,
@@ -130,15 +105,11 @@ extern void HandleFaultMessage(const char* msg);
 #ifdef FAULT_INJECTOR
 extern bool am_faulthandler;
 #define IsFaultHandler am_faulthandler
-#define SIMPLE_FAULT_INJECTOR(FaultIdentifier) \
-	FaultInjector_InjectFaultIfSet(FaultIdentifier, DDLNotSpecified, "", "")
-#define SIMPLE_FAULT_NAME_INJECTOR(FaultName) \
-	FaultInjector_InjectFaultNameIfSet(FaultName, DDLNotSpecified, "", "")
+#define SIMPLE_FAULT_INJECTOR(FaultName) \
+	FaultInjector_InjectFaultIfSet(FaultName, DDLNotSpecified, "", "")
 #else
 #define IsFaultHandler false
-#define SIMPLE_FAULT_INJECTOR(FaultIdentifier)
-#define SIMPLE_FAULT_NAME_INJECTOR(FaultName)
+#define SIMPLE_FAULT_INJECTOR(FaultName)
 #endif
 
 #endif	/* FAULTINJECTOR_H */
-

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -80,12 +80,6 @@ typedef struct FaultInjectorEntry_s {
 } FaultInjectorEntry_s;
 
 
-extern FaultInjectorType_e	FaultInjectorTypeStringToEnum(
-									char*		faultTypeString);
-
-extern DDLStatement_e FaultInjectorDDLStringToEnum(
-									char*	ddlString);
-
 extern Size FaultInjector_ShmemSize(void);
 
 extern void FaultInjector_ShmemInit(void);

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -1,22 +1,21 @@
 /*
  * faultinjector_lists.h
  *
- * List of fault injector identifiers, or "fault points", as well as fault
- * injector states and some other things. These are listed using C
- * preprocessor macros. To use, you must define the appropriate FI_* macros
- * before #including this file.
+ * List of fault injector types, states and some other things. These are
+ * listed using C preprocessor macros. To use, you must define the appropriate
+ * FI_* macros before #including this file.
  *
- * For example, to get an array of all the identifier strings, do:
+ * For example, to get an array of all the type strings, do:
  *
- * const char *FaultInject_Strings[] = {
- * #define FI_IDENT(id, str) str,
+ * const char *FaultInjectorTypeStrings[] = {
+ * #define FI_TYPE(id, str) str,
  * #include "utils/faultinjector_lists.h"
- * #undef FI_IDENT
+ * #undef FI_TYPE
  * };
  *
  *
- * To add a new fault injection point, simply add a new FI_IDENT line to the
- * list below.
+ * To add a new entry, simple add a new FI_* line to the appropriate list
+ * below.
  *
  *
  * Copyright 2009-2010, Greenplum Inc. All rights reserved.
@@ -25,243 +24,6 @@
 
 /* there is deliberately not an #ifndef FAULTINJECTOR_LISTS_H here */
 
-/*
- * Fault injection points.
- */
-#ifdef FI_IDENT
-FI_IDENT(FaultInjectorIdNotSpecified = 0, "")
-/*
- * affects all faults injected
- *		*) remove all faults injected from the segment
- *		*) display status for all faults injected
- */
-FI_IDENT(FaultInjectorIdAll, "all")
-/* inject fault when new connection is accepted in postmaster */
-FI_IDENT(Postmaster, "postmaster")
-/* inject fault when pg_control file is written */
-FI_IDENT(PgControl, "pg_control")
-/* inject fault when files in pg_xlog directory are written */
-FI_IDENT(PgXlog, "pg_xlog")
-/* inject fault during start prepare */
-FI_IDENT(StartPrepareTx, "start_prepare")
-/* inject fault before checkpoint is taken */
-FI_IDENT(Checkpoint, "checkpoint")
-/* inject fault during transaction start with DistributedTransactionContext in ENTRY_DB_SINGLETON mode */
-FI_IDENT(TransactionStartUnderEntryDbSingleton, "transaction_start_under_entry_db_singleton")
-/* inject fault after transaction is prepared */
-FI_IDENT(TransactionAbortAfterDistributedPrepared, "transaction_abort_after_distributed_prepared")
-/* inject fault after persistent state change is permanently stored during first pass */
-FI_IDENT(TransactionCommitPass1FromCreatePendingToCreated, "transaction_commit_pass1_from_create_pending_to_created")
-/* inject fault after persistent state change is permanently stored during first pass */
-FI_IDENT(TransactionCommitPass1FromDropInMemoryToDropPending, "transaction_commit_pass1_from_drop_in_memory_to_drop_pending")
-/* inject fault after persistent state change is permanently stored during first pass */
-FI_IDENT(TransactionCommitPass1FromAbortingCreateNeededToAbortingCreate, "transaction_commit_pass1_from_aborting_create_needed_to_aborting_create")
-/* inject fault after persistent state change is permanently stored during first pass */
-FI_IDENT(TransactionAbortPass1FromCreatePendingToAbortingCreate, "transaction_abort_pass1_from_create_pending_to_aborting_create")
-/* inject fault after persistent state change is permanently stored during first pass */
-FI_IDENT(TransactionAbortPass1FromAbortingCreateNeededToAbortingCreate, "transaction_abort_pass1_from_aborting_create_needed_to_aborting_create")
-/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
-FI_IDENT(TransactionCommitPass2FromDropInMemoryToDropPending, "transaction_commit_pass2_from_drop_in_memory_to_drop_pending")
-/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
-FI_IDENT(TransactionCommitPass2FromAbortingCreateNeededToAbortingCreate, "transaction_commit_pass2_from_aborting_create_needed_to_aborting_create")
-/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
-FI_IDENT(TransactionAbortPass2FromCreatePendingToAbortingCreate, "transaction_abort_pass2_from_create_pending_to_aborting_create")
-/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
-FI_IDENT(TransactionAbortPass2FromAbortingCreateNeededToAbortingCreate, "transaction_abort_pass2_from_aborting_create_needed_to_aborting_create")
-/* inject fault after persistent state change is permanently stored during first pass */
-FI_IDENT(FinishPreparedTransactionCommitPass1FromCreatePendingToCreated, "finish_prepared_transaction_commit_pass1_from_create_pending_to_created")
-/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
-FI_IDENT(FinishPreparedTransactionCommitPass2FromCreatePendingToCreated, "finish_prepared_transaction_commit_pass2_from_create_pending_to_created")
-/* inject fault after persistent state change is permanently stored during first pass (commit: create pending => created) */
-FI_IDENT(FinishPreparedTransactionAbortPass1FromCreatePendingToAbortingCreate, "finish_prepared_transaction_abort_pass1_from_create_pending_to_aborting_create")
-/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
-FI_IDENT(FinishPreparedTransactionAbortPass2FromCreatePendingToAbortingCreate, "finish_prepared_transaction_abort_pass2_from_create_pending_to_aborting_create")
-/* inject fault after persistent state change is permanently stored during first pass (abort: create pending => aborting create) */
-FI_IDENT(FinishPreparedTransactionCommitPass1FromDropInMemoryToDropPending, "finish_prepared_transaction_commit_pass1_from_drop_in_memory_to_drop_pending")
-/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
-FI_IDENT(FinishPreparedTransactionCommitPass2FromDropInMemoryToDropPending, "finish_prepared_transaction_commit_pass2_from_drop_in_memory_to_drop_pending")
-/* inject fault after persistent state change is permanently stored during first pass (commit: drop in memory => drop pending) */
-FI_IDENT(FinishPreparedTransactionCommitPass1AbortingCreateNeeded, "finish_prepared_transaction_commit_pass1_aborting_create_needed")
-/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
-FI_IDENT(FinishPreparedTransactionCommitPass2AbortingCreateNeeded, "finish_prepared_transaction_commit_pass2_aborting_create_needed")
-/* inject fault after persistent state change is permanently stored during first pass (create pending => created) */
-FI_IDENT(FinishPreparedTransactionAbortPass1AbortingCreateNeeded, "finish_prepared_transaction_abort_pass1_aborting_create_needed")
-/* inject fault after physical drop and before final persistent state change is permanently stored during second pass */
-FI_IDENT(FinishPreparedTransactionAbortPass2AbortingCreateNeeded, "finish_prepared_transaction_abort_pass2_aborting_create_needed")
-/* inject fault after transaction is prepared */
-FI_IDENT(OnePhaseTransactionCommit, "onephase_transaction_commit")
-/* inject fault before transaction commit is recorded in xlog (trigger filerep verification)*/
-FI_IDENT(TwoPhaseTransactionCommitPrepared, "twophase_transaction_commit_prepared")
-/* inject fault before transaction abort is recorded in xlog */
-FI_IDENT(TwoPhaseTransactionAbortPrepared, "twophase_transaction_abort_prepared")
-/* inject fault after prepare broadcast */
-FI_IDENT(DtmBroadcastPrepare, "dtm_broadcast_prepare")
-/* inject fault after commit broadcast */
-FI_IDENT(DtmBroadcastCommitPrepared, "dtm_broadcast_commit_prepared")
-/* inject fault after abort broadcast */
-FI_IDENT(DtmBroadcastAbortPrepared, "dtm_broadcast_abort_prepared")
-/* inject fault after distributed commit was inserted in xlog */
-FI_IDENT(DtmXLogDistributedCommit, "dtm_xlog_distributed_commit")
-/* inject fault before initializing dtm */
-FI_IDENT(DtmInit, "dtm_init")
-/* inject fault after writing prepare record */
-FI_IDENT(EndPreparedTwoPhase, "end_prepare_two_phase")
-/* inject fault after segment receives state transition request (sleep after creating two phase files) */
-FI_IDENT(SegmentTransitionRequest, "segment_transition_request")
-/* inject fault after segment is probed by FTS */
-FI_IDENT(SegmentProbeResponse, "segment_probe_response")
-/* inject fault after recording transaction commit for local transaction  */
-FI_IDENT(LocalTmRecordTransactionCommit, "local_tm_record_transaction_commit")
-/* inject fault to simulate memory allocation failure */
-FI_IDENT(MallocFailure, "malloc_failure")
-/* inject fault to simulate transaction abort failure  */
-FI_IDENT(AbortTransactionFail, "transaction_abort_failure")
-/* inject fault to simulate workfile creation failure  */
-FI_IDENT(WorkfileCreationFail, "workfile_creation_failure")
-/* inject fault to simulate workfile write failure  */
-FI_IDENT(WorkfileWriteFail, "workfile_write_failure")
-/* pretend that a query processed billions of rows  */
-FI_IDENT(WorkfileHashJoinFailure, "workfile_hashjoin_failure")
-/* inject fault before we close workfile in ExecHashJoinNewBatch */
-FI_IDENT(ExecutorRunHighProcessed, "executor_run_high_processed")
-/* large palloc inside MultiExecHash to attempt to exceed vmem limit */
-FI_IDENT(MultiExecHashLargeVmem, "multi_exec_hash_large_vmem")
-/* inject fault in ExecSort before doing the actual sort */
-FI_IDENT(ExecSortBeforeSorting, "execsort_before_sorting")
-/* inject fault in MKSort during the mergeruns phase */
-FI_IDENT(ExecSortMKSortMergeRuns, "execsort_mksort_mergeruns")
-/* inject fault after shared input scan retrieved a tuple */
-FI_IDENT(ExecShareInputNext, "execshare_input_next")
-/* inject fault after creation of checkpoint when basebackup requested */
-FI_IDENT(BaseBackupPostCreateCheckpoint, "base_backup_post_create_checkpoint")
-/* inject fault after compaction, but before the drop of the
- * segment file */
-FI_IDENT(CompactionBeforeSegmentFileDropPhase, "compaction_before_segmentfile_drop")
-/* inject fault after compaction and drop, but before
- * the cleanup phase for a relation */
-FI_IDENT(CompactionBeforeCleanupPhase, "compaction_before_cleanup_phase")
-/* inject fault before an append-only insert */
-FI_IDENT(AppendOnlyInsert, "appendonly_insert")
-/* inject fault before an append-only delete */
-FI_IDENT(AppendOnlyDelete, "appendonly_delete")
-/* inject fault before an append-only update */
-FI_IDENT(AppendOnlyUpdate, "appendonly_update")
-/* inject fault before creating an appendonly hash entry*/
-FI_IDENT(BeforeCreatingAnAOHashEntry, "before_creating_an_ao_hash_entry")
-/* inject fault in append-only compression function */
-FI_IDENT(AppendOnlySkipCompression, "appendonly_skip_compression")
-/* inject fault while reindex db is in progress */
-FI_IDENT(ReindexDB, "reindex_db")
-/* inject fault while reindex relation is in progress */
-FI_IDENT(ReindexRelation, "reindex_relation")
-/* inject fault at the beginning of rxThreadFunc */
-FI_IDENT(FaultInBackgroundWriterMain, "fault_in_background_writer_main")
-/* inject fault in cdbCopyStart after dispatch */
-FI_IDENT(CdbCopyStartAfterDispatch, "cdb_copy_start_after_dispatch")
-/* inject fault at the end of repair_frag */
-FI_IDENT(RepairFragEnd, "repair_frag_end")
-/* inject fault before truncate in vacuum full */
-FI_IDENT(VacuumFullBeforeTruncate, "vacuum_full_before_truncate")
-/* inject fault after truncate in vacuum full */
-FI_IDENT(VacuumFullAfterTruncate, "vacuum_full_after_truncate")
-/* inject fault at the end of first round of vacuumRelation loop */
-FI_IDENT(VacuumRelationEndOfFirstRound, "vacuum_relation_end_of_first_round")
-/* inject fault during the open relation of the drop phase of vacuumRelation loop */
-FI_IDENT(VacuumRelationOpenRelationDuringDropPhase, "vacuum_relation_open_relation_during_drop_phase")
-/* inject fault while adding PGPROC to procarray */
-FI_IDENT(ProcArray_Add, "procarray_add")
-/* inject fault before switching to a new batch in Hash Join */
-FI_IDENT(FaultExecHashJoinNewBatch, "exec_hashjoin_new_batch")
-/* pause FTS process before committing changes, until shutdown */
-FI_IDENT(FtsWaitForShutdown, "fts_wait_for_shutdown")
-/* inject fault in FTS loop */
-FI_IDENT(FtsProbe, "fts_probe")
-/* inject fault in FTS where it updates configuration */
-FI_IDENT(FtsUpdateConfig, "fts_update_config")
-/* inject fault in FTS message handler */
-FI_IDENT(FtsHandleMessage, "fts_handle_message")
-/* inject fault before cleaning up a runaway query */
-FI_IDENT(RunawayCleanup, "runaway_cleanup")
-/* inject fault while translating relcache entries */
-FI_IDENT(OptRelcacheTranslatorCatalogAccess, "opt_relcache_translator_catalog_access")
-/* inject fault before sending QE details during backend initialization */
-FI_IDENT(SendQEDetailsInitBackend, "send_qe_details_init_backend")
-/* inject fault in ProcessStartupPacket() */
-FI_IDENT(ProcessStartupPacketFault, "process_startup_packet")
-/* inject fault in cdbdisp_dispatchX*/
-FI_IDENT(AfterOneSliceDispatched, "after_one_slice_dispatched")
-/* inject fault in cdbdisp_dispatchX*/
-FI_IDENT(BeforeOneSliceDispatched, "before_one_slice_dispatched")
-/* inject fault in interconnect to skip sending the stop ack */
-FI_IDENT(InterconnectStopAckIsLost, "interconnect_stop_ack_is_lost")
-/* inject fault in interconnect to make palloc0 fail in setup */
-FI_IDENT(InterconnectSetupPalloc, "interconnect_setup_palloc")
-/* inject fault after qe got snapshot and interconnect*/
-FI_IDENT(QEGotSnapshotAndInterconnect, "qe_got_snapshot_and_interconnect")
-/* inject fault to 'skip' in order to flush all buffers in BgBufferSync() */
-FI_IDENT(FsyncCounter, "fsync_counter")
-/* inject fault to count buffers fsync'ed by checkpoint process */
-FI_IDENT(BgBufferSyncDefaultLogic, "bg_buffer_sync_default_logic")
-/* inject fault in FinishPreparedTransaction() right at start of function */
-FI_IDENT(FinishPreparedStartOfFunction, "finish_prepared_start_of_function")
-/* inject fault in FinishPreparedTransaction() after recording the commit prepared record */
-FI_IDENT(FinishPreparedAfterRecordCommitPrepared, "finish_prepared_after_record_commit_prepared")
-/* inject fault to report ERROR just after creating Gang */
-FI_IDENT(GangCreated, "gang_created")
-/* inject fault to report ERROR just after resource group is assigned on master */
-FI_IDENT(ResGroupAssignedOnMaster, "resgroup_assigned_on_master")
-/* inject fault before reading command */
-FI_IDENT(BeforeReadCommand, "before_read_command")
-/* inject fault before get checkpoint dtx information */
-FI_IDENT(CheckPointDtxInfo, "checkpoint_dtx_info")
-/* inject fault at WalSndLoop() function */
-FI_IDENT(WalSenderLoop, "wal_sender_loop")
-/* inject fault after WAL sender has processed caughtup within range */
-FI_IDENT(WalSenderAfterCaughtupWithinRange, "wal_sender_after_caughtup_within_range")
-/* inject fault at SyncRepWaitForLSN function for QueryCancelPending */
-FI_IDENT(SyncRepQueryCancel, "sync_rep_query_cancel")
-/* inject fault at start of function DistributedLog_AdvanceOldestXmin() */
-FI_IDENT(DistributedLogAdvanceOldestXmin, "distributedlog_advance_oldest_xmin")
-/* inject fault at initialization of wal sender */
-FI_IDENT(InitializeWalSender, "initialize_wal_sender")
-/* inject fault when fts connection is received on primary/mirror */
-FI_IDENT(FTSConnStartupPacket, "fts_conn_startup_packet")
-/*
- * inject fault to report recovery is hung to FTS. This fault only works with
- * FTSConnStartupPacket fault set to skip.
- */
-FI_IDENT(FTSRecoveryInProgress, "fts_recovery_in_progress")
-/* inject fault after CdbTryOpenRelation function */
-FI_IDENT(UpgradeRowLock, "upgrade_row_lock")
-/* inject fault in Gdd loop */
-FI_IDENT(GddProbe, "gdd_probe")
-/* inject fault after updating pg_database.datfrozenxid (but before committing) */
-FI_IDENT(VacuumUpdateDatFrozenXid, "vacuum_update_dat_frozen_xid")
-/* inject fault in initial OS collation locale lookup */
-FI_IDENT(CollateLocaleOsLookup, "collate_locale_os_lookup")
-/* inject fault before create resource group committing */
-FI_IDENT(CreateResourceGroupFail, "create_resource_group_fail")
-/* inject fault before auto vacuum worker calls do_autovacuum */
-FI_IDENT(AutoVacWorkerBeforeDoAutovacuum, "auto_vac_worker_before_do_autovacuum")
-/* inject fault when search DNS cache (only works for fts probe) */
-FI_IDENT(GetDnsCachedAddress, "get_dns_cached_address")
-/* inject fault before aquiring lock during AlterTableCreateAoBlkdirTable */
-FI_IDENT(BeforeAcquireLockDuringCreateAoBlkdirTable, "before_acquire_lock_during_create_ao_blkdir_table")
-/* inject fault during gang creation, before check for interrupts */
-FI_IDENT(CreateGangInProgress, "create_gang_in_progress")
-/* inject fault when creating new TOAST tables, to modify the chunk size */
-FI_IDENT(DecreaseToastMaxChunkSize, "decrease_toast_max_chunk_size")
-/* inject fault to let cleanupGang return false */
-FI_IDENT(CleanupQE, "cleanup_qe")
-/* inject fault in xLog_ao_insert() just before writing AO xlog record */
-FI_IDENT(XLogAoInsert, "xlog_ao_insert")
-/* inject fault just before commiting alter database set tablespace */
-FI_IDENT(InsideMoveDbTransaction, "inside_move_db_transaction")
-/* inject fault just after calculating redo record and before committing checkpoint record */
-FI_IDENT(CheckpointAfterRedoCalculated, "checkpoint_after_redo_calculated")
-/* inject fault to skip WAL flush on WAL receiver */
-FI_IDENT(WalRecvSkipFlush, "walrecv_skip_flush")
-#endif
 
 /*
  * Fault types. These indicate the action to do when the fault injection

--- a/src/pl/plpython/plpy_spi.c
+++ b/src/pl/plpython/plpy_spi.c
@@ -408,7 +408,7 @@ PLy_spi_execute_fetch_result(SPITupleTable *tuptable, int64 rows, int status)
 #ifdef FAULT_INJECTOR
 	if (rows >= 10000 && rows <= 1000000)
 	{
-		if (FaultInjector_InjectFaultIfSet(ExecutorRunHighProcessed,
+		if (FaultInjector_InjectFaultIfSet("executor_run_high_processed",
 											DDLNotSpecified,
 											"" /* databaseName */,
 											"" /* tableName */) == FaultInjectorTypeSkip)


### PR DESCRIPTION
This is back port of PR #7872 

It was mostly a clean cherry-pick.  I found an unused fault in 6X: `DtmInit` in `cdbtm.c` and removed it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
