### PR TITLE
docs - add info about configing hive access via jdbc

### DIFF
--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -136,7 +136,7 @@ Ensure that the JDBC driver for the external SQL database supports any property 
 
 #### <a id="jdbcimpers"></a>About JDBC User Impersonation
 
-The PXF JDBC Connector accesses external data stores on behalf of Greenplum Database end users. When you enable PXF JDBC user impersonation, the JDBC Connector uses the Greenplum Database user name to connect to the external data store. When PXF JDBC user impersonation is disabled (the default), the behavior of the JDBC Connector is dependent upon the external data store. For example, the JDBC connector uses the settings of certain Hive authentication and impersonation properties to determine the user. In some cases, you may be required to provide a `jdbc.user` setting, or add properties to the `jdbc.url` setting in the server `jdbc-site.xml` file.
+The PXF JDBC Connector accesses external data stores on behalf of Greenplum Database end users. When you enable PXF JDBC user impersonation, the JDBC Connector uses the name of the Greenplum Database user that accesses the PXF external table to try to connect to the external data store. When PXF JDBC user impersonation is disabled (the default), the behavior of the JDBC Connector is dependent upon the external data store. For example, the JDBC connector uses the settings of certain Hive authentication and impersonation properties to determine the user. In some cases, you may be required to provide a `jdbc.user` setting, or add properties to the `jdbc.url` setting in the server `jdbc-site.xml` file.
 
 The `pxf.impersonation.jdbc` property governs JDBC user impersonation. JDBC user impersonation is disabled by default. To enable JDBC user impersonation for a server configuration, set the property to true:
 
@@ -273,7 +273,7 @@ The PXF JDBC Connector is installed with the JAR files required to access Hive v
 
 ### <a id="cfg_server"></a>JDBC Server Configuration
 
-When you configure a PXF JDBC server for Hive access, you must specify the JDBC driver class name, database URL, and client credentials just as you would when configuring a JDBC server to an SQL database.
+When you configure a PXF JDBC server for Hive access, you must specify the JDBC driver class name, database URL, and client credentials just as you would when configuring a client connection to an SQL database.
 
 To access Hive via JDBC, you must specify the following properties and values in the `jdbc-site.xml` server configuration file:
 
@@ -282,7 +282,7 @@ To access Hive via JDBC, you must specify the following properties and values in
 | jdbc.driver | org.apache.hive.jdbc.HiveDriver |
 | jdbc.url | jdbc:hive2://\<hiveserver2_host>:\<hiveserver2_port>/\<database> |
 
-The value of the HiveServer2 authentication (`hive.server2.authentication`) and impersonation (`hive.server2.enable.doAs`) properties, and whether or not the Hadoop cluster in which the Hive service is running is utilizing Kerberos authentication, will inform the setting of other JDBC server configuration properties.
+The value of the HiveServer2 authentication (`hive.server2.authentication`) and impersonation (`hive.server2.enable.doAs`) properties, and whether or not the Hive service is utilizing Kerberos authentication, will inform the setting of other JDBC server configuration properties.
 
 The following table enumerates the Hive2 authentication and impersonation combinations supported by the PXF JDBC Connector, and identifies the JDBC server configuration required for each.
 
@@ -341,7 +341,7 @@ Perform the following procedure to configure a PXF JDBC server for Hive:
 
 6. Obtain the `hive-site.xml` file from your Hadoop cluster and examine the file.
 
