### PR TITLE
Fix a bug when setting globalxmin

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -251,14 +251,18 @@ TransactionId
 DistributedLog_GetOldestXmin(TransactionId oldestLocalXmin)
 {
 	TransactionId result;
-
 	result = DistributedLogShared->oldestXmin;
 
 	Assert(!IS_QUERY_DISPATCHER());
-	Assert (result != InvalidTransactionId);
-	Assert (!TransactionIdFollows(result, oldestLocalXmin));
+	elogif(Debug_print_full_dtm, LOG, "distributed oldestXmin is '%u'", result);
 
-	elogif(Debug_print_full_dtm, LOG, "oldestXmin is '%u'", result);
+	/*
+	 * Like in DistributedLog_AdvanceOldestXmin(), the shared oldestXmin
+	 * might already have been advanced past oldestLocalXmin.
+	 */
+	if (!TransactionIdIsValid(result) ||
+		TransactionIdFollows(result, oldestLocalXmin))
+		result = oldestLocalXmin;
 
 	return result;
 }

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1291,15 +1291,7 @@ GetOldestXmin(Relation rel, bool ignoreVacuum)
 	 */
 	if (IsPostmasterEnvironment && !IS_QUERY_DISPATCHER() &&
 		!IsBinaryUpgrade && !gp_maintenance_mode)
-	{
-		TransactionId distribOldestXmin;
-
-		distribOldestXmin = DistributedLog_GetOldestXmin(result);
-
-		if (TransactionIdIsValid(distribOldestXmin) &&
-			TransactionIdPrecedes(distribOldestXmin, result))
-			result = distribOldestXmin;
-	}
+		result = DistributedLog_GetOldestXmin(result);
 
 	return result;
 }


### PR DESCRIPTION
It's introduced in 'e00098', it happens in such case:

Tx 1: generate xid 1000 on segment 0 (xmin=1000, globalxmin=1000)
Tx 2: generate xid 2000 on segment 0 (xmin=1000, globalxmin=1000)
Tx 1: finish
Tx 3: generate xid 3000 on segment 0 (xmin=2000, globalxmin=1000)
Tx 2: finish
Tx 4: generate xid 4000 on segment 0 (xmin=3000, globalxmin=2000)

In this scenario, tx4 can advance the DistributedLogShared->oldestXmin to 2000,
tx3 should use its globalxmin 1000 instead of the value of
DistributedLogShared->oldestXmin.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
