### PR TITLE
Test view backwards compatibility

### DIFF
--- a/src/test/binary_swap/expected/views.out
+++ b/src/test/binary_swap/expected/views.out
@@ -1,0 +1,3 @@
+\c regression
+DROP VIEW IF EXISTS minimal_view;
+CREATE VIEW minimal_view AS SELECT 1;

--- a/src/test/binary_swap/schedule2
+++ b/src/test/binary_swap/schedule2
@@ -1,6 +1,6 @@
 test: pg_dumpall_other
 test: diff_dumps
-test: inserts
+test: inserts views
 test: pg_dumpall_other
 test: gpcheckcat
 

--- a/src/test/binary_swap/sql/views.sql
+++ b/src/test/binary_swap/sql/views.sql
@@ -1,0 +1,4 @@
+\c regression
+
+DROP VIEW IF EXISTS minimal_view;
+CREATE VIEW minimal_view AS SELECT 1;


### PR DESCRIPTION
After commit 679c10b3c10 broke backwards compatibility in 5X_STABLE, we
realized we didn't have a regression test to catch cases like that.

This commit causes the new binary to dump a (very minimal) view created
by an old binary. It would have caught something like 679c10b3c10. There
are more complexes cases that won't be caught by this. But here's a
start we can build on.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
