### PR TITLE
docs - resgroup MEMORY_LIMIT=0, MEMORY_SPILL_RATIO fallback

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -150,13 +150,13 @@
             </row>
             <row>
               <entry colname="col1">MEMORY_LIMIT</entry>
-              <entry colname="col2">The percentage of memory resources available to this resource
-                group.</entry>
+              <entry colname="col2">The percentage of reserved memory resources available to
+                this resource group.</entry>
             </row>
             <row>
               <entry colname="col1">MEMORY_SHARED_QUOTA</entry>
-              <entry colname="col2">The percentage of memory to share across transactions submitted
-                in this resource group.</entry>
+              <entry colname="col2">The percentage of reserved memory to share across transactions
+                submitted in this resource group.</entry>
             </row>
             <row>
               <entry colname="col1">MEMORY_SPILL_RATIO</entry>
@@ -380,17 +380,22 @@
         <codeblock>
 rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments</codeblock>
       </p>
-      <p>Each resource group reserves a percentage of the segment memory for resource management.
+      <p>Each resource group may reserve a percentage of the segment memory for resource management.
         You identify this percentage via the <codeph>MEMORY_LIMIT</codeph> value that you specify
         when you create the resource group. The minimum <codeph>MEMORY_LIMIT</codeph> percentage you
-        can specify for a resource group is 1, the maximum is 100.</p>
+        can specify for a resource group is 0, the maximum is 100. When <codeph>MEMORY_LIMIT</codeph>
+        is 0, Greenplum Database reserves no memory for the resource group, but uses resource
+        group global shared memory to fulfill all memory requests in the group. Refer to
+        <xref href="#topic833glob" type="topic" format="dita"/>
+        for more information about resource group global shared memory.</p>
       <p>The sum of <codeph>MEMORY_LIMIT</codeph>s specified for all resource groups that you define
         in your Greenplum Database cluster must not exceed 100.</p>
     </body>
     <topic id="mem_roles" xml:lang="en">
       <title>Additional Memory Limits for Role-based Resource Groups</title>
       <body>
-        <p>The memory reserved by a resource group for roles is further divided into fixed and
+        <p>If resource group memory is reserved for roles (non-zero
+          <codeph>MEMORY_LIMIT</codeph>), the memory is further divided into fixed and
           shared components. The <codeph>MEMORY_SHARED_QUOTA</codeph> value that you specify when
           you create the resource group identifies the percentage of reserved resource group memory
           that may be shared among the currently running transactions. This memory is allotted on a
@@ -399,9 +404,10 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
         <p>The minimum <codeph>MEMORY_SHARED_QUOTA</codeph> that you can specify is 0, the maximum
           is 100. The default <codeph>MEMORY_SHARED_QUOTA</codeph> is 20.</p>
         <p>As mentioned previously, <codeph>CONCURRENCY</codeph> identifies the maximum number of
-          concurrently running transactions permitted in a resource group for roles. The fixed
-          memory reserved by a resource group is divided into <codeph>CONCURRENCY</codeph> number of
-          transaction slots. Each slot is allocated a fixed, equal amount of resource group memory.
+          concurrently running transactions permitted in a resource group for roles. If fixed
+          memory is reserved by a resource group (non-zero <codeph>MEMORY_LIMIT</codeph>), 
+          it is divided into <codeph>CONCURRENCY</codeph> number of
+          transaction slots. Each slot is allocated a fixed, equal amount of the resource group memory.
           Greenplum Database guarantees this fixed memory to each transaction. <fig
             id="fig_py5_1sl_wlrg">
             <title>Resource Group Memory Allotments</title>
@@ -425,7 +431,7 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
           <p>Resource group global shared memory is available only to resource groups that you
             configure with the <codeph>vmtracker</codeph> memory auditor.</p>
           <p>When available, Greenplum Database allocates global shared memory to a transaction
-            after first allocating slot and resource group shared memory. Greenplum Database
+            after first allocating slot and resource group shared memory (if applicable). Greenplum Database
             allocates resource group global shared memory to transactions on a first-come
             first-served basis.</p>
           <note>Greenplum Database tracks, but does not actively monitor, transaction memory usage
