### PR TITLE
**Draft** gpstop: remove application_name whitelist

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -28,8 +28,9 @@ logger = get_default_logger()
 GPHOME=os.environ.get('GPHOME')
 
 #Default timeout for segment start
-SEGMENT_TIMEOUT_DEFAULT=600
-SEGMENT_STOP_TIMEOUT_DEFAULT=120
+#FIXME BEFORE COMMIT
+SEGMENT_TIMEOUT_DEFAULT=15
+SEGMENT_STOP_TIMEOUT_DEFAULT=10
 
 #"Command not found" return code in bash
 COMMAND_NOT_FOUND=127

--- a/gpMgmt/bin/gppylib/db/catalog.py
+++ b/gpMgmt/bin/gppylib/db/catalog.py
@@ -37,13 +37,9 @@ def getDatabaseList(conn):
     sql = "SELECT datname FROM pg_catalog.pg_database"
     return basicSQLExec(conn,sql)
 
-def getUserPIDs(conn, ignoreList):
+def getUserPIDs(conn):
     """dont count ourselves"""
     sql = """SELECT pid FROM pg_stat_activity WHERE pid != pg_backend_pid()"""
-    if ignoreList:
-        ignoreStr = ', '.join("'"+ pg.escape_string(i) +"'" for i in ignoreList)
-        sql = sql + ' and application_name not in (' + ignoreStr +')'
-
     return basicSQLExec(conn,sql)
 
 def doesSchemaExist(conn,schemaname):

--- a/gpMgmt/bin/gppylib/db/catalog.py
+++ b/gpMgmt/bin/gppylib/db/catalog.py
@@ -37,9 +37,9 @@ def getDatabaseList(conn):
     sql = "SELECT datname FROM pg_catalog.pg_database"
     return basicSQLExec(conn,sql)
 
-def getUserPIDs(conn):
+def getUserConnectionInfo(conn):
     """dont count ourselves"""
-    sql = """SELECT pid FROM pg_stat_activity WHERE pid != pg_backend_pid()"""
+    sql = """SELECT pid, usename, application_name, client_addr, client_hostname, client_port, backend_start, query FROM pg_stat_activity WHERE pid != pg_backend_pid() ORDER BY usename"""
     return basicSQLExec(conn,sql)
 
 def doesSchemaExist(conn,schemaname):

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -40,7 +40,7 @@ except ImportError, e:
 
 DEFAULT_NUM_WORKERS = 64
 logger = get_default_logger()
-
+NUMBER_OF_SECONDS_IN_A_YEAR = 31536000
 
 # ---------------------------------------------------------------
 class SegStopStatus:
@@ -81,7 +81,6 @@ def print_progress(pool, interval=10):
     # print_completed_percentage() returns True if we're done.
     while not print_completed_percentage():
         pool.join(interval)
-
 
 # ---------------------------------------------------------------
 class GpStop:
@@ -166,7 +165,9 @@ class GpStop:
                 # Disable Ctrl-C
                 signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-                self._stop_master()
+                while not self._stop_master():
+                    logger.info("foofoo")
+                    pass
             finally:
                 # Reenable Ctrl-C
                 self.cleanup()
@@ -419,31 +420,50 @@ class GpStop:
     def _stop_master(self, masterOnly=False):
         ''' shutsdown the master '''
 
-        self._stop_master_checks()
+        total_connections = None
+        if self.mode == 'smart' and self.timeout != NUMBER_OF_SECONDS_IN_A_YEAR:  #FIXME: make out-of-band
+            self.conn = dbconn.connect(self.dburl, utility=True)
+            total_connections = catalog.getUserConnectionInfo(self.conn)
+            self.conn.close()
+        elif self.mode == 'fast':
+            logger.info("Using WAIT mode of %s seconds" % self.timeout)
 
         e = GpEraFile(self.master_datadir, logger=get_logger_if_verbose())
         e.end_era()
 
         logger.info("Commencing Master instance shutdown with mode=%s" % self.mode)
         logger.info("Master segment instance directory=%s" % self.master_datadir)
+        logger.info("Master host=%s" % self.gparray.master.hostname)
 
         cmd = gp.MasterStop("stopping master", self.master_datadir, mode=self.mode, timeout=self.timeout)
         try:
