### PR TITLE
5X_STABLE: Fix deadlock between gprecoverseg and FTS probe

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -32,6 +32,7 @@ test: instr_in_shmem
 # deadlock tests run separately - because we don't know which one gets stuck.
 test: deadlock
 test: deadlock2
+test: fts_deadlock
 
 # test workfiles
 test: workfile/hashagg_spill workfile/hashjoin_spill workfile/materialize_spill workfile/sisc_mat_sort workfile/sisc_sort_spill workfile/sort_spill workfile/spilltodisk

--- a/src/test/regress/input/fts_deadlock.source
+++ b/src/test/regress/input/fts_deadlock.source
@@ -1,0 +1,28 @@
+--
+-- Test queries that can lead to deadlock on the gp_segment_configuration table
+-- between the QD backend and FTS. The queries could be gp_add_segment_mirror()
+-- and gp_remove_segment_mirror(), both are called during gprecoverseg.
+--
+-- The tests does not directly call the above functions but mimics them by
+-- locking gp_segment_configuration with ExclusiveLock from the same session
+-- that requests FTS probe.
+--
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL
+AS '@abs_builddir@/regress@DLSUFFIX@', 'cleanupAllGangs' LANGUAGE C;
+
+begin;
+lock gp_segment_configuration in exclusive mode;
+-- destroy current gang
+select cleanupAllGangs();
+-- error out when creating a gang, that should trigger FTS probe
+select gp_inject_fault_new('create_gang_in_progress', 'error', 1);
+-- trigger the fault by executing a MPP command
+create table dummy();
+-- the previous command should not block because of deadlock
+-- between FTS and the QD backend serving this session
+end;
+
+SELECT gp_inject_fault('create_gang_in_progress', 'reset', 1);

--- a/src/test/regress/output/fts_deadlock.source
+++ b/src/test/regress/output/fts_deadlock.source
@@ -1,0 +1,43 @@
+--
+-- Test queries that can lead to deadlock on the gp_segment_configuration table
+-- between the QD backend and FTS. The queries could be gp_add_segment_mirror()
+-- and gp_remove_segment_mirror(), both are called during gprecoverseg.
+--
+-- The tests does not directly call the above functions but mimics them by
+-- locking gp_segment_configuration with ExclusiveLock from the same session
+-- that requests FTS probe.
+--
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL
+AS '@abs_builddir@/regress@DLSUFFIX@', 'cleanupAllGangs' LANGUAGE C;
+begin;
+lock gp_segment_configuration in exclusive mode;
+-- destroy current gang
+select cleanupAllGangs();
+ cleanupallgangs 
+-----------------
+ t
+(1 row)
+
+-- error out when creating a gang, that should trigger FTS probe
+select gp_inject_fault_new('create_gang_in_progress', 'error', 1);
+NOTICE:  Success:
+ gp_inject_fault_new 
+---------------------
+ t
+(1 row)
+
+-- trigger the fault by executing a MPP command
+create table dummy();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+ERROR:  fault triggered, fault name:'create_gang_in_progress' fault type:'error'
+-- the previous command should not block because of deadlock
+-- between FTS and the QD backend serving this session
+end;
+SELECT gp_inject_fault('create_gang_in_progress', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+


### PR DESCRIPTION
 ```
    Fix deadlock between gprecoverseg and FTS probe

    The deadlock could happen during gp_{add,remove}_segment_mirror(),
    between QD and FTS.

    The sequence of opterations for those two functions is:
    1. Lock gp_segment_configuration table with `AccessExclusiveLock`
    2. Read the dbid of the mirror and its primary from the table
    3. Acquire `RowExclusiveLock` on gp_segment_configuration
    4. Add/Remove the mirror entry from gp_segment_configuration
    5. Close gp_segment_configuration but keep the locks
    6. Add/Remove entries in the psersistent tables that refers to the
    mirror on master, and dispatch this operation to all the segments
    7. Commit and release the locks on gp_segment_configuration

    The sequence of operations in FTSLoop() is:
    a. Lock gp_segment_configuration table with `AccessShareLock`
    b. Scan the table and store it into local cache `CdbComponentDatabases`
    c. Probe each segment according to the cache
    d. If new state of a segment is found, acquire `RowExclusiveLock` on
    gp_segment_configuration and update the entry.

    In step 6, the QD backend polls results from the QEs, and if it
    encounters internal error or timeouts during the poll(), it notifies the
    FTS process to probe the segments. However, if FTS is notified to probe,
    it will be blocked in step a waiting for the `AccessShareLock`, which
    will not be available until QD commits in step 7, hence deadlock
    happens.

    This patch avoids the deadlock by downgrading the lock in step 1 to
    ExclusiveLock.
```