### PR TITLE
Keep the order of reusing idle gangs

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -359,7 +359,12 @@ cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 		results->resultArray = NULL;
 	}
 
-	/* Recycle or destroy gang accordingly */
+	/*
+	 * Recycle or destroy gang accordingly.
+	 *
+	 * We must recycle them in the reverse order of AllocateGang() to restore
+	 * the original order of the idle gangs.
+	 */
 	foreach(lc, ds->allocatedGangs)
 	{
 		Gang *gp = lfirst(lc);

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -129,6 +129,11 @@ AllocateGang(CdbDispatcherState *ds, GangType type, List *segments)
 	newGang->allocated = true;
 	newGang->type = type;
 
+	/*
+	 * Push to the head of the allocated list, later in
+	 * cdbdisp_destroyDispatcherState() we should recycle them from the head to
+	 * restore the original order of the idle gangs.
+	 */
 	ds->allocatedGangs = lcons(newGang, ds->allocatedGangs);
 	ds->largestGangSize = Max(ds->largestGangSize, newGang->size);
 

--- a/src/test/regress/expected/gang_reuse.out
+++ b/src/test/regress/expected/gang_reuse.out
@@ -1,0 +1,149 @@
+-- This test is to verify the order of reusing idle gangs.
+--
+-- For example:
+-- In the same session,
+-- query 1 has 3 slices and it creates gang B, gang C and gang D.
+-- query 2 has 2 slices, we hope it reuses gang B and gang C instead of other
+-- cases like gang D and gang C.
+--
+-- In this way, the two queries can have the same send-receive port pair. It's
+-- useful in platform like Azure. Because Azure limits the number of different
+-- send-receive port pairs (AKA flow) in a certain time period.
+-- To verify the order we show the gang id in EXPLAIN ANALYZE output when
+-- gp_log_gang is 'debug', turn on this output.
+set gp_log_gang to 'debug';
+set gp_cached_segworkers_threshold to 10;
+set gp_vmem_idle_resource_timeout to '60s';
+set optimizer_enable_motion_broadcast to off;
+create table test_gang_reuse_t1 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- this query will create 3 reader gangs with ids C, D and E, we expect they
+-- will always be reused in the same order
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=6.019..6.019 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=5.614..6.010 rows=3 loops=1)
+         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=3.621..3.621 rows=1 loops=1)
+               ->  Hash Join  (cost=7518.50..87197179.56 rows=212759127 width=0) (never executed)
+                     Hash Cond: (a.c2 = c.c2)
+                     ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=8) (never executed)
+                           Hash Cond: (a.c2 = b.c2)
+                           ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                 Hash Key: a.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+                           ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
+                                 ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                       Hash Key: b.c2
+                                       ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
+                           ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                 Hash Key: c.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+ Planning time: 3.415 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice4)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 19.418 ms
+(27 rows)
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=4.816..4.816 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=3.549..4.806 rows=3 loops=1)
+         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=3.772..3.772 rows=1 loops=1)
+               ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=0) (never executed)
+                     Hash Cond: (a.c2 = b.c2)
+                     ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                           Hash Key: a.c2
+                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
+                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                 Hash Key: b.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+ Planning time: 1.300 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 8.568 ms
+(20 rows)
+
+-- so in this query the gangs C, D and E should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=4.357..4.357 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=3.881..4.346 rows=3 loops=1)
+         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=2.066..2.066 rows=1 loops=1)
+               ->  Hash Join  (cost=7518.50..87197179.56 rows=212759127 width=0) (never executed)
+                     Hash Cond: (a.c2 = c.c2)
+                     ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=8) (never executed)
+                           Hash Cond: (a.c2 = b.c2)
+                           ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                 Hash Key: a.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+                           ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
+                                 ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                       Hash Key: b.c2
+                                       ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
+                           ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                 Hash Key: c.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+ Planning time: 1.931 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice4)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 5.753 ms
+(27 rows)
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=5.047..5.047 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=4.225..5.010 rows=3 loops=1)
+         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=3.209..3.210 rows=1 loops=1)
+               ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=0) (never executed)
+                     Hash Cond: (a.c2 = b.c2)
+                     ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                           Hash Key: a.c2
+                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
+                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                 Hash Key: b.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+ Planning time: 1.231 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 6.223 ms
+(20 rows)
+

