### PR TITLE
Disallow ALTER TABLE ADD CONSTRAINT USING INDEX on a partition root

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -8852,6 +8852,18 @@ ATExecAddIndexConstraint(AlteredTableInfo *tab, Relation rel,
 	Assert(OidIsValid(index_oid));
 	Assert(stmt->isconstraint);
 
+	/*
+	 * Doing this on partitioned tables is not a simple feature to implement,
+	 * so let's punt for now.
+	 */
+	Oid rel_id = RelationGetRelid(rel);
+	bool is_root_or_interior_partition = rel_is_partitioned(rel_id)
+		|| rel_is_interior_partition(rel_id);
+	if (Gp_role != GP_ROLE_EXECUTE && is_root_or_interior_partition)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("ALTER TABLE / ADD CONSTRAINT USING INDEX is not supported on partitioned tables")));
+
 	indexRel = index_open(index_oid, AccessShareLock);
 
 	indexName = pstrdup(RelationGetRelationName(indexRel));

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -80,6 +80,8 @@ extern bool rel_has_appendonly_partition(Oid relid);
 
 extern bool rel_is_child_partition(Oid relid);
 
+extern bool rel_is_interior_partition(Oid relid);
+
 extern bool rel_is_leaf_partition(Oid relid);
 
 extern bool rel_partitioning_is_uniform(Oid rootOid);

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -974,3 +974,19 @@ create table parttab_x (a int4, b int4) distributed by (b);
 alter table parttab exchange partition for (1) with table parttab_x;
 alter table parttab alter partition for (1) exchange partition for (1) with table parttab_x;
 
+-- add constraint using index is forbidden on root and interior partitioned tables
+create table root_part(a int, b int)
+    partition by range(b)
+        subpartition by list(b)
+            subpartition template (subpartition leaf values (1))
+        (partition interior start(1) end(2) every(1));
+-- disallowed on root partitions
+create unique index on root_part(a, b);
+alter table root_part add primary key using index root_part_a_b_idx ;
+-- disallowed on interior partitions
+create unique index on root_part_1_prt_interior(a, b);
+alter table root_part_1_prt_interior add primary key using index root_part_1_prt_interior_a_b_idx1 ;
+-- allowed on leaf partitions
+create unique index on root_part_1_prt_interior_2_prt_leaf(a, b);
+alter table root_part_1_prt_interior_2_prt_leaf add primary key using index root_part_1_prt_interior_2_prt_leaf_a_b_idx2;
+drop table root_part;

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -2959,3 +2959,21 @@ alter table parttab exchange partition for (1) with table parttab_x;
 ERROR:  distribution policy for "parttab_x" must be the same as that for "parttab"
 alter table parttab alter partition for (1) exchange partition for (1) with table parttab_x;
 ERROR:  distribution policy for "parttab_x" must be the same as that for "parttab"
+-- add constraint using index is forbidden on root and interior partitioned tables
+create table root_part(a int, b int)
+    partition by range(b)
+        subpartition by list(b)
+            subpartition template (subpartition leaf values (1))
+        (partition interior start(1) end(2) every(1));
+-- disallowed on root partitions
+create unique index on root_part(a, b);
+alter table root_part add primary key using index root_part_a_b_idx ;
+ERROR:  ALTER TABLE / ADD CONSTRAINT USING INDEX is not supported on partitioned tables
+-- disallowed on interior partitions
+create unique index on root_part_1_prt_interior(a, b);
+alter table root_part_1_prt_interior add primary key using index root_part_1_prt_interior_a_b_idx1 ;
+ERROR:  ALTER TABLE / ADD CONSTRAINT USING INDEX is not supported on partitioned tables
+-- allowed on leaf partitions
+create unique index on root_part_1_prt_interior_2_prt_leaf(a, b);
+alter table root_part_1_prt_interior_2_prt_leaf add primary key using index root_part_1_prt_interior_2_prt_leaf_a_b_idx2;
+drop table root_part;


### PR DESCRIPTION
ADD CONSTRAINT USING INDEX is a new feature which didn't existing for 4 or 5 branches.
.This is taken from upstream commit eb7ed3f. With partition tables, the changes are not propagated to the leaf partitions if the operation is done on the root table, thus disallowed currently.

Signed-off-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
