### PR TITLE
Ensure temp relation files are removed from the file-system on a DROP.

### DIFF
--- a/src/backend/access/rmgrdesc/xactdesc.c
+++ b/src/backend/access/rmgrdesc/xactdesc.c
@@ -37,7 +37,11 @@ xact_desc_commit(StringInfo buf, xl_xact_commit *xlrec)
 		appendStringInfoString(buf, "; rels:");
 		for (i = 0; i < xlrec->nrels; i++)
 		{
-			char	   *path = relpathperm(xlrec->xnodes[i].node, MAIN_FORKNUM);
+			BackendId  backendId = xlrec-> xnodes[i].isTempRelation ?
+								  TempRelBackendId : InvalidBackendId;
+			char	   *path = relpathbackend(xlrec->xnodes[i].node,
+											  backendId,
+											  MAIN_FORKNUM);
 
 			appendStringInfo(buf, " %s", path);
 			pfree(path);
@@ -134,7 +138,11 @@ xact_desc_abort(StringInfo buf, xl_xact_abort *xlrec)
 		appendStringInfoString(buf, "; rels:");
 		for (i = 0; i < xlrec->nrels; i++)
 		{
-			char	   *path = relpathperm(xlrec->xnodes[i].node, MAIN_FORKNUM);
+			BackendId  backendId = xlrec-> xnodes[i].isTempRelation ?
+								  TempRelBackendId : InvalidBackendId;
+			char	   *path = relpathbackend(xlrec->xnodes[i].node,
+											  backendId,
+											  MAIN_FORKNUM);
 
 			appendStringInfo(buf, " %s", path);
 			pfree(path);

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -170,7 +170,7 @@ static void RecordTransactionCommitPrepared(TransactionId xid,
 								int nchildren,
 								TransactionId *children,
 								int nrels,
-								RelFileNodeWithStorageType *rels,
+								RelFileNodePendingDelete *rels,
 								int ninvalmsgs,
 								SharedInvalidationMessage *invalmsgs,
 								bool initfileinval);
@@ -178,7 +178,7 @@ static void RecordTransactionAbortPrepared(TransactionId xid,
 							   int nchildren,
 							   TransactionId *children,
 							   int nrels,
-							   RelFileNodeWithStorageType *rels);
+							   RelFileNodePendingDelete *rels);
 static void ProcessRecords(char *bufptr, TransactionId xid,
 			   const TwoPhaseCallback callbacks[]);
 static void RemoveGXact(GlobalTransaction gxact);
@@ -934,8 +934,8 @@ TwoPhaseGetDummyProc(TransactionId xid)
  *
  *	1. TwoPhaseFileHeader
  *	2. TransactionId[] (subtransactions)
- *	3. RelFileNodeWithStorageType[] (files to be deleted at commit)
- *	4. RelFileNodeWithStorageType[] (files to be deleted at abort)
+ *	3. RelFileNodePendingDelete[] (files to be deleted at commit)
+ *	4. RelFileNodePendingDelete[] (files to be deleted at abort)
  *	5. SharedInvalidationMessage[] (inval messages to be sent at commit)
  *	6. TwoPhaseRecordOnDisk
  *	7. ...
@@ -1038,8 +1038,8 @@ StartPrepare(GlobalTransaction gxact)
 	TransactionId xid = pgxact->xid;
 	TwoPhaseFileHeader hdr;
 	TransactionId *children;
-	RelFileNodeWithStorageType *commitrels;
-	RelFileNodeWithStorageType *abortrels;
+	RelFileNodePendingDelete *commitrels;
+	RelFileNodePendingDelete *abortrels;
 	SharedInvalidationMessage *invalmsgs;
 
 	/* Initialize linked list */
@@ -1083,12 +1083,12 @@ StartPrepare(GlobalTransaction gxact)
 	}
 	if (hdr.ncommitrels > 0)
 	{
-		save_state_data(commitrels, hdr.ncommitrels * sizeof(RelFileNodeWithStorageType));
+		save_state_data(commitrels, hdr.ncommitrels * sizeof(RelFileNodePendingDelete));
 		pfree(commitrels);
 	}
 	if (hdr.nabortrels > 0)
 	{
-		save_state_data(abortrels, hdr.nabortrels * sizeof(RelFileNodeWithStorageType));
+		save_state_data(abortrels, hdr.nabortrels * sizeof(RelFileNodePendingDelete));
 		pfree(abortrels);
 	}
 	if (hdr.ninvalmsgs > 0)