+            if self.mode == 'smart' and self.timeout == NUMBER_OF_SECONDS_IN_A_YEAR:
+                signal.signal(signal.SIGINT,  lambda signo, fname : logger.info("you are waiting forever...do it yourself or keep waiting!!") )
             cmd.run(validateAfter=True)
         except ExecutionError as err:
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
             logger.warning("master stop failed: %s" % err)
 
             if self.mode == 'smart':
                 logger.warning("Smart mode shutdown timed out due to: %s" % cmd.get_stderr())
+                if total_connections:
+                    # FIXME print out something cleaner
+                    logger.info("Connects to database: %s" % total_connections)
+                    logger.warning("There are other connections to this instance, shutdown mode smart aborted")
+                    logger.warning("Either remove connections, or use 'gpstop -M fast' or 'gpstop -M immediate'")
+                    logger.warning("See gpstop -? for all options")
+
                 mode_selection = userinput.ask_string("your_choice",
                                        "['(w)ait_forever', '(f)ast_mode', '(i)mmediate_mode']",
                                        'w',
                                        ['w', 'f', 'i'])
                 logger.info("your choice is %s" % mode_selection)
 
+                # FIXME: report user connections here to assist DBA(they can't access db now!)
                 if mode_selection == 'w':
-                    self.mode = 'smart'   #fixme...how to wait forever here?  Add a mode 'superslow'?
-                    logger.info("re-trying smart shutdown")
+                    self.mode = 'smart'
+                    self.timeout = NUMBER_OF_SECONDS_IN_A_YEAR   # wait for a year
+                    logger.info("re-trying smart shutdown with waiting forever")
                 elif mode_selection == 'f':
                     self.mode = 'fast'
                     logger.info("commencening fast shutdown...")
@@ -478,6 +498,8 @@ class GpStop:
                         if os.path.exists(lockfile):
                             logger.info("Clearing segment instance lock files")
                             os.remove(lockfile)
