### PR TITLE
Fix the race in commit_blocking_on_standby test properly

### DIFF
--- a/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
@@ -21,6 +21,10 @@ select gp_inject_fault_infinite2('walrecv_skip_flush', 'skip', dbid, hostname, p
  Success:                  
 (1 row)
 
+-- Generate some WAL to trigger the fault
+checkpoint;
+CHECKPOINT
+
 select gp_wait_until_triggered_fault2('walrecv_skip_flush', 1, dbid, hostname, port) from gp_segment_configuration where content=-1 and role='m';
  gp_wait_until_triggered_fault2 
 --------------------------------
@@ -31,7 +35,11 @@ select gp_wait_until_triggered_fault2('walrecv_skip_flush', 1, dbid, hostname, p
 -- LSN to be flushed on standby.
 1&: create table commit_blocking_on_standby_t1 (a int) distributed by (a);  <waiting ...>
 
--- The create table command should be seen as blocked.
+-- The create table command should be seen as blocked.  Wait until
+-- that happens.
+do $$ declare c int; /* in func */ i int; /* in func */ begin c := 0; /* in func */ i := 0; /* in func */ while c < 1 and i < 120 loop select count(*) into c from pg_stat_activity where waiting_reason = 'replication'; /* in func */ perform pg_sleep(0.5); /* in func */ end loop; /* in func */ if i = 120 then raise exception 'timeout waiting for command to get blocked'; /* in func */ end if; /* in func */ end; /* in func */ $$;
+DO
+
 select datname, waiting_reason, query from pg_stat_activity where waiting_reason = 'replication';
  datname        | waiting_reason | query                                                                  
 ----------------+----------------+------------------------------------------------------------------------


### PR DESCRIPTION
The test injects a skip fault on standby and then starts a create table command in background.  The create table command is expected to block due to the fault.  The test used to run the create table command before waiting for the fault to be triggered.  Sometimes, the command was found to complete without blocking if it reached faster than the previously started fault injection command.

Make the test deterministic by ensuring that the skip fault is triggered on standby and only then start the create table command. Introduce wait loop until the create table command is shown as waiting
in pg_stat_activity.

Commit 7be7e1b3e9cc tried to fix this hastily.  This patch should fix it properly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
