### PR TITLE
Fix perfsummary.py script to recognize new optimizer name in EXPLAIN

### DIFF
--- a/concourse/scripts/perfsummary.py
+++ b/concourse/scripts/perfsummary.py
@@ -192,8 +192,8 @@ class FileState:
                     if myLineNoRows == baseLineNoRows:
                         rows_change_found = True
                     else:
-                        myOptimizer = re.sub(r'Optimizer[ a-z]*:[ a-zA-Z0-9.]*', 'Optimizer:xxx', myLine)
-                        baseOptimizer = re.sub(r'Optimizer[ a-z]*:[ a-zA-Z0-9.]*', 'Optimizer:xxx', baseLine)
+                        myOptimizer = re.sub(r'Optimizer[ a-z]*:.*', 'Optimizer:xxx', myLine)
+                        baseOptimizer = re.sub(r'Optimizer[ a-z]*:.*', 'Optimizer:xxx', baseLine)
                         if myOptimizer != baseOptimizer:
                             # lines are different even with masked-out rows and cost
                             plan_change_found = True


### PR DESCRIPTION
This tool looks at EXPLAIN plans and recognizes the line with the
optimizer version. Recently, we added the string "(GPORCA)" to the
optimizer name.

The fix is to add parentheses to the characters we ignore in this line.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
