### PR TITLE
6X: CString doesn't need the varlena header space

### DIFF
--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -628,7 +628,7 @@ MemTuple memtuple_form_to(
 	if(!destlen)
 	{
 		Assert(!mtup);
-		mtup = (MemTuple) palloc(len);
+		mtup = (MemTuple) palloc0(len);
 	}
 	else if(*destlen < len)
 	{
@@ -659,6 +659,7 @@ MemTuple memtuple_form_to(
 	{
 		*destlen = len;
 		Assert(mtup);
+		memset(mtup, 0, len);
 	}
 
 	/* Set mtlen, this set the lead bit, len, and clears hasnull bit 
@@ -690,9 +691,6 @@ MemTuple memtuple_form_to(
 		/* if null bitmap is more than 4 bytes, add needed space */
 		start += pbind->null_bitmap_extra_size;
 		varlen_start += pbind->null_bitmap_extra_size;
-
-		/* clear null bitmap. */
-		memset(nullp, 0, memtuple_get_nullp_len(pbind));
 	}
 
 	/* It is very important to setup the null bitmap first before we 

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -810,7 +810,7 @@ DeserializeTuple(SerTupInfo *pSerInfo, StringInfo serialTup)
 			if (sz < 0)
 				elog(ERROR, "invalid length received for a CString");
 
-			p = palloc(sz + VARHDRSZ);
+			p = palloc(sz);
 
 			/* Then data */
 			pq_copymsgbytes(serialTup, p, sz);


### PR DESCRIPTION
CString only has the length and data in the serialized structure, no
need to allocate spaces for the varlena header.

(cherry picked from commit e4b8484, not interesting but I like 6X to have it)

"Zero out padding bytes for memtuple." were found while I was debugging
some other problems, take this opportunity to backport it also.