### PR TITLE
6X_STABLE: Behave: Unset `TZ` rather than setting to empty string

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -72,10 +72,9 @@ Feature: gpinitsystem tests
         And gpinitsystem should print "Log file scan check passed" to stdout
         And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
 
-    @skip_fixme_ubuntu18.04
     Scenario: gpinitsystem creates a cluster in default timezone
         Given the database is not running
-        And the environment variable "TZ" is not set
+        And "TZ" environment variable is not set
         And the system timezone is saved
         And the user runs command "rm -rf ../gpAux/gpdemo/datadirs/*"
         And the user runs command "mkdir ../gpAux/gpdemo/datadirs/qddir; mkdir ../gpAux/gpdemo/datadirs/dbfast1; mkdir ../gpAux/gpdemo/datadirs/dbfast2; mkdir ../gpAux/gpdemo/datadirs/dbfast3"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -843,12 +843,6 @@ def impl(context):
         raise Exception('Unable to establish a connection to database !!!')
 
 
-@given('the environment variable "{var}" is not set')
-def impl(context, var):
-    context.env_var = os.environ.get(var)
-    os.environ[var] = ''
-
-
 @given('the environment variable "{var}" is set to "{val}"')
 def impl(context, var, val):
     context.env_var = os.environ.get(var)


### PR DESCRIPTION
This is backport of Behave: Unset `TZ` rather than setting to empty string PR https://github.com/greenplum-db/gpdb/pull/7999.

In the Behave test for gpinitsystem, testing for database creation in default
timezone was done by setting the TZ variable to an empty string. On Ubuntu this
resulted in the `date +"%Z"` command giving `Universal` as the timezone rather
than `UTC`.

In this commit, the `TZ` variable is unset rather than set to an empty
string. Thus giving uniform behavior on Ubuntu and other platforms. Since we
already have a Behave step to unset a variable correctly, so we are removing
this incorrect step.

(cherry picked from commit 0af8d0e956f7cc90f443d7e051cb13d2cdf55893)

Co-authored-by: Jacob Champion <pchampion@pivotal.io>

