### PR TITLE
Turn optimizer_dpe_stats to on

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2186,13 +2186,13 @@ struct config_bool ConfigureNamesBool_gp[] =
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_dpe_stats", PGC_USERSET, LOGGING_WHAT,
+		{"optimizer_dpe_stats", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable statistics derivation for partitioned tables with dynamic partition elimination."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_dpe_stats,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 	{

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -150,29 +150,27 @@ explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                                         QUERY PLAN                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1293.00 rows=2 width=1)
-                     Hash Cond: bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id
-                     ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
-                     ->  Hash  (cost=862.00..862.00 rows=3 width=2)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=3 width=2)
-                                 Hash Key: bfv_tab2_facttable1.wk_id
-                                 ->  Hash Join  (cost=0.00..862.00 rows=3 width=2)
-                                       Hash Cond: bfv_tab2_facttable1.id = bfv_tab2_dimtabl1.id
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=6)
-                                             Hash Key: bfv_tab2_facttable1.id
-                                             ->  Sequence  (cost=0.00..431.00 rows=7 width=6)
-                                                   ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                                         Partitions selected: 20 (out of 20)
-                                                   ->  Dynamic Seq Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=7 width=6)
-                                       ->  Hash  (cost=431.00..431.00 rows=3 width=4)
-                                             ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(20 rows)
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1134.51 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1134.51 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..1134.51 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..1134.51 rows=1 width=1)
+                     Hash Cond: (bfv_tab2_facttable1.wk_id = bfv_tab2_dimdate.wk_id)
+                     ->  Nested Loop  (cost=0.00..703.51 rows=1 width=2)
+                           Join Filter: true
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                 ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..272.51 rows=1 width=2)
+                                 Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                                 ->  Dynamic Bitmap Index Scan on bfv_tab2_facttable1_1_prt_dflt_id_idx  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (id = bfv_tab2_dimtabl1.id)
+                     ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                           ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=10 width=2)
+                                       ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.57.0
+(18 rows)
 
 -- start_ignore
 create language plpythonu;

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -618,7 +618,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 
 select count(*) from range_table where id=1;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
  count 
 -------
      1


### PR DESCRIPTION
This guc allows the optimizer to estimate the cardinality in case of DPE much
more accurately. On the TPC-DS test suite, it improves the execution time for
query 13 from 114s to 28s and for query 48 from 84s to 34s.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
