### PR TITLE
Add tablespace oid to pg_xlogdump output

### DIFF
--- a/src/backend/access/rmgrdesc/xactdesc.c
+++ b/src/backend/access/rmgrdesc/xactdesc.c
@@ -99,6 +99,8 @@ xact_desc_commit(StringInfo buf, xl_xact_commit *xlrec)
 			pfree(path);
 		}
 	}
+	if (xlrec->tablespace_oid_to_delete_on_commit != InvalidOid)
+		appendStringInfo(buf, "; tablespace_oid_to_delete_on_commit: %u", xlrec->tablespace_oid_to_delete_on_commit);
 
 	/*
 -	 * MPP: Return end of regular commit information.
@@ -188,6 +190,8 @@ xact_desc_abort(StringInfo buf, xl_xact_abort *xlrec)
 			pfree(path);
 		}
 	}
+	if (xlrec->tablespace_oid_to_delete_on_abort != InvalidOid)
+		appendStringInfo(buf, "; tablespace_oid_to_delete_on_abort: %u", xlrec->tablespace_oid_to_delete_on_abort);
 }
 
 static void


### PR DESCRIPTION
Adds tablespace OID to `pg_xlogdump` output for `xl_xact_commit` and `xl_xact_abort` records for debugging purposes.  The OID information is actually redundant and can be backtraced through the commit record, however it could still be useful in case the first message is not available.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
