### PR TITLE
Add citext to default make target

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -12,6 +12,7 @@ $(call recurse,all install,src config)
 
 all:
 	$(MAKE) -C contrib/auto_explain all
+	$(MAKE) -C contrib/citext all
 	$(MAKE) -C contrib/file_fdw all
 	$(MAKE) -C contrib/formatter all
 	$(MAKE) -C contrib/formatter_fixedwidth all
@@ -46,6 +47,7 @@ html man:
 
 install:
 	$(MAKE) -C contrib/auto_explain $@
+	$(MAKE) -C contrib/citext $@
 	$(MAKE) -C contrib/file_fdw $@
 	$(MAKE) -C contrib/formatter $@
 	$(MAKE) -C contrib/formatter_fixedwidth $@
@@ -142,6 +144,7 @@ $(call recurse,installcheck-world, \
 			   src/pl \
 			   src/interfaces/gppc \
 			   contrib/auto_explain \
+			   contrib/citext \
 			   contrib/file_fdw \
 			   contrib/formatter_fixedwidth \
 			   contrib/extprotocol \

--- a/contrib/citext/Makefile
+++ b/contrib/citext/Makefile
@@ -8,6 +8,7 @@ DATA = citext--1.0.sql citext--1.1.sql citext--1.0--1.1.sql \
 PGFILEDESC = "citext - case-insensitive character string data type"
 
 REGRESS = citext
+REGRESS_OPTS += --init-file=$(top_srcdir)/src/test/regress/init_file
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config


### PR DESCRIPTION
Commit d0bf85634e9fb8437a57a171bad1de4bbfac9b42 added citext to the default make target of 5X_STABLE, but it was never added to master. This brings master in syn with 5X_STABLE.

Reported-by: Lisa Owen

Ping @lisakowen @kmacoskey 