### PR TITLE
Remove sync_tools remnants from PR pipeline

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -114,12 +114,6 @@ jobs:
             git submodule update --init --recursive
         inputs: [{ name: gpdb_pr }]
         outputs: [{ name: gpdb_src }]
-    - task: sync_tools_centos7
-      file: gpdb_pr/concourse/tasks/sync_tools.yml
-      image: gpdb6-centos7-build
-      params:
-        TARGET_OS: centos
-        TARGET_OS_VERSION: 7
     - task: compile_gpdb_centos7
       file: gpdb_pr/concourse/tasks/compile_gpdb.yml
       image: gpdb6-centos7-build


### PR DESCRIPTION
Commit 1315881c95a9 removed sync_tools from the build system.  This patch adjusts PR pipeline accordingly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
