### PR TITLE
Remove unused QAUTILS_FILES.txt

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -346,9 +346,6 @@ devel : gccVersionCheck HOMEDEP $(ISCONFIG)
 endif
 	$(BUILD_STEPS)
 
-ifneq "$(findstring $(BLD_GPDB_BUILDSET),partial aix_subset)" ""
-	@$(MAKE) qautils-tarball INSTLOC=$(INSTLOC)
-endif
 #---------------------------------------------------------------------
 # Release builds
 #---------------------------------------------------------------------
@@ -713,14 +710,6 @@ HOMEFAIL :
 	@echo "	The HOME environment variable is not set. Please set it to continue."
 	@echo
 	@exit 1
-
-##
-## Create qautils tarball.  This file contains the utils required to
-## support cdbfast runs.
-##
-
-qautils-tarball:
-	@$(TAR) -zcf releng/qautils-$(MPP_ARCH).tar.gz -C $(INSTLOC) $(shell cat releng/QAUTILS_FILES.txt)
 
 #---------------------------------------------------------------------
 # Cleanup

--- a/gpAux/releng/QAUTILS_FILES.txt
+++ b/gpAux/releng/QAUTILS_FILES.txt
@@ -1,4 +1,0 @@
-bin/explain.pl
-bin/explain.pm
-bin/gptorment.pl
-bin/pgbench


### PR DESCRIPTION
It is superseded by NON_PRODUCTION_FILES.txt

Co-authored-by: Amil Khanzada @amilkh 

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community


Note that we will be making some refactors/changes to separate_qautils_files_for_rc.bash/.yml and NON_PRODUCTION_FILES.txt in a later PR.