### PR TITLE
Print global transaction info for commit prepared WAL records

### DIFF
--- a/src/backend/access/rmgrdesc/xactdesc.c
+++ b/src/backend/access/rmgrdesc/xactdesc.c
@@ -199,6 +199,9 @@ xact_desc(StringInfo buf, XLogRecord *record)
 
 		appendStringInfo(buf, "commit prepared %u: ", xlrec->xid);
 		xact_desc_commit(buf, &xlrec->crec);
+
+		appendStringInfo(buf, " gid = %u-%.10u", xlrec->distribTimeStamp, xlrec->distribXid);
+		appendStringInfo(buf, " gxid = %u", xlrec->distribXid);
 	}
 	else if (info == XLOG_XACT_ABORT_PREPARED)
 	{


### PR DESCRIPTION
When creating WAL records for a twophase commit, we add the global
transaction info to distributed commit and distributed forget records
on the query dispatcher and to the commit prepared records on the
query executors. However, pg_xlogdump only prints this information for
the distributed commit and distributed forget records. We should do
the same for commit prepared records to more easily string together
transactions between QD and QE when comparing xlog dumps.

On query dispatcher:
distributed commit 2019-06-11 15:16:17.786319 PDT gid = 1560291226-0000000006, gxid = 6
distributed forget  gid = 1560291226-0000000006, gxid = 6

On query executor:
commit prepared 747: 2019-06-11 15:16:17.786660 PDT

Change query executor output to:
commit prepared 747: 2019-06-11 15:16:17.786660 PDT gid = 1560291226-0000000006 gxid = 6
