### PR TITLE
Re-enable `COPY (query) TO` on utility mode

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -7053,7 +7053,7 @@ truncateEolStr(char *str, EolType eol_type)
 static void
 copy_dest_startup(DestReceiver *self __attribute__((unused)), int operation __attribute__((unused)), TupleDesc typeinfo __attribute__((unused)))
 {
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role != GP_ROLE_EXECUTE)
 		return;
 	DR_copy    *myState = (DR_copy *) self;
 	myState->cstate = BeginCopyToOnSegment(myState->queryDesc);
@@ -7082,7 +7082,7 @@ copy_dest_receive(TupleTableSlot *slot, DestReceiver *self)
 static void
 copy_dest_shutdown(DestReceiver *self __attribute__((unused)))
 {
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role != GP_ROLE_EXECUTE)
 		return;
 	DR_copy    *myState = (DR_copy *) self;
 	EndCopyToOnSegment(myState->cstate);
@@ -7111,7 +7111,8 @@ CreateCopyDestReceiver(void)
 	self->pub.rDestroy = copy_dest_destroy;
 	self->pub.mydest = DestCopyOut;
 
-	self->cstate = NULL;		/* will be set later */
+	self->cstate = NULL;		/* need to be set later */
+	self->queryDesc = NULL;		/* need to be set later */
 	self->processed = 0;
 
 	return (DestReceiver *) self;

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -690,6 +690,15 @@ COPY segment_reject_limit_from to PROGRAM STDOUT;
 -- 'COPY (SELECT ...) TO' has supported 'ON SEGMENT'
 COPY (SELECT * FROM segment_reject_limit_from) TO '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT;
 
+-- 'COPY (SELECT ...) TO' on utility mode
+CREATE EXTERNAL WEB TABLE copy_cmd_utility(a text, b int)
+  EXECUTE E'PGOPTIONS="-c gp_session_role=utility" \\
+    psql -p $GP_MASTER_PORT $GP_DATABASE $GP_USER -c \\
+      "COPY (SELECT * FROM pg_class) TO \'/dev/null\'"'
+  ON MASTER FORMAT 'text' (DELIMITER ' ');
+SELECT a FROM copy_cmd_utility;
+DROP EXTERNAL WEB TABLE copy_cmd_utility;
+
 -- SREH is not supported by COPY TO.
 COPY segment_reject_limit_from to STDOUT log errors segment reject limit 3 rows;
 

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -725,6 +725,19 @@ LINE 1: COPY segment_reject_limit_from to PROGRAM STDOUT;
                                                   ^
 -- 'COPY (SELECT ...) TO' has supported 'ON SEGMENT'
 COPY (SELECT * FROM segment_reject_limit_from) TO '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT;
+-- 'COPY (SELECT ...) TO' on utility mode
+CREATE EXTERNAL WEB TABLE copy_cmd_utility(a text, b int)
+  EXECUTE E'PGOPTIONS="-c gp_session_role=utility" \\
+    psql -p $GP_MASTER_PORT $GP_DATABASE $GP_USER -c \\
+      "COPY (SELECT * FROM pg_class) TO \'/dev/null\'"'
+  ON MASTER FORMAT 'text' (DELIMITER ' ');
+SELECT a FROM copy_cmd_utility;
+  a   
+------
+ COPY
+(1 row)
+
+DROP EXTERNAL WEB TABLE copy_cmd_utility;
 -- SREH is not supported by COPY TO.
 COPY segment_reject_limit_from to STDOUT log errors segment reject limit 3 rows;
 ERROR:  COPY single row error handling only available using COPY FROM


### PR DESCRIPTION
It was disabled by accident several months ago while implementing
`COPY (query) TO ON SEGMENT`, re-enable it.

```
commit bad6cebc942ad2abc77b36b4d3a1d55236e33a18
Author: Jinbao Chen <jinchen@pivotal.io>
Date:   Tue Nov 13 12:37:13 2018 +0800

    Support 'copy (select statement) to file on segment' (#6077)
```

WARNING: there are no safety protections on utility mode, it's not
recommended except disaster recovery situation.

Co-authored-by: Weinan WANG <wewang@pivotal.io>