### PR TITLE
backport to 6x: Relax pulling up locus expression, to ignore typmod.

### DIFF
--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -254,6 +254,31 @@ union
 (13 rows)
 
 --
+-- Test pulling up distribution key expression, when the different branches
+-- of a UNION ALL have different typmods.
+--
+create table pullup_distkey_test(
+    a character varying,
+    b character varying(30)
+) distributed by (b);
+insert into pullup_distkey_test values ('foo', 'bar');
+with base as
+(
+  select a, b from pullup_distkey_test
+  union all
+  select 'xx' as a, 'bar' as b
+)
+select a from base
+union all
+select a from base where a = 'foo';
+  a  
+-----
+ foo
+ xx
+ foo
+(3 rows)
+
+--
 -- Setup
 --
 --start_ignore

--- a/src/test/regress/sql/union_gp.sql
+++ b/src/test/regress/sql/union_gp.sql
@@ -82,6 +82,28 @@ union
 (SELECT 'test2' as branch, id FROM test2);
 
 --
+-- Test pulling up distribution key expression, when the different branches
+-- of a UNION ALL have different typmods.
+--
+create table pullup_distkey_test(
+    a character varying,
+    b character varying(30)
+) distributed by (b);
+
+insert into pullup_distkey_test values ('foo', 'bar');
+
+with base as
+(
+  select a, b from pullup_distkey_test
+  union all
+  select 'xx' as a, 'bar' as b
+)
+select a from base
+union all
+select a from base where a = 'foo';
+
+
+--
 -- Setup
 --
 


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/7535 to 6X_STABLE. I'm creating this PR just to run the concourse pipeline on it. See https://github.com/greenplum-db/gpdb/pull/7535 for discussion.
