### PR TITLE
Remove VCS files from install directories

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -215,6 +215,13 @@ function build_and_test_orca()
     orca_src/concourse/build_and_test.py --build_type=RelWithDebInfo --output_dir=${OUTPUT_DIR}
 }
 
+function check_for_hidden_files() {
+    if find "${GREENPLUM_INSTALL_DIR}" -type f -name ".*" | grep -q "."; then
+        echo "Hidden files found in '${GREENPLUM_INSTALL_DIR}'..."
+        exit 1
+    fi
+}
+
 function _main() {
   mkdir gpdb_src/gpAux/ext
 
@@ -261,6 +268,7 @@ function _main() {
   include_zstd
   include_quicklz
   include_libstdcxx
+  check_for_hidden_files
   export_gpdb
   export_gpdb_extensions
   export_gpdb_win32_ccl

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -110,13 +110,17 @@ install: generate_greenplum_path_file
 	$(MAKE) set_scripts_version prefix=$(prefix)
 	# Remove unwanted files.
 	rm -rf $(DESTDIR)$(prefix)/bin/ext
+	rm -rf $(DESTDIR)$(prefix)/bin/.gitignore
 	rm -rf $(DESTDIR)$(prefix)/bin/pythonSrc
 	rm -rf $(DESTDIR)$(prefix)/bin/Makefile
 	rm -rf $(DESTDIR)$(prefix)/bin/src
 	rm -rf $(DESTDIR)$(prefix)/bin/gppylib
 	rm -rf $(DESTDIR)$(prefix)/bin/gpload_test
+	rm -rf $(DESTDIR)$(prefix)/bin/.rcfile
 	rm -rf $(DESTDIR)$(prefix)/bin/README*
+	rm -rf $(DESTDIR)$(prefix)/bin/lib/.gitignore
 	find $(DESTDIR)$(prefix)/lib/python/gppylib -name test -type d | xargs rm -rf
+	find $(DESTDIR)$(prefix)/lib/python -name .gitignore -type f | xargs rm -rf
 
 clean distclean:
 	$(MAKE) -C bin $@

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -120,7 +120,7 @@ install: generate_greenplum_path_file
 	rm -rf $(DESTDIR)$(prefix)/bin/README*
 	rm -rf $(DESTDIR)$(prefix)/bin/lib/.gitignore
 	find $(DESTDIR)$(prefix)/lib/python/gppylib -name test -type d | xargs rm -rf
-	find $(DESTDIR)$(prefix)/lib/python -name .gitignore -type f | xargs rm -rf
+	find $(DESTDIR)$(prefix)/lib/python -name .gitignore -type f -delete
 
 clean distclean:
 	$(MAKE) -C bin $@


### PR DESCRIPTION
The install target of gpMgmt's Makefile does a full recursive copy and
picks up unnecessary files (e.g., .gitignore). The Makefile already has
a pattern of removing unwanted files. This commit updates the list to
include .gitignore and pylint config files.

Authored-by: Bradford D. Boyle <bboyle@pivotal.io>