### PR TITLE
Hook up gpMgmt unittests to toplevel unittest-check target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,11 @@ install:
   - pip install --user --upgrade pip
   - pip install --user --pre psutil
   - pip install --user lockfile
-  - pip install --user setuptools
+  - pip install --user --upgrade setuptools
+  - pip install --user --upgrade six
+  - pip install --user --upgrade pbr
+  - pip install --user --upgrade funcsigs
+  - pip install --user mock
 
 env:
   - CC=gcc-6
@@ -87,6 +91,7 @@ script:
   - make install
   - source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
   - make unittest-check
+  - make -C gpMgmt/bin unittest-check
   - postgres --version
   - initdb --version
   - createdb --version

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -205,6 +205,9 @@ check: $(MOCK_BIN)
 	@TMPDIR=/tmp PYTHONPATH=$(SERVER_SRC):$(SERVER_SBIN):$(PYTHONPATH):$(PYTHONSRC_INSTALL_PYTHON_PATH):$(SRC)/ext:$(SBIN_DIR):$(LIB_DIR):$(PYLIB_DIR)/mock-1.0.1 \
 	gppylib/gpunit discover --verbose -s $(SRC)/gppylib -p "test_cluster*.py" 2>> $(SRC)/../gpMgmt_testunit_results.log 1>> $(SRC)/../gpMgmt_testunit_output.log
 
+.PHONY: unittest-check
+unittest-check: unitdevel
+
 unitdevel:
 	@echo "Running pure unit tests..."
 	PYTHONPATH=$(SERVER_SRC):$(SERVER_SBIN):$(PYTHONPATH):$(PYTHONSRC_INSTALL_PYTHON_PATH):$(SRC)/ext:$(SBIN_DIR):$(LIB_DIR):$(PYLIB_DIR)/mock-1.0.1 \

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
@@ -5,9 +5,10 @@
 
 import unittest
 from gppylib.commands.base import Command, WorkerPool, RemoteExecutionContext, GPHOME, LocalExecutionContext
+from gppylib.db.test import skipIfRunningOnCI
 from mock import patch
 
-
+@skipIfRunningOnCI()
 class WorkerPoolTestCase(unittest.TestCase):
 
     def tearDown(self):

--- a/gpMgmt/bin/gppylib/db/test/__init__.py
+++ b/gpMgmt/bin/gppylib/db/test/__init__.py
@@ -6,6 +6,8 @@ from gppylib.db.dbconn import connect, DbURL
 def skipIfRunningOnCI():
     if pwd.getpwuid( os.getuid() )[ 0 ] == 'travis':
         return unittest.skip("running in Travis CI")
+    else:
+        return lambda o: o
 
 def skipIfDatabaseDown():
     try:

--- a/gpMgmt/bin/gppylib/db/test/__init__.py
+++ b/gpMgmt/bin/gppylib/db/test/__init__.py
@@ -1,5 +1,11 @@
 import unittest
+import os
+import pwd
 from gppylib.db.dbconn import connect, DbURL
+
+def skipIfRunningOnCI():
+    if pwd.getpwuid( os.getuid() )[ 0 ] == 'travis':
+        return unittest.skip("running in Travis CI")
 
 def skipIfDatabaseDown():
     try:

--- a/gpMgmt/bin/gppylib/operations/test/regress/test_package/__init__.py
+++ b/gpMgmt/bin/gppylib/operations/test/regress/test_package/__init__.py
@@ -89,7 +89,7 @@ def get_host_list():
             master = seg.getSegmentHostName()
 
     #Deduplicate the hosts so that we
-    #dont install multiple times on the same host
+    #don't install multiple times on the same host
     segment_host_list = list(set(segment_host_list))
     if master in segment_host_list:
         segment_host_list.remove(master)
@@ -217,7 +217,7 @@ class RPMSpec:
     """Represents an RPM spec file used for creating an RPM"""
     def __init__(self, name, version, release, depends = []):
         """
-        @param depends: List of dependecies for the rpm
+        @param depends: List of dependencies for the rpm
         @type depends: List of strings
         """
         self.name = name
@@ -349,7 +349,7 @@ class GppkgTestCase(unittest.TestCase):
         @type gppkg_spec: GppkgSpec
         @param rpm_spec: The spec file required to build the main rpm
         @type rpm_spec: RPMSpec
-        @param dep_rpm_specs: List of all the dependecies of the main rpm
+        @param dep_rpm_specs: List of all the dependencies of the main rpm
         @type dep_rpm_specs: List of RPMSpecs
         @return: gppkg filename
         @rtype: string

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_reload.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_reload.py
@@ -3,10 +3,12 @@
 import os
 import unittest
 
+from gppylib.db.test import skipIfDatabaseDown
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations.reload import GpReload
 from mock import MagicMock, Mock, mock_open, patch
 
+@skipIfDatabaseDown()
 class GpReloadTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
@@ -7,12 +7,14 @@ import sys
 import mock
 
 from gppylib.commands.base import ExecutionError
