### PR TITLE
Remove dead command in Makefile

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -2,10 +2,6 @@
 # and Makefile.thirdparty
 default: all
 
-BLD_TOP=..
-
-ext_dir=$(BLD_TOP)/gpAux/ext
-
 top_builddir = ..
 include $(top_builddir)/src/Makefile.global
 
@@ -102,10 +98,6 @@ endif
 ifeq "$(with_quicklz)" "yes"
 	$(MAKE) -C quicklz installcheck
 endif
-
-	if [ -d "$(ext_dir)" ]; then \
-		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C installcheck USE_PGXS=1 ; \
-	fi
 
 unittest-check:
 	@if [ "$(enable_pxf)" = "yes" ]; then \


### PR DESCRIPTION
In fact, if you manage to get an extra directory created, you can
exercise the code being removed. It won't work anyway, with an error:

> make[1]: Entering directory '/build/gpdb/gpcontrib'
> make[1]: *** installcheck: No such file or directory.  Stop.
> make[1]: Leaving directory '/build/gpdb/gpcontrib'
> make: *** [Makefile:96: installcheck] Error 2

This should have been deleted in commit ad6b920fe648 as part of GPHDFS
removal.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
