### PR TITLE
Align find_other_exec() to upstream.

### DIFF
--- a/src/common/exec.c
+++ b/src/common/exec.c
@@ -324,21 +324,13 @@ find_other_exec(const char *argv0, const char *target,
 	if (validate_exec(retpath) != 0)
 		return -1;
 
-	/*
-	 * In PostgreSQL, the version check is always performed. In GPDB, this
-	 * is also used to find scripts that don't necessarily have the same
-	 * version output (in particular, pg_regress uses this to find gpdiff.pl)
-	 */
-	if (versionstr)
-	{
-		snprintf(cmd, sizeof(cmd), "\"%s\" -V", retpath);
+	snprintf(cmd, sizeof(cmd), "\"%s\" -V", retpath);
 
-		if (!pipe_read_line(cmd, line, sizeof(line)))
-			return -1;
+	if (!pipe_read_line(cmd, line, sizeof(line)))
+		return -1;
 
-		if (strcmp(line, versionstr) != 0)
-			return -2;
-	}
+	if (strcmp(line, versionstr) != 0)
+		return -2;
 
 	return 0;
 }

--- a/src/test/regress/GPTest.pm.in
+++ b/src/test/regress/GPTest.pm.in
@@ -35,7 +35,7 @@ our $VERSION = '##Version: ##';
 sub print_version
 {
 	print basename($0) . ' ' . $VERSION . "\n";
-	exit(1);
+	exit(0);
 }
 
 1;

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2475,7 +2475,7 @@ run_single_test(const char *test, test_function tfunc)
 static void
 find_helper_programs(const char *argv0)
 {
-	if (find_other_exec(argv0, "gpdiff.pl", NULL, gpdiffprog) != 0)
+	if (find_other_exec(argv0, "gpdiff.pl", "gpdiff.pl " GP_VERSION"\n", gpdiffprog) != 0)
 	{
 		char		full_path[MAXPGPATH];
 
@@ -2488,7 +2488,8 @@ find_helper_programs(const char *argv0)
 				progname, full_path);
 		exit(1);
 	}
-	if (find_other_exec(argv0, "gpstringsubs.pl", NULL, gpstringsubsprog) != 0)
+
+	if (find_other_exec(argv0, "gpstringsubs.pl", "gpstringsubs.pl " GP_VERSION"\n", gpstringsubsprog) != 0)
 	{
 		char		full_path[MAXPGPATH];
 


### PR DESCRIPTION
This function was modified in GPDB just for pg_regress. pg_regress
needs to locate gpdiff.pl and gpstringsubs.pl scripts where it uses
find_other_exec(). Since not correct version was passed to it, this
modification was required to find_other_exec(). These scripts have
code to correctly print the version information on "-V". So, regular
unmodified version of find_other_exec() works if the version is passed
correctly from pg_regress.


**Seeking input on this**
Ideally, I am thinking we can delete the file `src/test/regress/GPTest.pm.in` and config time (configure.in code for it) which substitutes the VERSION in it, as don't think need to check for exact version for these scripts, since we were anyways not checking for it. These scripts are part of the code and live in `src/test`, don't think version check helps anything. Maybe completely remove this unnecessary code and simply have these scripts print static strings on "-V" like "Greenplum Database" which can be checked instead. As don't think anything cares about the exact version for these scripts. But wish to seek feedback on it before deleting the code.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
