### PR TITLE
 Bound the wait and avoid hard-coded dbids in DTM recovery test

### DIFF
--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -19,7 +19,7 @@ CREATE
 -- next command executed is only after restart and doesn't go through
 -- while PANIC is still being processed by master, as master continues
 -- to accept connections for a while despite undergoing PANIC.
-CREATE OR REPLACE FUNCTION wait_till_master_shutsdown() RETURNS void AS $$ BEGIN loop PERFORM pg_sleep(.5); /* in func */ end loop; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION wait_till_master_shutsdown() RETURNS void AS $$ DECLARE i int; /* in func */ BEGIN i := 0; /* in func */ while i < 120 loop i := i + 1; /* in func */ PERFORM pg_sleep(.5); /* in func */ end loop; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE
 
 1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
@@ -46,16 +46,10 @@ CREATE
 -- COMMIT PREPARED across restart and instead abort the transaction
 -- after querying in-doubt prepared transactions from segments.
 -- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', 2);
- gp_inject_fault_infinite 
---------------------------
- t                        
-(1 row)
--- create utility session to segment which will be used to reset the fault
-0U: SELECT 1;
- ?column? 
-----------
- 1        
+1: SELECT gp_inject_fault_infinite2( 'finish_prepared_start_of_function', 'error', dbid, hostname, port) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault_infinite2 
+---------------------------
+ Success:                  
 (1 row)
 -- Start looping in background, till master panics and closes the session
 3&: SELECT wait_till_master_shutsdown();  <waiting ...>
@@ -65,11 +59,12 @@ PANIC:  unable to complete 'Commit Prepared' broadcast for gid = 1519017787-0000
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
--- Reset the fault using utility mode connection
-0U: SELECT gp_inject_fault('finish_prepared_start_of_function', 'reset', 2);
- gp_inject_fault 
------------------
- t               
+-- Reset the fault in utility mode because normal mode connection will
+-- not be accepted until DTX recovery is finished.
+-1U: SELECT gp_inject_fault2( 'finish_prepared_start_of_function', 'reset', dbid, hostname, port) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault2 
+------------------
+ Success:         
 (1 row)
 -- Join back to know master has completed postmaster reset.
 3<:  <... completed>
@@ -99,10 +94,10 @@ INSERT 10
 -- Start looping in background, till master panics and closes the
 -- session
 5&: SELECT wait_till_master_shutsdown();  <waiting ...>
