### PR TITLE
Backport extra_float_digits GUC maximum increase

### DIFF
--- a/src/backend/utils/adt/float.c
+++ b/src/backend/utils/adt/float.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/utils/adt/float.c,v 1.153.2.1 2009/03/04 22:08:28 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/utils/adt/float.c,v 1.163 2009/09/11 19:17:03 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -320,7 +320,7 @@ float4out(PG_FUNCTION_ARGS)
 				if (ndig < 1)
 					ndig = 1;
 
-				sprintf(ascii, "%.*g", ndig, num);
+				snprintf(ascii, MAXFLOATWIDTH + 1, "%.*g", ndig, num);
 			}
 	}
 
@@ -533,7 +533,7 @@ float8out(PG_FUNCTION_ARGS)
 				if (ndig < 1)
 					ndig = 1;
 
-				sprintf(ascii, "%.*g", ndig, num);
+				snprintf(ascii, MAXDOUBLEWIDTH + 1, "%.*g", ndig, num);
 			}
 	}
 

--- a/src/backend/utils/adt/geo_ops.c
+++ b/src/backend/utils/adt/geo_ops.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/utils/adt/geo_ops.c,v 1.102 2009/06/23 16:25:02 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/utils/adt/geo_ops.c,v 1.105 2009/09/11 19:17:03 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -83,8 +83,8 @@ static Point *line_interpt_internal(LINE *l1, LINE *l2);
 #define RDELIM_C		'>'
 
 /* Maximum number of characters printed by pair_encode() */
-/* ...+2+7 : 2 accounts for extra_float_digits max value */
-#define P_MAXLEN (2*(DBL_DIG+2+7)+1)
+/* ...+3+7 : 3 accounts for extra_float_digits max value */
+#define P_MAXLEN (2*(DBL_DIG+3+7)+1)
 
 
 /*

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1665,7 +1665,7 @@ static struct config_int ConfigureNamesInt[] =
 						 "(FLT_DIG or DBL_DIG as appropriate).")
 		},
 		&extra_float_digits,
-		0, -15, 2, NULL, NULL
+		0, -15, 3, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -444,7 +444,7 @@ log_autostats=off	# print additional autostats information
 					#   India
 					# You can create your own file in
 					# share/timezonesets/.
-#extra_float_digits = 0			# min -15, max 2
+#extra_float_digits = 0			# min -15, max 3
 #client_encoding = sql_ascii		# actually, defaults to database
 					# encoding
 

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -1228,7 +1228,7 @@ dumpMain(bool oids, const char *dumpencoding, int outputBlobs, int plainText, Re
 	 * If supported, set extra_float_digits so that we can dump float data
 	 * exactly (given correctly implemented float I/O code, anyway)
 	 */
-	do_sql_command(g_conn, "SET extra_float_digits TO 2");
+	do_sql_command(g_conn, "SET extra_float_digits TO 3");
 
 	/*
 	 * Let cdb_dump_include functions know whether or not to include

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -27,7 +27,7 @@
  *	http://archives.postgresql.org/pgsql-bugs/2010-02/msg00187.php
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/bin/pg_dump/pg_dump.c,v 1.546 2009/08/04 19:46:51 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/bin/pg_dump/pg_dump.c,v 1.547 2009/09/11 19:17:04 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -794,7 +794,10 @@ main(int argc, char **argv)
 	 * If supported, set extra_float_digits so that we can dump float data
 	 * exactly (given correctly implemented float I/O code, anyway)
 	 */
-	do_sql_command(g_conn, "SET extra_float_digits TO 2");
+	if (g_fout->remoteVersion >= 80500)
+		do_sql_command(g_conn, "SET extra_float_digits TO 3");
+	else if (g_fout->remoteVersion >= 70400)
+		do_sql_command(g_conn, "SET extra_float_digits TO 2");
 
 	/*
 	 * If synchronized scanning is supported, disable it, to prevent


### PR DESCRIPTION
We need this commit for gpbackup to backup float4 values correctly.
Without the extra precision, float4 columns that are being used as the
distribution key may not be backed up correctly for the distribution
hash check during COPY FROM SEGMENT.

As part of this backport, we also changed the logic in cdb_dump which is
Greenplum code.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Jimmy Yih <jyih@pivotal.io>

commit 8c5463a51176c8d2a01fcf154d7ac33fa9a74f6a
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Fri Sep 11 19:17:04 2009 +0000

    Increase the maximum value of extra_float_digits to 3, and have pg_dump
    use that value when the backend is new enough to allow it.  This responds
    to bug report from Keh-Cheng Chu pointing out that although 2 extra digits
    should be sufficient to dump and restore float8 exactly, it is possible to
    need 3 extra digits for float4 values.
