### PR TITLE
Don't bind outgoing TCP connections to a particular IP address.

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -618,9 +618,7 @@ setupOutgoingConnection(ChunkTransportState *transportStates, ChunkTransportStat
 {
 	CdbProcess         *cdbProc = conn->cdbProc;
 
-	int                 sockopt;
 	int                 n;
-
 	int			ret;
 	char		portNumberStr[32];
 	char	   *service;
@@ -634,13 +632,10 @@ setupOutgoingConnection(ChunkTransportState *transportStates, ChunkTransportStat
 	conn->remoteContentId = cdbProc->contentid;
 
 	/*
-	 * record the destination IP addr and port for error messages.
-	 * Since the IP addr might be IPv6, it might have ':' embedded, so in
-	 * that case, put '[]' around it so we can see that the string is an
-	 * IP and port (otherwise it might look just like an IP).
-	 *
-	 * Should we really put this info into these fields? Later we replace this with
-	 * the source IP and port (after the bind call).
+	 * record the destination IP addr and port for error messages. Since the
+	 * IP addr might be IPv6, it might have ':' embedded, so in that case, put
+	 * '[]' around it so we can see that the string is an IP and port
+	 * (otherwise it might look just like an IP).
 	 */
 	if (strchr(cdbProc->listenerAddr,':')!=0)
 		snprintf(conn->remoteHostAndPort, sizeof(conn->remoteHostAndPort),
@@ -701,82 +696,6 @@ setupOutgoingConnection(ChunkTransportState *transportStates, ChunkTransportStat
 							   "connection."),
 						errdetail("%s: %m", "fcntl(O_NONBLOCK)")));
 	}
-
-	/* Allow bind() to succeed even if the port is in TIME_WAIT state. */
-	sockopt = 1;
-	if (setsockopt(conn->sockfd, SOL_SOCKET, SO_REUSEADDR,
-				   (void *)&sockopt, sizeof(sockopt)) < 0)
-		ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-						errmsg("Interconnect error setting up outgoing "
-							   "connection."),
-						errdetail("%s: %m", "setsockopt(SO_REUSEADDR)")));
-
-
-	/*
-	 * To help with fault tolerance, try to use the same LAN adapter as was used
-	 * to connect the session to us.
-	 *
-	 * Bind that IP address to the socket.   But, we must insure that the source
-	 * address is the same address family as the destination address.
-	 *
-	 * The is especially important to check on the QD, since local
-	 * sessions are often AF_UNIX, and even if TCP, they could be either v6 or v4.
-	 *
-	 */
-
-
-	struct sockaddr_storage  saddr;
-	int saddr_len = addrs->ai_addrlen;
-	memset(&saddr, 0, sizeof(saddr));
-
-	if (MyProcPort->laddr.addr.ss_family == addrs->ai_family)
-	{
-		/* We need to copy the address so we can clear the port */
-
-		memcpy(&saddr, &MyProcPort->laddr.addr, MyProcPort->laddr.salen);
-		if (saddr.ss_family == AF_INET)
-			((struct sockaddr_in *)&saddr)->sin_port = 0; /* pick any available outbound port */
-		else if (saddr.ss_family == AF_INET6)
-			((struct sockaddr_in6 *)&saddr)->sin6_port = 0;
-
-
-		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-		{
-			char debugmsg[128];
-			inet_ntop(saddr.ss_family, (struct sockaddr *)&saddr, debugmsg, sizeof(debugmsg));
-			ereport(DEBUG4, (errmsg("bind outbound  %s", debugmsg)));
-		}
-	}
-	else
-	{
-		/*
-		 * bind to the "any ip address" "any port".  Not really necessary to use bind()
-		 * but this allows us to get the system assigned source IP and port without
-		 * waiting until after the connect() call.
-		 */
-		saddr.ss_family = addrs->ai_family;
-
-		/* We could set the address to INADDR_ANY or INADDR_ANY6 but those are just zeros anyway */
-	}
-
-	if (bind(conn->sockfd, (struct sockaddr *)&saddr, saddr_len) < 0)
-	{
-		char debugmsg[128];
-		inet_ntop(saddr.ss_family, (struct sockaddr *)&saddr, debugmsg, sizeof(debugmsg));
-		/* Should never get EADDRINUSE because we know it's our port. */
-		ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-						errmsg("Interconnect error setting up outgoing "
-							   "connection."),
-						errdetail("Could not bind to local addr %s. %m",
-								  debugmsg)));
-	}
-
-	/*
-	 * Get the source IP address and Port
-	 */
-	format_sockaddr((struct sockaddr *) &saddr, conn->remoteHostAndPort,
-					sizeof(conn->remoteHostAndPort));
-
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		ereport(DEBUG1, (errmsg("Interconnect connecting to seg%d slice%d %s "


### PR DESCRIPTION
Backport from master '8b8523e'

In the TCP interconnect, we used to bind outgoing TCP connections to the
same source IP address that the libpq connection came from. That can lead
to running out of ephemeral TCP ports. I was seeing errors, when running
the regression tests with the TCP interconnect:

ERROR:  interconnect error setting up outgoing connection
DETAIL:  Could not bind to local addr 2.0.0.0: Address already in use

This was easily reproducible, by running the parallel group of tests that
includes the qp_misc_jiras test. Apparantly that parallel group opens
especially many connections.

When a socket is bound to a particular IP address with bind(), it is also
allocated an ephemeral TCP port. On Linux, the range of ports available
can be seen in /proc/sys/net/ipv4/ip_local_port_range. It defaults to
32768-60999, but even if you increase the range, it's always quite
limited. bind() reserves the whole TCP port, even though multiple outgoing
connections could share the same source port, as long as their destination
IP address or port is different, because bind() doesn't know whether
you're going to use the port to listen for incoming connections, or for
establishing an outgoing connection. Listening for incoming connections
needs to reserve the port.

Linux kernel 4.2 introduced a new socket option, IP_BIND_ADDRESS_NO_PORT,
that we could use to give bind() a hint that we're using the socket for
an outgoing connection, so there's no need to reserve the whole port. But
actually, I don't think we should be calling bind() on outgoing
connections in the first place. I don't think the logic, to use the
incoming libpq connection's IP address as the source IP address of outgoing
interconnect connections, makes sense. The comment says that it is for
fault tolerance, but I don't buy that argument. If a network adapter is not
working, it should be disabled in the OS configuration so that it is not
used. It is not the application's job to make routing decisions.

Forcing the same source IP address seems outright wrong in some scenarios.
Imagine that the QD has two network adapters: one for connecting to the
outside world, and another for the internal network where the QEs are. In
that scenario, the interconnect connections between the QD and the QEs
should definitely *not* be established through the same network adapter as
the user's libpq connection.

Better to just remove the code to bind to a particular source IP address,
and let the OS do its job of routing TCP connections. (AFAICS, the UDP
interconnect never tried to force a particular source IP address when
sending.)

Reviewed-by: Paul Guo <pguo@pivotal.io>
Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/ITkZdACpcVQ/H_74phbMFgAJ

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
