### PR TITLE
gpexpand: improve timeout tests

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -15,7 +15,9 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand interview to add 2 new segment and 0 new host "ignored.host"
         Then the number of segments have been saved
         And user has created expansiontest tables
+        And 4000000 rows are inserted into table "expansiontest0" in schema "public" with column type list "int"
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
+        And 4000000 rows are inserted into table "expansiontest2" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
          And the user runs gpexpand to redistribute with duration "00:00:02"
         Then gpexpand should print "End time reached.  Stopping expansion." to stdout
@@ -38,7 +40,9 @@ Feature: expand the cluster by adding more segments
         And the cluster is setup for an expansion on hosts "mdw,sdw1"
         When the user runs gpexpand interview to add 2 new segment and 0 new host "ignored.host"
         Then user has created expansiontest tables
+        And 4000000 rows are inserted into table "expansiontest0" in schema "public" with column type list "int"
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
+        And 4000000 rows are inserted into table "expansiontest2" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         When the user runs gpexpand to redistribute with duration "00:00:02"
         Then gpexpand should print "End time reached.  Stopping expansion." to stdout
@@ -56,7 +60,9 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand interview to add 2 new segment and 0 new host "ignored.host"
         Then the number of segments have been saved
         And user has created expansiontest tables
+        And 4000000 rows are inserted into table "expansiontest0" in schema "public" with column type list "int"
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
+        And 4000000 rows are inserted into table "expansiontest2" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
          And the user runs gpexpand to redistribute with the --end flag
         Then gpexpand should print "End time reached.  Stopping expansion." to stdout


### PR DESCRIPTION
Some gpexpand behave tests verify the behaviors of the `--duration` and
`--end` arguments, they expect the gpexpand data redistribution phase to
exist after 2 seconds before all the redistribution are done.  However
internally gpexpand check for the timeout at a 5-second interval, if the
data redistribution completes within 5 seconds then the tests will fail.
This is just what is happening recently.

Improve these tests by queueing more tables for redistribution.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
