### PR TITLE
Fix COPY WITH OIDS

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3632,7 +3632,7 @@ CopyFrom(CopyState cstate)
 	if ((resultRelInfo->ri_TrigDesc != NULL &&
 		 (resultRelInfo->ri_TrigDesc->trig_insert_before_row ||
 		  resultRelInfo->ri_TrigDesc->trig_insert_instead_row)) ||
-		cstate->volatile_defexprs)
+		cstate->volatile_defexprs || cstate->oids)
 	{
 		useHeapMultiInsert = false;
 	}

--- a/src/test/regress/expected/copy2.out
+++ b/src/test/regress/expected/copy2.out
@@ -395,3 +395,16 @@ DROP FUNCTION truncate_in_subxact();
 DROP TABLE x, y;
 DROP FUNCTION fn_x_before();
 DROP FUNCTION fn_x_after();
+CREATE TABLE check_copy_with_oids (a int) WITH OIDS;
+NOTICE:  OIDS=TRUE is not recommended for user-created tables
+HINT:  Use OIDS=FALSE to prevent wrap-around of the OID counter.
+COPY check_copy_with_oids FROM stdin WITH (oids);
+SELECT oid, * from check_copy_with_oids;
+  oid  | a 
+-------+---
+ 12346 | 2
+ 12347 | 3
+ 12345 | 1
+(3 rows)
+
+DROP TABLE check_copy_with_oids;

--- a/src/test/regress/sql/copy2.sql
+++ b/src/test/regress/sql/copy2.sql
@@ -335,3 +335,12 @@ DROP FUNCTION truncate_in_subxact();
 DROP TABLE x, y;
 DROP FUNCTION fn_x_before();
 DROP FUNCTION fn_x_after();
+
+CREATE TABLE check_copy_with_oids (a int) WITH OIDS;
+COPY check_copy_with_oids FROM stdin WITH (oids);
+12345	1
+12346	2
+12347	3
+\.
+SELECT oid, * from check_copy_with_oids;
+DROP TABLE check_copy_with_oids;


### PR DESCRIPTION
Issue is that COPY WITH OIDS requires an OID from the QD for tuple
insert. However, in the case of multi-insert we don't yet have the
multiple OIDs required from the QD. Simplest approach is to disable
multi-insert on COPY WITH OIDS. A better solution may be to send a list
of OIDS from the QD which QE would use in multi-insert.

Issue also currently exists on 6X