### PR TITLE
Lock leaf partitions for all DML operations

### DIFF
--- a/src/test/isolation2/expected/dml_on_root_locks_all_parts.out
+++ b/src/test/isolation2/expected/dml_on_root_locks_all_parts.out
@@ -1,0 +1,92 @@
+-- For partitioned tables if a DML is run on the root table, we should
+-- take ExclusiveLock on the root and the child partitions. If lock is
+-- not taken on the leaf partition on the QD, there may be issues where
+-- a concurrent DML/Vaccum etc on the leaf partition may execute first and can cause
+-- issues. For example
+-- 1. It can cause a deadlock between the 2 DML operations.
+--      Consider the below example.
+--      INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,1000000)i;
+--      Session 1: BEGIN; DELETE FROM part_tbl; ==> Let's say it holds Exclusive lock on root table only. (not on leaf)
+--      Session 2: BEGIN; DELETE FROM part_tbl where a = 999999 or a = 1; ==> Delete will be dispatched to the segment as there is no lock on QD.
+--      If Session 1, first deletes the tuple a = 1 on segment 0, Session 2 will wait for transaction lock as it attempting to delete the same tuple.
+--      If Session 2, first deletes the tuple a = 999999 on segment 1, Session 1 will wait for transaction lock as it is attempting to delete the same tuple.
+--      This will cause a deadlock.
+--      Note: Same applies to UPDATE as well.
+-- 2. If AO vacuum is run concurrently on the child partition, it may result in corrupting the segfile state.
+--      Consider the below example:
+--      Session 1: DELETE FROM part_tbl where a = 10000000; ==> Let's say it holds Exclusive lock on root table only. (not on leaf)
+--      It will not take any lock on part_tbl_1_prt_1
+--      Session 2: VACUUM part_tbl_1_prt;
+--      VACUUM will be dispatched on the segment as there was no lock on QD. However, when in AO vacuum drop phase, it will try to acquire a lock on part_tbl_1_prt,
+--      but that lock may already be taken by Session1, Vaccum will consider that this table has been dropped and will leave the segfile in an inconsitent
+--      state, thus any consecutive operation touching the segfile will fail.
+-- Refer to the commit message for detailed steps for the above examples for reference.
+DROP TABLE IF EXISTS part_tbl;
+DROP
+CREATE TABLE part_tbl (a int, b int, c int) PARTITION BY RANGE (b) (start(1) end(2) every(1));
+CREATE
+
+INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,12)i;
+INSERT 12
+
+1: BEGIN;
+BEGIN
+-- DELETE will acquire Exclusive lock on root and leaf partition on QD.
+1: DELETE FROM part_tbl;
+DELETE 12
+
+-- Delete must hold an exclusive lock on the leaf partition on QD.
+SELECT GRANTED FROM pg_locks WHERE relation = 'part_tbl_1_prt_1'::regclass::oid AND mode='ExclusiveLock' AND gp_segment_id=-1 AND locktype='relation';
+granted
+-------
+t      
+(1 row)
+
+-- DELETE on the leaf partition must wait on the QD as Session 1 already holds ExclusiveLock.
+2&: DELETE FROM part_tbl_1_prt_1 WHERE b = 10;  <waiting ...>
+SELECT relation::regclass, mode, granted FROM pg_locks WHERE gp_segment_id=-1 AND granted='f';
+relation        |mode         |granted
+----------------+-------------+-------
+part_tbl_1_prt_1|ExclusiveLock|f      
+(1 row)
+
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+DELETE 0
+
+1: BEGIN;
+BEGIN
+-- UPDATE will acquire Exclusive lock on root and leaf partition on QD.
+1: UPDATE part_tbl SET c = 1; SELECT GRANTED FROM pg_locks WHERE relation = 'part_tbl_1_prt_1'::regclass::oid AND mode='ExclusiveLock' AND gp_segment_id=-1 AND locktype='relation';
+granted
+-------
+t      
+(1 row)
+
+-- UPDATE on leaf must be blocked on QD as previous UPDATE acquires Exclusive lock on the root and the leaf partitions
+2&: UPDATE part_tbl_1_prt_1 set c = 10;  <waiting ...>
+SELECT relation::regclass, mode, granted FROM pg_locks WHERE gp_segment_id=-1 AND granted='f';
+relation        |mode         |granted
+----------------+-------------+-------
+part_tbl_1_prt_1|ExclusiveLock|f      
+(1 row)
+
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+UPDATE 0
+
+1: BEGIN;
+BEGIN
+1: INSERT INTO part_tbl SELECT 1,1,1;
+INSERT 1
+SELECT GRANTED FROM pg_locks WHERE relation = 'part_tbl_1_prt_1'::regclass::oid AND mode='RowExclusiveLock' AND gp_segment_id=-1 AND locktype='relation';
+granted
+-------
+t      
+(1 row)
+1: COMMIT;
+COMMIT
+DROP TABLE part_tbl;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -17,6 +17,7 @@ test: instr_in_shmem_cleanup
 test: vacuum_full_recently_dead_tuple_due_to_distributed_snapshot
 test: resync_xlog_hints
 test: invalidated_toast_index
