### PR TITLE
Fix gpperfomon GUC definitions

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -602,42 +602,6 @@ int gp_log_fts;
 int gp_log_interconnect;
 
 /*
- * gp_enable_gpperfmon and gp_gpperfmon_send_interval are GUCs that we'd like
- * to have propagate from master to segments but we don't want non-super users
- * to be able to set it.  Unfortunately, as long as we use libpq to connect to
- * the segments its hard to create a clean way of doing this.
- *
- * Here we check and enforce that if the value is being set on the master its being
- * done as superuser and not a regular user.
- *
- */
-bool
-gpvars_check_gp_enable_gpperfmon(bool *newval, void **extra, GucSource source)
-{
-	if (Gp_role == GP_ROLE_DISPATCH && IsUnderPostmaster && GetCurrentRoleId() != InvalidOid && !superuser())
-	{
-		GUC_check_errcode(ERRCODE_INSUFFICIENT_PRIVILEGE);
-		GUC_check_errmsg("must be superuser to set gp_enable_gpperfmon");
-		return false;
-	}
-
-	return true;
-}
-
-bool
-gpvars_check_gp_gpperfmon_send_interval(int *newval, void **extra, GucSource source)
-{
-	if (Gp_role == GP_ROLE_DISPATCH && IsUnderPostmaster && GetCurrentRoleId() != InvalidOid && !superuser())
-	{
-		GUC_check_errcode(ERRCODE_INSUFFICIENT_PRIVILEGE);
-		GUC_check_errmsg("must be superuser to set gp_gpperfmon_send_interval");
-		return false;
-	}
-
-	return true;
-}
-
-/*
  * gpvars_check_gp_resource_manager_policy
  * gpvars_assign_gp_resource_manager_policy
  * gpvars_show_gp_resource_manager_policy

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1608,7 +1608,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_enable_gpperfmon,
 		false,
-		gpvars_check_gp_enable_gpperfmon, NULL, NULL
+		NULL, NULL, NULL
 	},
 
 	{
@@ -3770,14 +3770,14 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"gp_gpperfmon_send_interval", PGC_USERSET, LOGGING_WHAT,
+		{"gp_gpperfmon_send_interval", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Interval in seconds between sending messages to gpperfmon."),
 			NULL,
 			GUC_GPDB_ADDOPT
 		},
 		&gp_gpperfmon_send_interval,
 		1, 1, 3600,
-		gpvars_check_gp_gpperfmon_send_interval, NULL, NULL
+		NULL, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
GUC `gp_enable_gpperfmon` is defined to be set only at postmaster restart.  Having a check hook that checks if the process setting it has superuser privileges is meaningless.  The check hook is removed.

GUC `gp_gpperfmon_send_interval` is intended to be set only by superuser.  Adjust its definition accordingly and leverage checks built into GUC framework for superuser privileges.  The check hook for this GUC tried to achieve the same but incorrectly.  If the check hook was invoked at the beginning of main query processing loop by a backend process, it would crash.  At the beginning of the main loop, a transaction is not started yet.  The check hook invokes `superuser()` interface, which performs catalog access.  Doing so without starting a transaction is a recipe for crashing badly.  Such a crash was observed in production at least once.

The patch doesn't add any tests because, after removing the check hooks, the checks built into GUC framework are being used.  That code path is well exercised by existing regression tests.
