### PR TITLE
Fix markup in GPDB-additions to SGML docs.

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -16835,7 +16835,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         linkend="protocol-replication">. Corresponds to the replication protocol
         command <literal>CREATE_REPLICATION_SLOT ... PHYSICAL</literal>. The optional
         second parameter,  when <literal>true</>, specifies that the <acronym>LSN</>
-        for this replication slot be reserved immediately; the <acronym<LSN</>
+        for this replication slot be reserved immediately; the <acronym>LSN</>
         is otherwise reserved on first connection from a streaming replication
         client.
        </entry>

--- a/doc/src/sgml/ref/alter_resource_group.sgml
+++ b/doc/src/sgml/ref/alter_resource_group.sgml
@@ -5,7 +5,7 @@ PostgreSQL documentation
 
 <refentry id="SQL-ALTERRESOURCEGROUP">
  <refmeta>
-  <refentrytitle id="sql-alterresourcequeue-title">ALTER RESOURCE GROUP</refentrytitle>
+  <refentrytitle id="sql-alterresourcegroup-title">ALTER RESOURCE GROUP</refentrytitle>
   <refmiscinfo>SQL - Language Statements</refmiscinfo>
  </refmeta>
 

--- a/doc/src/sgml/ref/alter_resource_queue.sgml
+++ b/doc/src/sgml/ref/alter_resource_queue.sgml
@@ -185,7 +185,7 @@ where queue_attribute is:
   </para>
 
   <para>
-   Use <xref linkend="SQL-ALTERROLE" endterm="SQL-ALTERROLE-title"> 
+   Use <xref linkend="SQL-ALTERROLE" endterm="SQL-ALTERROLE"> 
    to add or remove users from a resource queue.  
   </para>
 
@@ -252,8 +252,8 @@ ALTER RESOURCE QUEUE myqueue WITHOUT (MAX_COST, MEMORY_LIMIT);
   <title>See Also</title>
 
   <simplelist type="inline">
-   <member><xref linkend="sql-createrole" endterm="sql-createrole-title"></member>
-   <member><xref linkend="sql-alterrole" endterm="sql-alterrole-title"></member>
+   <member><xref linkend="sql-createrole" endterm="sql-createrole"></member>
+   <member><xref linkend="sql-alterrole" endterm="sql-alterrole"></member>
    <member><xref linkend="sql-createresourcequeue" endterm="sql-createresourcequeue-title"></member>
    <member><xref linkend="sql-dropresourcequeue" endterm="sql-dropresourcequeue-title"></member>
      </simplelist>

