### PR TITLE
6X: basebackup: correctly terminate readlink() buffer

### DIFF
--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -1251,6 +1251,7 @@ sendDir(char *path, int basepathlen, bool sizeonly, List *tablespaces,
 				ereport(ERROR,
 						(errmsg("symbolic link \"%s\" target is too long",
 								pathbuf)));
+			linkpath[rllen] = '\0';
 
 			/* Lop off the dbid before sending the link target. */
 			char *file_sep_before_dbid_in_link_path = strrchr(linkpath, '/');


### PR DESCRIPTION
_This is a backport to `6X_STABLE` of https://github.com/greenplum-db/gpdb/pull/7977._

Buffer corruption was caused by not correctly terminating the
readlink(), as of commit ccfa3ab7b. We restored a previous line of code
that allows correct termination.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
