### PR TITLE
6X: resgroup: optimizations for oltp workloads

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3447,6 +3447,7 @@ shouldBypassQuery(const char *query_string)
 	List *parsetree_list; 
 	ListCell *parsetree_item;
 	Node *parsetree;
+	bool		bypass;
 
 	if (gp_resource_group_bypass)
 		return true;
@@ -3467,16 +3468,21 @@ shouldBypassQuery(const char *query_string)
 		return false;
 
 	/* Only bypass SET/RESET/SHOW command for now */
+	bypass = true;
 	foreach(parsetree_item, parsetree_list)
 	{
 		parsetree = (Node *) lfirst(parsetree_item);
 
 		if (nodeTag(parsetree) != T_VariableSetStmt &&
 			nodeTag(parsetree) != T_VariableShowStmt)
-			return false;
+		{
+			bypass = false;
+			break;
+		}
 	}
 
-	return true;
+	list_free_deep(parsetree_list);
+	return bypass;
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -124,12 +124,12 @@ struct ResGroupProcData
 {
 	Oid		groupId;
 
+	int32	memUsage;			/* memory usage of current proc */
+
 	ResGroupData		*group;
 	ResGroupSlotData	*slot;
 
 	ResGroupCaps	caps;
-
-	int32	memUsage;			/* memory usage of current proc */
 };
 
 /*
@@ -144,13 +144,13 @@ struct ResGroupSlotData
 {
 	Oid				groupId;
 
-	ResGroupCaps	caps;
-
 	int32			memQuota;	/* memory quota of current slot */
 	int32			memUsage;	/* total memory usage of procs belongs to this slot */
 	int				nProcs;		/* number of procs in this slot */
 
 	ResGroupSlotData	*next;
+
+	ResGroupCaps	caps;
 };
 
 /*
@@ -174,15 +174,6 @@ typedef struct ResGroupMemOperations
 struct ResGroupData
 {
 	Oid			groupId;		/* Id for this group */
-	ResGroupCaps	caps;		/* capabilities of this group */
-	volatile int			nRunning;		/* number of running trans */
-	volatile int	nRunningBypassed;		/* number of running trans in bypass mode */
-	PROC_QUEUE	waitProcs;		/* list of PGPROC objects waiting on this group */
-	int			totalExecuted;	/* total number of executed trans */
-	int			totalQueued;	/* total number of queued trans	*/
-	Interval	totalQueuedTime;/* total queue time */
-
-	bool		lockedForDrop;  /* true if resource group is dropped but not committed yet */
 
 	/*
 	 * memGap is calculated as:
@@ -207,32 +198,43 @@ struct ResGroupData
 	volatile int32	memUsage;
 	volatile int32	memSharedUsage;
 
+	volatile int			nRunning;		/* number of running trans */
+	volatile int	nRunningBypassed;		/* number of running trans in bypass mode */
+	int			totalExecuted;	/* total number of executed trans */
+	int			totalQueued;	/* total number of queued trans	*/
+	Interval	totalQueuedTime;/* total queue time */
+	PROC_QUEUE	waitProcs;		/* list of PGPROC objects waiting on this group */
+
 	/*
 	 * operation functions for resource group
 	 */
 	const ResGroupMemOperations *groupMemOps;
