### PR TITLE
 Pass correct in-progress array pointer for writing to file 

### DIFF
--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -714,7 +714,7 @@ dumpSharedLocalSnapshot_forCursor(void)
 		FileWriteFieldWithCount(count, f, src->snapshot.xmax);
 		FileWriteFieldWithCount(count, f, src->snapshot.xcnt);
 
-		if (!FileWriteOK(f, &src->snapshot.xip, src->snapshot.xcnt * sizeof(TransactionId)))
+		if (!FileWriteOK(f, src->snapshot.xip, src->snapshot.xcnt * sizeof(TransactionId)))
 			break;
 		count += src->snapshot.xcnt * sizeof(TransactionId);
 

--- a/src/backend/utils/time/test/Makefile
+++ b/src/backend/utils/time/test/Makefile
@@ -9,3 +9,14 @@ include $(top_builddir)/src/backend/mock.mk
 sharedsnapshot.t: \
 	$(MOCK_DIR)/backend/storage/ipc/shmem_mock.o \
 	$(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \
+	$(MOCK_DIR)/backend/utils/misc/faultinjector_mock.o
+
+.PHONY:
+%-check: %.t
+	$(MKDIR_P) 'base/pgsql_tmp'
+	./$*.t
+
+.PHONY:
+%-clean:
+	rm -rf base
+	rm -f $*.t $*_test.o

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -5,8 +5,99 @@
 
 #include "postgres.h"
 #include "utils/memutils.h"
+#include "utils/resowner.h"
+#include "utils/faultinjector.h"
+#include "utils/snapshot.h"
+#include "storage/fd.h"
 
 #include "../sharedsnapshot.c"
+
+/*
+ * Write shared snapshot to file using dumpSharedLocalSnapshot_forCursor()
+ * first.  Then read the snapshot from file using
+ * readSharedLocalSnapshot_forCursor().  Validate that the contents read from
+ * the file match what was written.
+ */
+void
+test_write_read_shared_snapshot_for_cursor(void **state)
+{
+#define XCNT 5
+	TransactionId xip[XCNT] = {100, 101, 103, 105, 109};
+	xipEntryCount = XCNT;
+
+	PGPROC writer_proc;
+
+	TopTransactionResourceOwner = ResourceOwnerCreate(NULL, "unittest resource owner");
+	CurrentResourceOwner = TopTransactionResourceOwner;
+	TopTransactionContext = CurrentMemoryContext;
+
+	/* create a dummy shared and local snapshot with 5 in-progress transactions */
+	SharedSnapshotSlot slot;
+	SharedLocalSnapshotSlot = &slot;
+	slot.slotindex = 1;
+	slot.slotid = 1;
+	slot.pid = 1000;
+	slot.writer_proc = &writer_proc;
+	slot.writer_xact = NULL;
+	slot.xid = 100;
+	slot.cid = 1;
+	slot.startTimestamp = 0;
+	slot.QDxid = 10;
+	slot.QDcid = 1;
+	slot.ready = true;
+	slot.segmateSync = 1;
+	slot.combocidcnt = 0;
+	slot.snapshot.xmin = 99;
+	slot.snapshot.xmax = 110;
+	slot.snapshot.xcnt = XCNT;
+	slot.snapshot.xip = xip;
+	slot.slotLock = NULL;
+
+	/* assume the role of a writer to write the snapshot */
+	Gp_role = GP_ROLE_EXECUTE;
+	Gp_is_writer = true;
+
+	expect_any(LWLockAcquire, l);
+	expect_any(LWLockAcquire, mode);
+	will_be_called(LWLockAcquire);
+
+	expect_any_count(FaultInjector_InjectFaultIfSet, faultName, 13);
+	expect_any_count(FaultInjector_InjectFaultIfSet, ddlStatement, 13);
+	expect_any_count(FaultInjector_InjectFaultIfSet, databaseName, 13);
+	expect_any_count(FaultInjector_InjectFaultIfSet, tableName, 13);
+	will_be_called_count(FaultInjector_InjectFaultIfSet, 13);
+
+	expect_any(LWLockRelease, l);
+	will_be_called(LWLockRelease);
+
+	MyProc = &writer_proc;
+	MyProc->pid = 1000;
+
+	/* write the snapshot to file */
+	dumpSharedLocalSnapshot_forCursor();
+
+	/* assume the role of a reader to read the snapshot */
+	PGPROC reader_proc;
+	MyProc = &reader_proc;
+	MyProc->pid = 1234;
+	lockHolderProcPtr = &writer_proc;
+	Gp_is_writer = false;
+
+	QEDtxContextInfo.segmateSync = slot.segmateSync;
+	QEDtxContextInfo.distributedXid = slot.QDxid;
+	QEDtxContextInfo.curcid = slot.QDcid;
+
+	SnapshotData snapshot;
+	snapshot.xip = palloc(XCNT * sizeof(TransactionId));
+
+	/* read snapshot from the same file */
+	readSharedLocalSnapshot_forCursor(&snapshot, DTX_CONTEXT_QE_READER);
+
+	assert_true(snapshot.xcnt == XCNT);
+	int i;
+	for (i=0; i<XCNT; i++)
+		assert_true(slot.snapshot.xip[i] == snapshot.xip[i]);
+}
 
 void
 test_boundaries_of_CreateSharedSnapshotArray(void **state)
@@ -56,8 +147,10 @@ main(int argc, char* argv[])
 	cmockery_parse_arguments(argc, argv);
 
 	const UnitTest tests[] = {
-		unit_test(test_boundaries_of_CreateSharedSnapshotArray)
+		unit_test(test_boundaries_of_CreateSharedSnapshotArray),
+		unit_test(test_write_read_shared_snapshot_for_cursor)
 	};
 	MemoryContextInit();
+	InitFileAccess();
 	return run_tests(tests);
 }


### PR DESCRIPTION
In case of extended queries, snapshot information is shared between reader and writer QEs using files.  The writer obtains a snapshot and writes it to file.  This patch fixes a bug that passed incorrect address of the array of in-progress transactions for writing to file.  The bug caused hard to reproduce
errors in production workloads that involved extended queries (bind/execute libpq messages, declare cursor statements, certain PL/* statements such as RETURN and EXECUTE in pl/pgsql).

To be back ported to all supported branches.