### PR TITLE
dbconn: search_path CVE followup

### DIFF
--- a/gpMgmt/bin/gppylib/db/dbconn.py
+++ b/gpMgmt/bin/gppylib/db/dbconn.py
@@ -197,6 +197,11 @@ def connect(dburl, utility=False, verbose=False,
         retries = 1
 
     options = []
+
+    # unset search path due to CVE-2018-1058
+    if unsetSearchPath:
+        options.append("-c search_path=")
+
     #by default, libpq will print WARNINGS to stdout
     if not verbose:
         options.append("-c CLIENT_MIN_MESSAGES=ERROR")
@@ -227,11 +232,6 @@ def connect(dburl, utility=False, verbose=False,
 
     # NOTE: the code to set ALWAYS_SECURE_SEARCH_PATH_SQL below assumes it is not part of an existing transaction
     conn = pgdb.pgdbCnx(cnx)
-
-    # unset search path due to CVE-2018-1058
-    if unsetSearchPath:
-        ALWAYS_SECURE_SEARCH_PATH_SQL = "SELECT pg_catalog.set_config('search_path', '', false)"
-        execSQL(conn, ALWAYS_SECURE_SEARCH_PATH_SQL).close()
 
     def __enter__(self):
         return self

--- a/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
+++ b/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
@@ -72,5 +72,13 @@ class ConnectTestCase(unittest.TestCase):
 
         self.assertEqual(result, '"$user",public')
 
+    def test_no_transaction_after_connect(self):
+        with dbconn.connect(self.url) as conn:
+            db = pg.DB(conn)
+            # this would fail if we were in a transaction DROP DATABASE cannot
+            # run inside a transaction block
+            db.query("DROP DATABASE IF EXISTS some_nonexistent_database")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
+++ b/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
@@ -8,9 +8,17 @@ from gppylib.db import dbconn
 class ConnectTestCase(unittest.TestCase):
     """A test case for dbconn.connect()."""
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # Connect to the database pointed to by PGHOST et al.
-        self.url = dbconn.DbURL()
+        with dbconn.connect(dbconn.DbURL()) as conn:
+            # using the pg.DB connection so that each SQL is done as a single
+            # transaction
+            db = pg.DB(conn)
+            test_database_name = "gpdb_test_database"
+            db.query("DROP DATABASE IF EXISTS %s" % test_database_name)
+            db.query("CREATE DATABASE %s" % test_database_name)
+            cls.url = dbconn.DbURL(dbname=test_database_name)
 
     def _raise_warning(self, db, msg):
         """Raises a WARNING message on the given pg.DB."""
@@ -71,6 +79,18 @@ class ConnectTestCase(unittest.TestCase):
             result = dbconn.execSQLForSingleton(conn, "SELECT setting FROM pg_settings WHERE name='search_path'")
 
         self.assertEqual(result, '"$user",public')
+
+    def test_search_path_cve_2018_1058(self):
+        with dbconn.connect(self.url) as conn:
+            dbconn.execSQL(conn, "CREATE TABLE public.Names (name VARCHAR(255))")
+            dbconn.execSQL(conn, "INSERT INTO public.Names VALUES ('AAA')")
+
+            dbconn.execSQL(conn, "CREATE FUNCTION public.lower(VARCHAR) RETURNS text AS $$ "
+                                 "  SELECT 'Alice was here: ' || $1;"
+                                 "$$ LANGUAGE SQL IMMUTABLE;")
+
+            name = dbconn.execSQLForSingleton(conn, "SELECT lower(name) FROM public.Names")
+            self.assertEqual(name, 'aaa')
 
     def test_no_transaction_after_connect(self):
         with dbconn.connect(self.url) as conn:


### PR DESCRIPTION
The unsetting of search_path started an implicit transaction that can affect the behavior of subsequent SQL statement. Therefore, after setting the search_path, we issue a commit.

We have also added tests to ensure that unsetting the search path prevents calling of unintended public functions, and we are using a test database for the tests.
