### PR TITLE
Complete FDW write (from master only)

### DIFF
--- a/contrib/pxf_fdw/pxf_fdw.h
+++ b/contrib/pxf_fdw/pxf_fdw.h
@@ -53,17 +53,6 @@ typedef struct PxfOptions
 								 * pxf_host, and pxf_protocol */
 }			PxfOptions;
 
-/*
- * FDW-specific information for ForeignScanState.fdw_state.
- */
-typedef struct PxfFdwExecutionState
-{
-	CopyState	cstate;			/* state of reading from PXF */
-	PxfOptions *options;		/* FDW options */
-	ProjectionInfo *proj_info;	/* Projection information */
-	List	   *quals;			/* Qualifiers for the query */
-}			PxfFdwExecutionState;
-
 /* Functions prototypes for pxf_option.c file */
 PxfOptions *PxfGetOptions(Oid foreigntableid);
 

--- a/contrib/pxf_fdw/pxf_fragment.c
+++ b/contrib/pxf_fdw/pxf_fragment.c
@@ -31,11 +31,11 @@ static void pxf_array_element_end(void *state, bool isnull);
  * Returns selected fragments that have been allocated to the current segment
  */
 List *
-getFragmentList(PxfOptions * options,
-				Relation relation,
-				char *filter_string,
-				ProjectionInfo *proj_info,
-				List *quals)
+GetFragmentList(PxfOptions *options,
+                Relation relation,
+                char *filter_string,
+                ProjectionInfo *proj_info,
+                List *quals)
 {
 	List	   *data_fragments;
 

--- a/contrib/pxf_fdw/pxf_fragment.h
+++ b/contrib/pxf_fdw/pxf_fragment.h
@@ -69,7 +69,7 @@ typedef struct FragmentData
 /*
  * Gets the fragments for the given uri location
  */
-extern List *getFragmentList(PxfOptions * options, Relation relation, char *filter_string, ProjectionInfo *proj_info, List *quals);
+extern List *GetFragmentList(PxfOptions * options, Relation relation, char *filter_string, ProjectionInfo *proj_info, List *quals);
 
 /*
  * Frees the given fragment

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -146,9 +146,6 @@ static const char BinarySignature[11] = "PGCOPY\n\377\r\n\0";
 
 
 /* non-export function prototypes */
-static CopyState BeginCopy(bool is_from, Relation rel, Node *raw_query,
-						   const char *queryString, List *attnamelist, List *options,
-						   TupleDesc tupDesc);
 static void EndCopy(CopyState cstate);
 static CopyState BeginCopyTo(Relation rel, Node *query, const char *queryString,
 							 const char *filename, bool is_program, List *attnamelist,
@@ -1723,7 +1720,7 @@ ProcessCopyOptions(CopyState cstate,
  * If in the text format, delimit columns with delimiter <delim> and print
  * NULL values as <null_print>.
  */
-static CopyState
+CopyState
 BeginCopy(bool is_from,
 		  Relation rel,
 		  Node *raw_query,

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -286,6 +286,9 @@ extern CopyState BeginCopyFrom(Relation rel, const char *filename,
 			  bool is_program, copy_data_source_cb data_source_cb,
 			  void *data_source_cb_extra,
 			  List *attnamelist, List *options, List *ao_segnos);
+extern CopyState BeginCopy(bool is_from, Relation rel, Node *raw_query,
+						   const char *queryString, List *attnamelist, List *options,
+						   TupleDesc tupDesc);
 extern CopyState
 BeginCopyToOnSegment(QueryDesc *queryDesc);
 extern void EndCopyToOnSegment(CopyState cstate);


### PR DESCRIPTION
This required adding a new function in `copy`:

extern CopyState BeginCopyToForeignTable(Relation forrel, List *options);

this is parallel with the existing one for external tables:

extern CopyState BeginCopyToForExternalTable(Relation extrel, List *options);

BeginCopyToForeignTable does much the same as
BeginCopyToForExternalTable, just checks for Foreign relation, not
external.

Merge PxfContext with PxfFdwScanState

Co-authored-by: Oliver Albertini <oalbertini@pivotal.io>
Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>
