### PR TITLE
Change the size of interconnect connection hash table

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -61,9 +61,10 @@ int			qe_identifier = 0;
 int			host_segments = 0;
 
 /*
- * total number of primary segments in this cluster
+ * size of hash table of interconnect connections
+ * equals to 2 * (the number of total segments)
  */
-int			total_segments = 0;
+int			ic_htab_size = 0;
 
 Gang      *CurrentGangCreating = NULL;
 
@@ -362,7 +363,7 @@ makeOptions(void)
  */
 bool
 build_gpqeid_param(char *buf, int bufsz,
-				   bool is_writer, int identifier, int hostSegs, int totalSegs)
+				   bool is_writer, int identifier, int hostSegs, int icHtabSize)
 {
 	int		len;
 #ifdef HAVE_INT64_TIMESTAMP
@@ -377,7 +378,7 @@ build_gpqeid_param(char *buf, int bufsz,
 
 	len = snprintf(buf, bufsz, "%d;" TIMESTAMP_FORMAT ";%s;%d;%d;%d",
 				   gp_session_id, PgStartTime,
-				   (is_writer ? "true" : "false"), identifier, hostSegs, totalSegs);
+				   (is_writer ? "true" : "false"), identifier, hostSegs, icHtabSize);
 
 	return (len > 0 && len < bufsz);
 }
@@ -451,14 +452,14 @@ cdbgang_parse_gpqeid_params(struct Port *port __attribute__((unused)),
 
 	if (gpqeid_next_param(&cp, &np))
 	{
-		total_segments = (int) strtol(cp, NULL, 10);
+		ic_htab_size = (int) strtol(cp, NULL, 10);
 	}
 
 	/* Too few items, or too many? */
 	if (!cp || np)
 		goto bad;
 
-	if (gp_session_id <= 0 || PgStartTime <= 0 || qe_identifier < 0 || host_segments <= 0 || total_segments <= 0)
+	if (gp_session_id <= 0 || PgStartTime <= 0 || qe_identifier < 0 || host_segments <= 0 || ic_htab_size <= 0)
 		goto bad;
 
 	pfree(gpqeid);

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -74,6 +74,7 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	newGangDefinition = buildGangDefinition(segments, segmentType);
 	CurrentGangCreating = newGangDefinition;
 	totalSegs = getgpsegmentCount();
+	Assert(totalSegs > 0);
 
 create_gang_retry:
 	Assert(newGangDefinition != NULL);
@@ -123,7 +124,7 @@ create_gang_retry:
 									 segdbDesc->isWriter,
 									 segdbDesc->identifier,
 									 segdbDesc->segment_database_info->hostSegs,
-									 totalSegs);
+									 totalSegs * 2);
 
 			if (!ret)
 				ereport(ERROR,

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -54,6 +54,7 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	int		i = 0;
 	int		size = 0;
 	bool	retry = false;
+	int		totalSegs = 0;
 
 	/*
 	 * true means connection status is confirmed, either established or in
@@ -72,6 +73,7 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	/* allocate and initialize a gang structure */
 	newGangDefinition = buildGangDefinition(segments, segmentType);
 	CurrentGangCreating = newGangDefinition;
+	totalSegs = getgpsegmentCount();
 
 create_gang_retry:
 	Assert(newGangDefinition != NULL);
@@ -120,7 +122,8 @@ create_gang_retry:
 			ret = build_gpqeid_param(gpqeid, sizeof(gpqeid),
 									 segdbDesc->isWriter,
 									 segdbDesc->identifier,
-									 segdbDesc->segment_database_info->hostSegs);
+									 segdbDesc->segment_database_info->hostSegs,
+									 totalSegs);
 
 			if (!ret)
 				ereport(ERROR,

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1510,7 +1510,7 @@ initConnHashTable(ConnHashTable *ht, MemoryContext cxt)
 	int			i;
 
 	ht->cxt = cxt;
-	ht->size = 2 * (Gp_role == GP_ROLE_DISPATCH ? getgpsegmentCount() : total_segments);
+	ht->size = Gp_role == GP_ROLE_DISPATCH ? (getgpsegmentCount() * 2) : ic_htab_size;
 	Assert(ht->size > 0);
 
 	if (ht->cxt)

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -177,7 +177,6 @@ struct ConnHashTable
 	int			size;
 };
 
-#define DEFAULT_CONN_HTAB_SIZE 16
 #define CONN_HASH_VALUE(icpkt) ((uint32)((((icpkt)->srcPid ^ (icpkt)->dstPid)) + (icpkt)->dstContentId))
 #define CONN_HASH_MATCH(a, b) (((a)->motNodeId == (b)->motNodeId && \
 								(a)->dstContentId == (b)->dstContentId && \
@@ -1511,7 +1510,8 @@ initConnHashTable(ConnHashTable *ht, MemoryContext cxt)
 	int			i;
 
 	ht->cxt = cxt;
-	ht->size = DEFAULT_CONN_HTAB_SIZE;
+	ht->size = 2 * (Gp_role == GP_ROLE_DISPATCH ? getgpsegmentCount() : total_segments);
+	Assert(ht->size > 0);
 
 	if (ht->cxt)
 	{

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -53,7 +53,7 @@ typedef struct Gang
 extern int qe_identifier;
 
 extern int host_segments;
-extern int total_segments;
+extern int ic_htab_size;
 
 extern MemoryContext GangContext;
 extern Gang *CurrentGangCreating;
@@ -87,7 +87,7 @@ extern void CheckForResetSession(void);
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);
 
 Gang *buildGangDefinition(List *segments, SegmentType segmentType);
-bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, int hostSegs, int totalSegs);
+bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, int hostSegs, int icHtabSize);
 
 char *makeOptions(void);
 extern bool segment_failure_due_to_recovery(const char *error_message);

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -53,6 +53,7 @@ typedef struct Gang
 extern int qe_identifier;
 
 extern int host_segments;
+extern int total_segments;
 
 extern MemoryContext GangContext;
 extern Gang *CurrentGangCreating;
@@ -86,7 +87,7 @@ extern void CheckForResetSession(void);
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);
 
 Gang *buildGangDefinition(List *segments, SegmentType segmentType);
-bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, int hostSegs);
+bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, int hostSegs, int totalSegs);
 
 char *makeOptions(void);
 extern bool segment_failure_due_to_recovery(const char *error_message);


### PR DESCRIPTION
As discussed in #6932, the size of interconnect connection hash table is 16,
which would be too small for large cluster and could bring too many hash table
collisions. Set to (2 * number segments).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
