### PR TITLE
Abort drop tablespace on error, delete files on commit.

### DIFF
--- a/src/backend/catalog/Makefile
+++ b/src/backend/catalog/Makefile
@@ -22,7 +22,9 @@ OBJS += pg_exttable.o pg_extprotocol.o \
        aoseg.o aoblkdir.o gp_fastsequence.o gp_segment_config.o \
        pg_attribute_encoding.o pg_compression.o aovisimap.o \
        pg_appendonly.o \
-       oid_dispatch.o aocatalog.o storage_tablespace.o storage_database.o
+       oid_dispatch.o aocatalog.o storage_tablespace.o storage_database.o \
+       storage_tablespace_twophase.o storage_tablespace_xact.o
+
 
 BKIFILES = postgres.bki postgres.description postgres.shdescription
 

--- a/src/backend/catalog/storage_tablespace.c
+++ b/src/backend/catalog/storage_tablespace.c
@@ -1,25 +1,31 @@
 #include "catalog/storage_tablespace.h"
 
 
-static Oid pending_tablespace_scheduled_for_deletion;
+static Oid pending_tablespace_scheduled_for_deletion_on_abort;
+static Oid pending_tablespace_scheduled_for_deletion_on_commit;
 static void (*unlink_tablespace_dir)(Oid tablespace_for_unlink, bool is_redo);
 
 
 static void
-tablespace_storage_reset(void)
+tablespace_storage_reset_on_abort(void)
 {
-	pending_tablespace_scheduled_for_deletion = InvalidOid;
+	pending_tablespace_scheduled_for_deletion_on_abort = InvalidOid;
+}
+
+static void
+tablespace_storage_reset_on_commit(void)
+{
+	pending_tablespace_scheduled_for_deletion_on_commit = InvalidOid;
 }
 
 static void
 perform_pending_tablespace_deletion_internal(Oid tablespace_oid_to_delete,
                                                          bool isRedo)
 {
-	if (tablespace_oid_to_delete == InvalidOid)
+	if (!OidIsValid(tablespace_oid_to_delete))
 		return;
 
 	unlink_tablespace_dir(tablespace_oid_to_delete, isRedo);
-	tablespace_storage_reset();
 } 
 
 void
