### PR TITLE
Protect against (un)intentional writes during Create External table transformations

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1625,13 +1625,31 @@ transformCreateExternalStmt(CreateExternalStmt *stmt, const char *queryString)
 	ListCell   *elements;
 	DistributedBy *likeDistributedBy = NULL;
 	bool	    bQuiet = false;	/* shut up transformDistributedBy messages */
-	bool		iswritable = stmt->iswritable;
+	bool		iswritable = false;
 
 	/* Set up pstate */
 	pstate = make_parsestate(NULL);
 	pstate->p_sourcetext = queryString;
 
 	memset(&cxt, 0, sizeof(CreateStmtContext));
+
+	/*
+	 * Create a temporary context in order to confine memory leaks due
+	 * to expansions within a short lived context
+	 */
+	cxt.tempCtx = AllocSetContextCreate(CurrentMemoryContext,
+							  "CreateExteranlStmt analyze context",
+							  ALLOCSET_DEFAULT_MINSIZE,
+							  ALLOCSET_DEFAULT_INITSIZE,
+							  ALLOCSET_DEFAULT_MAXSIZE);
+
+	/*
+	 * There exist transformations that might write on the passed on stmt.
+	 * Create a copy of it to both protect from (un)intentional writes and be
+	 * a bit more explicit of the intended ownership.
+	 */
+	stmt = (CreateExternalStmt *)copyObject(stmt);
+
 	cxt.pstate = pstate;
 	cxt.stmtType = "CREATE EXTERNAL TABLE";
 	cxt.relation = stmt->relation;
@@ -1648,6 +1666,8 @@ transformCreateExternalStmt(CreateExternalStmt *stmt, const char *queryString)
 
 	cxt.blist = NIL;
 	cxt.alist = NIL;
+
+	iswritable = stmt->iswritable;
 
 	/*
 	 * Run through each primary element in the table creation clause. Separate
@@ -1769,6 +1789,8 @@ transformCreateExternalStmt(CreateExternalStmt *stmt, const char *queryString)
 
 	result = lappend(cxt.blist, stmt);
 	result = list_concat(result, cxt.alist);
+
+	MemoryContextDelete(cxt.tempCtx);
 
 	return result;
 }

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -64,6 +64,35 @@ ERROR:  LIKE INCLUDING may not be used with this kind of relation
 LINE 1: CREATE EXTERNAL TABLE t_ext_a (LIKE t_ext INCLUDING ALL) LOC...
                                             ^
 CREATE EXTERNAL TABLE t_ext_b (LIKE t_ext) LOCATION ('file://127.0.0.1/tmp/foo') FORMAT 'text';
+-- Verify that an external table can be dropped and then recreated in consecutive attempts
+CREATE OR REPLACE FUNCTION drop_and_recreate_external_table()
+	RETURNS void
+	LANGUAGE plpgsql
+	VOLATILE
+AS $function$
+DECLARE
+BEGIN
+DROP EXTERNAL TABLE IF EXISTS t_ext_r;
+CREATE EXTERNAL TABLE t_ext_r (
+	name varchar
+)
+LOCATION ('GPFDIST://127.0.0.1/tmp/dummy') ON ALL
+FORMAT 'CSV' ( delimiter ' ' null '' escape '"' quote '"' )
+ENCODING 'UTF8';
+END;
+$function$;
+do $$
+begin
+  for i in 1..5 loop
+	PERFORM drop_and_recreate_external_table();
+  end loop;
+end;
+$$;
+NOTICE:  table "t_ext_r" does not exist, skipping
+CONTEXT:  SQL statement "DROP EXTERNAL TABLE IF EXISTS t_ext_r"
+PL/pgSQL function drop_and_recreate_external_table() line 4 at SQL statement
+SQL statement "SELECT drop_and_recreate_external_table()"
+PL/pgSQL function inline_code_block line 4 at PERFORM
 -- Verify created tables
 SELECT
 	c.relname,
@@ -76,9 +105,10 @@ FROM
 		LEFT OUTER JOIN pg_catalog.pg_exttable e ON (c.oid = e.reloid)
 WHERE
 	c.relname LIKE 't_ext%';
- relname | relstorage |        urilocation         |  execlocation  |                fmtopts                 
----------+------------+----------------------------+----------------+----------------------------------------
- t_ext   | x          | {file://127.0.0.1/tmp/foo} | {ALL_SEGMENTS} | delimiter '     ' null '\N' escape '\'
- t_ext_b | x          | {file://127.0.0.1/tmp/foo} | {ALL_SEGMENTS} | delimiter '     ' null '\N' escape '\'
-(2 rows)
+ relname | relstorage |             urilocation              |  execlocation  |                  fmtopts                   
+---------+------------+--------------------------------------+----------------+--------------------------------------------
+ t_ext   | x          | {file://127.0.0.1/tmp/foo}           | {ALL_SEGMENTS} | delimiter '     ' null '\N' escape '\'
+ t_ext_b | x          | {file://127.0.0.1/tmp/foo}           | {ALL_SEGMENTS} | delimiter '     ' null '\N' escape '\'
+ t_ext_r | x          | {gpfdist://127.0.0.1:8080/tmp/dummy} | {ALL_SEGMENTS} | delimiter ' ' null '' escape '"' quote '"'
+(3 rows)
 


### PR DESCRIPTION

It is possible, and does happen, that CreateExternalStmt will be written upon
during transformations. The transformer functions are not explicit regarding
ownership and some of them might (and do) invoke walkers that can (and do) write
on the transformed statement. However, some callers of these functions, do pass
arguments that should be considered read-only. Such an example is passing a
CreateExternalStmt which belongs to, and taken from, a cached plan which will be
correctly retained for subsequent executions.

Create a short-lived memory context in the transformCreateExternalStmt, which
will additionaly protect against leaks in long expanding statments, and operate
in a copy of the passed statement.

Addresses MPP-29970