### PR TITLE
docs - misc fdw- and foreign table-related doc updates

### DIFF
--- a/gpdb-doc/dita/admin_guide/external/g-foreign.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-foreign.xml
@@ -29,7 +29,7 @@
       Greenplum Database asks the foreign-data wrapper to fetch data from, or
       update data in (if supported by the wrapper), the remote source.</p>
     <note>The Pivotal Query Optimizer, GPORCA, does not support foreign tables.
-      A query on a foreign table always falls back to the Postgres query optimizer.</note>
+      A query on a foreign table always falls back to the Postgres Planner.</note>
     <p>Accessing remote data may require authenticating to the remote data
       source. This information can be provided by a <i>user mapping</i>,
       which can provide additional data such as a user name and password

--- a/gpdb-doc/dita/admin_guide/external/g-foreign.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-foreign.xml
@@ -10,11 +10,15 @@
     <p>You can access foreign data with help from a <i>foreign-data wrapper</i>.
       A foreign-data wrapper is a library that communicates with a remote
       data source. This library hides the source-specific connection and data
-      access details. Some foreign-data wrappers will be available as Greenplum
-      Database contrib modules, including <codeph>file_fdw</codeph> and
-      <codeph>postgres_fdw</codeph>. If none of the existing foreign-data wrappers
-      suit your needs, you can write your own as described in
-      <xref href="g-devel-fdw.xml#topic1"/>.</p>
+      access details. Foreign-data wrappers provided in the Greenplum Database
+      distribution, including <codeph>file_fdw</codeph> and
+      <codeph>postgres_fdw</codeph>, have been modified to take advantage
+      of Greenplum's parallel processing.</p>
+    <note>Most PostgreSQL foreign-data wrappers should work with Greenplum
+      Database. However, any foreign-data wrapper that is not provided in the
+      Greenplum distribution likely connects only through the master.</note>
+    <p>If none of the existing foreign-data wrappers suit your needs, you can
+      write your own as described in <xref href="g-devel-fdw.xml#topic1"/>.</p>
     <p>To access foreign data, you create a <i>foreign server</i> object,
       which defines how to connect to a particular remote data source
       according to the set of options used by its supporting foreign-data
@@ -24,6 +28,8 @@
       the Greenplum Database server. Whenever a foreign table is accessed,
       Greenplum Database asks the foreign-data wrapper to fetch data from, or
       update data in (if supported by the wrapper), the remote source.</p>
+    <note>The Pivotal Query Optimizer, GPORCA, does not support foreign tables.
+      A query on a foreign table always falls back to the Postgres query optimizer.</note>
     <p>Accessing remote data may require authenticating to the remote data
       source. This information can be provided by a <i>user mapping</i>,
       which can provide additional data such as a user name and password

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
@@ -123,7 +123,7 @@
           <title>Notes</title>
           <p>The Pivotal Query Optimizer, GPORCA, does not support foreign
            tables. A query on a foreign table always falls back to the Postgres
-           query optimizer.</p>
+           Planner.</p>
         </section>
         <section id="section6">
             <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
@@ -119,6 +119,12 @@
                 </plentry>
             </parml>
         </section>
+        <section id="section5">
+          <title>Notes</title>
+          <p>The Pivotal Query Optimizer, GPORCA, does not support foreign
+           tables. A query on a foreign table always falls back to the Postgres
+           query optimizer.</p>
+        </section>
         <section id="section6">
             <title>Examples</title>
             <p>Create a foreign table named <codeph>films</codeph> with the server named <codeph>film_server</codeph>:</p><codeblock>CREATE FOREIGN TABLE films (

--- a/gpdb-doc/dita/ref_guide/sql_commands/VACUUM.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/VACUUM.xml
@@ -135,7 +135,7 @@ VACUUM [FULL] [FREEZE] [VERBOSE] ANALYZE
       <p><codeph>VACUUM</codeph> causes a substantial increase in I/O traffic, which can cause poor
         performance for other active sessions. Therefore, it is advisable to vacuum the database at
         low usage times.</p>
-      <p><codeph>VACUUM</codeph> commands skip external tables.</p>
+      <p><codeph>VACUUM</codeph> commands skip external and foreign tables.</p>
       <p><codeph>VACUUM FULL</codeph> reclaims all expired row space, however it requires an
         exclusive lock on each table being processed, is a very expensive operation, and might take
         a long time to complete on large, distributed Greenplum Database tables. Perform


### PR DESCRIPTION
in this PR:
- vacuum skips foreign tables
- queries on foreign tables fall back to planner
- postgres fdws should work
- misc edits to "accessing foreign data" page

plan to backport to 6X_STABLE.