### PR TITLE
Document madlib 1.15 upgrade instructions

### DIFF
--- a/gpdb-doc/dita/ref_guide/extensions/madlib.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/madlib.xml
@@ -53,10 +53,10 @@
               >Pivotal Network</xref>.</li>
           <li>Copy the MADlib package to the Greenplum Database master host.</li>
           <li>Unpack the MADlib distribution package. For
-            example:<codeblock>$ tar xzvf madlib-1.15-gp5-rhel7-x86_64.tar.gz</codeblock></li>
+            example:<codeblock>$ tar xzvf madlib-1.16-gp5-rhel7-x86_64.tar.gz</codeblock></li>
           <li id="pz216990">Install the software package by running the <codeph>gppkg</codeph>
             command. For
-            example:<codeblock>$ gppkg -i ./madlib-1.15-gp5-rhel7-x86_64/madlib-1.15-gp5-rhel7-x86_64.gppkg</codeblock></li>
+            example:<codeblock>$ gppkg -i ./madlib-1.16-gp5-rhel7-x86_64/madlib-1.16-gp5-rhel7-x86_64.gppkg</codeblock></li>
         </ol>
       </body>
     </topic>
@@ -100,7 +100,20 @@
       <body>
         <p>To upgrade MADlib, run the <codeph>gppkg</codeph> utility with the <codeph>-u</codeph>
           option. This command upgrades an installed MADlib package to MADlib
-          1.15.<codeblock>$ gppkg -u madlib-1.15-gp5-rhel7-x86_64.gppkg</codeblock></p>
+          1.16.<codeblock>$ gppkg -u madlib-1.16-gp5-rhel7-x86_64.gppkg</codeblock></p>
+        <note>Upgrading from MADlib version 1.15 using <codeph>gppkg -U</codeph> does not work
+          because of a change in the post-uninstall script that was introduced in version 1.15.1. If
+          you are upgrading from MADlib version 1.15 to version 1.15.1 or newer, follow these
+            steps:<ol id="ol_itj_l4v_g3b">
+            <li>Remove the existing MADlib version 1.15 rpm (this does not affect the Greenplum
+              database installation):<codeblock>gppkg -r madlib-1.15.0</codeblock></li>
+            <li>Manually remove the remaining MADlib
+              files:<codeblock>rm -rf /usr/local/greenplum-db-5.20.0/madlib/Versions</codeblock></li>
+            <li>Install the newer MADlib version. For
+              example:<codeblock>$ gppkg -i ./madlib-1.16-gp5-rhel7-x86_64.gppkg</codeblock></li>
+            <li>Upgrade the MADlib functions in each database. For
+              example:<codeblock>madpack -p greenplum -c gpadmin@mdw:5432/testdb upgrade</codeblock></li>
+          </ol></note>
       </body>
     </topic>
     <topic id="topic_bql_bgd_3w">

--- a/gpdb-doc/dita/ref_guide/extensions/madlib.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/madlib.xml
@@ -108,7 +108,7 @@
             <li>Remove the existing MADlib version 1.15 rpm (this does not affect the Greenplum
               database installation):<codeblock>gppkg -r madlib-1.15.0</codeblock></li>
             <li>Manually remove the remaining MADlib
-              files:<codeblock>rm -rf /usr/local/greenplum-db-5.20.0/madlib/Versions</codeblock></li>
+              files:<codeblock>rm -rf /usr/local/greenplum-db-5.13.0/madlib/Versions</codeblock></li>
             <li>Install the newer MADlib version. For
               example:<codeblock>$ gppkg -i ./madlib-1.16-gp5-rhel7-x86_64.gppkg</codeblock></li>
             <li>Upgrade the MADlib functions in each database. For

--- a/gpdb-doc/dita/ref_guide/extensions/madlib.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/madlib.xml
@@ -44,7 +44,7 @@
     <topic id="topic4" xml:lang="en">
       <title>Installing the Greenplum Database MADlib Package</title>
       <body>
-        <p>Before you install the MADlib package, make sure that your Greenplum database is running,
+        <p>Before you install the MADlib package, make sure that your Greenplum atabase is running,
           you have sourced <codeph>greenplum_path.sh</codeph>, and that the<codeph>
             $MASTER_DATA_DIRECTORY</codeph> and <codeph>$GPHOME</codeph> variables are set.</p>
         <ol>
@@ -67,8 +67,8 @@
           MADlib functions to Greenplum Database. <codeph>madpack</codeph> is in
             <codeph>$GPHOME/madlib/bin</codeph>. </p>
         <codeblock>$ madpack [-s <varname>schema_name</varname>] -p greenplum -c <varname>user</varname>@<varname>host</varname>:<varname>port</varname>/<varname>database</varname> install</codeblock>
-        <p>For example, this command creates MADlib functions in the Greenplum database
-            <codeph>testdb</codeph> running on server <codeph>mdw</codeph> on port
+        <p>For example, this command creates MADlib functions in the 
+            <codeph>testdb</codeph> database running on server <codeph>mdw</codeph> on port
             <codeph>5432</codeph>. The <codeph>madpack</codeph> command logs in as the user
             <codeph>gpadmin</codeph> and prompts for password. The target schema is
             <codeph>madlib</codeph>.</p>
@@ -106,7 +106,7 @@
           you are upgrading from MADlib version 1.15 to version 1.15.1 or newer, follow these
             steps:<ol id="ol_itj_l4v_g3b">
             <li>Remove the existing MADlib version 1.15 rpm (this does not affect the Greenplum
-              database installation):<codeblock>gppkg -r madlib-1.15.0</codeblock></li>
+              Database installation):<codeblock>gppkg -r madlib-1.15.0</codeblock></li>
             <li>Manually remove the remaining MADlib
               files:<codeblock>rm -rf /usr/local/greenplum-db-5.13.0/madlib/Versions</codeblock></li>
             <li>Install the newer MADlib version. For
@@ -152,7 +152,7 @@ psql <varname>db_name</varname> -c "DROP FUNCTION IF EXISTS <varname>schema</var
       <title id="pz217588">Remove MADlib objects from the database</title>
       <body>
         <p>Use the <codeph>madpack uninstall</codeph> command to remove MADlib objects from a
-          Greenplum database. For example, this command removes MADlib objects from the database
+          database. For example, this command removes MADlib objects from the database
             <codeph>testdb</codeph>.</p>
         <codeblock>$ madpack  -s madlib -p greenplum -c gpadmin@mdw:5432/testdb uninstall</codeblock>
       </body>


### PR DESCRIPTION
MADlib upgrade instructions modified for Greenplum/gppkg installs.  This will go into 5X_STABLE and 4.x (but not 6X_STABLE) since 6.x support doesn't begin until MADlib 1.16.