### PR TITLE
Use pkg-config for detecting and enabling ZSTD

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -31,7 +31,7 @@ function configure() {
       # The full set of configure options which were used for building the
       # tree must be used here as well since the toplevel Makefile depends
       # on these options for deciding what to test. Since we don't ship
-      ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python PYTHON=python3 --enable-gpcloud --with-libxml --enable-mapreduce --enable-orafce --enable-tap-tests --disable-orca --with-openssl ${CONFIGURE_FLAGS}
+      ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python PYTHON=python3 --enable-gpcloud --with-libxml --enable-mapreduce --enable-orafce --enable-tap-tests --disable-orca --with-openssl PKG_CONFIG_PATH="${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS}
 
   popd
 }

--- a/concourse/scripts/ic_gpdb_resgroup.bash
+++ b/concourse/scripts/ic_gpdb_resgroup.bash
@@ -62,7 +62,7 @@ run_resgroup_test() {
             --without-zlib --without-rt --without-libcurl \
             --without-libedit-preferred --without-docdir --without-readline \
             --disable-gpcloud --disable-gpfdist --disable-orca \
-            --disable-pxf --without-python ${CONFIGURE_FLAGS}
+            --disable-pxf --without-python PKG_CONFIG_PATH="\${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS}
 
         make -C /home/gpadmin/gpdb_src/src/test/regress
         ssh sdw1 mkdir -p /home/gpadmin/gpdb_src/src/test/regress </dev/null

--- a/configure
+++ b/configure
@@ -720,6 +720,8 @@ with_apr_config
 with_libcurl
 with_rt
 with_quicklz
+ZSTD_LIBS
+ZSTD_CFLAGS
 with_zstd
 with_libbz2
 with_zlib
@@ -741,9 +743,6 @@ with_perl
 with_tcl
 ICU_LIBS
 ICU_CFLAGS
-PKG_CONFIG_LIBDIR
-PKG_CONFIG_PATH
-PKG_CONFIG
 with_icu
 enable_thread_safety
 INCLUDES
@@ -753,6 +752,9 @@ enable_gpcloud
 enable_mapreduce
 enable_orca
 autodepend
+PKG_CONFIG_LIBDIR
+PKG_CONFIG_PATH
+PKG_CONFIG
 TAS
 GCC
 CPP
@@ -932,6 +934,8 @@ PKG_CONFIG_LIBDIR
 ICU_CFLAGS
 ICU_LIBS
 XML2_CONFIG
+ZSTD_CFLAGS
+ZSTD_LIBS
 LDFLAGS_EX
 LDFLAGS_SL
 PERL
@@ -1651,6 +1655,8 @@ Some influential environment variables:
   ICU_CFLAGS  C compiler flags for ICU, overriding pkg-config
   ICU_LIBS    linker flags for ICU, overriding pkg-config
   XML2_CONFIG path to xml2-config utility
+  ZSTD_CFLAGS C compiler flags for ZSTD, overriding pkg-config
+  ZSTD_LIBS   linker flags for ZSTD, overriding pkg-config
   LDFLAGS_EX  extra linker flags for linking executables only
   LDFLAGS_SL  extra linker flags for linking shared libraries only
   PERL        Perl program
@@ -7489,6 +7495,129 @@ else
 fi
 
 
+#
+# Set up pkg_config in case we need it below
+#
+
+
+
+
+
+
+
+if test "x$ac_cv_env_PKG_CONFIG_set" != "xset"; then
+	if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
+set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $PKG_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+PKG_CONFIG=$ac_cv_path_PKG_CONFIG
+if test -n "$PKG_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
+$as_echo "$PKG_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+fi
+if test -z "$ac_cv_path_PKG_CONFIG"; then
+  ac_pt_PKG_CONFIG=$PKG_CONFIG
+  # Extract the first word of "pkg-config", so it can be a program name with args.
+set dummy pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_ac_pt_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $ac_pt_PKG_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_ac_pt_PKG_CONFIG="$ac_pt_PKG_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_ac_pt_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+ac_pt_PKG_CONFIG=$ac_cv_path_ac_pt_PKG_CONFIG
+if test -n "$ac_pt_PKG_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pt_PKG_CONFIG" >&5
+$as_echo "$ac_pt_PKG_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+  if test "x$ac_pt_PKG_CONFIG" = x; then
+    PKG_CONFIG=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    PKG_CONFIG=$ac_pt_PKG_CONFIG
+  fi
+else
+  PKG_CONFIG="$ac_cv_path_PKG_CONFIG"
+fi
+
+fi
+if test -n "$PKG_CONFIG"; then
+	_pkg_min_version=0.9.0
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
+$as_echo_n "checking pkg-config is at least version $_pkg_min_version... " >&6; }
+	if $PKG_CONFIG --atleast-pkgconfig-version $_pkg_min_version; then
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	else
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+		PKG_CONFIG=""
+	fi
+fi
 
 #
 # Automatic dependency tracking
