### PR TITLE
Changes for ORCA commit: Skip CXformPushGbBelowSetOp when arity > threshold

### DIFF
--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -19,4 +19,4 @@ params:
   BLD_TARGETS:
   OUTPUT_ARTIFACT_DIR: gpdb_artifacts
   CONFIGURE_FLAGS:
-  ORCA_TAG: v3.48.0
+  ORCA_TAG: v3.49.0

--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.48.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.49.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.48.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.49.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13982,7 +13982,7 @@ int
 main ()
 {
 
-return strncmp("3.48.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.49.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13992,7 +13992,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.48.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.49.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.48.0@gpdb/stable
+orca/v3.49.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -450,6 +450,7 @@ COptTasks::CreateOptimizerConfig
 	ULONG array_expansion_threshold = (ULONG) optimizer_array_expansion_threshold;
 	ULONG join_order_threshold = (ULONG) optimizer_join_order_threshold;
 	ULONG broadcast_threshold = (ULONG) optimizer_penalize_broadcast_threshold;
+	ULONG push_group_by_below_setop_threshold = (ULONG) optimizer_push_group_by_below_setop_threshold;
 
 	return GPOS_NEW(mp) COptimizerConfig
 						(
@@ -464,8 +465,9 @@ COptTasks::CreateOptimizerConfig
 								array_expansion_threshold,
 								join_order_threshold,
 								broadcast_threshold,
-								false /* don't create Assert nodes for constraints, we'll
+								false, /* don't create Assert nodes for constraints, we'll
 								      * enforce them ourselves in the executor */
+								push_group_by_below_setop_threshold
 								),
 						GPOS_NEW(mp) CWindowOids(OID(F_WINDOW_ROW_NUMBER), OID(F_WINDOW_RANK))
 						);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -377,6 +377,7 @@ int         optimizer_array_expansion_threshold;
 int         optimizer_join_order_threshold;
 int			optimizer_join_order;
 int			optimizer_cte_inlining_bound;
+int			optimizer_push_group_by_below_setop_threshold;
 bool		optimizer_force_multistage_agg;
 bool		optimizer_force_three_stage_scalar_dqa;
 bool		optimizer_force_expanded_distinct_aggs;
@@ -4032,6 +4033,17 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&optimizer_array_expansion_threshold,
 		100, 0, INT_MAX,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_push_group_by_below_setop_threshold", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Maximum number of children setops have to consider pushing group bys below it"),
+			NULL,
+			GUC_GPDB_ADDOPT | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_push_group_by_below_setop_threshold,
+		10, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -503,6 +503,7 @@ extern int optimizer_join_order_threshold;
 extern int optimizer_join_order;
 extern int optimizer_join_arity_for_associativity_commutativity;
 extern int optimizer_cte_inlining_bound;
+extern int optimizer_push_group_by_below_setop_threshold;
 extern bool optimizer_force_multistage_agg;
 extern bool optimizer_force_three_stage_scalar_dqa;
 extern bool optimizer_force_expanded_distinct_aggs;


### PR DESCRIPTION
This commits adds a new GUC that controls the xform:
optimizer_push_group_by_below_setop_threshold.

Also bump ORCA version to ???

