### PR TITLE
Document changes to utility input files

### DIFF
--- a/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
@@ -116,12 +116,12 @@
         <p>Use the interactive interview process to create your own input file unless your expansion
           scenario has atypical needs. </p>
         <p>The format for expansion input files is:</p>
-        <codeblock>hostname:address:port:datadir:dbid:content:preferred_role</codeblock>
+        <codeblock>hostname|address|port|datadir|dbid|content|preferred_role</codeblock>
         <p>For example:</p>
-        <codeblock>sdw5:sdw5-1:50011:/gpdata/primary/gp9:11:9:p
-sdw5:sdw5-2:50012:/gpdata/primary/gp10:12:10:p
-sdw5:sdw5-2:60011:/gpdata/mirror/gp9:13:9:m
-sdw5:sdw5-1:60012:/gpdata/mirror/gp10:14:10:m</codeblock>
+        <codeblock>sdw5|sdw5-1|50011|/gpdata/primary/gp9|11|9|p
+sdw5|sdw5-2|50012|/gpdata/primary/gp10|12|10|p
+sdw5|sdw5-2|60011|/gpdata/mirror/gp9|13|9|m
+sdw5|sdw5-1|60012|/gpdata/mirror/gp10|14|10|m</codeblock>
         <p>For each new segment, this format of expansion input file requires the following:</p>
         <table id="no165833">
           <title>Data for the expansion configuration file</title>

--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-segment-mirroring.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-segment-mirroring.xml
@@ -52,8 +52,8 @@
             instances per
           host:</p><codeblock>0=2|sdw1-1|41000|/data/mirror1/gp2
 1=3|sdw1-2|41001|/data/mirror2/gp3
-mirror2=0|sdw2-1|41000|/data/mirror1/gp0
-mirror3=1|sdw2-2|41001|/data/mirror2/gp1</codeblock></li>
+2=0|sdw2-1|41000|/data/mirror1/gp0
+3=1|sdw2-2|41001|/data/mirror2/gp1</codeblock></li>
         <li id="ki155430">Run the <codeph>gpaddmirrors</codeph> utility to enable mirroring in your
           Greenplum Database
             system:<codeblock>$ gpaddmirrors -i <i>mirror_config_file</i></codeblock><p>The

--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-segment-mirroring.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-enabling-segment-mirroring.xml
@@ -43,17 +43,17 @@
           starting point,
             run:<codeblock>$ gpaddmirrors -o <i>filename</i>          </codeblock><p>The format of
             the mirror configuration file is:
-            </p><codeblock>mirror<b><varname>row_id</varname></b>=<b><varname>contentID</varname></b>:<b><varname>address</varname></b>:<b><varname>port</varname></b>:<b><varname>data_dir</varname></b></codeblock><p>Where
+            </p><codeblock><b><varname>row_id</varname></b>=<b><varname>contentID</varname></b>|<b><varname>address</varname></b>|<b><varname>port</varname></b>|<b><varname>data_dir</varname></b></codeblock><p>Where
               <codeph>row_id</codeph> is the row in the file, <varname>contentID</varname> is the
             segment instance content ID, <varname>address</varname> is the host name or IP address
             of the segment host, <varname>port</varname> is the communication port, and
               <codeph>data_dir</codeph> is the segment instance data directory.</p><p>For example,
             this is contents of a mirror configuration file for two segment hosts and two segment
             instances per
-          host:</p><codeblock>mirror0=2:sdw1-1:41000:/data/mirror1/gp2
-mirror1=3:sdw1-2:41001:/data/mirror2/gp3
-mirror2=0:sdw2-1:41000:/data/mirror1/gp0
-mirror3=1:sdw2-2:41001:/data/mirror2/gp1</codeblock></li>
+          host:</p><codeblock>0=2|sdw1-1|41000|/data/mirror1/gp2
+1=3|sdw1-2|41001|/data/mirror2/gp3
+mirror2=0|sdw2-1|41000|/data/mirror1/gp0
+mirror3=1|sdw2-2|41001|/data/mirror2/gp1</codeblock></li>
         <li id="ki155430">Run the <codeph>gpaddmirrors</codeph> utility to enable mirroring in your
           Greenplum Database
             system:<codeblock>$ gpaddmirrors -i <i>mirror_config_file</i></codeblock><p>The

--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-when-a-segment-host-is-not-recoverable.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-when-a-segment-host-is-not-recoverable.xml
@@ -13,11 +13,11 @@
             <codeblock>$ gprecoverseg -i <i>recover_config_file</i>
       </codeblock>
             <p>Where the format of the <codeph><i>recover_config_file</i></codeph> file is:</p>
