### PR TITLE
Speed up gp_tablespace_with_faults by using xlog noop

### DIFF
--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -123,12 +123,6 @@ END;
 $$LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
-BEGIN
-END;
-$$ LANGUAGE plpgsql;
-
-
 create or replace function give_mirrors_time_to_catch_up() returns void as $$
 begin
     PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';

--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -74,8 +74,9 @@ $$ LANGUAGE plpgsql;
 
 create or replace function cleanup(content_id integer, tablespace_location_dir text) returns void as $$
 	begin
-		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
+		CHECKPOINT;
 		perform give_mirrors_time_to_catch_up();
+		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
 		perform remove_tablespace_location_directory(tablespace_location_dir);
 	end;
 $$ LANGUAGE plpgsql;
@@ -104,17 +105,43 @@ create or replace function list_tablespace_dbid_dirs(expected_number_of_tablespa
 $$ language plpythonu;
 
 
+CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
+    '@abs_builddir@/regress.so', 'insert_noop_xlog_record'
+LANGUAGE C EXECUTE ON MASTER;
+
+
+CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
+'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
+    LANGUAGE C EXECUTE ON ALL SEGMENTS;
+
+
+CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
+BEGIN
+    PERFORM insert_noop_xlog_record_master();
+    PERFORM insert_noop_xlog_record_all_segments();
+END;
+$$LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
+BEGIN
+END;
+$$ LANGUAGE plpgsql;
+
+
 create or replace function give_mirrors_time_to_catch_up() returns void as $$
-declare number_of_segments_behind integer;
 begin
-	checkpoint;
-	LOOP
-		select count(1) into number_of_segments_behind from gp_stat_replication where sent_location != replay_location;
-		EXIT WHEN number_of_segments_behind = 0;
-		perform pg_sleep(0.5);
-	END LOOP;
+    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM insert_noop_xlog_record();
+    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
 end;
 $$ language plpgsql;
+
+
+create or replace function wait_for_primaries_to_restart() returns boolean as $$
+	select count(gp_segment_id) > 0 from gp_dist_random('pg_tablespace');
+$$ language sql;
 
 
 create or replace function list_tablespace_catalog() returns table(gp_segment_id int, tablespace_name text, oid oid) as $$
@@ -186,6 +213,7 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select wait_for_primaries_to_restart();
 select give_mirrors_time_to_catch_up();
 select * from list_tablespace_catalog();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
@@ -236,6 +264,7 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
+select wait_for_primaries_to_restart();
 select give_mirrors_time_to_catch_up();
 select * from list_tablespace_catalog();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
@@ -391,6 +420,7 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
+select wait_for_primaries_to_restart();
 select give_mirrors_time_to_catch_up();
 select list_tablespace_dbid_dirs(0, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespace should no longer exist in the catalog
@@ -413,6 +443,7 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
+select wait_for_primaries_to_restart();
 select give_mirrors_time_to_catch_up();
 select list_tablespace_dbid_dirs(8, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog

--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -74,8 +74,8 @@ $$ LANGUAGE plpgsql;
 
 create or replace function cleanup(content_id integer, tablespace_location_dir text) returns void as $$
 	begin
-		CHECKPOINT;
-		perform give_mirrors_time_to_catch_up();
+		CHECKPOINT; -- ensure primary/master xlogs do not leak into following test
+		perform force_mirrors_to_catch_up();
 		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
 		perform remove_tablespace_location_directory(tablespace_location_dir);
 	end;
@@ -123,7 +123,7 @@ END;
 $$LANGUAGE plpgsql;
 
 
-create or replace function give_mirrors_time_to_catch_up() returns void as $$
+create or replace function force_mirrors_to_catch_up() returns void as $$
 begin
     PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
@@ -167,7 +167,7 @@ $$ language sql;
 
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select * from list_tablespace_catalog();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 DROP TABLESPACE my_tablespace_for_testing;
@@ -187,7 +187,7 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select * from list_tablespace_catalog();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 DROP TABLESPACE my_tablespace_for_testing;
@@ -208,7 +208,7 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select wait_for_primaries_to_restart();
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select * from list_tablespace_catalog();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 DROP TABLESPACE my_tablespace_for_testing;
@@ -226,7 +226,7 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select * from list_tablespace_catalog();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 DROP TABLESPACE my_tablespace_for_testing;
@@ -259,7 +259,7 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select wait_for_primaries_to_restart();
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select * from list_tablespace_catalog();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 DROP TABLESPACE my_tablespace_for_testing;
@@ -279,7 +279,7 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 select remove_tablespace_location_directory(:'tablespace_location');
 select setup_tablespace_location_dir_for_test(:'tablespace_location');
 create tablespace my_tablespace_for_testing LOCATION :'tablespace_location';
-select * from give_mirrors_time_to_catch_up();
+select * from force_mirrors_to_catch_up();
 
 -- force an aborted transaction which should no longer see a
 --     pending tablespace for deletion
@@ -290,7 +290,7 @@ abort;
 select * from list_tablespace_catalog_without_oid();
 
 -- the tablespace should exist on disk
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 DROP TABLESPACE my_tablespace_for_testing;
 select cleanup(:content_id_under_test, :'tablespace_location');
@@ -310,7 +310,7 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select * from list_tablespace_catalog();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 DROP TABLESPACE my_tablespace_for_testing;
@@ -327,7 +327,7 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(0, :'tablespace_location');
 -- the tablespace should no longer be in the catalog
 select * from list_tablespace_catalog_without_oid();
@@ -346,12 +346,12 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(8, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
 select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select cleanup(0, :'tablespace_location');
 
 
@@ -370,12 +370,12 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(8, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
 select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select cleanup(:content_id_under_test, :'tablespace_location');
 
 --
@@ -388,9 +388,9 @@ select remove_tablespace_location_directory(:'tablespace_location') from gp_dist
 select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-create table foobar (a int) tablespace my_tablespace_for_testing distributed by (a); 
+create table foobar (a int) tablespace my_tablespace_for_testing distributed by (a);
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(8, :'tablespace_location');
 -- the tablespace should still exist in the catalog
 select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
@@ -415,7 +415,7 @@ CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select wait_for_primaries_to_restart();
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(0, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespace should no longer exist in the catalog
 select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
@@ -438,7 +438,7 @@ CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select wait_for_primaries_to_restart();
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(8, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
 select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
@@ -461,7 +461,7 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
 select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
@@ -484,7 +484,7 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
+select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
 select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -109,10 +109,6 @@ BEGIN
     PERFORM insert_noop_xlog_record_all_segments();
 END;
 $$LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
-BEGIN
-END;
-$$ LANGUAGE plpgsql;
 create or replace function give_mirrors_time_to_catch_up() returns void as $$
 begin
     PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -70,8 +70,8 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 $$ LANGUAGE plpgsql;
 create or replace function cleanup(content_id integer, tablespace_location_dir text) returns void as $$
 	begin
-		CHECKPOINT;
-		perform give_mirrors_time_to_catch_up();
+		CHECKPOINT; -- ensure primary/master xlogs do not leak into following test
+		perform force_mirrors_to_catch_up();
 		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
 		perform remove_tablespace_location_directory(tablespace_location_dir);
 	end;
@@ -109,7 +109,7 @@ BEGIN
     PERFORM insert_noop_xlog_record_all_segments();
 END;
 $$LANGUAGE plpgsql;
-create or replace function give_mirrors_time_to_catch_up() returns void as $$
+create or replace function force_mirrors_to_catch_up() returns void as $$
 begin
     PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
@@ -150,9 +150,9 @@ select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespac
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 ERROR:  fault triggered, fault name:'after_xlog_create_tablespace' fault type:'error'
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -201,9 +201,9 @@ select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespac
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 ERROR:  fault triggered, fault name:'after_xlog_create_tablespace' fault type:'error'  (seg0 127.0.0.1:7002 pid=42782)
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -258,9 +258,9 @@ select wait_for_primaries_to_restart();
  t
 (1 row)
 
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -307,9 +307,9 @@ select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespac
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 ERROR:  fault triggered, fault name:'before_xlog_xact_prepare' fault type:'error'
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -376,9 +376,9 @@ select wait_for_primaries_to_restart();
  t
 (1 row)
 
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -431,9 +431,9 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 (1 row)
 
 create tablespace my_tablespace_for_testing LOCATION :'tablespace_location';
-select * from give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select * from force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -460,9 +460,9 @@ select * from list_tablespace_catalog_without_oid();
 (12 rows)
 
 -- the tablespace should exist on disk
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -498,9 +498,9 @@ select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespac
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 ERROR:  fault triggered, fault name:'before_xlog_xact_distributed_commit' fault type:'error'
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -557,9 +557,9 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -623,9 +623,9 @@ select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port)
 
 DROP TABLESPACE my_tablespace_for_testing;
 ERROR:  fault triggered, fault name:'after_xlog_tblspc_drop' fault type:'error'
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -659,9 +659,9 @@ select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_co
 (1 row)
 
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -706,9 +706,9 @@ select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port)
 
 DROP TABLESPACE my_tablespace_for_testing;
 ERROR:  fault triggered, fault name:'after_xlog_tblspc_drop' fault type:'error'
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -742,9 +742,9 @@ select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_co
 (1 row)
 
 DROP TABLESPACE my_tablespace_for_testing;
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -780,12 +780,12 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-create table foobar (a int) tablespace my_tablespace_for_testing distributed by (a); 
+create table foobar (a int) tablespace my_tablespace_for_testing distributed by (a);
 DROP TABLESPACE my_tablespace_for_testing;
 ERROR:  tablespace "my_tablespace_for_testing" is not empty
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -864,9 +864,9 @@ select wait_for_primaries_to_restart();
  t
 (1 row)
 
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -943,9 +943,9 @@ select wait_for_primaries_to_restart();
  t
 (1 row)
 
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -1022,9 +1022,9 @@ select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from
 
 DROP TABLESPACE my_tablespace_for_testing;
 ERROR:  fault triggered, fault name:'before_xlog_xact_prepare' fault type:'panic'
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 
@@ -1101,9 +1101,9 @@ select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from
 
 DROP TABLESPACE my_tablespace_for_testing;
 ERROR:  fault triggered, fault name:'before_xlog_xact_prepare' fault type:'error'
-select give_mirrors_time_to_catch_up();
- give_mirrors_time_to_catch_up 
--------------------------------
+select force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
  
 (1 row)
 

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -70,8 +70,9 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 $$ LANGUAGE plpgsql;
 create or replace function cleanup(content_id integer, tablespace_location_dir text) returns void as $$
 	begin
-		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
+		CHECKPOINT;
 		perform give_mirrors_time_to_catch_up();
+		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
 		perform remove_tablespace_location_directory(tablespace_location_dir);
 	end;
 $$ LANGUAGE plpgsql;
@@ -96,17 +97,33 @@ create or replace function list_tablespace_dbid_dirs(expected_number_of_tablespa
 		result.append(str(row))
 	return result
 $$ language plpythonu;
+CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
+    '@abs_builddir@/regress.so', 'insert_noop_xlog_record'
+LANGUAGE C EXECUTE ON MASTER;
+CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
+'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
+    LANGUAGE C EXECUTE ON ALL SEGMENTS;
+CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
+BEGIN
+    PERFORM insert_noop_xlog_record_master();
+    PERFORM insert_noop_xlog_record_all_segments();
+END;
+$$LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
+BEGIN
+END;
+$$ LANGUAGE plpgsql;
 create or replace function give_mirrors_time_to_catch_up() returns void as $$
-declare number_of_segments_behind integer;
 begin
-	checkpoint;
-	LOOP
-		select count(1) into number_of_segments_behind from gp_stat_replication where sent_location != replay_location;
-		EXIT WHEN number_of_segments_behind = 0;
-		perform pg_sleep(0.5);
-	END LOOP;
+    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM insert_noop_xlog_record();
+    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
 end;
 $$ language plpgsql;
+create or replace function wait_for_primaries_to_restart() returns boolean as $$
+	select count(gp_segment_id) > 0 from gp_dist_random('pg_tablespace');
+$$ language sql;
 create or replace function list_tablespace_catalog() returns table(gp_segment_id int, tablespace_name text, oid oid) as $$
 	select -1 as gp_segment_id, spcname::text, oid from pg_tablespace
 	UNION ALL
@@ -238,7 +255,13 @@ select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespac
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-ERROR:  fault triggered, fault name:'after_xlog_xact_prepare_flushed' fault type:'panic'
+ERROR:  fault triggered, fault name:'after_xlog_xact_prepare_flushed' fault type:'panic'  (seg0 127.0.0.1:7002 pid=28614)
+select wait_for_primaries_to_restart();
+ wait_for_primaries_to_restart 
+-------------------------------
+ t
+(1 row)
+
 select give_mirrors_time_to_catch_up();
  give_mirrors_time_to_catch_up 
 -------------------------------
@@ -350,7 +373,13 @@ select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespac
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-ERROR:  fault triggered, fault name:'before_xlog_xact_prepare' fault type:'panic'
+ERROR:  fault triggered, fault name:'before_xlog_xact_prepare' fault type:'panic'  (seg0 127.0.0.1:7002 pid=26919)
+select wait_for_primaries_to_restart();
+ wait_for_primaries_to_restart 
+-------------------------------
+ t
+(1 row)
+
 select give_mirrors_time_to_catch_up();
  give_mirrors_time_to_catch_up 
 -------------------------------
@@ -833,6 +862,12 @@ select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from
 DROP TABLESPACE my_tablespace_for_testing;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
 NOTICE:  Releasing segworker group to retry broadcast.
+select wait_for_primaries_to_restart();
+ wait_for_primaries_to_restart 
+-------------------------------
+ t
+(1 row)
+
 select give_mirrors_time_to_catch_up();
  give_mirrors_time_to_catch_up 
 -------------------------------
@@ -905,7 +940,13 @@ select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from
 (1 row)
 
 DROP TABLESPACE my_tablespace_for_testing;
-ERROR:  fault triggered, fault name:'after_xlog_xact_prepare_flushed' fault type:'panic'  (seg0 127.0.0.1:7002 pid=20870)
+ERROR:  fault triggered, fault name:'after_xlog_xact_prepare_flushed' fault type:'panic'  (seg0 127.0.0.1:7002 pid=27567)
+select wait_for_primaries_to_restart();
+ wait_for_primaries_to_restart 
+-------------------------------
+ t
+(1 row)
+
 select give_mirrors_time_to_catch_up();
  give_mirrors_time_to_catch_up 
 -------------------------------


### PR DESCRIPTION
- also, wait for primaries to recover after panics
- also, checkpoint at the end of each test to set redo point to not leak into next test
