### PR TITLE
Print backtrace when a SIGSEGV occurs in FTS

### DIFF
--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -131,6 +131,17 @@ FtsProbeMain(Datum main_arg)
 	pqsignal(SIGHUP, sigHupHandler);
 	pqsignal(SIGINT, sigIntHandler);
 
+	/*
+	 * CDB: Catch program error signals.
+	 *
+	 * Save our main thread-id for comparison during signals.
+	 */
+	main_tid = pthread_self();
+
+#ifdef SIGSEGV
+	pqsignal(SIGSEGV, CdbProgramErrorHandler);
+#endif
+
 	/* We're now ready to receive signals */
 	BackgroundWorkerUnblockSignals();
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3470,7 +3470,7 @@ StatementCancelHandler(SIGNAL_ARGS)
 
 
 /* CDB: Signal handler for program errors */
-static void
+void
 CdbProgramErrorHandler(SIGNAL_ARGS)
 {
     int			save_errno = errno;

--- a/src/include/postgres.h
+++ b/src/include/postgres.h
@@ -498,6 +498,7 @@ extern void ExceptionalCondition(const char *conditionName,
 					 const char *errorType,
 			 const char *fileName, int lineNumber) __attribute__((noreturn));
 
+extern void CdbProgramErrorHandler(SIGNAL_ARGS);
 
 #ifdef __cplusplus
 }   /* extern "C" */


### PR DESCRIPTION
This is used to track recent failures due to mysterious SIGSEGV in FTS
