### PR TITLE
Schema-qualify view in binary-swap cleanup step

### DIFF
--- a/src/test/binary_swap/expected/pretest_cleanup.out
+++ b/src/test/binary_swap/expected/pretest_cleanup.out
@@ -7,7 +7,7 @@
 -- For these cases, drop the offending tables/features/etc. in this file, which
 -- runs before the rest of the binary swap tests.
 \connect regression
-DROP VIEW IF EXISTS distinct_windowagg_view;
+DROP VIEW IF EXISTS olap_window_seq.distinct_windowagg_view;
 -- start_ignore
 -- This table exists to make sure that toast tables of different chunk sizes are
 -- handled by GPDB. Early versions of the 5.x server will fail to dump this

--- a/src/test/binary_swap/sql/pretest_cleanup.sql
+++ b/src/test/binary_swap/sql/pretest_cleanup.sql
@@ -9,7 +9,7 @@
 
 \connect regression
 
-DROP VIEW IF EXISTS distinct_windowagg_view;
+DROP VIEW IF EXISTS olap_window_seq.distinct_windowagg_view;
 
 -- start_ignore
 -- This table exists to make sure that toast tables of different chunk sizes are


### PR DESCRIPTION
Commit b65c4e0475 now schema-qualifies this view, so we need to schema-qualify it during the binary-swap cleanup too.

Authored-by: Chris Hajas <chajas@pivotal.io>