### PR TITLE
Behave: enable tablespace test on gpactivatestandby

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -61,7 +61,6 @@ Feature: gpactivatestandby
         And verify gpstate with options "-m" output is correct
         And clean up and revert back to original master
 
-    @skip_fixme_ubuntu18.04
     Scenario: tablespaces work
         Given the database is running
           And the standby is not initialized


### PR DESCRIPTION
Now that the root cause for a single failing test on Ubuntu18.04 has
been merged(c8a82c46ae), enable that test in the pipeline.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
