### PR TITLE
Introduce concourse_unit_tests to support TDD

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -41,6 +41,7 @@
 groups:
 - name: all
   jobs:
+  - concourse_unit_tests
 {% if "centos6" in os_types %}
   - compile_gpdb_centos6
   - compile_gpdb_binary_swap_centos6
@@ -355,6 +356,13 @@ resources:
     ignore_paths:
     - gpdb-doc/*
     - README*
+
+- name: bats_src
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/bats-core/bats-core.git
+    tag: v1.1.0
 
 {% if "centos6" in os_types %}
 - name: gpdb_src_binary_swap
@@ -837,6 +845,41 @@ anchors:
 ## ======================================================================
 
 jobs:
+
+## ======================================================================
+##  ____  _            _ _              _   _       _ _     _____         _
+## |  _ \(_)_ __   ___| (_)_ __   ___  | | | |_ __ (_) |_  |_   _|__  ___| |_ ___
+## | |_) | | '_ \ / _ \ | | '_ \ / _ \ | | | | '_ \| | __|   | |/ _ \/ __| __/ __|
+## |  __/| | |_) |  __/ | | | | |  __/ | |_| | | | | | |_    | |  __/\__ \ |_\__ \
+## |_|   |_| .__/ \___|_|_|_| |_|\___|  \___/|_| |_|_|\__|   |_|\___||___/\__|___/
+##         |_|
+## ======================================================================
+
+{% if "centos7" in os_types %}
+- name: concourse_unit_tests
+  plan:
+    - aggregate:
+      - get: bats_src
+      - get: gpdb_src
+        trigger: true
+      - get: gpdb6-centos7-build
+    - task: run_unit_tests
+      image: gpdb6-centos7-build
+      config:
+        inputs:
+          - name: bats_src
+          - name: gpdb_src
+        platform: linux
+        run:
+          path: bash
+          args:
+          - -exc
+          - |
+            bats_src/install.sh /usr/local
+            cd gpdb_src/concourse
+            bats -t scripts/*.bats
+            python -m unittest discover --verbose -s scripts/ -p *_test.py
+{% endif %}
 
 ## ======================================================================
 ##   ____                      _ _

--- a/concourse/scripts/remove_non_production_files.bats
+++ b/concourse/scripts/remove_non_production_files.bats
@@ -52,10 +52,10 @@ main() {
 
   run main
   [ "$status" -eq 0 ]
-  [[ "$output" =~ $'a\nb' ]]
+  [[ "$output" =~ "rm".*$'\n'.*"a".*$'\n'.*b ]]
 }
 
-@test "it works when there are no files to remove" {
+@test "it fails when there are no files to remove" {
   export INPUT_TARBALL="a.tar.gz"
   export NON_PRODUCTION_FILES="empty-NON_PRODUCTION_FILES.txt"
 
@@ -105,5 +105,6 @@ main() {
 
   run main
   [ "$status" -ne 0 ]
-  [[ "$output" =~ "rm: b: No such file or directory" ]]
+  # rm: cannot remove `b': No such file or directory
+  [[ "$output" =~ "rm".*"b".*"No such file or directory" ]]
 }

--- a/concourse/scripts/remove_non_production_files.sh
+++ b/concourse/scripts/remove_non_production_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 
@@ -9,7 +9,7 @@ main() {
   tar zxf "${INPUT_TARBALL}" -C "${tmp_dir}"
 
   cd "${tmp_dir}"
-  xargs rm -v < "${wd}/${NON_PRODUCTION_FILES}"
+  xargs rm -v < "${wd}/${NON_PRODUCTION_FILES}" || true
   if ! tar czf "${wd}/${OUTPUT_TARBALL}" * ; then
     echo "All files were removed so ${OUTPUT_TARBALL} cannot be created"
     exit 1


### PR DESCRIPTION
Concourse is critical for delivering software to our customers, but we don't have any test coverage around the existing scripts. This could be quite dangerous when you are adding new files or making changes to an existing scripts because bugs can be inadvertently introduced.

With this PR, we are introducing a new pattern of using BATS ([bash testing framework](https://github.com/sstephenson/bats)) and python unit testing for files inside the concourse/scripts folder, to enable developers to backfill tests / easily do TDD.

Co-authored-by: Mark Sliva @marksliva
Co-authored-by: Amil Khanzada @amilkh 

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed