### PR TITLE
Skip start the stats sender process when gpperfmon not enabled

### DIFF
--- a/src/backend/postmaster/perfmon_segmentinfo.c
+++ b/src/backend/postmaster/perfmon_segmentinfo.c
@@ -87,9 +87,7 @@ void SegmentInfoSenderMain(Datum main_arg)
 bool
 SegmentInfoSenderStartRule(Datum main_arg)
 {
-	/*
-	 * TODO: is this correct? either GUC is on will turn on this auxiliary process ? */
-	if (!gp_enable_gpperfmon && !gp_enable_query_metrics)
+	if (!gp_enable_gpperfmon)
 		return false;
 
 	/* FIXME: even for the utility mode? */


### PR DESCRIPTION
Before GP6, the stats sender process works for gpperfmon and metrics
collector. If any of them enabled, stats sender should start.
From GP6 metrics collector become a standalone bgworker.
So this commit fix startup condition for stats sender, now it only
starts when gpperfmon enabled.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
