### PR TITLE
Remove copying of .pl/.pm Perl scripts into bin/

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -633,8 +633,6 @@ mgmtcopy :
 	cp -rp $(GPMGMT)/bin/ext/* $(INSTLOC)/lib/python
 	cp -rp $(GPMGMT)/bin $(INSTLOC)
 	cp -rp $(GPMGMT)/sbin/* $(INSTLOC)/sbin/.
-	cp $(GPPGDIR)/src/test/regress/*.pl $(INSTLOC)/bin
-	cp $(GPPGDIR)/src/test/regress/*.pm $(INSTLOC)/bin
 	if [ ! -d ${INSTLOC}/docs ] ; then mkdir ${INSTLOC}/docs ; fi
 	if [ -d $(GPMGMT)/doc ]; then cp -rp $(GPMGMT)/doc $(INSTLOC)/docs/cli_help; fi
 	if [ -d $(GPMGMT)/demo/gpfdist_transform ]; then \

--- a/gpAux/releng/NON_PRODUCTION_FILES.txt
+++ b/gpAux/releng/NON_PRODUCTION_FILES.txt
@@ -1,5 +1,2 @@
-bin/explain.pl
-bin/explain.pm
-bin/gptorment.pl
 bin/pgbench
 bin/postgresql_conf_gp_additions

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -96,8 +96,6 @@ install: generate_greenplum_path_file
 
 	$(MAKE) -C sbin $@ prefix=$(DESTDIR)$(prefix)
 
-	cp $(top_builddir)/src/test/regress/*.pl $(DESTDIR)$(prefix)/bin
-	cp $(top_builddir)/src/test/regress/*.pm $(DESTDIR)$(prefix)/bin
 	if [ ! -d ${DESTDIR}${prefix}/docs ] ; then mkdir ${DESTDIR}${prefix}/docs ; fi
 	if [ -d doc ]; then cp -rp doc $(DESTDIR)$(prefix)/docs/cli_help; fi
 


### PR DESCRIPTION
w/ @marksliva 

None of the perl scripts in src/test/regress should be distributed to
customers, so this copying should not be happening.

These commits break the ICW jobs with messages like the below:
```
FAIL: testQuery01 (__main__.GPLoad_Env_TestCase)
[...]
Traceback (most recent call last):
  File "./TEST.py", line 417, in testQuery01
[...]
AssertionError: query resulted in diff:
/bin/sh: gpdiff.pl: command not found
```

https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-remove_cp_perl_files

We think these tests should be updated to call the proper Makefile target to build the perl scripts they are using. Right now, it's relying on some tech debt that builds the test-related .pl/.pm files into all of bin_gpdb, which ends up being shipped to customers except for NON_PRODUCTION_FILES.txt (which didn't work for explain.pm apparently?), which is not good.

```sh
$> find /usr/local/greenplum-db-6.0.0-beta.3/ -name *.pl
/usr/local/greenplum-db-6.0.0-beta.3/bin/gpstringsubs.pl
/usr/local/greenplum-db-6.0.0-beta.3/bin/get_ereport.pl
/usr/local/greenplum-db-6.0.0-beta.3/bin/gpsourcify.pl
/usr/local/greenplum-db-6.0.0-beta.3/bin/gpdiff.pl
/usr/local/greenplum-db-6.0.0-beta.3/bin/dld.pl
/usr/local/greenplum-db-6.0.0-beta.3/bin/atmsort.pl
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/regress/gpstringsubs.pl
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/regress/gpdiff.pl
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/regress/explain.pl
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/regress/atmsort.pl
$> find /usr/local/greenplum-db-6.0.0-beta.3/ -name *.pm
/usr/local/greenplum-db-6.0.0-beta.3/bin/atmsort.pm
/usr/local/greenplum-db-6.0.0-beta.3/bin/GPTest.pm
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/regress/atmsort.pm
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/regress/explain.pm
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/regress/GPTest.pm
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/perl/SimpleTee.pm
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/perl/RecursiveCopy.pm
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/perl/PostgresNode.pm
/usr/local/greenplum-db-6.0.0-beta.3/lib/postgresql/pgxs/src/test/perl/TestLib.pm
```

```sh
$> find /usr/local/greenplum-db-5.21.0/ -name *.pl
/usr/local/greenplum-db-5.21.0/bin/gpcheckmirrorseg.pl
/usr/local/greenplum-db-5.21.0/bin/gpstringsubs.pl
/usr/local/greenplum-db-5.21.0/bin/get_ereport.pl
/usr/local/greenplum-db-5.21.0/bin/gpsourcify.pl
/usr/local/greenplum-db-5.21.0/bin/gpdiff.pl
/usr/local/greenplum-db-5.21.0/bin/dld.pl
/usr/local/greenplum-db-5.21.0/bin/atmsort.pl
/usr/local/greenplum-db-5.21.0/lib/postgresql/pgxs/src/test/regress/gpstringsubs.pl
/usr/local/greenplum-db-5.21.0/lib/postgresql/pgxs/src/test/regress/gpdiff.pl
/usr/local/greenplum-db-5.21.0/lib/postgresql/pgxs/src/test/regress/explain.pl
/usr/local/greenplum-db-5.21.0/lib/postgresql/pgxs/src/test/regress/atmsort.pl
$> find /usr/local/greenplum-db-5.21.0/ -name *.pm
/usr/local/greenplum-db-5.21.0/bin/atmsort.pm
/usr/local/greenplum-db-5.21.0/bin/explain.pm
/usr/local/greenplum-db-5.21.0/lib/postgresql/pgxs/src/test/regress/atmsort.pm
/usr/local/greenplum-db-5.21.0/lib/postgresql/pgxs/src/test/regress/explain.pm
```