### PR TITLE
Invalidate cached plans on search_path changes

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -2731,6 +2731,28 @@ GetOverrideSearchPath(MemoryContext context)
 }
 
 /*
+ * OverrideSearchPathMatchesCurrent - does path match current setting?
+ */
+bool
+OverrideSearchPathMatchesCurrent(OverrideSearchPath *path)
+{
+	/* Easiest way to do this is GetOverrideSearchPath() and compare */
+	bool            result;
+	OverrideSearchPath *cur;
+
+	cur = GetOverrideSearchPath(CurrentMemoryContext);
+	if (path->addCatalog == cur->addCatalog &&
+		path->addTemp == cur->addTemp &&
+		equal(path->schemas, cur->schemas))
+		result = true;
+	else
+		result = false;
+	list_free(cur->schemas);
+	pfree(cur);
+	return result;
+}
+
+/*
  * PushOverrideSearchPath - temporarily override the search path
  *
  * We allow nested overrides, hence the push/pop terminology.  The GUC

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -118,6 +118,7 @@ extern Oid	GetTempToastNamespace(void);
 extern void ResetTempTableNamespace(void);
 
 extern OverrideSearchPath *GetOverrideSearchPath(MemoryContext context);
+extern bool OverrideSearchPathMatchesCurrent(OverrideSearchPath *path);
 extern void PushOverrideSearchPath(OverrideSearchPath *newpath);
 extern void PopOverrideSearchPath(void);
 

--- a/src/test/regress/expected/plancache.out
+++ b/src/test/regress/expected/plancache.out
@@ -163,7 +163,7 @@ select cache_test_2();
         10007
 (1 row)
 
---- Check that change of search_path is ignored by replans
+--- Check that change of search_path is honored when re-using cached plan
 create schema s1
   create table abc (f1 int);
 create schema s2
@@ -188,14 +188,14 @@ select f1 from abc;
 execute p1;
  f1  
 -----
- 123
+ 456
 (1 row)
 
 alter table s1.abc add column f2 float8;   -- force replan
 execute p1;
  f1  
 -----
- 123
+ 456
 (1 row)
 
 drop schema s1 cascade;

--- a/src/test/regress/expected/plancache.out
+++ b/src/test/regress/expected/plancache.out
@@ -198,6 +198,45 @@ execute p1;
  456
 (1 row)
 
+-- GPDB: Check that search_path change is honored in the plpgsql body
+-- (bug in upstream and fixed in v9.3)
+CREATE OR REPLACE FUNCTION s1.test_searchpath() RETURNS integer
+LANGUAGE 'plpgsql' AS $BODY$
+BEGIN
+	RETURN 1;
+END;
+$BODY$;
+CREATE OR REPLACE FUNCTION s2.test_searchpath() RETURNS integer
+LANGUAGE 'plpgsql' AS $BODY$
+BEGIN
+	RETURN 2;
+END;
+$BODY$;
+CREATE OR REPLACE FUNCTION public.test_searchpath(p_search_path character varying) RETURNS integer
+LANGUAGE 'plpgsql' AS $BODY$
+DECLARE v_ret integer = -1;
+BEGIN
+	-- The EXECUTE statement will force replanning
+	EXECUTE 'SET search_path to ' || p_search_path;
+	SELECT test_searchpath() into v_ret;
+	RETURN v_ret;
+END;
+$BODY$;
+SELECT * FROM public.test_searchpath('s1');
+ test_searchpath 
+-----------------
+               1
+(1 row)
+
+SELECT * FROM public.test_searchpath('s2');
+ test_searchpath 
+-----------------
+               2
+(1 row)
+
+DROP FUNCTION s1.test_searchpath();
+DROP FUNCTION s2.test_searchpath();
+DROP FUNCTION public.test_searchpath(p_search_path character varying);
 drop schema s1 cascade;
 NOTICE:  drop cascades to table s1.abc
 drop schema s2 cascade;

--- a/src/test/regress/sql/plancache.sql
+++ b/src/test/regress/sql/plancache.sql
@@ -94,7 +94,7 @@ create or replace temp view v1 as
   select 2+2+4+(select max(unique1) from tenk1) as f1;
 select cache_test_2();
 
---- Check that change of search_path is ignored by replans
+--- Check that change of search_path is honored when re-using cached plan
 
 create schema s1
   create table abc (f1 int);

--- a/src/test/regress/sql/plancache.sql
+++ b/src/test/regress/sql/plancache.sql
@@ -121,6 +121,41 @@ alter table s1.abc add column f2 float8;   -- force replan
 
 execute p1;
 
+-- GPDB: Check that search_path change is honored in the plpgsql body
+-- (bug in upstream and fixed in v9.3)
+
+CREATE OR REPLACE FUNCTION s1.test_searchpath() RETURNS integer
+LANGUAGE 'plpgsql' AS $BODY$
+BEGIN
+	RETURN 1;
+END;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION s2.test_searchpath() RETURNS integer
+LANGUAGE 'plpgsql' AS $BODY$
+BEGIN
+	RETURN 2;
+END;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION public.test_searchpath(p_search_path character varying) RETURNS integer
+LANGUAGE 'plpgsql' AS $BODY$
+DECLARE v_ret integer = -1;
+BEGIN
+	-- The EXECUTE statement will force replanning
+	EXECUTE 'SET search_path to ' || p_search_path;
+	SELECT test_searchpath() into v_ret;
+	RETURN v_ret;
+END;
+$BODY$;
+
+SELECT * FROM public.test_searchpath('s1');
+SELECT * FROM public.test_searchpath('s2');
+
+DROP FUNCTION s1.test_searchpath();
+DROP FUNCTION s2.test_searchpath();
+DROP FUNCTION public.test_searchpath(p_search_path character varying);
+
 drop schema s1 cascade;
 drop schema s2 cascade;
 


### PR DESCRIPTION
This commit contains the essence of the upstream commit 0d5fbdc157a introduced
in postgres 9.3.0. Unfortunately, there are enough substantial changes to the
codebases for direct backporting to be insufficient.

In this version, surprises to the user on search_path changes are mitigated by
forcing a replaning when the search_path upon which the plan cache entry was
created does not match the current one.