+        finally:
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
 
         logger.info('Attempting forceful termination of any leftover master process')
         (succeeded, mypid, file_datadir) = pg.ReadPostmasterTempFile.local("Read master tmp file",
@@ -487,20 +509,6 @@ class GpStop:
         logger.debug("Successfully shutdown the Master instance in admin mode")
 
         return True
-
-    ######
-    def _stop_master_checks(self):
-        logger.info("Commencing Master instance shutdown with mode='%s'" % self.mode)
-        logger.info("Master host=%s" % self.gparray.master.hostname)
-
-        if self.mode == 'smart':
-            pass
-        elif self.mode == 'fast':
-            if self.timeout == SEGMENT_STOP_TIMEOUT_DEFAULT:
-                logger.info("Using standard WAIT mode of %s seconds" % SEGMENT_STOP_TIMEOUT_DEFAULT)
-            else:
-                logger.info("Using WAIT mode of %s seconds" % self.timeout)
-        pass
 
     ######
     def _stop_standby(self):

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -37,15 +37,6 @@ try:
 except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
-"""
-GpstopCheckIgnoreList is a whitelist to ignore when checking active database connections
-
-In smart mode, we check the `pg_stat_activity` table for active sessions before calling
-the cluster stop routine. However, we need to ignore those that are part of the database
-implementation itself. For this purpose, we maintain a whitelist using its `application_name`
-field.
-"""
-GpstopCheckIgnoreList = ['gp_reserved_gpdiskquota']
 
 DEFAULT_NUM_WORKERS = 64
 logger = get_default_logger()
@@ -206,7 +197,8 @@ class GpStop:
                     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
                     if self.onlyThisHost is None:
-                        self._stop_master()
+                        while not self._stop_master():
+                            pass
                         self._stop_standby()
                     self._stop_segments(segs)
                     self._stop_gpmmon()
@@ -427,10 +419,7 @@ class GpStop:
     def _stop_master(self, masterOnly=False):
         ''' shutsdown the master '''
 
-        self.conn = dbconn.connect(self.dburl, utility=True)
         self._stop_master_checks()
-
-        self.conn.close()
 
         e = GpEraFile(self.master_datadir, logger=get_logger_if_verbose())
         e.end_era()
@@ -441,7 +430,32 @@ class GpStop:
         cmd = gp.MasterStop("stopping master", self.master_datadir, mode=self.mode, timeout=self.timeout)
         try:
             cmd.run(validateAfter=True)
-        except:
+        except ExecutionError as err:
+            logger.warning("master stop failed: %s" % err)
+
+            if self.mode == 'smart':
+                logger.warning("Smart mode shutdown timed out due to: %s" % cmd.get_stderr())
+                mode_selection = userinput.ask_string("your_choice",
+                                       "['(w)ait_forever', '(f)ast_mode', '(i)mmediate_mode']",
+                                       'w',
+                                       ['w', 'f', 'i'])
+                logger.info("your choice is %s" % mode_selection)
+
+                if mode_selection == 'w':
+                    self.mode = 'smart'   #fixme...how to wait forever here?  Add a mode 'superslow'?
+                    logger.info("re-trying smart shutdown")
+                elif mode_selection == 'f':
+                    self.mode = 'fast'
+                    logger.info("commencening fast shutdown...")
+                elif mode_selection == 'i':
+                    self.mode = 'immediate'
+                    logger.info("commenencing immediate shutdown...")
+                else:
+                    self.mode = 'immediate'
+                    logger.info("commenencing immediate shutdown...")
+
+                return False
+
             # Didn't stop in timeout or pg_ctl failed.  So try kill
             (succeeded, mypid, file_datadir) = pg.ReadPostmasterTempFile.local("Read master tmp file",
                                                                                self.dburl.pgport).getResults()
@@ -464,6 +478,7 @@ class GpStop:
                         if os.path.exists(lockfile):
                             logger.info("Clearing segment instance lock files")
                             os.remove(lockfile)
+
         logger.info('Attempting forceful termination of any leftover master process')
         (succeeded, mypid, file_datadir) = pg.ReadPostmasterTempFile.local("Read master tmp file",
                                                                            self.dburl.pgport).getResults()
@@ -471,33 +486,20 @@ class GpStop:
 
         logger.debug("Successfully shutdown the Master instance in admin mode")
 
+        return True
+
     ######
     def _stop_master_checks(self):
-        total_connections = len(catalog.getUserPIDs(self.conn, GpstopCheckIgnoreList))
-        logger.info("There are %d connections to the database" % total_connections)
-
-        if total_connections > 0 and self.mode == 'smart':
-            logger.warning("There are other connections to this instance, shutdown mode smart aborted")
-            logger.warning("Either remove connections, or use 'gpstop -M fast' or 'gpstop -M immediate'")
-            logger.warning("See gpstop -? for all options")
-            raise ExceptionNoStackTraceNeeded("Active connections. Aborting shutdown...")
-
         logger.info("Commencing Master instance shutdown with mode='%s'" % self.mode)
         logger.info("Master host=%s" % self.gparray.master.hostname)
 
         if self.mode == 'smart':
             pass
         elif self.mode == 'fast':
-            logger.info("Detected %d connections to database" % total_connections)
-            if total_connections > 0:
-                logger.info("Switching to WAIT mode")
-                logger.info("Will wait for shutdown to complete, this may take some time if")
-                logger.info("there are a large number of active complex transactions, please wait...")
+            if self.timeout == SEGMENT_STOP_TIMEOUT_DEFAULT:
+                logger.info("Using standard WAIT mode of %s seconds" % SEGMENT_STOP_TIMEOUT_DEFAULT)
             else:
-                if self.timeout == SEGMENT_STOP_TIMEOUT_DEFAULT:
-                    logger.info("Using standard WAIT mode of %s seconds" % SEGMENT_STOP_TIMEOUT_DEFAULT)
-                else:
-                    logger.info("Using WAIT mode of %s seconds" % self.timeout)
+                logger.info("Using WAIT mode of %s seconds" % self.timeout)
         pass
 
     ######

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -944,11 +944,6 @@ class GpStop:
         if options.parallel > 128 or options.parallel < 1:
             raise ProgramArgumentValidationException("Invalid value for parallel degree: %s" % options.parallel)
 
-        # Don't allow them to go below default
-        if options.timeout < SEGMENT_STOP_TIMEOUT_DEFAULT:
-            raise ProgramArgumentValidationException(
-                "Invalid timeout value.  Must be greater than %s seconds." % SEGMENT_STOP_TIMEOUT_DEFAULT)
-
         if args:
             raise ProgramArgumentValidationException(
                 "Argument %s is invalid.  Is an option missing a parameter?" % args[-1])

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -18,7 +18,7 @@ def before_all(context):
 
 def before_feature(context, feature):
     # we should be able to run gpexpand without having a cluster initialized
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors', 'gpconfig', 'gpssh-exkeys']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors', 'gpconfig', 'gpssh-exkeys', 'gpstop']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -93,7 +93,7 @@ def before_scenario(context, scenario):
     if 'gpssh-exkeys' in context.feature.tags:
         context.gpssh_exkeys_context = GpsshExkeysMgmtContext(context)
 
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors', 'gpconfig', 'gpssh-exkeys']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors', 'gpconfig', 'gpssh-exkeys', 'gpstop']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -112,8 +112,15 @@ def after_scenario(context, scenario):
         for tablespace in context.tablespaces.values():
             tablespace.cleanup()
 