@@ -466,23 +472,55 @@ rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_
             transaction spills to disk. Greenplum Database uses the
               <codeph>MEMORY_SPILL_RATIO</codeph> to determine the initial memory to allocate to a
             transaction.</p>
-          <p> The minimum <codeph>MEMORY_SPILL_RATIO</codeph> percentage that you can specify for a
-            resource group is 0. The maximum is 100. The default <codeph>MEMORY_SPILL_RATIO</codeph>
-            is 20.</p>
-          <p>You define the <codeph>MEMORY_SPILL_RATIO</codeph> when you create a resource group for
-            roles. You can selectively set this limit on a per-query basis at the session level with
+          <p>You can specify an integer percentage value from 0 to 100 inclusive for
+            <codeph>MEMORY_SPILL_RATIO</codeph>. The default <codeph>MEMORY_SPILL_RATIO</codeph>
+           is 20.</p>
+          <p>When <codeph>MEMORY_SPILL_RATIO</codeph> is 0, Greenplum Database uses the
+            <xref href="../ref_guide/config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+            server configuration parameter value to control initial query operator memory.</p>
+          <note>When you set <codeph>MEMORY_LIMIT</codeph> to 0,
+            <codeph>MEMORY_SPILL_RATIO</codeph> must also be set to 0.</note>
+          <p>You can selectively set the <codeph>MEMORY_SPILL_RATIO</codeph> on a per-query
+            basis at the session level with
             the <codeph><xref href="../ref_guide/config_params/guc-list.xml#memory_spill_ratio"
                 type="topic"/></codeph> server configuration parameter.</p>
           <section id="topic833low" xml:lang="en">
             <title>memory_spill_ratio and Low Memory Queries </title>
-            <p>A low <codeph>memory_spill_ratio</codeph> setting (for example, in the 0-2% range)
+            <p>A low <codeph>statement_mem</codeph> setting (for example, in the 10MB range)
               has been shown to increase the performance of queries with low memory requirements.
-              Use the <codeph>memory_spill_ratio</codeph> server configuration parameter to override
-              the setting on a per-query basis. For example:
-              <codeblock>SET memory_spill_ratio=0;</codeblock></p>
+              Use the <codeph>memory_spill_ratio</codeph> and <codeph>statement_mem</codeph>
+              server configuration parameters to override the setting on a per-query basis.
+              For example:
+              <codeblock>SET memory_spill_ratio=0;
+SET statement_mem='10 MB';</codeblock></p>
           </section>
         </body>
       </topic>
+    </topic>
+    <topic id="topic833fvs" xml:lang="en">
+      <title>About Using Reserved Resource Group Memory vs. Using Resource Group Global Shared Memory</title>
+      <body>
+        <p>When you do not reserve memory for a resource group (<codeph>MEMORY_LIMIT</codeph>
+          and <codeph>MEMORY_SPILL_RATIO</codeph> are set to 0):</p><ul>
+          <li>It increases the size of the resource group global shared memory pool.</li>
+          <li>The resource group functions similarly to a resource queue, using the
+            <xref href="../ref_guide/config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+            server configuration parameter value to control initial query operator memory.</li>
+          <li>Any query submitted in the resource group competes for resource group global
+            shared memory on a first-come, first-served basis with queries running in other
+            groups.</li>
+          <li>There is no guarantee that Greenplum Database will be able to allocate memory
+            for a query running in the resource group. The risk of a query in the group
+            encountering an out of memory (OOM) condition increases when there are many
+            concurrent queries consuming memory from the resource group global shared
+            memory pool at the same time.</li>
+        </ul>
+        <p>To reduce the risk of OOM for a query running in an important resource group,
+          consider reserving some fixed memory for the group. While reserving fixed memory
+          for a group reduces the size of the resource group global shared memory pool,
+          this may be a fair tradeoff to reduce the risk of encountering an OOM condition
+          in a query running in a critical resource group.</p>
+      </body>
     </topic>
     <topic id="topic833cons" xml:lang="en">
       <title>Other Memory Considerations</title>