-7. If the `hive.server2.authentication` property in `hive-site.xml` is set to `NOSASL`, HiveServer2 performs no authentication. You must add the following connection-level property to `jdbc-site.xml`:
+7. If the `hive.server2.authentication` property in `hive-site.xml` is set to `NOSASL`, HiveServer2 performs no authentication. Add the following connection-level property to `jdbc-site.xml`:
 
     ``` xml
     <property>
@@ -353,28 +353,28 @@ Perform the following procedure to configure a PXF JDBC server for Hive:
 
 8. If the `hive.server2.authentication` property in `hive-site.xml` is set to `NONE`, or the property is not specified, you must set the `jdbc.user` property. The value to which you set the `jdbc.user` property is dependent upon the `hive.server2.enable.doAs` impersonation setting in `hive-site.xml`:
 
-    1. If `hive.server2.enable.doAs` is set to `TRUE` (the default), Hive runs Hadoop operations on behalf of the user connecting to Hive.
-        1. *Choose/perform one of the following options*:
-            1. Set `jdbc.user` to specify the user that has read permission on all Hive data accessed by Greenplum Database. For example, to connect to Hive and run all requests as user `gpadmin`:
+    1. If `hive.server2.enable.doAs` is set to `TRUE` (the default), Hive runs Hadoop operations on behalf of the user connecting to Hive. *Choose/perform one of the following options*:
 
-                ``` xml
-                <property>
-                    <name>jdbc.user</name>
-                    <value>gpadmin</value>
-                </property>
-                ```
-            2. **Or**, turn on JDBC-level user impersonation so that PXF automatically uses the Greenplum Database user name to connect to Hive:
+        **Set** `jdbc.user` to specify the user that has read permission on all Hive data accessed by Greenplum Database. For example, to connect to Hive and run all requests as user `gpadmin`:
 
-                ``` xml
-                <property>
-                    <name>pxf.impersonation.jdbc</name>
-                    <value>true</value>
-                </property>
-                ```
-                If you enable JDBC impersonation in this manner, you must not specify a `jdbc.user` nor include the setting in the `jdbc.url`.
+        ``` xml
+        <property>
+            <name>jdbc.user</name>
+            <value>gpadmin</value>
+        </property>
+        ```
+        **Or**, turn on JDBC-level user impersonation so that PXF automatically uses the Greenplum Database user name to connect to Hive:
 
-        2. If required, create a PXF user configuration file to manage the password setting.
-    2. If `hive.server2.enable.doAs` is set to `FALSE`, Hive runs Hadoop operations as the user who started the HiveServer2 process, usually the user `hive`. PXF ignores the `jdbc.user` setting in this circumstance.
+        ``` xml
+        <property>
+            <name>pxf.impersonation.jdbc</name>
+            <value>true</value>
+        </property>
+        ```
+        If you enable JDBC impersonation in this manner, you must not specify a `jdbc.user` nor include the setting in the `jdbc.url`.
+
+    2. If required, create a PXF user configuration file to manage the password setting.
+    3. If `hive.server2.enable.doAs` is set to `FALSE`, Hive runs Hadoop operations as the user who started the HiveServer2 process, usually the user `hive`. PXF ignores the `jdbc.user` setting in this circumstance.
 
 9. If the `hive.server2.authentication` property in `hive-site.xml` is set to `KERBEROS`:
     1. Ensure that you have enabled Kerberos authentication for PXF as described in [Configuring PXF for Secure HDFS](pxf_kerbhdfs.html).
@@ -387,7 +387,7 @@ Perform the following procedure to configure a PXF JDBC server for Hive:
             <value>kerberos</value>
         </property>
         ```
-    4. You must add the `saslQop` property to `jdbc.url`, and set it to match the `hive.server2.thrift.sasl.qop` property setting in `hive-site.xml`. For example, if the `hive-site.xml` file includes the following property settting:
+    4. Add the `saslQop` property to `jdbc.url`, and set it to match the `hive.server2.thrift.sasl.qop` property setting in `hive-site.xml`. For example, if the `hive-site.xml` file includes the following property settting:
 
         ``` xml
         <property>
@@ -397,29 +397,31 @@ Perform the following procedure to configure a PXF JDBC server for Hive:
         ```
         You would add `;saslQop=auth-conf` to the `jdbc.url`.
        
-    5. You must add the HiverServer2 `principal` name to the `jdbc.url`. For example:
+    5. Add the HiverServer2 `principal` name to the `jdbc.url`. For example:
 
         <pre>
         jdbc:hive2://hs2server:10000/default;<b>principal=hive/hs2server@REALM</b>;saslQop=auth-conf
         </pre>
-    6. If `hive.server2.enable.doAs` is set to `TRUE` (the default), Hive runs Hadoop operations on behalf of the user connecting to Hive.
-        1. *Choose/perform one of the following options*:
-            1. Do not specify any additional properties. In this case, PXF initiates all Hadoop access with the identity provided in the PXF Kerberos principal (usually `gpadmin`).
-            2. Set the `hive.server2.proxy.user` property in the `jdbc.url` to specify the user that has read permission on all Hive data. For example, to connect to Hive and run all requests as the user named `integration` use the following `jdbc.url`:
+    6. If `hive.server2.enable.doAs` is set to `TRUE` (the default), Hive runs Hadoop operations on behalf of the user connecting to Hive. *Choose/perform one of the following options*:
 
-                <pre>
-                jdbc:hive2://hs2server:10000/default;principal=hive/hs2server@REALM;saslQop=auth-conf;<b>hive.server2.proxy.user=integration</b>
-                </pre>
-            3. Enable PXF JDBC impersonation in the `jdbc-site.xml` file so that PXF automatically uses the Greenplum Database user name to connect to Hive. For example:
+        **Do not** specify any additional properties. In this case, PXF initiates all Hadoop access with the identity provided in the PXF Kerberos principal (usually `gpadmin`).
 
