### PR TITLE
CString doesn't need the varlena header space

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -810,7 +810,7 @@ DeserializeTuple(SerTupInfo *pSerInfo, StringInfo serialTup)
 			if (sz < 0)
 				elog(ERROR, "invalid length received for a CString");
 
-			p = palloc(sz + VARHDRSZ);
+			p = palloc(sz);
 
 			/* Then data */
 			pq_copymsgbytes(serialTup, p, sz);


### PR DESCRIPTION
CString only has the length and data in the serialized structure, no
need to allocate spaces for the varlena header.
