### PR TITLE
docs - bring the pg_auth kerberos docs up-to-date with PG

### DIFF
--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -38,13 +38,13 @@
         up of a number of fields which are separated by spaces and/or tabs. Fields can contain white
         space if the field value is quoted. Records cannot be continued across lines. </p>
       <p>A record can have one of seven formats:
-        <codeblock>local      database  user  auth-method  [auth-options]
-host       database  user  address  auth-method  [auth-options]
-hostssl    database  user  address  auth-method  [auth-options]
-hostnossl  database  user  address  auth-method  [auth-options]
-host       database  user  IP-address  IP-mask  auth-method  [auth-options]
-hostssl    database  user  IP-address  IP-mask  auth-method  [auth-options]
-hostnossl  database  user  IP-address  IP-mask  auth-method  [auth-options]</codeblock></p>
+        <codeblock>local      <varname>database</varname>  <varname>user</varname>  <varname>auth-method</varname>  [<varname>auth-options</varname>]
+host       <varname>database</varname>  <varname>user</varname>  <varname>address</varname>  <varname>auth-method</varname>  [<varname>auth-options</varname>]
+hostssl    <varname>database</varname>  <varname>user</varname>  <varname>address</varname>  <varname>auth-method</varname>  [<varname>auth-options</varname>]
+hostnossl  <varname>database</varname>  <varname>user</varname>  <varname>address</varname>  <varname>auth-method</varname>  [<varname>auth-options</varname>]
+host       <varname>database</varname>  <varname>user</varname>  <varname>IP-address</varname>  <varname>IP-mask</varname>  <varname>auth-method</varname>  [<varname>auth-options</varname>]
+hostssl    <varname>database</varname>  <varname>user</varname>  <varname>IP-address</varname>  <varname>IP-mask</varname>  <varname>auth-method</varname>  [<varname>auth-options</varname>]
+hostnossl  <varname>database</varname>  <varname>user</varname>  <varname>IP-address</varname>  <varname>IP-mask</varname>  <varname>auth-method</varname>  [<varname>auth-options</varname>]</codeblock></p>
       <p>The meaning of the <codeph>pg_hba.conf</codeph> fields is as follows: <parml>
           <plentry>
             <pt><codeph>local</codeph></pt>
@@ -116,18 +116,19 @@ hostnossl  database  user  IP-address  IP-mask  auth-method  [auth-options]</cod
                 <codeph>samehost</codeph> to match any of the server's own IP addresses, or
                 <codeph>samenet</codeph> to match any address in any subnet to which the server is
               directly connected.</pd>
-            <pd>If a <varname>host name</varname> is specified (an address that is not an IP
+            <pd>If a host name is specified (an address that is not an IP
               address, IP range, or special key word is treated as a host name), that name is
               compared with the result of a reverse name resolution of the client IP address (for
               example, reverse DNS lookup, if DNS is used). Host name comparisons are case
               insensitive. If there is a match, then a forward name resolution (for example, forward
               DNS lookup) is performed on the host name to check whether any of the addresses it
               resolves to are equal to the client IP address. If both directions match, then the
-              entry is considered to match. (The host name that is used in
-                <codeph>pg_hba.conf</codeph> should be the one that address-to-name resolution of
-              the client's IP address returns, otherwise the line won't be matched. Some host name
-              databases allow associating an IP address with multiple host names, but the operating
-              system will only return one host name when asked to resolve an IP address.) </pd>
+              entry is considered to match. </pd>
+            <pd>The host name that is used in <codeph>pg_hba.conf</codeph> should be the one that
+              address-to-name resolution of the client's IP address returns, otherwise the line
+              won't be matched. Some host name databases allow associating an IP address with
+              multiple host names, but the operating system will only return one host name when
+              asked to resolve an IP address.</pd>
             <pd>A host name specification that starts with a dot (.) matches a suffix of the actual
               host name. So <codeph>.example.com</codeph> would match
                 <codeph>foo.example.com</codeph> (but not just <codeph>example.com</codeph>).</pd>
@@ -286,9 +287,9 @@ host    all   dba   192.168.0.0/32  md5</codeblock></li>
           password is sent across the connection: MD5-hashed and clear-text respectively. </p>
         <p>If you are at all concerned about password "sniffing" attacks then <codeph>md5</codeph>
           is preferred. Plain <codeph>password</codeph> should always be avoided if possible. If the
-          connection is protected by SSL encryption then password can be used safely (although SSL
-          certificate authentication might be a better choice if you are depending on using
-          SSL).</p>
+          connection is protected by SSL encryption then <codeph>password</codeph> can be used
+          safely (although SSL certificate authentication might be a better choice if you are
+          depending on using SSL).</p>
         <p>Following are some sample <codeph>pg_hba.conf</codeph> basic authentication
           entries:<codeblock>hostnossl    all   all        0.0.0.0   reject
 hostssl      all   testuser   0.0.0.0/0 md5
@@ -310,7 +311,7 @@ local        all   gpuser               ident</codeblock
           connection from the client using the <codeph>krbsrvname</codeph> connection parameter.
           (See <xref
             href="https://www.postgresql.org/docs/9.4/libpq-connect.html#LIBPQ-PARAMKEYWORDS"
-            format="html" scope="external">Connection Parameter Key Words</xref>.) In most
+            format="html" scope="external">Connection Parameter Key Words</xref> in the PostgreSQL documentation.) In most
           environments, this parameter never needs to be changed. Some Kerberos implementations
           might require a different service name, such as Microsoft Active Directory, which requires
           the service name to be in upper case (POSTGRES).</p>
