### PR TITLE
[5X Backport] Propagate external table format options to PXF headers

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -1938,7 +1938,7 @@ strip_quotes(char *source, char quote, char escape, int encoding)
  * next on a single source string, but changing whitespace is a bad idea
  * since you might lose data.
  */
-static char *
+char *
 strtokx2(const char *s,
 		 const char *whitespace,
 		 const char *delim,

--- a/src/include/access/fileam.h
+++ b/src/include/access/fileam.h
@@ -83,5 +83,6 @@ extern Oid	external_insert(ExternalInsertDesc extInsertDesc, HeapTuple instup);
 extern void external_insert_finish(ExternalInsertDesc extInsertDesc);
 extern void external_set_env_vars(extvar_t *extvar, char *uri, bool csv, char *escape, char *quote, bool header, uint32 scancounter);
 extern char *linenumber_atoi(char buffer[20], int64 linenumber);
+extern char *strtokx2(const char *s, const char *whitespace, const char *delim, const char *quote, char escape, bool e_strings, bool del_quotes, int encoding);
 
 #endif   /* FILEAM_H */


### PR DESCRIPTION
Currently, PXF is not propagating the format options in the external
table framework. In Foreign Data Wrappers, these options are defined at
the foreign table-level and are being propagated to PXF.

In order for the PXF Server to better support both FDW and external
tables we are consistently passing format information from both clients.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