@@ -8283,126 +8412,6 @@ $as_echo "$with_icu" >&6; }
 
 
 if test "$with_icu" = yes; then
-
-
-
-
-
-
-
-if test "x$ac_cv_env_PKG_CONFIG_set" != "xset"; then
-	if test -n "$ac_tool_prefix"; then
-  # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
-set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PKG_CONFIG+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $PKG_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  ;;
-esac
-fi
-PKG_CONFIG=$ac_cv_path_PKG_CONFIG
-if test -n "$PKG_CONFIG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
-$as_echo "$PKG_CONFIG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-fi
-if test -z "$ac_cv_path_PKG_CONFIG"; then
-  ac_pt_PKG_CONFIG=$PKG_CONFIG
-  # Extract the first word of "pkg-config", so it can be a program name with args.
-set dummy pkg-config; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_ac_pt_PKG_CONFIG+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $ac_pt_PKG_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_ac_pt_PKG_CONFIG="$ac_pt_PKG_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_ac_pt_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  ;;
-esac
-fi
-ac_pt_PKG_CONFIG=$ac_cv_path_ac_pt_PKG_CONFIG
-if test -n "$ac_pt_PKG_CONFIG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pt_PKG_CONFIG" >&5
-$as_echo "$ac_pt_PKG_CONFIG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-  if test "x$ac_pt_PKG_CONFIG" = x; then
-    PKG_CONFIG=""
-  else
-    case $cross_compiling:$ac_tool_warned in
-yes:)
-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
-ac_tool_warned=yes ;;
-esac
-    PKG_CONFIG=$ac_pt_PKG_CONFIG
-  fi
-else
-  PKG_CONFIG="$ac_cv_path_PKG_CONFIG"
-fi
-
-fi
-if test -n "$PKG_CONFIG"; then
-	_pkg_min_version=0.9.0
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
-$as_echo_n "checking pkg-config is at least version $_pkg_min_version... " >&6; }
-	if $PKG_CONFIG --atleast-pkgconfig-version $_pkg_min_version; then
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-	else
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-		PKG_CONFIG=""
-	fi
-fi
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for icu-uc icu-i18n" >&5
@@ -9313,6 +9322,8 @@ fi
 #
 # zstd
 #
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build with ZSTD support" >&5
+$as_echo_n "checking whether to build with ZSTD support... " >&6; }
 
 
 
@@ -9321,7 +9332,9 @@ if test "${with_zstd+set}" = set; then :
   withval=$with_zstd;
   case $withval in
     yes)
-      :
+
+$as_echo "#define USE_ZSTD 1" >>confdefs.h
+
       ;;
     no)
       :
@@ -9334,10 +9347,108 @@ if test "${with_zstd+set}" = set; then :
 else
   with_zstd=yes
 
+$as_echo "#define USE_ZSTD 1" >>confdefs.h
+
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_zstd" >&5
+$as_echo "$with_zstd" >&6; }
+
+
+if test "$with_zstd" = yes; then
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libzstd >= 1.1.1" >&5
+$as_echo_n "checking for libzstd >= 1.1.1... " >&6; }
+
+if test -n "$ZSTD_CFLAGS"; then
+    pkg_cv_ZSTD_CFLAGS="$ZSTD_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.1.1\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.1.1") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_ZSTD_CFLAGS=`$PKG_CONFIG --cflags "libzstd >= 1.1.1" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$ZSTD_LIBS"; then
+    pkg_cv_ZSTD_LIBS="$ZSTD_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.1.1\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.1.1") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_ZSTD_LIBS=`$PKG_CONFIG --libs "libzstd >= 1.1.1" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
 fi
 
 
 
