### PR TITLE
Bump ORCA version to 3.51.0

### DIFF
--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -19,4 +19,4 @@ params:
   BLD_TARGETS:
   OUTPUT_ARTIFACT_DIR: gpdb_artifacts
   CONFIGURE_FLAGS:
-  ORCA_TAG: v3.50.0
+  ORCA_TAG: v3.51.0

--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.50.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.51.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.50.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.51.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13982,7 +13982,7 @@ int
 main ()
 {
 
-return strncmp("3.50.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.51.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13992,7 +13992,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.50.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.51.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.50.0@gpdb/stable
+orca/v3.51.0@gpdb/stable
 
 [imports]
 include, * -> build/include


### PR DESCRIPTION
Improve PciIntervalFromScalarBoolOr() to use faster algorithm
Only allow const expr evaluation for (const cmp const) ignoring casts
Remove FDisjointLeft check in CRange::PrngExtend()

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Shreedhar Hardikar <shardikar@pivotal.io>