### PR TITLE
unset_search_path in CM utilities

### DIFF
--- a/gpAux/gpdemo/gpsegwalrep.py
+++ b/gpAux/gpdemo/gpsegwalrep.py
@@ -366,7 +366,7 @@ class ClusterConfiguration():
         print '%s: fetched cluster configuration' % (datetime.datetime.now())
 
         try:
-            with dbconn.connect(dburl, utility=True) as conn:
+            with dbconn.connect(dburl, utility=True, unsetSearchPath=False) as conn:
                resultsets  = dbconn.execSQL(conn, query).fetchall()
         except Exception, e:
             print e

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -222,7 +222,10 @@ def do_list(skipvalidation):
 def get_gucs_from_database(gucname):
     try:
         dburl = dbconn.DbURL()
-        conn = dbconn.connect(dburl, False)
+        # we always want to unset search path except when getting the
+        # 'search_path' GUC itself
+        unsetSearchPath = gucname != 'search_path'
+        conn = dbconn.connect(dburl, False, unsetSearchPath=unsetSearchPath)
         query = ToolkitQuery(gucname).query
         cursor = dbconn.execSQL(conn, query)
         # we assume that all roles are primary due to the query.

--- a/gpMgmt/bin/gppylib/db/test/regress/test_regress_catalog.py
+++ b/gpMgmt/bin/gppylib/db/test/regress/test_regress_catalog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
+# Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
 # Unit Testing of catalog module.
 #
@@ -20,16 +20,16 @@ logger=gplog.get_default_logger()
 
 @skipIfDatabaseDown()
 class catalogTestCase(unittest.TestCase):
-    
+
     def setUp(self):
         self.dburl=dbconn.DbURL()
-        self.conn = dbconn.connect(self.dburl)
-        
-    
+        self.conn = dbconn.connect(self.dburl, unsetSearchPath=False)
+
+
     def tearDown(self):
         self.conn.close()
         pass
 
 #------------------------------- Mainline --------------------------------
 if __name__ == '__main__':
-    unittest.main()    
+    unittest.main()

--- a/gpMgmt/bin/gppylib/db/test/test_catalog.py
+++ b/gpMgmt/bin/gppylib/db/test/test_catalog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
+# Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
 # Unit Testing of catalog module.
 #
@@ -20,16 +20,16 @@ logger=gplog.get_default_logger()
 
 @skipIfDatabaseDown()
 class catalogTestCase(unittest.TestCase):
-    
+
     def setUp(self):
         self.dburl=dbconn.DbURL()
-        self.conn = dbconn.connect(self.dburl)
-        
-    
+        self.conn = dbconn.connect(self.dburl, unsetSearchPath=False)
+
+
     def tearDown(self):
         self.conn.close()
         pass
-    
+
 #------------------------------- Mainline --------------------------------
 if __name__ == '__main__':
-    unittest.main()    
+    unittest.main()

--- a/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
+++ b/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
@@ -58,6 +58,19 @@ class ConnectTestCase(unittest.TestCase):
 
         self.assertEqual(actual, encoding)
 
+    def test_secure_search_path_set(self):
+
+        with dbconn.connect(self.url) as conn:
+            result = dbconn.execSQLForSingleton(conn, "SELECT setting FROM pg_settings WHERE name='search_path'")
+
+        self.assertEqual(result, '')
+
+    def test_secure_search_path_not_set(self):
+
+        with dbconn.connect(self.url, unsetSearchPath=False) as conn:
+            result = dbconn.execSQLForSingleton(conn, "SELECT setting FROM pg_settings WHERE name='search_path'")
+
+        self.assertEqual(result, '"$user",public')
 
 if __name__ == '__main__':
     unittest.main()

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -32,7 +32,7 @@ def before_feature(context, feature):
         create_database(context, 'incr_analyze')
         drop_database_if_exists(context, 'incr_analyze_2')
         create_database(context, 'incr_analyze_2')
-        context.conn = dbconn.connect(dbconn.DbURL(dbname='incr_analyze'))
+        context.conn = dbconn.connect(dbconn.DbURL(dbname='incr_analyze'), unsetSearchPath=False)
         context.dbname = 'incr_analyze'
 
         # setting up the tables that will be used