@@ -27,38 +33,83 @@ TablespaceStorageInit(void (*unlink_tablespace_dir_function)(Oid tablespace_oid,
 {
 	unlink_tablespace_dir = unlink_tablespace_dir_function;
 
-	tablespace_storage_reset();
+	tablespace_storage_reset_on_abort();
+	tablespace_storage_reset_on_commit();
 }
 
+/*
+ * For abort:
+ */
 void
-ScheduleTablespaceDirectoryDeletion(Oid tablespace_oid)
+ScheduleTablespaceDirectoryDeletionForAbort(Oid tablespace_oid)
 {
-	pending_tablespace_scheduled_for_deletion = tablespace_oid;
+	pending_tablespace_scheduled_for_deletion_on_abort = tablespace_oid;
 }
 
 Oid
-GetPendingTablespaceForDeletion(void)
+GetPendingTablespaceForDeletionForAbort(void)
 {
-	return pending_tablespace_scheduled_for_deletion;
+	return pending_tablespace_scheduled_for_deletion_on_abort;
 }
 
 void
-DoPendingTablespaceDeletion(void)
+DoPendingTablespaceDeletionForAbort(void)
 {
 	perform_pending_tablespace_deletion_internal(
-		GetPendingTablespaceForDeletion(),
+		GetPendingTablespaceForDeletionForAbort(),
 		false
 		);
+	tablespace_storage_reset_on_abort();
 }
 
 void
-DoTablespaceDeletion(Oid tablespace_oid_to_delete)
+UnscheduleTablespaceDirectoryDeletionForAbort(void)
+{
+	tablespace_storage_reset_on_abort();
+}
+
+
+/* 
+ * For commit:
+ */
+void
+ScheduleTablespaceDirectoryDeletionForCommit(Oid tablespaceoid)
+{
+	pending_tablespace_scheduled_for_deletion_on_commit = tablespaceoid;
+}
+
+
+void
+UnscheduleTablespaceDirectoryDeletionForCommit(void)
+{
+	tablespace_storage_reset_on_commit();
+}
+
+
+Oid
+GetPendingTablespaceForDeletionForCommit(void)
+{
+	return pending_tablespace_scheduled_for_deletion_on_commit;
+}
+
+
+void
+DoPendingTablespaceDeletionForCommit(void)
+{
+	perform_pending_tablespace_deletion_internal(
+		GetPendingTablespaceForDeletionForCommit(),
+		false);
+
+	tablespace_storage_reset_on_commit();
+}
+
+
+/*
+ * For Xlog redo:
+ *
+ */
+void
+DoTablespaceDeletionForRedoXlog(Oid tablespace_oid_to_delete)
 {
 	perform_pending_tablespace_deletion_internal(tablespace_oid_to_delete, true);
-}
-
-void
-UnscheduleTablespaceDirectoryDeletion(void)
-{
-	tablespace_storage_reset();
 }

--- a/src/backend/catalog/storage_tablespace_twophase.c
+++ b/src/backend/catalog/storage_tablespace_twophase.c
@@ -1,0 +1,32 @@
+/*-------------------------------------------------------------------------
+ *
+ * storage_tablespace_twophase.c
+ *
+ *	  implement hooks for twophase and tablespace storage
+ *
+ * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
+ *
+ *
+ * IDENTIFICATION
+ *	  src/backend/catalog/storage_tablespace_twophase.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "catalog/storage_tablespace.h"
+#include "access/twophase_storage_tablespace.h"
+
+
+void
+AtTwoPhaseCommit_TablespaceStorage()
+{
+	DoPendingTablespaceDeletionForCommit();
+	UnscheduleTablespaceDirectoryDeletionForAbort();
+}
+
+
+void
+AtTwoPhaseAbort_TablespaceStorage()
+{
+	DoPendingTablespaceDeletionForAbort();
+	UnscheduleTablespaceDirectoryDeletionForCommit();
+}

--- a/src/backend/catalog/storage_tablespace_xact.c
+++ b/src/backend/catalog/storage_tablespace_xact.c
@@ -1,0 +1,48 @@
+/*-------------------------------------------------------------------------
+ *
+ * storage_tablespace_xact.c
+ *
+ *	  implement hooks for transactions and tablespace storage
+ *
+ * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
+ *
+ *
+ * IDENTIFICATION
+ *	  src/backend/catalog/storage_tablespace_xact.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+
+#include "access/xact_storage_tablespace.h"
+#include "catalog/storage_tablespace.h"
+
+
+/*
+ * AtCommit_TablespaceStorage:
+ *
+ * Needs to happen before locks are released to ensure that no
+ * concurrent sessions are using the tablespace storage.
+ *
+ */
+void
+AtCommit_TablespaceStorage(void)
+{
+	DoPendingTablespaceDeletionForCommit();
+	UnscheduleTablespaceDirectoryDeletionForAbort();
+}
+
+
+/*
+ * AtAbort_TablespaceStorage:
+ *
+ * Needs to happen before locks are released to ensure that no
+ * concurrent sessions are using the tablespace storage.
+ *
+ */
+void
+AtAbort_TablespaceStorage(void)
+{
+	DoPendingTablespaceDeletionForAbort();
+	UnscheduleTablespaceDirectoryDeletionForCommit();
+}

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -112,6 +112,11 @@ static void create_tablespace_directories(const char *location,
 							  const Oid tablespaceoid);
 static bool destroy_tablespace_directories(Oid tablespaceoid, bool redo);
 
+static bool is_tablespace_empty(const Oid tablespace_oid);
+static void ensure_tablespace_directory_is_empty(const Oid tablespaceoid, const char *tablespace_name);
+
+static void unlink_during_redo(Oid tablepace_oid_to_unlink);
+static void unlink_without_redo(Oid tablespace_oid_to_unlink);
 
 /*
  * Each database using a table space is isolated into its own name space
@@ -413,7 +418,7 @@ CreateTableSpace(CreateTableSpaceStmt *stmt)
 	/*
 	 * Mark tablespace for deletion on abort.
 	 */
-	ScheduleTablespaceDirectoryDeletion(tablespaceoid);
+	ScheduleTablespaceDirectoryDeletionForAbort(tablespaceoid);
 
 	SIMPLE_FAULT_INJECTOR("after_xlog_create_tablespace");
 	
@@ -454,6 +459,87 @@ CreateTableSpace(CreateTableSpaceStmt *stmt)
 	return InvalidOid;			/* keep compiler quiet */
 #endif   /* HAVE_SYMLINK */
 }
+
+/*
+ * Logic for iterating over database directories originally appeared in
+ * destroy_tablespace_directories.
+ *
+ * Note: it is ok for the database directories to exist, but we don't want
+ * them to contain data.
+ */
+static bool
+is_tablespace_empty(const Oid tablespace_oid)
+{
+	char	   *linkloc_with_version_dir;
+	DIR		   *dirdesc;
+	struct dirent *de;
+	char	   *subfile;
+	int is_empty = true;
+
+	linkloc_with_version_dir = psprintf("pg_tblspc/%u/%s", tablespace_oid,
+										GP_TABLESPACE_VERSION_DIRECTORY);
+
+	dirdesc = AllocateDir(linkloc_with_version_dir);
+
+	while (dirdesc != NULL && (de = ReadDir(dirdesc, linkloc_with_version_dir)) != NULL)
+	{
+		if (strcmp(de->d_name, ".") == 0 ||
+			strcmp(de->d_name, "..") == 0)
+			continue;
+
+		subfile = psprintf("%s/%s", linkloc_with_version_dir, de->d_name);
+
+		if (!directory_is_empty(subfile)) {
+			is_empty = false;
+		}
+
+		pfree(subfile);
+	}
+
+	FreeDir(dirdesc);
+	pfree(linkloc_with_version_dir);
+
+	return is_empty;
+}
+
+
+static void 
+ensure_tablespace_directory_is_empty(const Oid tablespace_oid,
+									 const char *tablespace_name) {
+	if (tablespace_oid == InvalidOid)
+		return;
+
+	if (is_tablespace_empty(tablespace_oid))
+		return;
+
+	/*
+	 * There can be lingering empty files in the directories, left behind by for
+	 * example DROP TABLE, that have been scheduled for deletion at next
+	 * checkpoint (see comments in mdunlink() for details).  We force a
+	 * checkpoint which will clean out any lingering files, and try again.
+	 *
+	 * XXX On Windows, an unlinked file persists in the directory listing
+	 * until no process retains an open handle for the file.  The DDL
+	 * commands that schedule files for unlink send invalidation messages
+	 * directing other PostgreSQL processes to close the files.  DROP
+	 * TABLESPACE should not give up on the tablespace becoming empty
+	 * until all relevant invalidation processing is complete.
+	 *
+	 * note: comment taken from DropTableSpace and reworded to be appropriate
+	 * for ensure_tablespace_directory_is_empty.
+	 */
+	RequestCheckpoint(CHECKPOINT_IMMEDIATE | CHECKPOINT_FORCE | CHECKPOINT_WAIT);
+
+	if (is_tablespace_empty(tablespace_oid))
+		return;
+
+
+
+	ereport(ERROR, (
+		errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+		errmsg("tablespace \"%s\" is not empty", tablespace_name)));
+}
+
 
 /*
  * Drop a table space
@@ -549,37 +635,7 @@ DropTableSpace(DropTableSpaceStmt *stmt)
 	 */
 	LWLockAcquire(TablespaceCreateLock, LW_EXCLUSIVE);
 
-	/*
-	 * Try to remove the physical infrastructure.
-	 */
-	if (!destroy_tablespace_directories(tablespaceoid, false))
-	{
-		/*
-		 * Not all files deleted?  However, there can be lingering empty files
-		 * in the directories, left behind by for example DROP TABLE, that
-		 * have been scheduled for deletion at next checkpoint (see comments
-		 * in mdunlink() for details).  We could just delete them immediately,
-		 * but we can't tell them apart from important data files that we
-		 * mustn't delete.  So instead, we force a checkpoint which will clean
-		 * out any lingering files, and try again.
-		 *
-		 * XXX On Windows, an unlinked file persists in the directory listing
-		 * until no process retains an open handle for the file.  The DDL
-		 * commands that schedule files for unlink send invalidation messages
-		 * directing other PostgreSQL processes to close the files.  DROP
-		 * TABLESPACE should not give up on the tablespace becoming empty
-		 * until all relevant invalidation processing is complete.
-		 */
-		RequestCheckpoint(CHECKPOINT_IMMEDIATE | CHECKPOINT_FORCE | CHECKPOINT_WAIT);
-		if (!destroy_tablespace_directories(tablespaceoid, false))
-		{
-			/* Still not empty, the files must be important then */
-			ereport(ERROR,
-					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-					 errmsg("tablespace \"%s\" is not empty",
-							tablespacename)));
-		}
-	}
+	ensure_tablespace_directory_is_empty(tablespaceoid, tablespacename);
 
 	/* Record the filesystem change in XLOG */
 	{
@@ -594,6 +650,10 @@ DropTableSpace(DropTableSpaceStmt *stmt)
 
 		(void) XLogInsert(RM_TBLSPC_ID, XLOG_TBLSPC_DROP, rdata);
 	}
