### PR TITLE
Behave: Execute DDL to start a distributed transaction.

### DIFF
--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -778,6 +778,9 @@ def wait_for_unblocked_transactions(context, num_retries=150):
         try:
             with dbconn.connect(dbconn.DbURL()) as conn:
                 # Cursor.execute() will issue an implicit BEGIN for us.
+                # Empty block of 'BEGIN' and 'END' won't start a distributed transaction,
+                # execute a DDL query to start a distributed transaction.
+                conn.cursor().execute('CREATE TEMP TABLE temp_test(a int)')
                 conn.cursor().execute('COMMIT')
                 break
         except Exception as e:


### PR DESCRIPTION
The optimization in commit 7228a19 changed the details for some transactions in Greenplum. This caused failures in our Behave tests, which used a particular idiom to make sure a cluster state change(such as a mirror going down, etc) was properly reflected in gp_segment_configuration.

The initial fix for this in 6X(bd2d9ea56c6a4d21f692ff078bd95000f6cd8852) backported a change from master(dcbff04616e1baa7e631bff67ddd58ef78a300f4) that made the state change more reliable on master. This updates that backport to force a full transaction, to ensure the state change is properly reflected when wait_for_unblocked_transactions() returns.

In this commit we have incorporated the changes in utils.py from https://github.com/greenplum-db/gpdb/commit/b43629be3d84b00eb0e57dd285ba1da98ca1c27b to issue a DDL to force a distributed transaction.

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>
Co-authored-by: Nikolaos Kalampalikis <nkalampalikis@pivotal.io>