-6: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'fatal', 1);
- gp_inject_fault 
------------------
- t               
+6: SELECT gp_inject_fault2( 'dtm_broadcast_commit_prepared', 'fatal', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault2 
+------------------
+ Success:         
 (1 row)
 6: CREATE TABLE commit_fatal_fault_test_table(a int, b int);
 PANIC:  fault triggered, fault name:'dtm_broadcast_commit_prepared' fault type:'fatal'
@@ -123,10 +118,10 @@ server closed the connection unexpectedly
  transaction | gid | prepared | owner | database 
 -------------+-----+----------+-------+----------
 (0 rows)
-7: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'reset', 1);
- gp_inject_fault 
------------------
- t               
+7: SELECT gp_inject_fault2( 'dtm_broadcast_commit_prepared', 'reset', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault2 
+------------------
+ Success:         
 (1 row)
 
 -- Scenario 3: Inject ERROR after prepare phase has completed to
@@ -140,15 +135,15 @@ server closed the connection unexpectedly
 -- Start looping in background, till master panics and closes the
 -- session
 8&: SELECT wait_till_master_shutsdown();  <waiting ...>
-9: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'error', 1);
- gp_inject_fault 
------------------
- t               
+9: SELECT gp_inject_fault2( 'transaction_abort_after_distributed_prepared', 'error', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault2 
+------------------
+ Success:         
 (1 row)
-9: SELECT gp_inject_fault('dtm_broadcast_abort_prepared', 'fatal', 1);
- gp_inject_fault 
------------------
- t               
+9: SELECT gp_inject_fault2('dtm_broadcast_abort_prepared', 'fatal', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault2 
+------------------
+ Success:         
 (1 row)
 9: CREATE TABLE abort_fatal_fault_test_table(a int, b int);
 ERROR:  fault triggered, fault name:'transaction_abort_after_distributed_prepared' fault type:'error'
@@ -168,15 +163,15 @@ LINE 1: SELECT count(*) from abort_fatal_fault_test_table;
  transaction | gid | prepared | owner | database 
 -------------+-----+----------+-------+----------
 (0 rows)
-10: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'reset', 1);
- gp_inject_fault 
------------------
- t               
+10: SELECT gp_inject_fault2( 'transaction_abort_after_distributed_prepared', 'reset', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault2 
+------------------
+ Success:         
 (1 row)
-10: SELECT gp_inject_fault('dtm_broadcast_abort_prepared', 'reset', 1);
- gp_inject_fault 
------------------
- t               
+10: SELECT gp_inject_fault2('dtm_broadcast_abort_prepared', 'reset', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault2 
+------------------
+ Success:         
 (1 row)
 
 -- Scenario 4: QE panics after writing prepare xlog record. This
@@ -200,32 +195,32 @@ ALTER
  t              
 (1 row)
 -- skip FTS probes always
-11: SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
- gp_inject_fault_infinite 
---------------------------
- t                        
+11: SELECT gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault_infinite2 
+---------------------------
+ Success:                  
 (1 row)
 11: SELECT gp_request_fts_probe_scan();
  gp_request_fts_probe_scan 
 ---------------------------
  t                         
 (1 row)
-11: select gp_wait_until_triggered_fault('fts_probe', 1, 1);
- gp_wait_until_triggered_fault 
--------------------------------
- t                             
+11: select gp_wait_until_triggered_fault2('fts_probe', 1, dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
+ gp_wait_until_triggered_fault2 
+--------------------------------
+ Success:                       
 (1 row)
-11: SELECT gp_inject_fault('end_prepare_two_phase', 'infinite_loop', dbid) from gp_segment_configuration where role = 'p' and content = 0;
- gp_inject_fault 
------------------
- t               
+11: SELECT gp_inject_fault2( 'end_prepare_two_phase', 'infinite_loop', dbid, hostname, port) from gp_segment_configuration where role='p' and content=0;
+ gp_inject_fault2 
+------------------
+ Success:         
 (1 row)
 -- statement to trigger fault after writing prepare record
 12&: DELETE FROM QE_panic_test_table;  <waiting ...>
-11: SELECT gp_wait_until_triggered_fault('end_prepare_two_phase', 1, dbid) from gp_segment_configuration where role = 'p' and content = 0;
- gp_wait_until_triggered_fault 
--------------------------------
- t                             
+11: SELECT gp_wait_until_triggered_fault2( 'end_prepare_two_phase', 1, dbid, hostname, port) from gp_segment_configuration where role='p' and content=0;
+ gp_wait_until_triggered_fault2 
+--------------------------------
+ Success:                       
 (1 row)
 11: SELECT pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 0;
  pg_ctl                                                                                               
@@ -250,10 +245,10 @@ DETAIL:
  transaction | gid | prepared | owner | database 
 -------------+-----+----------+-------+----------
 (0 rows)
-13: SELECT gp_inject_fault('fts_probe', 'reset', 1);
- gp_inject_fault 
------------------
- t               
+13: SELECT gp_inject_fault2('fts_probe', 'reset', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault2 
+------------------
+ Success:         
 (1 row)
 13: alter system reset dtx_phase2_retry_count;
 ALTER

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -21,8 +21,12 @@ include: helpers/server_helpers.sql;
 CREATE OR REPLACE FUNCTION wait_till_master_shutsdown()
 RETURNS void AS
 $$
+  DECLARE
+    i int; /* in func */
   BEGIN
-    loop
+    i := 0; /* in func */
+    while i < 120 loop
+      i := i + 1; /* in func */
       PERFORM pg_sleep(.5); /* in func */
     end loop; /* in func */
   END; /* in func */
@@ -41,15 +45,18 @@ $$ LANGUAGE plpgsql;
 -- COMMIT PREPARED across restart and instead abort the transaction
 -- after querying in-doubt prepared transactions from segments.
 -- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', 2);
--- create utility session to segment which will be used to reset the fault
-0U: SELECT 1;
+1: SELECT gp_inject_fault_infinite2(
+   'finish_prepared_start_of_function', 'error', dbid, hostname, port)
+   from gp_segment_configuration where content=0 and role='p';
 -- Start looping in background, till master panics and closes the session
 3&: SELECT wait_till_master_shutsdown();
 -- Start transaction which should hit PANIC as COMMIT PREPARED will fail to one segment
 1: CREATE TABLE commit_phase1_panic(a int, b int);
--- Reset the fault using utility mode connection
-0U: SELECT gp_inject_fault('finish_prepared_start_of_function', 'reset', 2);
+-- Reset the fault in utility mode because normal mode connection will
+-- not be accepted until DTX recovery is finished.
+-1U: SELECT gp_inject_fault2(
+     'finish_prepared_start_of_function', 'reset', dbid, hostname, port)
+     from gp_segment_configuration where content=0 and role='p';
 -- Join back to know master has completed postmaster reset.
 3<:
 -- Start a session on master which would complete the DTM recovery and hence COMMIT PREPARED
@@ -67,13 +74,17 @@ $$ LANGUAGE plpgsql;
 -- Start looping in background, till master panics and closes the
 -- session
 5&: SELECT wait_till_master_shutsdown();
-6: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'fatal', 1);
+6: SELECT gp_inject_fault2(
+   'dtm_broadcast_commit_prepared', 'fatal', dbid, hostname, port)
+   from gp_segment_configuration where role='p' and content=-1;
 6: CREATE TABLE commit_fatal_fault_test_table(a int, b int);
 5<:
 -- Start a session on master which would complete the DTM recovery and hence COMMIT PREPARED
 7: SELECT count(*) from commit_fatal_fault_test_table;
 7: SELECT * FROM gp_dist_random('pg_prepared_xacts');
-7: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'reset', 1);
+7: SELECT gp_inject_fault2(
+   'dtm_broadcast_commit_prepared', 'reset', dbid, hostname, port)
+   from gp_segment_configuration where role='p' and content=-1;
 
 -- Scenario 3: Inject ERROR after prepare phase has completed to
 -- trigger abort. Then on abort inject FATAL on master before sending
@@ -86,14 +97,20 @@ $$ LANGUAGE plpgsql;
 -- Start looping in background, till master panics and closes the
 -- session
 8&: SELECT wait_till_master_shutsdown();
-9: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'error', 1);
-9: SELECT gp_inject_fault('dtm_broadcast_abort_prepared', 'fatal', 1);
+9: SELECT gp_inject_fault2(
+   'transaction_abort_after_distributed_prepared', 'error', dbid, hostname, port)
+   from gp_segment_configuration where role='p' and content=-1;
+9: SELECT gp_inject_fault2('dtm_broadcast_abort_prepared', 'fatal', dbid, hostname, port)
+   from gp_segment_configuration where role='p' and content=-1;
 9: CREATE TABLE abort_fatal_fault_test_table(a int, b int);
 8<:
 10: SELECT count(*) from abort_fatal_fault_test_table;
 10: SELECT * FROM gp_dist_random('pg_prepared_xacts');
-10: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'reset', 1);
-10: SELECT gp_inject_fault('dtm_broadcast_abort_prepared', 'reset', 1);
+10: SELECT gp_inject_fault2(
+    'transaction_abort_after_distributed_prepared', 'reset', dbid, hostname, port)
+    from gp_segment_configuration where role='p' and content=-1;
+10: SELECT gp_inject_fault2('dtm_broadcast_abort_prepared', 'reset', dbid, hostname, port)
+    from gp_segment_configuration where role='p' and content=-1;
 
 -- Scenario 4: QE panics after writing prepare xlog record. This
 -- should cause master to broadcast abort and QEs handle the abort in
@@ -108,17 +125,24 @@ $$ LANGUAGE plpgsql;
 11: alter system set dtx_phase2_retry_count to 1500;
 11: select pg_reload_conf();
 -- skip FTS probes always
-11: SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
+11: SELECT gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port)
+    from gp_segment_configuration where role='p' and content=-1;
 11: SELECT gp_request_fts_probe_scan();
