### PR TITLE
6X Backport: Fix an issue caused by mismatched targetlist of Motion node

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -7094,18 +7094,5 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
                                                 : NULL,
                                               subplan);
 
-	/**
-	 * If plan has a flow node, and its child is projection capable,
-	 * then ensure all entries of hashExpr are in the targetlist.
-	 */
-	if (subplan->flow &&
-		subplan->flow->hashExprs &&
-		is_projection_capable_plan(subplan))
-	{
-		subplan->targetlist = add_to_flat_tlist_junk(subplan->targetlist,
-													 subplan->flow->hashExprs,
-													 true /* resjunk */);
-	}
-
 	return motion;
 }								/* cdbpathtoplan_create_motion_plan */

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1820,3 +1820,26 @@ select * from init_main_plan_parallel where exists (select * from pg_class);
 ----+----
 (0 rows)
 
+-- A subplan whose targetlist might be expanded to make sure all entries of its
+-- hashExpr are in its targetlist, test the motion node above it also updated
+-- its targetlist, otherwise, a wrong answer or a crash happens.
+DROP TABLE IF EXISTS TEST_IN;
+NOTICE:  table "test_in" does not exist, skipping
+CREATE TABLE TEST_IN(
+    C01  FLOAT,
+    C02  NUMERIC(10,0)
+) DISTRIBUTED RANDOMLY;
+--insert repeatable records:
+INSERT INTO TEST_IN
+SELECT
+    ROUND(RANDOM()*1E1),ROUND(RANDOM()*1E1)
+FROM GENERATE_SERIES(1,1E4::BIGINT) I;
+ANALYZE TEST_IN;
+SELECT COUNT(*) FROM
+TEST_IN A
+WHERE A.C01 IN(SELECT C02 FROM TEST_IN);
+ count 
+-------
+ 10000
+(1 row)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1922,3 +1922,25 @@ select * from init_main_plan_parallel where exists (select * from pg_class);
 ----+----
 (0 rows)
 
+-- A subplan whose targetlist might be expanded to make sure all entries of its
+-- hashExpr are in its targetlist, test the motion node above it also updated
+-- its targetlist, otherwise, a wrong answer or a crash happens.
+DROP TABLE IF EXISTS TEST_IN;
+CREATE TABLE TEST_IN(
+    C01  FLOAT,
+    C02  NUMERIC(10,0)
+) DISTRIBUTED RANDOMLY;
+--insert repeatable records:
+INSERT INTO TEST_IN
+SELECT
+    ROUND(RANDOM()*1E1),ROUND(RANDOM()*1E1)
+FROM GENERATE_SERIES(1,1E4::BIGINT) I;
+ANALYZE TEST_IN;
+SELECT COUNT(*) FROM
+TEST_IN A
+WHERE A.C01 IN(SELECT C02 FROM TEST_IN);
+ count 
+-------
+ 10000
+(1 row)
+

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -775,3 +775,24 @@ select relname from pg_class where exists(select * from init_main_plan_parallel)
 -- case2: init plan is not parallel, main plan is parallel
 select * from init_main_plan_parallel where exists (select * from pg_class);
 
+
+-- A subplan whose targetlist might be expanded to make sure all entries of its
+-- hashExpr are in its targetlist, test the motion node above it also updated
+-- its targetlist, otherwise, a wrong answer or a crash happens.
+DROP TABLE IF EXISTS TEST_IN;
+CREATE TABLE TEST_IN(
+    C01  FLOAT,
+    C02  NUMERIC(10,0)
+) DISTRIBUTED RANDOMLY;
+
+--insert repeatable records:
+INSERT INTO TEST_IN
+SELECT
+    ROUND(RANDOM()*1E1),ROUND(RANDOM()*1E1)
+FROM GENERATE_SERIES(1,1E4::BIGINT) I;
+
+ANALYZE TEST_IN;
+
+SELECT COUNT(*) FROM
+TEST_IN A
+WHERE A.C01 IN(SELECT C02 FROM TEST_IN);


### PR DESCRIPTION
A Motion node may has a subplan whose targetlist need to be expanded
to make sure all entries of the subplan's hashExpr are in its
targetlist, in this case, the motion node should also update its
targetlist, otherwise, the difference of targetlist will cause
Motion node parse the tuple (especially for MemTuple) incorrectly
with a mismatched tuple description, make wrong result or even crash.

For a subplan, if we can get a Expr for distkey column from the
targetlist, the Expr must be in the targetlist or reference the
Vars in the targetlist, The old logic is, if the Expr is valid,
the Expr that reference Vars is also added to the targetlist.
For example, a subplan has targetlist (c1) and the locus whose
distkey is (c1::float8), so the Expr returned will be one
referenced Vars in the targetlist and then the old targetlist
will be extended to (c1, c1::float8). Obviously, the extension
of targetlist here is unnecessary, the Expr can evaluate from
Vars, meanwhile, motion need to transfer more columns in a tuple.

Co-authored-by: Adam Lee <ali@pivotal.io>
Reviewed-by: Heikki Linnakangas <hlinnakangas@pivotal.io>
Reviewed-by: Richard Guo <rguo@pivotal.io>
Reviewed-by: Daniel Gustafsson <dgustafsson@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