+if test $pkg_failed = yes; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libzstd >= 1.1.1" 2>&1`
+        else
+	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libzstd >= 1.1.1" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$ZSTD_PKG_ERRORS" >&5
+
+	as_fn_error $? "Package requirements (libzstd >= 1.1.1) were not met:
+
+$ZSTD_PKG_ERRORS
+
+Consider adjusting the PKG_CONFIG_PATH environment variable if you
+installed software in a non-standard prefix.
+
+Alternatively, you may set the environment variables ZSTD_CFLAGS
+and ZSTD_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details." "$LINENO" 5
+elif test $pkg_failed = untried; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
+is in your PATH or set the PKG_CONFIG environment variable to the full
+path to pkg-config.
+
+Alternatively, you may set the environment variables ZSTD_CFLAGS
+and ZSTD_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details.
+
+To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+See \`config.log' for more details" "$LINENO" 5; }
+else
+	ZSTD_CFLAGS=$pkg_cv_ZSTD_CFLAGS
+	ZSTD_LIBS=$pkg_cv_ZSTD_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+fi
+fi
 
 #
 # quicklz
@@ -13056,59 +13167,6 @@ fi
 
 fi
 
-if test "$with_zstd" = yes; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ZSTD_compressCCtx in -lzstd" >&5
-$as_echo_n "checking for ZSTD_compressCCtx in -lzstd... " >&6; }
-if ${ac_cv_lib_zstd_ZSTD_compressCCtx+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lzstd  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char ZSTD_compressCCtx ();
-int
-main ()
-{
-return ZSTD_compressCCtx ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_zstd_ZSTD_compressCCtx=yes
-else
-  ac_cv_lib_zstd_ZSTD_compressCCtx=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_zstd_ZSTD_compressCCtx" >&5
-$as_echo "$ac_cv_lib_zstd_ZSTD_compressCCtx" >&6; }
-if test "x$ac_cv_lib_zstd_ZSTD_compressCCtx" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBZSTD 1
-_ACEOF
-
-  LIBS="-lzstd $LIBS"
-
-else
-  as_fn_error $? "zstd library not found
-If you have libzstd already installed, see config.log for details on the
-failure.  It is possible the compiler isn't looking in the proper directory.
-Use --without-zstd to disable zstd support." "$LINENO" 5
-fi
-
-fi
-
 if test "$with_quicklz" = yes; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for qlz_compress in -lquicklz" >&5
 $as_echo_n "checking for qlz_compress in -lquicklz... " >&6; }
@@ -15136,26 +15194,6 @@ if test "x$ac_cv_header_bzlib_h" = xyes; then :
 
 else
   as_fn_error $? "header file <bzlib.h> is required for bzip2 support" "$LINENO" 5
-fi
-
-
-fi
-
-# Check for zstd.h and zstd_errors.h
-if test "$with_zstd" = yes; then
-  ac_fn_c_check_header_mongrel "$LINENO" "zstd.h" "ac_cv_header_zstd_h" "$ac_includes_default"
-if test "x$ac_cv_header_zstd_h" = xyes; then :
-
-else
-  as_fn_error $? "header file <zstd.h> is required for zstd support" "$LINENO" 5
-fi
-
-
-  ac_fn_c_check_header_mongrel "$LINENO" "zstd_errors.h" "ac_cv_header_zstd_errors_h" "$ac_includes_default"
-if test "x$ac_cv_header_zstd_errors_h" = xyes; then :
-
-else
-  as_fn_error $? "header file <zstd_errors.h> is required for zstd support" "$LINENO" 5
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -744,6 +744,10 @@ else
 fi
 AC_SUBST(TAS)
 
+#
+# Set up pkg_config in case we need it below
+#
+PKG_PROG_PKG_CONFIG
 
 #
 # Automatic dependency tracking
@@ -1110,9 +1114,16 @@ AC_SUBST(with_libbz2)
 #
 # zstd
 #
-PGAC_ARG_BOOL(with, zstd, yes,
-              [do not build with Zstandard])
+AC_MSG_CHECKING([whether to build with ZSTD support])
+PGAC_ARG_BOOL(with, zstd, yes, [do not build with Zstandard],
+              [AC_DEFINE([USE_ZSTD], 1, [Define to build with zstd support. (--with-zstd)])])
+AC_MSG_RESULT([$with_zstd])
 AC_SUBST(with_zstd)
+
+if test "$with_zstd" = yes; then
+  dnl zstd_errors.h was renamed from error_public.h in v1.1.1
+  PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.1.1])
+fi
 
 #
 # quicklz
@@ -1367,14 +1378,6 @@ if test "$with_zlib" = yes; then
 If you have zlib already installed, see config.log for details on the
 failure.  It is possible the compiler isn't looking in the proper directory.
 Use --without-zlib to disable zlib support.])])
-fi
-
-if test "$with_zstd" = yes; then
-  AC_CHECK_LIB(zstd, ZSTD_compressCCtx, [],
-               [AC_MSG_ERROR([zstd library not found
-If you have libzstd already installed, see config.log for details on the
-failure.  It is possible the compiler isn't looking in the proper directory.
-Use --without-zstd to disable zstd support.])])
 fi
 
 if test "$with_quicklz" = yes; then
@@ -1681,12 +1684,6 @@ fi
 # Check for bzlib.h
 if test "$with_libbz2" = yes ; then
   AC_CHECK_HEADER(bzlib.h, [], [AC_MSG_ERROR([header file <bzlib.h> is required for bzip2 support])], [])
-fi
-
-# Check for zstd.h and zstd_errors.h
-if test "$with_zstd" = yes; then
-  AC_CHECK_HEADER(zstd.h, [], [AC_MSG_ERROR([header file <zstd.h> is required for zstd support])])
-  AC_CHECK_HEADER(zstd_errors.h, [], [AC_MSG_ERROR([header file <zstd_errors.h> is required for zstd support])])
 fi
 
 # Check for quicklz.h

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -263,6 +263,8 @@ BITCODE_CXXFLAGS = @BITCODE_CXXFLAGS@
 have_yaml 		= @have_yaml@
 YAML_LIBS		= @YAML_LIBS@
 with_zstd 		= @with_zstd@
+ZSTD_CFLAGS		= @ZSTD_CFLAGS@
+ZSTD_LIBS		= @ZSTD_LIBS@
 with_quicklz		= @with_quicklz@
 EVENT_LIBS		= @EVENT_LIBS@
 
@@ -276,7 +278,7 @@ CPP = @CPP@
 CPPFLAGS = @CPPFLAGS@
 PG_SYSROOT = @PG_SYSROOT@
 
-override CPPFLAGS := $(ICU_CFLAGS) $(CPPFLAGS)
+override CPPFLAGS := $(ICU_CFLAGS) $(ZSTD_CFLAGS) $(CPPFLAGS)
 
 ifdef PGXS
 override CPPFLAGS := -I$(includedir_server) -I$(includedir_internal) $(CPPFLAGS)
@@ -328,6 +330,9 @@ UUID_EXTRA_OBJS = @UUID_EXTRA_OBJS@
 LLVM_LIBS=@LLVM_LIBS@
 LD = @LD@
 with_gnu_ld = @with_gnu_ld@
+
+# Greenplum uses zstd in frontend and backend
+LIBS := $(LIBS) $(ZSTD_LIBS)
 
 # It's critical that within LDFLAGS, all -L switches pointing to build-tree
 # directories come before any -L switches pointing to external directories.

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -815,7 +815,7 @@ validate_and_adjust_options(StdRdOptions *result,
 		if (result->compresstype[0] &&
 			(pg_strcasecmp(result->compresstype, "zstd") == 0))
 		{
-#ifndef HAVE_LIBZSTD
+#ifndef USE_ZSTD
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("Zstandard library is not supported by this build"),
@@ -979,7 +979,7 @@ validateAppendOnlyRelOptions(int blocksize,
 
 		if (comptype && (pg_strcasecmp(comptype, "zstd") == 0))
 		{
-#ifndef HAVE_LIBZSTD
+#ifndef USE_ZSTD
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("Zstandard library is not supported by this build"),

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -32,12 +32,12 @@
 #include "utils/memutils.h"
 #include "pg_trace.h"
 
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 /* Zstandard library is provided */
 #include <zstd.h>
 /* zstandard compression level to use. */
 #define COMPRESS_LEVEL 3
-#endif			/* HAVE_LIBZSTD */
+#endif
 
 /*
  * For each block reference registered with XLogRegisterBuffer, we fill in
@@ -823,7 +823,7 @@ static bool
 XLogCompressBackupBlock(char *page, uint16 hole_offset, uint16 hole_length,
 						char *dest, uint16 *dlen)
 {
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 	static ZSTD_CCtx  *cxt = NULL;      /* ZSTD compression context */
 	int32		orig_len = BLCKSZ - hole_length;
 	int32		len;

--- a/src/backend/access/transam/xlogreader.c
+++ b/src/backend/access/transam/xlogreader.c
@@ -25,10 +25,10 @@
 #include "common/pg_lzcompress.h"
 #include "replication/origin.h"
 
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 /* Zstandard library is provided */
 #include <zstd.h>
-#endif			/* HAVE_LIBZSTD */
+#endif
 
 #ifndef FRONTEND
 #include "utils/memutils.h"
@@ -1475,7 +1475,7 @@ bool
 zstd_decompress_backupblock(const char *source, int32 slen, char *dest,
 							int32 rawsize, char *errormessage)
 {
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 		unsigned long long uncompressed_size;
 		int dst_length_used;
 		static ZSTD_DCtx  *cxt = NULL;      /* ZSTD decompression context */

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -521,7 +521,7 @@ compresstype_is_valid(char *comptype)
 #ifdef HAVE_LIBZ
 			"zlib",
 #endif
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 			"zstd",
 #endif
 			"rle_type", "none"};

--- a/src/backend/cdb/cdbsrlz.c
+++ b/src/backend/cdb/cdbsrlz.c
@@ -19,7 +19,7 @@
 #include "nodes/nodes.h"
 #include "utils/memutils.h"
 
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 /* Zstandard library is provided */
 
 #include <zstd.h>
@@ -30,7 +30,7 @@ static char *uncompress_string(const char *src, int size, int *uncompressed_size
 /* zstandard compression level to use. */
 #define COMPRESS_LEVEL 3
 
-#endif			/* HAVE_LIBZSTD */
+#endif			/* USE_ZSTD */
 
 /*
  * This is used by dispatcher to serialize Plan and Query Trees for
@@ -51,7 +51,7 @@ serializeNode(Node *node, int *size, int *uncompressed_size_out)
 	Assert(pszNode != NULL);
 
 	/* If we have been compiled with libzstd, use it to compress it */
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 	sNode = compress_string(pszNode, uncompressed_size, size);
 	pfree(pszNode);
 #else
@@ -73,27 +73,27 @@ Node *
 deserializeNode(const char *strNode, int size)
 {
 	Node	   *node;
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 	char	   *sNode;
 	int			uncompressed_len;
-#endif			/* HAVE_LIBZSTD */
+#endif
 
 	Assert(strNode != NULL);
 
 	/* If we have been compiled with libzstd, decompress */
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 	sNode = uncompress_string(strNode, size, &uncompressed_len);
 	Assert(sNode != NULL);
 	node = readNodeFromBinaryString(sNode, uncompressed_len);
 	pfree(sNode);
 #else
 	node = readNodeFromBinaryString(strNode, size);
-#endif			/* HAVE_LIBZSTD */
+#endif
 
 	return node;
 }
 
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 /*
  * Compress a (binary) string using libzstd
  *
@@ -177,4 +177,4 @@ uncompress_string(const char *src, int size, int *uncompressed_size_p)
 
 	return (char *) result;
 }
-#endif			/* HAVE_LIBZSTD */
+#endif			/* USE_ZSTD */

--- a/src/backend/mock.mk
+++ b/src/backend/mock.mk
@@ -18,7 +18,7 @@ override CPPFLAGS+= -I$(top_srcdir)/src/backend/libpq \
 
 # TODO: add ldl for quick hack; we need to figure out why
 # postgres in src/backend/Makefile doesn't need this and -pthread.
-MOCK_LIBS := -ldl $(filter-out -ledit, $(LIBS)) $(LDAP_LIBS_BE) $(ICU_LIBS)
+MOCK_LIBS := -ldl $(filter-out -ledit, $(LIBS)) $(LDAP_LIBS_BE) $(ICU_LIBS) $(ZSTD_LIBS)
 
 # These files are not linked into test programs.
 EXCL_OBJS=\

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -41,7 +41,7 @@
 
 #include "postgres.h"
 
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 #include <zstd.h>
 #endif
 
@@ -139,7 +139,7 @@ struct BufFile
 	} state;
 
 	/* ZStandard compression support */
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 	zstd_context *zstd_context;	/* ZStandard library handles. */
 
 	/*
@@ -513,7 +513,7 @@ BufFileClose(BufFile *file)
 		pfree(file->buffer.data);
 
 	/* release zstd handles */
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 	if (file->zstd_context)
 		zstd_free_context(file->zstd_context);
 #endif
@@ -1208,7 +1208,7 @@ BufFilePledgeSequential(BufFile *buffile)
 /*
  * The rest of the code is only needed when compression support is compiled in.
  */
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 
 #define BUFFILE_ZSTD_COMPRESSION_LEVEL 1
 

--- a/src/backend/storage/file/gp_compress.c
+++ b/src/backend/storage/file/gp_compress.c
@@ -22,7 +22,7 @@
 #include "utils/guc.h"
 #include "utils/resowner.h"
 
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 #include <zstd.h>
 #endif
 
@@ -119,7 +119,7 @@ void gp_decompress(
 /*
  * Support for tracking ZSTD handles with resource owners.
  */
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 
 static dlist_head open_zstd_handles;
 static bool zstd_resowner_callback_registered;
@@ -187,4 +187,4 @@ zstd_free_callback(ResourceReleasePhase phase,
 	}
 }
 
-#endif	/* HAVE_LIBZSTD */
+#endif	/* USE_ZSTD */

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4840,7 +4840,7 @@ lookup_autostats_mode_by_value(GpAutoStatsModeValue val)
 static bool
 check_gp_workfile_compression(bool *newval, void **extra, GucSource source)
 {
-#ifndef HAVE_LIBZSTD
+#ifndef USE_ZSTD
 	if (*newval)
 	{
 		GUC_check_errmsg("workfile compresssion is not supported by this build");

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -438,9 +438,6 @@
 /* Define to 1 if you have the `z' library (-lz). */
 #undef HAVE_LIBZ
 
