### PR TITLE
docs - GPCC no longer depends on gpperfmon_install

### DIFF
--- a/gpdb-doc/dita/admin_guide/intro/about_utilities.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_utilities.xml
@@ -32,11 +32,10 @@
       metrics. </p>
     <p otherprops="pivotal">Pivotal provides an optional system monitoring and management tool,
       Greenplum Command Center, which administrators can install and enable with Greenplum Database.
-      Greenplum Command Center, which depends upon the <codeph>gpperfmon</codeph> database, provides
-      a web-based user interface for viewing the system metrics and allows administrators to perform
-      additional system management tasks. For more information about Greenplum Command Center, see
-      the <xref href="https://gpcc.docs.pivotal.io" format="html" scope="external">Greenplum Command
-        Center documentation</xref>.</p>
+      Greenplum Command Center provides a web-based user interface for viewing system metrics and
+      allows administrators to perform additional system management tasks. For more information
+      about Greenplum Command Center, see the <xref href="https://gpcc.docs.pivotal.io"
+        format="html" scope="external">Greenplum Command Center documentation</xref>.</p>
     <fig id="kf145043" otherprops="pivotal">
       <title>Greenplum Command Center Architecture</title>
       <image href="../graphics/cc_arch_gpdb.png" placement="break" width="299px" height="304px"

--- a/gpdb-doc/dita/admin_guide/managing/monitor.xml
+++ b/gpdb-doc/dita/admin_guide/managing/monitor.xml
@@ -24,12 +24,12 @@
           <codeph>gpperfmon</codeph> database in the <cite>Greenplum Database Reference
         Guide</cite>.</p>
       <p otherprops="pivotal">Pivotal Greenplum Command Center, an optional web-based interface,
-        graphically displays the metrics collected in the <codeph>gpperfmon</codeph> database and
-        provides additional system management tools. Download the Greenplum Command Center package
-        from <xref href="https://network.pivotal.io/products/pivotal-gpdb" scope="external" format="html">Pivotal
-          Network</xref> and view the documentation at the <xref href="http://gpcc.docs.pivotal.io"
-          scope="external" format="html">Greenplum Command Center Documentation</xref> web site.
-      </p>
+        provides cluster status information, graphical administrative tools, real-time query
+        monitoring, and historical cluster and query data. Download the Greenplum Command Center
+        package from <xref href="https://network.pivotal.io/products/pivotal-gpdb" scope="external"
+          format="html">Pivotal Network</xref> and view the documentation at the <xref
+          href="http://gpcc.docs.pivotal.io" scope="external" format="html">Greenplum Command Center
+          Documentation</xref> web site. </p>
     </body>
   </topic>
   <topic id="topic3" xml:lang="en">

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -538,14 +538,9 @@ SET statement_mem='10 MB';</codeblock></p>
     <body>
       <p>Using Pivotal Greenplum Command Center, an administrator can create and manage resource
         groups, change roles' resource groups, and create workload management rules. </p>
-      <p>Workload management rules are defined in Command Center and stored in Greenplum Database.
-        When a transaction is submitted, Greenplum Database calls the workload management database
-        extension to evaluate and apply the rules. </p>
       <p>Workload management assignment rules assign transactions to different resource groups based
         on user-defined criteria. If no assignment rule is matched, Greenplum Database assigns the
-        transaction to the role's default resource group. Workload management idle session kill
-        rules set the maximum number of seconds that sessions managed by a resource group can remain
-        idle before they are terminated.</p>
+        transaction to the role's default resource group.
       <p>Refer to the <xref href="http://gpcc.docs.pivotal.io/latest" format="html" scope="external"
           >Greenplum Command Center documentation</xref> for more information about creating and
         managing resource groups and workload management rules. </p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2995,7 +2995,7 @@
     <title>gp_enable_gpperfmon</title>
     <body>
       <p>Enables or disables the data collection agents that populate the <codeph>gpperfmon</codeph>
-        database for Greenplum Command Center.</p>
+        database.</p>
       <table id="gp_enable_gpperfmon_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -3661,7 +3661,7 @@
     <body>
       <p>Sets the frequency that the Greenplum Database server processes send query execution
         updates to the data collection agent processes used to populate the
-          <codeph>gpperfmon</codeph> database for Command Center. Query operations executed during
+          <codeph>gpperfmon</codeph> database. Query operations executed during
         this interval are sent through UDP to the segment monitor agents. If you find that an
         excessive number of UDP packets are dropped during long-running, complex queries, you may
         consider increasing this value.</p>