@@ -1276,9 +1276,9 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
 	TwoPhaseFileHeader *hdr;
 	TransactionId latestXid;
 	TransactionId *children;
-	RelFileNodeWithStorageType *commitrels;
-	RelFileNodeWithStorageType *abortrels;
-	RelFileNodeWithStorageType *delrels;
+	RelFileNodePendingDelete *commitrels;
+	RelFileNodePendingDelete *abortrels;
+	RelFileNodePendingDelete *delrels;
 	int			ndelrels;
 	SharedInvalidationMessage *invalmsgs;
 
@@ -1362,10 +1362,10 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
 	bufptr = buf + MAXALIGN(sizeof(TwoPhaseFileHeader));
 	children = (TransactionId *) bufptr;
 	bufptr += MAXALIGN(hdr->nsubxacts * sizeof(TransactionId));
-	commitrels = (RelFileNodeWithStorageType *) bufptr;
-	bufptr += MAXALIGN(hdr->ncommitrels * sizeof(RelFileNodeWithStorageType));
-	abortrels = (RelFileNodeWithStorageType *) bufptr;
-	bufptr += MAXALIGN(hdr->nabortrels * sizeof(RelFileNodeWithStorageType));
+	commitrels = (RelFileNodePendingDelete *) bufptr;
+	bufptr += MAXALIGN(hdr->ncommitrels * sizeof(RelFileNodePendingDelete));
+	abortrels = (RelFileNodePendingDelete *) bufptr;
+	bufptr += MAXALIGN(hdr->nabortrels * sizeof(RelFileNodePendingDelete));
 	invalmsgs = (SharedInvalidationMessage *) bufptr;
 	bufptr += MAXALIGN(hdr->ninvalmsgs * sizeof(SharedInvalidationMessage));
 
@@ -1812,8 +1812,8 @@ RecoverPreparedTransactions(void)
 		bufptr = buf + MAXALIGN(sizeof(TwoPhaseFileHeader));
 		subxids = (TransactionId *) bufptr;
 		bufptr += MAXALIGN(hdr->nsubxacts * sizeof(TransactionId));
-		bufptr += MAXALIGN(hdr->ncommitrels * sizeof(RelFileNodeWithStorageType));
-		bufptr += MAXALIGN(hdr->nabortrels * sizeof(RelFileNodeWithStorageType));
+		bufptr += MAXALIGN(hdr->ncommitrels * sizeof(RelFileNodePendingDelete));
+		bufptr += MAXALIGN(hdr->nabortrels * sizeof(RelFileNodePendingDelete));
 		bufptr += MAXALIGN(hdr->ninvalmsgs * sizeof(SharedInvalidationMessage));
 
 		/*
@@ -1896,7 +1896,7 @@ RecordTransactionCommitPrepared(TransactionId xid,
 								int nchildren,
 								TransactionId *children,
 								int nrels,
-							    RelFileNodeWithStorageType *rels,
+								RelFileNodePendingDelete *rels,
 								int ninvalmsgs,
 								SharedInvalidationMessage *invalmsgs,
 								bool initfileinval)
@@ -1940,7 +1940,7 @@ RecordTransactionCommitPrepared(TransactionId xid,
 	{
 		rdata[0].next = &(rdata[1]);
 		rdata[1].data = (char *) rels;
-		rdata[1].len = nrels * sizeof(RelFileNodeWithStorageType);
+		rdata[1].len = nrels * sizeof(RelFileNodePendingDelete);
 		rdata[1].buffer = InvalidBuffer;
 		lastrdata = 1;
 	}
@@ -2016,7 +2016,7 @@ RecordTransactionAbortPrepared(TransactionId xid,
 							   int nchildren,
 							   TransactionId *children,
 							   int nrels,
-							   RelFileNodeWithStorageType *rels)
+							   RelFileNodePendingDelete *rels)
 {
 	XLogRecData rdata[3];
 	int			lastrdata = 0;
@@ -2046,7 +2046,7 @@ RecordTransactionAbortPrepared(TransactionId xid,
 	{
 		rdata[0].next = &(rdata[1]);
 		rdata[1].data = (char *) rels;
-		rdata[1].len = nrels * sizeof(RelFileNodeWithStorageType);
+		rdata[1].len = nrels * sizeof(RelFileNodePendingDelete);
 		rdata[1].buffer = InvalidBuffer;
 		lastrdata = 1;
 	}

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1277,7 +1277,7 @@ RecordTransactionCommit(void)
 	bool		markXidCommitted;
 	TransactionId latestXid = InvalidTransactionId;
 	int			nrels;
-	RelFileNodeWithStorageType *rels;
+	RelFileNodePendingDelete *rels;
 	int			nchildren;
 	TransactionId *children;
 	int			nmsgs = 0;
@@ -1431,7 +1431,7 @@ RecordTransactionCommit(void)
 			{
 				rdata[0].next = &(rdata[1]);
 				rdata[1].data = (char *) rels;
-				rdata[1].len = nrels * sizeof(RelFileNodeWithStorageType);
+				rdata[1].len = nrels * sizeof(RelFileNodePendingDelete);
 				rdata[1].buffer = InvalidBuffer;
 				lastrdata = 1;
 			}
@@ -1826,7 +1826,7 @@ RecordTransactionAbort(bool isSubXact)
 	TransactionId xid;
 	TransactionId latestXid;
 	int			nrels;
-	RelFileNodeWithStorageType *rels;
+	RelFileNodePendingDelete *rels;
 	int			nchildren;
 	TransactionId *children;
 	XLogRecData rdata[3];
@@ -1903,7 +1903,7 @@ RecordTransactionAbort(bool isSubXact)
 	{
 		rdata[0].next = &(rdata[1]);
 		rdata[1].data = (char *) rels;
-		rdata[1].len = nrels * sizeof(RelFileNodeWithStorageType);
+		rdata[1].len = nrels * sizeof(RelFileNodePendingDelete);
 		rdata[1].buffer = InvalidBuffer;
 		lastrdata = 1;
 	}
@@ -6004,7 +6004,7 @@ static void
 xact_redo_commit_internal(TransactionId xid, XLogRecPtr lsn,
 						  TransactionId *sub_xids, int nsubxacts,
 						  SharedInvalidationMessage *inval_msgs, int nmsgs,
-						  RelFileNodeWithStorageType *xnodes, int nrels,
+						  RelFileNodePendingDelete *xnodes, int nrels,
 						  Oid dbId, Oid tsId,
 						  uint32 xinfo,
 						  DistributedTransactionId distribXid,

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -1702,7 +1702,7 @@ ForgetDatabaseFsyncRequests(Oid dbid)
  * DropRelationFiles -- drop files of all given relations
  */
 void
