### PR TITLE
Fix the error for ALTER USER ALL

### DIFF
--- a/src/backend/catalog/pg_db_role_setting.c
+++ b/src/backend/catalog/pg_db_role_setting.c
@@ -234,7 +234,7 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 			appendStringInfo(&buffer, "ALTER DATABASE %s ",
 							 quote_identifier(dbname));
 		else
-			elog(ERROR, "ALTER without DATABASE or ROLE"); /* shouldn't happen */
+			appendStringInfo(&buffer, "ALTER ROLE ALL ");
 
 		if (setstmt->kind ==  VAR_RESET_ALL)
 			appendStringInfo(&buffer, "RESET ALL");

--- a/src/test/regress/expected/role.out
+++ b/src/test/regress/expected/role.out
@@ -147,3 +147,8 @@ select rolconfig from pg_roles where rolname = 'guctestrole';
 (1 row)
 
 reset role;
+-- Test ALTER USER ALL
+BEGIN;
+ALTER USER ALL SET application_name TO 'alter_user_all_test';
+ALTER USER ALL RESET ALL;
+ROLLBACK;

--- a/src/test/regress/sql/role.sql
+++ b/src/test/regress/sql/role.sql
@@ -99,7 +99,6 @@ DROP GROUP market;
 DROP USER jona11;
 DROP USER jona12;
 
-
 -- Test that a non-superuser cannot use ALTER USER RESET ALL to reset
 -- superuser-only GUCs. (A bug that was fixed in PostgreSQL commit
 -- e429448f33.)
@@ -123,3 +122,9 @@ set role guctestrole;
 alter user guctestrole reset all;
 select rolconfig from pg_roles where rolname = 'guctestrole';
 reset role;
+
+-- Test ALTER USER ALL
+BEGIN;
+ALTER USER ALL SET application_name TO 'alter_user_all_test';
+ALTER USER ALL RESET ALL;
+ROLLBACK;


### PR DESCRIPTION
Previously, we cannot reconstruct the statement and dispatch it to
QEs in AlterSetting() if role and database are zero, we report an error
instead. Actually, when both role and database are not specified, it's
a ALTER USER ALL statement, this commit reconstruct it well.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