+
+	bool		lockedForDrop;  /* true if resource group is dropped but not committed yet */
+
+	ResGroupCaps	caps;		/* capabilities of this group */
 };
 
 struct ResGroupControl
 {
-	HTAB			*htbl;
-	int 			segmentsOnMaster;
-
-	/*
-	 * The hash table for resource groups in shared memory should only be populated
-	 * once, so we add a flag here to implement this requirement.
-	 */
-	bool			loaded;
-
 	int32			totalChunks;	/* total memory chunks on this segment */
 	volatile int32	freeChunks;		/* memory chunks not allocated to any group,
 									will be used for the query which group share
 									memory is not enough*/
 
 	int32			chunkSizeInBits;
+	int 			segmentsOnMaster;
 
 	ResGroupSlotData	*slots;		/* slot pool shared by all resource groups */
 	ResGroupSlotData	*freeSlot;	/* head of the free list */
+
+	HTAB			*htbl;
+
+	/*
+	 * The hash table for resource groups in shared memory should only be populated
+	 * once, so we add a flag here to implement this requirement.
+	 */
+	bool			loaded;
 
 	int				nGroups;
 	ResGroupData	groups[1];

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2975,6 +2975,10 @@ groupSetMemorySpillRatio(const ResGroupCaps *caps)
 {
 	char value[64];
 
+	/* No need to set memory_spill_ratio if it is already up-to-date */
+	if (caps->memSpillRatio == memory_spill_ratio)
+		return;
+
 	snprintf(value, sizeof(value), "%d", caps->memSpillRatio);
 	set_config_option("memory_spill_ratio", value, PGC_USERSET, PGC_S_RESGROUP,
 					  GUC_ACTION_SET, true, 0);

--- a/src/backend/utils/resource_manager/resource_manager.c
+++ b/src/backend/utils/resource_manager/resource_manager.c
@@ -30,35 +30,10 @@
 bool	ResourceScheduler = false;						/* Is scheduling enabled? */
 ResourceManagerPolicy Gp_resource_manager_policy;
 
-static bool resourceGroupActivated = false;
-
-bool
-IsResQueueEnabled(void)
-{
-	return ResourceScheduler &&
-		Gp_resource_manager_policy == RESOURCE_MANAGER_POLICY_QUEUE;
-}
-
 /*
- * Caution: resource group may be enabled but not activated.
+ * Global variables.
  */
-bool
-IsResGroupEnabled(void)
-{
-	return ResourceScheduler &&
-		Gp_resource_manager_policy == RESOURCE_MANAGER_POLICY_GROUP;
-}
-
-/*
- * Resource group do not govern the auxiliary processes and special backends
- * like ftsprobe, filerep process, so we need to check if resource group is
- * actually activated
- */
-bool
-IsResGroupActivated(void)
-{
-	return IsResGroupEnabled() && resourceGroupActivated;
-}
+bool		ResGroupActivated = false;
 
 void
 ResManagerShmemInit(void)
@@ -105,7 +80,7 @@ InitResManager(void)
 		InitResGroups();
 		ResGroupOps_AdjustGUCs();
 
-		resourceGroupActivated = true;
+		ResGroupActivated = true;
 	}
 	else
 	{

--- a/src/include/utils/resource_manager.h
+++ b/src/include/utils/resource_manager.h
@@ -18,6 +18,25 @@
 #include "utils/resscheduler.h"
 #include "utils/resgroup.h"
 
+#define IsResQueueEnabled() \
+	(ResourceScheduler && \
+	 Gp_resource_manager_policy == RESOURCE_MANAGER_POLICY_QUEUE)
+
+/*
+ * Caution: resource group may be enabled but not activated.
+ */
+#define IsResGroupEnabled() \
+	(ResourceScheduler && \
+	 Gp_resource_manager_policy == RESOURCE_MANAGER_POLICY_GROUP)
+
+/*
+ * Resource group do not govern the auxiliary processes and special backends
+ * like ftsprobe, filerep process, so we need to check if resource group is
+ * actually activated
+ */
+#define IsResGroupActivated() \
+	(ResGroupActivated)
+
 typedef enum
 {
 	RESOURCE_MANAGER_POLICY_QUEUE,
@@ -29,11 +48,7 @@ typedef enum
  */
 extern bool	ResourceScheduler;
 extern ResourceManagerPolicy Gp_resource_manager_policy;
-
-extern bool IsResQueueEnabled(void);
-extern bool IsResGroupEnabled(void);
-
-extern bool IsResGroupActivated(void);
+extern bool ResGroupActivated;
 
 extern void ResManagerShmemInit(void);
 extern void InitResManager(void);


### PR DESCRIPTION
In this PR we make several optimizations for oltp workloads:

- resgroup: only sync memory_spill_ratio when necessary
- resgroup: convert some checker funcs to macros
- resgroup: free the temp parse tree after bypass mode checking
- resgroup: reorder resource group struct properties

With these optimizations there should be 20% tps improvement for the select-only benchmark in resource group mode.  Please refer to each commit for details.

( this is the 6X version of https://github.com/greenplum-db/gpdb/pull/7960 )

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
