### PR TITLE
Propagate external table format options to PXF headers

### DIFF
--- a/gpcontrib/pxf/test/pxfheaders_test.c
+++ b/gpcontrib/pxf/test/pxfheaders_test.c
@@ -23,6 +23,7 @@
 #include "cmockery.h"
 
 #include "postgres.h"
+#include "nodes/makefuncs.h"
 #include "utils/memutils.h"
 
 /* Define UNIT_TESTING so that the extension can skip declaring PG_MODULE_MAGIC */

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -88,7 +88,6 @@ static int	external_getdata_callback(void *outbuf, int datasize, void *extra);
 static int	external_getdata(URL_FILE *extfile, CopyState pstate, void *outbuf, int maxread);
 static void external_senddata(URL_FILE *extfile, CopyState pstate);
 static void external_scan_error_callback(void *arg);
-static List *parseCopyFormatString(Relation rel, char *fmtstr, char fmttype);
 static void parseCustomFormatString(char *fmtstr, char **formatter_name, List **formatter_params);
 static Oid lookupCustomFormatter(char *formatter_name, bool iswritable);
 static void justifyDatabuf(StringInfo buf);
@@ -98,7 +97,6 @@ static char *get_eol_delimiter(List *params);
 static void external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape,
 				 char *quote, int eol_type, bool header, uint32 scancounter, List *params);
 
-static List *appendCopyEncodingOption(List *copyFmtOpts, int encoding);
 
 /* ----------------------------------------------------------------
 *				   external_ interface functions
@@ -1896,7 +1894,7 @@ strtokx2(const char *s,
 	return start;
 }
 
-static List *
+List *
 parseCopyFormatString(Relation rel, char *fmtstr, char fmttype)
 {
 	char	   *token;
@@ -2314,7 +2312,7 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 	sprintf(extvar->GP_LINE_DELIM_LENGTH, "%d", line_delim_len);
 }
 
-static List *
+List *
 appendCopyEncodingOption(List *copyFmtOpts, int encoding)
 {
 	return lappend(copyFmtOpts, makeDefElem("encoding", (Node *)makeString((char *)pg_encoding_to_char(encoding))));

--- a/src/include/access/fileam.h
+++ b/src/include/access/fileam.h
@@ -92,4 +92,7 @@ extern int popen_with_stderr(int *rwepipe, const char *exe, bool forwrite);
 extern int pclose_with_stderr(int pid, int *rwepipe, StringInfo sinfo);
 extern char *make_command(const char *cmd, extvar_t *ev);
 
+extern List *parseCopyFormatString(Relation rel, char *fmtstr, char fmttype);
+extern List *appendCopyEncodingOption(List *copyFmtOpts, int encoding);
+
 #endif   /* FILEAM_H */


### PR DESCRIPTION
Currently, PXF is not propagating the format options in the external
table framework. In Foreign Data Wrappers, these options are defined at
the foreign table-level and are being propagated to PXF.

In order for the PXF Server to better support both FDW and external
tables we are consistently passing format information from both clients.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
