### PR TITLE
Fix issue that GPDB auxiliary backend cannot start in QE

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -6236,7 +6236,7 @@ bgworker_should_start_mpp(BackgroundWorker *worker)
 	 * or BgWorkerStart_ConsistentState because it's not safe to do a read
 	 * or write if DTX is not recovered.
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (IsUnderMasterDispatchMode())
 	{
 		if (!*shmDtmStarted &&
 			(start_time == BgWorkerStart_ConsistentState ||


### PR DESCRIPTION
background worker is not scheduled until distributed transactions
are recovered if it needs to start at BgWorkerStart_RecoveryFinished
or BgWorkerStart_ConsistentState because it's not safe to do a read
or write if DTX is not recovered. GPDB is designed to do this check
in master only, however Gp_role == GP_ROLE_DISPATCH is not a
sufficient check for master.

Spotted by Wang Hao <haowang@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
