### PR TITLE
Allow privileges to succeed when regress is run multiple times.

### DIFF
--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1755,6 +1755,10 @@ DROP OWNED BY regressuser1;
 -- regression test: superuser create a schema and authorize it to a non-superuser
 CREATE ROLE "non_superuser_schema";
 CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
+-- clean up
+DROP SCHEMA test_non_superuser_schema;
+DROP ROLE "non_superuser_schema";
+-- clean up file
 DROP USER regressuser1;
 DROP USER regressuser2;
 DROP USER regressuser3;

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -1063,7 +1063,11 @@ DROP OWNED BY regressuser1;
 -- regression test: superuser create a schema and authorize it to a non-superuser
 CREATE ROLE "non_superuser_schema";
 CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
+-- clean up
+DROP SCHEMA test_non_superuser_schema;
+DROP ROLE "non_superuser_schema";
 
+-- clean up file
 DROP USER regressuser1;
 DROP USER regressuser2;
 DROP USER regressuser3;


### PR DESCRIPTION
Currently, role creation fails the second time regress is run because
roles are global and are not removed when the regression database is
dropped and a new database is created.

Drop the schema and the role to follow the pattern set up by the
previous tests in this file.
