### PR TITLE
 Fix wrong results for aggs containing a correlated subquery

### DIFF
--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -826,9 +826,39 @@ CQueryMutators::RunExtractAggregatesMutator
 			{
 				// If Var references the top level query inside an Aggref that also
 				// references top level query, the Aggref is moved to the derived query
-				// (see comments in Aggref if-case above). Thus, these Vars reference
+				// (see comments in Aggref if-case above). Thus, these Var references
 				// are brought up to the top-query level.
+				// e.g:
+				// explain select (select sum(foo.a) from jazz) from foo group by a, b;
+				// is transformed into
+				// select (select fnew.sum_t from jazz)
+				// from (select foo.a, foo.b, sum(foo.a) sum_t
+				//       from foo group by foo.a, foo.b) fnew;
+				//
+				// Note the foo.a var which is in sum() in a subquery must now become a
+				// var referencing the current query level.
 				var->varlevelsup = 0;
+				return (Node *) var;
+			}
+
+			// Skip vars inside Aggrefs, since they have already been fixed when they
+			// were moved into the derived query in ConvertToDerivedTable(), and thus,
+			// the relative varno, varattno & varlevelsup should still be valid.
+			// e.g:
+			// SELECT foo.b+1, avg(( SELECT bar.f FROM bar
+			//                       WHERE bar.d = foo.b)) AS t
+			// FROM foo GROUP BY foo.b;
+			// is transformed into
+			// SELECT fnew.b+1, fnew.avg_t
+			// FROM (SELECT foo.b,`avg(( SELECT bar.f FROM bar
+			//                           WHERE bar.d = foo.b)) AS t
+			//       FROM foo) fnew;
+			//
+			// Note the foo.b outerref in subquery inside the avg() aggregation.
+			// Because it is inside the aggregation, it was pushed down along with
+			// the aggregate function, and thus does not need to be fixed.
+			if (context->m_is_mutating_agg_arg)
+			{
 				return (Node *) var;
 			}
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -8768,9 +8768,37 @@ select max(b), (select foo.a * count(bar.e) from bar), (with cte as (select e, m
 select b + (a+1) from foo group by b, a+1;
  ?column? 
 ----------
-        7
-        3
         5
+        3
+        7
+(3 rows)
+
+-- subselects inside aggs
+SELECT  foo.b+1, avg (( SELECT bar.f FROM bar WHERE bar.d = foo.b)) AS t FROM foo GROUP BY foo.b;
+ ?column? | t 
+----------+---
+        2 | 1
+        3 | 2
+        4 | 3
+(3 rows)
+
+SELECT foo.b+1, sum( 1 + (SELECT bar.f FROM bar WHERE bar.d = ANY (SELECT jazz.g FROM jazz WHERE jazz.h = foo.b))) AS t FROM foo GROUP BY foo.b;
+ERROR:  correlated subquery with skip-level correlations is not supported
+select foo.b+1, sum((with cte as (select * from jazz) select 1 from cte where cte.h = foo.b)) as t FROM foo GROUP BY foo.b;
+ ?column? | t 
+----------+---
+        3 | 1
+        4 |  
+        2 |  
+(3 rows)
+
+-- ctes inside aggs
+select foo.b+1, sum((with cte as (select * from jazz) select 1 from cte cte1, cte cte2 where cte1.h = foo.b)) as t FROM foo GROUP BY foo.b;
+ ?column? | t 
+----------+---
+        3 | 1
+        4 |  
+        2 |  
 (3 rows)
 
 drop table foo, bar, jazz;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -8791,6 +8791,41 @@ select b + (a+1) from foo group by b, a+1;
         7
 (3 rows)
 
+-- subselects inside aggs
+SELECT  foo.b+1, avg (( SELECT bar.f FROM bar WHERE bar.d = foo.b)) AS t FROM foo GROUP BY foo.b;
+ ?column? | t 
+----------+---
+        4 | 3
+        2 | 1
+        3 | 2
+(3 rows)
+
+SELECT foo.b+1, sum( 1 + (SELECT bar.f FROM bar WHERE bar.d = ANY (SELECT jazz.g FROM jazz WHERE jazz.h = foo.b))) AS t FROM foo GROUP BY foo.b;
+ ?column? | t 
+----------+---
+        2 |  
+        3 | 3
+        4 |  
+(3 rows)
+
+select foo.b+1, sum((with cte as (select * from jazz) select 1 from cte where cte.h = foo.b)) as t FROM foo GROUP BY foo.b;
+ ?column? | t 
+----------+---
+        2 |  
+        3 | 1
+        4 |  
+(3 rows)
+
+-- ctes inside aggs
+select foo.b+1, sum((with cte as (select * from jazz) select 1 from cte cte1, cte cte2 where cte1.h = foo.b)) as t FROM foo GROUP BY foo.b;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+ ?column? | t 
+----------+---
+        3 | 1
+        4 |  
+        2 |  
+(3 rows)
+
 drop table foo, bar, jazz;
 create table orca.t77(C952 text) WITH (compresstype=zlib,compresslevel=2,appendonly=true,blocksize=393216,checksum=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c952' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -729,6 +729,16 @@ select max(b), (select foo.a * count(bar.e) from bar), (with cte as (select e, m
 -- complex expression in group by & targetlist
 select b + (a+1) from foo group by b, a+1;
 
+-- subselects inside aggs
+SELECT  foo.b+1, avg (( SELECT bar.f FROM bar WHERE bar.d = foo.b)) AS t FROM foo GROUP BY foo.b;
+
+SELECT foo.b+1, sum( 1 + (SELECT bar.f FROM bar WHERE bar.d = ANY (SELECT jazz.g FROM jazz WHERE jazz.h = foo.b))) AS t FROM foo GROUP BY foo.b;
+
+select foo.b+1, sum((with cte as (select * from jazz) select 1 from cte where cte.h = foo.b)) as t FROM foo GROUP BY foo.b;
+
+-- ctes inside aggs
+select foo.b+1, sum((with cte as (select * from jazz) select 1 from cte cte1, cte cte2 where cte1.h = foo.b)) as t FROM foo GROUP BY foo.b;
+
 drop table foo, bar, jazz;
 
 create table orca.t77(C952 text) WITH (compresstype=zlib,compresslevel=2,appendonly=true,blocksize=393216,checksum=true);


### PR DESCRIPTION
This commit handles a missed case in the previous commit: "Fix
algebrization of subqueries in queries with complex GROUP BYs".

The logic inside RunExtractAggregatesMutator's Var case was intended to
fix top-level Vars inside subqueries in the targetlist, but also
incorrectly fixed top-level Vars in subqueries inside of aggregates.
