### PR TITLE
Update AA jobs to pass along the OS version

### DIFF
--- a/concourse/pipelines/5X_STABLE-generated.yml
+++ b/concourse/pipelines/5X_STABLE-generated.yml
@@ -4009,7 +4009,8 @@ jobs:
     file: madlib_ci/concourse/tasks/madlib_test_gppkg.yml
     image: centos-gpdb-dev-6
     params:
-      TEST_OS: centos
+      TEST_OS: centos6
+      DBVER: gpdb5
       ORCA: "off"
 
 - name: Postgis_Test_Planner_centos6
@@ -4063,7 +4064,8 @@ jobs:
     file: madlib_ci/concourse/tasks/madlib_test_gppkg.yml
     image: centos-gpdb-dev-6
     params:
-      TEST_OS: centos
+      TEST_OS: centos6
+      DBVER: gpdb5
       ORCA: "on"
 
 - name: Postgis_Test_Orca_centos6
@@ -4117,7 +4119,8 @@ jobs:
     file: madlib_ci/concourse/tasks/madlib_test_gppkg.yml
     image: centos-gpdb-dev-7
     params:
-      TEST_OS: centos
+      TEST_OS: centos7
+      DBVER: gpdb5
       ORCA: "off"
 
 - name: Postgis_Test_Planner_centos7
@@ -4171,7 +4174,8 @@ jobs:
     file: madlib_ci/concourse/tasks/madlib_test_gppkg.yml
     image: centos-gpdb-dev-7
     params:
-      TEST_OS: centos
+      TEST_OS: centos7
+      DBVER: gpdb5
       ORCA: "on"
 
 - name: Postgis_Test_Orca_centos7

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -3623,7 +3623,8 @@ jobs:
     file: madlib_ci/concourse/tasks/madlib_test_gppkg.yml
     image: centos-gpdb-dev-[[ platform_version ]]
     params:
-      TEST_OS: centos
+      TEST_OS: centos[[ platform_version ]]
+      DBVER: gpdb5
       ORCA: "[[ orca_state ]]"
 
 - name: Postgis_Test_[[ test_name ]]


### PR DESCRIPTION
This change is added to test the new Deep learning module introduced as
part of MADlib version 1.16. For centos, since this module is supported only for
centos7, thus adding explicit versions of centos.  Also, adding new var
`DBVER` to specify the GPDB version.
This change is only for 5X and not master, since currently MADlib 1.16 is only
supported for GPDB5.