### PR TITLE
Include OSL file for Greenplum Database release

### DIFF
--- a/concourse/pipelines/gpdb_opensource_release.yml
+++ b/concourse/pipelines/gpdb_opensource_release.yml
@@ -38,6 +38,13 @@ resources:
     repository: ((gpdb-release-repository))
     access_token: ((gpdb-release-access-token))
 
+- name: license_file
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-for-oss))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: osl/released/gpdb6/open_source_license_greenplum-database-(.*)-[a-z0-9]+-[0-9]+.txt
+
 ## gp internal artifacts
 - name: python-centos6
   type: gcs
@@ -280,6 +287,7 @@ jobs:
     - get: gpdb_src
       trigger: true
       passed: [release]
+    - get: license_file
   - task: gpdb_github_release
     file: gpdb_src/concourse/tasks/gpdb_github_release.yml
   - put: gpdb_release
@@ -290,3 +298,4 @@ jobs:
       globs:
         - release_artifacts/*.tar.gz
         - release_artifacts/*.zip
+        - license_file/*.txt


### PR DESCRIPTION
Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/dev:gpdb-oss-release
after runing the dev pipeline, the osl file will show in https://github.com/gp-releng/gpdb/releases/tag/6.0.0-beta.3-218-g5649d9a7fc


Co-authored-by: Shaoqi Bai <sbai@pivotal.io>
Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>