### PR TITLE
Backport 6X_STABLE: Add flag to pg_regress to display failure diffs on stdout.

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -96,6 +96,7 @@ char	   *outputdir = ".";
 char	   *prehook = "";
 char	   *psqldir = PGBINDIR;
 char	   *launcher = NULL;
+bool        print_failure_diffs_is_enabled = false;
 bool 		optimizer_enabled = false;
 bool 		resgroup_enabled = false;
 static _stringlist *loadlanguage = NULL;
@@ -1748,6 +1749,32 @@ file_line_count(const char *file)
 	return l;
 }
 
+static FILE *
+open_file_for_reading(const char *filename) {
+	FILE *file = fopen(filename, "r");
+
+	if (!file)
+	{
+		fprintf(stderr, _("%s: could not open file \"%s\" for reading: %s\n"),
+				progname, filename, strerror(errno));
+		exit(1);
+	}
+
+	return file;
+}
+
+static void
+print_contents_of_file(const char* filename) {
+	FILE *file;
+	char string[1024];
+
+	file = open_file_for_reading(filename);
+	while (fgets(string, sizeof(string), file))
+		fprintf(stdout, "%s", string);
+
+	fclose(file);
+}
+
 bool
 file_exists(const char *file)
 {
@@ -2722,6 +2749,7 @@ help(void)
 	printf(_("  --ao-dir=DIR              directory name prefix containing generic\n"));
 	printf(_("                            UAO row and column tests\n"));
 	printf(_("  --ignore-plans            ignore any explain plan diffs\n"));
+	printf(_("  --print-failure-diffs     Print the diff file to standard out after a failure\n"));
 	printf(_("\n"));
 	printf(_("Options for \"temp-install\" mode:\n"));
 	printf(_("  --extra-install=DIR       additional directory to install (e.g., contrib)\n"));
@@ -2776,6 +2804,7 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 		{"exclude-tests", required_argument, NULL, 27},
 		{"ignore-plans", no_argument, NULL, 28},
 		{"prehook", required_argument, NULL, 29},
+		{"print-failure-diffs", no_argument, NULL, 30},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -2907,6 +2936,9 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 				break;
 			case 29:
 				prehook = strdup(optarg);
+				break;
+			case 30:
+				print_failure_diffs_is_enabled = true;
 				break;
 			default:
 				/* getopt_long already emitted a complaint */
@@ -3356,6 +3388,9 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 
 	if (file_size(difffilename) > 0)
 	{
+		if (print_failure_diffs_is_enabled)
+			print_contents_of_file(difffilename);
+
 		printf(_("The differences that caused some tests to fail can be viewed in the\n"
 				 "file \"%s\".  A copy of the test summary that you see\n"
 				 "above is saved in the file \"%s\".\n\n"),


### PR DESCRIPTION
This backports commits from master that enable these features:

When given --print-failure-diffs, pg_regress prints the contents of
regression.diffs after a failure.

(cherry picked from commit b53650103130d2a5b7ca2ca31a5cb45835004945)

Print pg_regress failure diffs using fgets.

(cherry picked from commit 99e541687f8fd8efafc854030c7ae73cb910f979)

