### PR TITLE
Revert "Disable shareinputscan with outer refs."

### DIFF
--- a/src/backend/optimizer/plan/planshare.c
+++ b/src/backend/optimizer/plan/planshare.c
@@ -141,15 +141,6 @@ static ShareInputScan *make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 
 	Assert(IsA(inputplan, Material) || IsA(inputplan, Sort));
 
-	/*
-	 * Currently GPDB doesn't fully support shareinputscan referencing outer
-	 * rels.
-	 */
-	if (!bms_is_empty(inputplan->extParam))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("shareinputscan with outer refs is not supported by GPDB")));
-
 	sisc = makeNode(ShareInputScan);
 	incr_plan_nsharer(inputplan);
 
@@ -224,8 +215,6 @@ prepare_plan_for_sharing(PlannerInfo *root, Plan *common)
 		shared->plan_width = common->plan_width;
 		shared->dispatch = common->dispatch;
 		shared->flow = copyObject(common->flow); 
-		shared->extParam = bms_copy(common->extParam);
-		shared->allParam = bms_copy(common->allParam);
 
 		m->share_id = SHARE_ID_NOT_ASSIGNED;
 		m->share_type = SHARE_MATERIAL;

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -30,10 +30,3 @@ SELECT * FROM
 ---+---+---+---+---+---
 (0 rows)
 
-SELECT *,
-        (
-        WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
-        SELECT 1 FROM cte c1, cte c2
-        )
-        FROM bar;
-ERROR:  shareinputscan with outer refs is not supported by GPDB

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -27,10 +27,3 @@ SELECT * FROM
         JOIN bar ON b = c
         ) AS XY
         JOIN jazz on c = e AND b = f;
-
-SELECT *,
-        (
-        WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
-        SELECT 1 FROM cte c1, cte c2
-        )
-        FROM bar;


### PR DESCRIPTION
This reverts commit fbc512efeee858690aae31a9603e1a3e307b455d.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
