### PR TITLE
Bump ORCA version from 3.55 to 3.57

### DIFF
--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -19,4 +19,4 @@ params:
   BLD_TARGETS:
   OUTPUT_ARTIFACT_DIR: gpdb_artifacts
   CONFIGURE_FLAGS:
-  ORCA_TAG: v3.55.0
+  ORCA_TAG: v3.56.0

--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -19,4 +19,4 @@ params:
   BLD_TARGETS:
   OUTPUT_ARTIFACT_DIR: gpdb_artifacts
   CONFIGURE_FLAGS:
-  ORCA_TAG: v3.56.0
+  ORCA_TAG: v3.57.0

--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.56.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.57.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.56.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.57.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.55.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.56.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.55.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.56.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -13982,7 +13982,7 @@ int
 main ()
 {
 
-return strncmp("3.56.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.57.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13992,7 +13992,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.56.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.57.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/configure
+++ b/configure
@@ -13982,7 +13982,7 @@ int
 main ()
 {
 
-return strncmp("3.55.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.56.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -13992,7 +13992,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.55.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.56.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.56.0@gpdb/stable
+orca/v3.57.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.55.0@gpdb/stable
+orca/v3.56.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/src/include/gpopt/utils/COptServer.h
+++ b/src/include/gpopt/utils/COptServer.h
@@ -23,7 +23,6 @@
 #include "gpos/common/CSyncHashtableAccessByIter.h"
 #include "gpos/common/CSyncHashtableIter.h"
 #include "gpos/net/CSocket.h"
-#include "gpos/sync/CSpinlock.h"
 #include "gpos/task/CTask.h"
 
 // forward declarations

--- a/src/include/gpopt/utils/COptServer.h
+++ b/src/include/gpopt/utils/COptServer.h
@@ -91,18 +91,6 @@ namespace gpoptudfs
 
 			};
 
-			typedef CSyncHashtable<SConnectionDescriptor, ULONG_PTR, CSpinlockOS>
-				ConnectionHT;
-
-			typedef CSyncHashtableAccessByKey<SConnectionDescriptor, ULONG_PTR, CSpinlockOS>
-				ConnectionKeyAccessor;
-
-			typedef CSyncHashtableIter<SConnectionDescriptor, ULONG_PTR, CSpinlockOS>
-				ConnectionIter;
-
-			typedef CSyncHashtableAccessByIter<SConnectionDescriptor, ULONG_PTR, CSpinlockOS>
-				ConnectionIterAccessor;
-
 			// path where socket is initialized
 			const CHAR *m_socket_path;
 


### PR DESCRIPTION
The associated GPORCA PRs are:

- https://github.com/greenplum-db/gporca/pull/503 (add project node on top of groupby)
- https://github.com/greenplum-db/gporca/pull/510 (remove multi-threading code)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