@@ -5292,7 +5292,7 @@
   <topic id="gpperfmon_port">
     <title>gpperfmon_port</title>
     <body>
-      <p>Sets the port on which all data collection agents (for Command Center) communicate with the
+      <p>Sets the port on which all data collection agents communicate with the
         master. </p>
       <table id="gpperfmon_port_table">
         <tgroup cols="3">

--- a/gpdb-doc/dita/ref_guide/gpperfmon/dbref.xml
+++ b/gpdb-doc/dita/ref_guide/gpperfmon/dbref.xml
@@ -4,9 +4,7 @@
   <title>The gpperfmon Database</title>
   <body>
     <p>The <codeph>gpperfmon</codeph> database is a dedicated database where data collection agents
-      on Greenplum segment hosts save query and system statistics. <ph otherprops="pivotal">The
-        optional Greenplum Command Center management tool depends upon the
-          <codeph>gpperfmon</codeph> database for query history.</ph></p>
+      on Greenplum segment hosts save query and system statistics. </p>
     <p>The <codeph>gpperfmon</codeph> database is created using the
         <codeph>gpperfmon_install</codeph> command-line utility. The utility creates the database
       and the <codeph>gpmon</codeph> database role and enables the data collection agents on the

--- a/gpdb-doc/dita/security-guide/topics/gpcc.xml
+++ b/gpdb-doc/dita/security-guide/topics/gpcc.xml
@@ -10,7 +10,7 @@
         <codeph>gpmetrics</codeph> schema in the gpperfmon database, which contains metrics and
       query history tables populated by the Greenplum Database metrics collector module.</p>
     <note>The <codeph>gpperfmon_install</codeph> utility also creates the gpperfmon database and
-        <codeph>gpmon</codeph> role, but Command Center no longer uses the history tables it creates
+        <codeph>gpmon</codeph> role, but Command Center no longer requires the history tables it creates
       in the database. Do not use <codeph>gpperfmon_install</codeph> unless you need the old query
       history tables for some other purpose. <codeph>gpperfmon_install</codeph> enables the
         <codeph>gpmmon</codeph> and <codeph>gpsmon</codeph> agents, which add unnecessary load to
@@ -43,7 +43,7 @@ host    gpperfmon   gpmon    ::1/128             md5</codeblock></p>
           start</codeph> command. </p>
       <p>Because the <codeph>.pgpass</codeph> file contains the plain-text password of the
           <codeph>gpmon</codeph> user, you may want to remove it and supply the
-          <codeph>gpmon</codeph> password using a more secure method. The gpmon password is needed
+          <codeph>gpmon</codeph> password using a more secure method. The <codeph>gpmon</codeph> password is needed
         when you run the <codeph>gpcc start</codeph>, <codeph>gpcc stop</codeph>, or <codeph>gpcc
           status</codeph> commands. You can add the <codeph>-W</codeph> option to the
           <codeph>gpcc</codeph> command to have the command prompt you to enter the password.
@@ -65,7 +65,7 @@ host    gpperfmon   gpmon    ::1/128             md5</codeblock></p>
           <codeph>pg_hba.conf</codeph> file and either add or edit a line for the user so that the
         gpperfmon database is included in the database field. For example:</p>
       <codeblock>host     gpperfmon,accounts   user1     127.0.0.1/28    md5</codeblock>
-      <p>The Command Center application includes an Admin interface to add, remove, and edit entries
+      <p>The Command Center web application includes an Admin interface to add, remove, and edit entries
         in the <codeph>pg_hba.conf</codeph> file and reload the file into Greenplum Database. </p>
       <p>Command Center has the following types of users:<ul id="ul_tdv_qnt_g5">
           <li><i>Self Only</i> users can view metrics and view and cancel their own queries. Any
@@ -87,7 +87,7 @@ host    gpperfmon   gpmon    ::1/128             md5</codeblock></p>
             Greenplum Database users with the <codeph>SUPERUSER</codeph> privilege have Admin
             permissions in Command Center.</li>
         </ul></p>
-      <p>The Command Center application has an Admin interface you can use to change a Command
+      <p>The Command Center web application has an Admin interface you can use to change a Command
         Center user's access level. </p>
     </section>
     <section>

--- a/gpdb-doc/dita/security-guide/topics/gpcc.xml
+++ b/gpdb-doc/dita/security-guide/topics/gpcc.xml
@@ -3,20 +3,27 @@
 <topic id="topic_zyt_rxp_f5">
   <title>Greenplum Command Center Security</title>
   <body>
