### PR TITLE
gen_pipeline: Do not call `suggested_*()` functions in `gen_pipeline()`.

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -194,8 +194,13 @@ def create_pipeline(args):
 
 
 def gen_pipeline(args, pipeline_name, secret_files,
-                 git_remote=suggested_git_remote(),
-                 git_branch=suggested_git_branch()):
+                 git_remote=None,
+                 git_branch=None):
+
+    if git_remote is None:
+        git_remote = suggested_git_remote()
+    if git_branch is None:
+        git_branch = suggested_git_branch()
 
     secrets = ""
     for secret in secret_files:


### PR DESCRIPTION
The `gen_pipeline()` function called the `suggested_git_remote()` and the
`suggested_git_branch()` functions as default values for the `git_remote` and
`git_branch` parameters.  For `prod` pipeline, the `gen_pipeline()` function is
called with GPDB repo and `BASE_BRANCH`.  However, the `suggested_*()` functions
are called in the `gen_pipeline()` function definition resulting in error as
they are not applicable for the production branches.

Therefore, in this commit we have used `None` as the default and call the
`suggested_*()` functions only if the corresponding parameters are not provided
by the caller.

Co-authored-by: Jacob Champion <pchampion@pivotal.io>
