### PR TITLE
Auxiliary bgworkers should skip resource group assignment

### DIFF
--- a/src/backend/utils/resource_manager/resource_manager.c
+++ b/src/backend/utils/resource_manager/resource_manager.c
@@ -18,6 +18,7 @@
 #include "cdb/memquota.h"
 #include "executor/spi.h"
 #include "postmaster/fts.h"
+#include "postmaster/postmaster.h"
 #include "replication/walsender.h"
 #include "utils/faultinjector.h"
 #include "utils/guc.h"
@@ -64,6 +65,7 @@ InitResManager(void)
 	else if  (IsResGroupEnabled() &&
 			 (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) &&
 			 IsUnderPostmaster &&
+			 !amAuxiliaryBgWorker() &&
 			 !am_walsender && !am_ftshandler && !IsFaultHandler)
 	{
 		/*


### PR DESCRIPTION
In https://github.com/greenplum-db/gpdb/pull/7364 DTX, GDD, FTS processes
are converted to auxiliary bgworkers, and shared_preload_libraries are
loaded before auxiliary bgworkers fully started. This result in resource
group assignment affects auxiliary bgworkers internal transactions.
Especially for DTX process, it gets locked by start transaction on calling
resgroup_assign_hook.
This fix makes auxiliary bgworkers skip resource group initialization to
skip all resgroup assignments.

Co-authored-by: Wang Hao <haowang@pivotal.io>
Co-authored-by: Ru Yang <ruyang@pivotal.io>
Reviewed-by: Ning Yu <nyu@pivotal.io>
Reviewed-by: Pengzhou Tang <ptang@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
