### PR TITLE
 Make fts_recovery_in_progress more robust

### DIFF
--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -100,6 +100,26 @@ select role, preferred_role, mode, status from gp_segment_configuration where co
 
 -- The remaining steps are to bring back the cluster to original state.
 -- start_ignore
+-- Wait until content 0 mirror is promoted otherwise, gprecoverseg
+-- that runs after will fail.
+do $$
+declare
+  y int;
+begin
+  for i in 1..120 loop
+    begin
+      select count(*) into y from gp_dist_random('gp_id');
+      raise notice 'got % results, mirror must have been promoted', y;
+      return;
+    exception
+      when others then
+        raise notice 'mirror may not be promoted yet: %', sqlerrm;
+        perform pg_sleep(0.5);
+    end;
+  end loop;
+end;
+$$;
+NOTICE:  got 3 results, mirror must have been promoted
 \! gprecoverseg -av
 -- end_ignore
 -- loop while segments come in sync

--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -9,12 +9,11 @@ select role, preferred_role, mode, status from gp_segment_configuration where co
  m    | m              | s    | u
 (2 rows)
 
-select gp_inject_fault_infinite('fts_conn_startup_packet', 'skip', dbid)
+select gp_inject_fault_infinite2('fts_conn_startup_packet', 'skip', dbid, hostname, port)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
- gp_inject_fault_infinite 
---------------------------
- t
+ gp_inject_fault_infinite2 
+---------------------------
+ Success:
 (1 row)
 
 -- to make test deterministic and fast
@@ -49,12 +48,11 @@ select gp_request_fts_probe_scan();
  t
 (1 row)
 
-select gp_wait_until_triggered_fault('fts_conn_startup_packet', 3, dbid)
+select gp_wait_until_triggered_fault2('fts_conn_startup_packet', 3, dbid, hostname, port)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
- gp_wait_until_triggered_fault 
--------------------------------
- t
+ gp_wait_until_triggered_fault2 
+--------------------------------
+ Success:
 (1 row)
 
 select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
@@ -67,12 +65,11 @@ select role, preferred_role, mode, status from gp_segment_configuration where co
 -- test other scenario where recovery on primary is hung and hence FTS marks
 -- primary down and promotes mirror. When 'fts_recovery_in_progress' is set to
 -- skip it mimics the behavior of hung recovery on primary.
-select gp_inject_fault_infinite('fts_recovery_in_progress', 'skip', dbid)
+select gp_inject_fault_infinite2('fts_recovery_in_progress', 'skip', dbid, hostname, port)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=26540)
- gp_inject_fault_infinite 
---------------------------
- t
+ gp_inject_fault_infinite2 
+---------------------------
+ Success:
 (1 row)
 
 -- We call gp_request_fts_probe_scan twice to guarantee that the scan happens
@@ -168,19 +165,10 @@ select role, preferred_role, mode, status from gp_segment_configuration where co
 \!gpstop -u
 -- end_ignore
 -- cleanup steps
-select gp_inject_fault('fts_recovery_in_progress', 'reset', dbid)
+select gp_inject_fault2('all', 'reset', dbid, hostname, port)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=30929)
- gp_inject_fault 
------------------
- t
-(1 row)
-
-select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid)
-from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.0.1:25432 pid=27127)
- gp_inject_fault 
------------------
- t
+ gp_inject_fault2 
+------------------
+ Success:
 (1 row)
 

--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -3,7 +3,7 @@
 -- in-recovery to FTS, primary is not actually going through crash-recovery in
 -- test.
 select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
-select gp_inject_fault_infinite('fts_conn_startup_packet', 'skip', dbid)
+select gp_inject_fault_infinite2('fts_conn_startup_packet', 'skip', dbid, hostname, port)
 from gp_segment_configuration where content = 0 and role = 'p';
 -- to make test deterministic and fast
 -- start_ignore
@@ -23,14 +23,14 @@ from gp_segment_configuration where content = 0 and role = 'p';
 select pg_sleep(5);
 show gp_fts_probe_retries;
 select gp_request_fts_probe_scan();
-select gp_wait_until_triggered_fault('fts_conn_startup_packet', 3, dbid)
+select gp_wait_until_triggered_fault2('fts_conn_startup_packet', 3, dbid, hostname, port)
 from gp_segment_configuration where content = 0 and role = 'p';
 select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
 
 -- test other scenario where recovery on primary is hung and hence FTS marks
 -- primary down and promotes mirror. When 'fts_recovery_in_progress' is set to
 -- skip it mimics the behavior of hung recovery on primary.
-select gp_inject_fault_infinite('fts_recovery_in_progress', 'skip', dbid)
+select gp_inject_fault_infinite2('fts_recovery_in_progress', 'skip', dbid, hostname, port)
 from gp_segment_configuration where content = 0 and role = 'p';
 -- We call gp_request_fts_probe_scan twice to guarantee that the scan happens
 -- after the fts_recovery_in_progress fault has been injected. If periodic fts
@@ -104,7 +104,5 @@ select role, preferred_role, mode, status from gp_segment_configuration where co
 -- end_ignore
 
 -- cleanup steps
-select gp_inject_fault('fts_recovery_in_progress', 'reset', dbid)
-from gp_segment_configuration where content = 0 and role = 'p';
-select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid)
+select gp_inject_fault2('all', 'reset', dbid, hostname, port)
 from gp_segment_configuration where content = 0 and role = 'p';


### PR DESCRIPTION
The test is found to fail intermittently in CI when the gprecoverseg command is fired and a mirror that was promoted by FTS is still undergoing promotion.  Fix this by running a distributed query in a loop until the query runs successfully.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