-    <p>Greenplum Command Center (GPCC) is a web-based application for monitoring and managing
-      Greenplum clusters. GPCC works with data collected by agents running on the segment hosts and
-      saved to the gpperfmon database. The gpperfmon database is created by running the
-        <codeph>gpperfmon_install</codeph> utility, which also creates the <codeph>gpmon</codeph>
-      database role that GPCC uses to access the gpperfmon database. </p>
+    <p>Greenplum Command Center is a web-based application for monitoring and managing Greenplum
+      clusters. Command Center works with data collected by agents running on the segment hosts and
+      saved to the gpperfmon database. Installing Command Center creates the gpperfmon database and
+      the <codeph>gpmon</codeph> database role if they do not already exist. It creates the
+        <codeph>gpmetrics</codeph> schema in the gpperfmon database, which contains metrics and
+      query history tables populated by the Greenplum Database metrics collector module.</p>
+    <note>The <codeph>gpperfmon_install</codeph> utility also creates the gpperfmon database and
+        <codeph>gpmon</codeph> role, but Command Center no longer uses the history tables it creates
+      in the database. Do not use <codeph>gpperfmon_install</codeph> unless you need the old query
+      history tables for some other purpose. <codeph>gpperfmon_install</codeph> enables the
+        <codeph>gpmmon</codeph> and <codeph>gpsmon</codeph> agents, which add unnecessary load to
+      the Greenplum Database system if you do not need the old history tables.</note>
     <section>
       <title>The gpmon User</title>
-      <p>The <codeph>gpperfmon_install</codeph> utility creates the <codeph>gpmon</codeph> database
-        role and adds the role to the <codeph>pg_hba.conf</codeph> file with the following
+      <p>The  Command Center installer creates the <codeph>gpmon</codeph> database role and adds the
+        role to the <codeph>pg_hba.conf</codeph> file with the following
         entries:<codeblock>local    gpperfmon   gpmon         md5
 host     all         gpmon         127.0.0.1/28    md5
 host     all         gpmon         ::1/128         md5</codeblock>These
         entries allow <codeph>gpmon</codeph> to establish a local socket connection to the gpperfmon
-        database and a TCP/IP connection to any database. </p>
+        database and a TCP/IP connection to any database.</p>
       <p>The <codeph>gpmon</codeph> database role is a superuser. In a secure or production
         environment, it may be desirable to restrict the <codeph>gpmon</codeph> user to just the
         gpperfmon database. Do this by editing the <codeph>gpmon</codeph> host entry in the
@@ -25,28 +32,42 @@ host     all         gpmon         ::1/128         md5</codeblock>These
         <codeph>gpperfmon</codeph>:<codeblock>local   gpperfmon   gpmon                        md5
 host    gpperfmon   gpmon    127.0.0.1/28        md5
 host    gpperfmon   gpmon    ::1/128             md5</codeblock></p>