@@ -756,7 +794,11 @@ gpstart
       <p id="iz152723">When you create a resource group for a role, you must provide
           <codeph>CPU_RATE_LIMIT</codeph> or <codeph>CPUSET</codeph> and
           <codeph>MEMORY_LIMIT</codeph> limit values. These limits identify the percentage of
-        Greenplum Database resources to allocate to this resource group. For example, to create a
+        Greenplum Database resources to allocate to this resource group. You specify a
+         <codeph>MEMORY_LIMIT</codeph> to reserve a fixed amount of memory for the resource
+         group. If you specify a <codeph>MEMORY_LIMIT</codeph> of 0, Greenplum Database
+         uses global shared memory to fulfill all memory requirements for the resource group.</p>
+      <p>For example, to create a
         resource group named <i>rgroup1</i> with a CPU limit of 20 and a memory limit of 25:</p>
       <p>
         <codeblock>=# CREATE RESOURCE GROUP <i>rgroup1</i> WITH (CPU_RATE_LIMIT=20, MEMORY_LIMIT=25);

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -69,6 +69,25 @@
             Compressing spill files may help to avoid overloading the disk subsystem with IO
             operations. </p>
         </li>
+        <li>
+          <p>
+            <b>memory_spill_ratio</b>
+          </p>
+          <p>Set <codeph>memory_spill_ratio</codeph> to increase or decrease the amount
+            of query operator memory Greenplum Database allots to a query. When <codeph>memory_spill_ratio</codeph>
+            is larger than 0, it represents the percentage of resource group memory to
+            allot to query operators. If concurrency is high, this memory amount may be small
+            even when <codeph>memory_spill_ratio</codeph> is set to the max value of 100.
+            When you set <codeph>memory_spill_ratio</codeph> to 0, Greenplum Database uses
+            the <codeph>statement_mem</codeph> setting to determine the initial amount of
+            query operator memory to allot.</p>
+        </li>
+        <li>
+          <b>statement_mem</b>
+          <p>When <codeph>memory_spill_ratio</codeph> is 0, Greenplum Database uses the
+            <codeph>statement_mem</codeph> setting to determine the amount of memory
+            to allocate to a query.</p>
+        </li>
       </ul>
       <p>Other considerations:</p>
       <ul id="ul_xv2_phn_2z">
@@ -96,7 +115,7 @@
         <li>Use the <codeph>CONCURRENCY</codeph> resource group parameter to limit the
             number of active queries that members of a particular resource group can run
             concurrently.</li>