-DropRelationFiles(RelFileNodeWithStorageType *delrels, int ndelrels, bool isRedo)
+DropRelationFiles(RelFileNodePendingDelete *delrels, int ndelrels, bool isRedo)
 {
 	SMgrRelation *srels;
 	char         *srelstorages;
@@ -1712,7 +1712,10 @@ DropRelationFiles(RelFileNodeWithStorageType *delrels, int ndelrels, bool isRedo
 	srelstorages = palloc(sizeof(char) * ndelrels);
 	for (i = 0; i < ndelrels; i++)
 	{
-		SMgrRelation srel = smgropen(delrels[i].node, InvalidBackendId);
+		/* GPDB: backend can only be TempRelBackendId or InvalidBackendId for a
+		 * given relfile since we don't tie temp relations to their backends. */
+		SMgrRelation srel = smgropen(delrels[i].node,
+			delrels[i].isTempRelation ? TempRelBackendId : InvalidBackendId);
 
 		if (isRedo)
 		{

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -149,7 +149,7 @@ typedef struct xl_xact_commit
 	Oid			dbId;			/* MyDatabaseId */
 	Oid			tsId;			/* MyDatabaseTableSpace */
 	/* Array of RelFileNode(s) to drop at commit */
-	RelFileNodeWithStorageType xnodes[1];		/* VARIABLE LENGTH ARRAY */
+	RelFileNodePendingDelete xnodes[1];		/* VARIABLE LENGTH ARRAY */
 	/* ARRAY OF COMMITTED SUBTRANSACTION XIDs FOLLOWS */
 	/* ARRAY OF SHARED INVALIDATION MESSAGES FOLLOWS */
 	/* DISTRIBUTED XACT STUFF FOLLOWS */
@@ -179,7 +179,7 @@ typedef struct xl_xact_abort
 	int			nrels;			/* number of RelFileNodes */
 	int			nsubxacts;		/* number of subtransaction XIDs */
 	/* Array of RelFileNode(s) to drop at abort */
-	RelFileNodeWithStorageType xnodes[1];		/* VARIABLE LENGTH ARRAY */
+	RelFileNodePendingDelete xnodes[1];		/* VARIABLE LENGTH ARRAY */
 	/* ARRAY OF ABORTED SUBTRANSACTION XIDs FOLLOWS */
 } xl_xact_abort;
 

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301906041
+#define CATALOG_VERSION_NO	301906191
 
 #endif

--- a/src/include/catalog/storage.h
+++ b/src/include/catalog/storage.h
@@ -29,7 +29,7 @@ extern void RelationTruncate(Relation rel, BlockNumber nblocks);
  * naming
  */
 extern void smgrDoPendingDeletes(bool isCommit);
-extern int	smgrGetPendingDeletes(bool forCommit, RelFileNodeWithStorageType **ptr);
+extern int	smgrGetPendingDeletes(bool forCommit, RelFileNodePendingDelete **ptr);
 extern void AtSubCommit_smgr(void);
 extern void AtSubAbort_smgr(void);
 extern void PostPrepare_smgr(void);

--- a/src/include/storage/relfilenode.h
+++ b/src/include/storage/relfilenode.h
@@ -105,15 +105,17 @@ inline static bool RelFileNode_IsEmpty(
 }
 
 /*
- * Augmenting a relfilenode with a storeage type provides a way to make optimal
+ * Augmenting a relfilenode with a storage type provides a way to make optimal
  * decisions in smgr and md layer. This is purposefully kept out of RelFileNode
  * for performance concerns where RelFileNode used in a hotpath for BufferTag
- * hashing.
+ * hashing. The isTempRelation flag is necessary to support file-system removal 
+ * of temporary relations on a two-phase commit/abort.
  */
-typedef struct RelFileNodeWithStorageType
+typedef struct RelFileNodePendingDelete
 {
 	RelFileNode node;
+	bool isTempRelation;
 	char relstorage;
-} RelFileNodeWithStorageType;
+} RelFileNodePendingDelete;
 
 #endif   /* RELFILENODE_H */

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -138,7 +138,7 @@ extern void RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum,
 					 BlockNumber segno);
 extern void ForgetRelationFsyncRequests(RelFileNode rnode, ForkNumber forknum);
 extern void ForgetDatabaseFsyncRequests(Oid dbid);
-extern void DropRelationFiles(RelFileNodeWithStorageType *delrels, int ndelrels, bool isRedo);
+extern void DropRelationFiles(RelFileNodePendingDelete *delrels, int ndelrels, bool isRedo);
 
 /* smgrtype.c */
 extern Datum smgrout(PG_FUNCTION_ARGS);

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -237,6 +237,8 @@ test: psql_gp_commands pg_resetxlog dropdb_check_shared_buffer_cache gp_upgrade_
 # Check for shmem leak for instrumentation slots
 test: instr_in_shmem_verify
 
+test: temp_relation
+
 # This cannot run in parallel because other tests could increment the Oid
 # counters and make the Oid counter observations hardcoded in the answer file
 # incorrect.

--- a/src/test/regress/input/temp_relation.source
+++ b/src/test/regress/input/temp_relation.source
@@ -1,0 +1,56 @@
+CREATE SCHEMA temp_relation;
+SET search_path TO temp_relation;
+
+-- Functions to assert physical existence of a temp relfilenode
+CREATE FUNCTION temp_relfilenode_master(rel text) RETURNS TABLE(gp_segment_id int)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  WITH
+  rel_relfilenodename AS
+    (SELECT 't_' || relfilenode AS relfilenodename FROM pg_class WHERE relname=rel),
+  db_relfilenodenames AS
+    (SELECT pg_ls_dir('./base/' || t.dboid || '/') AS relfilenodename
+      FROM (SELECT oid AS dboid FROM pg_database WHERE datname = 'regression') t)
+  SELECT gp_execution_segment()
+    FROM rel_relfilenodename r, db_relfilenodenames d
+    WHERE r.relfilenodename = d.relfilenodename;
+  $fn$
+EXECUTE ON MASTER;
+
+CREATE FUNCTION temp_relfilenode_segments(rel text) RETURNS TABLE(gp_segment_id int)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  WITH
+  rel_relfilenodename AS
+    (SELECT 't_' || relfilenode AS relfilenodename FROM pg_class WHERE relname=rel),
+  db_relfilenodenames AS
+    (SELECT pg_ls_dir('./base/' || t.dboid || '/') AS relfilenodename
+      FROM (SELECT oid AS dboid FROM pg_database WHERE datname = 'regression') t)
+  SELECT gp_execution_segment()
+    FROM rel_relfilenodename r, db_relfilenodenames d
+    WHERE r.relfilenodename = d.relfilenodename;
+  $fn$
+EXECUTE ON ALL SEGMENTS;
+
+CREATE FUNCTION temp_relfilenode_primaries(rel text) RETURNS TABLE(gp_segment_id int)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  SELECT temp_relfilenode_master(rel) AS segno
+  UNION
+  SELECT temp_relfilenode_segments(rel) AS segno
+  ORDER BY segno;
+  $fn$;
+
+-- When we create a temporary table
+CREATE TEMPORARY TABLE temp_table(i int);
+
+-- The table's relfilenode physically exists on the master and the segment primaries
+SELECT temp_relfilenode_primaries('temp_table');
+
+-- Then after we drop the same table
+
+DROP TABLE temp_table;
+
+-- The table's relfilenode is cleaned up on the master and the segment primaries
+SELECT temp_relfilenode_primaries('temp_table');
+DROP SCHEMA temp_relation CASCADE;

--- a/src/test/regress/output/temp_relation.source
+++ b/src/test/regress/output/temp_relation.source
@@ -1,0 +1,66 @@
+CREATE SCHEMA temp_relation;
+SET search_path TO temp_relation;
+-- Functions to assert physical existence of a temp relfilenode
+CREATE FUNCTION temp_relfilenode_master(rel text) RETURNS TABLE(gp_segment_id int)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  WITH
+  rel_relfilenodename AS
+    (SELECT 't_' || relfilenode AS relfilenodename FROM pg_class WHERE relname=rel),
+  db_relfilenodenames AS
+    (SELECT pg_ls_dir('./base/' || t.dboid || '/') AS relfilenodename
+      FROM (SELECT oid AS dboid FROM pg_database WHERE datname = 'regression') t)
+  SELECT gp_execution_segment()
+    FROM rel_relfilenodename r, db_relfilenodenames d
+    WHERE r.relfilenodename = d.relfilenodename;
+  $fn$
+EXECUTE ON MASTER;
+CREATE FUNCTION temp_relfilenode_segments(rel text) RETURNS TABLE(gp_segment_id int)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  WITH
+  rel_relfilenodename AS
+    (SELECT 't_' || relfilenode AS relfilenodename FROM pg_class WHERE relname=rel),
+  db_relfilenodenames AS
+    (SELECT pg_ls_dir('./base/' || t.dboid || '/') AS relfilenodename
+      FROM (SELECT oid AS dboid FROM pg_database WHERE datname = 'regression') t)
+  SELECT gp_execution_segment()
+    FROM rel_relfilenodename r, db_relfilenodenames d
+    WHERE r.relfilenodename = d.relfilenodename;
+  $fn$
+EXECUTE ON ALL SEGMENTS;
+CREATE FUNCTION temp_relfilenode_primaries(rel text) RETURNS TABLE(gp_segment_id int)
+STRICT STABLE LANGUAGE SQL AS
+  $fn$
+  SELECT temp_relfilenode_master(rel) AS segno
+  UNION
+  SELECT temp_relfilenode_segments(rel) AS segno
+  ORDER BY segno;
+  $fn$;
+-- When we create a temporary table
+CREATE TEMPORARY TABLE temp_table(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- The table's relfilenode physically exists on the master and the segment primaries
+SELECT temp_relfilenode_primaries('temp_table');
+ temp_relfilenode_primaries 
+----------------------------
+                         -1
+                          0
+                          1
+                          2
+(4 rows)
+
+-- Then after we drop the same table
+DROP TABLE temp_table;
+-- The table's relfilenode is cleaned up on the master and the segment primaries
+SELECT temp_relfilenode_primaries('temp_table');
+ temp_relfilenode_primaries 
+----------------------------
+(0 rows)
+
+DROP SCHEMA temp_relation CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to function temp_relfilenode_master(text)
+drop cascades to function temp_relfilenode_segments(text)
+drop cascades to function temp_relfilenode_primaries(text)


### PR DESCRIPTION
This fixes issue:#7922. For a DROP on a relation, after the COMMIT
PREPARED record is written on the QE, we remove the relation file from
disk (call to DropRelationFiles() inside FinishPreparedTransaction()).
While doing so, we need to know whether the relation is a temp relation
such that the file deletion code can prepend the 't_' prefix to the
relfilenode name.  Apart from the case above, whenever we have code
dropping temporary relation files as a part of the 2PC mechanism, we
have to ensure that we have enough information to construct the correct
filesystem path to the temp relation's relfilenode.

This commit ensures that we persist a flag specifying whether a relation
is temporary through the 2PC infrastructure, in order to access it while
performing the file removal inside DropRelationFiles.