@@ -48,7 +48,7 @@ def before_feature(context, feature):
         minirepro_db = 'minireprodb'
         drop_database_if_exists(context, minirepro_db)
         create_database(context, minirepro_db)
-        context.conn = dbconn.connect(dbconn.DbURL(dbname=minirepro_db))
+        context.conn = dbconn.connect(dbconn.DbURL(dbname=minirepro_db), unsetSearchPath=False)
         context.dbname = minirepro_db
         dbconn.execSQL(context.conn, 'create table t1(a integer, b integer)')
         dbconn.execSQL(context.conn, 'create table t2(c integer, d integer)')

--- a/gpMgmt/test/behave/mgmt_utils/steps/analyzedb_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/analyzedb_mgmt_utils.py
@@ -213,7 +213,7 @@ def impl(context, mod_count, table, schema, dbname):
 
 @then('root stats are populated for partition table "{tablename}" for database "{dbname}"')
 def impl(context, tablename, dbname):
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         query = "select count(*) from pg_statistic where starelid='%s'::regclass;" % tablename
         num_tuples = dbconn.execSQLForSingleton(conn, query)
         if num_tuples == 0:
@@ -230,7 +230,7 @@ def get_mod_count_in_state_file(dbname, schema, table):
 
 
 def create_long_lived_conn(context, dbname):
-    context.long_lived_conn = dbconn.connect(dbconn.DbURL(dbname=dbname))
+    context.long_lived_conn = dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)
 
 
 def table_found_in_state_file(dbname, qualified_table):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -86,7 +86,7 @@ def make_data_directory_called(data_directory_name):
 
 
 def _get_mirror_count():
-    with dbconn.connect(dbconn.DbURL(dbname='template1')) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
         sql = """SELECT count(*) FROM gp_segment_configuration WHERE role='m'"""
         count_row = dbconn.execSQL(conn, sql).fetchone()
         return count_row[0]

--- a/gpMgmt/test/behave_utils/cluster_expand.py
+++ b/gpMgmt/test/behave_utils/cluster_expand.py
@@ -73,7 +73,7 @@ class Gpexpand:
     def get_redistribute_status(self):
         sql = 'select status from gpexpand.status order by updated desc limit 1'
         dburl = dbconn.DbURL(dbname=self.database)
-        conn = dbconn.connect(dburl, encoding='UTF8')
+        conn = dbconn.connect(dburl, encoding='UTF8', unsetSearchPath=False)
         status = dbconn.execSQLForSingleton(conn, sql)
         if status == 'EXPANSION COMPLETE':
             rc = 0

--- a/gpMgmt/test/behave_utils/gpexpand_dml.py
+++ b/gpMgmt/test/behave_utils/gpexpand_dml.py
@@ -29,7 +29,7 @@ class TestDML(threading.Thread):
         self.prepare()
 
     def run(self):
-        conn = dbconn.connect(dbconn.DbURL(dbname=self.dbname))
+        conn = dbconn.connect(dbconn.DbURL(dbname=self.dbname), unsetSearchPath=False)
 
         self.loop(conn)
         self.verify(conn)