+test: dml_on_root_locks_all_parts
 
 test: setup
 # Tests on Append-Optimized tables (row-oriented).

--- a/src/test/isolation2/sql/dml_on_root_locks_all_parts.sql
+++ b/src/test/isolation2/sql/dml_on_root_locks_all_parts.sql
@@ -1,0 +1,59 @@
+-- For partitioned tables if a DML is run on the root table, we should
+-- take ExclusiveLock on the root and the child partitions. If lock is
+-- not taken on the leaf partition on the QD, there may be issues where
+-- a concurrent DML/Vaccum etc on the leaf partition may execute first and can cause
+-- issues. For example
+-- 1. It can cause a deadlock between the 2 DML operations.
+--      Consider the below example.
+--      INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,1000000)i;
+--      Session 1: BEGIN; DELETE FROM part_tbl; ==> Let's say it holds Exclusive lock on root table only. (not on leaf)
+--      Session 2: BEGIN; DELETE FROM part_tbl where a = 999999 or a = 1; ==> Delete will be dispatched to the segment as there is no lock on QD.
+--      If Session 1, first deletes the tuple a = 1 on segment 0, Session 2 will wait for transaction lock as it attempting to delete the same tuple.
+--      If Session 2, first deletes the tuple a = 999999 on segment 1, Session 1 will wait for transaction lock as it is attempting to delete the same tuple.
+--      This will cause a deadlock.
+--      Note: Same applies to UPDATE as well.
+-- 2. If AO vacuum is run concurrently on the child partition, it may result in corrupting the segfile state.
+--      Consider the below example:
+--      Session 1: DELETE FROM part_tbl where a = 10000000; ==> Let's say it holds Exclusive lock on root table only. (not on leaf)
+--      It will not take any lock on part_tbl_1_prt_1
+--      Session 2: VACUUM part_tbl_1_prt;
+--      VACUUM will be dispatched on the segment as there was no lock on QD. However, when in AO vacuum drop phase, it will try to acquire a lock on part_tbl_1_prt,
+--      but that lock may already be taken by Session1, Vaccum will consider that this table has been dropped and will leave the segfile in an inconsitent
+--      state, thus any consecutive operation touching the segfile will fail.
+-- Refer to the commit message for detailed steps for the above examples for reference.
+DROP TABLE IF EXISTS part_tbl;
+CREATE TABLE part_tbl (a int, b int, c int) PARTITION BY RANGE (b) (start(1) end(2) every(1));
+
+INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,12)i;
+
+1: BEGIN;
+-- DELETE will acquire Exclusive lock on root and leaf partition on QD.
+1: DELETE FROM part_tbl;
+
+-- Delete must hold an exclusive lock on the leaf partition on QD.
+SELECT GRANTED FROM pg_locks WHERE relation = 'part_tbl_1_prt_1'::regclass::oid AND mode='ExclusiveLock' AND gp_segment_id=-1 AND locktype='relation';
+
+-- DELETE on the leaf partition must wait on the QD as Session 1 already holds ExclusiveLock.
+2&: DELETE FROM part_tbl_1_prt_1 WHERE b = 10;
+SELECT relation::regclass, mode, granted FROM pg_locks WHERE gp_segment_id=-1 AND granted='f';
+
+1: COMMIT;
+2<:
+
+1: BEGIN;
+-- UPDATE will acquire Exclusive lock on root and leaf partition on QD.
+1: UPDATE part_tbl SET c = 1; 
+SELECT GRANTED FROM pg_locks WHERE relation = 'part_tbl_1_prt_1'::regclass::oid AND mode='ExclusiveLock' AND gp_segment_id=-1 AND locktype='relation';
+
+-- UPDATE on leaf must be blocked on QD as previous UPDATE acquires Exclusive lock on the root and the leaf partitions
+2&: UPDATE part_tbl_1_prt_1 set c = 10;
+SELECT relation::regclass, mode, granted FROM pg_locks WHERE gp_segment_id=-1 AND granted='f';
+
+1: COMMIT;
+2<:
+
+1: BEGIN;
+1: INSERT INTO part_tbl SELECT 1,1,1;
+SELECT GRANTED FROM pg_locks WHERE relation = 'part_tbl_1_prt_1'::regclass::oid AND mode='RowExclusiveLock' AND gp_segment_id=-1 AND locktype='relation';
+1: COMMIT;
+DROP TABLE part_tbl;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -300,10 +300,19 @@ begin;
 delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