@@ -339,7 +340,7 @@ kadmin% <b>ktadd -k krb5.keytab postgres/server.my.domain.org</b></codeblock>
           principal <codeph>fred@EXAMPLE.COM</codeph> would be able to connect. To also allow
           principal <codeph>fred/users.example.com@EXAMPLE.COM</codeph>, use a user name map, as
           described in <xref href="https://www.postgresql.org/docs/9.4/auth-username-maps.html"
-            format="html" scope="external">User Name Maps</xref>.</p>
+            format="html" scope="external">User Name Maps</xref> in the PostgreSQL documentation.</p>
         <p>The following configuration options are supported for GSSAPI: </p>
         <parml>
           <plentry>

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -171,19 +171,19 @@ hostnossl  <varname>database</varname>  <varname>user</varname>  <varname>IP-add
         attempt, so the order of the records is significant. Typically, earlier records will have
         tight connection match parameters and weaker authentication methods, while later records
         will have looser match parameters and stronger authentication methods. For example, you
-        might wish to use trust authentication for local TCP/IP connections but require a password
-        for remote TCP/IP connections. In this case a record specifying trust authentication for
-        connections from 127.0.0.1 would appear before a record specifying password authentication
+        might wish to use <codeph>trust</codeph> authentication for local TCP/IP connections but require a password
+        for remote TCP/IP connections. In this case a record specifying <codeph>trust</codeph> authentication for
+        connections from 127.0.0.1 would appear before a record specifying <codeph>password</codeph> authentication
         for a wider range of allowed client IP addresses.</p>
       <p>The <codeph>pg_hba.conf</codeph> file is read on start-up and when the main server process
         receives a SIGHUP signal. If you edit the file on an active system, you must reload the file
         using this command:<codeblock>$ gpstop -u</codeblock></p>
       <note type="caution">For a more secure system, remove records for remote connections that use
-        trust authentication from the <codeph>pg_hba.conf</codeph> file. Trust authentication grants
+        <codeph>trust</codeph> authentication from the <codeph>pg_hba.conf</codeph> file. <codeph>rust</codeph> authentication grants
         any user who can connect to the server access to the database using any role they specify.
-        You can safely replace trust authentication with ident authentication for local UNIX-socket
-        connections. You can also use ident authentication for local and remote TCP clients, but the
-        client host must be running an ident service and you must trust the integrity of that
+        You can safely replace <codeph>trust</codeph> authentication with <codeph>ident</codeph> authentication for local UNIX-socket
+        connections. You can also use <codeph>ident</codeph> authentication for local and remote TCP clients, but the
+        client host must be running an ident service and you must <codeph>trust</codeph> the integrity of that
         machine.</note>
     </body>
   </topic>
@@ -193,13 +193,13 @@ hostnossl  <varname>database</varname>  <varname>user</varname>  <varname>IP-add
       <p>Initially, the <codeph>pg_hba.conf</codeph> file is set up with generous permissions for
         the gpadmin user and no database access for other Greenplum Database roles. You will need to
         edit the <codeph>pg_hba.conf</codeph> file to enable users' access to databases and to
-        secure the gpadmin user. Consider removing entries that have trust authentication, since
+        secure the gpadmin user. Consider removing entries that have <codeph>trust</codeph> authentication, since
         they allow anyone with access to the server to connect with any role they choose. For local
-        (UNIX socket) connections, use ident authentication, which requires the operating system
-        user to match the role specified. For local and remote TCP connections, ident authentication
+        (UNIX socket) connections, use <codeph>ident</codeph> authentication, which requires the operating system
+        user to match the role specified. For local and remote TCP connections, <codeph>ident</codeph> authentication
         requires the client's host to run an indent service. You could install an ident service on
