### PR TITLE
Disbale test cases of gpfdist_ssl

### DIFF
--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -6,9 +6,9 @@ default: installcheck
 REGRESS = exttab1 custom_format gpfdist2
 
 ifeq ($(enable_gpfdist),yes)
-ifeq ($(with_openssl),yes)
-	REGRESS += gpfdist_ssl
-endif
+#ifeq ($(with_openssl),yes)
+#	REGRESS += gpfdist_ssl
+#endif
 endif
 
 PSQLDIR = $(prefix)/bin
@@ -16,10 +16,10 @@ REGRESS_OPTS = --init-file=init_file
 
 installcheck: watchdog
 ifeq ($(enable_gpfdist),yes)
-ifeq ($(with_openssl),yes)
-	cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists data/gpfdist_ssl/certs_matching
-	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_not_matching
-endif
+#ifeq ($(with_openssl),yes)
+#	cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists data/gpfdist_ssl/certs_matching
+#	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_not_matching
+#endif
 endif
 	$(top_builddir)/src/test/regress/pg_regress --psqldir=$(PSQLDIR) --dbname=gpfdist_regression $(REGRESS) $(REGRESS_OPTS)
 


### PR DESCRIPTION
The test cases of gpfdist_ssl sometimes
fail on pipeline. We don't know the root
cause yet. So just disable them. And we will
enable them after fixing.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