-      <p>The password used to authenticate the <codeph>gpmon</codeph> user is set by the
-          <codeph>gpperfmon_install</codeph> utility and is stored in the <codeph>gpadmin</codeph>
-        home directory in the <codeph>~/.pgpass</codeph> file. The <codeph>~/.pgpass</codeph> file
-        must be owned by the <codeph>gpadmin</codeph> user and be RW-accessible only by the
-          <codeph>gpadmin</codeph> user. To change the <codeph>gpmon</codeph> password, use the
-          <codeph>ALTER ROLE</codeph> command to change the password in the database, change the
-        password in the <codeph>~/.pgpass</codeph> file, and then restart GPCC with the
-          <codeph>gpcmdr --restart <varname>instance_name</varname></codeph> command. </p>
-      <note>The GPCC web server can be configured to encrypt connections with SSL. Two-way
-        authentication with public keys can also be enabled for GPCC users. However, the
-          <codeph>gpmon</codeph> user always uses md5 authentication with the password saved in the
-          <codeph>~/.pgpass</codeph> file.</note>
-      <p>GPCC does not allow logins from any role configured with trust authentication, including
-        the <codeph>gpadmin</codeph> user. </p>
+      <p>The password used to authenticate the <codeph>gpmon</codeph> user is stored in the
+          <codeph>gpadmin</codeph> home directory in the <codeph>~/.pgpass</codeph> file. The
+          <codeph>~/.pgpass</codeph> file must be owned by the <codeph>gpadmin</codeph> user and be
+        RW-accessible only by the <codeph>gpadmin</codeph> user. The Command Center installer
+        creates the <codeph>gpmon</codeph> role with the default password "changeme".  Be sure to
+        change the  password immediately after you install Command Center. Use the <codeph>ALTER
+          ROLE</codeph> command to change the password in the database, change the password in the
+          <codeph>~/.pgpass</codeph> file, and then restart Command Center with the <codeph>gpcc
+          start</codeph> command. </p>
+      <p>Because the <codeph>.pgpass</codeph> file contains the plain-text password of the
+          <codeph>gpmon</codeph> user, you may want to remove it and supply the
+          <codeph>gpmon</codeph> password using a more secure method. The gpmon password is needed
+        when you run the <codeph>gpcc start</codeph>, <codeph>gpcc stop</codeph>, or <codeph>gpcc
+          status</codeph> commands. You can add the <codeph>-W</codeph> option to the
+          <codeph>gpcc</codeph> command to have the command prompt you to enter the password.
+        Alternatively, you can set the <codeph>PGPASSWORD</codeph> environment variable to the gpmon
+        password before you run the <codeph>gpcc</codeph> command.</p>
+      <p>Command Center does not allow logins from any role configured with trust authentication,
+        including the <codeph>gpadmin</codeph> user. </p>
       <p>The <codeph>gpmon</codeph> user can log in to the Command Center Console and has access to
-        all of the application's features. You can allow other database roles access to GPCC so that
-        you can secure the <codeph>gpmon</codeph> user and restrict other users' access to GPCC
-        features. Setting up other GPCC users is described in the next section. </p>
+        all of the application's features. You can allow other database roles access to Command
+        Center so that you can secure the <codeph>gpmon</codeph> user and restrict other users'
+        access to Command Center features. Setting up other Command Center users is described in the
+        next section. </p>
     </section>
     <section>
       <title>Greenplum Command Center Users</title>
-      <p>GPCC has the following types of users:<ul id="ul_tdv_qnt_g5">
+      <p>To log in to the Command Center web application, a user must be allowed access to the
+        gpperfmon database in <codeph>pg_hba.conf</codeph>. For example, to make
+          <codeph>user1</codeph> a regular Command Center user, edit the
+          <codeph>pg_hba.conf</codeph> file and either add or edit a line for the user so that the
+        gpperfmon database is included in the database field. For example:</p>
+      <codeblock>host     gpperfmon,accounts   user1     127.0.0.1/28    md5</codeblock>
+      <p>The Command Center application includes an Admin interface to add, remove, and edit entries
+        in the <codeph>pg_hba.conf</codeph> file and reload the file into Greenplum Database. </p>
+      <p>Command Center has the following types of users:<ul id="ul_tdv_qnt_g5">
           <li><i>Self Only</i> users can view metrics and view and cancel their own queries. Any
             Greenplum Database user successfully authenticated through the Greenplum Database
             authentication system can access Greenplum Command Center with Self Only permission.
@@ -66,27 +87,15 @@ host    gpperfmon   gpmon    ::1/128             md5</codeblock></p>
             Greenplum Database users with the <codeph>SUPERUSER</codeph> privilege have Admin
             permissions in Command Center.</li>
         </ul></p>
-      <p>To log in to the GPCC web application, a user must be allowed access to the gpperfmon
-        database in <codeph>pg_hba.conf</codeph>. For example, to make <codeph>user1</codeph> a
-        regular GPCC user, edit the <codeph>pg_hba.conf</codeph> file and either add or edit a line
-        for the user so that the gpperfmon database is included in the database field. For
-        example:</p>
-      <codeblock>host     gpperfmon,accounts   user1     127.0.0.1/28    md5</codeblock>
-      <p>To designate a user as an operator, grant the <codeph>gpcc_operator</codeph> role to the
-        user:<codeblock>=# GRANT gpcc_operator TO <varname>user</varname>;</codeblock></p>
-      <p>You can also grant <codeph>gpcc_operator</codeph> to a group role to make all members of
-        the group GPCC operators.</p>
-      <p>See the <codeph>gpperfmon_install</codeph> reference in <cite>Greenplum Database Utility
-          Guide</cite> for more information about managing the <codeph>gpperfmon</codeph>
-        database.</p>
+      <p>The Command Center application has an Admin interface you can use to change a Command
+        Center user's access level. </p>
     </section>
     <section>
       <title>Enabling SSL for Greenplum Command Center</title>