+
+	ScheduleTablespaceDirectoryDeletionForCommit(tablespaceoid);
+
+	SIMPLE_FAULT_INJECTOR("after_xlog_tblspc_drop");
 
 	/*
 	 * Note: because we checked that the tablespace was empty, there should be
@@ -636,7 +696,6 @@ DropTableSpace(DropTableSpaceStmt *stmt)
 			 errmsg("tablespaces are not supported on this platform")));
 #endif   /* HAVE_SYMLINK */
 }
-
 
 /*
  * create_tablespace_directories
@@ -781,17 +840,127 @@ create_tablespace_directories(const char *location, const Oid tablespaceoid)
 	pfree(location_with_version_dir);
 }
 
+
 /*
- * Added as a function to expose destroy_tablespace_directories
+ * This block was moved from DropTableSpace, just before inserting the
+ * XLOG_TBLSPC_CREATE record we'd drop the directories.
+ *
+ * We needed to move it later in the two-phase commit process to ensure
+ * files would still exist to roll back to during an abort.
+ */
+static void
+unlink_without_redo(Oid tablespace_oid_to_unlink)
+{
+	/*
+	 * Explicitly set isRedo to true, even though we're not really doing
+	 * redo behavior right now. This avoids throwing an error out of
+	 * destroy_tablespace_directories, which by now is too late in the
+	 * commit to handle the error.
+	 */
+	bool is_redo_flag_for_destroy_tablespace_directories = true;
+
+	if (!destroy_tablespace_directories(tablespace_oid_to_unlink, is_redo_flag_for_destroy_tablespace_directories))
+	{
+		/*
+		 * Not all files deleted?  However, there can be lingering empty files
+		 * in the directories, left behind by for example DROP TABLE, that
+		 * have been scheduled for deletion at next checkpoint (see comments
+		 * in mdunlink() for details).  We could just delete them immediately,
+		 * but we can't tell them apart from important data files that we
+		 * mustn't delete.  So instead, we force a checkpoint which will clean
+		 * out any lingering files, and try again.
+		 *
+		 * XXX On Windows, an unlinked file persists in the directory listing
+		 * until no process retains an open handle for the file.  The DDL
+		 * commands that schedule files for unlink send invalidation messages
+		 * directing other PostgreSQL processes to close the files.  DROP
+		 * TABLESPACE should not give up on the tablespace becoming empty
+		 * until all relevant invalidation processing is complete.
+		 */
+		RequestCheckpoint(CHECKPOINT_IMMEDIATE | CHECKPOINT_FORCE | CHECKPOINT_WAIT);
+
+		if (!destroy_tablespace_directories(tablespace_oid_to_unlink, is_redo_flag_for_destroy_tablespace_directories))
+		{
+			/*
+			 * Still not empty, the files must be important then
+			 *
+			 * GPDB: transformed to warning to avoid throwing an error
+			 */
+			ereport(WARNING,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					errmsg("tablespace with oid \"%u\" is not empty",
+						tablespace_oid_to_unlink)));
+		}
+	}
+}
+
+/*
+ * This was moved from tblspc_redo so it could be executed at the end
+ * of a two-phase commit.
+ */
+static void
+unlink_during_redo(Oid tablepace_oid_to_unlink)
+{
+	/*
+	 * If we issued a WAL record for a drop tablespace it implies that
+	 * there were no files in it at all when the DROP was done. That means
+	 * that no permanent objects can exist in it at this point.
+	 *
+	 * It is possible for standby users to be using this tablespace as a
+	 * location for their temporary files, so if we fail to remove all
+	 * files then do conflict processing and try again, if currently
+	 * enabled.
+	 *
+	 * Other possible reasons for failure include bollixed file
+	 * permissions on a standby server when they were okay on the primary,
+	 * etc etc. There's not much we can do about that, so just remove what
+	 * we can and press on.
+	 */
+	if (!destroy_tablespace_directories(tablepace_oid_to_unlink, true))
+	{
+		ResolveRecoveryConflictWithTablespace(tablepace_oid_to_unlink);
+
+		/*
+		 * If we did recovery processing then hopefully the backends who
+		 * wrote temp files should have cleaned up and exited by now.  So
+		 * retry before complaining.  If we fail again, this is just a LOG
+		 * condition, because it's not worth throwing an ERROR for (as
+		 * that would crash the database and require manual intervention
+		 * before we could get past this WAL record on restart).
+		 */
+		if (!destroy_tablespace_directories(tablepace_oid_to_unlink, true))
+			ereport(LOG, 
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE), 
+					errmsg("directories for tablespace %u could not be removed", 
+						tablepace_oid_to_unlink), 
+					errhint("You can remove the directories manually if necessary.")));
+	}
+}
+
+/*
+ * Added to expose destroy_tablespace_directories
  * while minimizing the diff with upstream.
+ * 
+ * We unlink at the end of a two-phase commit, to ensure that there are files
+ * to fall back to if there is an abort.
+ * 
  */
 void 
 UnlinkTablespaceDirectory(Oid tablepace_oid_to_unlink, bool isRedo) 
 {
-	if (!destroy_tablespace_directories(tablepace_oid_to_unlink, isRedo))
-		ereport(WARNING, (
-			errmsg("tablespace directory delete failed for tablespace id: %d", tablepace_oid_to_unlink)
-			));
+	/*
+	 * Acquire TablespaceCreateLock to ensure that no TablespaceCreateDbspace
+	 * is running concurrently.
+	 */
+	LWLockAcquire(TablespaceCreateLock, LW_EXCLUSIVE);
+
+	if (isRedo) {
+		unlink_during_redo(tablepace_oid_to_unlink);
+	} else {
+		unlink_without_redo(tablepace_oid_to_unlink);
+	}
+
+	LWLockRelease(TablespaceCreateLock);
 }
 
 /*
@@ -819,7 +988,9 @@ destroy_tablespace_directories(Oid tablespaceoid, bool redo)
 	char	   *subfile;
 	struct stat st;
 
-	elog(DEBUG5, "destroy_tablespace_directories for tablespace %d on dbid %d",
+	Assert(LWLockHeldByMe(TablespaceCreateLock));
+
+	elog(DEBUG5, "destroy_tablespace_directories for tablespace %u on dbid %d",
 		tablespaceoid, GpIdentity.dbid);
 
 	linkloc_with_version_dir = psprintf("pg_tblspc/%u/%s", tablespaceoid,
@@ -1697,44 +1868,13 @@ tblspc_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 	}
 	else if (info == XLOG_TBLSPC_DROP)
 	{
-		xl_tblspc_drop_rec *xlrec = (xl_tblspc_drop_rec *) XLogRecGetData(record);
-		
-		elog(DEBUG3, "replaying XLOG_TBLSPC_DROP for tablespace oid: %d", xlrec->ts_id);
-
 		/*
-		 * If we issued a WAL record for a drop tablespace it implies that
-		 * there were no files in it at all when the DROP was done. That means
-		 * that no permanent objects can exist in it at this point.
+		 * We no longer remove tablespace directories while replaying
+		 * XLOG_TBLSPC_DROP. We wait until the commit for the tablespace drop
+		 * gets replayed.
 		 *
-		 * It is possible for standby users to be using this tablespace as a
-		 * location for their temporary files, so if we fail to remove all
-		 * files then do conflict processing and try again, if currently
-		 * enabled.
-		 *
-		 * Other possible reasons for failure include bollixed file
-		 * permissions on a standby server when they were okay on the primary,
-		 * etc etc. There's not much we can do about that, so just remove what
-		 * we can and press on.
+		 * See UnlinkTablespaceDirectory().
 		 */
