### PR TITLE
6X: Fix memory quota calculation of aggregation

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2276,7 +2276,8 @@ uint64 PlanStateOperatorMemKB(const PlanState *ps)
 	{
 		if (IsA(ps, AggState))
 		{
-			result = ps->plan->operatorMemKB + MemoryAccounting_RequestQuotaIncrease();
+			/* Retrieve all relinquished memory (quota the other node not using) */
+			result = ps->plan->operatorMemKB + (MemoryAccounting_RequestQuotaIncrease() >> 10);
 		}
 		else
 			result = ps->plan->operatorMemKB;


### PR DESCRIPTION
MemoryAccounting_RequestQuotaIncrease() returns a number in bytes, but
here expects kB.

(cherry picked from commit 79c83ea1de71123e499902f5aca0c632c31695f2)

This is the 6X version of #8162
