### PR TITLE
Fix flaky in query_info_hook_test when interconnect in TCP mode

### DIFF
--- a/src/test/regress/output/query_info_hook_test.source
+++ b/src/test/regress/output/query_info_hook_test.source
@@ -47,13 +47,6 @@ ALTER TABLE queryInfoHookTable1 SET DISTRIBUTED BY (name);
 WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
-WARNING:  Plan node executing node_type: RESULT
-WARNING:  Plan node finished
-WARNING:  Query done
-WARNING:  Query submit
-WARNING:  Query start
-WARNING:  Plan node initializing
-WARNING:  Plan node executing node_type: MOTION
 WARNING:  Plan node finished
 WARNING:  Plan node finished
 WARNING:  Query done
@@ -64,10 +57,6 @@ WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
 WARNING:  Plan node executing node_type: MOTION
-WARNING:  Plan node executing node_type: HASHJOIN
-WARNING:  Plan node executing node_type: HASH
-WARNING:  Plan node finished
-WARNING:  Query done
 WARNING:  Plan node finished
 WARNING:  Plan node finished
 WARNING:  Plan node finished

--- a/src/test/regress/query_info_hook_test/query_info_hook_test.c
+++ b/src/test/regress/query_info_hook_test/query_info_hook_test.c
@@ -1,6 +1,7 @@
 #include "postgres.h"
 
 #include "fmgr.h"
+#include "cdb/cdbvars.h"
 #include "utils/metrics_utils.h"
 #include "nodes/execnodes.h"
 #include "nodes/print.h"
@@ -32,6 +33,11 @@ _PG_fini(void)
 static void
 test_hook(QueryMetricsStatus status, void* args)
 {
+	if (Gp_role != GP_ROLE_DISPATCH)
+		return;
+	if (GpIdentity.segindex > -1)
+		return;
+
 	switch (status)
 	{
 		case METRICS_PLAN_NODE_INITIALIZE:


### PR DESCRIPTION
The goal of query_info_hook_test is to ensure query_info_collect_hook
are placed in porper location for emitting query execution metrics.
This test was flaky due to uncertain order of calling between QD and
QEs when the interconnect in TCP mode.
This fix simply silent all QEs from emitting messages.
This is acceptable from the scope of this test because we just want
to make sure hooks are called at correct timing for a single backend.
It should not be disturbed by query dispatching between QD and QEs.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
