### PR TITLE
Extract new error message fields

### DIFF
--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -206,84 +206,6 @@ top:
 }
 
 /*
- * _bt_ao_check_unique -- Check for violation of unique index constraint
- *  for AO/CO tables.
- *
- * Returns InvalidTransactionId if there is no conflict, else an xact ID
- * we must wait for to see if it commits a conflicting tuple.	If an actual
- * conflict is detected, no return --- just ereport().
- */
-static TransactionId
-_bt_ao_check_unique(Relation rel, Relation aoRel, ItemPointer tid)
-{
-	SnapshotData SnapshotDirty;
-	TransactionId xwait = InvalidTransactionId;
-	
-	Assert(RelationIsAppendOptimized(aoRel));
-
-	InitDirtySnapshot(SnapshotDirty);
-	
-	if (RelationIsAoRows(aoRel))
-	{
-		AppendOnlyFetchDesc aoFetchDesc =
-			appendonly_fetch_init(aoRel, &SnapshotDirty, &SnapshotDirty);
-
-		if (appendonly_fetch(aoFetchDesc, (AOTupleId*)tid, NULL))
-		{
-			xwait =
-				(TransactionIdIsValid(SnapshotDirty.xmin)) ?
-				SnapshotDirty.xmin : SnapshotDirty.xmax;
-
-			/*
-			 * If this tuple is not being updated by other transaction,
-			 * then we have a definite conflict. Ereport here.
-			 */
-			if (!TransactionIdIsValid(xwait))
-				ereport(ERROR,
-						(errcode(ERRCODE_UNIQUE_VIOLATION),
-						 errmsg("duplicate key violates unique constraint \"%s\"",
-								RelationGetRelationName(rel))));
-		}
-	
-		appendonly_fetch_finish(aoFetchDesc);
-		pfree(aoFetchDesc);
-	}
-	else
-	{
-		TupleDesc tupleDesc = RelationGetDescr(aoRel);
-		bool *proj = palloc0(tupleDesc->natts * sizeof(bool));
-		AOCSFetchDesc aocsFetchDesc;
-		
-		/* Just set the first column */
-		proj[0] = true;
-		aocsFetchDesc =	aocs_fetch_init(aoRel, &SnapshotDirty, &SnapshotDirty, proj);
-
-		if (aocs_fetch(aocsFetchDesc, (AOTupleId*)tid, NULL))
-		{
-			xwait =
-				(TransactionIdIsValid(SnapshotDirty.xmin)) ?
-				SnapshotDirty.xmin : SnapshotDirty.xmax;
-
-			/*
-			 * If this tuple is not being updated by other transaction,
-			 * then we have a definite conflict. Ereport here.
-			 */
-			if (!TransactionIdIsValid(xwait))
-				ereport(ERROR,
-						(errcode(ERRCODE_UNIQUE_VIOLATION),
-						 errmsg("duplicate key violates unique constraint \"%s\"",
-								RelationGetRelationName(rel))));
-		}
-	
-		pfree(proj);
-		aocs_fetch_finish(aocsFetchDesc);
-		pfree(aocsFetchDesc);
-	}
-
-	return xwait;
-}
-
-/*
  *	_bt_check_unique() -- Check for violation of unique index constraint
  *
  * offset points to the first possible item that could conflict. It can
@@ -369,156 +291,157 @@ _bt_check_unique(Relation rel, IndexTuple itup, Relation heapRel,
 
 				/* okay, we gotta fetch the heap tuple ... */
 				curitup = (IndexTuple) PageGetItem(page, curitemid);
+				htid = curitup->t_tid;
 
 				/*
-				 * If the parent relation is an AO/CO table, we have to find out
-				 * if this tuple is actually in the table.
+				 * AO/CO table actually does not support uniq contraint
+				 * Ensure never get here when the parent relation is an AO/CO table
 				 */
 				if (RelationIsAppendOptimized(heapRel))
