### PR TITLE
Make Multi-DQA on subquery work.

### DIFF
--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -342,3 +342,71 @@ SELECT DISTINCT distinct_test();
 (1 row)
 
 DROP FUNCTION distinct_test();
+-- Test multi-phase aggregate with subquery scan
+create table multiagg_with_subquery (i int, j int, k int, m int) distributed by (i);
+insert into multiagg_with_subquery select i, i+1, i+2, i+3 from generate_series(1, 10)i;
+explain (costs off)
+select count(distinct j), count(distinct k), count(distinct m) from (select j,k,m from multiagg_with_subquery group by j,k,m ) sub group by j;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)
+   ->  Hash Join
+         Hash Cond: (NOT (share0_ref3.j IS DISTINCT FROM share0_ref1.j))
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.j IS DISTINCT FROM share0_ref2.j))
+               ->  HashAggregate
+                     Group Key: share0_ref3.j
+                     ->  HashAggregate
+                           Group Key: share0_ref3.j, share0_ref3.j
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: share0_ref3.j
+                                 ->  HashAggregate
+                                       Group Key: share0_ref3.j, share0_ref3.j
+                                       ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  HashAggregate
+                           Group Key: share0_ref2.j
+                           ->  HashAggregate
+                                 Group Key: share0_ref2.j, share0_ref2.k
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: share0_ref2.j
+                                       ->  HashAggregate
+                                             Group Key: share0_ref2.j, share0_ref2.k
+                                             ->  Shared Scan (share slice:id 2:0)
+         ->  Hash
+               ->  HashAggregate
+                     Group Key: share0_ref1.j
+                     ->  HashAggregate
+                           Group Key: share0_ref1.j, share0_ref1.m
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                 Hash Key: share0_ref1.j
+                                 ->  HashAggregate
+                                       Group Key: share0_ref1.j, share0_ref1.m
+                                       ->  Shared Scan (share slice:id 4:0)
+                                             ->  Materialize
+                                                   ->  HashAggregate
+                                                         Group Key: multiagg_with_subquery.j, multiagg_with_subquery.k, multiagg_with_subquery.m
+                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                                               Hash Key: multiagg_with_subquery.j, multiagg_with_subquery.k, multiagg_with_subquery.m
+                                                               ->  HashAggregate
+                                                                     Group Key: multiagg_with_subquery.j, multiagg_with_subquery.k, multiagg_with_subquery.m
+                                                                     ->  Seq Scan on multiagg_with_subquery
+ Optimizer: Postgres query optimizer
+(43 rows)
+
+select count(distinct j), count(distinct k), count(distinct m) from (select j,k,m from multiagg_with_subquery group by j,k,m ) sub group by j;
+ count | count | count 
+-------+-------+-------
+     1 |     1 |     1
+     1 |     1 |     1
+     1 |     1 |     1
+     1 |     1 |     1
+     1 |     1 |     1
+     1 |     1 |     1
+     1 |     1 |     1
+     1 |     1 |     1
+     1 |     1 |     1
+     1 |     1 |     1
+(10 rows)
+
+drop table multiagg_with_subquery;

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -146,3 +146,11 @@ $$;
 SELECT DISTINCT distinct_test();
 
 DROP FUNCTION distinct_test();
+
+-- Test multi-phase aggregate with subquery scan
+create table multiagg_with_subquery (i int, j int, k int, m int) distributed by (i);
+insert into multiagg_with_subquery select i, i+1, i+2, i+3 from generate_series(1, 10)i;
+explain (costs off)
+select count(distinct j), count(distinct k), count(distinct m) from (select j,k,m from multiagg_with_subquery group by j,k,m ) sub group by j;
+select count(distinct j), count(distinct k), count(distinct m) from (select j,k,m from multiagg_with_subquery group by j,k,m ) sub group by j;
+drop table multiagg_with_subquery;


### PR DESCRIPTION
When generating plan for multi-DQA, we need to build a coplan on base of
the shared scan for each distinct DQA, and then join the coplans back
together. And while building the coplan for each DQA, the arrays for
RelOptInfo and RangeTblEntry for the PlannerInfo would be rebuild and
the original arrays would have been replaced. So, for the DQA other than
the first one, we need to restore the arrays to what they are like for
the original shared scan plan before building coplan for it.

This patch fixes #7413

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