+from gppylib.db.test import skipIfRunningOnCI
 from gppylib.operations.utils import RemoteOperation, ParallelOperation
 from gppylib.operations.test_utils_helper import TestOperation, RaiseOperation, RaiseOperation_Nested, \
     RaiseOperation_Unsafe, RaiseOperation_Unpicklable, RaiseOperation_Safe, MyException, ExceptionWithArgs
 from operations.unix import ListFiles
 from test.unit.gp_unittest import GpTestCase, run_tests
 
+@skipIfRunningOnCI()
 class UtilsTestCase(GpTestCase):
     """
     Requires GPHOME set. Does actual ssh to localhost.

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand_status.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand_status.py
@@ -5,19 +5,16 @@
 #
 
 import os
+import unittest
 
 from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
 from gppylib.commands import gp
 from gppylib.db import dbconn
+from gppylib.db.test import skipIfDatabaseDown
 
 class Context(object):
     filename = os.path.join(gp.get_masterdatadir(), 'gpexpand.status')
-    dbname = os.getenv('PGDATABASE', 'postgres')
-    dburl = dbconn.DbURL(dbname=dbname)
-    conn = dbconn.connect(dburl)
     day = 0
-
-ctx = Context()
 
 def get_gpexpand_status():
     st = gp.get_gpexpand_status()
@@ -101,9 +98,11 @@ def expanded_table(name):
         return wrapper
     return decorator
 
+@skipIfDatabaseDown()
 class GpExpandUtils(GpTestCase):
 
     def setUp(self):
+        ctx = Context()
         ctx.day = 1
         dbconn.execSQL(ctx.conn, '''
             DROP SCHEMA IF EXISTS gpexpand CASCADE;

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gphostcachelookup.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gphostcachelookup.py
@@ -9,6 +9,7 @@ import os, sys
 import unittest
 from gppylib import gplog
 from gppylib.commands.base import Command, ExecutionError
+from gppylib.db.test import skipIfRunningOnCI
 
 FILEDIR=os.path.expanduser("~")
 FILENAME=".gphostcache"
@@ -24,6 +25,7 @@ except Exception, e:
 
 GPHOSTLOOKUP = os.path.join(os.getenv('GPHOME'), 'bin/lib/', 'gphostcachelookup.py')
 
+@skipIfRunningOnCI()
 class GpHostCacheLookupTestCase(unittest.TestCase):
 
     LOOKUP_FAIL_MSG = '__lookup_of_hostname_failed__'

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpinitsystem.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpinitsystem.py
@@ -33,12 +33,6 @@ class GpInitSystemTest(GpTestCase):
         output = p.stdout.read()
         self.assertIn("[INFO]:-Checking configuration parameters, please wait...", output)
 
-    def test_option_help_prints_docs_usage(self):
-        p = Popen([self.gpinitsystem_path, '--help'], stdout=PIPE)
-        output = p.stdout.read()
-        self.assertIn("Initializes a Greenplum Database system by using configuration", output)
-        self.assertNotIn("Creates a new Greenplum Database instance", output)
-
     def test_invalid_option_prints_raw_usage(self):
         p = Popen([self.gpinitsystem_path, '--unknown-option'], stdout=PIPE)
         output = p.stdout.read()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gppkg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gppkg.py
@@ -1,10 +1,13 @@
 from mock import *
 from gp_unittest import *
+from gppylib.db.test import skipIfRunningOnCI
 from gppylib.programs.gppkg import GpPkgProgram
 
+import unittest
 import sys
 
-
+@unittest.skipUnless(sys.platform.startswith("linux"), "requires linux")
+@skipIfRunningOnCI()
 class GpPkgProgramTestCase(GpTestCase):
     def setUp(self):
         self.mock_cmd = Mock()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpssh.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpssh.py
@@ -6,8 +6,9 @@ import sys
 from mock import patch
 
 from gp_unittest import GpTestCase
+from gppylib.db.test import skipIfRunningOnCI
 
-
+@skipIfRunningOnCI()
 class GpSshTestCase(GpTestCase):
     def setUp(self):
         # because gpssh does not have a .py extension, we have to use imp to import it

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
@@ -1,11 +1,12 @@
 from mock import *
 
 from gp_unittest import *
+from gppylib.db.test import skipIfDatabaseDown
 from gppylib.gparray import GpArray, Segment
 from gppylib.commands.base import CommandResult
 from gppylib.operations.rebalanceSegments import GpSegmentRebalanceOperation
 
-
+@skipIfDatabaseDown()
 class RebalanceSegmentsTestCase(GpTestCase):
     def setUp(self):
         self.pool = Mock()

--- a/gpMgmt/requirements-dev.txt
+++ b/gpMgmt/requirements-dev.txt
@@ -1,2 +1,3 @@
 behave~=1.2.6
 coverage~=4.5
+mock


### PR DESCRIPTION
When poking about in `gpMgmt/` I realized that we have a ton of unit tests in there which are never automatically executed anywhere. This adds proper `skip` steps where required to make the tests run locally for me and hooks them up to `make unittest-check` which is executed in the CI.

The total runtime increase on my laptop was 19 seconds so it seemed perfectly worth it.