-                ``` xml
-                <property>
-                    <name>pxf.impersonation.jdbc</name>
-                    <value>true</value>
-                </property>
-                ```
-                If you enable JDBC impersonation, you must not explicitly specify a `hive.server2.proxy.user` in the `jdbc.url`.
-        2. If required, create a PXF user configuration file to manage the password setting.
+        **Or**, set the `hive.server2.proxy.user` property in the `jdbc.url` to specify the user that has read permission on all Hive data. For example, to connect to Hive and run all requests as the user named `integration` use the following `jdbc.url`:
+
+        <pre>
+        jdbc:hive2://hs2server:10000/default;principal=hive/hs2server@REALM;saslQop=auth-conf;<b>hive.server2.proxy.user=integration</b>
+        </pre>
+
+        **Or**, enable PXF JDBC impersonation in the `jdbc-site.xml` file so that PXF automatically uses the Greenplum Database user name to connect to Hive. For example:
+
+        ``` xml
+        <property>
+            <name>pxf.impersonation.jdbc</name>
+            <value>true</value>
+        </property>
+        ```
+        If you enable JDBC impersonation, you must not explicitly specify a `hive.server2.proxy.user` in the `jdbc.url`.
+    6. If required, create a PXF user configuration file to manage the password setting.
     7. If `hive.server2.enable.doAs` is set to `FALSE`, Hive runs Hadoop operations with the identity provided by the PXF Kerberos principal (usually `gpadmin`).
 
 10. Save your changes and exit the editor.

--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -288,17 +288,17 @@ The following table enumerates the Hive2 authentication and impersonation combin
 
 Table heading key:
 
-- .authentication -> "hive.server2.authentication Setting"
-- .enable.doAs -> "hive.server2.enable.doAs Setting"
+- authentication -> Hive hive.server2.authentication Setting
+- enable.doAs -> Hive hive.server2.enable.doAs Setting
 
-| .authentication  |  .enable.doAs | Authentication | Configuration Required |
+| authentication  |  enable.doAs | Authenticated User | Configuration Required |
 |------------------|---------------|----------------|-------------------|
 | `NOSASL` | n/a | No authentication | Must set `jdbc.connection.property.auth` = `noSasl`  |
-| `NONE`, or not specified | `TRUE` | User name | Set `jdbc.user` |
+| `NONE`, or not specified | `TRUE` | User name that you provide | Set `jdbc.user` |
 | `NONE`, or not specified | `TRUE` | Greenplum user name | Set `pxf.impersonation.jdbc` = `true` |
 | `NONE`, or not specified | `FALSE` | Name of the user who started Hive, typically `hive`  | None |
 | `KERBEROS` | `TRUE` | Identity provided in the PXF Kerberos principal, typically `gpadmin` | None |
-| `KERBEROS` | `TRUE` | User name  | Set `hive.server2.proxy.user` in `jdbc.url`  |
+| `KERBEROS` | `TRUE` | User name that you provide  | Set `hive.server2.proxy.user` in `jdbc.url`  |
 | `KERBEROS` | `TRUE` | Greenplum user name  | Set `pxf.impersonation.jdbc` = `true` |
 | `KERBEROS` | `FALSE` | Identity provided in the PXF Kerberos principal, typically `gpadmin` |  None |
 

--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -134,7 +134,7 @@ Example: To set the `search_path` parameter before running a query in a PostgreS
 
 Ensure that the JDBC driver for the external SQL database supports any property that you specify.
 
-#### <a id="jdbcimpers"></a>JDBC User Impersonation
+#### <a id="jdbcimpers"></a>About JDBC User Impersonation
 
 The PXF JDBC Connector accesses external data stores on behalf of Greenplum Database end users. When you enable PXF JDBC user impersonation, the JDBC Connector uses the Greenplum Database user name to connect to the external data store. When PXF JDBC user impersonation is disabled (the default), the behavior of the JDBC Connector is dependent upon the external data store. For example, the JDBC connector uses the settings of certain Hive authentication and impersonation properties to determine the user. In some cases, you may be required to provide a `jdbc.user` setting, or add properties to the `jdbc.url` setting in the server `jdbc-site.xml` file.
 

--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -17,11 +17,11 @@ In previous releases of Greenplum Database, you may have specified the JDBC driv
 
 **Note**: PXF external tables that you previously created that directly specified the JDBC connection options will continue to work. If you want to move these tables to use JDBC file-based server configuration, you must create a server configuration, drop the external tables, and then recreate the tables specifying an appropriate `SERVER=<server_name>` clause.
 
-### <a id="cfg_jar"></a>JDBC Driver JAR Registration
+## <a id="cfg_jar"></a>JDBC Driver JAR Registration
 
 The PXF JDBC Connector is installed with the `postgresql-9.1-901-1.jdbc4.jar` JAR file. If you require a different JDBC driver, ensure that you install the JDBC driver JAR file for the external SQL database in the `$PXF_CONF/lib` directory on each segment host. Be sure to install JDBC driver JAR files that are compatible with your JRE version. See [Registering PXF JAR Dependencies](reg_jar_depend.html) for additional information.
 
