### PR TITLE
Dispatch GUC setting commands with parameters quoted

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7415,7 +7415,7 @@ DispatchSetPGVariable(const char *name, List *args, bool is_local)
 		if (is_local)
 			appendStringInfo(&buffer, "LOCAL ");
 
-		appendStringInfo(&buffer, "%s TO ", name);
+		appendStringInfo(&buffer, "%s TO ", quote_identifier(name));
 
 		foreach(l, args)
 		{

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -769,3 +769,10 @@ NOTICE:  text search configuration "no_such_config" does not exist
 select func_with_bad_set();
 ERROR:  invalid value for parameter "default_text_search_config": "no_such_config"
 reset check_function_bodies;
+SET "request.header.user-agent" = 'curl/7.29.0';
+SHOW "request.header.user-agent";
+ request.header.user-agent 
+---------------------------
+ curl/7.29.0
+(1 row)
+

--- a/src/test/regress/sql/guc.sql
+++ b/src/test/regress/sql/guc.sql
@@ -275,3 +275,6 @@ set default_text_search_config = no_such_config;
 select func_with_bad_set();
 
 reset check_function_bodies;
+
+SET "request.header.user-agent" = 'curl/7.29.0';
+SHOW "request.header.user-agent";


### PR DESCRIPTION
```
SET "request.header.user-agent" = 'curl/7.29.0';
```

The double quote characters are needed in the above command, but
Greenplum lost them while dispatching, which reports a syntax error.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`