### PR TITLE
Fix compile issue for PyGreSQL on MacOS.

### DIFF
--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/setup.py
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/setup.py
@@ -109,10 +109,13 @@ include_dirs = ['include', pg_include_dir,  pg_include_dir_server]
 pg_libdir = pg_config('libdir')
 library_dirs = [pg_libdir]
 
-libraries=['pq']
+libraries = ['pq']
+extra_compile_args = ['-O2']
 
 if sys.platform == "win32":
     include_dirs.append(os.path.join(pg_include_dir_server, 'port/win32'))
+elif sys.platform == 'darwin' and sys.maxsize > 2**32:
+    extra_compile_args.extend(['-arch', 'x86_64'])
 
 setup(
     name="PyGreSQL",
@@ -135,7 +138,7 @@ setup(
         include_dirs = include_dirs,
         library_dirs = library_dirs,
         libraries = libraries,
-        extra_compile_args = ['-O2']
+        extra_compile_args = extra_compile_args
     )],
     classifiers=[
         "Development Status :: 6 - Mature",


### PR DESCRIPTION
When building file `_pg.so` on MacOS platform, distutil will invoke
clang compiler with arguments `-arch x86_64 -arch i386`. But type
`int128` is not available for i386 architecture, thus following error occurs:

```
In file included from pgmodule.c:32:
In file included from include/postgres.h:47:
include/c.h:427:9: error: __int128 is not supported on this target
typedef PG_INT128_TYPE int128
        ^
include/pg_config.h:838:24: note: expanded from macro 'PG_INT128_TYPE'
                       ^
In file included from pgmodule.c:32:
In file included from include/postgres.h:47:
include/c.h:433:18: error: __int128 is not supported on this target
```

By adding `['-arch', 'x86_64']` into `extra_compile_args`, distutil will
remove `-arch i386` from compiler arguments, thus fixes compile error.