-				{
-					TransactionId xwait =
-						_bt_ao_check_unique(rel, heapRel, &curitup->t_tid);
+					elog(ERROR,
+							"append-only tables do not support unique indexes");
 
-					if (TransactionIdIsValid(xwait))
-						return xwait;
+				/*
+				 * If we are doing a recheck, we expect to find the tuple we
+				 * are rechecking.  It's not a duplicate, but we have to keep
+				 * scanning.
+				 */
+				if (checkUnique == UNIQUE_CHECK_EXISTING &&
+					ItemPointerCompare(&htid, &itup->t_tid) == 0)
+				{
+					found = true;
 				}
-				else
+
+				/*
+				 * We check the whole HOT-chain to see if there is any tuple
+				 * that satisfies SnapshotDirty.  This is necessary because we
+				 * have just a single index entry for the entire chain.
+				 */
+				else if (heap_hot_search(&htid, heapRel, &SnapshotDirty,
+										 &all_dead))
 				{
-					htid = curitup->t_tid;
+					TransactionId xwait;
 
 					/*
-					 * If we are doing a recheck, we expect to find the tuple we
-					 * are rechecking.  It's not a duplicate, but we have to keep
-					 * scanning.
+					 * It is a duplicate. If we are only doing a partial
+					 * check, then don't bother checking if the tuple is being
+					 * updated in another transaction. Just return the fact
+					 * that it is a potential conflict and leave the full
+					 * check till later.
 					 */
-					if (checkUnique == UNIQUE_CHECK_EXISTING &&
-						ItemPointerCompare(&htid, &itup->t_tid) == 0)
+					if (checkUnique == UNIQUE_CHECK_PARTIAL)
 					{
-						found = true;
-					}
-
-					/*
-					 * We check the whole HOT-chain to see if there is any tuple
-					 * that satisfies SnapshotDirty.  This is necessary because we
-					 * have just a single index entry for the entire chain.
-					 */
-					else if (heap_hot_search(&htid, heapRel, &SnapshotDirty, &all_dead))
-					{
-						TransactionId xwait;
-
-						/*
-						 * It is a duplicate. If we are only doing a partial
-						 * check, then don't bother checking if the tuple is being
-						 * updated in another transaction. Just return the fact
-						 * that it is a potential conflict and leave the full
-						 * check till later.
-						 */
-						if (checkUnique == UNIQUE_CHECK_PARTIAL)
-						{
-							if (nbuf != InvalidBuffer)
-								_bt_relbuf(rel, nbuf);
-							*is_unique = false;
-							return InvalidTransactionId;
-						}
-
-						/*
-						 * If this tuple is being updated by other transaction
-						 * then we have to wait for its commit/abort.
-						 */
-						xwait = (TransactionIdIsValid(SnapshotDirty.xmin)) ?
-							SnapshotDirty.xmin : SnapshotDirty.xmax;
-
-						if (TransactionIdIsValid(xwait))
-						{
-							if (nbuf != InvalidBuffer)
-								_bt_relbuf(rel, nbuf);
-							/* Tell _bt_doinsert to wait... */
-							return xwait;
-						}
-						
-						/*
-						 * Otherwise we have a definite conflict.  But before
-						 * complaining, look to see if the tuple we want to insert
-						 * is itself now committed dead --- if so, don't complain.
-						 * This is a waste of time in normal scenarios but we must
-						 * do it to support CREATE INDEX CONCURRENTLY.
-						 *
-						 * We must follow HOT-chains here because during
-						 * concurrent index build, we insert the root TID though
-						 * the actual tuple may be somewhere in the HOT-chain.
-						 * While following the chain we might not stop at the
-						 * exact tuple which triggered the insert, but that's OK
-						 * because if we find a live tuple anywhere in this chain,
-						 * we have a unique key conflict.  The other live tuple is
-						 * not part of this chain because it had a different index
-						 * entry.
-						 */
-						htid = itup->t_tid;
-						if (heap_hot_search(&htid, heapRel, SnapshotSelf, NULL))
-						{
-							/* Normal case --- it's still live */
-						}
-						else
-						{
-							/*
-							 * It's been deleted, so no error, and no need to
-							 * continue searching.
-							 */
-							break;
-						}
-
-						/*
-						 * This is a definite conflict.  Break the tuple down into
-						 * datums and report the error.  But first, make sure we
-						 * release the buffer locks we're holding ---
-						 * BuildIndexValueDescription could make catalog accesses,
-						 * which in the worst case might touch this same index and
-						 * cause deadlocks.
-						 */
 						if (nbuf != InvalidBuffer)
 							_bt_relbuf(rel, nbuf);
-						_bt_relbuf(rel, buf);
-	
-						{
-							Datum	values[INDEX_MAX_KEYS];
-							bool	isnull[INDEX_MAX_KEYS];
-							char	   *key_desc;
-	
-							index_deform_tuple(itup, RelationGetDescr(rel),
-											   values, isnull);
-
-							key_desc = BuildIndexValueDescription(rel, values,
-																  isnull);
-
-							ereport(ERROR,
-									(errcode(ERRCODE_UNIQUE_VIOLATION),
-									 errmsg("duplicate key value violates unique constraint \"%s\"",
-											RelationGetRelationName(rel)),
-									 key_desc ? errdetail("Key %s already exists.",
-											key_desc) : 0,
-									 errtableconstraint(heapRel,
-											RelationGetRelationName(rel))));
-						}
+						*is_unique = false;
+						return InvalidTransactionId;
 					}
-					else if (all_dead)
+
+					/*
+					 * If this tuple is being updated by other transaction
+					 * then we have to wait for its commit/abort.
+					 */
+					xwait = (TransactionIdIsValid(SnapshotDirty.xmin)) ?
+						SnapshotDirty.xmin : SnapshotDirty.xmax;
+
+					if (TransactionIdIsValid(xwait))
+					{
+						if (nbuf != InvalidBuffer)
+							_bt_relbuf(rel, nbuf);
+						/* Tell _bt_doinsert to wait... */
+						return xwait;
+					}
+
+					/*
+					 * Otherwise we have a definite conflict.  But before
+					 * complaining, look to see if the tuple we want to insert
+					 * is itself now committed dead --- if so, don't complain.
+					 * This is a waste of time in normal scenarios but we must
+					 * do it to support CREATE INDEX CONCURRENTLY.
+					 *
+					 * We must follow HOT-chains here because during
+					 * concurrent index build, we insert the root TID though
+					 * the actual tuple may be somewhere in the HOT-chain.
+					 * While following the chain we might not stop at the
+					 * exact tuple which triggered the insert, but that's OK
+					 * because if we find a live tuple anywhere in this chain,
+					 * we have a unique key conflict.  The other live tuple is
+					 * not part of this chain because it had a different index
+					 * entry.
+					 */
+					htid = itup->t_tid;
+					if (heap_hot_search(&htid, heapRel, SnapshotSelf, NULL))
+					{
+						/* Normal case --- it's still live */
+					}
+					else
 					{
 						/*
-						 * The conflicting tuple (or whole HOT chain) is dead to
-						 * everyone, so we may as well mark the index entry
-						 * killed.
+						 * It's been deleted, so no error, and no need to
+						 * continue searching
 						 */
-						ItemIdMarkDead(curitemid);
-						opaque->btpo_flags |= BTP_HAS_GARBAGE;
-
-						/*
-						 * Mark buffer with a dirty hint, since state is not
-						 * crucial. Be sure to mark the proper buffer dirty.
-						 */
-						if (nbuf != InvalidBuffer)
-							MarkBufferDirtyHint(nbuf, true);
-						else
-							MarkBufferDirtyHint(buf, true);
+						break;
 					}
+
+					/*
+					 * Check for a conflict-in as we would if we were going to
+					 * write to this page.  We aren't actually going to write,
+					 * but we want a chance to report SSI conflicts that would
+					 * otherwise be masked by this unique constraint violation.
+					 */
+					CheckForSerializableConflictIn(rel, NULL, buf);
+
+					/*
+					 * This is a definite conflict.  Break the tuple down into
+					 * datums and report the error.  But first, make sure we
+					 * release the buffer locks we're holding ---
+					 * BuildIndexValueDescription could make catalog accesses,
+					 * which in the worst case might touch this same index and
+					 * cause deadlocks.
+					 */
+					if (nbuf != InvalidBuffer)
+						_bt_relbuf(rel, nbuf);
+					_bt_relbuf(rel, buf);
+
+					{
+						Datum		values[INDEX_MAX_KEYS];
+						bool		isnull[INDEX_MAX_KEYS];
+						char	   *key_desc;
+
+						index_deform_tuple(itup, RelationGetDescr(rel),
+										   values, isnull);
+
+						key_desc = BuildIndexValueDescription(rel, values,
+															  isnull);
+
+						ereport(ERROR,
+								(errcode(ERRCODE_UNIQUE_VIOLATION),
+								 errmsg("duplicate key value violates unique constraint \"%s\"",
+										RelationGetRelationName(rel)),
+								 key_desc ? errdetail("Key %s already exists.",
+													  key_desc) : 0,
+								 errtableconstraint(heapRel,
+											 RelationGetRelationName(rel))));
+					}
+				}
+				else if (all_dead)
+				{
+					/*
+					 * The conflicting tuple (or whole HOT chain) is dead to
+					 * everyone, so we may as well mark the index entry
+					 * killed.
+					 */
+					ItemIdMarkDead(curitemid);
+					opaque->btpo_flags |= BTP_HAS_GARBAGE;
+
+					/*
+					 * Mark buffer with a dirty hint, since state is not
+					 * crucial. Be sure to mark the proper buffer dirty.
+					 */
+					if (nbuf != InvalidBuffer)
+						MarkBufferDirtyHint(nbuf, true);
+					else
+						MarkBufferDirtyHint(buf, true);
 				}
 			}
 		}

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -575,6 +575,26 @@ cdbdisp_get_PQerror(PGresult *pgresult)
 	if (fld)
 		errcontext("%s", fld);
 
