### PR TITLE
Refactor EXISTS sublink pull-up.

### DIFF
--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10912,7 +10912,11 @@ insert into wst1 select i, i from generate_series(1,10) i;
 insert into wst2 select i, i from generate_series(1,10) i;
 -- NB: the rank() is need to force materialization (via Sort) in the subplan
 select count(*) from wst0 where exists (select 1, rank() over (order by wst1.a1) from wst1 where a1 = (select b2 from wst2 where a0=a2+5));
-ERROR:  correlated subquery with skip-level correlations is not supported
+ count 
+-------
+     5
+(1 row)
+
 --
 -- Test to ensure sane behavior when DML queries are optimized by ORCA by
 -- enforcing a non-master gather motion, controlled by

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -775,9 +775,15 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
  99 | 62 | 1 | 43
 (8 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ i  | j  | i | j 
+----+----+---+---
+  1 |  1 | 1 | 1
+  1 |  1 | 1 | 1
+ 78 | -1 | 1 | 1
+ 99 | 62 | 1 | 1
+(4 rows)
+
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -971,9 +977,31 @@ select * from A where exists (select * from C,B where C.j = A.j and exists (sele
  99 | 62
 (4 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and exists (select * from C where C.i = B.i));
-ERROR:  correlated subquery with skip-level correlations is not supported
+ i  | j  | i  | j  
+----+----+----+----
+  1 |  1 |  2 |  7
+  1 |  1 |  2 |  7
+ 99 | 62 |  2 |  7
+ 78 | -1 |  2 |  7
+ 99 | 62 | -1 | 62
+ 99 | 62 | 32 |  5
+ 78 | -1 | -1 | 62
+ 78 | -1 | 32 |  5
+  1 |  1 | -1 | 62
+  1 |  1 | 32 |  5
+  1 |  1 | -1 | 62
+  1 |  1 | 32 |  5
+ 99 | 62 |  1 | 43
+ 99 | 62 |  1 |  1
+ 78 | -1 |  1 | 43
+ 78 | -1 |  1 |  1
+  1 |  1 |  1 | 43
+  1 |  1 |  1 |  1
+  1 |  1 |  1 | 43
+  1 |  1 |  1 |  1
+(20 rows)
+
 select * from A where exists (select * from B, C where C.j = A.j and exists (select sum(C.i) from C where C.i != 10 and C.i = B.i)) order by 1, 2;
  i  | j  
 ----+----
@@ -983,9 +1011,15 @@ select * from A where exists (select * from B, C where C.j = A.j and exists (sel
  99 | 62
 (4 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ i  | j  
+----+----
+  1 |  1
+  1 |  1
+ 78 | -1
+ 99 | 62
+(4 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 20;
  i  | i  |  j  
 ----+----+-----
@@ -1047,9 +1081,12 @@ select * from A where exists (select * from C where C.i = A.i and exists (select
  99 | 62
 (1 row)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and A.j < 10));
-ERROR:  correlated subquery with skip-level correlations is not supported
+ i  | j  
+----+----
+ 78 | -1
+(1 row)
+
 select * from A where exists (select * from C where C.i = A.i and not exists (select * from B where C.j = B.j and B.j < 10)) order by 1,2;
  i  | j  
 ----+----

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -813,7 +813,6 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
  99 | 62 | 1 | 43
 (8 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
  i  | j  | i | j 
 ----+----+---+---
@@ -1035,7 +1034,6 @@ select * from A where exists (select * from C,B where C.j = A.j and exists (sele
  99 | 62
 (4 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and exists (select * from C where C.i = B.i));
  i  | j  | i  | j  
 ----+----+----+----
@@ -1070,7 +1068,6 @@ select * from A where exists (select * from B, C where C.j = A.j and exists (sel
  99 | 62
 (4 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2;
  i  | j  
 ----+----
@@ -1141,7 +1138,6 @@ select * from A where exists (select * from C where C.i = A.i and exists (select
  99 | 62
 (1 row)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and A.j < 10));
  i  | j  
 ----+----

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -255,20 +255,12 @@ select * from int4_tbl o where not exists
 explain (costs off)
 select * from int4_tbl o where exists
   (select 1 from int4_tbl i where i.f1=o.f1 limit 0);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on int4_tbl o
-         Filter: (SubPlan 1)
-         SubPlan 1
-           ->  Limit
-                 ->  Result
-                       Filter: (i.f1 = o.f1)
-                       ->  Materialize
-                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                   ->  Seq Scan on int4_tbl i
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
  Optimizer: Postgres query optimizer
-(11 rows)
+(3 rows)
 
 --
 -- Test cases to catch unpleasant interactions between IN-join processing
@@ -706,7 +698,10 @@ where a.thousand = b.thousand
   and exists ( select 1 from tenk1 c where b.hundred = c.hundred
                    and not exists ( select 1 from tenk1 d
                                     where a.thousand = d.thousand ) );
-ERROR:  correlated subquery with skip-level correlations is not supported
+ thousand 
+----------
+(0 rows)
+
 --
 -- Check that nested sub-selects are not pulled up if they contain volatiles
 --

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1839,3 +1839,276 @@ where s.i < 10 and val.x < 110;
   10
 (17 rows)
 
+-- EXISTS sublink simplication
+drop table if exists simplify_sub;
+NOTICE:  table "simplify_sub" does not exist, skipping
+create table simplify_sub (i int) distributed by (i);
+insert into simplify_sub values (1);
+insert into simplify_sub values (2);
+-- limit n
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+(0 rows)
+
+-- aggregates without GROUP BY or HAVING
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+(0 rows)
+
+drop table if exists simplify_sub;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1969,3 +1969,346 @@ where s.i < 10 and val.x < 110;
   10
 (17 rows)
 
+-- EXISTS sublink simplication
+drop table if exists simplify_sub;
+NOTICE:  table "simplify_sub" does not exist, skipping
+create table simplify_sub (i int) distributed by (i);
+insert into simplify_sub values (1);
+insert into simplify_sub values (2);
+-- limit n
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1
+     ->  Result
+           ->  Result
+                 ->  Limit
+                       ->  Result
+                             Filter: (simplify_sub.i = simplify_sub_1.i)
+                             ->  Materialize
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(14 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1
+     ->  Result
+           ->  Result
+                 ->  Limit
+                       ->  Result
+                             Filter: (simplify_sub.i = simplify_sub_1.i)
+                             ->  Materialize
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(14 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Semi Join
+         Join Filter: true
+         ->  Seq Scan on simplify_sub
+         ->  Limit
+               ->  Result
+                     ->  Result
+                           One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(9 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Anti Join
+         Join Filter: true
+         ->  Seq Scan on simplify_sub
+         ->  Result
+               One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+(0 rows)
+
+-- aggregates without GROUP BY or HAVING
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Result
+   ->  Result
+         One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(4 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Result
+   ->  Result
+         One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(4 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+(0 rows)
+
+drop table if exists simplify_sub;

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -183,7 +183,6 @@ select A.i from A where A.i = all (select B.i from B where A.i = B.i) order by A
 
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C)) order by 1,2,3,4;
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = 1)) order by 1,2,3,4;
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
@@ -211,11 +210,9 @@ with t as (select * from qp_csq_t2) select b from qp_csq_t1 where exists(select 
 
 select * from A where exists (select * from C where C.j = A.j) order by 1,2;
 select * from A where exists (select * from C,B where C.j = A.j and exists (select * from C where C.i = B.i)) order by 1,2;
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and exists (select * from C where C.i = B.i));
 
 select * from A where exists (select * from B, C where C.j = A.j and exists (select sum(C.i) from C where C.i != 10 and C.i = B.i)) order by 1, 2;
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2;
 
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 20;
@@ -224,7 +221,6 @@ select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.
 select * from A where exists (select * from C where C.j = A.j and not exists (select sum(B.i) from B where B.i = C.i));
 
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and B.j < 10)) order by 1,2;
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and A.j < 10));
 select * from A where exists (select * from C where C.i = A.i and not exists (select * from B where C.j = B.j and B.j < 10)) order by 1,2;
 

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -824,3 +824,79 @@ select val.x
     values ((select s.i + 1 from onerowtmp)), (s.i + 101)
   ) as val(x)
 where s.i < 10 and val.x < 110;
+
+-- EXISTS sublink simplication
+
+drop table if exists simplify_sub;
+
+create table simplify_sub (i int) distributed by (i);
+insert into simplify_sub values (1);
+insert into simplify_sub values (2);
+
+-- limit n
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+
+-- aggregates without GROUP BY or HAVING
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+
+drop table if exists simplify_sub;


### PR DESCRIPTION
GPDB performs several types of optimization when pulling up EXISTS
sublink, trying to eliminate the sublink altogether if possible. This
mainly includes two cases: 1) the subquery has limit 0, 2) the subquery
has aggregates without GROUP BY or HAVING. But previously it failed to
do it correctly and would give wrong results in the case of 'limit
0/all/null' or 'offset null'.

Also previously GPDB would add LIMIT 1 to the EXISTS sublink if it is
uncorrelated and supposed to become a InitPlan, which helps gain some
performance. But this trick does not work anymore because from 9.5
(IIRC) simplify_EXISTS_query will remove the LIMIT clause if LIMIT with
a constant positive value.

This patch refactors function convert_EXISTS_sublink_to_join() to fix
the known issues as well as to make it more aligned with PostgreSQL. It
also removes the 'LIMIT 1' trick.

This patch fixes #7545

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
