### PR TITLE
 Fix small memory leak in partial-aggregate deserialization functions.

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -298,10 +298,12 @@ makeHashAggEntryForInput(AggState *aggstate, TupleTableSlot *inputslot, uint32 h
 	entry->next = NULL;
 
 	/*
-	 * Copy memtuple into group_buf. Remember to always allocate
-	 * enough space before calling ExecCopySlotMemTupleTo() because
-	 * this function will call palloc() to allocate bigger space if
-	 * the given one is not big enough, which is what we want to avoid.
+	 * Calculate the tup_len we need.
+	 *
+	 * Since *tup_len is 0 and inline_toast is false, the only thing
+	 * memtuple_form_to() does here is calculating the tup_len.
+	 *
+	 * The memtuple_form_to() next time does the actual memtuple copy.
 	 */
 	entry->tuple_and_aggs = (void *)memtuple_form_to(hashslot->tts_mt_bind,
 													 values,
@@ -331,6 +333,9 @@ makeHashAggEntryForInput(AggState *aggstate, TupleTableSlot *inputslot, uint32 h
 		}
 	}
 
+	/*
+	 * Form memtuple into group_buf.
+	 */
 	entry->tuple_and_aggs = mpool_alloc(hashtable->group_buf,
 										MAXALIGN(MAXALIGN(tup_len) + aggs_len));
 	len = tup_len;

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -2888,6 +2888,22 @@ makeNumericAggState(FunctionCallInfo fcinfo, bool calcSumX2)
 }
 
 /*
+ * Like makeNumericAggState(), but allocate the state in the current memory
+ * context.
+ */
+static NumericAggState *
+makeNumericAggStateCurrentContext(bool calcSumX2)
+{
+	NumericAggState *state;
+
+	state = (NumericAggState *) palloc0(sizeof(NumericAggState));
+	state->calcSumX2 = calcSumX2;
+	state->agg_context = CurrentMemoryContext;
+
+	return state;
+}
+
+/*
  * Accumulate a new input value for numeric aggregate functions.
  */
 static void
@@ -3085,7 +3101,7 @@ numeric_combine(PG_FUNCTION_ARGS)
 	{
 		old_context = MemoryContextSwitchTo(agg_context);
 
-		state1 = makeNumericAggState(fcinfo, true);
+		state1 = makeNumericAggStateCurrentContext(true);
 		state1->N = state2->N;
 		state1->NaNcount = state2->NaNcount;
 		state1->maxScale = state2->maxScale;
@@ -3176,7 +3192,7 @@ numeric_avg_combine(PG_FUNCTION_ARGS)
 	{
 		old_context = MemoryContextSwitchTo(agg_context);
 
-		state1 = makeNumericAggState(fcinfo, false);
+		state1 = makeNumericAggStateCurrentContext(false);
 		state1->N = state2->N;
 		state1->NaNcount = state2->NaNcount;
 		state1->maxScale = state2->maxScale;
@@ -3295,12 +3311,12 @@ numeric_avg_deserialize(PG_FUNCTION_ARGS)
 
 	/*
 	 * Copy the bytea into a StringInfo so that we can "receive" it using the
-	 * standard pq API.
+	 * standard recv-function infrastructure.
 	 */
 	initStringInfo(&buf);
 	appendBinaryStringInfo(&buf, VARDATA(sstate), VARSIZE(sstate) - VARHDRSZ);
 
-	result = makeNumericAggState(fcinfo, false);
+	result = makeNumericAggStateCurrentContext(false);
 
 	/* N */
 	result->N = pq_getmsgint64(&buf);
@@ -3414,12 +3430,12 @@ numeric_deserialize(PG_FUNCTION_ARGS)
 
 	/*
 	 * Copy the bytea into a StringInfo so that we can "receive" it using the
-	 * standard pq API.
+	 * standard recv-function infrastructure.
 	 */
 	initStringInfo(&buf);
 	appendBinaryStringInfo(&buf, VARDATA(sstate), VARSIZE(sstate) - VARHDRSZ);
 
-	result = makeNumericAggState(fcinfo, false);
+	result = makeNumericAggStateCurrentContext(false);
 
 	/* N */
 	result->N = pq_getmsgint64(&buf);
@@ -3522,6 +3538,21 @@ makeInt128AggState(FunctionCallInfo fcinfo, bool calcSumX2)
 	state->calcSumX2 = calcSumX2;
 
 	MemoryContextSwitchTo(old_context);
+
+	return state;
+}
+
+/*
+ * Like makeInt128AggState(), but allocate the state in the current memory
+ * context.
+ */
+static Int128AggState *
+makeInt128AggStateCurrentContext(bool calcSumX2)
+{
+	Int128AggState *state;
+
+	state = (Int128AggState *) palloc0(sizeof(Int128AggState));
+	state->calcSumX2 = calcSumX2;
 
 	return state;
 }
@@ -3801,12 +3832,12 @@ numeric_poly_deserialize(PG_FUNCTION_ARGS)
 
 	/*
 	 * Copy the bytea into a StringInfo so that we can "receive" it using the
-	 * standard pq API.
+	 * standard recv-function infrastructure.
 	 */
 	initStringInfo(&buf);
 	appendBinaryStringInfo(&buf, VARDATA(sstate), VARSIZE(sstate) - VARHDRSZ);
 
-	result = makePolyNumAggState(fcinfo, false);
+	result = makePolyNumAggStateCurrentContext(false);
 
 	/* N */
 	result->N = pq_getmsgint64(&buf);
@@ -3939,7 +3970,8 @@ int8_avg_combine(PG_FUNCTION_ARGS)
 
 /*
  * int8_avg_serialize
- *		Serialize PolyNumAggState into bytea using the standard pq API.
+ *		Serialize PolyNumAggState into bytea using the standard
+ *		recv-function infrastructure.
  *
  * int8_avg_deserialize(int8_avg_serialize(state)) must result in a state which
  * matches the original input state.
@@ -4017,12 +4049,12 @@ int8_avg_deserialize(PG_FUNCTION_ARGS)
 
 	/*
 	 * Copy the bytea into a StringInfo so that we can "receive" it using the
-	 * standard pq API.
+	 * standard recv-function infrastructure.
 	 */
 	initStringInfo(&buf);
 	appendBinaryStringInfo(&buf, VARDATA(sstate), VARSIZE(sstate) - VARHDRSZ);
 
-	result = makePolyNumAggState(fcinfo, false);
+	result = makePolyNumAggStateCurrentContext(false);
 
 	/* N */
 	result->N = pq_getmsgint64(&buf);


### PR DESCRIPTION
This backports upstream commit bd1693e89e7e6c458d0563f6cc67a7c99a45251a,
slightly modified to resolve the comments conflict.

        Author: Tom Lane <tgl@sss.pgh.pa.us>
        Date:   Thu Jun 23 10:55:59 2016 -0400

            Fix small memory leak in partial-aggregate deserialization functions.

            A deserialize function's result is short-lived data during partial
            aggregation, since we're just going to pass it to the combine function
            and then it's of no use anymore.  However, the built-in deserialize
            functions allocated their results in the aggregate state context,
            resulting in a query-lifespan memory leak.  It's probably not possible for
            this to amount to anything much at present, since the number of leaked
            results would only be the number of worker processes.  But it might become
            a problem in future.  To fix, don't use the same convenience subroutine for
            setting up results that the aggregate transition functions use.

            David Rowley

            Report: <10050.1466637736@sss.pgh.pa.us>