-		if (!destroy_tablespace_directories(xlrec->ts_id, true))
-		{
-			ResolveRecoveryConflictWithTablespace(xlrec->ts_id);
-
-			/*
-			 * If we did recovery processing then hopefully the backends who
-			 * wrote temp files should have cleaned up and exited by now.  So
-			 * retry before complaining.  If we fail again, this is just a LOG
-			 * condition, because it's not worth throwing an ERROR for (as
-			 * that would crash the database and require manual intervention
-			 * before we could get past this WAL record on restart).
-			 */
-			if (!destroy_tablespace_directories(xlrec->ts_id, true))
-				ereport(LOG,
-						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				 errmsg("directories for tablespace %u could not be removed",
-						xlrec->ts_id),
-						 errhint("You can remove the directories manually if necessary.")));
-		}
 	}
 	else
 		elog(PANIC, "tblspc_redo: unknown op code %u", info);

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -566,7 +566,7 @@ BaseInit(void)
 	InitBufferPoolAccess();
 
 	/* 
-	 * Initialize tablespace smgr component
+	 * Initialize catalog tablespace storage component
 	 * with knowledge of how to perform unlink.
 	 * 
 	 * Needed for xlog replay and normal operations.

--- a/src/include/access/twophase_storage_tablespace.h
+++ b/src/include/access/twophase_storage_tablespace.h
@@ -1,0 +1,23 @@
+/*-------------------------------------------------------------------------
+ *
+ * twophase_storage_tablespace.h
+ *
+ *	  Hooks to be implemented for twophase for tablespace storage:
+ *
+ *
+ * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
+ *
+ * src/include/access/twophase_storage_tablespace.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef ACCESS_TWOPHASE_STORAGE_TABLESPACE_H
+#define ACCESS_TWOPHASE_STORAGE_TABLESPACE_H
+
+
+void AtTwoPhaseCommit_TablespaceStorage(void);
+void AtTwoPhaseAbort_TablespaceStorage(void);
+
+
+#endif //ACCESS_TWOPHASE_STORAGE_TABLESPACE_H

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -149,6 +149,7 @@ typedef struct xl_xact_commit
 	int			nmsgs;			/* number of shared inval msgs */
 	Oid			dbId;			/* MyDatabaseId */
 	Oid			tsId;			/* MyDatabaseTableSpace */
+	Oid			tablespace_oid_to_delete_on_commit;
 	DistributedTransactionTimeStamp distribTimeStamp; /**/
 	DistributedTransactionId        distribXid;       /**/
 	/* Array of RelFileNode(s) to drop at commit */
@@ -183,7 +184,7 @@ typedef struct xl_xact_abort
 	int			nrels;			/* number of RelFileNodes */
 	int			ndeldbs;		/* number of DbDirNodes */
 	int			nsubxacts;		/* number of subtransaction XIDs */
-	Oid         tablespace_oid_to_abort;
+	Oid         tablespace_oid_to_delete_on_abort;
 	/* Array of RelFileNode(s) to drop at abort */
 	RelFileNodePendingDelete xnodes[1];		/* VARIABLE LENGTH ARRAY */
 	/* ARRAY OF ABORTED SUBTRANSACTION XIDs FOLLOWS */