--- a/doc/src/sgml/ref/alter_role.sgml
+++ b/doc/src/sgml/ref/alter_role.sgml
@@ -182,8 +182,8 @@ ALTER ROLE <replaceable class="PARAMETER">name</replaceable> RESOURCE GROUP {<re
       <listitem>
        <para>
         The <literal>RESOURCE QUEUE</literal> that this role is in, or 
-		<literal>NONE</literal> to remove the role from any resource queuing 
-		restrictions. See <xref linkend="sql-createresourcequeue" 
+        <literal>NONE</literal> to remove the role from any resource queuing 
+        restrictions. See <xref linkend="sql-createresourcequeue" 
         endterm="sql-createresourcequeue-title"> for more information.
        </para>
       </listitem>

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -1268,5 +1268,5 @@ ALTER TABLE distributors DROP CONSTRAINT distributors_pkey,
 </refentry>
 
 <!-- Keep this comment at the end of the file
-	 GPDB_92_MERGE_FIXME: Why not follow pg upstram to format for 'alter table' document?
+     GPDB_92_MERGE_FIXME: Why not follow pg upstram to format for 'alter table' document?
 -->

--- a/doc/src/sgml/ref/create_external_table.sgml
+++ b/doc/src/sgml/ref/create_external_table.sgml
@@ -122,79 +122,79 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
     External tables are comprised of flat files that reside outside of the database. 
     Creating an external table allows you to access these flat files as though they 
     were a regular database table. External table data can be queried directly (and in parallel) 
-	using SQL commands. You can, for example, select, join, or sort external table data. 
-	You can also create views and synonyms for external tables. However external tables 
-	are read-only. DML operations (<command>UPDATE</command>, <command>INSERT</command>, <command>DELETE</command>, or <command>TRUNCATE</command>) are not allowed, 
-	and you cannot create indexes on external tables.
+    using SQL commands. You can, for example, select, join, or sort external table data. 
+    You can also create views and synonyms for external tables. However external tables 
+    are read-only. DML operations (<command>UPDATE</command>, <command>INSERT</command>, <command>DELETE</command>, or <command>TRUNCATE</command>) are not allowed, 
+    and you cannot create indexes on external tables.
   </para>
   
   <para>
     An external table definition can be thought of as a view that allows running any 
-	SQL query against external data without requiring that data to first be loaded 
-	into the database. External tables provide an easy way to perform basic extraction, 
-	transformation, and loading (ETL) tasks that are common in data warehousing. 
-	External table files are read in parallel by the Greenplum Database segment instances, 
-	so they also provide a means for fast data loading. External tables should not be used 
-	for frequently queried tables.
+    SQL query against external data without requiring that data to first be loaded 
+    into the database. External tables provide an easy way to perform basic extraction, 
+    transformation, and loading (ETL) tasks that are common in data warehousing. 
+    External table files are read in parallel by the Greenplum Database segment instances, 
+    so they also provide a means for fast data loading. External tables should not be used 
+    for frequently queried tables.
   </para>
   
   <para>
-	You may specify multiple external data sources or URIs (uniform resource identifiers) 
-	with the <literal>LOCATION</literal> clause — up to the number of primary segment instances 
-	in your Greenplum Database array. Each URI points to an external data file or other data 
-	source. These URIs do not need to exist prior to defining an external table (<command>CREATE EXTERNAL TABLE</command> 
-	does not validate the URIs specified). However you will get an error if they cannot be found 
-	when querying the external table.
+    You may specify multiple external data sources or URIs (uniform resource identifiers) 
+    with the <literal>LOCATION</literal> clause — up to the number of primary segment instances 
+    in your Greenplum Database array. Each URI points to an external data file or other data 
+    source. These URIs do not need to exist prior to defining an external table (<command>CREATE EXTERNAL TABLE</command> 
+    does not validate the URIs specified). However you will get an error if they cannot be found 
+    when querying the external table.
   </para>
   
   <para>
     There are three protocols that you can use to access the external table data sources. 
-	You may use one of the following protocols per <command>CREATE EXTERNAL TABLE</command> statement 
-	(cannot mix protocols): 
+    You may use one of the following protocols per <command>CREATE EXTERNAL TABLE</command> statement 
+    (cannot mix protocols): 
   </para>
   
   <para>
-	gpfdist — If using the <literal>gpfdist://</literal> protocol, you must have the 
-	Greenplum file distribution program (<literal>gpfdist</literal>) running on the host where the external 
-	data files reside. This program points to a given directory on the file host and 
-	serves external data files to all Greenplum Database segments in parallel. 
-	All primary segments access the external file(s) in parallel regardless of how 
-	many URIs you specify when defining the external table. <literal>gpfdist</literal> 
-	is located in <literal>$GPHOME/bin<literal> on your Greenplum Database master host. 
+    gpfdist — If using the <literal>gpfdist://</literal> protocol, you must have the 
+    Greenplum file distribution program (<literal>gpfdist</literal>) running on the host where the external 
+    data files reside. This program points to a given directory on the file host and 
+    serves external data files to all Greenplum Database segments in parallel. 
+    All primary segments access the external file(s) in parallel regardless of how 
+    many URIs you specify when defining the external table. <literal>gpfdist</literal> 
+    is located in <literal>$GPHOME/bin<literal> on your Greenplum Database master host. 
   </para>
   
   <para>
     file — If using the <literal>file://</literal> protocol the external data file(s) 
-	must reside on a segment host in a location accessible by the Greenplum super user 
-	(gpadmin). The number of URIs specified corresponds to the number of segment 
-	instances that will work in parallel to access the external table. So for 
-	example, if you have a Greenplum Database system with 8 primary segments and 
-	you specify 2 external files, only 2 of the 8 segments will access the external 
-	table in parallel at query time. The number of external files per segment host 
-	cannot exceed the number of primary segment instances on that host. For example, 
-	if your array has 4 primary segment instances per segment host, you may place 
-	4 external files on each segment host. Also, the host name used in the URI 
-	must match the segment host name as registered in the 
-	<literal>gp_segment_configuration</literal> system catalog table.
+    must reside on a segment host in a location accessible by the Greenplum super user 
+    (gpadmin). The number of URIs specified corresponds to the number of segment 
+    instances that will work in parallel to access the external table. So for 
+    example, if you have a Greenplum Database system with 8 primary segments and 
+    you specify 2 external files, only 2 of the 8 segments will access the external 
+    table in parallel at query time. The number of external files per segment host 
+    cannot exceed the number of primary segment instances on that host. For example, 
+    if your array has 4 primary segment instances per segment host, you may place 
+    4 external files on each segment host. Also, the host name used in the URI 
+    must match the segment host name as registered in the 
+    <literal>gp_segment_configuration</literal> system catalog table.
   </para>
   
   <para>
     http — If using the <literal>http://</literal> protocol the external data file(s) 
-	must reside on a web server that is accessible by the Greenplum segment hosts. 
-	The number of URIs specified corresponds to the number of segment instances 
-	that will work in parallel to access the external table. So for example, 
-	if you have a Greenplum Database system with 8 primary segments and you specify 2 
-	external files, only 2 of the 8 segments will access the external table in 
-	parallel at query time.
-	</para>
-	
+    must reside on a web server that is accessible by the Greenplum segment hosts. 
+    The number of URIs specified corresponds to the number of segment instances 
+    that will work in parallel to access the external table. So for example, 
+    if you have a Greenplum Database system with 8 primary segments and you specify 2 
+    external files, only 2 of the 8 segments will access the external table in 
+    parallel at query time.
+    </para>
+    
   <para>
     The <literal>FORMAT</literal> clause is used to describe how the external 
-	table files are formatted. The files can be in either plain text (TEXT) 
-	or comma separated values (CSV) format. If the data in the file does not 
-	use the default column delimiter, escape character, null string and so on, 
-	you must specify the additional formatting options so that the data in 
-	the external file is read correctly by Greenplum Database.
+    table files are formatted. The files can be in either plain text (TEXT) 
+    or comma separated values (CSV) format. If the data in the file does not 
+    use the default column delimiter, escape character, null string and so on, 
+    you must specify the additional formatting options so that the data in 
+    the external file is read correctly by Greenplum Database.
 </para>
 
 </refsect1>
@@ -218,8 +218,8 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
     <listitem>
      <para>
       The name of a column to create in the external table. 
-	  Unlike regular tables, external tables do not have column 
-	  constraints or default values, so do not specify those.
+      Unlike regular tables, external tables do not have column 
+      constraints or default values, so do not specify those.
      </para>
     </listitem>
    </varlistentry>
@@ -238,8 +238,8 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
     <listitem>
      <para>
       Specifies the URI of the external data source(s) to be used to populate the external table. 
-	  If the host name is omitted, localhost is assumed. If port is omitted for http and gpfdist protocols, 
-	  port 8080 is assumed.
+      If the host name is omitted, localhost is assumed. If port is omitted for http and gpfdist protocols, 
+      port 8080 is assumed.
      </para>
     </listitem>
    </varlistentry>
@@ -249,7 +249,7 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
     <listitem>
      <para>
       Specifies the format of the external file(s) - either plain text 
-	  (<literal>TEXT</literal>) or comma separated values (<literal>CSV</literal>) format.
+      (<literal>TEXT</literal>) or comma separated values (<literal>CSV</literal>) format.
      </para>
     </listitem>
    </varlistentry>
@@ -259,8 +259,8 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
     <listitem>
      <para>
       Specifies a single character that separates columns within 
-	  each row (line) of the external file. The default 
-	  is a tab character in TEXT mode, a comma in CSV mode.
+      each row (line) of the external file. The default 
+      is a tab character in TEXT mode, a comma in CSV mode.
      </para>
     </listitem>
    </varlistentry>
@@ -270,12 +270,12 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
     <listitem>
      <para>
       Specifies the string that represents a null value. 
-	  The default is \N (backslash-N) in TEXT mode, and an 
-	  empty value with no quotations in CSV mode. You might 
-	  prefer an empty string even in TEXT mode for cases where 
-	  you do not want to distinguish nulls from empty strings. 
-	  When using external tables, any data item that matches this 
-	  string will be considered a null value. 
+      The default is \N (backslash-N) in TEXT mode, and an 
+      empty value with no quotations in CSV mode. You might 
+      prefer an empty string even in TEXT mode for cases where 
+      you do not want to distinguish nulls from empty strings. 
+      When using external tables, any data item that matches this 
+      string will be considered a null value. 
      </para>
     </listitem>
    </varlistentry>
@@ -285,15 +285,15 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
     <listitem>
      <para>
       Specifies the single character that is used for C escape sequences 
-	  (such as \n,\t,\100, and so on) and for escaping data characters 
-	  that might otherwise be taken as row or column delimiters. Make 
-	  sure to choose an escape character that is not used anywhere in 
-	  your actual column data. The default escape character is a 
-	  \ (backslash), however it is possible to specify any other 
-	  character to represent an escape. It is also possible to 
-	  disable escaping by specifying the value <literal>OFF</literal> as the escape value. 
-	  This is very useful for data such as web log data that has many 
-	  embedded backslashes that are not intended to be escapes. 
+      (such as \n,\t,\100, and so on) and for escaping data characters 
+      that might otherwise be taken as row or column delimiters. Make 
+      sure to choose an escape character that is not used anywhere in 
+      your actual column data. The default escape character is a 
+      \ (backslash), however it is possible to specify any other 
+      character to represent an escape. It is also possible to 
+      disable escaping by specifying the value <literal>OFF</literal> as the escape value. 
+      This is very useful for data such as web log data that has many 
+      embedded backslashes that are not intended to be escapes. 
      </para>
     </listitem>
    </varlistentry>
@@ -303,13 +303,13 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
     <listitem>
      <para>
       For CSV formatted files, specifies that the first line in the 
-	  external file(s) is a header row (contains the names of 
-	  the table columns) and should not be included as data for the 
-	  external table. If using multiple external files, all files must 
-	  have a header row. If using the <literal>gpfdist://</literal> protocol, 
-	  do not use the <literal>HEADER</literal> clause. Instead, 
-	  specify the header (<literal>-h</literal>) option when 
-	  starting the <literal>gpfdist</literal> utility.
+      external file(s) is a header row (contains the names of 
+      the table columns) and should not be included as data for the 
+      external table. If using multiple external files, all files must 
+      have a header row. If using the <literal>gpfdist://</literal> protocol, 
+      do not use the <literal>HEADER</literal> clause. Instead, 
+      specify the header (<literal>-h</literal>) option when 
+      starting the <literal>gpfdist</literal> utility.
      </para>
     </listitem>
    </varlistentry>
@@ -328,9 +328,9 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
     <listitem>
      <para>
       In CSV mode, processes each specified column as though 
-	  it were quoted and hence not a NULL value. For the default 
-	  null string in CSV mode (nothing between two delimiters), 
-	  this causes missing values to be evaluated as zero-length strings.
+      it were quoted and hence not a NULL value. For the default 
+      null string in CSV mode (nothing between two delimiters), 
+      this causes missing values to be evaluated as zero-length strings.
      </para>
     </listitem>
    </varlistentry>
@@ -343,23 +343,23 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
 
    <para>
      There is a system view named <literal>pg_max_external_files</literal> that you can use 
-	 to determine how many external table files are permitted per external table. 
-	 This view lists the available file slots per segment host (if using the <literal>file://</literal> protocol). 
-	 For example: <literal>SELECT * FROM pg_max_external_files;</literal>
+     to determine how many external table files are permitted per external table. 
+     This view lists the available file slots per segment host (if using the <literal>file://</literal> protocol). 
+     For example: <literal>SELECT * FROM pg_max_external_files;</literal>
   </para>
   <para>
       During dump/restore operations, only external table definitions will be backed up 
-	  and restored. The data files will not be included. You can use <command>CREATE TABLE AS</command>, 
-	  <command>SELECT INTO</command>, or <command>INSERT...SELECT</command> to load external table 
-	  data files into another (non-external) database table, and the data will be 
-	  loaded in parallel according to the external table definition. 
+      and restored. The data files will not be included. You can use <command>CREATE TABLE AS</command>, 
+      <command>SELECT INTO</command>, or <command>INSERT...SELECT</command> to load external table 
+      data files into another (non-external) database table, and the data will be 
+      loaded in parallel according to the external table definition. 
   </para>
   <para>
-	  If an external table file has a data error, any operation that reads from the 
-	  external table will fail. Similar to <command>COPY</command>, loading from 
-	  external tables is an all or nothing operation.
+      If an external table file has a data error, any operation that reads from the 
+      external table will fail. Similar to <command>COPY</command>, loading from 
+      external tables is an all or nothing operation.
   </para>
-	 
+     
 </refsect1>
 
 
@@ -381,9 +381,9 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
 
  <para>
     Create an external table named <structname>ext_customer</> using 
-	the <literal>gpfdist</> protocol and a text formatted file 
-	named <structname>customers.txt</> with a pipe (|) as the 
-	column delimiter and an empty space as null:
+    the <literal>gpfdist</> protocol and a text formatted file 
+    named <structname>customers.txt</> with a pipe (|) as the 
+    column delimiter and an empty space as null:
    <programlisting>
      CREATE EXTERNAL TABLE ext_customer (id int, name text, sponsor text) 
      LOCATION ( 'gpfdist://*.txt' ) 

--- a/doc/src/sgml/ref/create_resource_queue.sgml
+++ b/doc/src/sgml/ref/create_resource_queue.sgml
@@ -224,7 +224,7 @@ where queue_attribute is:
   </para>
 
   <para>
-   Use <xref linkend="SQL-ALTERROLE" endterm="SQL-ALTERROLE-title"> 
+   Use <xref linkend="SQL-ALTERROLE" endterm="SQL-ALTERROLE"> 
    to add or remove users from a resource queue.  
   </para>
 
@@ -282,8 +282,8 @@ CREATE RESOURCE QUEUE myqueue WITH (ACTIVE_STATEMENTS=30, MAX_COST=5000.00);
   <title>See Also</title>
 
   <simplelist type="inline">
-   <member><xref linkend="sql-createrole" endterm="sql-createrole-title"></member>
-   <member><xref linkend="sql-alterrole" endterm="sql-alterrole-title"></member>
+   <member><xref linkend="sql-createrole" endterm="sql-createrole"></member>
+   <member><xref linkend="sql-alterrole" endterm="sql-alterrole"></member>
    <member><xref linkend="sql-alterresourcequeue" endterm="sql-alterresourcequeue-title"></member>
    <member><xref linkend="sql-dropresourcequeue" endterm="sql-dropresourcequeue-title"></member>
      </simplelist>

--- a/doc/src/sgml/ref/create_role.sgml
+++ b/doc/src/sgml/ref/create_role.sgml
@@ -339,7 +339,7 @@ CREATE ROLE <replaceable class="PARAMETER">name</replaceable> [ [ WITH ] <replac
         You can assign the <literal>default_group</literal> resource group to any role.
        </para>
        <para>
-	See <xref linkend="sql-createresourcegroup" 
+        See <xref linkend="sql-createresourcegroup" 
         endterm="sql-createresourcegroup-title"> for more information.
        </para>
       </listitem>
@@ -350,7 +350,7 @@ CREATE ROLE <replaceable class="PARAMETER">name</replaceable> [ [ WITH ] <replac
       <listitem>
        <para>
         The <literal>RESOURCE QUEUE</literal> that this role is in.
-		See <xref linkend="sql-createresourcequeue" 
+        See <xref linkend="sql-createresourcequeue" 
         endterm="sql-createresourcequeue-title"> for more information.
        </para>
       </listitem>

--- a/doc/src/sgml/ref/drop_resource_queue.sgml
+++ b/doc/src/sgml/ref/drop_resource_queue.sgml
@@ -105,7 +105,7 @@ ALTER ROLE RESOURCE QUEUE none;
   <title>See Also</title>
 
   <simplelist type="inline">
-   <member><xref linkend="sql-alterrole" endterm="sql-alterrole-title"></member>
+   <member><xref linkend="sql-alterrole" endterm="sql-alterrole"></member>
    <member><xref linkend="sql-createresourcequeue" endterm="sql-createresourcequeue-title"></member>
   <member><xref linkend="sql-alterresourcequeue" endterm="sql-alterresourcequeue-title"></member>
   </simplelist>

--- a/doc/src/sgml/ref/initdb.sgml
+++ b/doc/src/sgml/ref/initdb.sgml
@@ -324,8 +324,8 @@ PostgreSQL documentation
      <term><option>--text-search-config=<replaceable>CFG</></option></term>
      <listitem>
       <para>
-	   Sets the default text search configuration.
-	   See <xref linkend="guc-default-text-search-config"> for further information.
+       Sets the default text search configuration.
+       See <xref linkend="guc-default-text-search-config"> for further information.
       </para>
      </listitem>
     </varlistentry>

--- a/doc/src/sgml/ref/pg_dumpall.sgml
+++ b/doc/src/sgml/ref/pg_dumpall.sgml
@@ -180,6 +180,11 @@ PostgreSQL documentation
        <para>
         Dump <literal>resource groups</literal> and <literal>role</literal>
         to <literal>resource groups</literal> associations.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
       <term><option>--lock-wait-timeout=<replaceable class="parameter">timeout</replaceable></option></term>
       <listitem>
        <para>

--- a/doc/src/sgml/ref/select.sgml
+++ b/doc/src/sgml/ref/select.sgml
@@ -39,21 +39,21 @@ SELECT [ ALL | DISTINCT [ ON ( <replaceable class="parameter">expression</replac
     [ WHERE <replaceable class="parameter">condition</replaceable> ]
     [ GROUP BY <replaceable class="parameter">grouping_element</replaceable> [, ...] ]
     [ HAVING <replaceable class="parameter">condition</replaceable> [, ...] ]
-	[ WINDOW <replaceable class="parameter">window_name</replaceable> AS (<replaceable class="parameter">window_specification</replaceable>) ]
+    [ WINDOW <replaceable class="parameter">window_name</replaceable> AS (<replaceable class="parameter">window_specification</replaceable>) ]
     [ { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] <replaceable class="parameter">select</replaceable> ]
     [ ORDER BY <replaceable class="parameter">expression</replaceable> [ ASC | DESC | USING <replaceable class="parameter">operator</replaceable> ] [ NULLS { FIRST | LAST } ] [, ...] ]
     [ LIMIT { <replaceable class="parameter">count</replaceable> | ALL } ]
     [ OFFSET <replaceable class="parameter">start</replaceable> [ ROW | ROWS ] ]
     [ FETCH { FIRST | NEXT } [ <replaceable class="parameter">count</replaceable> ] { ROW | ROWS } ONLY ]
     [ FOR { UPDATE | NO KEY UPDATE | SHARE | KEY SHARE } [ OF <replaceable class="parameter">table_name</replaceable> [, ...] ] [ NOWAIT ] [...] ]
-	
+
 where <replaceable class="parameter">grouping_element</replaceable> can be one of:
     ()
     <replaceable class="parameter">expression</replaceable>
     ROLLUP ( [ <replaceable class="parameter">expression</replaceable> [, ...] ] )
     CUBE ( [ <replaceable class="parameter">expression</replaceable> [, ...] ] )
     GROUPING SETS ( ( <replaceable class="parameter">grouping_element</replaceable> [, ...] ) ) 
-	
+
 
 where <replaceable class="parameter">window_specification</replaceable> can be:
     [ <replaceable class="parameter">window_name</replaceable> ]


### PR DESCRIPTION
We don't build the HTML docs in GPDB like we do in PostgreSQL, but let's
be tidy anyway.

* We don't allow tabs in SGML files. There's a "make check-tabs" target
  to check for them.

* Fix reference to non-existing SQL-ALTERROLE-title sections. (Should be
  SQL-ALTERROLE)

* Fix copy-pasto in link to ALTER RESOURCE GROUP.

* In func.sgml, a tag was typoed.

* In pg_dumpall.sgml, the term-tag is not allowed in this part in DocBook
  format.
