### PR TITLE
6X: Don't mark FDW or external table actions needing two phase commit

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1535,7 +1535,8 @@ static void
 ExecCheckXactReadOnly(PlannedStmt *plannedstmt)
 {
 	ListCell   *l;
-    int         rti;
+	int         rti;
+	char		relstorage;
 
 	/*
 	 * CREATE TABLE AS or SELECT INTO?
@@ -1564,6 +1565,14 @@ ExecCheckXactReadOnly(PlannedStmt *plannedstmt)
 			continue;
 
 		if ((rte->requiredPerms & (~ACL_SELECT)) == 0)
+			continue;
+
+		/*
+		 * External and foreign tables don't need two phase commit which is for
+		 * local mpp tables
+		 */
+		relstorage = get_rel_relstorage(rte->relid);
+		if (relstorage == RELSTORAGE_EXTERNAL || relstorage == RELSTORAGE_FOREIGN)
 			continue;
 
 		if (isTempNamespace(get_rel_namespace(rte->relid)))


### PR DESCRIPTION
FDW or External table's INSERT actions are actually just some defined
callbacks but not real heap table INSERT actions.

Don't mark transactions doing write just because they insert into
foreign or external tables, some FDW extensions report an error because
they don't see XACT_EVENT_PRE_PREPARE coming.

(cherry picked from commit be7499de1d7f2863bc3d575be82ff99b3e793080)

backported from #8043