-            <codeblock>&lt;<varname>failed_host</varname>&gt;:&lt;<varname>port</varname>&gt;:&lt;<varname>data_dir</varname>&gt;[ &lt;<varname>recovery_host</varname>&gt;:&lt;<varname>port</varname>&gt;:&lt;<varname>recovery_data_dir</varname>&gt;]
+            <codeblock>&lt;<varname>failed_host</varname>&gt;|&lt;<varname>port</varname>&gt;|&lt;<varname>data_dir</varname>&gt;[ &lt;<varname>recovery_host</varname>&gt;|&lt;<varname>port</varname>&gt;|&lt;<varname>recovery_data_dir</varname>&gt;]
 </codeblock>
             <p>For example, to recover to a different host than the failed host without additional
                   tablespaces configured (besides the default <i>pg_system</i> tablespace):</p>
-            <codeblock>sdw1-1:50001:/data1/mirror/gpseg16 sdw4-1:50001:/data1/recover1/gpseg16
+            <codeblock>sdw1-1|50001|/data1/mirror/gpseg16 sdw4-1|50001|/data1/recover1/gpseg16
 </codeblock>
             <p>For information about creating a segment instance recovery file, see <codeph><xref
                               href="../../../utility_guide/admin_utilities/gprecoverseg.xml"

--- a/gpdb-doc/dita/admin_guide/managing/highavail.xml
+++ b/gpdb-doc/dita/admin_guide/managing/highavail.xml
@@ -442,12 +442,12 @@
             example:</p>
           <codeblock>$ gprecoverseg -i <i>recover_config_file</i></codeblock>
           <p>Where the format of <codeph><i>recover_config_file</i></codeph> is:</p>
