### PR TITLE
5X: Add tests for idle gang reusing order

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -42,6 +42,7 @@
 #include "utils/tuplesort.h"
 #include "utils/tuplesort_mk.h"
 #include "cdb/cdbdisp.h"                /* CheckDispatchResult() */
+#include "cdb/cdbgang.h"                /* Gang */
 #include "cdb/cdbexplain.h"             /* cdbexplain_recvExecStats */
 #include "cdb/cdbpartition.h"
 #include "cdb/cdbpullup.h"              /* cdbpullup_targetlist() */
@@ -811,6 +812,9 @@ appendGangAndDirectDispatchInfo(StringInfo str, PlanState *planstate, int sliceI
 		{
 			int numSegments;
 			appendStringInfo(str, "  (slice%d;", sliceId);
+
+			if (slice->primaryGang && gp_log_gang >= GPVARS_VERBOSITY_DEBUG)
+				appendStringInfo(str, " gang%d;", slice->primaryGang->gang_id);
 
 			if (slice->directDispatch.isDirectDispatch)
 			{

--- a/src/test/regress/expected/gang_reuse.out
+++ b/src/test/regress/expected/gang_reuse.out
@@ -1,0 +1,197 @@
+-- This test is to verify the order of reusing idle gangs.
+--
+-- For example:
+-- In the same session,
+-- query 1 has 3 slices and it creates gang B, gang C and gang D.
+-- query 2 has 2 slices, we hope it reuses gang B and gang C instead of other
+-- cases like gang D and gang C.
+--
+-- In this way, the two queries can have the same send-receive port pair. It's
+-- useful in platform like Azure. Because Azure limits the number of different
+-- send-receive port pairs (AKA flow) in a certain time period.
+-- To verify the order we show the gang id in EXPLAIN ANALYZE output when
+-- gp_log_gang is 'debug', turn on this output.
+set gp_log_gang to 'debug';
+set gp_cached_segworkers_threshold to 10;
+set gp_vmem_idle_resource_timeout to '60s';
+set optimizer_enable_motion_broadcast to off;
+create table test_gang_reuse_t1 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- this query will create 3 reader gangs with ids C, D and E, we expect they
+-- will always be reused in the same order
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=9695775.68..9695775.69 rows=1 width=8)
+   Rows out:  1 rows with 5.290 ms to end.
+   ->  Gather Motion 3:1  (slice4; gang1; segments: 3)  (cost=9695775.62..9695775.67 rows=1 width=8)
+         Rows out:  3 rows at destination with 3.393 ms to first row, 5.276 ms to end.
+         ->  Aggregate  (cost=9695775.62..9695775.63 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 3.209 ms to first row, 3.210 ms to end.
+               ->  Hash Join  (cost=7518.50..8100082.16 rows=212759127 width=0)
+                     Hash Cond: a.c2 = b.c2
+                     Rows out:  0 rows (seg0) with 3.581 ms to end.
+                     ->  Hash Join  (cost=3759.25..99322.62 rows=2471070 width=8)
+                           Hash Cond: a.c2 = c.c2
+                           Rows out:  (No row requested) 0 rows (seg0) with 0 ms to end.
+                           ->  Redistribute Motion 3:3  (slice1; gang2; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                 Hash Key: a.c2
+                                 Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                                 ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4)
+                                       Rows out:  0 rows (seg0) with 0.039 ms to end.
+                           ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4)
+                                 Rows in:  (No row requested) 0 rows (seg0) with 0 ms to end.
+                                 ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                       Hash Key: c.c2
+                                       Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                                       ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4)
+                                             Rows out:  0 rows (seg0) with 0.038 ms to end.
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4)
+                           Rows in:  0 rows (seg0) with 0.007 ms to end, start offset by 16 ms.
+                           ->  Redistribute Motion 3:3  (slice3; gang4; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                 Hash Key: b.c2
+                                 Rows out:  0 rows at destination (seg0) with 0.006 ms to end.
+                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4)
+                                       Rows out:  0 rows (seg0) with 0.039 ms to end.
+ Slice statistics:
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 183K bytes avg x 3 workers, 183K bytes max (seg0).
+   (slice2)    Executor memory: 183K bytes avg x 3 workers, 183K bytes max (seg0).
+   (slice3)    Executor memory: 183K bytes avg x 3 workers, 183K bytes max (seg0).
+   (slice4)    Executor memory: 4331K bytes avg x 3 workers, 4331K bytes max (seg0).
+ Statement statistics:
+   Memory used: 128000K bytes
+ Optimizer status: legacy query optimizer
+ Total runtime: 18.173 ms
+(41 rows)
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=117855.72..117855.73 rows=1 width=8)
+   Rows out:  1 rows with 5.035 ms to end.
+   ->  Gather Motion 3:1  (slice3; gang1; segments: 3)  (cost=117855.65..117855.70 rows=1 width=8)
+         Rows out:  3 rows at destination with 3.929 ms to first row, 5.021 ms to end.
+         ->  Aggregate  (cost=117855.65..117855.66 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 4.779 ms to end.
+               ->  Hash Join  (cost=3759.25..99322.62 rows=2471070 width=0)
+                     Hash Cond: a.c2 = b.c2
+                     Rows out:  0 rows (seg0) with 4.777 ms to end.
+                     ->  Redistribute Motion 3:3  (slice1; gang2; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                           Hash Key: a.c2
+                           Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4)
+                                 Rows out:  0 rows (seg0) with 0.018 ms to end.
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4)
+                           Rows in:  0 rows (seg0) with 0.715 ms to end, start offset by 3.835 ms.
+                           ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                 Hash Key: b.c2
+                                 Rows out:  0 rows at destination (seg0) with 0.714 ms to end.
+                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4)
+                                       Rows out:  0 rows (seg0) with 0.018 ms to end.
+ Slice statistics:
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice2)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice3)    Executor memory: 8363K bytes avg x 3 workers, 8363K bytes max (seg0).
+ Statement statistics:
+   Memory used: 128000K bytes
+ Optimizer status: legacy query optimizer
+ Total runtime: 6.204 ms
+(30 rows)
+
+-- so in this query the gangs C, D and E should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=9695775.68..9695775.69 rows=1 width=8)
+   Rows out:  1 rows with 2.958 ms to first row, 2.959 ms to end.
+   ->  Gather Motion 3:1  (slice4; gang1; segments: 3)  (cost=9695775.62..9695775.67 rows=1 width=8)
+         Rows out:  3 rows at destination with 2.201 ms to first row, 2.947 ms to end.
+         ->  Aggregate  (cost=9695775.62..9695775.63 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 2.310 ms to end.
+               ->  Hash Join  (cost=7518.50..8100082.16 rows=212759127 width=0)
+                     Hash Cond: a.c2 = b.c2
+                     Rows out:  0 rows (seg0) with 2.732 ms to end.
+                     ->  Hash Join  (cost=3759.25..99322.62 rows=2471070 width=8)
+                           Hash Cond: a.c2 = c.c2
+                           Rows out:  (No row requested) 0 rows (seg0) with 0 ms to end.
+                           ->  Redistribute Motion 3:3  (slice1; gang2; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                 Hash Key: a.c2
+                                 Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                                 ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4)
+                                       Rows out:  0 rows (seg0) with 0.012 ms to end.
+                           ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4)
+                                 Rows in:  (No row requested) 0 rows (seg0) with 0 ms to end.
+                                 ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                       Hash Key: c.c2
+                                       Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                                       ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4)
+                                             Rows out:  0 rows (seg0) with 0.012 ms to end.
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4)
+                           Rows in:  0 rows (seg0) with 1.279 ms to end, start offset by 2.221 ms.
+                           ->  Redistribute Motion 3:3  (slice3; gang4; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                 Hash Key: b.c2
+                                 Rows out:  0 rows at destination (seg0) with 1.278 ms to end.
+                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4)
+                                       Rows out:  0 rows (seg0) with 0.014 ms to end.
+ Slice statistics:
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice2)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice3)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice4)    Executor memory: 4331K bytes avg x 3 workers, 4331K bytes max (seg0).
+ Statement statistics:
+   Memory used: 128000K bytes
+ Optimizer status: legacy query optimizer
+ Total runtime: 4.583 ms
+(41 rows)
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=117855.72..117855.73 rows=1 width=8)
+   Rows out:  1 rows with 4.315 ms to end.
+   ->  Gather Motion 3:1  (slice3; gang1; segments: 3)  (cost=117855.65..117855.70 rows=1 width=8)
+         Rows out:  3 rows at destination with 3.083 ms to first row, 4.302 ms to end.
+         ->  Aggregate  (cost=117855.65..117855.66 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 2.793 ms to end.
+               ->  Hash Join  (cost=3759.25..99322.62 rows=2471070 width=0)
+                     Hash Cond: a.c2 = b.c2
+                     Rows out:  0 rows (seg0) with 3.941 ms to end.
+                     ->  Redistribute Motion 3:3  (slice1; gang2; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                           Hash Key: a.c2
+                           Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4)
+                                 Rows out:  0 rows (seg0) with 0.012 ms to end.
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4)
+                           Rows in:  0 rows (seg0) with 1.351 ms to end, start offset by 2.359 ms.
+                           ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4)
+                                 Hash Key: b.c2
+                                 Rows out:  0 rows at destination (seg0) with 1.349 ms to end.
+                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4)
+                                       Rows out:  0 rows (seg0) with 0.015 ms to end.
+ Slice statistics:
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice2)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice3)    Executor memory: 8363K bytes avg x 3 workers, 8363K bytes max (seg0).
+ Statement statistics:
+   Memory used: 128000K bytes
+ Optimizer status: legacy query optimizer
+ Total runtime: 5.753 ms
+(30 rows)
+

