### PR TITLE
Reduce the high cpu usage of postmaster when DTX is recovering

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -6379,11 +6379,7 @@ maybe_start_bgworker(void)
 		if (bgworker_should_start_now(rw->rw_worker.bgw_start_time))
 		{
 			if (!bgworker_should_start_mpp(&rw->rw_worker))
-			{
-				/* tell ServerLoop to try again */
-				StartWorkerNeeded = true;
 				continue;
-			}
 
 			/* reset crash time before trying to start worker */
 			rw->rw_crashed_at = 0;


### PR DESCRIPTION
bgworker_should_start_mpp() is mainly used to check whether the DTX
recovery process has recovered the distributed transactions and set
the shmDtmStarted to true. We used to let postmaster keep trying if
a DTX recovery process didn't finish and it kept postmaster in a
very high CPU usage which is not cool. Because DTX recovery process
is also a bgworker and a bgworker quiting will also force a call to
maybe_start_bgworker(), it's unnecessary to set StartWorkerNeeded to
tell postmaster keep trying.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