-11: select gp_wait_until_triggered_fault('fts_probe', 1, 1);
-11: SELECT gp_inject_fault('end_prepare_two_phase', 'infinite_loop', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+11: select gp_wait_until_triggered_fault2('fts_probe', 1, dbid, hostname, port)
+    from gp_segment_configuration where role='p' and content=-1;
+11: SELECT gp_inject_fault2(
+    'end_prepare_two_phase', 'infinite_loop', dbid, hostname, port)
+    from gp_segment_configuration where role='p' and content=0;
 -- statement to trigger fault after writing prepare record
 12&: DELETE FROM QE_panic_test_table;
-11: SELECT gp_wait_until_triggered_fault('end_prepare_two_phase', 1, dbid) from gp_segment_configuration where role = 'p' and content = 0;
+11: SELECT gp_wait_until_triggered_fault2(
+    'end_prepare_two_phase', 1, dbid, hostname, port)
+    from gp_segment_configuration where role='p' and content=0;
 11: SELECT pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 0;
 12<:
 13: SELECT count(*) from QE_panic_test_table;
 13: SELECT * FROM gp_dist_random('pg_prepared_xacts');
-13: SELECT gp_inject_fault('fts_probe', 'reset', 1);
+13: SELECT gp_inject_fault2('fts_probe', 'reset', dbid, hostname, port)
+    from gp_segment_configuration where role='p' and content=-1;
 13: alter system reset dtx_phase2_retry_count;
 13: select pg_reload_conf();

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -193,8 +193,9 @@ class SQLIsolationExecutor(object):
             """
             query = ("SELECT hostname, port FROM gp_segment_configuration WHERE"
                      " content = %s AND role = '%s'") % (contentid, role)
-            con = self.connectdb(self.dbname)
+            con = self.connectdb(self.dbname, given_opt="-c gp_session_role=utility")
             r = con.query(query).getresult()
+            con.close()
             if len(r) == 0:
                 raise Exception("Invalid content %s" % contentid)
             if r[0][0] == socket.gethostname():


### PR DESCRIPTION
The test used to wait indefinitely for master to shutdown (PANIC) due to all retries failing in the second phase of 2PC.  The indefinite wait would actually be indefinite if the roles for content0 primary and mirror are flipped.  The roles would flip because of a previously failing test.  Fix this by making the wait bounded.  Also use new fault injector API, while at it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
