### PR TITLE
Fix test flakiness in ALTER DATABASE SET TABLESPACE setup

### DIFF
--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -203,6 +203,9 @@ CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tables
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
 
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
@@ -256,6 +259,9 @@ CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tables
 
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
 
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -317,6 +323,9 @@ CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tables
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
 
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
@@ -376,6 +385,9 @@ CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tables
 
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
 
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -439,6 +451,9 @@ CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tables
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
 
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
@@ -498,6 +513,9 @@ CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tables
 
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
 
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -561,6 +579,9 @@ CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tables
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
 
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
@@ -619,6 +640,9 @@ CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tables
 
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
 
 -- And we record the filesystem state for the database in the source tablespace
 -- Note: We can't use a temporary table as PANICS wipe them out
@@ -682,6 +706,9 @@ CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tables
 
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
 
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -182,6 +182,13 @@ CREATE TABLESPACE adst_source_tablespace LOCATION :'adst_source_tablespace_locat
 CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tablespace_location';
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -292,6 +299,13 @@ CREATE TABLESPACE adst_source_tablespace LOCATION :'adst_source_tablespace_locat
 CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tablespace_location';
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -407,6 +421,13 @@ CREATE TABLESPACE adst_source_tablespace LOCATION :'adst_source_tablespace_locat
 CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tablespace_location';
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -528,6 +549,13 @@ CREATE TABLESPACE adst_source_tablespace LOCATION :'adst_source_tablespace_locat
 CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tablespace_location';
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -656,6 +684,13 @@ CREATE TABLESPACE adst_source_tablespace LOCATION :'adst_source_tablespace_locat
 CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tablespace_location';
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -777,6 +812,13 @@ CREATE TABLESPACE adst_source_tablespace LOCATION :'adst_source_tablespace_locat
 CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tablespace_location';
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -905,6 +947,13 @@ CREATE TABLESPACE adst_source_tablespace LOCATION :'adst_source_tablespace_locat
 CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tablespace_location';
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -1025,6 +1074,13 @@ CREATE TABLESPACE adst_source_tablespace LOCATION :'adst_source_tablespace_locat
 CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tablespace_location';
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
+
 -- And we record the filesystem state for the database in the source tablespace
 -- Note: We can't use a temporary table as PANICS wipe them out
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -1146,6 +1202,13 @@ CREATE TABLESPACE adst_source_tablespace LOCATION :'adst_source_tablespace_locat
 CREATE TABLESPACE adst_destination_tablespace LOCATION :'adst_destination_tablespace_location';
 -- And we create a database in the source tablespace
 CREATE DATABASE alter_db TABLESPACE adst_source_tablespace;
+-- And we ensure that the mirrors have applied the filesystem changes for CREATE DATABASE
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
+
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.


### PR DESCRIPTION
Previously, we did not wait for the mirrors to apply the filesystem
changes involved in a CREATE DATABASE command before 'stat'ing
relfilenodes in all the database instances (including mirrors) in the
test setup. This flakiness was introduced in PR #7792.

Co-authored-by: David Kimura <dkimura@pivotal.io>
