### PR TITLE
Make gpload tests self-contained

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -629,8 +629,6 @@ mgmtcopy :
 	cp -rp $(GPMGMT)/bin/ext/* $(INSTLOC)/lib/python
 	cp -rp $(GPMGMT)/bin $(INSTLOC)
 	cp -rp $(GPMGMT)/sbin/* $(INSTLOC)/sbin/.
-	cp $(GPPGDIR)/src/test/regress/*.pl $(INSTLOC)/bin
-	cp $(GPPGDIR)/src/test/regress/*.pm $(INSTLOC)/bin
 	if [ ! -d ${INSTLOC}/docs ] ; then mkdir ${INSTLOC}/docs ; fi
 	if [ -d $(GPMGMT)/doc ]; then cp -rp $(GPMGMT)/doc $(INSTLOC)/docs/cli_help; fi
 	if [ -d $(GPMGMT)/demo/gpfdist_transform ]; then \

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -96,8 +96,6 @@ install: generate_greenplum_path_file
 
 	$(MAKE) -C sbin $@ prefix=$(DESTDIR)$(prefix)
 
-	cp $(top_builddir)/src/test/regress/*.pl $(DESTDIR)$(prefix)/bin
-	cp $(top_builddir)/src/test/regress/*.pm $(DESTDIR)$(prefix)/bin
 	if [ ! -d ${DESTDIR}${prefix}/docs ] ; then mkdir ${DESTDIR}${prefix}/docs ; fi
 	if [ -d doc ]; then cp -rp doc $(DESTDIR)$(prefix)/docs/cli_help; fi
 

--- a/gpMgmt/bin/gpload_test/.gitignore
+++ b/gpMgmt/bin/gpload_test/.gitignore
@@ -4,3 +4,8 @@ gpload/config
 gpload2/config
 gpload2/setup.out
 gpload2/data_file.txt
+GPTest.pm
+gpstringsubs.pl
+gpdiff.pl
+atmsort.pm
+explain.pm

--- a/gpMgmt/bin/gpload_test/Makefile
+++ b/gpMgmt/bin/gpload_test/Makefile
@@ -1,5 +1,25 @@
-installcheck:
+top_builddir=../../..
+include $(top_builddir)/src/Makefile.global
+
+gpstringsubs.pl:
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpstringsubs.pl
+
+gpdiff.pl: atmsort.pm explain.pm GPTest.pm
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpdiff.pl
+
+atmsort.pm:
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/atmsort.pm
+
+explain.pm:
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/explain.pm
+
+GPTest.pm:
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/GPTest.pm
+
+.PHONY: installcheck
+installcheck: gpdiff.pl gpstringsubs.pl
 	@cd gpload && ./TEST.py
 	@cd gpload2 && ./TEST.py
 
-.PHONY: installcheck
+clean distclean:
+	rm -f gpdiff.pl atmsort.pm explain.pm GPTest.pm gpstringsubs.pl

--- a/gpMgmt/bin/gpload_test/gpload/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload/TEST.py
@@ -181,17 +181,17 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
     # Gets the suitePath name to add init_file
     suitePath = f1[0:f1.rindex( "/" )]
     if os.path.exists(suitePath + "/init_file"):
-        (ok, out) = run('gpdiff.pl -w ' + optionalFlags + \
+        (ok, out) = run('../gpdiff.pl -w ' + optionalFlags + \
                               ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s/global_init_file --gp_init_file=%s/init_file '
                               '%s %s > %s 2>&1' % (LMYD, suitePath, f1, f2, dfile))
 
     else:
         if os.path.exists(myinitfile):
-            (ok, out) = run('gpdiff.pl -w ' + optionalFlags + \
+            (ok, out) = run('../gpdiff.pl -w ' + optionalFlags + \
                                   ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s/global_init_file --gp_init_file=%s '
                                   '%s %s > %s 2>&1' % (LMYD, myinitfile, f1, f2, dfile))
         else:
-            (ok, out) = run( 'gpdiff.pl -w ' + optionalFlags + \
+            (ok, out) = run( '../gpdiff.pl -w ' + optionalFlags + \
                               ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s/global_init_file '
                               '%s %s > %s 2>&1' % ( LMYD, f1, f2, dfile ) )
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -306,17 +306,17 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
     # Gets the suitePath name to add init_file
     suitePath = f1[0:f1.rindex( "/" )]
     if os.path.exists(suitePath + "/init_file"):
-        (ok, out) = run('gpdiff.pl -w ' + optionalFlags + \
+        (ok, out) = run('../gpdiff.pl -w ' + optionalFlags + \
                               ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s/global_init_file --gp_init_file=%s/init_file '
                               '%s %s > %s 2>&1' % (LMYD, suitePath, f1, f2, dfile))
 
     else:
         if os.path.exists(myinitfile):
-            (ok, out) = run('gpdiff.pl -w ' + optionalFlags + \
+            (ok, out) = run('../gpdiff.pl -w ' + optionalFlags + \
                                   ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s/global_init_file --gp_init_file=%s '
                                   '%s %s > %s 2>&1' % (LMYD, myinitfile, f1, f2, dfile))
         else:
-            (ok, out) = run( 'gpdiff.pl -w ' + optionalFlags + \
+            (ok, out) = run( '../gpdiff.pl -w ' + optionalFlags + \
                               ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s/global_init_file '
                               '%s %s > %s 2>&1' % ( LMYD, f1, f2, dfile ) )
 


### PR DESCRIPTION
The installation target in gpMgm/ blindly copied Perl programs and modules in order for the gpload test to be able to run gpdiff from PATH. This causes non-production code to be erroneously installed and required an elaborate dance to remove before packaging.

This removes the installation and instead installs the required Perl code from regress as symlinks just like how other test suites are doing it.

A careful observer might note that TEST_REMOTE.py still call the Perl programs from PATH, and that's Ok (for now) as it's only to be invoked via the clients package CI and that CI performs a copy step of gpdiff much like how this patch does a symlink.

This PR is an attempt at solving the issue discussed in PR #8237. If this works then we can remove all the uses of NON_PRODUCTION_FILES, but I've opted for keeping that for now as it involves reconfiguring pipelines.