-      <p>The GPCC web server can be configured to support SSL so that client connections are
-        encrypted. A server certificate can be generated when the Command Center instance is created
-        or you can supply an existing certificate. </p>
-      <p>Two-way authentication with public key encryption can also be enabled for GPCC. See the
-          <cite>Greenplum Command Center Administration Guide</cite> for instructions. </p>
+      <p>The Command Center web server can be configured to support SSL so that client connections
+        are encrypted. To enable SSL, install a <codeph>.pem</codeph> file containing the web
+        server's certificate and private key on the web server host and then enter the full path to
+        the <codeph>.pem</codeph> file when prompted by the Command Center installer.</p>
     </section>
     <section>
       <title>Enabling Kerberos Authentication for Greenplum Command Center Users</title>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpperfmon_install.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpperfmon_install.xml
@@ -4,8 +4,8 @@
 <topic id="topic1">
   <title>gpperfmon_install</title>
   <body>
-    <p>Installs the <codeph>gpperfmon</codeph> database, which is used by Greenplum Command Center,
-      and optionally enables the data collection agents.</p>
+    <p>Installs the <codeph>gpperfmon</codeph> database and optionally enables the data collection
+      agents.</p>
     <section id="section2">
       <title>Synopsis</title>
       <codeblock><b>gpperfmon_install --port <varname>gpdb_port</varname> </b>
@@ -16,6 +16,17 @@
     </section>
     <section id="section3">
       <title>Description</title>
+      <note otherprops="pivotal">Do not run the <codeph>gpperfmon_install</codeph> utility if you
+        plan to use Pivotal Greenplum Command Center to manage your Greenplum Database system.
+        Command Center no longer uses the history tables that <codeph>gpperfmon_install</codeph>
+        creates. Enabling the gpperfmon data collection agents (<codeph>gpmmon</codeph> and
+          <codeph>gpsmon</codeph>) adds unnecessary load to the system. Instead, run the Command
+        Center installer. The installer creates the <codeph>gpperfmon</codeph> database with the
+          <codeph>gpmetrics</codeph> schema Command Center needs and enables the Command Center
+        agent (<codeph>ccagent</codeph>) to collect real-time system metrics and query information
+        from the Greenplum Database metrics collector module. See the <xref
+          href="https://gpcc.docs.pivotal.io/latest/welcome.html" format="html" scope="external"
+          >Greenplum Command Center</xref> documentation for more information. </note>
       <p>The <codeph>gpperfmon_install</codeph> utility automates the steps required to enable the
         data collection agents. You must be the Greenplum Database system user
           (<codeph>gpadmin</codeph>) to run this utility. The <codeph>--port</codeph> option is
@@ -82,10 +93,11 @@ host       all           gpmon  ::1/128        <b>password</b></codeblock></p>
           it):<codeblock>*:5432:gpperfmon:gpmon:<varname>gpmon_password</varname></codeblock> If
           your password file is not located in the default location (<codeph>~/.pgpass</codeph>),
           use the <codeph>--pgpass</codeph> option to specify the file location.</li>
-        <li id="ou140687">Sets the server configuration parameters for Greenplum Command Center. The
-          following parameters must be enabled for the data collection agents to begin collecting
-          data. The utility sets the following parameters in the Greenplum Database
-            <codeph>postgresql.conf</codeph> configuration files:<ul id="ul_wrp_dtx_wr">
+        <li id="ou140687">Sets the server configuration parameters for the
+            <codeph>gpperfmon</codeph> database. The following parameters must be enabled for the
+          data collection agents to begin collecting data. The utility sets the following parameters
+          in the Greenplum Database <codeph>postgresql.conf</codeph> configuration files:<ul
+            id="ul_wrp_dtx_wr">
             <li><codeph>gp_enable_gpperfmon=on</codeph> (in all <codeph>postgresql.conf</codeph>
               files)</li>
             <li><codeph>gpperfmon_port=8888</codeph> (in all <codeph>postgresql.conf</codeph> files) </li>
@@ -107,8 +119,8 @@ host       all           gpmon  ::1/128        <b>password</b></codeblock></p>
           <pd>In addition to creating the <codeph>gpperfmon</codeph> database, performs the
             additional steps required to enable the data collection agents. When
               <codeph>--enable</codeph> is specified the utility will also create and configure the
