### PR TITLE
docs - pxf now bundled with postgresql 42.2.5 jar

### DIFF
--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -19,7 +19,7 @@ In previous releases of Greenplum Database, you may have specified the JDBC driv
 
 ## <a id="cfg_jar"></a>JDBC Driver JAR Registration
 
-The PXF JDBC Connector is installed with the `postgresql-9.1-901-1.jdbc4.jar` JAR file. If you require a different JDBC driver, ensure that you install the JDBC driver JAR file for the external SQL database in the `$PXF_CONF/lib` directory on each segment host. Be sure to install JDBC driver JAR files that are compatible with your JRE version. See [Registering PXF JAR Dependencies](reg_jar_depend.html) for additional information.
+The PXF JDBC Connector is installed with the `postgresql-42.2.5.jar` JAR file. If you require a different JDBC driver, ensure that you install the JDBC driver JAR file for the external SQL database in the `$PXF_CONF/lib` directory on each segment host. Be sure to install JDBC driver JAR files that are compatible with your JRE version. See [Registering PXF JAR Dependencies](reg_jar_depend.html) for additional information.
 
 ## <a id="cfg_server"></a>JDBC Server Configuration
 

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -251,21 +251,11 @@ This procedure will typically be performed by the Greenplum Database administrat
 </configuration>
     ```
 
-2. [Download](https://jdbc.postgresql.org/download.html) a PostgreSQL JDBC driver JAR file and note the location of the downloaded file.
-
-3. Copy the JDBC driver JAR file to `$PXF_CONF/lib` on the Greenplum Database master host. For example:
-
-    ``` shell
-    gpadmin@gpmaster$ cp postgresql-42.2.6.jar $PXF_CONF/lib/postgresql-42.2.6.jar
-    ``` 
-
-3. Synchronize these changes to the PXF configuration to the Greenplum Database cluster. For example:
+3. Synchronize the PXF server configuration to the Greenplum Database cluster. For example:
 
     ``` shell
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
     ``` 
-
-6. Restart PXF on each Greenplum Database segment host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).
 
 #### <a id="ex_readjdbc"></a>Read from the PostgreSQL Table
 

--- a/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_pxf.html.md.erb
@@ -256,7 +256,7 @@ This procedure will typically be performed by the Greenplum Database administrat
 3. Copy the JDBC driver JAR file to `$PXF_CONF/lib` on the Greenplum Database master host. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp postgresql-42.2.5.jar $PXF_CONF/lib/postgresql-42.2.5.jar
+    gpadmin@gpmaster$ cp postgresql-42.2.6.jar $PXF_CONF/lib/postgresql-42.2.6.jar
     ``` 
 
 3. Synchronize these changes to the PXF configuration to the Greenplum Database cluster. For example:


### PR DESCRIPTION
docs changes related to https://github.com/greenplum-db/pxf/pull/183.

in this PR:
- update the postgresql driver jar version bundled with pxf
- update the jdbc example to reference the 42.2.6 jdbc driver jar, since it wouldn't make sense to download the same jar that pxf ships with.