-        the master host and then use ident authentication for local TCP connections, for example
-          <codeph>127.0.0.1/28</codeph>. Using ident authentication for remote TCP connections is
+        the master host and then use <codeph>ident</codeph> authentication for local TCP connections, for example
+          <codeph>127.0.0.1/28</codeph>. Using <codeph>ident</codeph> authentication for remote TCP connections is
         less secure because it requires you to trust the integrity of the ident service on the
         client's host. </p>
       <note otherprops="pivotal"> Greenplum Command Center provides an interface for editing the
@@ -265,8 +265,8 @@ host    all   dba   192.168.0.0/32  md5</codeblock></li>
             <plentry>
               <pt>Ident</pt>
               <pd>Authenticates based on the client's operating system user name. This is secure for
-                local socket connections. Using ident for TCP connections from remote hosts requires
-                that the client's host is running an ident service. The ident authentication method
+                local socket connections. Using <codeph>ident</codeph> for TCP connections from remote hosts requires
+                that the client's host is running an ident service. The <codeph>ident</codeph> authentication method
                 should only be used with remote hosts on a trusted, closed network. </pd>
             </plentry>
             <plentry>
@@ -326,7 +326,7 @@ local        all   gpuser               ident</codeblock
             <codeph>krb_realm</codeph> parameter, or enable <codeph>include_realm</codeph> and use
           user name mapping to check the realm.</p>
         <p>Make sure that your server keytab file is readable (and preferably only readable) by the
-          gpadmin server account. The location of the key file is specified by the <xref
+          <codeph>gpadmin</codeph> server account. The location of the key file is specified by the <xref
             href="../../ref_guide/config_params/guc-list.xml#krb_server_keyfile"/> configuration
           parameter. For security reasons, it is recommended to use a separate keytab just for the
           Greenplum Database server rather than opening up permissions on the system keytab

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -26,7 +26,7 @@
       <p>Client access and authentication is controlled by a configuration file named
           <codeph>pg_hba.conf</codeph> (the standard PostgreSQL host-based authentication file). For
         detailed information about this file, see <xref
-          href="https://www.postgresql.org/docs/9.1/auth-pg-hba-conf.html" format="html"
+          href="https://www.postgresql.org/docs/9.4/auth-pg-hba-conf.html" format="html"
           scope="external">The pg_hba.conf File</xref> in the PostgreSQL documentation. </p>
       <p>In Greenplum Database, the <codeph>pg_hba.conf</codeph> file of the master instance
         controls client access and authentication to your Greenplum system. The segments also have
@@ -36,59 +36,63 @@
       <p>The general format of the <codeph>pg_hba.conf</codeph> file is a set of records, one per
         line. Blank lines are ignored, as is any text after a # comment character. A record is made
         up of a number of fields which are separated by spaces and/or tabs. Fields can contain white
-        space if the field value is quoted. Records cannot be continued across lines. Each remote
-        client access record is in this format:
-        <codeblock>host   database   role   address   authentication-method
-</codeblock></p>
-      <p>A UNIX-domain socket access record is in this format:
-        <codeblock>local   database   role   authentication-method
-</codeblock></p>
+        space if the field value is quoted. Records cannot be continued across lines. </p>
+      <p>A record can have one of seven formats:
+        <codeblock>local      database  user  auth-method  [auth-options]
+host       database  user  address  auth-method  [auth-options]
+hostssl    database  user  address  auth-method  [auth-options]
+hostnossl  database  user  address  auth-method  [auth-options]
+host       database  user  IP-address  IP-mask  auth-method  [auth-options]
+hostssl    database  user  IP-address  IP-mask  auth-method  [auth-options]
+hostnossl  database  user  IP-address  IP-mask  auth-method  [auth-options]</codeblock></p>
       <p>The meaning of the <codeph>pg_hba.conf</codeph> fields is as follows: <parml>
           <plentry>
-            <pt>local</pt>
-            <pd> Matches connection attempts using UNIX-domain sockets. Without a record of this
+            <pt><codeph>local</codeph></pt>
+            <pd>Matches connection attempts using UNIX-domain sockets. Without a record of this
               type, UNIX-domain socket connections are disallowed. </pd>
           </plentry>
           <plentry>
-            <pt>host</pt>
+            <pt><codeph>host</codeph></pt>
             <pd>Matches connection attempts made using TCP/IP. Remote TCP/IP connections will not be
               possible unless the server is started with an appropriate value for the
