### PR TITLE
Fix memory leaks and spilling issues of hash aggregation

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -1584,7 +1584,6 @@ writeHashEntry(AggState *aggstate, BatchFileInfo *file_info,
 			serializedVal = FunctionCallInvoke(&fcinfo);
 
 			datum_size = datumGetSize(serializedVal, byteaTranstypeByVal, byteaTranstypeLen);
-			pfree(DatumGetPointer(pergroupstate->transValue));
 			BufFileWriteOrError(file_info->wfile,
 								DatumGetPointer(serializedVal), datum_size);
 			pfree(DatumGetPointer(serializedVal));

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -28,12 +28,15 @@
 
 #include "access/hash.h"
 #include "catalog/pg_type.h"
+#include "executor/execHHashagg.h"
 #include "libpq/pqformat.h"
 #include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
+#include "nodes/execnodes.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/int8.h"
+#include "utils/memutils.h"
 #include "utils/numeric.h"
 
 /* ----------
@@ -2870,13 +2873,23 @@ makeNumericAggState(FunctionCallInfo fcinfo, bool calcSumX2)
 	NumericAggState *state;
 	MemoryContext agg_context;
 	MemoryContext old_context;
+	int agg_type;
 
-	if (!AggCheckCallContext(fcinfo, &agg_context))
+	if (!(agg_type = AggCheckCallContext(fcinfo, &agg_context)))
 		elog(ERROR, "aggregate function called in non-aggregate context");
 
 	old_context = MemoryContextSwitchTo(agg_context);
 
-	state = (NumericAggState *) palloc0(sizeof(NumericAggState));
+	AggState *aggstate = (AggState *)fcinfo->context;
+	if (agg_type == AGG_CONTEXT_AGGREGATE && aggstate->hhashtable)
+	{
+		state = (NumericAggState *) mpool_alloc(aggstate->hhashtable->group_buf, sizeof(NumericAggState));
+		MemSet(state, 0, sizeof(NumericAggState));
+	}
+	else
+	{
+		state = (NumericAggState *) palloc0(sizeof(NumericAggState));
+	}
 	state->calcSumX2 = calcSumX2;
 	state->agg_context = agg_context;
 	quick_init_var(&state->sumX);
@@ -3101,7 +3114,7 @@ numeric_combine(PG_FUNCTION_ARGS)
 	{
 		old_context = MemoryContextSwitchTo(agg_context);
 
-		state1 = makeNumericAggStateCurrentContext(true);
+		state1 = makeNumericAggState(fcinfo, true);
 		state1->N = state2->N;
 		state1->NaNcount = state2->NaNcount;
 		state1->maxScale = state2->maxScale;
@@ -3192,7 +3205,7 @@ numeric_avg_combine(PG_FUNCTION_ARGS)
 	{
 		old_context = MemoryContextSwitchTo(agg_context);
 
-		state1 = makeNumericAggStateCurrentContext(false);
+		state1 = makeNumericAggState(fcinfo, false);
 		state1->N = state2->N;
 		state1->NaNcount = state2->NaNcount;
 		state1->maxScale = state2->maxScale;
@@ -3528,13 +3541,23 @@ makeInt128AggState(FunctionCallInfo fcinfo, bool calcSumX2)
 	Int128AggState *state;
 	MemoryContext agg_context;
 	MemoryContext old_context;
+	int agg_type;
 
-	if (!AggCheckCallContext(fcinfo, &agg_context))
+	if (!(agg_type = AggCheckCallContext(fcinfo, &agg_context)))
 		elog(ERROR, "aggregate function called in non-aggregate context");
 
 	old_context = MemoryContextSwitchTo(agg_context);
 
-	state = (Int128AggState *) palloc0(sizeof(Int128AggState));
+	AggState *aggstate = (AggState *)fcinfo->context;
+	if (agg_type == AGG_CONTEXT_AGGREGATE && aggstate->hhashtable)
+	{
+		state = (Int128AggState *) mpool_alloc(aggstate->hhashtable->group_buf, sizeof(Int128AggState));
+		MemSet(state, 0, sizeof(Int128AggState));
+	}
+	else
+	{
+		state = (Int128AggState *) palloc0(sizeof(Int128AggState));
+	}
 	state->calcSumX2 = calcSumX2;
 
 	MemoryContextSwitchTo(old_context);

--- a/src/include/executor/execHHashagg.h
+++ b/src/include/executor/execHHashagg.h
@@ -168,6 +168,9 @@ typedef struct HashAggTable
 	SpillFile *curr_spill_file;
 	int curr_spill_level;
 
+	/* The memory context for (de)serialization */
+	MemoryContext serialization_cxt;
+
 	/*
 	 * The space to buffer the free hash entries and AggStatePerGroups. Using this,
 	 * we can reduce palloc/pfree calls.

--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -89,6 +89,13 @@ create table aggspill (i int, j int, t text) distributed by (i);
 insert into aggspill select i, i*2, i::text from generate_series(1, 10000) i;
 insert into aggspill select i, i*2, i::text from generate_series(1, 100000) i;
 insert into aggspill select i, i*2, i::text from generate_series(1, 1000000) i;
+-- Test the spilling with serial/deserial functions involved
+-- The transition type of numeric is internal, and hence it uses the serial/deserial functions when spilling
+drop table if exists aggspill_numeric_avg;
+create table aggspill_numeric_avg (a int, b int, c numeric) distributed by (a);
+insert into aggspill_numeric_avg (select i, i + 1, i * 1.1111 from generate_series(1, 500000) as i);
+insert into aggspill_numeric_avg (select i, i + 1, i * 1.1111 from generate_series(1, 500000) as i);
+analyze aggspill_numeric_avg;
 -- No spill with large statement memory 
 set statement_mem = '125MB';
 select count(*) from (select i, count(*) from aggspill group by i,j having count(*) = 1) g;
@@ -112,6 +119,12 @@ select count(*) from (select i, count(*) from aggspill group by i,j having count
  90000
 (1 row)
 
+select count(*) from (select a, avg(b), avg(c) from aggspill_numeric_avg group by a) g;
+ count  
+--------
+ 500000
+(1 row)
+
 -- Reduce the statement memory, nbatches and entrysize even further to cause multiple overflows
 set gp_hashagg_default_nbatches = 4;
 set statement_mem = '5MB';
@@ -126,6 +139,12 @@ select count(*) from (select i, count(*) from aggspill group by i,j,t having cou
  count 
 -------
  10000
+(1 row)
+
+select count(*) from (select a, avg(b), avg(c) from aggspill_numeric_avg group by a) g;
+ count  
+--------
+ 500000
 (1 row)
 
 drop schema hashagg_spill cascade;


### PR DESCRIPTION
Fix #7787 and #7984 

PR #5528 changed the transValue of aggstate to type INTERNAL, which are pointers with data allocated in aggcontext. It has two issues causing OOM and memory leaks.

1, just the pointers of aggstates are spilled, doesn't decrease the memory usage.
2, aggstates are not in the group_buf now, but Greenplum decides if to spill based on the usage of group_buf.

This PR fixes these two issues via using group_buf for aggregate transition data and serialize them while spilling hash table.