### PR TITLE
Add --tablespace-dir option to pg_regress

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -93,6 +93,7 @@ _stringlist *dblist = NULL;
 bool		debug = false;
 char	   *inputdir = ".";
 char	   *outputdir = ".";
+char	   *tablespacedir = ".";
 char	   *prehook = "";
 char	   *psqldir = PGBINDIR;
 char	   *launcher = NULL;
@@ -774,7 +775,7 @@ convert_sourcefiles_in(char *source_subdir, char *dest_dir, char *dest_subdir, c
 	if (!directory_exists(dest_subdir))
 		make_directory(dest_subdir);
 
-	snprintf(testtablespace, MAXPGPATH, "%s/testtablespace", outputdir);
+	snprintf(testtablespace, MAXPGPATH, "%s/testtablespace", tablespacedir);
 
 #ifdef WIN32
 
@@ -2750,6 +2751,7 @@ help(void)
 	printf(_("                            UAO row and column tests\n"));
 	printf(_("  --ignore-plans            ignore any explain plan diffs\n"));
 	printf(_("  --print-failure-diffs     Print the diff file to standard out after a failure\n"));
+	printf(_("  --tablespace-dir=DIR      place tablespace files in DIR/testtablespace (default \"./testtablespace\")\n"));
 	printf(_("\n"));
 	printf(_("Options for \"temp-install\" mode:\n"));
 	printf(_("  --extra-install=DIR       additional directory to install (e.g., contrib)\n"));
@@ -2805,6 +2807,7 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 		{"ignore-plans", no_argument, NULL, 28},
 		{"prehook", required_argument, NULL, 29},
 		{"print-failure-diffs", no_argument, NULL, 30},
+		{"tablespace-dir", required_argument, NULL, 80},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -2940,6 +2943,9 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 			case 30:
 				print_failure_diffs_is_enabled = true;
 				break;
+			case 80:
+				tablespacedir = strdup(optarg);
+				break;
 			default:
 				/* getopt_long already emitted a complaint */
 				fprintf(stderr, _("\nTry \"%s -h\" for more information.\n"),
@@ -2979,6 +2985,7 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 	inputdir = make_absolute_path(inputdir);
 	outputdir = make_absolute_path(outputdir);
 	dlpath = make_absolute_path(dlpath);
+	tablespacedir = make_absolute_path(tablespacedir);
 
 	/*
 	 * Initialization


### PR DESCRIPTION
This allows a user to specify regress options to consistently make
isolation2 tests for pg_basebackup_with_tablespaces pass.

Currently, the tests fail if the user's source directory creates
a tablespace location directory path that is longer than the 100
character limit for pg_basebackup to add a tablespace location
directory to the backup.

Before:

    isolation2.sh --load-extension=gp_inject_fault --print-failure-diffs pg_basebackup_with_tablespaces

```
============== running regression test queries        ==============
test pg_basebackup_with_tablespaces ... FAILED

======================
 1 of 1 tests failed.
======================

--- \/Users\/adamberlin\/workspace\/gpdb7\/src\/test\/isolation2\/expected\/pg_basebackup_with_tablespaces\.out	2019-07-22 16:21:02.000000000 -0400
+++ \/Users\/adamberlin\/workspace\/gpdb7\/src\/test\/isolation2\/results\/pg_basebackup_with_tablespaces\.out	2019-07-22 16:21:02.000000000 -0400
@@ -159,17 +159,21 @@

 -- When we create a full backup
 select pg_basebackup(address, 100, port, 'some_replication_slot', '/Users/adamberlin/workspace/gpdb7/src/test/isolation2/testtablespace/some_basebackup_datadir', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
- pg_basebackup
----------------
-
+ pg_basebackup
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+ WARNING:  symbolic link "pg_tblspc/196749" target is too long and will not be added to the backup
+DETAIL:  The symbolic link with target "/Users/adamberlin/workspace/gpdb7/src/test/isolation2/testtablespace/some_basebackup_tablespace_c0/2" is too long Symlink targets with length greater than 100 characters would be truncated
 (1 row)

 -- Then we should have one directory in the newly created target tablespace, some_database_without_tablespace
 select count_of_items_in_directory('/Users/adamberlin/workspace/gpdb7/src/test/isolation2/testtablespace/some_basebackup_tablespace_c0/100/GPDB_*/');
- count_of_items_in_directory
------------------------------
- 1
-(1 row)
+ERROR:  subprocess.CalledProcessError: Command 'ls /Users/adamberlin/workspace/gpdb7/src/test/isolation2/testtablespace/some_basebackup_tablespace_c0/100/GPDB_*/' returned non-zero exit status 1 (plpy_elog.c:121)
+CONTEXT:  Traceback (most recent call last):
+  PL/Python function "count_of_items_in_directory", line 4, in <module>
+    results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+  PL/Python function "count_of_items_in_directory", line 222, in check_output
+PL/Python function "count_of_items_in_directory"

 -- Then we should have six directories under some_basebackup_tablespace - db id = {1, 3, 4, 6, 7, 8}. 100 should not be present.
 select count_of_items_in_directory('/Users/adamberlin/workspace/gpdb7/src/test/isolation2/testtablespace/some_basebackup_tablespace');

======================================================================

The differences that caused some tests to fail can be viewed in the
file "/Users/adamberlin/workspace/gpdb7/src/test/isolation2/regression.diffs".  A copy of the test summary that you see
above is saved in the file "/Users/adamberlin/workspace/gpdb7/src/test/isolation2/regression.out".
```

After:
    
    isolation2.sh --tablespace-dir=/tmp/testtablespace --load-extension=gp_inject_fault --print-failure-diffs pg_basebackup_with_tablespaces

```
============== running regression test queries        ==============
test pg_basebackup_with_tablespaces ... ok

=====================
 All 1 tests passed.
=====================
```