-/* Define to 1 if you have the `zstd' library (-lzstd). */
-#undef HAVE_LIBZSTD
-
 /* Define to 1 if the system has the type `locale_t'. */
 #undef HAVE_LOCALE_T
 
@@ -1061,6 +1058,9 @@
 
 /* Define to select Win32-style shared memory. */
 #undef USE_WIN32_SHARED_MEMORY
+
+/* Define to build with zstd support. (--with-zstd) */
+#undef USE_ZSTD
 
 /* Define to 1 if `wcstombs_l' requires <xlocale.h>. */
 #undef WCSTOMBS_L_IN_XLOCALE

--- a/src/include/pg_config.h.win32
+++ b/src/include/pg_config.h.win32
@@ -808,6 +808,9 @@
 /* Define to select Win32-style semaphores. */
 #define USE_WIN32_SEMAPHORES 1
 
+/* Define to build with zstd support. (--with-zstd) */
+#undef USE_ZSTD
+
 /* Define to 1 if `wcstombs_l' requires <xlocale.h>. */
 /* #undef WCSTOMBS_L_IN_XLOCALE */
 

--- a/src/include/storage/gp_compress.h
+++ b/src/include/storage/gp_compress.h
@@ -16,7 +16,7 @@
 #ifndef GP_COMPRESS_H
 #define GP_COMPRESS_H
 
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 #include "zstd.h"
 #endif
 
