### PR TITLE
Fix gpperfmon misspellings in documentation

### DIFF
--- a/gpdb-doc/dita/admin_guide/perf_troubleshoot.xml
+++ b/gpdb-doc/dita/admin_guide/perf_troubleshoot.xml
@@ -116,7 +116,7 @@ a.current_query
                         href="managing/monitor.xml#topic_slt_ddv_1q"/>.</p>
                 <p>You can enable a dedicated database, <codeph>gpperfmon</codeph>, in which data
                     collection agents running on each segment host save query and system utilization
-                    metrics. Refer to the <codeph>gperfmon_install</codeph> management utility
+                    metrics. Refer to the <codeph>gpperfmon_install</codeph> management utility
                     reference in the <cite>Greenplum Database Management Utility Reference
                         Guide</cite> for help creating the <codeph>gpperfmon</codeph> database and
                     managing the agents. See documentation for the tables and views in the

--- a/gpdb-doc/dita/ref_guide/gpperfmon/dbref.xml
+++ b/gpdb-doc/dita/ref_guide/gpperfmon/dbref.xml
@@ -76,7 +76,7 @@
     </section>
     <section id="section_ok2_wd1_41b">
       <title>Alert Log Processing and Log Rotation</title>
-      <p>When the <codeph>gp_gperfmon_enable</codeph> server configuration parameter is set to true,
+      <p>When the <codeph>gp_enable_gpperfmon</codeph> server configuration parameter is set to true,
         the Greenplum Database syslogger writes alert messages to a <codeph>.csv</codeph> file in
         the <codeph>$MASTER_DATA_DIRECTORY/gpperfmon/logs</codeph> directory. </p>
       <p>The level of messages written to the log can be set to <codeph>none</codeph>,


### PR DESCRIPTION
The correct name of the gpperfmon installation tool is gpperfmon_install and the GUC for enabling it is gp_enable_gpperfmon.