### PR TITLE
gparray: Add version check when connecting to cluster

### DIFF
--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -21,7 +21,7 @@ import traceback
 from gppylib.utils import checkNotNone, checkIsInt
 from gppylib    import gplog
 from gppylib.db import dbconn
-from gppylib.gpversion import GpVersion
+from gppylib.gpversion import GpVersion, MAIN_VERSION
 from gppylib.commands.unix import *
 import os
 
@@ -962,6 +962,8 @@ class GpArray:
         for row in dbconn.execSQL(conn, "SELECT version()"):
             version_str = row[0]
         version = GpVersion(version_str)
+        if not version.isVersionCurrentRelease():
+            raise Exception("Cannot connect to GPDB version %s from installed version %s"%(version.getVersionRelease(), MAIN_VERSION[0]))
 
         config_rows = dbconn.execSQL(conn, '''
         SELECT dbid, content, role, preferred_role, mode, status,

--- a/gpMgmt/bin/gppylib/gpversion.py
+++ b/gpMgmt/bin/gppylib/gpversion.py
@@ -18,8 +18,7 @@ if sys.version_info < (2, 5, 0) or sys.version_info >= (3, 0, 0):
                      % os.path.split(__file__)[-1])
     sys.exit(1)
 
-
-MAIN_VERSION = [5,99,99]    # version number for main
+MAIN_VERSION = [7,99,99]    # version number for main
 
 
 #============================================================
@@ -48,8 +47,10 @@ class GpVersion:
                 '4.1',
                 '4.2',
                 '4.3',
-                '5'
-              ]
+                '5',
+                '6',
+                '7'
+    ]
 
     #------------------------------------------------------------
     def __init__(self, version):
@@ -178,9 +179,9 @@ class GpVersion:
 
 
         # If part of the conversion process above failed, throw an error,
-        except:
-            raise StandardError("Unrecognised Greenplum Version '%s'" % 
-                                str(version))
+        except Exception as e:
+            raise StandardError("Unrecognised Greenplum Version '%s' due to %s" %
+                                (str(version), str(e)))
 
     #------------------------------------------------------------
     def __cmp__(self, other):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
@@ -249,7 +249,13 @@ class GpArrayTestCase(GpTestCase):
         actual = sorted(actual)
         for i in range(len(expected)):
             self.assertEquals(expected[i], actual[i])
-    
+
+    @patch('gppylib.db.dbconn.execSQL', return_value=[['PostgreSQL 8.3.23 (Greenplum Database 5.0.0 build dev) on x86_64-pc-linux-gnu, compiled by GCC gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-17) compiled on Feb  9 2017 23:06:31']])
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    def test_initFromCatalog_mismatched_versions(self, mock_connect, mock_execSQL):
+        with self.assertRaisesRegexp(Exception, 'Cannot connect to GPDB version 5 from installed version 7'):
+            GpArray.initFromCatalog(None)
+
 def convert_bool(val):
     if val == 't':
         return True

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpversion.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpversion.py
@@ -99,11 +99,11 @@ class GpVersionTestCase(unittest.TestCase):
         self.assertEqual(v_2.getVersionRelease(), "4.2")
        
     def test_case_7(self):
-        vLong = GpVersion("PostgreSQL 8.3.23 (Greenplum Database 5.0.0 build dev) on x86_64-pc-linux-gnu, compiled by GCC gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-17) compiled on Feb  9 2017 23:06:31")
+        vLong = GpVersion("PostgreSQL 9.4.20 (Greenplum Database 7.0.0 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0, 64-bit compiled on Jul  8 2019 16:27:59")
         self.assertTrue(vLong.isVersionCurrentRelease() == True )
         self.assertTrue(vLong.getVersionBuild() == 'dev')
-        self.assertTrue(vLong.getVersionRelease() == "5")
-        self.assertTrue(vLong.isVersionRelease("5.0"))
+        self.assertTrue(vLong.getVersionRelease() == "7")
+        self.assertTrue(vLong.isVersionRelease("7.0"))
         self.assertTrue(vLong.isVersionRelease("3.2") == False)
         self.assertTrue(vLong > "4.0.0")
         self.assertTrue(vLong > "4.0")


### PR DESCRIPTION
Previously, it was possible for a utility to connect to a database of
the wrong version, if you for instance had a 5 instance running and
ran a 6 utility.  There was logic in gppylib to check GPDB versions,
but it was not being used anywhere and had not been updated since GPDB
5.

This commit updates the version logic to the current version and adds
a check in initFromCatalog() that will error out if it tries to connect
to a database of a different version.

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>
Co-authored-by: Nikolaos Kalampalikis <nkalampalikis@pivotal.io>