-                <codeph>listen_addresses</codeph> server configuration parameter. </pd>
+                <codeph>listen_addresses</codeph> server configuration parameter. Greenplum Database
+              by default allows connections from all hosts (<codeph>'*'</codeph>).</pd>
           </plentry>
           <plentry>
-            <pt>hostssl</pt>
+            <pt><codeph>hostssl</codeph></pt>
             <pd>Matches connection attempts made using TCP/IP, but only when the connection is made
               with SSL encryption. SSL must be enabled at server start time by setting the
-                <codeph>ssl</codeph> configuration parameter. Requires SSL authentication be
+                <codeph>ssl</codeph> configuration parameter to on. Requires SSL authentication be
               configured in <codeph>postgresql.conf</codeph>. See <xref
                 href="#topic_fzv_wb2_jr/ssl_postgresql" format="dita"/>. </pd>
           </plentry>
           <plentry>
-            <pt>hostnossl</pt>
-            <pd> Matches connection attempts made over TCP/IP that do not use SSL. Requires SSL
-              authentication be configured in <codeph>postgresql.conf</codeph>. See <xref
-                href="#topic_fzv_wb2_jr/ssl_postgresql" format="dita"/>.</pd>
+            <pt><codeph>hostnossl</codeph></pt>
+            <pd> Matches connection attempts made over TCP/IP that do not use SSL. </pd>
           </plentry>
           <plentry>
-            <pt>database</pt>
+            <pt><codeph><varname>database</varname></codeph></pt>
             <pd>Specifies which database names this record matches. The value <codeph>all</codeph>
               specifies that it matches all databases. Multiple database names can be supplied by
               separating them with commas. A separate file containing database names can be
               specified by preceding the file name with <codeph>@</codeph>. </pd>
           </plentry>
           <plentry>
-            <pt> role </pt>
-            <pd>Specifies which database role names this record matches. The value all specifies
-              that it matches all roles. If the specified role is a group and you want all members
-              of that group to be included, precede the role name with a <codeph>+</codeph>.
-              Multiple role names can be supplied by separating them with commas. A separate file
-              containing role names can be specified by preceding the file name with a
-                <codeph>@</codeph>. </pd>
+            <pt><codeph><varname>user</varname></codeph></pt>
+            <pd>Specifies which database role names this record matches. The value
+                <codeph>all</codeph> specifies that it matches all roles. If the specified role is a
+              group and you want all members of that group to be included, precede the role name
+              with a <codeph>+</codeph>. Multiple role names can be supplied by separating them with
+              commas. A separate file containing role names can be specified by preceding the file
+              name with <codeph>@</codeph>. </pd>
           </plentry>
           <plentry>
-            <pt> address </pt>
+            <pt>
+              <codeph><varname>address</varname></codeph>
+            </pt>
             <pd>Specifies the client machine addresses that this record matches. This field can
-              contain an IP address, an IP address range, or a host name. </pd>
+              contain either a host name, an IP address range, or one of the special key words
+              mentioned below. </pd>
             <pd>An IP address range is specified using standard numeric notation for the range's
               starting address, then a slash (<codeph>/</codeph>) and a CIDR mask length. The mask
               length indicates the number of high-order bits of the client IP address that must
@@ -106,48 +110,80 @@
               IPv4 or 128 for IPv6. In a network address, do not omit trailing zeroes.</pd>
             <pd>An entry given in IPv4 format will match only IPv4 connections, and an entry given
               in IPv6 format will match only IPv6 connections, even if the represented address is in
