### PR TITLE
Fix a resource group bug

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3667,7 +3667,10 @@ sessionSetSlot(ResGroupSlotData *slot)
 static ResGroupSlotData *
 sessionGetSlot(void)
 {
-	return (ResGroupSlotData *) MySessionState->resGroupSlot;
+	if (MySessionState == NULL)
+		return NULL;
+	else
+		return (ResGroupSlotData *) MySessionState->resGroupSlot;
 }
 
 /*

--- a/src/backend/utils/session_state.c
+++ b/src/backend/utils/session_state.c
@@ -172,6 +172,7 @@ SessionState_Release(SessionState *acquired)
 		acquired->cleanupCountdown = CLEANUP_COUNTDOWN_BEFORE_RUNAWAY;
 		acquired->activeProcessCount = 0;
 		acquired->idle_start = 0;
+		Assert(acquired->resGroupSlot == NULL);
 		acquired->resGroupSlot = NULL;
 
 #ifdef USE_ASSERT_CHECKING


### PR DESCRIPTION
'MySessionState' is destroyed before 'groupWaitCancel' is called when shutdown. Access the
member of 'MySessionState' in 'groupWaitCancel' may cause segment fault.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