+    if 'gpstop' in scenario.effective_tags:
+        context.execute_steps(u'''
+            # restart the cluster so that subsequent tests re-use the existing demo cluster
+            Then the user runs "gpstart -a"
+            And gpstart should return a return code of 0
+            ''')
+
     # NOTE: gpconfig after_scenario cleanup is in the step `the gpconfig context is setup`
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpinitstandby', 'gpconfig']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpinitstandby', 'gpconfig', 'gpstop']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -1,0 +1,22 @@
+@gpstop
+Feature: gpstop behave tests
+
+    Scenario: gpstop succeeds
+        Given a standard local demo cluster is running
+         When the user runs "gpstop -a"
+         Then gpstop should return a return code of 0
+
+    Scenario: when there are user connections gpstop waits to shutdown until a user makes a selection
+        Given a standard local demo cluster is running
+          And the user asynchronously runs "psql postgres" and the process is saved
+         When the user runs gpstop -a -t 4 and selects f
+          And gpstop should print "'\(s\)mart_mode', '\(f\)ast_mode', '\(i\)mmediate_mode'" to stdout
+         Then gpstop should return a return code of 0
+
+    Scenario: when there are user connections gpstop waits to shutdown until a user connections are disconnected
+        Given a standard local demo cluster is running
+          And the user asynchronously runs "psql postgres" and the process is saved
+          And the user asynchronously sets up to end that process in 3 seconds
+         When the user runs gpstop -a -t 1 and selects s
+          And gpstop should print "'\(s\)mart_mode', '\(f\)ast_mode', '\(i\)mmediate_mode'" to stdout
+          Then gpstop should return a return code of 0

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -123,7 +123,10 @@ def run_gpcommand(context, command, cmd_prefix=''):
 
 def run_gpcommand_async(context, command):
     cmd = Command(name='run %s' % command, cmdStr='$GPHOME/bin/%s' % (command))
-    context.asyncproc = cmd.runNoWait()
+    asyncproc = cmd.runNoWait()
+    if 'asyncproc' not in context:
+        context.asyncproc = asyncproc
+
 
 def check_stdout_msg(context, msg, escapeStr = False):
     if escapeStr:


### PR DESCRIPTION
See https://github.com/greenplum-db/gpdb/pull/8063 for the full PR.

This is a draft PR to receive early feedback on any major design considerations while we add tests. We would like reviewers since gpstop is a critical component that touches many utilities.

Use pg_ctl to allow background worker connections during shutdown and remove application_name whitelist, which was checked to allow smart shutdown to proceed. When pg_ctl timeout prompt user to continue shutting down in smart mode while waiting forever, or shutdown in fast or immediate mode. We allow the user to send a SIGINT to interrupt a long-running smart mode shutdown and resend either a fast or immediate shutdown.

Background workers started by extensions and other internals can make their own user connections. Postgres internally ignores background connections for smart mode, but gpstop does not. Thus, rely on the server to know when it is safe to shutdown, and remove the upfront connection check from gpstop's smart shutdown mode.

**Considerations:**
- We allow SIGINT to interrupt a long wait, but there are some potential race conditions. We do not know of better way to interrupt the long-running pg_ctl smart shutdown.
- For gpstop, keep a general goal of "don't exit until the cluster has stopped". This is slightly different from pg_ctl's contract (pg_ctl can time out and exit before the cluster has stopped), but we have a good reason for deviating as we have multiple instances of Postgres to worry about.