- coalesce  |     mode      | locktype |  node  
------------+---------------+----------+--------
- partlockt | ExclusiveLock | relation | master
-(1 row)
+     coalesce      |     mode      | locktype |  node  
+-------------------+---------------+----------+--------
+ partlockt         | ExclusiveLock | relation | master
+ partlockt_1_prt_1 | ExclusiveLock | relation | master
+ partlockt_1_prt_2 | ExclusiveLock | relation | master
+ partlockt_1_prt_3 | ExclusiveLock | relation | master
+ partlockt_1_prt_4 | ExclusiveLock | relation | master
+ partlockt_1_prt_5 | ExclusiveLock | relation | master
+ partlockt_1_prt_6 | ExclusiveLock | relation | master
+ partlockt_1_prt_7 | ExclusiveLock | relation | master
+ partlockt_1_prt_8 | ExclusiveLock | relation | master
+ partlockt_1_prt_9 | ExclusiveLock | relation | master
+(10 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
        coalesce        |       mode       | locktype |    node    


### PR DESCRIPTION
For partitioned tables, in case of DELETE/UPDATE or INSERT operation on the
root table, we must acquire ExclusiveLock or RowExclusiveLock respectively on
the root and leaf partitions, so that any other operation requesting lock
higher than AccessShareLock and ShareLock must wait on QD.  For example AO
VACUUM should be blocked by the lock on the partition table on QD taken by the
DML statements, otherwise, this leads to inconsistent segfile state between QD
and QE, and it will fail the next operation on the same segfile.

resultRelations may not have all the entries including the root and leaf
partition tables, so explicitly acquire locks on all the tables.  For example:
INSERT / DELETE / UPDATE plans on Partitioned tables produced by ORCA only has
the root table info in resultRelations. Similarly, INSERT plans produced by
planner only has the root table info as well.

The below repro used to create inconsistencies in the segfiles. The test case
added does not have the below repro, as the behavior to acquire lock changes
after the fix and this repro is no longer valid. But, at the nutshell, when a
DML operation is run on a partitioned table, it should take lock on the leaf
partition at QD.
**Scenario1: Concurrent AO Vacuum on leaf and DELETE on root.**
Session 1:
```
create table t1 (a int, b int) with (appendonly=true) partition by range (b) (start(1) end(2) every(1));
Set Debug_appendonly_print_segfile_choice=on;
Set Debug_appendonly_print_compaction=on;
set client_min_messages = 'log';
Start session 1
Begin;
insert into t1 select i%2, 1 from generate_series(1,12)i;
```

Go to Session 2
```
insert into t1 select i%2, 1 from generate_series(1,12)i;
```

Go to Session1:
```
commit;
```

Go to Session 2:
```
select gp_inject_fault('fault_during_exec_dynamic_table_scan', 'suspend', 2);
select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 2);
```

Go to Session 3:
```
Set optimizer=on;
begin;
delete from t1 where a = 3; ==> This will wait
```

Go to Session 1;
```
Vacuum t1_1_prt_1;  ==> This will wait
```

Go to Session 2:
```
select gp_inject_fault('fault_during_exec_dynamic_table_scan', 'reset', 2);
select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 2);
```
Go to Session 3:
```
Commit;
```

```
Select * from gp_dist_random(‘pg.aoseg.pg_aoseg_<relid>’); will now have an entry with the state as 2…
```

Go to Session 1:
```
Begin;
Insert into t1 select 1,1;
```

Go to Session 2:
```
Insert into t1 select 1,1; => This should give the error.
```

Had to change the location of injecting fault.
```
diff --git a/src/backend/executor/nodeDynamicTableScan.c b/src/backend/executor/nodeDynamicTableScan.c
index a9470c81..ebac57bb 100644
--- a/src/backend/executor/nodeDynamicTableScan.c
+++ b/src/backend/executor/nodeDynamicTableScan.c
@@ -214,6 +214,7 @@ ExecDynamicTableScan(DynamicTableScanState *node)
                node->shouldCallHashSeqTerm = true;
        }

+       SIMPLE_FAULT_INJECTOR(FaultDuringExecDynamicTableScan);
```

**Scenario2: Concurrent DML on leaf and root partition may cause deadlock**
```
    CREATE TABLE part_tbl (a int, b int, c int) PARTITION BY RANGE(b) (START(1) END(1) EVERY(1));
    INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,1000000)i;
```
Session 1: 

```
BEGIN; DELETE FROM part_tbl; ==> Let's say it holds Exclusive lock on root table only. (not on leaf)
    Note: Trigger the session 2 DELETE command immediately after triggering DELETE on session 1.
```
    
Session 2: 
```
BEGIN; DELETE FROM part_tbl_1_prt_1 where a = 999999 or a = 1; ==> Delete will be dispatched to the segment as there is no lock on QD.
```
    
If Session 1, first deletes the tuple a = 1 on segment 0, Session 2 will wait for transaction lock as it attempting to delete the same tuple.
and if Session 2, first deletes the tuple a = 999999 on segment 1, Session 1 will wait for transaction lock as it is attempting to delete the same tuple.
    This will cause a deadlock.
    Note: Same applies to UPDATE as well.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