-              the IPv4-in-IPv6 range.
-              <note>Entries in IPv6 format will be rejected if the host system C library does not
-                have support for IPv6 addresses.</note></pd>
-            <pd>If a host name is specified (an address that is not an IP address or IP range is
-              treated as a host name), that name is compared with the result of a reverse name
-              resolution of the client IP address (for example, reverse DNS lookup, if DNS is used).
-              Host name comparisons are case insensitive. If there is a match, then a forward name
-              resolution (for example, forward DNS lookup) is performed on the host name to check
-              whether any of the addresses it resolves to are equal to the client IP address. If
-              both directions match, then the entry is considered to match. </pd>
-            <pd>Some host name databases allow associating an IP address with multiple host names,
-              but the operating system only returns one host name when asked to resolve an IP
-              address. The host name that is used in <codeph>pg_hba.conf</codeph> must be the one
-              that the address-to-name resolution of the client IP address returns, otherwise the
-              line will not be considered a match. </pd>
+              the IPv4-in-IPv6 range. <note>Entries in IPv6 format will be rejected if the host
+                system C library does not have support for IPv6 addresses.</note></pd>
+            <pd>You can also write <codeph>all</codeph> to match any IP address,
+                <codeph>samehost</codeph> to match any of the server's own IP addresses, or
+                <codeph>samenet</codeph> to match any address in any subnet to which the server is
+              directly connected.</pd>
+            <pd>If a <varname>host name</varname> is specified (an address that is not an IP
+              address, IP range, or special key word is treated as a host name), that name is
+              compared with the result of a reverse name resolution of the client IP address (for
+              example, reverse DNS lookup, if DNS is used). Host name comparisons are case
+              insensitive. If there is a match, then a forward name resolution (for example, forward
+              DNS lookup) is performed on the host name to check whether any of the addresses it
+              resolves to are equal to the client IP address. If both directions match, then the
+              entry is considered to match. (The host name that is used in
+                <codeph>pg_hba.conf</codeph> should be the one that address-to-name resolution of
+              the client's IP address returns, otherwise the line won't be matched. Some host name
+              databases allow associating an IP address with multiple host names, but the operating
+              system will only return one host name when asked to resolve an IP address.) </pd>
+            <pd>A host name specification that starts with a dot (.) matches a suffix of the actual
+              host name. So <codeph>.example.com</codeph> would match
+                <codeph>foo.example.com</codeph> (but not just <codeph>example.com</codeph>).</pd>
             <pd>When host names are specified in <codeph>pg_hba.conf</codeph>, you should ensure
-              that name resolution is reasonably fast. It can be of advantage to set up a local name
+              that name resolution is reasonably fast. It can be advantageous to set up a local name
               resolution cache such as <codeph>nscd</codeph>. Also, you can enable the server
               configuration parameter <codeph>log_hostname</codeph> to see the client host name
               instead of the IP address in the log. </pd>
           </plentry>
           <plentry>
-            <pt>IP-address</pt>
-            <pt>IP-mask </pt>
-            <pd>These fields can be used as an alternative to the CIDR address notation. Instead of
-              specifying the mask length, the actual mask is specified in a separate column. For
+            <pt><codeph><varname>IP-address</varname></codeph></pt>
+            <pt><codeph><varname>IP-mask</varname></codeph>
+            </pt>
+            <pd>These two fields can be used as an alternative to the CIDR address notation. Instead
+              of specifying the mask length, the actual mask is specified in a separate column. For
               example, <codeph>255.0.0.0</codeph> represents an IPv4 CIDR mask length of 8, and
                 <codeph>255.255.255.255</codeph> represents a CIDR mask length of 32. </pd>
           </plentry>
           <plentry>
-            <pt> authentication-method </pt>
-            <pd> Specifies the authentication method to use when connecting. See <xref
-                href="#topic_nyh_gwd_jr" format="dita"/> for options. </pd>
+            <pt>
+              <codeph><varname>auth-method</varname></codeph>
+            </pt>
+            <pd> Specifies the authentication method to use when a connection matches this record.
+              See <xref href="#topic_nyh_gwd_jr" format="dita"/> for options. </pd>
+          </plentry>
+          <plentry>
+            <pt><codeph><varname>auth-options</varname></codeph></pt>
+            <pd>After the <codeph><varname>auth-method</varname></codeph> field, there can be
+              field(s) of the form <codeph><varname>name=value</varname></codeph> that specify
+              options for the authentication method. Details about which options are available for
+              which authentication methods are described in <xref href="#topic_nyh_gwd_jr"
+                format="dita"/>.</pd>
           </plentry>
         </parml></p>
