### PR TITLE
docs - [pg->gp]_dist_wait_status UDF name change

### DIFF
--- a/gpdb-doc/dita/admin_guide/dml.xml
+++ b/gpdb-doc/dita/admin_guide/dml.xml
@@ -385,7 +385,32 @@
           <codeph>gp_dist_wait_status()</codeph> user-defined function. You can use the output of
         this function to determine which transactions are waiting on locks, which transactions are
         holding locks, the lock types and mode, the waiter and holder session identifiers, and
-        which segments are executing the transactions.</p>
+        which segments are executing the transactions. Sample output of the
+          <codeph>gp_dist_wait_status()</codeph> function follows:</p>
+      <codeblock>SELECT * FROM pg_catalog.gp_dist_wait_status();
+-[ RECORD 1 ]----+--------------
+segid            | 0
+waiter_dxid      | 11
+holder_dxid      | 12
+holdTillEndXact  | t
+waiter_lpid      | 31249
+holder_lpid      | 31458
+waiter_lockmode  | ShareLock
+waiter_locktype  | transactionid
+waiter_sessionid | 8
+holder_sessionid | 9
+-[ RECORD 2 ]----+--------------
+segid            | 1
+waiter_dxid      | 12
+holder_dxid      | 11
+holdTillEndXact  | t
+waiter_lpid      | 31467
+holder_lpid      | 31250
+waiter_lockmode  | ShareLock
+waiter_locktype  | transactionid
+waiter_sessionid | 9
+holder_sessionid | 8
+</codeblock>
       <p>When it cancels a transaction to break a deadlock, the Global Deadlock Detector reports the
         following error message:</p>
       <codeblock>ERROR:  canceling statement due to user request: "cancelled by global deadlock detector"</codeblock>

--- a/gpdb-doc/dita/admin_guide/dml.xml
+++ b/gpdb-doc/dita/admin_guide/dml.xml
@@ -382,19 +382,10 @@
          will abort a statement before it would ever trigger a deadlock check in that
          session.</note>
       <p>To view lock waiting information for all segments, run the
-          <codeph>pg_dist_wait_status()</codeph> user-defined function. You can use the output of
+          <codeph>gp_dist_wait_status()</codeph> user-defined function. You can use the output of
         this function to determine which transactions are waiting on locks, which transactions are
-        holding locks, and which segments are executing the transactions. Sample output of the
-          <codeph>pg_dist_wait_status()</codeph> function follows:</p>
-      <codeblock>SELECT * FROM pg_dist_wait_status();
- segid | waiter_dxid | holder_dxid | holdTillEndXact 
--------+-------------+-------------+-----------------
-    -1 |          29 |          28 | t
-     0 |          28 |          26 | t
-     0 |          27 |          29 | t
-     1 |          26 |          27 | t
-(4 rows)
-</codeblock>
+        holding locks, the lock types and mode, the waiter and holder session identifiers, and
+        which segments are executing the transactions.</p>
       <p>When it cancels a transaction to break a deadlock, the Global Deadlock Detector reports the
         following error message:</p>
       <codeblock>ERROR:  canceling statement due to user request: "cancelled by global deadlock detector"</codeblock>


### PR DESCRIPTION
global deadlock detector UDF name change.  also, the UDF returns more info.  removed the sample output because i could not generate any "real" output with the new fields, and didn't notice any test output for the UDF.

@gaos1 - if your team has some sample output, please provide and i will add that back in.  thanks!