--- a/src/test/regress/expected/gang_reuse_optimizer.out
+++ b/src/test/regress/expected/gang_reuse_optimizer.out
@@ -1,0 +1,197 @@
+-- This test is to verify the order of reusing idle gangs.
+--
+-- For example:
+-- In the same session,
+-- query 1 has 3 slices and it creates gang B, gang C and gang D.
+-- query 2 has 2 slices, we hope it reuses gang B and gang C instead of other
+-- cases like gang D and gang C.
+--
+-- In this way, the two queries can have the same send-receive port pair. It's
+-- useful in platform like Azure. Because Azure limits the number of different
+-- send-receive port pairs (AKA flow) in a certain time period.
+-- To verify the order we show the gang id in EXPLAIN ANALYZE output when
+-- gp_log_gang is 'debug', turn on this output.
+set gp_log_gang to 'debug';
+set gp_cached_segworkers_threshold to 10;
+set gp_vmem_idle_resource_timeout to '60s';
+set optimizer_enable_motion_broadcast to off;
+create table test_gang_reuse_t1 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- this query will create 3 reader gangs with ids C, D and E, we expect they
+-- will always be reused in the same order
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   Rows out:  1 rows with 0.033 ms to end.
+   ->  Gather Motion 3:1  (slice4; gang1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
+         Rows out:  3 rows at destination with 0.015 ms to first row, 0.020 ms to end.
+         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 42 ms to end.
+               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
+                     Hash Cond: public.test_gang_reuse_t1.c2 = public.test_gang_reuse_t1.c2
+                     Rows out:  0 rows (seg0) with 42 ms to end.
+                     ->  Redistribute Motion 3:3  (slice1; gang2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           Hash Key: public.test_gang_reuse_t1.c2
+                           Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                           ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                 Rows out:  0 rows (seg0) with 0.052 ms to end.
+                     ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+                           Rows in:  0 rows (seg0) with 39 ms to end, start offset by 175 ms.
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: public.test_gang_reuse_t1.c2 = public.test_gang_reuse_t1.c2
+                                 Rows out:  0 rows (seg0) with 39 ms to end.
+                                 ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                       Hash Key: public.test_gang_reuse_t1.c2
+                                       Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                                       ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                             Rows out:  0 rows (seg0) with 0.043 ms to end.
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       Rows in:  0 rows (seg0) with 36 ms to end, start offset by 177 ms.
+                                       ->  Redistribute Motion 3:3  (slice3; gang4; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             Hash Key: public.test_gang_reuse_t1.c2
+                                             Rows out:  0 rows at destination (seg0) with 36 ms to end.
+                                             ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                                   Rows out:  0 rows (seg0) with 0.072 ms to end.
+ Slice statistics:
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice2)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice3)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice4)    Executor memory: 8443K bytes avg x 3 workers, 8443K bytes max (seg0).
+ Statement statistics:
+   Memory used: 128000K bytes
+ Optimizer status: PQO version 3.55.0
+ Total runtime: 565.611 ms
+(41 rows)
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8)
+   Rows out:  1 rows with 0.066 ms to end.
+   ->  Gather Motion 3:1  (slice3; gang1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+         Rows out:  3 rows at destination with 0.038 ms to first row, 0.043 ms to end.
+         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 31 ms to end.
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1)
+                     Hash Cond: public.test_gang_reuse_t1.c2 = public.test_gang_reuse_t1.c2
+                     Rows out:  0 rows (seg0) with 31 ms to end.
+                     ->  Redistribute Motion 3:3  (slice1; gang2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           Hash Key: public.test_gang_reuse_t1.c2
+                           Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                           ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                 Rows out:  0 rows (seg0) with 0.014 ms to end.
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           Rows in:  0 rows (seg0) with 26 ms to end, start offset by 62 ms.
+                           ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 Hash Key: public.test_gang_reuse_t1.c2
+                                 Rows out:  0 rows at destination (seg0) with 26 ms to end.
+                                 ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                       Rows out:  0 rows (seg0) with 0.014 ms to end.
+ Slice statistics:
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice2)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice3)    Executor memory: 8363K bytes avg x 3 workers, 8363K bytes max (seg0).
+ Statement statistics:
+   Memory used: 128000K bytes
+ Optimizer status: PQO version 3.55.0
+ Total runtime: 355.137 ms
+(30 rows)
+
+-- so in this query the gangs C, D and E should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   Rows out:  1 rows with 0.040 ms to end.
+   ->  Gather Motion 3:1  (slice4; gang1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
+         Rows out:  3 rows at destination with 0.020 ms to first row, 0.025 ms to end.
+         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 42 ms to end.
+               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
+                     Hash Cond: public.test_gang_reuse_t1.c2 = public.test_gang_reuse_t1.c2
+                     Rows out:  0 rows (seg0) with 42 ms to end.
+                     ->  Redistribute Motion 3:3  (slice1; gang2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           Hash Key: public.test_gang_reuse_t1.c2
+                           Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                           ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                 Rows out:  0 rows (seg0) with 0.014 ms to end.
+                     ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+                           Rows in:  0 rows (seg0) with 39 ms to end, start offset by 81 ms.
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: public.test_gang_reuse_t1.c2 = public.test_gang_reuse_t1.c2
+                                 Rows out:  0 rows (seg0) with 39 ms to end.
+                                 ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                       Hash Key: public.test_gang_reuse_t1.c2
+                                       Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                                       ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                             Rows out:  0 rows (seg0) with 0.014 ms to end.
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       Rows in:  0 rows (seg0) with 36 ms to end, start offset by 82 ms.
+                                       ->  Redistribute Motion 3:3  (slice3; gang4; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             Hash Key: public.test_gang_reuse_t1.c2
+                                             Rows out:  0 rows at destination (seg0) with 36 ms to end.
+                                             ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                                   Rows out:  0 rows (seg0) with 0.015 ms to end.
+ Slice statistics:
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice2)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice3)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice4)    Executor memory: 8443K bytes avg x 3 workers, 8443K bytes max (seg0).
+ Statement statistics:
+   Memory used: 128000K bytes
+ Optimizer status: PQO version 3.55.0
+ Total runtime: 470.906 ms
+(41 rows)
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8)
+   Rows out:  1 rows with 0.055 ms to end.
+   ->  Gather Motion 3:1  (slice3; gang1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+         Rows out:  3 rows at destination with 0.017 ms to first row, 0.022 ms to end.
+         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 31 ms to end.
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1)
+                     Hash Cond: public.test_gang_reuse_t1.c2 = public.test_gang_reuse_t1.c2
+                     Rows out:  0 rows (seg0) with 31 ms to end.
+                     ->  Redistribute Motion 3:3  (slice1; gang2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           Hash Key: public.test_gang_reuse_t1.c2
+                           Rows out:  (No row requested) 0 rows at destination (seg0) with 0 ms to end.
+                           ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                 Rows out:  0 rows (seg0) with 0.051 ms to end.
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           Rows in:  0 rows (seg0) with 26 ms to end, start offset by 62 ms.
+                           ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 Hash Key: public.test_gang_reuse_t1.c2
+                                 Rows out:  0 rows at destination (seg0) with 26 ms to end.
+                                 ->  Table Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4)
+                                       Rows out:  0 rows (seg0) with 0.014 ms to end.
+ Slice statistics:
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice2)    Executor memory: 171K bytes avg x 3 workers, 171K bytes max (seg0).
+   (slice3)    Executor memory: 8363K bytes avg x 3 workers, 8363K bytes max (seg0).
+ Statement statistics:
+   Memory used: 128000K bytes
+ Optimizer status: PQO version 3.55.0
+ Total runtime: 356.684 ms
+(30 rows)
+

