### PR TITLE
Clear exported snapshots before transaction ID is reset

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3335,6 +3335,14 @@ AbortTransaction(void)
 	}
 
 	/*
+	 * Exported snapshots must be cleared before transaction ID is reset.  In
+	 * GPDB, transaction ID is reset below.  In PostgreSQL, because 2PC is not
+	 * needed, exported snapshots are cleared and transaction ID is reset
+	 * later in CleanupTransaction().  We must perform both the actions here.
+	 */
+	AtEOXact_Snapshot(false);	/* and release the transaction's snapshots */
+
+	/*
 	 * Do abort to all QE. NOTE: we don't process
 	 * signals to prevent recursion until we've notified the QEs.
 	 *
@@ -3394,7 +3402,6 @@ CleanupTransaction(void)
 	 * do abort cleanup processing
 	 */
 	AtCleanup_Portals();		/* now safe to release portal memory */
-	AtEOXact_Snapshot(false);	/* and release the transaction's snapshots */
 
 	CurrentResourceOwner = NULL;	/* and resource owner */
 	if (TopTransactionResourceOwner)

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -842,3 +842,16 @@ FROM pg_locks WHERE locktype='transactionid';
 (1 row)
 
 ROLLBACK;
+-- Test that exported snapshots are cleared upon abort.  In Greenplum,
+-- exported snapshots are cleared earlier than PostgreSQL during
+-- abort.
+begin;
+select count(1) = 1 from pg_catalog.pg_export_snapshot();
+ ?column? 
+----------
+ t
+(1 row)
+
+select pg_cancel_backend(pg_backend_pid());
+ERROR:  canceling statement due to user request
+rollback;

--- a/src/test/regress/sql/distributed_transactions.sql
+++ b/src/test/regress/sql/distributed_transactions.sql
@@ -584,3 +584,11 @@ SELECT CASE WHEN count(*) < 50 THEN 'not many XID locks'
             ELSE 'lots of XID locks: ' || count(*) END
 FROM pg_locks WHERE locktype='transactionid';
 ROLLBACK;
+
+-- Test that exported snapshots are cleared upon abort.  In Greenplum,
+-- exported snapshots are cleared earlier than PostgreSQL during
+-- abort.
+begin;
+select count(1) = 1 from pg_catalog.pg_export_snapshot();
+select pg_cancel_backend(pg_backend_pid());
+rollback;


### PR DESCRIPTION
Greenplum diverges from upstream PostgreSQL in abort transaction workflow. Greenplum must dispatch ABORT command to QEs.  Consequently, transaction ID in top transaction state is reset before broadcasting the ABORT.

Exported snapshots are closely tied to the transaction that exported them. They must be cleared before the transaction that exported them ceases to exist. In order to abide by this sequence of operations, Greenplum must also clear exported snapshots before marking the transaction as invalid.  This patch moves the call to clear exported snapshots at a location that is right for Greenplum.

Fixes Github issue #8020

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
