### PR TITLE
6X_STABLE: Behave: Correctly kill processes during gprecoverseg tests

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -171,7 +171,6 @@ Feature: gprecoverseg tests
         And the backup pid file is deleted on "primary" segment
         And the background pid is killed on "primary" segment
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gprecoverseg full recovery testing
         Given the database is running
@@ -187,7 +186,6 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gprecoverseg with -i and -o option
         Given the database is running
@@ -206,7 +204,6 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gprecoverseg should not throw exception for empty input file
         Given the database is running
@@ -224,7 +221,6 @@ Feature: gprecoverseg tests
         Then all the segments are running
         And the segments are synchronized
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gprecoverseg should use the same setting for data_checksums for a full recovery
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -66,11 +66,8 @@ def impl(context, seg):
 
     datadir_grep = '[' + datadir[0] + ']' + datadir[1:]
     cmdStr = "ps ux | grep %s | awk '{print $2}' | xargs kill" % datadir_grep
-    cmd = Command(name='get %s pid: %s' % (seg, cmdStr),
-                  cmdStr=cmdStr,
-                  ctxt=REMOTE,
-                  remoteHost=seghost)
-    cmd.run()
+
+    subprocess.check_call(['ssh', seghost, cmdStr])
 
 @then('the saved primary segment reports the same value for sql "{sql_cmd}" db "{dbname}" as was saved')
 def impl(context, sql_cmd, dbname):


### PR DESCRIPTION
This is a backport of the Behave: Correctly kill processes during gprecoverseg tests PR https://github.com/greenplum-db/gpdb/pull/7994.

We were not killing the postmaster processes because of the following reasons.

1. The `$` symbols passed to `Command` was expanded on the local machine due to
the `RemoteExecutionContext` implementation.  This made the awk filter a no-op.

2. We did not catch this on Centos because the Centos implementation of
/bin/kill will kill as many of the processes as are valid and ignoring the
invalid ones.  However, Ubuntu fails fast if any of the arguments are invalid.

3. The test step did not validate the result of `Command.run()`.  Thus ignoring
the failure.

We have replaced `Command` by `subprocess.check_call()`.

(cherry picked from commit a9f4e969a792303e8b142191611f98dd41a5ce41)

Co-authored-by: Jacob Champion <pchampion@pivotal.io>
Co-authored-by: Shoaib Lari <slari@pivotal.io>

