### PR TITLE
Improve select statement with locking clause

### DIFF
--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -647,6 +647,7 @@ ExecSquelchNode(PlanState *node)
 		case T_BitmapOrState:
 		case T_DynamicBitmapHeapScanState:
 		case T_LimitState:
+		case T_LockRowsState:
 		case T_NestLoopState:
 		case T_MergeJoinState:
 		case T_RepeatState:

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3815,13 +3815,6 @@ checkCanOptSelectLockingClause(SelectStmt *stmt)
 	if (!IsA(linitial(stmt->fromClause), RangeVar))
 		return false;
 
-	/*
-	 * In Greenplum, the results of limit can only be known on QD,
-	 * so we cannot lock correct tuples on QEs.
-	 */
-	if (stmt->limitCount != NULL || stmt->limitOffset != NULL)
-		return false;
-
 	if (!stmt->lockingClause)
 		return false;
 

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -1784,17 +1784,18 @@ ABORT
 1: begin;
 BEGIN
 1: explain select * from t_lockmods order by c limit 1 for update;
- QUERY PLAN                                                                        
------------------------------------------------------------------------------------
- Limit  (cost=2.07..2.10 rows=1 width=10)                                          
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.07..2.10 rows=1 width=10) 
-         Merge Key: c                                                              
-         ->  Limit  (cost=2.07..2.08 rows=1 width=10)                              
-               ->  Sort  (cost=2.07..2.09 rows=2 width=10)                         
-                     Sort Key: c                                                   
-                     ->  Seq Scan on t_lockmods  (cost=0.00..2.05 rows=2 width=10) 
- Optimizer: Postgres query optimizer                                               
-(8 rows)
+ QUERY PLAN                                                                              
+-----------------------------------------------------------------------------------------
+ Limit  (cost=3.07..3.11 rows=1 width=10)                                                
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=3.07..3.11 rows=1 width=10)       
+         Merge Key: c                                                                    
+         ->  Limit  (cost=3.07..3.09 rows=1 width=10)                                    
+               ->  LockRows  (cost=3.07..3.14 rows=2 width=10)                           
+                     ->  Sort  (cost=3.07..3.09 rows=2 width=10)                         
+                           Sort Key: c                                                   
+                           ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10) 
+ Optimizer: Postgres query optimizer                                                     
+(9 rows)
 1: select * from t_lockmods order by c limit 1 for update;
  c 
 ---
@@ -1804,7 +1805,7 @@ BEGIN
  locktype | mode            | granted | relation   
 ----------+-----------------+---------+------------
  relation | AccessShareLock | t       | t_lockmods 
- relation | ExclusiveLock   | t       | t_lockmods 
+ relation | RowShareLock    | t       | t_lockmods 
 (2 rows)
 1: abort;
 ABORT
@@ -1838,12 +1839,12 @@ BEGIN
 1: explain select * from t_lockmods order by c for update;
  QUERY PLAN                                                                  
 -----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.16..2.17 rows=5 width=10) 
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.11..3.17 rows=5 width=10) 
    Merge Key: c                                                              
-   ->  Sort  (cost=2.16..2.17 rows=2 width=10)                               
-         Sort Key: c                                                         
-         ->  LockRows  (cost=0.00..2.10 rows=2 width=10)                     
-               ->  Seq Scan on t_lockmods  (cost=0.00..2.05 rows=2 width=10) 
+   ->  LockRows  (cost=3.11..3.17 rows=2 width=10)                           
+         ->  Sort  (cost=3.11..3.12 rows=2 width=10)                         
+               Sort Key: c                                                   
+               ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10) 
  Optimizer: Postgres query optimizer                                         
 (7 rows)
 1: select * from t_lockmods order by c for update;


### PR DESCRIPTION
With GDD enabled, and under some simple cases (refer
the commit 6ebce73 and the function checkCanOptSelectLockingClause
for details), we might also do some optimizations for the
select statement with locking clause and limit clause.

Greenplum generates two-stage-merge sort or limit plan to implement
sort or limit and we can only lock tuples on segments. We prefer
locking more tuples on segments rather than locking the whole table.
Without the whole table lock, performance for OLTP should be improved.

Also, after lockrows data cannot be assumed in order, but we do merge
gather after lockrows. It is reasonable because even for postgres:
`select * from t order by c for update` cannot guarantee result's order.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
