### PR TITLE
6X backport: Skip the fts probe on the master instead of the primary

### DIFF
--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -67,7 +67,7 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 
 		-- intentionally skip fts during these tests
 		-- we know we're going to be inducing errors and panics on primaries
-		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
+		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = -1 and role = 'p';
 	end;
 $$ LANGUAGE plpgsql;
 

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -65,7 +65,7 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 
 		-- intentionally skip fts during these tests
 		-- we know we're going to be inducing errors and panics on primaries
-		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
+		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = -1 and role = 'p';
 	end;
 $$ LANGUAGE plpgsql;
 create or replace function cleanup(content_id integer, tablespace_location_dir text) returns void as $$


### PR DESCRIPTION
We accidentally skipped the fts probe on the primary in
f2ca17a0242b6 when it should be skipped on the master. The fault point
'fts_probe' can only be encountered on the master.

(cherry picked from commit 3e1332aded1c8d8455975f98945ae738097f02e2)
