### PR TITLE
Refactor to remove XLOG_XACT_ONE_PHASE_COMMIT xlog record

### DIFF
--- a/src/backend/access/rmgrdesc/xactdesc.c
+++ b/src/backend/access/rmgrdesc/xactdesc.c
@@ -245,13 +245,6 @@ xact_desc(StringInfo buf, XLogRecord *record)
 		appendStringInfo(buf, "distributed forget ");
 		xact_desc_distributed_forget(buf, xlrec);
 	}
-	else if (info == XLOG_XACT_ONE_PHASE_COMMIT)
-	{
-		xl_xact_commit *xlrec = (xl_xact_commit *) rec;
-
-		appendStringInfoString(buf, "one-phase commit: ");
-		xact_desc_commit(buf, xlrec);
-	}
 	else
 		appendStringInfoString(buf, "UNKNOWN");
 }

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1287,8 +1287,8 @@ RecordTransactionCommit(void)
 	bool		isDtxPrepared = 0;
 	TMGXACT_LOG gxact_log;
 	XLogRecPtr	recptr = InvalidXLogRecPtr;
-	DistributedTransactionTimeStamp distribTimeStamp;
-	DistributedTransactionId distribXid;
+	DistributedTransactionTimeStamp distribTimeStamp = 0;
+	DistributedTransactionId distribXid = 0;
 
 	/* Like in CommitTransaction(), treat a QE reader as if there was no XID */
 	if (DistributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON ||
@@ -1484,14 +1484,10 @@ RecordTransactionCommit(void)
 
 				insertedDistributedCommitted();
 			}
-			else if (Gp_role == GP_ROLE_EXECUTE && MyTmGxact->isOnePhaseCommit)
+			else
 			{
 				xlrec.distribTimeStamp = distribTimeStamp;
 				xlrec.distribXid = distribXid;
-				recptr = XLogInsert(RM_XACT_ID, XLOG_XACT_ONE_PHASE_COMMIT, rdata);
-			}
-			else
-			{
 				recptr = XLogInsert(RM_XACT_ID, XLOG_XACT_COMMIT, rdata);
 			}
 
@@ -6390,7 +6386,7 @@ xact_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribut
 	{
 		xl_xact_commit *xlrec = (xl_xact_commit *) XLogRecGetData(record);
 
-		xact_redo_commit(xlrec, record->xl_xid, lsn, 0, 0);
+		xact_redo_commit(xlrec, record->xl_xid, lsn, xlrec->distribXid, xlrec->distribTimeStamp);
 	}
 	else if (info == XLOG_XACT_ABORT)
 	{
@@ -6437,12 +6433,6 @@ xact_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribut
 		if (standbyState >= STANDBY_INITIALIZED)
 			ProcArrayApplyXidAssignment(xlrec->xtop,
 										xlrec->nsubxacts, xlrec->xsub);
-	}
-	else if (info == XLOG_XACT_ONE_PHASE_COMMIT)
-	{
-		xl_xact_commit *xlrec = (xl_xact_commit *) XLogRecGetData(record);
-
-		xact_redo_commit(xlrec, record->xl_xid, lsn, xlrec->distribTimeStamp, xlrec->distribXid);
 	}
 	else
 		elog(PANIC, "xact_redo: unknown op code %u", info);

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5669,8 +5669,7 @@ getRecordTimestamp(XLogRecord *record, TimestampTz *recordXtime)
 		*recordXtime = ((xl_xact_commit_compact *) XLogRecGetData(record))->xact_time;
 		return true;
 	}
-	if (record->xl_rmid == RM_XACT_ID &&
-		(record_info == XLOG_XACT_COMMIT || record_info == XLOG_XACT_ONE_PHASE_COMMIT))
+	if (record->xl_rmid == RM_XACT_ID && record_info == XLOG_XACT_COMMIT)
 	{
 		*recordXtime = ((xl_xact_commit *) XLogRecGetData(record))->xact_time;
 		return true;
@@ -5728,9 +5727,7 @@ recoveryStopsBefore(XLogRecord *record)
 		return false;
 	record_info = record->xl_info & ~XLR_INFO_MASK;
 
-	if (record_info == XLOG_XACT_COMMIT_COMPACT ||
-		record_info == XLOG_XACT_COMMIT ||
-		record_info == XLOG_XACT_ONE_PHASE_COMMIT)
+	if (record_info == XLOG_XACT_COMMIT_COMPACT || record_info == XLOG_XACT_COMMIT)
 	{
 		isCommit = true;
 		recordXid = record->xl_xid;
@@ -5850,7 +5847,6 @@ recoveryStopsAfter(XLogRecord *record)
 	if (record->xl_rmid == RM_XACT_ID &&
 		(record_info == XLOG_XACT_COMMIT_COMPACT ||
 		 record_info == XLOG_XACT_COMMIT ||
-		 record_info == XLOG_XACT_ONE_PHASE_COMMIT ||
 		 record_info == XLOG_XACT_COMMIT_PREPARED ||
 		 record_info == XLOG_XACT_ABORT ||
 		 record_info == XLOG_XACT_ABORT_PREPARED))
@@ -5888,7 +5884,6 @@ recoveryStopsAfter(XLogRecord *record)
 
 			if (record_info == XLOG_XACT_COMMIT_COMPACT ||
 				record_info == XLOG_XACT_COMMIT ||
-				record_info == XLOG_XACT_ONE_PHASE_COMMIT ||
 				record_info == XLOG_XACT_COMMIT_PREPARED)
 			{
 				ereport(LOG,
@@ -6015,7 +6010,6 @@ recoveryApplyDelay(XLogRecord *record)
 	if (!(record->xl_rmid == RM_XACT_ID &&
 		  (record_info == XLOG_XACT_COMMIT_COMPACT ||
 		   record_info == XLOG_XACT_COMMIT ||
-		   record_info == XLOG_XACT_ONE_PHASE_COMMIT ||
 		   record_info == XLOG_XACT_COMMIT_PREPARED)))
 		return false;
 

--- a/src/backend/replication/logical/decode.c
+++ b/src/backend/replication/logical/decode.c
@@ -223,7 +223,6 @@ DecodeXactOp(LogicalDecodingContext *ctx, XLogRecordBuffer *buf)
 	switch (info)
 	{
 		case XLOG_XACT_COMMIT:
-		case XLOG_XACT_ONE_PHASE_COMMIT:
 			{
 				xl_xact_commit *xlrec;
 				TransactionId *subxacts = NULL;

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -118,7 +118,6 @@ typedef void (*SubXactCallback) (SubXactEvent event, SubTransactionId mySubid,
 #define XLOG_XACT_COMMIT_COMPACT	0x60
 #define XLOG_XACT_DISTRIBUTED_COMMIT 0x70
 #define XLOG_XACT_DISTRIBUTED_FORGET 0x80
-#define XLOG_XACT_ONE_PHASE_COMMIT	0x90
 
 typedef struct xl_xact_assignment
 {


### PR DESCRIPTION
Issue is that in Postgres 9.5 there is a fixed amount of xl_info flags
that can be used. GPDB commit b587100923e2 added another flag which in
GPDB 9.5 merge branch exceeds the amount available.

Ashwin noticed the difference between XLOG_XACT_ONE_PHASE_COMMIT and
XLOG_XACT_COMMIT records is if distributed info is set. Instead we can
use a same record type in both cases if we setup distributed info in
RecordTransactionCommit() and then pass the distributed info through
xact_redo().