### PR TITLE
docs - can now reset pxf on host and cluster

### DIFF
--- a/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
@@ -105,5 +105,5 @@ Perform the following procedure to reset PXF on each segment host in your Greenp
     gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster reset
     ```
 
-**Note**: After you reset PXF, you must (re)initialize and (re)start PXF to use the service again.
+**Note**: After you reset PXF, you must initialize and start PXF to use the service again.
 

--- a/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
@@ -28,6 +28,8 @@ PXF provides two management commands that you can use for initialization:
 - [`pxf cluster init`](ref/pxf-cluster.html) - initialize all PXF service instances in the Greenplum Database cluster
 - [`pxf init`](ref/pxf.html) - initialize the PXF service instance on the current Greenplum Database host
 
+PXF also provides similar `reset` commands that you can use to reset your PXF configuration.
+
 ## <a id="init_pxf"></a> PXF Configuration Properties
 
 PXF supports both internal and user-customizable configuration properties. Initializing PXF generates PXF internal configuration files, setting default properties specific to your configuration. Initializing PXF also generates configuration file templates for user-customizable settings such as custom profiles and PXF runtime and logging settings.
@@ -39,14 +41,14 @@ PXF internal configuration files are located in your Greenplum Database installa
 During initialization, PXF creates the `$PXF_CONF` directory if necessary, and then populates it with subdirectories and template files. Refer to [PXF User Configuration Directories](about_pxf_dir.html#usercfg) for a list of these directories and their contents.
 
 
-### <a id="init-pxf-prereq" class="no-quick-link"></a>Prerequisites
+## <a id="init-pxf-prereq"></a>Prerequisites
 
 Before initializing PXF in your Greenplum Database cluster, ensure that:
 
 - Your Greenplum Database cluster is up and running.
 - You have identified the PXF user configuration directory filesystem location, `$PXF_CONF`, and that the `gpadmin` user has the necessary permissions to create, or write to, this directory.
  
-### <a id="init-pxf-steps" class="no-quick-link"></a>Procedure
+## <a id="init-pxf-steps"></a>Procedure
 
 Perform the following procedure to initialize PXF on each segment host in your Greenplum Database cluster.
 
@@ -65,4 +67,43 @@ Perform the following procedure to initialize PXF on each segment host in your G
     The `init` command creates the PXF web application and initializes the internal PXF configuration. The `init` command also creates the `$PXF_CONF` user configuration directory if it does not exist, and populates the `conf` and `templates` directories with user-customizable configuration templates. If `$PXF_CONF` exists, PXF updates only the `templates` directory.
 
     **Note**: The PXF service runs only on the segment hosts. However,`pxf cluster init` also sets up the PXF user configuration directories on the Greenplum Database master and standby master hosts.
+
+
+## <a id="pxf-reset"></a>Resetting PXF
+
+Should you need to, you can reset PXF to its uninitialized state. You might choose to reset PXF if you specified an incorrect `PXF_CONF` directory, or if you want to start the initialization procedure from scratch.
+
+When you reset PXF, PXF prompts you to confirm the operation. If you confirm, PXF removes the following runtime files and directories (where `PXF_HOME=$GPHOME/pxf`):
+
+- `$PXF_HOME/conf/pxf-private.classpath`
+- `$PXF_HOME/pxf-service`
+- `$PXF_HOME/run`
+
+PXF does not remove the `$PXF_CONF` directory during a reset operation.
+
+You must stop the PXF service instance on a segment host before you can reset PXF on the host.
+
+### <a id="reset-pxf-steps"></a>Procedure
+
+Perform the following procedure to reset PXF on each segment host in your Greenplum Database cluster.
+
+1. Log in to the Greenplum Database master node:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    ```
+
+2. Stop the PXF service instances on each segment host. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster stop
+    ```
+
+3. Reset the PXF service instances on all Greenplum hosts. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster reset
+    ```
+
+**Note**: After you reset PXF, you must (re)initialize and (re)start PXF to use the service again.
 

