### PR TITLE
Schema qualify tables in create_table_distpol regress test

### DIFF
--- a/src/test/regress/sql/create_table_distpol.sql
+++ b/src/test/regress/sql/create_table_distpol.sql
@@ -1,5 +1,9 @@
 -- Test effective distribution policy after different variants of CREATE TABLE
 
+-- start_ignore
+CREATE SCHEMA create_table_distpol;
+SET search_path TO create_table_distpol;
+-- end_ignore
 
 -- Make sure random default distribution works for CTAS
 SET gp_create_table_random_default_distribution=on;


### PR DESCRIPTION
This test is run in a parallel group and uses table names that collide
with other tests that either run before it, or concurrent with it. This
leads to difficult-to-debug CI failures. Commit 95a33fb41dd already
address a similar issue in two other tests in the same group, but
somehow missed this.

This commit schema qualifies all objects in that test.

Co-authored-by: Taylor Vesely <tvesely@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
