### PR TITLE
Use the correct time unit in BackoffSweeper backend

### DIFF
--- a/src/backend/postmaster/backoff.c
+++ b/src/backend/postmaster/backoff.c
@@ -1208,7 +1208,7 @@ BackoffSweeperLoop(void)
 		/* Sleep a while. */
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-					   gp_resqueue_priority_sweeper_interval * 1000L);
+					   gp_resqueue_priority_sweeper_interval);
 		ResetLatch(&MyProc->procLatch);
 
 		/* emergency bailout if postmaster has died */


### PR DESCRIPTION
Commit bfd1f46cdca853 used the wrong time unit (expect Ms, passed with Us)
in BackoffSweeper backend which makes it cannot re-calculate the CPU shares
in time and the normal backends will sleep more CPU ticks than before in
CHECK_FOR_INTERRUPTS and cause a performance downgrade.
