### PR TITLE
Add long flags to package_tarball.bash with TDD

### DIFF
--- a/concourse/scripts/package_tarball.bash
+++ b/concourse/scripts/package_tarball.bash
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-set -u -e -x
+set -eux
 
 main() {
-  tar czf "$dst_tarball" -C "$src_root" .
+  tar -czf "$dst_tarball" -C "$src_root" .
 }
 
 main "$@"

--- a/concourse/scripts/package_tarball.bats
+++ b/concourse/scripts/package_tarball.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+TEST_DIR="test_dir"
+
+setup() {
+  mkdir "${TEST_DIR}"
+  cd "${TEST_DIR}"
+
+  export dst_tarball="dst.tar.gz"
+  export src_root="src_root"
+
+  mkdir "${src_root}"
+  touch "${src_root}/"{a,b,c}
+}
+
+teardown() {
+  cd ..
+  rm -rf "${TEST_DIR}"
+}
+
+main() {
+  ../scripts/package_tarball.bash
+}
+
+@test "it fails if any variables are unbound" {
+  unset src_root dst_tarball
+
+  run main
+  [ "${status}" -ne 0 ]
+}
+
+@test "it fails when src_root is a non-existent directory" {
+  export src_root="not-a-file"
+
+  run main
+  [ "${status}" -ne 0 ]
+}
+
+@test "it works when src_root is empty" {
+  rm -rf "${src_root}/*"
+
+  run main
+  [ "${status}" -eq 0 ]
+}
+
+@test "it properly tars file in src_root/" {
+  run main
+  [ "${status}" -eq 0 ]
+
+  run tar tf "$dst_tarball"
+  [ "${status}" -eq 0 ]
+  [[ "${output}" =~ a ]]
+  [[ "${output}" =~ b ]]
+  [[ "${output}" =~ c ]]
+}


### PR DESCRIPTION
package_tarball.bash is used in many places outside of the gpdb
repository so any modifications should be done very carefully.

This commit also introduces package_tarball.bats as an example file for
other concourse users wishing to add .bats files.

Authored-by: Amil Khanzada <akhanzada@pivotal.io>

This fixes the red concourse_unit_tests job on master/6X_STABLE.
https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-package-tarball-bats
Will need to cherry-pick to 6X_STABLE.