--- a/src/test/regress/explain.pm
+++ b/src/test/regress/explain.pm
@@ -1385,6 +1385,12 @@ sub prune_heavily
     return
         unless (exists($node->{short}));
 
+    # example: (slice1; gang3; segments: 3)
+    if ($node->{short} =~ m/.*\(slice\d+; gang(\d+);.*\).*/)
+    {
+        $node->{gangid} = int($1);
+    }
+
     if ($node->{short} =~ m/Delete\s*\(slice.*segment.*\)\s*\(row.*width.*\)/)
     {
         # QA-1309: fix strange DELETE operator formatting

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -19,7 +19,7 @@ test: gp_metadata variadic_parameters default_parameters function_extensions spi
 
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table gp_create_view resource_queue_with_rule
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions
-test: bitmap_index gp_dump_query_oids analyze gp_owner_permission incremental_analyze
+test: bitmap_index gp_dump_query_oids analyze gp_owner_permission incremental_analyze gang_reuse
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules
 # dispatch should always run seperately from other cases.
 test: dispatch

--- a/src/test/regress/sql/gang_reuse.sql
+++ b/src/test/regress/sql/gang_reuse.sql
@@ -1,0 +1,43 @@
+-- This test is to verify the order of reusing idle gangs.
+--
+-- For example:
+-- In the same session,
+-- query 1 has 3 slices and it creates gang B, gang C and gang D.
+-- query 2 has 2 slices, we hope it reuses gang B and gang C instead of other
+-- cases like gang D and gang C.
+--
+-- In this way, the two queries can have the same send-receive port pair. It's
+-- useful in platform like Azure. Because Azure limits the number of different
+-- send-receive port pairs (AKA flow) in a certain time period.
+
+-- To verify the order we show the gang id in EXPLAIN ANALYZE output when
+-- gp_log_gang is 'debug', turn on this output.
+set gp_log_gang to 'debug';
+set gp_cached_segworkers_threshold to 10;
+set gp_vmem_idle_resource_timeout to '60s';
+set optimizer_enable_motion_broadcast to off;
+
+create table test_gang_reuse_t1 (c1 int, c2 int);
+
+-- this query will create 3 reader gangs with ids C, D and E, we expect they
+-- will always be reused in the same order
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;
+
+-- so in this query the gangs C, D and E should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+  join test_gang_reuse_t1 c using (c2)
+;
+
+-- so in this query the gangs C and D should be used
+explain analyze select count(*) from test_gang_reuse_t1 a
+  join test_gang_reuse_t1 b using (c2)
+;


### PR DESCRIPTION
In commit bef41d287239729e0e4d0d6aa0ea22ca51de1efb we improved the idle
gang reusing order, now we add tests for it.

Co-authored-by: Paul Guo <pguo@pivotal.io>
Co-authored-by: Ning Yu <nyu@pivotal.io>
(cherry picked from commit 51a7ea27f9f55088ff08b9cda7d356a62c5fb0df)

## Background
Weeks ago we committed bef41d287239729e0e4d0d6aa0ea22ca51de1efb on 5X_STABLE branch directly to fix an urgent bug.  Tests were not added at that time.

Later we ported it to master branch with tests in 51a7ea27f9f55088ff08b9cda7d356a62c5fb0df.  Now we backport the tests to 5X_STABLE branch to complete the normal workflow.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
