### PR TITLE
Doc tablespace path limit of 100 characters

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
@@ -47,7 +47,10 @@
           <pd>The absolute path to the directory (host system file location) that will be the root
             directory for the tablespace. When registering a tablepace, the directory should be
             empty and must be owned by the Greenplum Database system user. The directory must be
-            specified by an absolute path name.</pd>
+            specified by an absolute path name of no more than 100 characters. (The location is used
+            to create a symlink target in the <filepath>pg_tblspc</filepath> directory, and symlink
+            targets are truncated to 100 characters when sending to TAR utilities such as
+              <codeph>pg_basebackup</codeph>.)</pd>
           <pd>For each segment instance, you can specify a different directory for the tablespace in
             the <codeph>WITH</codeph> clause.</pd>
         </plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
@@ -49,8 +49,8 @@
             empty and must be owned by the Greenplum Database system user. The directory must be
             specified by an absolute path name of no more than 100 characters. (The location is used
             to create a symlink target in the <filepath>pg_tblspc</filepath> directory, and symlink
-            targets are truncated to 100 characters when sending to TAR utilities such as
-              <codeph>pg_basebackup</codeph>.)</pd>
+            targets are truncated to 100 characters when sending to <codeph>tar</codeph> from
+            utilities such as <codeph>pg_basebackup</codeph>.)</pd>
           <pd>For each segment instance, you can specify a different directory for the tablespace in
             the <codeph>WITH</codeph> clause.</pd>
         </plentry>
@@ -64,7 +64,8 @@
           <pd>If a segment instance is not listed in the <codeph>WITH</codeph> clause, Greenplum
             Database uses the directory specified in the <codeph>LOCATION</codeph> clause.</pd>
           <pd>When registering a tablepace, the directories should be empty and must be owned by the
-            Greenplum Database system user.</pd>
+            Greenplum Database system user. Each directory must be specified by an absolute path
+            name of no more than 100 characters.</pd>
         </plentry>
       </parml>
     </section>


### PR DESCRIPTION
Adding note to docs to cover error message addition in https://github.com/greenplum-db/gpdb/pull/7661