@@ -46,7 +46,7 @@ class TestDML(threading.Thread):
             ) DISTRIBUTED BY (c1);
         '''.format(tablename=self.tablename)
 
-        conn = dbconn.connect(dbconn.DbURL(dbname=self.dbname))
+        conn = dbconn.connect(dbconn.DbURL(dbname=self.dbname), unsetSearchPath=False)
         dbconn.execSQL(conn, sql)
 
         self.prepare_extra(conn)

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -31,7 +31,7 @@ if master_data_dir is None:
 def execute_sql(dbname, sql):
     result = None
 
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         result = dbconn.execSQL(conn, sql)
         conn.commit()
 
@@ -39,7 +39,7 @@ def execute_sql(dbname, sql):
 
 def execute_sql_singleton(dbname, sql):
     result = None
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         result = dbconn.execSQLForSingleton(conn, sql)
 
     if result is None:
@@ -204,7 +204,7 @@ def stop_database(context):
 
 def stop_primary(context, content_id):
     get_psegment_sql = 'select datadir, hostname from gp_segment_configuration where content=%i and role=\'p\';' % content_id
-    with dbconn.connect(dbconn.DbURL(dbname='template1')) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
         cur = dbconn.execSQL(conn, get_psegment_sql)
         rows = cur.fetchall()
         seg_data_dir = rows[0][0]
@@ -227,14 +227,14 @@ def run_gprecoverseg():
 
 
 def getRows(dbname, exec_sql):
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         curs = dbconn.execSQL(conn, exec_sql)
         results = curs.fetchall()
     return results
 
 
 def getRow(dbname, exec_sql):
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         curs = dbconn.execSQL(conn, exec_sql)
         result = curs.fetchone()
     return result
@@ -244,7 +244,7 @@ def check_db_exists(dbname, host=None, port=0, user=None):
     LIST_DATABASE_SQL = 'SELECT datname FROM pg_database'
 
     results = []
-    with dbconn.connect(dbconn.DbURL(hostname=host, username=user, port=port, dbname='template1')) as conn:
+    with dbconn.connect(dbconn.DbURL(hostname=host, username=user, port=port, dbname='template1'), unsetSearchPath=False) as conn:
         curs = dbconn.execSQL(conn, LIST_DATABASE_SQL)
         results = curs.fetchall()
 
@@ -259,7 +259,7 @@ def create_database_if_not_exists(context, dbname, host=None, port=0, user=None)
     if not check_db_exists(dbname, host, port, user):
         create_database(context, dbname, host, port, user)
     context.dbname = dbname
-    context.conn = dbconn.connect(dbconn.DbURL(dbname=context.dbname))
+    context.conn = dbconn.connect(dbconn.DbURL(dbname=context.dbname), unsetSearchPath=False)
 
 def create_database(context, dbname=None, host=None, port=0, user=None):
     LOOPS = 10
@@ -294,7 +294,7 @@ def get_segment_hostnames(context, dbname):
 
 
 def check_table_exists(context, dbname, table_name, table_type=None, host=None, port=0, user=None):
-    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname), unsetSearchPath=False) as conn:
         if '.' in table_name:
             schemaname, tablename = table_name.split('.')
             SQL_format = """
@@ -347,14 +347,14 @@ def drop_external_table_if_exists(context, table_name, dbname):
 
 def drop_table_if_exists(context, table_name, dbname, host=None, port=0, user=None):
     SQL = 'drop table if exists %s' % table_name
-    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname), unsetSearchPath=False) as conn:
         dbconn.execSQL(conn, SQL)
         conn.commit()
 
 
 def drop_external_table(context, table_name, dbname, host=None, port=0, user=None):
     SQL = 'drop external table %s' % table_name
-    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname), unsetSearchPath=False) as conn:
         dbconn.execSQL(conn, SQL)
         conn.commit()
 
@@ -365,7 +365,7 @@ def drop_external_table(context, table_name, dbname, host=None, port=0, user=Non
 
 def drop_table(context, table_name, dbname, host=None, port=0, user=None):
     SQL = 'drop table %s' % table_name
-    with dbconn.connect(dbconn.DbURL(hostname=host, username=user, port=port, dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(hostname=host, username=user, port=port, dbname=dbname), unsetSearchPath=False) as conn:
         dbconn.execSQL(conn, SQL)
         conn.commit()
 
@@ -387,7 +387,7 @@ def drop_schema_if_exists(context, schema_name, dbname):
 
 def drop_schema(context, schema_name, dbname):
     SQL = 'drop schema %s cascade' % schema_name
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         dbconn.execSQL(conn, SQL)
         conn.commit()
     if check_schema_exists(context, schema_name, dbname):
@@ -445,7 +445,7 @@ def create_external_partition(context, tablename, dbname, port, filename):
 
     drop_table_str = "Drop table %s_ret;" % (tablename)
 
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         dbconn.execSQL(conn, create_table_str)
         dbconn.execSQL(conn, create_ext_table_str)
         dbconn.execSQL(conn, alter_table_str)
@@ -484,7 +484,7 @@ def create_partition(context, tablename, storage_type, dbname, compression_type=
 
     create_table_str = create_table_str + ";"
 
-    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname), unsetSearchPath=False) as conn:
         dbconn.execSQL(conn, create_table_str)
         conn.commit()
 
@@ -499,7 +499,7 @@ def populate_partition(tablename, start_date, dbname, data_offset, rowcount=1094
     insert_sql_str += "; insert into %s select i+%d, 'restore', i + date '%s' from generate_series(0,%d) as i" % (
     tablename, data_offset, start_date, rowcount)
 
-    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname), unsetSearchPath=False) as conn:
         dbconn.execSQL(conn, insert_sql_str)
         conn.commit()
 
@@ -508,7 +508,7 @@ def create_indexes(context, table_name, indexname, dbname):
     btree_index_sql = "create index btree_%s on %s using btree(column1);" % (indexname, table_name)
     bitmap_index_sql = "create index bitmap_%s on %s using bitmap(column3);" % (indexname, table_name)
     index_sql = btree_index_sql + bitmap_index_sql
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         dbconn.execSQL(conn, index_sql)
         conn.commit()
     validate_index(context, table_name, dbname)
@@ -524,7 +524,7 @@ def validate_index(context, table_name, dbname):
 def create_schema(context, schema_name, dbname):
     if not check_schema_exists(context, schema_name, dbname):
         schema_sql = "create schema %s" % schema_name
-        with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+        with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
             dbconn.execSQL(conn, schema_sql)
             conn.commit()
 
@@ -547,7 +547,7 @@ def create_int_table(context, table_name, table_type='heap', dbname='testdb'):
         raise Exception('Invalid table type specified')
 
     SELECT_TABLE_SQL = 'select count(*) from %s' % table_name
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         dbconn.execSQL(conn, CREATE_TABLE_SQL)
         conn.commit()
 
@@ -605,7 +605,7 @@ def check_row_count(context, tablename, dbname, nrows):
     else:
         dburl = dbconn.DbURL(dbname=dbname)
 
-    with dbconn.connect(dburl) as conn:
+    with dbconn.connect(dburl, unsetSearchPath=False) as conn:
         result = dbconn.execSQLForSingleton(conn, NUM_ROWS_QUERY)
     if result != nrows:
         raise Exception('%d rows in table %s.%s, expected row count = %d' % (result, dbname, tablename, nrows))
@@ -697,7 +697,7 @@ def create_dir(host, directory):
 def check_count_for_specific_query(dbname, query, nrows):
     NUM_ROWS_QUERY = '%s' % query
     # We want to bubble up the exception so that if table does not exist, the test fails
-    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
         result = dbconn.execSQLForSingleton(conn, NUM_ROWS_QUERY)
     if result != nrows:
         raise Exception('%d rows in query: %s. Expected row count = %d' % (result, query, nrows))
@@ -709,7 +709,7 @@ def get_primary_segment_host_port():
     """
     FIRST_PRIMARY_DBID = 2
     get_psegment_sql = 'select hostname, port from gp_segment_configuration where dbid=%i;' % FIRST_PRIMARY_DBID
-    with dbconn.connect(dbconn.DbURL(dbname='template1')) as conn:
+    with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
         cur = dbconn.execSQL(conn, get_psegment_sql)
         rows = cur.fetchall()
         primary_seg_host = rows[0][0]
@@ -779,7 +779,7 @@ def wait_for_unblocked_transactions(context, num_retries=150):
     attempt = 0
     while attempt < num_retries:
         try:
-            with dbconn.connect(dbconn.DbURL()) as conn:
+            with dbconn.connect(dbconn.DbURL(), unsetSearchPath=False) as conn:
                 # Cursor.execute() will issue an implicit BEGIN for us.
                 # Empty block of 'BEGIN' and 'END' won't start a distributed transaction,
                 # execute a DDL query to start a distributed transaction.


### PR DESCRIPTION
For commands called directly by the user, we provide the fix.

Since Behave and unit tests are supposed to behave as a normal user, we do not provide the fix.  The fix is supposed to be done by the commands themselves, and we want to test with an unmodified search_path in the actual tests.

All commits that are part of this PR will be squashed into one before merging into master, as this is one logical commit.

I am including @pivotal-ning-yu because we explicitly change the search_path for all `dbconn.connect()` statements under the assumption that that code explicitly schema-qualifies all references, but we wanted a review for that.

The apparently out-of-place commit `Behave CLI tests: use n1-standard-2 for ccp clusters` is because we say many failures in the Behave CLI tests with that setting.  We believe this PR is unrelated to that failure, but we include it here so our test pipeline will pass and not hide additional failures we might have caused.  I have tagged @pivotal-pa-toolsmiths so they can look just at this commit and provide feedback on any negative implications.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
