### PR TITLE
Update sysctl settings to match new recommendations

### DIFF
--- a/concourse/tasks/run_behave_on_ccp_cluster.yml
+++ b/concourse/tasks/run_behave_on_ccp_cluster.yml
@@ -24,6 +24,42 @@ run:
         install_python_hacks
     '"
 
+    # setting sysctl settings
+    while read LINE; do
+        host=$(echo $LINE | awk '{ print $3 }')
+        ssh -n $host "sudo bash -c '
+            # minimal settings
+            sysctl -w kernel.shmall=\`expr \$(getconf _PHYS_PAGES) / 2\`
+            sysctl -w kernel.shmmax=\`expr \$(/sbin/sysctl -n kernel.shmall) \* \$(getconf PAGE_SIZE)\`
+            sysctl -w kernel.shmmni=4096
+            sysctl -w vm.overcommit_memory=2
+            sysctl -w vm.overcommit_ratio=95
+            sysctl -w net.ipv4.ip_local_port_range=\"10000 65535\"
+            # additional settings
+            sysctl -w kernel.sem=\"500 2048000 200 40960\"
+            sysctl -w kernel.sysrq=1
+            sysctl -w kernel.core_uses_pid=1
+            sysctl -w kernel.msgmnb=65536
+            sysctl -w kernel.msgmax=65536
+            sysctl -w kernel.msgmni=2048
+            sysctl -w net.ipv4.tcp_syncookies=1
+            sysctl -w net.ipv4.conf.default.accept_source_route=0
+            sysctl -w net.ipv4.tcp_max_syn_backlog=4096
+            sysctl -w net.ipv4.conf.all.arp_filter=1
+            sysctl -w net.core.netdev_max_backlog=10000
+            sysctl -w net.core.rmem_max=2097152
+            sysctl -w net.core.wmem_max=2097152
+            sysctl -w vm.swappiness=10
+            sysctl -w vm.zone_reclaim_mode=0
+            sysctl -w vm.dirty_expire_centisecs=500
+            sysctl -w vm.dirty_writeback_centisecs=100
+            sysctl -w vm.dirty_background_ratio=0
+            sysctl -w vm.dirty_ratio=0
+            sysctl -w vm.dirty_background_bytes=1610612736
+            sysctl -w vm.dirty_bytes=4294967296
+        '"
+    done <cluster_env_files/etc_hostfile
+
     ssh -t mdw "
         source /home/gpadmin/gpdb_src/concourse/scripts/common.bash
         install_python_requirements_on_multi_host /home/gpadmin/gpdb_src/gpMgmt/requirements-dev.txt


### PR DESCRIPTION
The recommended sysctl settings for user clusters are out-of-date, and after some investigation we've discovered a good minimal set of recommended defaults.  These will be updated in the documentation, but we also want to set them in the VMs used for our CLI Behave tests so that we use values similar to those that users will have in their environments, so this commit adds a section to the Concourse cluster task file to do so.

---

We used [Andreas' blog post](http://engineering.pivotal.io/post/virtual_memory_settings_in_linux_-_the_problem_with_overcommit) and [Jacob's email to the mailing list](https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/0ubaHTY7m5M) as starting points in our investigation.  We welcome any thoughts/discussion on the values chosen.