### PR TITLE
Find the correct RelOptInfo for subquery when processing SubqueryScan.

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -1772,6 +1772,8 @@ make_three_stage_agg_plan(PlannerInfo *root, MppGroupContext *ctx)
 							 package_plan_as_rte(root, coquery, coplan, eref, NIL, &coroot));
 			ctx->dqaArgs[i].coplan = add_subqueryscan(root, NULL, i + 1, coquery, coplan);
 
+			coplan->subqueryRel = NULL;
+
 			coplans = lappend(coplans, coplan);
 			coroots = lappend(coroots, coroot);
 		}
@@ -4598,6 +4600,8 @@ add_second_stage_agg(PlannerInfo *root,
 
 	result_plan = add_subqueryscan(root, p_current_pathkeys,
 								   1, subquery, result_plan);
+
+	((SubqueryScan *) result_plan)->subplan->subqueryRel = NULL;
 
 	/* Add an Agg node */
 	/* convert current_numGroups to long int */

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1387,6 +1387,9 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 
 	rel->subroot = subroot;
 
+	/* Record the subquery's RelOptInfo */
+	rel->subplan->subqueryRel = rel;
+
 	/* Isolate the params needed by this specific subplan */
 	rel->subplan_params = root->plan_params;
 	root->plan_params = NIL;

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1290,7 +1290,15 @@ set_subqueryscan_references(PlannerInfo *root,
 	Plan	   *result;
 
 	/* Need to look up the subquery's RelOptInfo, since we need its subroot */
-	rel = find_base_rel(root, plan->scan.scanrelid);
+
+	/*
+	 * If this is the subquery formed in set_base_rel_sizes(), we have record
+	 * its RelOptInfo in plan->subqueryRel. Else, we can find its RelOptInfo in
+	 * root->simple_rel_array.
+	 */
+	rel = plan->subplan->subqueryRel;
+	if (!rel)
+		rel = find_base_rel(root, plan->scan.scanrelid);
 	/*
 	 * The Assert() on RelOptInfo's subplan being same as the
 	 * subqueryscan's subplan, is valid in Upstream but not for GPDB,

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -281,6 +281,14 @@ typedef struct Plan
 	 * The parent motion node of a plan node.
 	 */
 	struct Plan *motionNode;
+
+	/*
+	 * CDB: If this is a plan for subquery, we record the subquery's RelOptInfo
+	 * here. It is needed in set_subqueryscan_references(), but due to
+	 * rebuild_simple_rel_and_rte() for multi-phase agg, we cannot find it in
+	 * the root->simple_rel_array, so keep it here.
+	 */
+	struct RelOptInfo *subqueryRel;
 } Plan;
 
 /* ----------------

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -328,3 +328,43 @@ select my_numeric_avg(n) from numerictesttab;
  5.5000000000000000
 (1 row)
 
+-- Test multi-phase aggregate with subquery scan
+create table multiagg_with_subquery (i int, j int, k int) distributed by (i);
+explain (costs off)
+select count(distinct j), count(distinct k) from (select j,k from multiagg_with_subquery group by j,k ) sub group by j;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Hash Join
+         Hash Cond: (NOT (share0_ref2.j IS DISTINCT FROM share0_ref1.j))
+         ->  HashAggregate
+               Group Key: share0_ref2.j
+               ->  HashAggregate
+                     Group Key: share0_ref2.j, share0_ref2.j
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: share0_ref2.j
+                           ->  HashAggregate
+                                 Group Key: share0_ref2.j, share0_ref2.j
+                                 ->  Shared Scan (share slice:id 1:0)
+         ->  Hash
+               ->  HashAggregate
+                     Group Key: share0_ref1.j
+                     ->  HashAggregate
+                           Group Key: share0_ref1.j, share0_ref1.k
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: share0_ref1.j
+                                 ->  HashAggregate
+                                       Group Key: share0_ref1.j, share0_ref1.k
+                                       ->  Shared Scan (share slice:id 3:0)
+                                             ->  Materialize
+                                                   ->  HashAggregate
+                                                         Group Key: multiagg_with_subquery.j, multiagg_with_subquery.k
+                                                         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                                               Hash Key: multiagg_with_subquery.j, multiagg_with_subquery.k
+                                                               ->  HashAggregate
+                                                                     Group Key: multiagg_with_subquery.j, multiagg_with_subquery.k
+                                                                     ->  Seq Scan on multiagg_with_subquery
+ Optimizer: Postgres query optimizer
+(31 rows)
+
+drop table multiagg_with_subquery;

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -134,3 +134,9 @@ CREATE AGGREGATE my_numeric_avg(numeric) (
 create temp table numerictesttab as select g::numeric as n from generate_series(1,10) g;
 
 select my_numeric_avg(n) from numerictesttab;
+
+-- Test multi-phase aggregate with subquery scan
+create table multiagg_with_subquery (i int, j int, k int) distributed by (i);
+explain (costs off)
+select count(distinct j), count(distinct k) from (select j,k from multiagg_with_subquery group by j,k ) sub group by j;
+drop table multiagg_with_subquery;


### PR DESCRIPTION
When making two/three stage aggregate, GPDB needs to rebuild arrays for
RelOptInfo and RangeTblEntry for the PlannerInfo when the underlying
range tables are transformed. To do that, rebuild_simple_rel_and_rte()
just allocates a new memory area for the arrays, without retaining the
original RelOptInfos. As a result, when processing SubqueryScan for
subquery formed in set_base_rel_sizes(), we cannot find its RelOptInfo.

This patch tries to resolve this problem by recording the origin
RelOptInfo for subquery formed in set_base_rel_sizes() in
plan->subqueryRel.

This patch fixes #7413

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