@@ -66,7 +66,7 @@ extern void gp_decompress(
  * If the transaction is aborted, the handle will be automatically closed,
  * when the resource owner is destroyed.
  */
-#ifdef HAVE_LIBZSTD
+#ifdef USE_ZSTD
 
 typedef struct
 {
@@ -80,7 +80,7 @@ typedef struct
 extern void zstd_free_context(zstd_context *context);
 extern zstd_context *zstd_alloc_context(void);
 
-#endif	/* HAVE_LIBZSTD */
+#endif	/* USE_ZSTD */
 
 
 #endif


### PR DESCRIPTION
Use `pkg-config` for detecting and enabling ZSTD

- Replaced `HAVE_LIBZSTD` (artifact of `AC_CHECK_LIB`) with a dedicated macro `USE_ZSTD`

- Use `pkg-config` version requirement, instead of a a manual and error-prone `AC_CHECK_HEADER`

- On system where the headers and library objects are not located in the default search path, simply specify `PKG_CONFIG_PATH` while invoking `configure` or override both `ZSTD_LIBS` and `ZSTD_CFLAGS` -- not that I encourage it, but if you feel compelled to avoid `pkg-config,` this option is available 

Discussion on https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/Vs5omcqRvZQ

[resolves greenplum-db/gpdb#7381]
FIXME:

- [x] Fix our build env to have the .pc files for zstd (why was it lost in the first place?)