--- a/src/include/access/xact_storage_tablespace.h
+++ b/src/include/access/xact_storage_tablespace.h
@@ -1,0 +1,22 @@
+/*-------------------------------------------------------------------------
+ *
+ * xact_storage_tablespace.h
+ *
+ *	  Hooks to be implemented for transactions for tablespace storage:
+ *
+ *
+ * Portions Copyright (c) 2012-Present Pivotal Software, Inc.
+ *
+ * src/include/access/xact_storage_tablespace.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef ACCESS_XACT_STORAGE_TABLESPACE_H
+#define ACCESS_XACT_STORAGE_TABLESPACE_H
+
+
+void AtCommit_TablespaceStorage(void);
+void AtAbort_TablespaceStorage(void);
+
+
+#endif // ACCESS_XACT_STORAGE_TABLESPACE_H

--- a/src/include/catalog/storage_tablespace.h
+++ b/src/include/catalog/storage_tablespace.h
@@ -15,12 +15,19 @@
 
 
 extern void TablespaceStorageInit(void (*unlink_tablespace_dir)(Oid tablespace_dir, bool isRedo));
-extern void ScheduleTablespaceDirectoryDeletion(Oid tablespaceoid);
-extern void UnscheduleTablespaceDirectoryDeletion(void);
 
-extern Oid GetPendingTablespaceForDeletion(void);
-extern void DoPendingTablespaceDeletion(void);
-extern void DoTablespaceDeletion(Oid tablespace_to_delete);
+extern void ScheduleTablespaceDirectoryDeletionForAbort(Oid tablespaceoid);
+extern void UnscheduleTablespaceDirectoryDeletionForAbort(void);
+extern Oid GetPendingTablespaceForDeletionForAbort(void);
+extern void DoPendingTablespaceDeletionForAbort(void);
+
+extern void ScheduleTablespaceDirectoryDeletionForCommit(Oid tablespaceoid);
+extern void UnscheduleTablespaceDirectoryDeletionForCommit(void);
+extern Oid GetPendingTablespaceForDeletionForCommit(void);
+extern void DoPendingTablespaceDeletionForCommit(void);
+
+
+extern void DoTablespaceDeletionForRedoXlog(Oid tablespace_oid_to_delete);
 
 
 #endif // STORAGE_TABLESPACE_H

--- a/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
+++ b/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
@@ -1,7 +1,7 @@
 -- TEST 1: block checkpoint on segments
 
 -- pause the 2PC after setting inCommit flag
-select gp_inject_fault_infinite('twophase_transaction_commit_prepared', 'suspend', 3);
+select gp_inject_fault_infinite('before_xlog_xact_commit_prepared', 'suspend', 3);
  gp_inject_fault_infinite 
 --------------------------
  t                        
@@ -17,7 +17,7 @@ CREATE
 2&: commit;  <waiting ...>
 
 -- wait for the fault to trigger since following checkpoint could be faster
-select gp_wait_until_triggered_fault('twophase_transaction_commit_prepared', 1, 3);
+select gp_wait_until_triggered_fault('before_xlog_xact_commit_prepared', 1, 3);
  gp_wait_until_triggered_fault 
 -------------------------------
  t                             
@@ -27,7 +27,7 @@ select gp_wait_until_triggered_fault('twophase_transaction_commit_prepared', 1, 
 1U&: checkpoint;  <waiting ...>
 
 -- resume the 2PC after setting inCommit flag
-select gp_inject_fault('twophase_transaction_commit_prepared', 'reset', 3);
+select gp_inject_fault('before_xlog_xact_commit_prepared', 'reset', 3);
  gp_inject_fault 
 -----------------
  t               

--- a/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
+++ b/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
@@ -1,7 +1,7 @@
 -- TEST 1: block checkpoint on segments
 
 -- pause the 2PC after setting inCommit flag
-select gp_inject_fault_infinite('twophase_transaction_commit_prepared', 'suspend', 3);
+select gp_inject_fault_infinite('before_xlog_xact_commit_prepared', 'suspend', 3);
 
 -- trigger a 2PC, and it will block at commit;
 2: checkpoint;
@@ -10,13 +10,13 @@ select gp_inject_fault_infinite('twophase_transaction_commit_prepared', 'suspend
 2&: commit;
 
 -- wait for the fault to trigger since following checkpoint could be faster
-select gp_wait_until_triggered_fault('twophase_transaction_commit_prepared', 1, 3);
+select gp_wait_until_triggered_fault('before_xlog_xact_commit_prepared', 1, 3);
 
 -- do checkpoint on segment content 1 in utility mode, and it should block
 1U&: checkpoint;
 
 -- resume the 2PC after setting inCommit flag
-select gp_inject_fault('twophase_transaction_commit_prepared', 'reset', 3);
+select gp_inject_fault('before_xlog_xact_commit_prepared', 'reset', 3);
 2<:
 1U<:
 

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -35,6 +35,7 @@ table_functions.out
 table_functions_optimizer.out
 /tablespace.out
 /temp_tablespaces.out
+/temp_relation.out
 transient_types.out
 workfile_mgr_test.out
 trigger_sets_oid.out

--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -64,6 +64,10 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 		-- setup faults
 		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
 		perform gp_inject_fault2(fault_name, fault_action_type, dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
+
+		-- intentionally skip fts during these tests
+		-- we know we're going to be inducing errors and panics on primaries
+		perform gp_inject_fault2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
 	end;
 $$ LANGUAGE plpgsql;
 
@@ -107,6 +111,7 @@ begin
 	LOOP
 		select count(1) into number_of_segments_behind from gp_stat_replication where sent_location != replay_location;
 		EXIT WHEN number_of_segments_behind = 0;
+		perform pg_sleep(0.5);
 	END LOOP;
 end;
 $$ language plpgsql;
@@ -288,6 +293,184 @@ select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_l
 DROP TABLESPACE my_tablespace_for_testing;
 select cleanup(:content_id_under_test, :'tablespace_location');
 
+
+--
+-- DROP TABLESPACE tests
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+select remove_tablespace_location_directory(:'tablespace_location');
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select list_tablespace_dbid_dirs(0, :'tablespace_location');
+-- the tablespace should no longer be in the catalog
+select * from list_tablespace_catalog_without_oid();
+select cleanup(-1, :'tablespace_location');
+
+
+--
+-- An error after XLOG_TBLSPC_DROP
+--
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+select remove_tablespace_location_directory(:'tablespace_location');
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select list_tablespace_dbid_dirs(8, :'tablespace_location');
+select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select cleanup(0, :'tablespace_location');
+
+
+--
+-- An error after XLOG_TBLSPC_DROP on master
+--
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test -1
+
+select remove_tablespace_location_directory(:'tablespace_location');
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select list_tablespace_dbid_dirs(8, :'tablespace_location');
+select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select cleanup(:content_id_under_test, :'tablespace_location');
+
+--
+-- When the tablespace is not empty, it should not be allowed to be dropped:
+--
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+select remove_tablespace_location_directory(:'tablespace_location');
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+create table foobar (a int) tablespace my_tablespace_for_testing distributed by (a); 
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select list_tablespace_dbid_dirs(8, :'tablespace_location');
+-- the tablespace should still exist in the catalog
+select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
+drop table foobar;
+drop tablespace my_tablespace_for_testing;
+select cleanup(0, :'tablespace_location');
+
+
+--
+-- A panic before XLOG_XACT_COMMIT_PREPARED on primary
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test 0
+\set fault_type panic
+\set fault_name before_xlog_xact_commit_prepared
+
+select remove_tablespace_location_directory(:'tablespace_location');
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select list_tablespace_dbid_dirs(0, :'tablespace_location');
+select * from list_tablespace_catalog_without_oid(); -- the tablespace should no longer exist in the catalog
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select cleanup(:content_id_under_test, :'tablespace_location');
+
+
+--
+-- A panic after XLOG_XACT_PREPARED on primary
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test 0
+\set fault_type panic
+\set fault_name after_xlog_xact_prepare_flushed
+
+select remove_tablespace_location_directory(:'tablespace_location');
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select list_tablespace_dbid_dirs(8, :'tablespace_location');
+select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+DROP TABLESPACE my_tablespace_for_testing;
+select cleanup(:content_id_under_test, :'tablespace_location');
+
+--
+-- A panic before XLOG_XACT_PREPARED on primary
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test 0
+\set fault_type panic
+\set fault_name before_xlog_xact_prepare
+\set expected_number_of_tablespaces 8
+
+select remove_tablespace_location_directory(:'tablespace_location');
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
+select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+DROP TABLESPACE my_tablespace_for_testing;
+select cleanup(:content_id_under_test, :'tablespace_location');
+
+--
+-- An error before XLOG_XACT_PREPARED on primary
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test 0
+\set fault_type error
+\set fault_name before_xlog_xact_prepare
+\set expected_number_of_tablespaces 8
+
+select remove_tablespace_location_directory(:'tablespace_location');
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
+select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+DROP TABLESPACE my_tablespace_for_testing;
+select cleanup(:content_id_under_test, :'tablespace_location');
+
+--
+-- An error after XLOG_XACT_DISTRIBUTED_COMMIT on master
+-- tested manually, as a crash causes test to stop running.
+-- Success, expected 0 tablespaces, got 0 tablespaces
+--
 
 --
 -- Disable this feature as it is not the default behavior

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -62,6 +62,10 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 		-- setup faults
 		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
 		perform gp_inject_fault2(fault_name, fault_action_type, dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
+
+		-- intentionally skip fts during these tests
+		-- we know we're going to be inducing errors and panics on primaries
+		perform gp_inject_fault2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
 	end;
 $$ LANGUAGE plpgsql;
 create or replace function cleanup(content_id integer, tablespace_location_dir text) returns void as $$
@@ -99,6 +103,7 @@ begin
 	LOOP
 		select count(1) into number_of_segments_behind from gp_stat_replication where sent_location != replay_location;
 		EXIT WHEN number_of_segments_behind = 0;
+		perform pg_sleep(0.5);
 	END LOOP;
 end;
 $$ language plpgsql;
@@ -501,6 +506,611 @@ select cleanup(:content_id_under_test, :'tablespace_location');
  
 (1 row)
 
+--
+-- DROP TABLESPACE tests
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+select remove_tablespace_location_directory(:'tablespace_location');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+(1 row)
+
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+ 
+ 
+(3 rows)
+
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+ setup_tablespace_location_dir_for_test 
+----------------------------------------
+ 
+(1 row)
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select list_tablespace_dbid_dirs(0, :'tablespace_location');
+                list_tablespace_dbid_dirs                 
+----------------------------------------------------------
+ {Success,"expected 0 tablespaces","found 0 tablespaces"}
+(1 row)
+
+-- the tablespace should no longer be in the catalog
+select * from list_tablespace_catalog_without_oid();
+ gp_segment_id | tablespace_name 
+---------------+-----------------
+             0 | pg_default
+             0 | pg_global
+             1 | pg_default
+             1 | pg_global
+             2 | pg_default
+             2 | pg_global
+            -1 | pg_default
+            -1 | pg_global
+(8 rows)
+
+select cleanup(-1, :'tablespace_location');
+ cleanup 
+---------
+ 
+(1 row)
+
+--
+-- An error after XLOG_TBLSPC_DROP
+--
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+select remove_tablespace_location_directory(:'tablespace_location');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+(1 row)
+
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+ 
+ 
+(3 rows)
+
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+ setup_tablespace_location_dir_for_test 
+----------------------------------------
+ 
+(1 row)
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+ERROR:  fault triggered, fault name:'after_xlog_tblspc_drop' fault type:'error'
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select list_tablespace_dbid_dirs(8, :'tablespace_location');
+                                                                                                                                                    list_tablespace_dbid_dirs                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {Success,"expected 8 tablespaces","found 8 tablespaces",/tmp/my_tablespace_for_testing/1,/tmp/my_tablespace_for_testing/2,/tmp/my_tablespace_for_testing/3,/tmp/my_tablespace_for_testing/4,/tmp/my_tablespace_for_testing/5,/tmp/my_tablespace_for_testing/6,/tmp/my_tablespace_for_testing/7,/tmp/my_tablespace_for_testing/8}
+(1 row)
+
+select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
+ gp_segment_id |      tablespace_name      
+---------------+---------------------------
+             0 | my_tablespace_for_testing
+             0 | pg_default
+             0 | pg_global
+             1 | my_tablespace_for_testing
+             1 | pg_default
+             1 | pg_global
+             2 | my_tablespace_for_testing
+             2 | pg_default
+             2 | pg_global
+            -1 | my_tablespace_for_testing
+            -1 | pg_default
+            -1 | pg_global
+(12 rows)
+
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select cleanup(0, :'tablespace_location');
+ cleanup 
+---------
+ 
+(1 row)
+
+--
+-- An error after XLOG_TBLSPC_DROP on master
+--
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test -1
+select remove_tablespace_location_directory(:'tablespace_location');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+(1 row)
+
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+ 
+ 
+(3 rows)
+
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+ setup_tablespace_location_dir_for_test 
+----------------------------------------
+ 
+(1 row)
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+ERROR:  fault triggered, fault name:'after_xlog_tblspc_drop' fault type:'error'
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select list_tablespace_dbid_dirs(8, :'tablespace_location');
+                                                                                                                                                    list_tablespace_dbid_dirs                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {Success,"expected 8 tablespaces","found 8 tablespaces",/tmp/my_tablespace_for_testing/1,/tmp/my_tablespace_for_testing/2,/tmp/my_tablespace_for_testing/3,/tmp/my_tablespace_for_testing/4,/tmp/my_tablespace_for_testing/5,/tmp/my_tablespace_for_testing/6,/tmp/my_tablespace_for_testing/7,/tmp/my_tablespace_for_testing/8}
+(1 row)
+
+select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
+ gp_segment_id |      tablespace_name      
+---------------+---------------------------
+             0 | my_tablespace_for_testing
+             0 | pg_default
+             0 | pg_global
+             1 | my_tablespace_for_testing
+             1 | pg_default
+             1 | pg_global
+             2 | my_tablespace_for_testing
+             2 | pg_default
+             2 | pg_global
+            -1 | my_tablespace_for_testing
+            -1 | pg_default
+            -1 | pg_global
+(12 rows)
+
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select cleanup(:content_id_under_test, :'tablespace_location');
+ cleanup 
+---------
+ 
+(1 row)
+
+--
+-- When the tablespace is not empty, it should not be allowed to be dropped:
+--
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+select remove_tablespace_location_directory(:'tablespace_location');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+(1 row)
+
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+ 
+ 
+(3 rows)
+
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+ setup_tablespace_location_dir_for_test 
+----------------------------------------
+ 
+(1 row)
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+create table foobar (a int) tablespace my_tablespace_for_testing distributed by (a); 
+DROP TABLESPACE my_tablespace_for_testing;
+ERROR:  tablespace "my_tablespace_for_testing" is not empty
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select list_tablespace_dbid_dirs(8, :'tablespace_location');
+                                                                                                                                                    list_tablespace_dbid_dirs                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {Success,"expected 8 tablespaces","found 8 tablespaces",/tmp/my_tablespace_for_testing/1,/tmp/my_tablespace_for_testing/2,/tmp/my_tablespace_for_testing/3,/tmp/my_tablespace_for_testing/4,/tmp/my_tablespace_for_testing/5,/tmp/my_tablespace_for_testing/6,/tmp/my_tablespace_for_testing/7,/tmp/my_tablespace_for_testing/8}
+(1 row)
+
+-- the tablespace should still exist in the catalog
+select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
+ gp_segment_id |      tablespace_name      
+---------------+---------------------------
+             0 | my_tablespace_for_testing
+             0 | pg_default
+             0 | pg_global
+             1 | my_tablespace_for_testing
+             1 | pg_default
+             1 | pg_global
+             2 | my_tablespace_for_testing
+             2 | pg_default
+             2 | pg_global
+            -1 | my_tablespace_for_testing
+            -1 | pg_default
+            -1 | pg_global
+(12 rows)
+
+drop table foobar;
+drop tablespace my_tablespace_for_testing;
+select cleanup(0, :'tablespace_location');
+ cleanup 
+---------
+ 
+(1 row)
+
+--
+-- A panic before XLOG_XACT_COMMIT_PREPARED on primary
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test 0
+\set fault_type panic
+\set fault_name before_xlog_xact_commit_prepared
+select remove_tablespace_location_directory(:'tablespace_location');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+(1 row)
+
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+ 
+ 
+(3 rows)
+
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+ setup_tablespace_location_dir_for_test 
+----------------------------------------
+ 
+(1 row)
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select list_tablespace_dbid_dirs(0, :'tablespace_location');
+                list_tablespace_dbid_dirs                 
+----------------------------------------------------------
+ {Success,"expected 0 tablespaces","found 0 tablespaces"}
+(1 row)
+
+select * from list_tablespace_catalog_without_oid(); -- the tablespace should no longer exist in the catalog
+ gp_segment_id | tablespace_name 
+---------------+-----------------
+             0 | pg_default
+             0 | pg_global
+             1 | pg_default
+             1 | pg_global
+             2 | pg_default
+             2 | pg_global
+            -1 | pg_default
+            -1 | pg_global
+(8 rows)
+
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+select cleanup(:content_id_under_test, :'tablespace_location');
+ cleanup 
+---------
+ 
+(1 row)
+
+--
+-- A panic after XLOG_XACT_PREPARED on primary
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test 0
+\set fault_type panic
+\set fault_name after_xlog_xact_prepare_flushed
+select remove_tablespace_location_directory(:'tablespace_location');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+(1 row)
+
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+ 
+ 
+(3 rows)
+
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+ setup_tablespace_location_dir_for_test 
+----------------------------------------
+ 
+(1 row)
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+ERROR:  fault triggered, fault name:'after_xlog_xact_prepare_flushed' fault type:'panic'  (seg0 127.0.0.1:7002 pid=20870)
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select list_tablespace_dbid_dirs(8, :'tablespace_location');
+                                                                                                                                                    list_tablespace_dbid_dirs                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {Success,"expected 8 tablespaces","found 8 tablespaces",/tmp/my_tablespace_for_testing/1,/tmp/my_tablespace_for_testing/2,/tmp/my_tablespace_for_testing/3,/tmp/my_tablespace_for_testing/4,/tmp/my_tablespace_for_testing/5,/tmp/my_tablespace_for_testing/6,/tmp/my_tablespace_for_testing/7,/tmp/my_tablespace_for_testing/8}
+(1 row)
+
+select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
+ gp_segment_id |      tablespace_name      
+---------------+---------------------------
+            -1 | my_tablespace_for_testing
+            -1 | pg_default
+            -1 | pg_global
+             0 | my_tablespace_for_testing
+             0 | pg_default
+             0 | pg_global
+             1 | my_tablespace_for_testing
+             1 | pg_default
+             1 | pg_global
+             2 | my_tablespace_for_testing
+             2 | pg_default
+             2 | pg_global
+(12 rows)
+
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+select cleanup(:content_id_under_test, :'tablespace_location');
+ cleanup 
+---------
+ 
+(1 row)
+
+--
+-- A panic before XLOG_XACT_PREPARED on primary
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test 0
+\set fault_type panic
+\set fault_name before_xlog_xact_prepare
+\set expected_number_of_tablespaces 8
+select remove_tablespace_location_directory(:'tablespace_location');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+(1 row)
+
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+ 
+ 
+(3 rows)
+
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+ setup_tablespace_location_dir_for_test 
+----------------------------------------
+ 
+(1 row)
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+ERROR:  fault triggered, fault name:'before_xlog_xact_prepare' fault type:'panic'
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
+                                                                                                                                                    list_tablespace_dbid_dirs                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {Success,"expected 8 tablespaces","found 8 tablespaces",/tmp/my_tablespace_for_testing/1,/tmp/my_tablespace_for_testing/2,/tmp/my_tablespace_for_testing/3,/tmp/my_tablespace_for_testing/4,/tmp/my_tablespace_for_testing/5,/tmp/my_tablespace_for_testing/6,/tmp/my_tablespace_for_testing/7,/tmp/my_tablespace_for_testing/8}
+(1 row)
+
+select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
+ gp_segment_id |      tablespace_name      
+---------------+---------------------------
+             0 | my_tablespace_for_testing
+             0 | pg_default
+             0 | pg_global
+             1 | my_tablespace_for_testing
+             1 | pg_default
+             1 | pg_global
+             2 | my_tablespace_for_testing
+             2 | pg_default
+             2 | pg_global
+            -1 | my_tablespace_for_testing
+            -1 | pg_default
+            -1 | pg_global
+(12 rows)
+
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+select cleanup(:content_id_under_test, :'tablespace_location');
+ cleanup 
+---------
+ 
+(1 row)
+
+--
+-- An error before XLOG_XACT_PREPARED on primary
+--
+\set tablespace_location '/tmp/my_tablespace_for_testing'
+\set content_id_under_test 0
+\set fault_type error
+\set fault_name before_xlog_xact_prepare
+\set expected_number_of_tablespaces 8
+select remove_tablespace_location_directory(:'tablespace_location');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+(1 row)
+
+select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
+ remove_tablespace_location_directory 
+--------------------------------------
+ 
+ 
+ 
+(3 rows)
+
+select setup_tablespace_location_dir_for_test(:'tablespace_location');
+ setup_tablespace_location_dir_for_test 
+----------------------------------------
+ 
+(1 row)
+
+CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+ERROR:  fault triggered, fault name:'before_xlog_xact_prepare' fault type:'error'
+select give_mirrors_time_to_catch_up();
+ give_mirrors_time_to_catch_up 
+-------------------------------
+ 
+(1 row)
+
+select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
+                                                                                                                                                    list_tablespace_dbid_dirs                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {Success,"expected 8 tablespaces","found 8 tablespaces",/tmp/my_tablespace_for_testing/1,/tmp/my_tablespace_for_testing/2,/tmp/my_tablespace_for_testing/3,/tmp/my_tablespace_for_testing/4,/tmp/my_tablespace_for_testing/5,/tmp/my_tablespace_for_testing/6,/tmp/my_tablespace_for_testing/7,/tmp/my_tablespace_for_testing/8}
+(1 row)
+
+select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
+ gp_segment_id |      tablespace_name      
+---------------+---------------------------
+             0 | my_tablespace_for_testing
+             0 | pg_default
+             0 | pg_global
+             1 | my_tablespace_for_testing
+             1 | pg_default
+             1 | pg_global
+             2 | my_tablespace_for_testing
+             2 | pg_default
+             2 | pg_global
+            -1 | my_tablespace_for_testing
+            -1 | pg_default
+            -1 | pg_global
+(12 rows)
+
+select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault2 
+------------------
+ Success:
+(1 row)
+
+DROP TABLESPACE my_tablespace_for_testing;
+select cleanup(:content_id_under_test, :'tablespace_location');
+ cleanup 
+---------
+ 
+(1 row)
+
+--
+-- An error after XLOG_XACT_DISTRIBUTED_COMMIT on master
+-- tested manually, as a crash causes test to stop running.
+-- Success, expected 0 tablespaces, got 0 tablespaces
+--
 --
 -- Disable this feature as it is not the default behavior
 --

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -13,6 +13,7 @@
 /oid_wraparound.sql
 /security_label.sql
 /temp_tablespaces.sql
+/temp_relation.sql
 /tablespace.sql
 
 /gp_tablespace_path_too_long.sql


### PR DESCRIPTION
We add information to the TwoPhaseHeaderFile about which tablespace we're
attempting to drop. We also schedule a tablespace for deletion (similar
to CREATE TABLESPACE) on commit, which waits until the transaction
is being committed to perform the filesystem deletion.

We also modified the distributed_commit record to pass the tablespace to
be dropped to the standby. And, we modified the abort record, to help
back out of a drop on the mirrors.

Co-authored-by: Taylor Vesely <tvesely@pivotal.io>
Co-authored-by: Alexandra Wang <lewang@pivotal.io>


todo:

- [x] free variables created from AllocateDir
- [x] reintroduce destroy_database_directories called multiple times
- [x] investigate former tblspc_redo behaviors.
- [x] handle compact commit
- [x] test scenarios of drop tablespace then create tablespace for warning conditions
- [x] consider locking 
- [x] disable fts during test scenarios