### PR TITLE
Remove deletion of no longer existing files

### DIFF
--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -256,6 +256,3 @@ clean distclean maintainer-clean: clean-lib
 	rm -f $(output_files) $(input_files)
 	rm -rf ./testtablespace ./testtablespace_*
 	rm -rf $(pg_regress_clean_files)
-	rm -f data/pg_class32.data
-	rm -f gmon.out
-	rm -f $(srcdir)/sql/cppudf.sql


### PR DESCRIPTION
The list of files to clean in test/regress contained references to files no longer present.  `pg_class32` was an intermediate file in a test for upgrades from Greenplum 3.2 to 3.3/3.4; `cppudf.sql` was added in an Orca testsuite commit which seems to have never used that file at all; `gmon.out` is an output file generated by `gperf` and all `gperf` invocations have been removed from tests.