### PR TITLE
Remove remnants of ignore-header in atmsort/gpdiff

### DIFF
--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -36,7 +36,6 @@ my $cpref = '';
 my $dpref = '';
 
 my $glob_ignore_plans;
-my $glob_ignore_whitespace;
 my @glob_init;
 
 my $glob_orderwarn;
@@ -49,7 +48,6 @@ sub atmsort_init
 {
     my %args = (
         # defaults
-        IGNORE_HEADERS  => 0,
         IGNORE_PLANS    => 0,
         INIT_FILES      => [],
         ORDER_WARN      => 0,
@@ -60,22 +58,18 @@ sub atmsort_init
     );
 
     $glob_ignore_plans        = 0;
-    $glob_ignore_whitespace   = 0;
     @glob_init                = ();
 
     $glob_orderwarn           = 0;
     $glob_verbose             = 0;
     $glob_fqo                 = {count => 0};
 
-    my $ignore_headers;
     my $ignore_plans;
     my @init_file;
     my $verbose;
     my $orderwarn;
 
     $glob_ignore_plans        = $args{IGNORE_PLANS};
-
-    $glob_ignore_whitespace   = $ignore_headers; # XXX XXX: for now
 
     @glob_init = @{$args{INIT_FILES}};
 
@@ -930,26 +924,6 @@ sub format_query_output
     {
         my @ggg= @{$outarr};
 
-        if ($glob_ignore_whitespace)
-        {
-           my @ggg2;
-
-           for my $line (@ggg)
-           {
-              # remove all leading, trailing whitespace (changes sorting)
-              # and whitespace around column separators
-              $line =~ s/^(\s+|\s+$)//;
-              $line =~ s/\|\s+/\|/gm;
-              $line =~ s/\s+\|/\|/gm;
-
-              $line .= "\n" # replace linefeed if necessary
-                unless ($line =~ m/\n$/);
-
-              push @ggg2, $line;
-           }
-           @ggg= @ggg2;
-        }
-
         if ($glob_orderwarn)
         {
             # If no ordering cols specified (no directive), and SELECT has
@@ -998,25 +972,6 @@ sub format_query_output
     {
         my @ggg= sort @{$outarr};
 
-        if ($glob_ignore_whitespace)
-        {
-           my @ggg2;
-
-           for my $line (@ggg)
-           {
-              # remove all leading, trailing whitespace (changes sorting)
-              # and whitespace around column separators
-              $line =~ s/^(\s+|\s+$)//;
-              $line =~ s/\|\s+/\|/gm;
-              $line =~ s/\s+\|/\|/gm;
-
-              $line .= "\n" # replace linefeed if necessary
-                unless ($line =~ m/\n$/);
-
-              push @ggg2, $line;
-           }
-           @ggg= sort @ggg2;
-        }
         for my $line (@ggg)
         {
             print $atmsort_outfh $bpref, $prefix, $line;

--- a/src/test/regress/gpdiff.pl
+++ b/src/test/regress/gpdiff.pl
@@ -41,7 +41,6 @@ on the standard options.  The following options are specific to gpdiff:
     -man                  full documentation
     -version              print gpdiff version and underlying diff version
     -verbose              print verbose info
-    -gpd_ignore_headers   ignore header lines in query output
     -gpd_ignore_plans     ignore explain plan content in input files
     -gpd_init <file>      load initialization file
 
@@ -64,16 +63,6 @@ on the standard options.  The following options are specific to gpdiff:
 =item B<-verbose>
 
     Prints verbose information.
-
-=item B<-gpd_ignore_headers>
-
-gpdiff/atmsort expect PostgreSQL "psql-style" output for SELECT
-statements, with a two line header composed of the column names,
-separated by vertical bars (|), and a "separator" line of dashes and
-pluses beneath, followed by the row output.  The psql utility performs
-some formatting to adjust the column widths to match the size of the
-row output.  Setting this parameter causes gpdiff to ignore any
-differences in the column naming and format widths globally.
 
 =item B<-gpd_ignore_plans>
 
@@ -264,7 +253,6 @@ if (1)
         "help" => sub { lazy_pod2usage(-msg => $pmsg, -exitstatus => 1) },
         "version|v" => \&print_version ,
         "verbose|Verbose" => \$glob_atmsort_args{VERBOSE},
-        "gpd_ignore_headers|gp_ignore_headers" => \$glob_atmsort_args{IGNORE_HEADERS},
         "gpd_ignore_plans|gp_ignore_plans" => \$glob_atmsort_args{IGNORE_PLANS},
         "gpd_init|gp_init_file=s" => \@{$glob_atmsort_args{INIT_FILES}}
     );


### PR DESCRIPTION
Commit 3168a6274ad326a64980385af059d820841cb84c removed support for
ignoring table header whitespace differences in test output, but the
patch was a few bricks shy of a load. There were enough leftover bits
that the option could be invoked, but without it actually working.
This removes the leftovers.

Looking at this it became clear that we had a whitespace ignore which
was dead code, as it couldn't be triggered from the outside. Rather
than trying to revive more cruft in atmsort, this removes the code
since we clearly aren't using it.