### PR TITLE
(5X)Fix bug: initplan may clean up gangs allocated to parent plan

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2862,7 +2862,7 @@ CommitTransaction(void)
 	/* we're now in a consistent state to handle an interrupt. */
 	RESUME_INTERRUPTS();
 
-	freeGangsForPortal(NULL);
+	freeGangsForPortal(NULL, NULL);
 
 	/* Release resource group slot at the end of a transaction */
 	if (ShouldUnassignResGroup())
@@ -3354,7 +3354,7 @@ AbortTransaction(void)
 	 */
 	RESUME_INTERRUPTS();
 
-	freeGangsForPortal(NULL);
+	freeGangsForPortal(NULL, NULL);
 
 	/* If a query was cancelled, then cleanup reader gangs. */
 	if (QueryCancelCleanup)

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1560,7 +1560,7 @@ initTM(void)
 
 		RestoreToUser(olduser);
 
-		freeGangsForPortal(NULL);
+		freeGangsForPortal(NULL, NULL);
 	}
 	else
 	{
@@ -1594,7 +1594,7 @@ initTM(void)
 					Persistent_PostDTMRecv_RemoveHashEntry(MyDatabaseId);
 
 					RestoreToUser(olduser);
-					freeGangsForPortal(NULL);
+					freeGangsForPortal(NULL, NULL);
 				}
 				releaseTmLock();
 			}

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -115,7 +115,7 @@ static bool readerGangsExist(void);
  * @type can be GANGTYPE_ENTRYDB_READER, GANGTYPE_SINGLETON_READER or GANGTYPE_PRIMARY_READER.
  */
 Gang *
-AllocateReaderGang(GangType type, char *portal_name)
+AllocateReaderGang(GangType type, char *portal_name, EState *estate)
 {
 	MemoryContext oldContext = NULL;
 	Gang *gp = NULL;
@@ -193,6 +193,7 @@ AllocateReaderGang(GangType type, char *portal_name)
 
 	/* let the gang know which portal it is being assigned to */
 	gp->portal_name = (portal_name ? pstrdup(portal_name) : (char *) NULL);
+	gp->estate = estate;
 
 	addGangToAllocated(gp);
 
@@ -274,10 +275,12 @@ AllocateWriterGang()
 
 		MemoryContextSwitchTo(oldContext);
 	}
-	
+
 	ELOG_DISPATCHER_DEBUG("AllocateWriterGang end.");
 
 	primaryWriterGang = writerGang;
+	writerGang->estate = NULL;
+
 	return writerGang;
 }
 
@@ -492,6 +495,7 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 	newGangDefinition->noReuse = false;
 	newGangDefinition->dispatcherActive = false;
 	newGangDefinition->portal_name = NULL;
+	newGangDefinition->estate = NULL;
 	newGangDefinition->perGangContext = perGangContext;
 	newGangDefinition->db_descriptors =
 			(SegmentDatabaseDescriptor *) palloc0(size * sizeof(SegmentDatabaseDescriptor));
