### PR TITLE
Protect against (un)intentional writes during Create External table t…

### DIFF
--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -267,6 +267,32 @@ SELECT count(*) FROM pg_exttable WHERE command = 'echo "cascadetest";';
 DROP EXTERNAL TABLE cascadetest;
 SELECT count(*) FROM pg_exttable WHERE command = 'echo "cascadetest";';
 
+-- Verify that an external table can be dropped and then recreated in consecutive attempts
+CREATE OR REPLACE FUNCTION drop_and_recreate_external_table()
+	RETURNS void
+	LANGUAGE plpgsql
+	VOLATILE
+AS $function$
+DECLARE
+BEGIN
+DROP EXTERNAL TABLE IF EXISTS t_ext_r;
+CREATE EXTERNAL TABLE t_ext_r (
+	name varchar
+)
+LOCATION ('GPFDIST://127.0.0.1/tmp/dummy') ON ALL
+FORMAT 'CSV' ( delimiter ' ' null '' escape '"' quote '"' )
+ENCODING 'UTF8';
+END;
+$function$;
+
+do $$
+begin
+  for i in 1..5 loop
+	PERFORM drop_and_recreate_external_table();
+  end loop;
+end;
+$$;
+
 CREATE SCHEMA exttabletest;
 CREATE
 	EXTERNAL TABLE exttabletest.ext_nation (n_nationkey integer, n_name char(25), n_regionkey integer, n_comment varchar(152))

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -353,6 +353,35 @@ SELECT count(*) FROM pg_exttable WHERE command = 'echo "cascadetest";';
      0
 (1 row)
 
+-- Verify that an external table can be dropped and then recreated in consecutive attempts
+CREATE OR REPLACE FUNCTION drop_and_recreate_external_table()
+	RETURNS void
+	LANGUAGE plpgsql
+	VOLATILE
+AS $function$
+DECLARE
+BEGIN
+DROP EXTERNAL TABLE IF EXISTS t_ext_r;
+CREATE EXTERNAL TABLE t_ext_r (
+	name varchar
+)
+LOCATION ('GPFDIST://127.0.0.1/tmp/dummy') ON ALL
+FORMAT 'CSV' ( delimiter ' ' null '' escape '"' quote '"' )
+ENCODING 'UTF8';
+END;
+$function$;
+do $$
+begin
+  for i in 1..5 loop
+	PERFORM drop_and_recreate_external_table();
+  end loop;
+end;
+$$;
+NOTICE:  table "t_ext_r" does not exist, skipping
+CONTEXT:  SQL statement "DROP EXTERNAL TABLE IF EXISTS t_ext_r"
+PL/pgSQL function "drop_and_recreate_external_table" line 3 at SQL statement
+SQL statement "SELECT  drop_and_recreate_external_table()"
+PL/pgSQL function "inline_code_block" line 3 at PERFORM
 CREATE SCHEMA exttabletest;
 CREATE
 	EXTERNAL TABLE exttabletest.ext_nation (n_nationkey integer, n_name char(25), n_regionkey integer, n_comment varchar(152))


### PR DESCRIPTION
…ransformations

It is possible, and does happen, that CreateExternalStmt will be written upon
during transformations. The transformer functions are not explicit regarding
ownership and some of them might (and do) invoke walkers that can (and do) write
on the transformed statement. However, some callers of these functions, do pass
arguments that should be concidered read only. Such an example is passing a
CreateExternalStmt which belongs to, and taken from, a cached plan which will be
correctly retained for subsequent executions.

Create a short lived memory context in the transformCreateExternalStmt, which
will additionaly protect against leaks in long expanding statments, and operate
in a copy of the passed statement.

Reviewed-by: Asim R P <apraveen@pivotal.io>
Reviewed-by: BaiShaoqi <sbai@pivotal.io>

(Cherry-picked from b47df8d3c5 and amended to fit the current release)