-      <note type="caution">For a more secure system, consider removing records for remote
-        connections that use trust authentication from the <codeph>pg_hba.conf</codeph> file. Trust
-        authentication grants any user who can connect to the server access to the database using
-        any role they specify. You can safely replace trust authentication with ident authentication
-        for local UNIX-socket connections. You can also use ident authentication for local and
-        remote TCP clients, but the client host must be running an ident service and you must trust
-        the integrity of that machine.</note>
+      <p>Files included by @ constructs are read as lists of names, which can be separated by either
+        whitespace or commas. Comments are introduced by #, just as in <codeph>pg_hba.conf</codeph>,
+        and nested @ constructs are allowed. Unless the file name following @ is an absolute path,
+        it is taken to be relative to the directory containing the referencing file.</p>
+      <p>The <codeph>pg_hba.conf</codeph> records are examined sequentially for each connection
+        attempt, so the order of the records is significant. Typically, earlier records will have
+        tight connection match parameters and weaker authentication methods, while later records
+        will have looser match parameters and stronger authentication methods. For example, you
+        might wish to use trust authentication for local TCP/IP connections but require a password
+        for remote TCP/IP connections. In this case a record specifying trust authentication for
+        connections from 127.0.0.1 would appear before a record specifying password authentication
+        for a wider range of allowed client IP addresses.</p>
+      <p>The <codeph>pg_hba.conf</codeph> file is read on start-up and when the main server process
+        receives a SIGHUP signal. If you edit the file on an active system, you must reload the file
+        using this command:<codeblock>$ gpstop -u</codeblock></p>
+      <note type="caution">For a more secure system, remove records for remote connections that use
+        trust authentication from the <codeph>pg_hba.conf</codeph> file. Trust authentication grants
+        any user who can connect to the server access to the database using any role they specify.
+        You can safely replace trust authentication with ident authentication for local UNIX-socket
+        connections. You can also use ident authentication for local and remote TCP clients, but the
+        client host must be running an ident service and you must trust the integrity of that
+        machine.</note>
     </body>
   </topic>
   <topic id="topic_xwr_rvd_jr">
@@ -165,8 +201,12 @@
           <codeph>127.0.0.1/28</codeph>. Using ident authentication for remote TCP connections is
         less secure because it requires you to trust the integrity of the ident service on the
         client's host. </p>
-      <p>This example shows how to edit the <codeph>pg_hba.conf</codeph> file of the master to allow
-        remote client access to all databases from all roles using encrypted password
+      <note otherprops="pivotal"> Greenplum Command Center provides an interface for editing the
+          <codeph>pg_hba.conf</codeph> file. It verifies entries before you save them, keeps a
+        version history of the file so that you can reload a previous version of the file, and
+        reloads the file into Greenplum Database. </note>
+      <p>This example shows how to edit the <codeph>pg_hba.conf</codeph> file on the master host to
+        allow remote client access to all databases from all roles using encrypted password
         authentication. </p>
       <p>To edit <codeph>pg_hba.conf</codeph>:<ol id="ol_krz_zvd_jr">
           <li>Open the file <codeph>$MASTER_DATA_DIRECTORY/pg_hba.conf</codeph> in a text
@@ -185,8 +225,7 @@ host    all   gpadmin   ::1/128       ident
 # passwords to authenticate the user
 # Note that to use SHA-256 encryption, replace md5 with
 # password in the line below
-host    all   dba   192.168.0.0/32  md5
-</codeblock></li>
+host    all   dba   192.168.0.0/32  md5</codeblock></li>
         </ol></p>
     </body>
   </topic>
@@ -215,17 +254,8 @@ host    all   dba   192.168.0.0/32  md5
       </ul>
       <section id="basic_auth">
         <title>Basic Authentication</title>
-        <p>The following basic authentication methods are supported: <parml id="ul_zsk_kwd_jr">
-            <plentry>
-              <pt>Password or MD5</pt>
-              <pd>Requires clients to provide a password, one of either: <ul id="ul_m21_nwd_jr">
-                  <li>Md5 &#8211; password transmitted as an MD5 hash.</li>
-                  <li>Password &#8211; A password transmitted in clear text. Always use SSL
-                    connections to prevent password sniffing during transit. This is configurable,
-                    see "Encrypting Passwords" in the <i>Greenplum Database Administrator Guide</i>
-                    for more information.</li>
-                </ul></pd>
-            </plentry>
+        <p>
+          <parml id="ul_zsk_kwd_jr">
             <plentry>
               <pt>Reject</pt>
               <pd>Reject the connections with the matching parameters. You should typically use this
@@ -238,64 +268,112 @@ host    all   dba   192.168.0.0/32  md5
                 that the client's host is running an ident service. The ident authentication method
                 should only be used with remote hosts on a trusted, closed network. </pd>
             </plentry>
-          </parml></p>
-        <p>Following are some sample <codeph>pg_hba.conf</codeph> basic authentication
-          entries:<codeblock>hostnossl    all   all        0.0.0.0   reject
-hostssl      all   testuser   0.0.0.0/0 md5
-local        all   gpuser               ident
-</codeblock></p>
-      </section>
-      <section id="kerberos_auth">
-        <title>Kerberos Authentication</title>
-        <p>You can authenticate against a Kerberos server (RFC 2743, 1964).</p>
-        <p>The format for Kerberos authentication in the <codeph>pg_hba.conf</codeph> file
-          is:<codeblock>servicename/hostname@realm</codeblock></p>
-        <p>The following options may be added to the entry:<parml>
             <plentry>
