### PR TITLE
postinit: refuse dispatch-mode connections to QEs

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -119,6 +119,24 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the backup pid file is deleted on "primary" segment
 
+    Scenario: pg_isready functions on recovered segments
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+         When user stops all primary processes
+          And user can start transactions
+
+         When the user runs "gprecoverseg -a"
+         Then gprecoverseg should return a return code of 0
+          And the segments are synchronized
+
+         When the user runs "gprecoverseg -ar"
+         Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized
+          And pg_isready reports all primaries are accepting connections
+
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -118,3 +118,10 @@ def impl(context, output):
         if segment.isSegmentMirror():
             expected = r'\(dbid {}\): {}'.format(segment.dbid, output)
             check_stdout_msg(context, expected)
+
+@then('pg_isready reports all primaries are accepting connections')
+def impl(context):
+    gparray = GpArray.initFromCatalog(dbconn.DbURL())
+    primary_segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary()]
+    for seg in primary_segs:
+        subprocess.check_call(['pg_isready', '-h', seg.getSegmentHostName(), '-p', str(seg.getSegmentPort())])

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1125,6 +1125,14 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 				(errcode(ERRCODE_CANNOT_CONNECT_NOW),
 				 errmsg("System was started in master-only utility mode - only utility mode connections are allowed")));
 	}
+	else if ((Gp_session_role == GP_ROLE_DISPATCH) && !IS_QUERY_DISPATCHER())
+	{
+		ereport(FATAL,
+				(errcode(ERRCODE_CANNOT_CONNECT_NOW),
+				 errmsg("connections to primary segments are not allowed"),
+				 errdetail("This database instance is running as a primary segment in a Greenplum cluster and does not permit direct connections."),
+				 errhint("To force a connection anyway (dangerous!), use utility mode.")));
+	}
 
 	/* Process pg_db_role_setting options */
 	process_settings(MyDatabaseId, GetSessionUserId());

--- a/src/test/regress/expected/gp_connections.out
+++ b/src/test/regress/expected/gp_connections.out
@@ -1,3 +1,6 @@
+--
+-- GPDB internal connection tests
+--
 -- create a new user
 drop user if exists user_disallowed_via_local;
 create user user_disallowed_via_local with login;
@@ -34,3 +37,15 @@ select * from t1_of_user_disallowed_via_local, pg_sleep(0);
 
 -- cleanup settings if any
 \! sed -i '/user_disallowed_via_local/d' $MASTER_DATA_DIRECTORY/pg_hba.conf;
+--
+-- Segment connection tests
+--
+-- We should not be able to directly connect to a primary segment.
+SELECT port FROM gp_segment_configuration
+			WHERE content <> -1 AND role = 'p'
+			LIMIT 1
+\gset
+\connect - - - :port
+\connect: FATAL:  connections to primary segments are not allowed
+DETAIL:  This database instance is running as a primary segment in a Greenplum cluster and does not permit direct connections.
+HINT:  To force a connection anyway (dangerous!), use utility mode.

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -36,8 +36,8 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
 
-# test gpdb internal connection
-test: internal_connection
+# test gpdb internal and segment connections
+test: gp_connections
 
 # bitmap_index triggers recovery, run it seperately
 test: bitmap_index

--- a/src/test/regress/sql/gp_connections.sql
+++ b/src/test/regress/sql/gp_connections.sql
@@ -1,3 +1,7 @@
+--
+-- GPDB internal connection tests
+--
+
 -- create a new user
 drop user if exists user_disallowed_via_local;
 create user user_disallowed_via_local with login;
@@ -26,3 +30,17 @@ select * from t1_of_user_disallowed_via_local, pg_sleep(0);
 
 -- cleanup settings if any
 \! sed -i '/user_disallowed_via_local/d' $MASTER_DATA_DIRECTORY/pg_hba.conf;
+
+--
+-- Segment connection tests
+--
+
+-- We should not be able to directly connect to a primary segment.
+SELECT port FROM gp_segment_configuration
+			WHERE content <> -1 AND role = 'p'
+			LIMIT 1
+\gset
+\connect - - - :port
+
+-- DON'T PUT ANYTHING BELOW THIS TEST! It'll be ignored since the above \connect
+-- fails and exits the script. Add them above, instead.


### PR DESCRIPTION
Prior to this commit, standard connections made to a primary segment
would hang forever if that segment was not started in utility mode,
because the call to cdb_setup() waits for a state that will never
arrive. The hang exists in 6X as well, for slightly different reasons
(an infinite wait on a semaphore).

Some utilities make use of pg_isready to verify segment status, and a
hung backend will report an incorrect status for the segment, which is
how this bug was discovered. The hung backend sticks around forever in
startup state as well.

Add an explicit check on QE segments that the incoming session does not
expect a dispatcher role, and bail out at the same place that we would
normally complain about a mismatched utility-mode connection. (If the
incoming session is set to the executor role, we'll raise a FATAL for
other reasons, but at least we won't hang.)

Adding an explicit test for pg_isready proved tricky here, since the TAP
framework currently has no way to easily start a standalone QE. We opted
for a more end-to-end regression test using the same reproduction case
as the original bug.

Co-authored-by: Jacob Champion <pchampion@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