-### <a id="cfg_server"></a>JDBC Server Configuration
+## <a id="cfg_server"></a>JDBC Server Configuration
 
 When you configure the PXF JDBC Connector, you add at least one named PXF server configuration for the connector as described in [About PXF Server Configuration](cfg_server.html#cfgproc). You can also configure one or more statically-defined queries to run against the remote SQL database.
 
@@ -38,7 +38,7 @@ The required properties in the `jdbc-site.xml` server template file follow:
 
 <div class="note">When you configure a PXF JDBC server, you specify the external database user credentials to PXF in clear text in a configuration file.</div>
 
-#### <a id="connprop"></a>Connection-Level Properties
+### <a id="connprop"></a>Connection-Level Properties
 
 To set additional JDBC connection-level properties, add `jdbc.connection.property.<CPROP_NAME>` properties to `jdbc-site.xml`. PXF passes these properties to the JDBC driver when it establishes the connection to the external SQL database (`DriverManager.getConnection()`).
 
@@ -59,7 +59,7 @@ Example: To set the `createDatabaseIfNotExist` connection property on a JDBC con
 
 Ensure that the JDBC driver for the external SQL database supports any connection-level property that you specify.
 
-#### <a id="conntransiso"></a>Connection Transaction Isolation Property
+### <a id="conntransiso"></a>Connection Transaction Isolation Property
 
 The SQL standard defines four transaction isolation levels. The level that you specify for a given connection to an external SQL database determines how and when the changes made by one transaction executed on the connection are visible to another.
 
@@ -86,7 +86,7 @@ For example, to set the transaction isolation level to *Read uncommitted*, add t
 
 Different SQL databases support different transaction isolation levels. Ensure that the external database supports the level that you specify.
 
-#### <a id="stateprop"></a>Statement-Level Properties
+### <a id="stateprop"></a>Statement-Level Properties
 
 The PXF JDBC Connector executes a query or insert command on an external SQL database table in a *statement*. The Connector exposes properties that enable you to configure certain aspects of the statement before the command is executed in the external database. The Connector supports the following statement-level properties:
 
@@ -109,7 +109,7 @@ Example: To set the read fetch size to 5000, add the following property block to
 
 Ensure that the JDBC driver for the external SQL database supports any statement-level property that you specify.
 
-#### <a id="sessprop"></a>Session-Level Properties
+### <a id="sessprop"></a>Session-Level Properties
 
 To set session-level properties, add the `jdbc.session.property.<SPROP_NAME>` property to `jdbc-site.xml`. PXF will `SET` these properties in the external database before executing a query.
 
@@ -134,9 +134,11 @@ Example: To set the `search_path` parameter before running a query in a PostgreS
 
 Ensure that the JDBC driver for the external SQL database supports any property that you specify.
 
-#### <a id="jdbcimpers"></a>About JDBC User Impersonation
+### <a id="jdbcimpers"></a>About JDBC User Impersonation
 
-The PXF JDBC Connector accesses external data stores on behalf of Greenplum Database end users. When you enable PXF JDBC user impersonation, the JDBC Connector uses the name of the Greenplum Database user that accesses the PXF external table to try to connect to the external data store. When PXF JDBC user impersonation is disabled (the default), the behavior of the JDBC Connector is dependent upon the external data store. For example, the JDBC connector uses the settings of certain Hive authentication and impersonation properties to determine the user. In some cases, you may be required to provide a `jdbc.user` setting, or add properties to the `jdbc.url` setting in the server `jdbc-site.xml` file.
+The PXF JDBC Connector uses the `jdbc.user` setting or information in the `jdbc.url` to determine the identity of the user to connect to the external data store. When PXF JDBC user impersonation is disabled (the default), the behavior of the JDBC Connector is further dependent upon the external data store. For example, if you are using the JDBC Connector to access Hive, the Connector uses the settings of certain Hive authentication and impersonation properties to determine the user. You may be required to provide a `jdbc.user` setting, or add properties to the `jdbc.url` setting in the server `jdbc-site.xml` file.
+
+When you enable PXF JDBC user impersonation, the PXF JDBC Connector accesses the external data store on behalf of a Greenplum Database end user. The Connector uses the name of the Greenplum Database user that accesses the PXF external table to try to connect to the external data store.
 
 The `pxf.impersonation.jdbc` property governs JDBC user impersonation. JDBC user impersonation is disabled by default. To enable JDBC user impersonation for a server configuration, set the property to true:
 
@@ -147,9 +149,9 @@ The `pxf.impersonation.jdbc` property governs JDBC user impersonation. JDBC user
 </property>
 ```
 
-When you enable JDBC user impersonation for a PXF server, PXF overrides any `jdbc-site.xml` or `<greenplum_user_name>-user.xml` `jdbc.user` property setting with the Greenplum Database user name. For user impersonation to work effectively, the target database should not require a password for this user. When this is not desirable, you can manage the password via the `jdbc.password` property setting in a `<greenplum_user_name>-user.xml` PXF user configuration file. Refer to [Configuring a PXF User](cfg_server.html#usercfg) for more information about per-server, per-Greenplum-user configuration.
+When you enable JDBC user impersonation for a PXF server, PXF overrides the value of a `jdbc.user` property setting defined in either `jdbc-site.xml` or `<greenplum_user_name>-user.xml`, or specified in the external table DDL, with the Greenplum Database user name. For user impersonation to work effectively when the external data store requires passwords to authenticate connecting users, you must specify the `jdbc.password` setting for each user that can be impersonated in that user's `<greenplum_user_name>-user.xml` property override file. Refer to [Configuring a PXF User](cfg_server.html#usercfg) for more information about per-server, per-Greenplum-user configuration.
 
-### <a id="namedquery"></a>JDBC Named Query Configuration
+## <a id="namedquery"></a>JDBC Named Query Configuration
 
 A PXF *named query* is a static query that you configure, and that PXF runs in the remote SQL database.
 
@@ -162,7 +164,7 @@ To configure and use a PXF JDBC named query:
 PXF runs the query each time the user invokes a `SELECT` command on the Greenplum Database external table.
 
 
-#### <a id="namedquery_define"></a>Defining a Named Query
+### <a id="namedquery_define"></a>Defining a Named Query
 
 You create a named query by adding the query statement to a text file that has the following naming format: `<query_name>.sql`. You can define one or more named queries for a JDBC server configuration. Each query must reside in a separate text file.
 
@@ -181,7 +183,7 @@ GROUP BY c.name, c.city, o.month
 
 Do not provide the ending semicolon (`;`) for the SQL statement.
 
-#### <a id="namedquery_pub"></a>Query Naming
+### <a id="namedquery_pub"></a>Query Naming
 
 The Greenplum Database user references a named query by specifying the query file name without the extension. For example, if you define a query in a file named `report.sql`, the name of that query is `report`.
 
@@ -197,12 +199,12 @@ LOCATION ('pxf://query:report?PROFILE=JDBC&SERVER=mydb ...')
 
 Refer to [About Using Named Queries](jdbc_pxf.html#about_nq) for information about using PXF JDBC named queries.
 
-### <a id="cfg_override"></a>Overriding the JDBC Server Configuration
+## <a id="cfg_override"></a>Overriding the JDBC Server Configuration
 
 You can override the JDBC server configuration by directly specifying certain JDBC properties via custom options in the `CREATE EXTERNAL TABLE` command `LOCATION` clause. Refer to [Overriding the JDBC Server Configuration](jdbc_pxf.html#jdbc_override) for additional information.
 
 
-### <a id="cfg_proc" class="no-quick-link"></a>Example Configuration Procedure
+## <a id="cfg_proc"></a>Example Configuration Procedure
 
 Ensure that you have initialized PXF before you configure a JDBC Connector server.
 
@@ -267,11 +269,10 @@ You can use the PXF JDBC Connector to retrieve data from Hive. You can also use 
 
 This topic describes how to configure the PXF JDBC Connector to access Hive. When you configure Hive access with JDBC, you must take into account the Hive user impersonation setting, as well as whether or not the Hadoop cluster is secured with Kerberos.
 
-### <a id="cfg_jar"></a>JDBC Driver JAR Registration
+
+### <a id="hive_cfg_server"></a>JDBC Server Configuration
 
 The PXF JDBC Connector is installed with the JAR files required to access Hive via JDBC, `hive-jdbc-<version>.jar` and `hive-service-<version>.jar`, and automatically registers these JARs.
-
-### <a id="cfg_server"></a>JDBC Server Configuration
 
 When you configure a PXF JDBC server for Hive access, you must specify the JDBC driver class name, database URL, and client credentials just as you would when configuring a client connection to an SQL database.
 
@@ -282,16 +283,18 @@ To access Hive via JDBC, you must specify the following properties and values in
 | jdbc.driver | org.apache.hive.jdbc.HiveDriver |
 | jdbc.url | jdbc:hive2://\<hiveserver2_host>:\<hiveserver2_port>/\<database> |
 
-The value of the HiveServer2 authentication (`hive.server2.authentication`) and impersonation (`hive.server2.enable.doAs`) properties, and whether or not the Hive service is utilizing Kerberos authentication, will inform the setting of other JDBC server configuration properties.
+The value of the HiveServer2 authentication (`hive.server2.authentication`) and impersonation (`hive.server2.enable.doAs`) properties, and whether or not the Hive service is utilizing Kerberos authentication, will inform the setting of other JDBC server configuration properties. These properties are defined in the `hive-site.xml` configuration file in the Hadoop cluster. You will need to obtain the values of these properties.
 
-The following table enumerates the Hive2 authentication and impersonation combinations supported by the PXF JDBC Connector, and identifies the JDBC server configuration required for each.
+The following table enumerates the Hive2 authentication and impersonation combinations supported by the PXF JDBC Connector. It identifies the possible Hive user identities and the JDBC server configuration required for each.
 
 Table heading key:
 
-- authentication -> Hive hive.server2.authentication Setting
-- enable.doAs -> Hive hive.server2.enable.doAs Setting
+- *authentication* -> Hive hive.server2.authentication Setting
+- *enable.doAs* -> Hive hive.server2.enable.doAs Setting
+- *User Identity* -> Identity that HiveServer2 will use to access data
+- *Configuration Required* -> PXF JDBC Connector or Hive configuration required for *User Identity*
 
-| authentication  |  enable.doAs | Authenticated User | Configuration Required |
+| authentication  |  enable.doAs | User Identity | Configuration Required |
 |------------------|---------------|----------------|-------------------|
 | `NOSASL` | n/a | No authentication | Must set `jdbc.connection.property.auth` = `noSasl`  |
 | `NONE`, or not specified | `TRUE` | User name that you provide | Set `jdbc.user` |
@@ -303,6 +306,8 @@ Table heading key:
 | `KERBEROS` | `FALSE` | Identity provided in the PXF Kerberos principal, typically `gpadmin` |  None |
 
 **Note**: There are additional configuration steps required when Hive utilizes Kerberos authentication.
+
+### <a id="hive_cfg_server_proc"></a>Example Configuration Procedure
 
 Perform the following procedure to configure a PXF JDBC server for Hive:
 

--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -19,7 +19,7 @@ In previous releases of Greenplum Database, you may have specified the JDBC driv
 
 ### <a id="cfg_jar"></a>JDBC Driver JAR Registration
 
-The PXF JDBC Connector is installed with the `postgresql-8.4-702.jdbc4.jar` JAR file. If you require a different JDBC driver, ensure that you install the JDBC driver JAR file for the external SQL database in the `$PXF_CONF/lib` directory on each segment host. Be sure to install JDBC driver JAR files that are compatible with your JRE version. See [Registering PXF JAR Dependencies](reg_jar_depend.html) for additional information.
+The PXF JDBC Connector is installed with the `postgresql-9.1-901-1.jdbc4.jar` JAR file. If you require a different JDBC driver, ensure that you install the JDBC driver JAR file for the external SQL database in the `$PXF_CONF/lib` directory on each segment host. Be sure to install JDBC driver JAR files that are compatible with your JRE version. See [Registering PXF JAR Dependencies](reg_jar_depend.html) for additional information.
 
 ### <a id="cfg_server"></a>JDBC Server Configuration
 
@@ -134,6 +134,20 @@ Example: To set the `search_path` parameter before running a query in a PostgreS
 
 Ensure that the JDBC driver for the external SQL database supports any property that you specify.
 
+#### <a id="jdbcimpers"></a>JDBC User Impersonation
+
+The PXF JDBC Connector accesses external data stores on behalf of Greenplum Database end users. When you enable PXF JDBC user impersonation, the JDBC Connector uses the Greenplum Database user name to connect to the external data store. When PXF JDBC user impersonation is disabled (the default), the behavior of the JDBC Connector is dependent upon the external data store. For example, the JDBC connector uses the settings of certain Hive authentication and impersonation properties to determine the user. In some cases, you may be required to provide a `jdbc.user` setting, or add properties to the `jdbc.url` setting in the server `jdbc-site.xml` file.
+
+The `pxf.impersonation.jdbc` property governs JDBC user impersonation. JDBC user impersonation is disabled by default. To enable JDBC user impersonation for a server configuration, set the property to true:
+
+``` xml
+<property>
+    <name>pxf.impersonation.jdbc</name>
+    <value>true</value>
+</property>
+```
+
+When you enable JDBC user impersonation for a PXF server, PXF overrides any `jdbc-site.xml` or `<greenplum_user_name>-user.xml` `jdbc.user` property setting with the Greenplum Database user name. For user impersonation to work effectively, the target database should not require a password for this user. When this is not desirable, you can manage the password via the `jdbc.password` property setting in a `<greenplum_user_name>-user.xml` PXF user configuration file. Refer to [Configuring a PXF User](cfg_server.html#usercfg) for more information about per-server, per-Greenplum-user configuration.
 
 ### <a id="namedquery"></a>JDBC Named Query Configuration
 
@@ -242,6 +256,175 @@ In this procedure, you name and add a PXF JDBC server configuration for a Postgr
 6. Save your changes and exit the editor.
 
 7. Use the `pxf cluster sync` command to copy the new server configuration to the Greenplum Database cluster. For example:
+    
+    ``` shell
+    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
+    ```
+
+## <a id="hive_cfg"></a>Configuring Hive Access
+
+You can use the PXF JDBC Connector to retrieve data from Hive. You can also use a JDBC named query to submit a custom SQL query to Hive and retrieve the results using the JDBC Connector.
+
+This topic describes how to configure the PXF JDBC Connector to access Hive. When you configure Hive access with JDBC, you must take into account the Hive user impersonation setting, as well as whether or not the Hadoop cluster is secured with Kerberos.
+
+### <a id="cfg_jar"></a>JDBC Driver JAR Registration
+
+The PXF JDBC Connector is installed with the JAR files required to access Hive via JDBC, `hive-jdbc-<version>.jar` and `hive-service-<version>.jar`, and automatically registers these JARs.
+
+### <a id="cfg_server"></a>JDBC Server Configuration
+
+When you configure a PXF JDBC server for Hive access, you must specify the JDBC driver class name, database URL, and client credentials just as you would when configuring a JDBC server to an SQL database.
+
+To access Hive via JDBC, you must specify the following properties and values in the `jdbc-site.xml` server configuration file:
+
+| Property       |  Value |
+|----------------|--------|
+| jdbc.driver | org.apache.hive.jdbc.HiveDriver |
+| jdbc.url | jdbc:hive2://\<hiveserver2_host>:\<hiveserver2_port>/\<database> |
+
+The value of the HiveServer2 authentication (`hive.server2.authentication`) and impersonation (`hive.server2.enable.doAs`) properties, and whether or not the Hadoop cluster in which the Hive service is running is utilizing Kerberos authentication, will inform the setting of other JDBC server configuration properties.
+
+The following table enumerates the Hive2 authentication and impersonation combinations supported by the PXF JDBC Connector, and identifies the JDBC server configuration required for each.
+
+Table heading key:
+
+- .authentication -> "hive.server2.authentication Setting"
+- .enable.doAs -> "hive.server2.enable.doAs Setting"
+
+| .authentication  |  .enable.doAs | Authentication | Configuration Required |
+|------------------|---------------|----------------|-------------------|
+| `NOSASL` | n/a | No authentication | Must set `jdbc.connection.property.auth` = `noSasl`  |
+| `NONE`, or not specified | `TRUE` | User name | Set `jdbc.user` |
+| `NONE`, or not specified | `TRUE` | Greenplum user name | Set `pxf.impersonation.jdbc` = `true` |
+| `NONE`, or not specified | `FALSE` | Name of the user who started Hive, typically `hive`  | None |
+| `KERBEROS` | `TRUE` | Identity provided in the PXF Kerberos principal, typically `gpadmin` | None |
+| `KERBEROS` | `TRUE` | User name  | Set `hive.server2.proxy.user` in `jdbc.url`  |
+| `KERBEROS` | `TRUE` | Greenplum user name  | Set `pxf.impersonation.jdbc` = `true` |
+| `KERBEROS` | `FALSE` | Identity provided in the PXF Kerberos principal, typically `gpadmin` |  None |
+
+**Note**: There are additional configuration steps required when Hive utilizes Kerberos authentication.
+
+Perform the following procedure to configure a PXF JDBC server for Hive:
+
+1. Log in to your Greenplum Database master node:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    ```
+
+2. Choose a name for the JDBC server.
+
+3. Create the `$PXF_HOME/servers/<server_name>` directory. For example, use the following command to create a JDBC server configuration named `hivejdbc1`:
+
+    ``` shell
+    gpadmin@gpmaster$ mkdir $PXF_CONF/servers/hivejdbc1
+    ````
+
+4. Copy the PXF JDBC server template file to the server configuration directory. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ cp $PXF_CONF/templates/jdbc-site.xml $PXF_CONF/servers/hivejdbc1/
+    ```
+        
+5. Open the `jdbc-site.xml` file in the editor of your choice and set the `jdbc.driver` and `jdbc.url` properties. Be sure to specify your Hive host, port, and database name:
+
+    ``` xml
+    <property>
+        <name>jdbc.driver</name>
+        <value>org.apache.hive.jdbc.HiveDriver</value>
+    </property>
+    <property>
+        <name>jdbc.url</name>
+        <value>jdbc:hive2://<hiveserver2_host>:<hiveserver2_port>/<database></value>
+    </property>
+    ```
+
+6. Obtain the `hive-site.xml` file from your Hadoop cluster and examine the file.
+
+7. If the `hive.server2.authentication` property in `hive-site.xml` is set to `NOSASL`, HiveServer2 performs no authentication. You must add the following connection-level property to `jdbc-site.xml`:
+
+    ``` xml
+    <property>
+        <name>jdbc.connection.property.auth</name>
+        <value>noSasl</value>
+    </property>
+    ```
+    Alternatively, you may choose to add `;auth=noSasl` to the `jdbc.url`.
+
+8. If the `hive.server2.authentication` property in `hive-site.xml` is set to `NONE`, or the property is not specified, you must set the `jdbc.user` property. The value to which you set the `jdbc.user` property is dependent upon the `hive.server2.enable.doAs` impersonation setting in `hive-site.xml`:
+
+    1. If `hive.server2.enable.doAs` is set to `TRUE` (the default), Hive runs Hadoop operations on behalf of the user connecting to Hive.
+        1. *Choose/perform one of the following options*:
+            1. Set `jdbc.user` to specify the user that has read permission on all Hive data accessed by Greenplum Database. For example, to connect to Hive and run all requests as user `gpadmin`:
+
+                ``` xml
+                <property>
+                    <name>jdbc.user</name>
+                    <value>gpadmin</value>
+                </property>
+                ```
+            2. **Or**, turn on JDBC-level user impersonation so that PXF automatically uses the Greenplum Database user name to connect to Hive:
+
+                ``` xml
+                <property>
+                    <name>pxf.impersonation.jdbc</name>
+                    <value>true</value>
+                </property>
+                ```
+                If you enable JDBC impersonation in this manner, you must not specify a `jdbc.user` nor include the setting in the `jdbc.url`.
+
+        2. If required, create a PXF user configuration file to manage the password setting.
+    2. If `hive.server2.enable.doAs` is set to `FALSE`, Hive runs Hadoop operations as the user who started the HiveServer2 process, usually the user `hive`. PXF ignores the `jdbc.user` setting in this circumstance.
+
+9. If the `hive.server2.authentication` property in `hive-site.xml` is set to `KERBEROS`:
+    1. Ensure that you have enabled Kerberos authentication for PXF as described in [Configuring PXF for Secure HDFS](pxf_kerbhdfs.html).
+    2. Ensure that you have configured the Hadoop cluster as the `default` PXF server.
+    3. Ensure that the `$PXF_CONF/servers/default/core-site.xml` file includes the following setting:
+
+        ``` xml
+        <property>
+            <name>hadoop.security.authentication</name>
+            <value>kerberos</value>
+        </property>
+        ```
+    4. You must add the `saslQop` property to `jdbc.url`, and set it to match the `hive.server2.thrift.sasl.qop` property setting in `hive-site.xml`. For example, if the `hive-site.xml` file includes the following property settting:
+
+        ``` xml
+        <property>
+            <name>hive.server2.thrift.sasl.qop</name>
+            <value>auth-conf</value>
+        </property>
+        ```
+        You would add `;saslQop=auth-conf` to the `jdbc.url`.
+       
+    5. You must add the HiverServer2 `principal` name to the `jdbc.url`. For example:
+
+        <pre>
+        jdbc:hive2://hs2server:10000/default;<b>principal=hive/hs2server@REALM</b>;saslQop=auth-conf
+        </pre>
+    6. If `hive.server2.enable.doAs` is set to `TRUE` (the default), Hive runs Hadoop operations on behalf of the user connecting to Hive.
+        1. *Choose/perform one of the following options*:
+            1. Do not specify any additional properties. In this case, PXF initiates all Hadoop access with the identity provided in the PXF Kerberos principal (usually `gpadmin`).
+            2. Set the `hive.server2.proxy.user` property in the `jdbc.url` to specify the user that has read permission on all Hive data. For example, to connect to Hive and run all requests as the user named `integration` use the following `jdbc.url`:
+
+                <pre>
+                jdbc:hive2://hs2server:10000/default;principal=hive/hs2server@REALM;saslQop=auth-conf;<b>hive.server2.proxy.user=integration</b>
+                </pre>
+            3. Enable PXF JDBC impersonation in the `jdbc-site.xml` file so that PXF automatically uses the Greenplum Database user name to connect to Hive. For example:
+
+                ``` xml
+                <property>
+                    <name>pxf.impersonation.jdbc</name>
+                    <value>true</value>
+                </property>
+                ```
+                If you enable JDBC impersonation, you must not explicitly specify a `hive.server2.proxy.user` in the `jdbc.url`.
+        2. If required, create a PXF user configuration file to manage the password setting.
+    7. If `hive.server2.enable.doAs` is set to `FALSE`, Hive runs Hadoop operations with the identity provided by the PXF Kerberos principal (usually `gpadmin`).
+
+10. Save your changes and exit the editor.
+
+11. Use the `pxf cluster sync` command to copy the new server configuration to the Greenplum Database cluster. For example:
     
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -53,6 +53,8 @@ The PXF JDBC connector supports the following data types:
 
 Any data type not listed above is not supported by the PXF JDBC connector.
 
+**Note**: The JDBC connector does not support reading or writing Hive data stored as a byte array (`byte[]`).
+
 ## <a id="queryextdata"></a>Accessing an External SQL Database
 The PXF JDBC connector supports a single profile named `Jdbc`. You can both read data from and write data to an external SQL database table with this profile. You can also use the connector to run a static, named query in external SQL database and read the results.
 


### PR DESCRIPTION
can use the PXF JDBC connector to access hive.  there are some restrictions and a special configuration procedure that needs to take into account the hive authentication and impersonation settings in the hadoop/hive cluster.

in this PR:
- new section "About JDBC User Impersonation" on the jdbc connector configuration page
- new topic and procedure for "Configuring Hive Access"
- the PXF_USER_IMPERSONATION discussion is located under the configuration topic for Hadoop connectors.  thought it might confuse matters if i mentioned that it doesn't govern hive access with the JDBC connector there, or mentioned PXF_USER_IMPERSONATION in the new hive via jdbc topic.  let me know if you think otherwise.
- also snuck in an edit for the new postgres jdbc JAR version ...

doc review site links:
- new "About JDBC User Impersonation" topic - http://docs-lisa-pxf-hivejdbc.cfapps.io/6-0/pxf/jdbc_cfg.html#jdbcimpers
- new "Configuring Hive Access" topic - http://docs-lisa-pxf-hivejdbc.cfapps.io/6-0/pxf/jdbc_cfg.html#hive_cfg
