### PR TITLE
Fix OpenSSL config loading of Windows client tools

### DIFF
--- a/concourse/scripts/compile_gpdb_remote_windows.bat
+++ b/concourse/scripts/compile_gpdb_remote_windows.bat
@@ -1,7 +1,7 @@
 @call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
 @echo on
 cd %WORK_DIR%\gpdb_src\src\tools\msvc
-echo our $config = {gss =^> 'C:/ext', openssl =^> 'c:/ext', zlib =^> 'c:/ext'}; >config.pl
+echo our $config = {gss =^> 'C:/windows/system32/ext', openssl =^> 'C:/windows/system32/ext', zlib =^> 'C:/windows/system32/ext'}; >config.pl
 
 perl build.pl client
 perl install.pl %WORK_DIR%\greenplum-db-devel client
@@ -10,7 +10,7 @@ REM build gpfdist
 cd %WORK_DIR%\gpdb_src\src\bin\gpfdist
 mkdir build
 cd build
-cmake -DCMAKE_PREFIX_PATH:PATH=C:\ext -DCMAKE_INSTALL_PREFIX:PATH=%WORK_DIR%\greenplum-db-devel -G "Visual Studio 15 2017 Win64" ..
+cmake -DCMAKE_PREFIX_PATH:PATH=C:\windows\system32\ext -DCMAKE_INSTALL_PREFIX:PATH=%WORK_DIR%\greenplum-db-devel -G "Visual Studio 15 2017 Win64" ..
 cmake --build . --config Release --target ALL_BUILD
 cmake --build . --config Release --target INSTALL
 
@@ -24,7 +24,7 @@ cmake --build . --config Release --target INSTALL
 
 REM create msi package
 cd %WORK_DIR%\gpdb_src\gpAux\client\install\src\windows\
-@call CopyDependencies.bat C:\ext %WORK_DIR%\greenplum-db-devel
+@call CopyDependencies.bat C:\windows\system32\ext %WORK_DIR%\greenplum-db-devel
 @call CreatePackage.bat %WORK_DIR%\greenplum-db-devel %GPDB_VERSION%
 
 move *.msi %WORK_DIR%


### PR DESCRIPTION
OpenSSL will load config file under the path it's being configured.
If the path is writable by non-admin user, a malicious user can
potentially inject code on OpenSSL invocation. Change dependency
path to C:\windows\system32

Reference: https://curl.haxx.se/docs/CVE-2019-5443.html
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