+	fld = PQresultErrorField(pgresult, PG_DIAG_SCHEMA_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_SCHEMA_NAME, fld);
+
+	fld = PQresultErrorField(pgresult, PG_DIAG_TABLE_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_TABLE_NAME, fld);
+
+	fld = PQresultErrorField(pgresult, PG_DIAG_COLUMN_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_COLUMN_NAME, fld);
+
+	fld = PQresultErrorField(pgresult, PG_DIAG_DATATYPE_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_DATATYPE_NAME, fld);
+
+	fld = PQresultErrorField(pgresult, PG_DIAG_CONSTRAINT_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_CONSTRAINT_NAME, fld);
+
 	Assert(TopTransactionContext);
 	oldcontext = MemoryContextSwitchTo(TopTransactionContext);
 	ErrorData *edata = errfinish_and_return(0);

--- a/src/test/regress/expected/gp_constraints.out
+++ b/src/test/regress/expected/gp_constraints.out
@@ -45,8 +45,20 @@ INSERT INTO PRIMARY_TBL VALUES (1, 'one');
 INSERT INTO PRIMARY_TBL VALUES (2, 'two');
 INSERT INTO tmp VALUES (1, 'three');
 INSERT INTO PRIMARY_TBL SELECT * FROM tmp;
-ERROR:  duplicate key value violates unique constraint "primary_tbl_pkey"
+ERROR:  duplicate key value violates unique constraint "primary_tbl_pkey"  (seg1 127.0.0.1:25433 pid=6874)
 DETAIL:  Key (i)=(1) already exists.
