### PR TITLE
Fix tcp interconnect hang

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1710,6 +1710,8 @@ SetupTCPInterconnect(EState *estate)
 		ML_CHECK_FOR_INTERRUPTS(estate->interconnect_context->teardownActive);
 		n = select(highsock + 1, (fd_set *)&rset, (fd_set *)&wset, (fd_set *)&eset, &timeout);
 		ML_CHECK_FOR_INTERRUPTS(estate->interconnect_context->teardownActive);
+		if (Gp_role == GP_ROLE_DISPATCH)
+			checkForCancelFromQD(estate->interconnect_context);
 
 		elapsed_ms = gp_get_elapsed_ms(&startTime);
 

--- a/src/test/regress/expected/ic.out
+++ b/src/test/regress/expected/ic.out
@@ -480,7 +480,7 @@ commit;
 drop table ic_test_1;
 /*
  * If message queue of connection is failed to be allocated in
- * SetupUDPIFCInterconnect_Internal() , it should be handled properly
+ * SetupUDPIFCInterconnect_Internal(), it should be handled properly
  * in TeardownUDPIFCInterconnect_Internal().
  */
 CREATE TABLE a (i INT, j INT) DISTRIBUTED BY (i);
@@ -502,3 +502,25 @@ NOTICE:  Success:
  t
 (1 row)
 
+-- Test sender QE errors out when setup outgoing connection, the receiver QE is waiting,
+-- at this time, QD should be able to process the error and cancel the receiver QE.
+CREATE TABLE test_ic_error(a INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT * FROM test_ic_error;
+ERROR:  fault triggered, fault name:'interconnect_setup_palloc' fault type:'error'  (seg0 slice1 172.17.0.4:25432 pid=450764)
+SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+DROP TABLE test_ic_error;

--- a/src/test/regress/sql/ic.sql
+++ b/src/test/regress/sql/ic.sql
@@ -212,3 +212,12 @@ SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 1);
 SELECT * FROM a;
 DROP TABLE a;
 SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 1);
+
+
+-- Test sender QE errors out when setup outgoing connection, the receiver QE is waiting,
+-- at this time, QD should be able to process the error and cancel the receiver QE.
+CREATE TABLE test_ic_error(a INT);
+SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 2);
+SELECT * FROM test_ic_error;
+SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 2);
+DROP TABLE test_ic_error;


### PR DESCRIPTION
There was a hang like this: when one QE errors out before 'SetupInterconnect',
QD will keep waiting for the incoming connections to be established and doesn't
check the error message from dispatcher. Other QEs are finished and hang in
function 'waitOnOutbound'.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
