### PR TITLE
Remove variable self-assignment in gpload

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2221,7 +2221,6 @@ class gpload:
             if val.startswith("E'") and val.endswith("'") and len(val[2:-1].decode('unicode-escape')) == 1:
                 subval = val[2:-1]
                 if subval == "\\'":
-                    val = val
                     self.formatOpts += "%s %s " % (specify_str, val)
                 else:
                     val = subval.decode('unicode-escape')


### PR DESCRIPTION
Setting a variable to itself is a no-op which can be removed. This may have been introduced in error and instead masking a real bug, but if it so then we have lived with it for two years so I'm opting for removing.
