### PR TITLE
Fix ic test case

### DIFF
--- a/src/test/regress/expected/ic.out
+++ b/src/test/regress/expected/ic.out
@@ -504,7 +504,7 @@ NOTICE:  Success:
 
 -- Test sender QE errors out when setup outgoing connection, the receiver QE is waiting,
 -- at this time, QD should be able to process the error and cancel the receiver QE.
-CREATE TABLE test_ic_error(a INT);
+CREATE TABLE test_ic_error(a INT, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 2);
@@ -514,8 +514,8 @@ NOTICE:  Success:
  t
 (1 row)
 
-SELECT * FROM test_ic_error;
-ERROR:  fault triggered, fault name:'interconnect_setup_palloc' fault type:'error'  (seg0 slice1 172.17.0.4:25432 pid=450764)
+SELECT * FROM test_ic_error t1, test_ic_error t2 where t1.a=t2.b;
+ERROR:  fault triggered, fault name:'interconnect_setup_palloc' fault type:'error'  (seg0 slice2 172.17.0.4:25432 pid=68446)
 SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 2);
 NOTICE:  Success:
  gp_inject_fault 

--- a/src/test/regress/sql/ic.sql
+++ b/src/test/regress/sql/ic.sql
@@ -216,8 +216,8 @@ SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 1);
 
 -- Test sender QE errors out when setup outgoing connection, the receiver QE is waiting,
 -- at this time, QD should be able to process the error and cancel the receiver QE.
-CREATE TABLE test_ic_error(a INT);
+CREATE TABLE test_ic_error(a INT, b int);
 SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 2);
-SELECT * FROM test_ic_error;
+SELECT * FROM test_ic_error t1, test_ic_error t2 where t1.a=t2.b;
 SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 2);
 DROP TABLE test_ic_error;


### PR DESCRIPTION
Single-slice query won't trigger fault injector 'InterconnectSetupPalloc' on QE
when gp_interconnect_type is 'UDPIFC'.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
