### PR TITLE
gpsegstart: remove incorrect SegmentStart parameter

### DIFF
--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -261,7 +261,6 @@ class GpSegStart:
                                   self.num_cids,
                                   self.era,
                                   self.mirroringMode,
-                                  self.master_checksum_version,
                                   timeout=self.timeout,
                                   specialMode=self.specialMode,
                                   wrapper=self.wrapper,


### PR DESCRIPTION
Commit a993ef03c inadvertently introduced `gp_role=utility` in the postmaster arguments when starting segments via gpsegstart. This is because the sixth argument to SegmentStart is a boolean (`utilityMode`, which defaults to `False`) but that commit incorrectly passes the `master_checksum_version` instead. If checksums are enabled on master (which sets the checksum version to 1, a truthy value), this code will enable utility mode for the started segments.

SegmentStart does not take a checksum version argument, so remove it entirely.

Ashwin noticed this in #6334, but we hadn't put two and two together until now. An ideal followup would be to remove the huge number of layers that make mistakes like this so easy to miss.

## Checklist
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