-              <pt>Map</pt>
-              <pd>Map system and database users.</pd>
+              <pt>md5</pt>
+              <pd>Require the client to supply a double-MD5-hashed password for authentication.
+              </pd>
             </plentry>
             <plentry>
-              <pt>Include_realm</pt>
-              <pd>Option to specify realm name included in the system-user name in the ident map
-                file.</pd>
-            </plentry>
-            <plentry>
-              <pt>Krb_realm</pt>
-              <pd>Specify the realm name for matching the principals.</pd>
-            </plentry>
-            <plentry>
-              <pt>Krb_server_hostname</pt>
-              <pd>The hostname of the service principal.</pd>
-            </plentry>
-          </parml></p>
-        <p>Following is an example <codeph>pg_hba.conf</codeph> entry for
-          Kerberos:<codeblock>host    all all 0.0.0.0/0   krb5
-hostssl all all 0.0.0.0/0   krb5 map=krbmap
-</codeblock></p>
-        <p>The following Kerberos server settings are specified in <codeph>postgresql.conf</codeph>: <parml>
-            <plentry>
-              <pt><codeph>krb_server_key <i>file</i></codeph></pt>
-              <pd>Sets the location of the Kerberos server key file.</pd>
-            </plentry>
-            <plentry>
-              <pt>
-                <codeph>krb_srvname <i>string</i></codeph></pt>
-              <pd>Kerberos service name.</pd>
-            </plentry>
-            <plentry>
-              <pt><codeph>krb_caseins_users <i>boolean</i></codeph></pt>
-              <pd>Case-sensitivity. The default is off. </pd>
-            </plentry>
-          </parml></p>
-        <p>The following client setting is specified as a connection parameter: <parml>
-            <plentry>
-              <pt>
-                <codeph>Krbsrvname</codeph></pt>
-              <pd>The Kerberos service name to use for authentication.</pd>
+              <pt>password</pt>
+              <pd>Require the client to supply an unencrypted password for authentication. Since the
+                password is sent in clear text over the network, this should not be used on
+                untrusted networks.</pd>
             </plentry>
           </parml>
         </p>