@@ -1286,6 +1290,13 @@ static bool cleanupGang(Gang *gp)
 {
 	int i = 0;
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR(FreeGangInitPlan) == FaultInjectorTypeSkip &&
+		gp->size == 1 &&
+		gp->type == GANGTYPE_SINGLETON_READER)
+		return false;
+#endif
+
 	ELOG_DISPATCHER_DEBUG("cleanupGang: cleaning gang id %d type %d size %d, "
 			"was used for portal: %s",
 			gp->gang_id, gp->type, gp->size,
@@ -1480,14 +1491,19 @@ void cleanupPortalGangs(Portal portal)
  * cleanupGang() tells us that the gang has a problem, the gang has
  * been free()ed and we should discard it -- otherwise it is good as
  * far as we can tell.
+ *
+ * An extra parameter `estate` is passed to this function:
+ *   - If estate is NULL, the function will try to recyle the gangs
+ *     in the specific portal
+ *   - otherwise, this function only touches those gangs with
+ *     gang->estate same as the parameter.
  */
-void freeGangsForPortal(char *portal_name)
+void freeGangsForPortal(char *portal_name, EState *estate)
 {
 	MemoryContext oldContext;
 	ListCell *cur_item = NULL;
 	ListCell *prev_item = NULL;
 	List *reuseList = NULL;
-
 
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
@@ -1545,7 +1561,21 @@ void freeGangsForPortal(char *portal_name)
 		Gang *gp = (Gang *) lfirst(cur_item);
 		ListCell *next_item = lnext(cur_item);
 
-		if (isTargetPortal(gp->portal_name, portal_name))
+		/*
+		 * When estate is not NULL, we are sure that this
+		 * function is called by ExecutorEnd, and it should
+		 * ingore those gangs not allocated by the specific
+		 * executor context.
+		 *
+		 * Think of a case: main plan contains a initplan,
+		 * and initplan will invoke spi_execute which will
+		 * build a new executor context and allocate gangs.
+		 * When SPI finish executing, it should not touch
+		 * the gangs allocated in the main plan's executor
+		 * context.
+		 */
+		if (isTargetPortal(gp->portal_name, portal_name) &&
+			(estate == NULL || estate == gp->estate))
 		{
 			ELOG_DISPATCHER_DEBUG("Returning a reader N-gang to the available list");
 
@@ -1555,7 +1585,10 @@ void freeGangsForPortal(char *portal_name)
 
 			/* we only return the gang to the available list if it is good */
 			if (cleanupGang(gp))
+			{
+				gp->estate = NULL;
 				reuseList = lappend(reuseList, gp);
+			}
 			else
 				DisconnectAndDestroyGang(gp);
 
@@ -1586,7 +1619,11 @@ void freeGangsForPortal(char *portal_name)
 		Gang *gp = (Gang *) lfirst(cur_item);
 		ListCell *next_item = lnext(cur_item);
 
-		if (isTargetPortal(gp->portal_name, portal_name))
+		/*
+		 * See the comments above for handling allocatedReaderGangsN.
+		 */
+		if (isTargetPortal(gp->portal_name, portal_name) &&
+			(estate == NULL || estate == gp->estate))
 		{
 			ELOG_DISPATCHER_DEBUG("Returning a reader 1-gang to the available list");
 
@@ -1596,7 +1633,10 @@ void freeGangsForPortal(char *portal_name)
 
 			/* we only return the gang to the available list if it is good */
 			if (cleanupGang(gp))
+			{
+				gp->estate = NULL;
 				availableReaderGangs1 = lappend(availableReaderGangs1, gp);
+			}
 			else
 				DisconnectAndDestroyGang(gp);
 

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -203,7 +203,7 @@ static void test__createReaderGang(void **state)
 	mockLibpq(conn, motionListener, qePid);
 
 	cdbgang_setAsync(false);
-	Gang * gang = AllocateReaderGang(GANGTYPE_PRIMARY_READER, portalName);
+	Gang * gang = AllocateReaderGang(GANGTYPE_PRIMARY_READER, portalName, NULL);
 
 	/* validate gang */
 	assert_int_equal(gang->size, TOTOAL_SEGMENTS);

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -336,7 +336,7 @@ PortalCleanup(Portal portal)
 				 */
 				if (Gp_role == GP_ROLE_DISPATCH)
 				{
-					freeGangsForPortal((char *) portal->name);
+					freeGangsForPortal((char *) portal->name, NULL);
 					cleanupPortalGangs(portal);
 				}
 

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1711,7 +1711,7 @@ AssignGangs(QueryDesc *queryDesc)
 			}
 			else
 			{
-				inv.vecNgangs[i] = AllocateReaderGang(GANGTYPE_PRIMARY_READER, queryDesc->portal_name);
+				inv.vecNgangs[i] = AllocateReaderGang(GANGTYPE_PRIMARY_READER, queryDesc->portal_name, estate);
 			}
 		}
 	}
@@ -1720,7 +1720,7 @@ AssignGangs(QueryDesc *queryDesc)
 		inv.vec1gangs_primary_reader = (Gang **) palloc(sizeof(Gang *) * inv.num1gangs_primary_reader);
 		for (i = 0; i < inv.num1gangs_primary_reader; i++)
 		{
-			inv.vec1gangs_primary_reader[i] = AllocateReaderGang(GANGTYPE_SINGLETON_READER, queryDesc->portal_name);
+			inv.vec1gangs_primary_reader[i] = AllocateReaderGang(GANGTYPE_SINGLETON_READER, queryDesc->portal_name, estate);
 		}
 	}
 	if (inv.num1gangs_entrydb_reader > 0)
@@ -1728,7 +1728,7 @@ AssignGangs(QueryDesc *queryDesc)
 		inv.vec1gangs_entrydb_reader = (Gang **) palloc(sizeof(Gang *) * inv.num1gangs_entrydb_reader);
 		for (i = 0; i < inv.num1gangs_entrydb_reader; i++)
 		{
-			inv.vec1gangs_entrydb_reader[i] = AllocateReaderGang(GANGTYPE_ENTRYDB_READER, queryDesc->portal_name);
+			inv.vec1gangs_entrydb_reader[i] = AllocateReaderGang(GANGTYPE_ENTRYDB_READER, queryDesc->portal_name, estate);
 		}
 	}
 
@@ -1762,7 +1762,7 @@ ReleaseGangs(QueryDesc *queryDesc)
 {
 	Assert(queryDesc != NULL);
 
-	freeGangsForPortal(queryDesc->portal_name);
+	freeGangsForPortal(queryDesc->portal_name, queryDesc->estate);
 }
 
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -347,6 +347,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault in FinishPreparedTransaction() after recording the commit prepared record */
 	_("gang_created"),
 		/* inject fault to report ERROR just after creating Gang */
