### PR TITLE
gpMgmt: fix connect-time test races

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -55,7 +55,7 @@ Feature: gpstate tests
     Scenario: gpstate -c logs cluster info for a cluster that is unsynchronized
         Given a standard local demo cluster is running
         When user stops all mirror processes
-        And an FTS probe is triggered
+        And user can start transactions
         And the user runs "gpstate -c"
         Then gpstate output looks like
             | Status                        | Data State  | Primary | Datadir                 | Port   | Mirror | Datadir                        | Port   |
@@ -350,7 +350,7 @@ Feature: gpstate tests
     Scenario: gpstate -i warns if any mirrors are marked down
         Given a standard local demo cluster is running
           And user stops all mirror processes
-          And an FTS probe is triggered
+          And user can start transactions
         When the user runs "gpstate -i"
         Then gpstate output looks like
 		  | Host | Datadir                        | Port   | Version                                                                           |

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -828,19 +828,7 @@ def stop_segments(context, segment_type):
 @when('user can start transactions')
 @then('user can start transactions')
 def impl(context):
-    num_retries = 150
-    attempt = 0
-    while attempt < num_retries:
-        try:
-            with dbconn.connect(dbconn.DbURL()) as conn:
-                break
-        except Exception as e:
-            attempt += 1
-            pass
-        time.sleep(1)
-
-    if attempt == num_retries:
-        raise Exception('Unable to establish a connection to database !!!')
+    wait_for_unblocked_transactions(context)
 
 
 @given('the environment variable "{var}" is set to "{val}"')

--- a/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
@@ -9,6 +9,7 @@ from test.behave_utils.utils import (
     trigger_fts_probe,
     run_gprecoverseg,
     execute_sql,
+    wait_for_unblocked_transactions,
 )
 
 
@@ -88,6 +89,7 @@ def step_impl(context):
 @when(u'a mirror has crashed')
 def step_impl(context):
     run_command(context, "ps aux | grep dbfast_mirror1 | awk '{print $2}' | xargs kill -9")
+    wait_for_unblocked_transactions(context)
 
 
 @when(u'I create a cluster')
@@ -128,6 +130,7 @@ def step_impl(context):
 @given(u'a preferred primary has failed')
 def step_impl(context):
     stop_primary(context, 0)
+    wait_for_unblocked_transactions(context)
 
 
 @when('primary and mirror switch to non-preferred roles')

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -765,3 +765,25 @@ def replace_special_char_env(str):
 
 def escape_string(string, conn):
     return pg.DB(db=conn).escape_string(string)
+
+
+def wait_for_unblocked_transactions(context, num_retries=150):
+    """
+    Tries once a second to successfully commit a transaction to the database
+    running on PGHOST/PGPORT. Raises an Exception after failing <num_retries>
+    times.
+    """
+    attempt = 0
+    while attempt < num_retries:
+        try:
+            with dbconn.connect(dbconn.DbURL()) as conn:
+                # Cursor.execute() will issue an implicit BEGIN for us.
+                conn.cursor().execute('COMMIT')
+                break
+        except Exception as e:
+            attempt += 1
+            pass
+        time.sleep(1)
+
+    if attempt == num_retries:
+        raise Exception('Unable to establish a connection to database !!!')


### PR DESCRIPTION
Fix some test races that were exposed by the previous commit, which
removed the wait for a transaction from dbconn.connect(). gpstate tests
need to explicitly wait for transactions instead of issuing FTS probes
alone; replication_slots tests need to wait for transactions before
continuing when segments are killed off.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