--- a/src/test/regress/expected/gang_reuse_optimizer.out
+++ b/src/test/regress/expected/gang_reuse_optimizer.out
@@ -1,0 +1,149 @@
+-- This test is to verify the order of reusing idle gangs.
+--
+-- For example:
+-- In the same session,
+-- query 1 has 3 slices and it creates gang B, gang C and gang D.
+-- query 2 has 2 slices, we hope it reuses gang B and gang C instead of other
+-- cases like gang D and gang C.
+--
+-- In this way, the two queries can have the same send-receive port pair. It's
+-- useful in platform like Azure. Because Azure limits the number of different
+-- send-receive port pairs (AKA flow) in a certain time period.
+-- To verify the order we show the gang id in EXPLAIN ANALYZE output when
+-- gp_log_gang is 'debug', turn on this output.
+set gp_log_gang to 'debug';
+set gp_cached_segworkers_threshold to 10;
+set gp_vmem_idle_resource_timeout to '60s';
+set optimizer_enable_motion_broadcast to off;
+create table test_gang_reuse_t1 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- this query will create 3 reader gangs with ids C, D and E, we expect they
+-- will always be reused in the same order
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.447..4.447 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=3.563..4.437 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.334..4.334 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (never executed)
+                     Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
+                     ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           Hash Key: test_gang_reuse_t1.c2
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                     ->  Hash  (cost=862.00..862.00 rows=1 width=4) (never executed)
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4) (never executed)
+                                 Hash Cond: (test_gang_reuse_t1_1.c2 = test_gang_reuse_t1_2.c2)
+                                 ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                       Hash Key: test_gang_reuse_t1_1.c2
+                                       ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                                       ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                             Hash Key: test_gang_reuse_t1_2.c2
+                                             ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (never executed)
+ Planning time: 82.403 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice4)    Executor memory: 4192K bytes avg x 3 workers, 4192K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Execution time: 26.149 ms
+(27 rows)
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=4.706..4.706 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=4.697..4.700 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=3.688..3.688 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (never executed)
+                     Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
+                     ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           Hash Key: test_gang_reuse_t1.c2
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                 Hash Key: test_gang_reuse_t1_1.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+ Planning time: 12.168 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Execution time: 5.858 ms
+(20 rows)
+
+-- so in this query the gangs C, D and E should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=3.645..3.645 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=2.705..3.632 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.024..4.024 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (never executed)
+                     Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
+                     ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           Hash Key: test_gang_reuse_t1.c2
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                     ->  Hash  (cost=862.00..862.00 rows=1 width=4) (never executed)
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4) (never executed)
+                                 Hash Cond: (test_gang_reuse_t1_1.c2 = test_gang_reuse_t1_2.c2)
+                                 ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                       Hash Key: test_gang_reuse_t1_1.c2
+                                       ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                                       ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                             Hash Key: test_gang_reuse_t1_2.c2
+                                             ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (never executed)
+ Planning time: 44.030 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice4)    Executor memory: 4192K bytes avg x 3 workers, 4192K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Execution time: 6.743 ms
+(27 rows)
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=3.480..3.480 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=3.201..3.473 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=2.975..2.976 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (never executed)
+                     Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
+                     ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           Hash Key: test_gang_reuse_t1.c2
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                 Hash Key: test_gang_reuse_t1_1.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+ Planning time: 9.705 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Execution time: 4.820 ms
+(20 rows)
+

--- a/src/test/regress/explain.pm
+++ b/src/test/regress/explain.pm
@@ -1273,6 +1273,12 @@ sub prune_heavily
     return
         unless (exists($node->{short}));
 
+    # example: (slice1; gang3; segments: 3)
+    if ($node->{short} =~ m/.*\(slice\d+; gang(\d+);.*\).*/)
+    {
+        $node->{gangid} = int($1);
+    }
+
     # example: (slice1; segments: 3)
     if ($node->{short} =~ m/.*\(.*segment.*:\s+(\d+).*\).*/)
     {

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -255,7 +255,7 @@ test: fts_recovery_in_progress
 test: autovacuum-template0
 
 # gpexpand introduce the partial tables, check them if they can run correctly
-test: gangsize
+test: gangsize gang_reuse
 
 # some utilities do not work while doing gpexpand, check them can print correct message
 test: run_utility_gpexpand_phase1

--- a/src/test/regress/sql/gang_reuse.sql
+++ b/src/test/regress/sql/gang_reuse.sql
@@ -1,0 +1,43 @@
+-- This test is to verify the order of reusing idle gangs.
+--
+-- For example:
+-- In the same session,
+-- query 1 has 3 slices and it creates gang B, gang C and gang D.
+-- query 2 has 2 slices, we hope it reuses gang B and gang C instead of other
+-- cases like gang D and gang C.
+--
+-- In this way, the two queries can have the same send-receive port pair. It's
+-- useful in platform like Azure. Because Azure limits the number of different
+-- send-receive port pairs (AKA flow) in a certain time period.
+
+-- To verify the order we show the gang id in EXPLAIN ANALYZE output when
+-- gp_log_gang is 'debug', turn on this output.
+set gp_log_gang to 'debug';
+set gp_cached_segworkers_threshold to 10;
+set gp_vmem_idle_resource_timeout to '60s';
+set optimizer_enable_motion_broadcast to off;
+
+create table test_gang_reuse_t1 (c1 int, c2 int);
+
+-- this query will create 3 reader gangs with ids C, D and E, we expect they
+-- will always be reused in the same order
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+
+-- so in this query the gangs C, D and E should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;


### PR DESCRIPTION
For example:
In the same session,
query 1 has 3 slices and it creates gang 1, gang 2 and gang 3.
query 2 has 2 slices, we hope it reuses gang 1 and gang 2 instead of other
cases like gang 3 and gang 2.

In this way, the two queries can have the same send-receive port pair. It's
useful in platform like Azure. Because Azure limits the number of different
send-receive port pairs (AKA flow) in a certain time period.

Co-authored-by: Hubert Zhang <hzhang@pivotal.io>
Co-authored-by: Paul Guo <pguo@pivotal.io>
Co-authored-by: Ning Yu <nyu@pivotal.io>

This is the master version of https://github.com/greenplum-db/gpdb/pull/8094, tests are also included.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
