### PR TITLE
Adding a typedef for a type referenced in dead code

### DIFF
--- a/src/include/gpopt/utils/COptServer.h
+++ b/src/include/gpopt/utils/COptServer.h
@@ -91,6 +91,9 @@ namespace gpoptudfs
 
 			};
 
+			typedef CSyncHashtable<SConnectionDescriptor, ULONG_PTR>
+			ConnectionHT;
+
 			// path where socket is initialized
 			const CHAR *m_socket_path;
 


### PR DESCRIPTION
In my earlier PR #8149 I removed some typedefs using the CSpinlockOS
class that no longer exists. However, one of those typedefs, ConnectionHT
was still used in the class. It did not cause any compilation errors,
probably because this class is unused.

To be consistent and to make the code easier to read, this PR adds back
the missing typedef. In the long term we could consider removing the
entire class COptServer.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
