### PR TITLE
Infinitely disable fts during gp_tablespace_with_faults

### DIFF
--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -67,7 +67,7 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 
 		-- intentionally skip fts during these tests
 		-- we know we're going to be inducing errors and panics on primaries
-		perform gp_inject_fault2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
+		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
 	end;
 $$ LANGUAGE plpgsql;
 

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -65,7 +65,7 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 
 		-- intentionally skip fts during these tests
 		-- we know we're going to be inducing errors and panics on primaries
-		perform gp_inject_fault2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
+		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
 	end;
 $$ LANGUAGE plpgsql;
 create or replace function cleanup(content_id integer, tablespace_location_dir text) returns void as $$


### PR DESCRIPTION
Ooops.

We only injected the skip fault for fts once, causing a race condition
in the test. Here's the problematic timeline:

1. Inject skip fault for fts
2. Fts runs, skip fault is gone
3. Panic primary
4. Inject Noop record into mirror
5. Promote mirror
6. Noop record never replayed and test fails.


--

This change should go back to 6X.