### PR TITLE
6X back port: Remove unused function

### DIFF
--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -546,11 +546,6 @@ static inline unsigned char *memtuple_get_nullp(MemTuple mtup, MemTupleBinding *
 {
 	return mtup->PRIVATE_mt_bits + (mtbind_has_oid(pbind) ? sizeof(Oid) : 0);
 }
-static inline int memtuple_get_nullp_len(MemTupleBinding *pbind)
-{
-	return (pbind->tupdesc->natts + 7) >> 3;
-}
-
 
 /* form a memtuple from values and isnull, to a prespecified buffer */
 MemTuple memtuple_form_to(


### PR DESCRIPTION
I noticed a warning about `memtuple_get_nullp_len()` when compiling 6X today and cherry-picked the fix from master.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