-          <codeblock>filespaceOrder=[<i>filespace1_name</i>[:<i>filespace2_name</i>:...]<i>failed_host_address</i>:
-<i>port</i>:<i>fselocation</i> [<i>recovery_host_address</i>:<i>port</i>:<i>replication_port</i>:<i>fselocation</i>
-[:<i>fselocation</i>:...]]</codeblock>
+          <codeblock>filespaceOrder=[<i>filespace1_name</i>[|<i>filespace2_name</i>|...]<i>failed_host_address</i>|
+<i>port</i>|<i>fselocation</i> [<i>recovery_host_address</i>|<i>port</i>|<i>replication_port</i>|<i>fselocation</i>
+[|<i>fselocation</i>|...]]</codeblock>
           <p>For example, to recover to a different host than the failed host without additional
             filespaces configured (besides the default <i>pg_system</i> filespace):</p>
-          <codeblock>filespaceOrder=sdw5-2:50002:/gpdata/gpseg2 sdw9-2:50002:53002:/gpdata/gpseg2</codeblock>
+          <codeblock>filespaceOrder=sdw5-2|50002|/gpdata/gpseg2 sdw9-2|50002|53002|/gpdata/gpseg2</codeblock>
           <p>The <i>gp_segment_configuration</i> and <i>pg_filespace_entry</i> system catalog tables
             can help determine your current segment configuration so you can plan your mirror
             recovery configuration. For example, run the following query:</p>

--- a/gpdb-doc/dita/admin_guide/managing/highavail.xml
+++ b/gpdb-doc/dita/admin_guide/managing/highavail.xml
@@ -196,16 +196,16 @@
               as a starting point,
                 run:<codeblock>$ gpaddmirrors -o <i>filename</i></codeblock><p>The format of the
                 mirror configuration file is:
-                </p><codeblock>filespaceOrder=[<i>filespace1_fsname</i>[:<i>filespace2_fsname</i>:...] 
-<i>mirror</i>[<i>content</i>]=<i>content</i>:<i>address</i>:<i>port</i>:<i>mir_replication_port</i>:
-<i>pri_replication_port</i>:<i>fselocation</i>[:<i>fselocation</i>:...]</codeblock><p>For
+                </p><codeblock>filespaceOrder=[<i>filespace1_fsname</i>[|<i>filespace2_fsname</i>|...] 
+[<i>content</i>]=<i>content</i>|<i>address</i>|<i>port</i>|<i>mir_replication_port</i>|
+<i>pri_replication_port</i>|<i>fselocation</i>[|<i>fselocation</i>|...]</codeblock><p>For
                 example, a configuration for two segment hosts and two segments per host, with no
                 additional filespaces configured besides the default <i>pg_system</i>
                 filespace):</p><codeblock>filespaceOrder=
-mirror0=0:sdw1:sdw1-1:52001:53001:54001:/gpdata/mir1/gp0
-mirror1=1:sdw1:sdw1-2:52002:53002:54002:/gpdata/mir1/gp1
-mirror2=2:sdw2:sdw2-1:52001:53001:54001:/gpdata/mir1/gp2
-mirror3=3:sdw2:sdw2-2:52002:53002:54002:/gpdata/mir1/gp3
+0=0|sdw1|sdw1-1|52001|53001|54001|/gpdata/mir1/gp0
+1=1|sdw1|sdw1-2|52002|53002|54002|/gpdata/mir1/gp1
+2=2|sdw2|sdw2-1|52001|53001|54001|/gpdata/mir1/gp2
+3=3|sdw2|sdw2-2|52002|53002|54002|/gpdata/mir1/gp3
 </codeblock></li>
             <li id="ki155430">Run the <codeph>gpaddmirrors</codeph> utility to enable mirroring in
               your Greenplum Database

--- a/gpdb-doc/dita/best_practices/ha.xml
+++ b/gpdb-doc/dita/best_practices/ha.xml
@@ -421,15 +421,15 @@
           <li>Create an input file for the <codeph>gpmovemirrors</codeph> utility with an entry for
             each mirror that must be moved.<p>The <codeph>gpmovemirrors</codeph> input file has the
               following
-              format:<codeblock><varname>contentID</varname>:<varname>address</varname>:<varname>port</varname>:<varname>data_dir</varname> <varname>new_address</varname>:<varname>port</varname>:<varname>data_dir</varname></codeblock></p>Where
+              format:<codeblock><varname>contentID</varname>|<varname>address</varname>|<varname>port</varname>|<varname>data_dir</varname> <varname>new_address</varname>|<varname>port</varname>|<varname>data_dir</varname></codeblock></p>Where
               <varname>contentID</varname> is the segment instance content ID,
               <varname>address</varname> is the host name or IP address of the segment host,
               <varname>port</varname> is the communication port, and <codeph>data_dir</codeph> is
             the segment instance data directory.<p>The following example
                 <codeph>gpmovemirrors</codeph> input file specifies three mirror segments to move.
-              <codeblock>1:sdw2:50001:/data2/mirror/gpseg1 sdw3:50001:/data/mirror/gpseg1
-2:sdw2:50001:/data2/mirror/gpseg2 sdw4:50001:/data/mirror/gpseg2
-3:sdw3:50001:/data2/mirror/gpseg3 sdw1:50001:/data/mirror/gpseg3
+              <codeblock>1|sdw2|50001|/data2/mirror/gpseg1 sdw3|50001|/data/mirror/gpseg1
+2|sdw2|50001|/data2/mirror/gpseg2 sdw4|50001|/data/mirror/gpseg2
+3|sdw3|50001|/data2/mirror/gpseg3 sdw1|50001|/data/mirror/gpseg3
 </codeblock></p></li>
           <li>Run <codeph>gpmovemirrors</codeph> with a command like the
             following:<codeblock>gpmovemirrors -i <varname>mirror_config_file</varname></codeblock></li>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpaddmirrors.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpaddmirrors.xml
@@ -53,14 +53,14 @@ Enter mirror segment data directory location 2 of 2 &gt; /gpdb/m2</codeblock>
                 detailed configuration file using the <codeph>-i</codeph> option. This is useful if
                 you want your mirror segments on a completely different set of hosts than your
                 primary segments. The format of the mirror configuration file is:</p>
-            <codeblock>mirror<varname>&lt;row_id></varname>=<varname>&lt;contentID></varname>:<varname>&lt;address></varname>:<varname>&lt;port></varname>:<varname>&lt;data_dir></varname></codeblock>
+            <codeblock><varname>&lt;row_id></varname>=<varname>&lt;contentID></varname>|<varname>&lt;address></varname>|<varname>&lt;port></varname>|<varname>&lt;data_dir></varname></codeblock>
             <p>Where <codeph>row_id</codeph> is the row in the file, <varname>contentID</varname> is
                 the segment instance content ID, <varname>address</varname> is the host name or IP
                 address of the segment host, <varname>port</varname> is the communication port, and
                     <codeph>data_dir</codeph> is the segment instance data directory.</p>
             <p>For
-                example:<codeblock>mirror0=0:sdw1-1:60000:/gpdata/mir1/gp0
-mirror1=1:sdw1-1:60001:/gpdata/mir2/gp1</codeblock></p>
+                example:<codeblock>0=0|sdw1-1|60000|/gpdata/mir1/gp0
+1=1|sdw1-1|60001|/gpdata/mir2/gp1</codeblock></p>
             <p>The <codeph>gp_segment_configuration</codeph> system catalog table can help you
                 determine your current primary segment configuration so that you can plan your
                 mirror segment configuration. For example, run the following query:</p>
@@ -110,7 +110,7 @@ mirror1=1:sdw1-1:60001:/gpdata/mir2/gp1</codeblock></p>
                         the system. The format of this file is as follows (as per attributes in the
                             <codeph>gp_segment_configuration</codeph> catalog table):</pd>
                     <pd>
-                        <codeblock>mirror<varname>&lt;row_id></varname>=<varname>&lt;contentID></varname>:<varname>&lt;address></varname>:<varname>&lt;port></varname>:<varname>&lt;data_dir></varname></codeblock>
+                        <codeblock><varname>&lt;row_id></varname>=<varname>&lt;contentID></varname>|<varname>&lt;address></varname>|<varname>&lt;port></varname>|<varname>&lt;data_dir></varname></codeblock>
                     </pd>
                     <pd>
                         <p>Where <codeph>row_id</codeph> is the row in the file,
@@ -191,10 +191,10 @@ mirror1=1:sdw1-1:60001:/gpdata/mir2/gp1</codeblock></p>
                 from your primary data:</p>
             <codeblock>$ gpaddmirrors -i mirror_config_file</codeblock>
             <p>Where <codeph>mirror_config_file</codeph> looks something like this:</p>
-            <codeblock>mirror0=0:sdw1-1:52001:/gpdata/mir1/gp0
-mirror1=1:sdw1-2:52002:/gpdata/mir2/gp1
-mirror2=2:sdw2-1:52001:/gpdata/mir1/gp2
-mirror3=3:sdw2-2:52002:/gpdata/mir2/gp3</codeblock>
+            <codeblock>0=0|sdw1-1|52001|/gpdata/mir1/gp0
+1=1|sdw1-2|52002|/gpdata/mir2/gp1
+2=2|sdw2-1|52001|/gpdata/mir1/gp2
+3=3|sdw2-2|52002|/gpdata/mir2/gp3</codeblock>
             <p>Generate a sample mirror configuration file with the <codeph>-o</codeph> option to
                 use with <codeph>gpaddmirrors -i</codeph>:</p>
             <codeblock>$ gpaddmirrors -o /home/gpadmin/sample_mirror_config</codeblock>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpexpand.xml
@@ -147,7 +147,7 @@
           <pd>Specifies the name of the expansion configuration file, which contains one line for
             each segment to be added in the format of:</pd>
           <pd>
-            <varname>hostname:address:port:datadir:dbid:content:preferred_role</varname>
+            <varname>hostname|address|port|datadir|dbid|content|preferred_role</varname>
           </pd>
         </plentry>
         <plentry>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpmovemirrors.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpmovemirrors.xml
@@ -51,7 +51,7 @@
             line inside the configuration file has the following format (as per attributes in the
               <codeph>gp_segment_configuration</codeph> catalog table):</pd>
           <pd>
-            <codeblock><varname>contentID</varname>:<varname>address</varname>:<varname>port</varname>:<varname>data_dir</varname> <varname>new_address</varname>:<varname>port</varname>:<varname>data_dir</varname></codeblock>
+            <codeblock><varname>contentID</varname>|<varname>address</varname>|<varname>port</varname>|<varname>data_dir</varname> <varname>new_address</varname>|<varname>port</varname>|<varname>data_dir</varname></codeblock>
           </pd>
           <pd>Where <varname>contentID</varname> is the segment instance content ID,
               <varname>address</varname> is the host name or IP address of the segment host,
@@ -81,9 +81,9 @@
       <p>Moves mirrors from an existing Greenplum Database system to a different set of hosts:</p>
       <codeblock>$ gpmovemirrors -i move_config_file</codeblock>
       <p>Where the <codeph>move_config_file</codeph> looks something like this:</p>
-      <codeblock>1:sdw2:50001:/data2/mirror/gpseg1 sdw3:50001:/data/mirror/gpseg1
-2:sdw2:50001:/data2/mirror/gpseg2 sdw4:50001:/data/mirror/gpseg2
-3:sdw3:50001:/data2/mirror/gpseg3 sdw1:50001:/data/mirror/gpseg3
+      <codeblock>1|sdw2|50001|/data2/mirror/gpseg1 sdw3|50001|/data/mirror/gpseg1
+2|sdw2|50001|/data2/mirror/gpseg2 sdw4|50001|/data/mirror/gpseg2
+3|sdw3|50001|/data2/mirror/gpseg3 sdw1|50001|/data/mirror/gpseg3
 </codeblock>
     </section>
   </body>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gprecoverseg.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gprecoverseg.xml
@@ -50,7 +50,7 @@
         segment back online on the same host and data directory location on which it was originally
         configured. In this case, use the following format for the recovery configuration file
         (using <codeph>-i</codeph>).</p>
-      <codeblock>&lt;failed_host_address&gt;:&lt;port&gt;:&lt;data_directory&gt; </codeblock>
+      <codeblock>&lt;failed_host_address&gt;|&lt;port&gt;|&lt;data_directory&gt; </codeblock>
       <p>In some cases, this may not be possible (for example, if a host was physically damaged and
         cannot be recovered). In this situation, <codeph>gprecoverseg</codeph> allows you to recover
         failed segments to a completely new host (using <codeph>-p</codeph>), on an alternative data
@@ -58,8 +58,8 @@
         supplying a recovery configuration file (using <codeph>-i</codeph>) in the following format.
         The word <b>SPACE</b> indicates the location of a required space. Do not add additional
         spaces.</p>
-      <codeblock>&lt;failed_host_address&gt;:&lt;port&gt;:&lt;data_directory&gt;<b>SPACE</b>
-&lt;recovery_host_address&gt;:&lt;port&gt;:&lt;data_directory&gt;
+      <codeblock>&lt;failed_host_address&gt;|&lt;port&gt;|&lt;data_directory&gt;<b>SPACE</b>
+&lt;recovery_host_address&gt;|&lt;port&gt;|&lt;data_directory&gt;
 </codeblock>
       <p>See the <codeph>-i</codeph> option below for details and examples of a recovery
         configuration file.</p>
@@ -121,23 +121,23 @@
           <pd>Specifies the name of a file with the details about failed segments to recover. Each
             line in the file is in the following format. The word <b>SPACE</b> indicates the
             location of a required space. Do not add additional
-                spaces.<codeblock>&lt;failed_host_address&gt;:&lt;port&gt;:&lt;data_directory&gt;<b>SPACE</b> 
-&lt;recovery_host_address&gt;:&lt;port&gt;:&lt;data_directory&gt;
+                spaces.<codeblock>&lt;failed_host_address&gt;|&lt;port&gt;|&lt;data_directory&gt;<b>SPACE</b> 
+&lt;recovery_host_address&gt;|&lt;port&gt;|&lt;data_directory&gt;
 </codeblock><p><b>Comments</b></p><p>Lines
               beginning with <codeph>#</codeph> are treated as comments and ignored.</p>
             <p><b>Segments to Recover</b></p><p>Each line after the first specifies a segment to
               recover. This line can have one of two formats. In the event of in-place recovery,
               enter one group of colon delimited fields in the line. For example:</p><p>
-              <codeblock>failedAddress:failedPort:failedDataDirectory</codeblock>
+              <codeblock>failedAddress|failedPort|failedDataDirectory</codeblock>
             </p><p>For recovery to a new location, enter two groups of fields separated by a space
               in the line. The required space is indicated by <b>SPACE</b>. Do not add additional
               spaces.</p><p>
-              <codeblock>failedAddress:failedPort:failedDataDirectory<b>SPACE</b>newAddress:
-newPort:newDataDirectory</codeblock>
+              <codeblock>failedAddress|failedPort|failedDataDirectory<b>SPACE</b>newAddress|
+newPort|newDataDirectory</codeblock>
             </p><p><b>Examples</b></p><p><b>In-place recovery of a single mirror</b></p>
-            <codeblock>sdw1-1:50001:/data1/mirror/gpseg16</codeblock>
+            <codeblock>sdw1-1|50001|/data1/mirror/gpseg16</codeblock>
             <p><b>Recovery of a single mirror to a new host</b></p>
-            <codeblock>sdw1-1:50001:/data1/mirror/gpseg16<b>SPACE</b>sdw4-1:50001:/data1/recover1/gpseg16</codeblock>
+            <codeblock>sdw1-1|50001|/data1/mirror/gpseg16<b>SPACE</b>sdw4-1|50001|/data1/recover1/gpseg16</codeblock>
             <p><b>Obtaining a Sample File</b></p>
             <p>You can use the <codeph>-o</codeph> option to output a sample recovery configuration
               file to use as a starting point.</p></pd>


### PR DESCRIPTION
Change input file format (separators, mostly) for gpmovemirrors, gpaddmirrors, gprecoverseg, and gpexpand.  

These are the doc changes associated with https://github.com/greenplum-db/gpdb/pull/7777