### PR TITLE
Fix aocs table block version mismatch

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -448,6 +448,7 @@ aocs_beginscan_internal(Relation relation,
 						TupleDesc relationTupleDesc, bool *proj)
 {
 	AOCSScanDesc scan;
+	Form_pg_attribute att;
 	int			nvp;
 	int			i;
 
@@ -483,7 +484,8 @@ aocs_beginscan_internal(Relation relation,
 	scan->num_proj_atts = 0;
 	for (i = 0; i < scan->relationTupleDesc->natts; i++)
 	{
-		if (proj[i])
+		att = scan->relationTupleDesc->attrs[i];
+		if (proj[i] && !att->attisdropped)
 			scan->proj_atts[scan->num_proj_atts++] = i;
 	}
 

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -448,7 +448,6 @@ aocs_beginscan_internal(Relation relation,
 						TupleDesc relationTupleDesc, bool *proj)
 {
 	AOCSScanDesc scan;
-	Form_pg_attribute att;
 	int			nvp;
 	int			i;
 
@@ -484,8 +483,7 @@ aocs_beginscan_internal(Relation relation,
 	scan->num_proj_atts = 0;
 	for (i = 0; i < scan->relationTupleDesc->natts; i++)
 	{
-		att = scan->relationTupleDesc->attrs[i];
-		if (proj[i] && !att->attisdropped)
+		if (proj[i])
 			scan->proj_atts[scan->num_proj_atts++] = i;
 	}
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14662,11 +14662,11 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 					/* bound of -1 are fine because this has no effect on data */
 					tname->arrayBounds = lappend(tname->arrayBounds,
 												 makeInteger(-1));
-
-				/* Per column encoding settings */
-				if (col_encs)
-					cd->encoding = col_encs[attno];
 			}
+
+			/* Per column encoding settings */
+			if (col_encs)
+				cd->encoding = col_encs[attno];
 
 			tname->location = -1;
 			cd->typeName = tname;

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -770,3 +770,20 @@ reset enable_indexscan;
 -- (e.g. column_compression).
 set client_min_messages='WARNING';
 drop schema aocs_addcol cascade;
+-- Test case: alter column on table with dummy columns
+-- Given we have an AOCS table with columns using rle_type compression.
+create table aocs_with_compress(a smallint, b smallint, c smallint) with (appendonly=true, orientation=column, compresstype=rle_type);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into aocs_with_compress values (1, 1, 1), (2, 2, 2);
+-- And we drop one of those columns from the table.
+alter table aocs_with_compress drop column b;
+-- When we reorganize the table, which creates a dummy column without
+-- compresstype to represent the dropped column.
+alter table aocs_with_compress set with (reorganize=true);
+-- Then we can still successfully alter a column type, which requires scan to
+-- skip dummy column whose compresstype is different than segfile on disk.
+-- Since compresstype can decide AOCO block version, validation checks
+-- comparing a dummy column with the segfile would otherwise reveal version
+-- mismatches.
+alter table aocs_with_compress alter column c type integer;

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -770,20 +770,14 @@ reset enable_indexscan;
 -- (e.g. column_compression).
 set client_min_messages='WARNING';
 drop schema aocs_addcol cascade;
--- Test case: alter column on table with dummy columns
--- Given we have an AOCS table with columns using rle_type compression.
+-- Test case: alter column on a table after reorganize
+-- For an AOCS table with columns using rle_type compression, the
+-- implementation of 'reorganize' at 62d66c063fd did not set compression type
+-- for dropped columns. This led to an error 'Bad datum stream Dense block
+-- version'.
 create table aocs_with_compress(a smallint, b smallint, c smallint) with (appendonly=true, orientation=column, compresstype=rle_type);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into aocs_with_compress values (1, 1, 1), (2, 2, 2);
--- And we drop one of those columns from the table.
 alter table aocs_with_compress drop column b;
--- When we reorganize the table, which creates a dummy column without
--- compresstype to represent the dropped column.
 alter table aocs_with_compress set with (reorganize=true);
--- Then we can still successfully alter a column type, which requires scan to
--- skip dummy column whose compresstype is different than segfile on disk.
--- Since compresstype can decide AOCO block version, validation checks
--- comparing a dummy column with the segfile would otherwise reveal version
--- mismatches.
+-- The following operation must not fail
 alter table aocs_with_compress alter column c type integer;

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -433,3 +433,19 @@ reset enable_indexscan;
 -- (e.g. column_compression).
 set client_min_messages='WARNING';
 drop schema aocs_addcol cascade;
+
+-- Test case: alter column on table with dummy columns
+-- Given we have an AOCS table with columns using rle_type compression.
+create table aocs_with_compress(a smallint, b smallint, c smallint) with (appendonly=true, orientation=column, compresstype=rle_type);
+insert into aocs_with_compress values (1, 1, 1), (2, 2, 2);
+-- And we drop one of those columns from the table.
+alter table aocs_with_compress drop column b;
+-- When we reorganize the table, which creates a dummy column without
+-- compresstype to represent the dropped column.
+alter table aocs_with_compress set with (reorganize=true);
+-- Then we can still successfully alter a column type, which requires scan to
+-- skip dummy column whose compresstype is different than segfile on disk.
+-- Since compresstype can decide AOCO block version, validation checks
+-- comparing a dummy column with the segfile would otherwise reveal version
+-- mismatches.
+alter table aocs_with_compress alter column c type integer;

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -434,18 +434,15 @@ reset enable_indexscan;
 set client_min_messages='WARNING';
 drop schema aocs_addcol cascade;
 
--- Test case: alter column on table with dummy columns
--- Given we have an AOCS table with columns using rle_type compression.
+-- Test case: alter column on a table after reorganize
+-- For an AOCS table with columns using rle_type compression, the
+-- implementation of 'reorganize' at 62d66c063fd did not set compression type
+-- for dropped columns. This led to an error 'Bad datum stream Dense block
+-- version'.
 create table aocs_with_compress(a smallint, b smallint, c smallint) with (appendonly=true, orientation=column, compresstype=rle_type);
 insert into aocs_with_compress values (1, 1, 1), (2, 2, 2);
--- And we drop one of those columns from the table.
 alter table aocs_with_compress drop column b;
--- When we reorganize the table, which creates a dummy column without
--- compresstype to represent the dropped column.
 alter table aocs_with_compress set with (reorganize=true);
--- Then we can still successfully alter a column type, which requires scan to
--- skip dummy column whose compresstype is different than segfile on disk.
--- Since compresstype can decide AOCO block version, validation checks
--- comparing a dummy column with the segfile would otherwise reveal version
--- mismatches.
+-- The following operation must not fail
 alter table aocs_with_compress alter column c type integer;
+


### PR DESCRIPTION
Issue is that drop column followed by reorganize leads to loss of column
encoding settings of dropped column. When the column's compresstype
encoding is incorrect, we can encounter block version mismatch error
later during block info validation check of the dropped column.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>