### PR TITLE
[5X Bug] Reload checkpoint xlog to prevent xlog overwriting.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6598,6 +6598,11 @@ StartupXLOG(void)
 					ereport(FATAL,
 							(errmsg("could not find redo location referenced by checkpoint record"),
 							 errhint("If you are not restoring from a backup, try removing the file \"%s/backup_label\".", DataDir)));
+				/*
+				 * Reload the checkpoint xlog again since we need to process
+				 * it later.
+				 * */
+				record = ReadCheckpointRecord(checkPointLoc, 0);
 			}
 		}
 		else


### PR DESCRIPTION
gpdb supports extended checkpoint record compared with upstream checkpoint
xlog. StartupXLOG() has a bug that leads to checkpoint xlog is overwritten
before the extened part is processed.

This was found with the following repro steps.

1. Remove standby using 'gpinitstandby -ra'
2. Running loop of creating tables.
3. In another terminal, initialize and add a standby using gpinitstandby, for example,

gpinitstandby -s dev6 -a -P 16432 -F pg_system:/home/gpadmin/ws/gpdb5/gpAux/gpdemo/datadirs/standby/demoDataDir-1

Typically you will see a gpinitstandby log like this:
20190611:02:06:12:024242 gpinitstandby:dev6:gpadmin-[ERROR]:-Failed to create standby

and pg_log shows there is a fatal log in the startup process.