### PR TITLE
Rid resource group on hashagg spill evaluation

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -314,9 +314,7 @@ makeHashAggEntryForInput(AggState *aggstate, TupleTableSlot *inputslot, uint32 h
 
 	if (GET_TOTAL_USED_SIZE(hashtable) + MAXALIGN(MAXALIGN(tup_len) + aggs_len) >=
 		hashtable->max_mem)
-	{
-			return NULL;
-	}
+		return NULL;
 
 	/*
 	 * Form memtuple into group_buf.
@@ -362,9 +360,7 @@ makeHashAggEntryForGroup(AggState *aggstate, void *tuple_and_aggs,
 	MemoryContext oldcxt;
 
 	if (GET_TOTAL_USED_SIZE(hashtable) + input_size >= hashtable->max_mem)
-	{
-			return NULL;
-	}
+		return NULL;
 
 	copy_tuple_and_aggs = mpool_alloc(hashtable->group_buf, input_size);
 	memcpy(copy_tuple_and_aggs, tuple_and_aggs, input_size);

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -315,22 +315,7 @@ makeHashAggEntryForInput(AggState *aggstate, TupleTableSlot *inputslot, uint32 h
 	if (GET_TOTAL_USED_SIZE(hashtable) + MAXALIGN(MAXALIGN(tup_len) + aggs_len) >=
 		hashtable->max_mem)
 	{
-		if (IsResGroupEnabled())
-		{
-			elog(HHA_MSG_LVL,
-				 "HashAgg: no enough operator memory to store new tuple: "
-				 "operator memory is %.0f bytes, "
-				 "current used size is %.0f bytes, "
-				 "need %lu bytes to store the new tuple; "
-				 "the overuse is allowed in resource group mode",
-				 hashtable->max_mem,
-				 GET_TOTAL_USED_SIZE(hashtable),
-				 MAXALIGN(MAXALIGN(tup_len) + aggs_len));
-		}
-		else
-		{
 			return NULL;
-		}
 	}
 
 	/*
@@ -378,22 +363,7 @@ makeHashAggEntryForGroup(AggState *aggstate, void *tuple_and_aggs,
 
 	if (GET_TOTAL_USED_SIZE(hashtable) + input_size >= hashtable->max_mem)
 	{
-		if (IsResGroupEnabled())
-		{
-			elog(HHA_MSG_LVL,
-				 "HashAgg: no enough operator memory to store new group keys and aggregate values: "
-				 "operator memory is %.0f bytes, "
-				 "current used size is %.0f bytes, "
-				 "need %d bytes to store the new data; "
-				 "the overuse is allowed in resource group mode",
-				 hashtable->max_mem,
-				 GET_TOTAL_USED_SIZE(hashtable),
-				 input_size);
-		}
-		else
-		{
 			return NULL;
-		}
 	}
 
 	copy_tuple_and_aggs = mpool_alloc(hashtable->group_buf, input_size);


### PR DESCRIPTION
Resource group believe memory access speed always faster than disk,
and it adds hashagg executor node spill mechanism into its memory management.
If the hash table size overwhelms `max_mem`, in resource group model, the hash
table does not spill and fan out data. Resource group wants to grant more memory
for the hash table. However, this strategy impact hash collision rate, so that
some performance regression in some OLAP query.

We rid resource group guc when hashagg evaluate if it needs to spill.

Co-authored-by: Adam Li <ali@pivotal.io>