--- a/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
@@ -15,6 +15,7 @@ where `<command>` is:
 ``` pre
 help
 init
+reset
 start
 status
 stop
@@ -26,6 +27,7 @@ sync
 The `pxf cluster` utility command manages PXF on the master, standby master, and on all Greenplum Database segment hosts. You can use the utility to:
 
 - Initialize PXF configuration on all hosts in the Greenplum Database cluster.
+- Reset the PXF service instance on all hosts to its uninitialized state.
 - Start and stop the PXF service instance on all segment hosts.
 - Display the status of the PXF service instance on all segment hosts.
 - Synchronize the PXF configuration from the Greenplum Database master host to the standby master and to all segment hosts.
@@ -41,6 +43,9 @@ The `pxf cluster` utility command manages PXF on the master, standby master, and
 
 <dt>init</dt>
 <dd>Initialize the PXF service instance on the master, standby master, and on all segment hosts. When you initialize PXF across your Greenplum Database cluster, you must identify the PXF user configuration directory via an environment variable named `$PXF_CONF`. If you do not set `$PXF_CONF` prior to initializing PXF, PXF returns an error.</dd>
+
+<dt>reset</dt>
+<dd>Reset the PXF service instance on the master, standby master, and on all segment hosts. Resetting removes PXF runtime files and directories, and returns PXF to an uninitialized state. You must stop the PXF service instance running on each segment host before you reset PXF in your Greenplum Database cluster.</dd>
 
 <dt>start</dt>
 <dd>Start the PXF service instance on all segment hosts.</dd>

--- a/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
@@ -16,6 +16,7 @@ where \<command\> is:
 cluster
 help
 init
+reset
 restart
 start
 status
@@ -28,11 +29,11 @@ version
 
 The `pxf` utility manages the PXF configuration and the PXF service instance on the local Greenplum Database host.
 
-You can initialize PXF on the master, master standby, or a specific segment host. You can also synchronize the PXF configuration from the master to these hosts.
+You can initialize or reset PXF on the master, master standby, or a specific segment host. You can also synchronize the PXF configuration from the master to these hosts.
 
 You can start, stop, or restart the PXF service instance on a specific segment host, or display the status of the PXF service instance running on a segment host.
 
-(Use the [`pxf cluster`](pxf-cluster.html#topic1) command to initialize PXF on all hosts, synchronize the PXF configuration to the Greenplum Database cluster, or to start, stop, or display the status of the PXF service instance on all segment hosts in the cluster.)
+(Use the [`pxf cluster`](pxf-cluster.html#topic1) command to initialize or reset PXF on all hosts, synchronize the PXF configuration to the Greenplum Database cluster, or to start, stop, or display the status of the PXF service instance on all segment hosts in the cluster.)
 
 ## <a id="commands"></a>Commands
 
@@ -44,6 +45,9 @@ You can start, stop, or restart the PXF service instance on a specific segment h
 
 <dt>init</dt>
 <dd>Initialize the PXF service instance on the host. When you initialize PXF, you must identify the PXF user configuration directory via an environment variable named `$PXF_CONF`. If you do not set `$PXF_CONF` prior to initializing PXF, PXF prompts you to accept or decline the default user configuration directory, `$HOME/pxf`, during the initialization process. See [Options](pxf.html#options).</dd>
+
+<dt>reset</dt>
+<dd>Reset the PXF service instance running on the host. Resetting removes PXF runtime files and directories, and returns PXF to an uninitialized state. You must stop the PXF service instance running on a segment host before you reset PXF on the host.</dd>
 
 <dt>restart</dt>
 <dd>Restart the PXF service instance running on the segment host.</dd>
@@ -69,6 +73,11 @@ The `pxf init` command takes the following option:
 
 <dt>-y </dt>
 <dd>Do not prompt, use the default `$PXF_CONF` directory location if the environment variable is not set.</dd>
+
+The `pxf reset` command takes the following option:
+
+<dt>-f | --force </dt>
+<dd>Do not prompt before resetting the PXF service instance; reset without user interaction.</dd>
 
 The `pxf sync` command, run on the Greenplum Database master host, takes the following option:
 


### PR DESCRIPTION
docs updates for https://github.com/greenplum-db/pxf/pull/189

doc review site links:
- discussion on initialization page:  http://docs-lisa-pxf-reset.cfapps.io/6-0/pxf/init_pxf.html
- pxf command reference page:  http://docs-lisa-pxf-reset.cfapps.io/6-0/pxf/ref/pxf.html
- pxf cluster command reference page:  http://docs-lisa-pxf-reset.cfapps.io/6-0/pxf/ref/pxf-cluster.html