+-- database object names as separate fields in error messages can be shown when VERBOSITY set to verbose
+\set VERBOSITY verbose
+-- start_ignore
+INSERT INTO PRIMARY_TBL SELECT * FROM tmp;
+ERROR:  23505: duplicate key value violates unique constraint "primary_tbl_pkey"  (seg1 127.0.0.1:25433 pid=6874)
+DETAIL:  Key (i)=(1) already exists.
+SCHEMA NAME:  gpdb_insert
+TABLE NAME:  primary_tbl
+CONSTRAINT NAME:  primary_tbl_pkey
+LOCATION:  _bt_check_unique, nbtinsert.c:500
+-- end_ignore
+\set VERBOSITY default
 SELECT '' AS four, * FROM PRIMARY_TBL;
  four | i |  t  
 ------+---+-----

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -97,6 +97,7 @@ test: partial_table
 test: partition partition1 partition_indexing parruleord partition_storage partition_ddl partition_with_user_defined_function partition_unlogged partition_subquery partition_with_user_defined_function_that_truncates
 
 test: index_constraint_naming index_constraint_naming_partition index_constraint_naming_upgrade
+test: gp_constraints
 # 'partition_locking' gets confused if other backends run concurrently and
 # hold locks.
 test: partition_locking

--- a/src/test/regress/sql/gp_constraints.sql
+++ b/src/test/regress/sql/gp_constraints.sql
@@ -39,6 +39,12 @@ INSERT INTO PRIMARY_TBL VALUES (2, 'two');
 
 INSERT INTO tmp VALUES (1, 'three');
 INSERT INTO PRIMARY_TBL SELECT * FROM tmp;
+-- database object names as separate fields in error messages can be shown when VERBOSITY set to verbose
+\set VERBOSITY verbose
+-- start_ignore
+INSERT INTO PRIMARY_TBL SELECT * FROM tmp;
+-- end_ignore
+\set VERBOSITY default
 
 SELECT '' AS four, * FROM PRIMARY_TBL;
 


### PR DESCRIPTION
Extract new error message fields

Postgres 991f3e5ab3f8196d18d5b313c81a5f744f3baaea introduce new error message fields, but `cdbdisp_get_PQerror()`
did not extract these newly added message field, this results client can not see those fields from libpq.
This fix github issue https://github.com/greenplum-db/gpdb/issues/7934

Also bring back gp_constraints test, it hasn't been run for unknown reason.

Also AO/CO table actually does not support uniq contraint,
so_bt_ao_check_unique should never be called. delete it, and add an
condition to insure never get there
Also reformat the if else condition to avoid extra conflict when merge
with upstream
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