+	_("free_gang_initplan"),
+	/* inject fault to skip when test cleanupGang */
 	_("resgroup_assigned_on_master"),
 		/* inject fault to report ERROR just after resource group is assigned on master */
 	_("before_read_command"),
@@ -1069,6 +1071,7 @@ FaultInjector_NewHashEntry(
 			case CreateResourceGroupFail:
 			case CreateGangInProgress:
 			case GangCreated:
+			case FreeGangInitPlan:
 
 			case DecreaseToastMaxChunkSize:
 			case ProcessStartupPacketFault:

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -54,6 +54,9 @@ typedef struct Gang
 	/* should be destroyed if set */
 	bool noReuse;
 
+	/* the estate that assign this gang */
+	EState	   *estate;
+
 	/* memory context */
 	MemoryContext perGangContext;
 } Gang;
@@ -65,7 +68,7 @@ extern int host_segments;
 extern MemoryContext GangContext;
 extern Gang *CurrentGangCreating;
 
-extern Gang *AllocateReaderGang(GangType type, char *portal_name);
+extern Gang *AllocateReaderGang(GangType type, char *portal_name, EState *estate);
 
 extern Gang *AllocateWriterGang(void);
 
@@ -75,7 +78,7 @@ extern bool GangOK(Gang *gp);
 
 extern List *getCdbProcessesForQD(int isPrimary);
 
-extern void freeGangsForPortal(char *portal_name);
+extern void freeGangsForPortal(char *portal_name, EState *estate);
 
 extern void DisconnectAndDestroyGang(Gang *gp);
 extern void DisconnectAndDestroyAllGangs(bool resetSession);

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -232,6 +232,7 @@ typedef enum FaultInjectorIdentifier_e {
 	FinishPreparedAfterRecordCommitPrepared,
 
 	GangCreated,
+	FreeGangInitPlan,
 
 	ResGroupAssignedOnMaster,
 

--- a/src/test/regress/expected/freegang_initplan.out
+++ b/src/test/regress/expected/freegang_initplan.out
@@ -1,0 +1,47 @@
+create extension if not exists gp_inject_fault;
+create table t_freegang_initplan(c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create or replace function f_freegang_initplan() returns int as
+$$
+begin
+  insert into t_freegang_initplan select * from generate_series(1, 10);
+  return 1;
+end;
+$$
+language plpgsql;
+select gp_inject_fault('free_gang_initplan', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select gp_inject_fault('free_gang_initplan', 'skip', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- the following query will generate initplan, and initplan should not
+-- cleanup gang allocated to parent plan.
+create table t_freegang_initplan_test as select f_freegang_initplan();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'f_freegang_initplan' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select gp_wait_until_triggered_fault('free_gang_initplan', 1, 1);
+NOTICE:  Success:
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t
+(1 row)
+
+select * from t_freegang_initplan_test;
+ f_freegang_initplan 
+---------------------
+                   1
+(1 row)
+
+drop function f_freegang_initplan();
+drop table t_freegang_initplan;
+drop table t_freegang_initplan_test;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -223,4 +223,6 @@ test: oid_wraparound
 
 test: autovacuum-template0
 
+test: freegang_initplan
+
 # end of tests

--- a/src/test/regress/sql/freegang_initplan.sql
+++ b/src/test/regress/sql/freegang_initplan.sql
@@ -1,0 +1,27 @@
+create extension if not exists gp_inject_fault;
+
+create table t_freegang_initplan(c int);
+
+create or replace function f_freegang_initplan() returns int as
+$$
+begin
+  insert into t_freegang_initplan select * from generate_series(1, 10);
+  return 1;
+end;
+$$
+language plpgsql;
+
+select gp_inject_fault('free_gang_initplan', 'reset', 1);
+select gp_inject_fault('free_gang_initplan', 'skip', 1);
+
+-- the following query will generate initplan, and initplan should not
+-- cleanup gang allocated to parent plan.
+create table t_freegang_initplan_test as select f_freegang_initplan();
+
+select gp_wait_until_triggered_fault('free_gang_initplan', 1, 1);
+
+select * from t_freegang_initplan_test;
+
+drop function f_freegang_initplan();
+drop table t_freegang_initplan;
+drop table t_freegang_initplan_test;


### PR DESCRIPTION
When initplan finished, it will call the function freegangsforportal,
this function recycles or destroys the allocated gangs (including
those gangs allocated to parent plan). The might lead to invalid
memory reference when later dispatch parent plan to its gangs.

In this commit, we add a field `dispatched` in the Gang struct,
if this field is false, the gang will not be destroyed.

Co-authored-by: Hubert Zhang <hzhang@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
- [x] Wait for PM's greenlight