-              <codeph>gpmon</codeph> superuser account and set the Command Center server
-            configuration parameters in the <codeph>postgresql.conf</codeph> files.</pd>
+              <codeph>gpmon</codeph> superuser account and set the gpperfmon server configuration
+            parameters in the <codeph>postgresql.conf</codeph> files.</pd>
         </plentry>
         <plentry>
           <pt>--password <varname>gpmon_password</varname></pt>
@@ -162,9 +174,8 @@ host       all           gpmon  ::1/128        <b>password</b></codeblock></p>
                 <codeph>queries_history</codeph> table. For queries with shorter run times, no
               historical data is collected. Defaults to 20 seconds.</p>
             <p>If you know that you want to collect data for all queries, you can set this parameter
-              to a low value. Setting the minimum query run time to zero, however, collects data
-              even for the numerous queries run by Greenplum Command Center, creating a large amount
-              of data that may not be useful.</p>
+              to a low value. Setting the minimum query run time to zero, however, collects data for
+              even trivial queries and can create a large amount of data that may not be useful.</p>
           </stentry>
         </strow>
         <strow>
@@ -212,33 +223,23 @@ host       all           gpmon  ::1/128        <b>password</b></codeblock></p>
           <stentry>smdw_aliases</stentry>
           <stentry>This parameter allows you to specify additional host names for the standby
             master. For example, if the standby master has two NICs, you can
-              enter:<codeblock>smdw_aliases=smdw-1,smdw-2</codeblock><p>This optional fault
-              tolerance parameter is useful if the Greenplum Command Center loses connectivity with
-              the standby master. Instead of continuously retrying to connect to host smdw, it will
-              try to connect to the NIC-based aliases of <codeph>smdw-1</codeph> and/or
-                <codeph>smdw-2</codeph>. This ensures that the Command Center Console can
-              continuously poll and monitor the standby master.</p></stentry>
+            enter:<codeblock>smdw_aliases=smdw-1,smdw-2</codeblock></stentry>
         </strow>
       </simpletable>
     </section>
     <section>
       <title>Notes</title>
-      <p>The <codeph>gpperfmon</codeph> database and Greenplum Command Center require the
-          <codeph>gpmon</codeph> role. After the <codeph>gpperfmon</codeph> database and
-          <codeph>gpmon</codeph> role have been created, you can change the password for the
-          <codeph>gpmon</codeph> role and update the information that Greenplum Command Center uses
-        to connect to the <codeph>gpperfmon</codeph> database: </p>
+      <p>The <codeph>gpperfmon</codeph> database requires the <codeph>gpmon</codeph> role. After the
+          <codeph>gpperfmon</codeph> database and <codeph>gpmon</codeph> role have been created, you
+        can change the password for the <codeph>gpmon</codeph> role: </p>
       <ol id="ol_wss_knp_wr">
         <li>Log in to Greenplum Database as a superuser and change the <codeph>gpmon</codeph>
           password with the <codeph>ALTER ROLE</codeph>
           command.<codeblock># ALTER ROLE gpmon WITH PASSWORD '<varname>new_password</varname>' ;</codeblock></li>
-        <li>Update the password in <codeph>.pgpass</codeph> file that is used by Greenplum Command
-          Center. The default file location is the <codeph>gpadmin</codeph> home directory
-            (<codeph>~/.pgpass</codeph>). The <codeph>.pgpass</codeph> file contains a line with the
-            <codeph>gpmon</codeph>
+        <li>Update the password in the <codeph>.pgpass</codeph> file. The default file location is
+          the <codeph>gpadmin</codeph> home directory (<codeph>~/.pgpass</codeph>). The
+            <codeph>.pgpass</codeph> file contains a line with the <codeph>gpmon</codeph>
           password.<codeblock>*:5432:gpperfmon:gpmon:<varname>new_password</varname></codeblock></li>
-        <li>Restart the Greenplum Command Center with the Command Center <codeph>gpcmdr</codeph>
-          utility. <codeblock>$ gpcmdr --restart</codeblock></li>
       </ol>
       <p>The gpperfmon monitoring system requires some initialization after startup. Monitoring
         information appears after a few minutes have passed, and not immediately after installation


### PR DESCRIPTION
This PR fixes docs that claim gpperfmon is required by Command Center and warns users 
against running gpperfmon_install if they will be using Command Center 5. GPCC 5 installer
creates gpperfmon and gpmon user with the new history tables in the gpmetrics schema 
and without enabling the gpmmon/gpsmon agents. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