-        <li>Use the <codeph>MEMORY_LIMIT</codeph> and <codeph>MEMORY_SHARED_QUOTA</codeph>
+        <li>Use the <codeph>MEMORY_LIMIT</codeph> and <codeph>MEMORY_SPILL_RATIO</codeph>
             parameters to control the maximum amount of memory that queries running in the
            resource group can consume.</li>
         <li>Greenplum Database assigns unreserved memory (100 - (sum of all resource
@@ -113,11 +132,13 @@
     </section>
     <section id="section113x" xml:lang="en">
       <title>Low Memory Queries</title>
-      <p>A low <codeph>memory_spill_ratio</codeph> setting (for example, in the 0-2% range)
+      <p>A low <codeph>statement_mem</codeph> setting (for example, in the 10MB range)
         has been shown to increase the performance of queries with low memory requirements.
-        Use the <codeph>memory_spill_ratio</codeph> server configuration parameter to override
-        the setting on a per-query basis. For example:
-        <codeblock>SET memory_spill_ratio=0;</codeblock></p>
+        Use the <codeph>memory_spill_ratio</codeph> and <codeph>statement_mem</codeph>
+        server configuration parameter to override the setting on a per-query basis.
+        For example:
+        <codeblock>SET memory_spill_ratio=0;
+SET statement_mem='10 MB';</codeblock></p>
     </section>
     <section id="section177x" xml:lang="en">
       <title>Administrative Utilities and admin_group Concurrency</title>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -7493,15 +7493,12 @@
   <topic id="max_statement_mem">
     <title>max_statement_mem</title>
     <body>
-      <note>The <codeph>max_statement_mem</codeph> server configuration parameter is enforced only
-        when resource queue-based resource management is active.</note>
       <p>Sets the maximum memory limit for a query. Helps avoid out-of-memory errors on a segment
         host during query processing as a result of setting <codeph><xref href="#statement_mem"
             format="dita"/>
-        </codeph>too high. When <codeph><xref href="#gp_resqueue_memory_policy" format="dita"
-          />=auto</codeph>, <codeph>statement_mem</codeph> and resource queue memory limits control
-        query memory usage. Taking into account the configuration of a single segment host,
-        calculate this setting as follows:</p>
+        </codeph>too high.</p>
+      <p>Taking into account the configuration of a single segment host,
+        calculate <codeph>max_statement_mem</codeph> as follows:</p>
       <p>
         <codeph>(seghost_physical_memory) / (average_number_concurrent_queries)</codeph>
       </p>
@@ -7546,6 +7543,11 @@
         increase the initial memory allocation.</p>
       <p>When you set <codeph>memory_spill_ratio</codeph> at the session level, Greenplum Database
         does not perform semantic validation on the new value until you next perform a query.</p>
+      <p>You can specify an integer percentage value from 0 to 100 inclusive. If you
+        specify a value of 0, Greenplum Database uses the
+            <xref href="#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+        server configuration parameter value to control the initial query operator memory
+        amount.</p>
       <table id="memory_spill_ratio_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -9218,23 +9220,33 @@
   <topic id="statement_mem">
     <title>statement_mem</title>
     <body>
-      <note>The <codeph>statement_mem</codeph> server configuration parameter is enforced only when
-        resource queue-based resource management is active.</note>
       <p>Allocates segment host memory per query. The amount of memory allocated with this parameter
         cannot exceed <codeph><xref href="#max_statement_mem" format="dita"/></codeph> or the memory
-        limit on the resource queue through which the query was submitted. When <codeph><xref
+        limit on the resource queue or resource group through which the query was submitted.
+        If additional memory is required for a query, temporary spill files on disk are used.</p>
+      <p><i>If you are using resource groups to control resource allocation in your Greenplum
+        Database cluster</i>:</p><ul>
+        <li>Greenplum Database uses <codeph>statement_mem</codeph> to control query memory
+          usage when the resource group <codeph>MEMORY_SPILL_RATIO</codeph> is set to 0.</li>
+        <li>You can use the following calculation to estimate a reasonable <codeph>statement_mem</codeph>
+          value:
+          <codeblock>rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments
+statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
+      </ul>
+      <p><i>If you are using resource queues to control resource allocation in your Greenplum
+        Database cluster</i>:</p><ul>
+        <li>When <codeph><xref
             href="#gp_resqueue_memory_policy" format="dita"/> =auto</codeph>,
           <codeph>statement_mem</codeph> and resource queue memory limits control query memory
-        usage. </p>
-      <p>If additional memory is required for a query, temporary spill files on disk are used.</p>
-      <p>This calculation can be used to estimate a reasonable value for a wide variety of
-        situations.</p>
-      <codeblock>( <varname>gp_vmem_protect_limit</varname>GB * .9 ) / <varname>max_expected_concurrent_queries</varname></codeblock>
-      <p>With the <varname>gp_vmem_protect_limit</varname> set to 8192MB (8GB) and assuming a
-        maximum of 40 concurrent queries with a 10% buffer </p>
-      <p>
-        <codeblock>(8GB * .9) / 40 = .18GB = 184MB</codeblock>
-      </p>
+        usage. </li>
+        <li>You can use the following calculation to estimate a reasonable
+          <codeph>statement_mem</codeph> value for a wide variety of situations:
+          <codeblock>( <varname>gp_vmem_protect_limit</varname>GB * .9 ) / <varname>max_expected_concurrent_queries</varname></codeblock>
+          <p>For example, with a <varname>gp_vmem_protect_limit</varname> set to 8192MB (8GB)
+            and assuming a maximum of 40 concurrent queries with a 10% buffer, you would use
+            the following calculation to determine the <codeph>statement_mem</codeph> value:</p>
+          <codeblock>(8GB * .9) / 40 = .18GB = 184MB</codeblock></li>
+      </ul>
       <p>When changing both <codeph>max_statement_mem</codeph> and <codeph>statement_mem</codeph>,
           <codeph>max_statement_mem</codeph> must be changed first, or listed first in the
           <systemoutput>postgresql.conf</systemoutput> file.</p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -9230,7 +9230,7 @@
           usage when the resource group <codeph>MEMORY_SPILL_RATIO</codeph> is set to 0.</li>
         <li>You can use the following calculation to estimate a reasonable <codeph>statement_mem</codeph>
           value:
-          <codeblock>rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments
+          <codeblock>rg_perseg_mem = ((RAM * (vm.overcommit_ratio / 100) + SWAP) * gp_resource_group_memory_limit) / num_active_primary_segments_per_host
 statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
       </ul>
       <p><i>If you are using resource queues to control resource allocation in your Greenplum

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1249,7 +1249,13 @@
                 >gp_vmem_protect_segworker_cache_limit</xref>
             </p>
             <p>
+              <xref href="guc-list.xml#max_statement_mem" type="section">max_statement_mem</xref>
+            </p>
+            <p>
               <xref href="guc-list.xml#memory_spill_ratio" type="section">memory_spill_ratio</xref>
+            </p>
+            <p>
+              <xref href="guc-list.xml#statement_mem" type="section">statement_mem</xref>
             </p>
             <p><xref href="guc-list.xml#vmem_process_interrupt" type="section"
                 >vmem_process_interrupt</xref></p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.xml
@@ -10,8 +10,8 @@
       <codeblock id="sql_command_synopsis">ALTER RESOURCE GROUP <varname>name</varname> SET <varname>group_attribute</varname> <varname>value</varname></codeblock>
 <p>where <varname>group_attribute</varname> is one of:</p>
       <codeblock>CONCURRENCY <varname>integer</varname>
-CPU_RATE_LIMIT <varname>integer</varname>
-CPUSET <varname>tuple</varname>
+CPU_RATE_LIMIT <varname>integer</varname> 
+CPUSET <varname>tuple</varname> 
 MEMORY_LIMIT <varname>integer</varname>
 MEMORY_SHARED_QUOTA <varname>integer</varname>
 MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
@@ -67,11 +67,18 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
         </plentry>
         <plentry>
           <pt>MEMORY_LIMIT <varname>integer</varname></pt>
-          <pd>The percentage of memory resources to allocate to
-            this resource group. The minimum memory percentage for a resource group is 1.
-            The maximum is 100. The sum of the
+          <pd>The percentage of Greenplum Database memory resources to reserve for 
+            this resource group. The minimum memory percentage for a resource group is 0.
+            The maximum is 100.</pd>
+          <pd>When <codeph>MEMORY_LIMIT</codeph> is 0, Greenplum Database reserves no
+            memory for the resource group, but uses global shared memory to fulfill all
+            memory requests in the group. If <codeph>MEMORY_LIMIT</codeph> is 0,
+            <codeph>MEMORY_SPILL_RATIO</codeph> must also be 0.</pd>
+          <pd>The sum of the
             <codeph>MEMORY_LIMIT</codeph>s of all resource groups defined in the
-            Greenplum Database cluster must not exceed 100.</pd>
+            Greenplum Database cluster must not exceed 100. If this sum is less
+            than 100, Greenplum Database allocates any unreserved memory to a resource
+            group global shared memory pool.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>
@@ -82,10 +89,12 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
         </plentry>
         <plentry>
           <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>
-          <pd>The memory usage threshold for memory-intensive operators in a transaction
-            issued in the resource group. The minimum memory spill ratio percentage for a
-            resource group is 0. The maximum is 100. The default
-            <codeph>MEMORY_SPILL_RATIO</codeph> value is 20.</pd>
+          <pd>The memory usage threshold for memory-intensive operators in a transaction.
+            You can specify an integer percentage value from 0 to 100 inclusive. The default
+            <codeph>MEMORY_SPILL_RATIO</codeph> value is 20. When <codeph>MEMORY_SPILL_RATIO</codeph>
+            is 0, Greenplum Database uses the
+            <xref href="../config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+            server configuration parameter value to control initial query operator memory.</pd>
         </plentry>
       </parml>
     </section>
@@ -104,7 +113,7 @@ MEMORY_SPILL_RATIO <varname>integer</varname></codeblock>
       <codeblock>ALTER RESOURCE GROUP rgroup2 SET CPU_RATE_LIMIT 45;</codeblock>
       <p>Update the memory limit for a resource group: </p>
       <codeblock>ALTER RESOURCE GROUP rgroup3 SET MEMORY_LIMIT 30;</codeblock>
-      <p>Increase the memory spill ratio for a resource group from the default: </p>
+      <p>Update the memory spill ratio for a resource group: </p>
       <codeblock>ALTER RESOURCE GROUP rgroup4 SET MEMORY_SPILL_RATIO 25;</codeblock>
       <p>Reserve CPU core 1 for a resource group: </p>
       <codeblock>ALTER RESOURCE GROUP rgroup5 SET CPUSET '1';</codeblock>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.xml
@@ -63,7 +63,14 @@ MEMORY_LIMIT=<varname>integer</varname>
         </plentry>
         <plentry>
           <pt>MEMORY_LIMIT <varname>integer</varname></pt>
-          <pd>Required. The total percentage of Greenplum Database memory resources to allocate to this resource group. The minimum memory percentage you can specify for a resource group is 1. The maximum is 100. The sum of the <codeph>MEMORY_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.</pd>
+          <pd>Required. The total percentage of Greenplum Database memory resources to reserve for this
+            resource group. The minimum memory percentage you can specify for a resource
+            group is 0. The maximum is 100.</pd>
+          <pd>When you specify a <codeph>MEMORY_LIMIT</codeph> of 0, Greenplum Database
+            reserves no memory for the resource group, but uses global shared memory to
+            fulfill all memory requests in the group. If <codeph>MEMORY_LIMIT</codeph> is 0,
+           <codeph>MEMORY_SPILL_RATIO</codeph> must also be 0.</pd>
+          <pd>The sum of the <codeph>MEMORY_LIMIT</codeph> values specified for all resource groups defined in the Greenplum Database cluster must be less than or equal to 100.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_SHARED_QUOTA <varname>integer</varname></pt>
@@ -71,7 +78,13 @@ MEMORY_LIMIT=<varname>integer</varname>
         </plentry>
         <plentry>
           <pt>MEMORY_SPILL_RATIO <varname>integer</varname></pt>
-          <pd>The memory usage threshold for memory-intensive operators in a transaction. When this threshold is reached, a transaction spills to disk. The minimum memory spill ratio percentage you can specify for a resource group is 0. The maximum is 100. The default <codeph>MEMORY_SPILL_RATIO</codeph> value is 20.</pd>
+          <pd>The memory usage threshold for memory-intensive operators in a transaction.
+            When this threshold is reached, a transaction spills to disk. You can specify
+            an integer percentage value  from 0 to 100 inclusive. The default
+            <codeph>MEMORY_SPILL_RATIO</codeph> value is 20. When <codeph>MEMORY_SPILL_RATIO</codeph>
+            is 0, Greenplum Database uses the
+            <xref href="../config_params/guc-list.xml#statement_mem" format="dita"><codeph>statement_mem</codeph></xref>
+            server configuration parameter value to control initial query operator memory.</pd>
         </plentry>
         <plentry>
           <pt>MEMORY_AUDITOR {vmtracker | cgroup}</pt>


### PR DESCRIPTION
backport the relevant changes for resource group statement_mem fallback to 5X_STABLE.

questions:
1.  did any of the default limit settings for admin_group and default_group change?
2.  MEMORY_LIMIT is still required, right?