+        <p>The password-based authentication methods are <codeph>md5</codeph> and
+            <codeph>password</codeph>. These methods operate similarly except for the way that the
+          password is sent across the connection: MD5-hashed and clear-text respectively. </p>
+        <p>If you are at all concerned about password "sniffing" attacks then <codeph>md5</codeph>
+          is preferred. Plain <codeph>password</codeph> should always be avoided if possible. If the
+          connection is protected by SSL encryption then password can be used safely (although SSL
+          certificate authentication might be a better choice if you are depending on using
+          SSL).</p>
+        <p>Following are some sample <codeph>pg_hba.conf</codeph> basic authentication
+          entries:<codeblock>hostnossl    all   all        0.0.0.0   reject
+hostssl      all   testuser   0.0.0.0/0 md5
+local        all   gpuser               ident</codeblock></p>
+      </section>
+      <section id="kerberos_auth">
+        <title>GSSAPI Authentication</title>
+        <p>GSSAPI is an industry-standard protocol for secure authentication defined in RFC 2743.
+          Greenplum Database supports GSSAPI with Kerberos authentication according to RFC 1964.
+          GSSAPI provides automatic authentication (single sign-on) for systems that support it. The
+          authentication itself is secure, but the data sent over the database connection will be
+          sent unencrypted unless SSL is used.</p>
+        <p>The <codeph>gss</codeph> authentication method is only available for TCP/IP
+          connections.</p>
+        <p>When GSSAPI uses Kerberos, it uses a standard principal in the format
+              <codeph><varname>servicename/hostname@realm</varname></codeph>. The Greenplum Database
+          server will accept any principal that is included in the keytab file used by the server,
+          but care needs to be taken to specify the correct principal details when making the
+          connection from the client using the <codeph>krbsrvname</codeph> connection parameter.
+          (See <xref
+            href="https://www.postgresql.org/docs/9.4/libpq-connect.html#LIBPQ-PARAMKEYWORDS"
+            format="html" scope="external">Connection Parameter Key Words</xref>.) In most
+          environments, this parameter never needs to be changed. Some Kerberos implementations
+          might require a different service name, such as Microsoft Active Directory, which requires
+          the service name to be in upper case (POSTGRES).</p>
+        <p><codeph><varname>hostname</varname></codeph> is the fully qualified host name of the
+          server machine. The service principal's realm is the preferred realm of the server
+          machine.</p>
+        <p>Client principals must have their Greenplum Database user name as their first component,
+          for example <codeph>gpusername@realm</codeph>. Alternatively, you can use a user name
+          mapping to map from the first component of the principal name to the database user name.
+          By default, Greenplum Database does not check the realm of the client. If you have
+          cross-realm authentication enabled and need to verify the realm, use the
+            <codeph>krb_realm</codeph> parameter, or enable <codeph>include_realm</codeph> and use
+          user name mapping to check the realm.</p>
+        <p>Make sure that your server keytab file is readable (and preferably only readable) by the
+          gpadmin server account. The location of the key file is specified by the <xref
+            href="../../ref_guide/config_params/guc-list.xml#krb_server_keyfile"/> configuration
+          parameter. For security reasons, it is recommended to use a separate keytab just for the
+          Greenplum Database server rather than opening up permissions on the system keytab
+          file.</p>
+        <p>The keytab file is generated by the Kerberos software; see the Kerberos documentation for
+          details. The following example is for MIT-compatible Kerberos 5 implementations:</p>
+        <codeblock>kadmin% <b>ank -randkey postgres/server.my.domain.org</b>
+kadmin% <b>ktadd -k krb5.keytab postgres/server.my.domain.org</b></codeblock>
+        <p>When connecting to the database make sure you have a ticket for a principal matching the
+          requested database user name. For example, for database user name <codeph>fred</codeph>,
+          principal <codeph>fred@EXAMPLE.COM</codeph> would be able to connect. To also allow
+          principal <codeph>fred/users.example.com@EXAMPLE.COM</codeph>, use a user name map, as
+          described in <xref href="https://www.postgresql.org/docs/9.4/auth-username-maps.html"
+            format="html" scope="external">User Name Maps</xref>.</p>
+        <p>The following configuration options are supported for GSSAPI: </p>
+        <parml>
+          <plentry>
+            <pt><codeph>include_realm</codeph></pt>
+            <pd>If set to 1, the realm name from the authenticated user principal is included in the
+              system user name that is passed through user name mapping. This is the recommended
+              configuration as, otherwise, it is impossible to differentiate users with the same
+              username who are from different realms. The default for this parameter is 0 (meaning
+              to not include the realm in the system user name) but may change to 1 in a future
+              version of Greenplum Database. You can set it explicitly to avoid any issues when
+              upgrading.</pd>
+          </plentry>
+          <plentry>
+            <pt><codeph>map</codeph></pt>
+            <pd>Allows for mapping between system and database user names. For a GSSAPI/Kerberos
+              principal, such as <codeph>username@EXAMPLE.COM</codeph> (or, less commonly,
+                <codeph>username/hostbased@EXAMPLE.COM</codeph>), the default user name used for
+              mapping is <codeph>username</codeph> (or <codeph>username/hostbased</codeph>,
+              respectively), unless <codeph>include_realm</codeph> has been set to 1 (as
+              recommended, see above), in which case <codeph>username@EXAMPLE.COM</codeph> (or
+                <codeph>username/hostbased@EXAMPLE.COM</codeph>) is what is seen as the system
+              username when mapping. </pd>
+          </plentry>
+        </parml>
+        <parml>
+          <plentry>
+            <pt><codeph>krb_realm</codeph></pt>
+            <pd>
+              <p>Sets the realm to match user principal names against. If this parameter is set,
+                only users of that realm will be accepted. If it is not set, users of any realm can
+                connect, subject to whatever user name mapping is done.</p>
+            </pd>
+          </plentry>
+        </parml>
       </section>
       <section id="ldap_auth">
         <title>LDAP Authentication</title>
@@ -380,8 +458,7 @@ hostssl all all 0.0.0.0/0   krb5 map=krbmap
           <codeblock>host all testuser 0.0.0.0/0 ldap ldap
 ldapserver=ldapserver.greenplum.com ldapport=389 ldapprefix="cn=" ldapsuffix=",ou=people,dc=greenplum,dc=com"
 hostssl   all   ldaprole   0.0.0.0/0   ldap
-ldapserver=ldapserver.greenplum.com ldaptls=1 ldapprefix="cn=" ldapsuffix=",ou=people,dc=greenplum,dc=com"          
-        </codeblock></p>
+ldapserver=ldapserver.greenplum.com ldaptls=1 ldapprefix="cn=" ldapsuffix=",ou=people,dc=greenplum,dc=com"</codeblock></p>
       </section>
     </body>
   </topic>


### PR DESCRIPTION
This PR updates the pg_hba.conf description and Kerberos (gss) authorization sections in the security guide from Postgres 9.4 topics.

This topic is rendered here: https://docs-litzell-gssapi.cfapps.io 



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
