### PR TITLE
gpload: sanitize search_path for most queries

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/query1.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query1.ans
@@ -1,7 +1,7 @@
 2017-03-28 09:21:42|INFO|gpload session started 2017-03-28 09:21:42
 2017-03-28 09:21:42|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:42|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f47c27ce_1397_11e7_b323_0242ac110005
+2017-03-28 09:21:42|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_f47c27ce_1397_11e7_b323_0242ac110005
 2017-03-28 09:21:42|INFO|running time: 0.07 seconds
 2017-03-28 09:21:42|INFO|rows Inserted          = 16
 2017-03-28 09:21:42|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-03-28 09:21:42|INFO|gpload session started 2017-03-28 09:21:42
 2017-03-28 09:21:42|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:42|INFO|reusing external table ext_gpload_reusable_f47c27ce_1397_11e7_b323_0242ac110005
+2017-03-28 09:21:42|INFO|reusing external table public.ext_gpload_reusable_f47c27ce_1397_11e7_b323_0242ac110005
 2017-03-28 09:21:42|INFO|running time: 0.06 seconds
 2017-03-28 09:21:42|INFO|rows Inserted          = 16
 2017-03-28 09:21:42|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query10.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query10.ans
@@ -1,8 +1,8 @@
 2017-04-10 07:02:23|INFO|gpload session started 2017-04-10 07:02:23
 2017-04-10 07:02:23|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:02:23|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:02:23|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2017-04-10 07:02:23|INFO|did not find an external table to reuse. creating ext_gpload_reusable_a5c30bb0_1dbb_11e7_9075_0242ac110005
+2017-04-10 07:02:23|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2017-04-10 07:02:23|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_a5c30bb0_1dbb_11e7_9075_0242ac110005
 2017-04-10 07:02:23|INFO|running time: 0.08 seconds
 2017-04-10 07:02:23|INFO|rows Inserted          = 1
 2017-04-10 07:02:23|INFO|rows Updated           = 32
@@ -11,8 +11,8 @@
 2017-04-10 07:02:23|INFO|gpload session started 2017-04-10 07:02:23
 2017-04-10 07:02:23|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:02:23|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:02:23|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2017-04-10 07:02:23|INFO|reusing external table ext_gpload_reusable_a5c30bb0_1dbb_11e7_9075_0242ac110005
+2017-04-10 07:02:23|INFO|reusing staging table public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2017-04-10 07:02:23|INFO|reusing external table public.ext_gpload_reusable_a5c30bb0_1dbb_11e7_9075_0242ac110005
 2017-04-10 07:02:23|INFO|running time: 0.08 seconds
 2017-04-10 07:02:23|INFO|rows Inserted          = 0
 2017-04-10 07:02:23|INFO|rows Updated           = 33

--- a/gpMgmt/bin/gpload_test/gpload2/query12.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query12.ans
@@ -1,8 +1,8 @@
 2017-04-10 07:02:24|INFO|gpload session started 2017-04-10 07:02:24
 2017-04-10 07:02:24|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:02:24|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:02:24|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
-2017-04-10 07:02:24|INFO|did not find an external table to reuse. creating ext_gpload_reusable_a6481ef4_1dbb_11e7_a351_0242ac110005
+2017-04-10 07:02:24|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
+2017-04-10 07:02:24|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_a6481ef4_1dbb_11e7_a351_0242ac110005
 2017-04-10 07:02:24|INFO|running time: 0.08 seconds
 2017-04-10 07:02:24|INFO|rows Inserted          = 1
 2017-04-10 07:02:24|INFO|rows Updated           = 34
@@ -11,8 +11,8 @@
 2017-04-10 07:02:24|INFO|gpload session started 2017-04-10 07:02:24
 2017-04-10 07:02:24|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:02:24|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:02:24|INFO|reusing staging table staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
-2017-04-10 07:02:24|INFO|reusing external table ext_gpload_reusable_a6481ef4_1dbb_11e7_a351_0242ac110005
+2017-04-10 07:02:24|INFO|reusing staging table public.staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
+2017-04-10 07:02:24|INFO|reusing external table public.ext_gpload_reusable_a6481ef4_1dbb_11e7_a351_0242ac110005
 2017-04-10 07:02:24|INFO|running time: 0.08 seconds
 2017-04-10 07:02:24|INFO|rows Inserted          = 0
 2017-04-10 07:02:24|INFO|rows Updated           = 35

--- a/gpMgmt/bin/gpload_test/gpload2/query13.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query13.ans
@@ -1,8 +1,8 @@
 2017-04-10 07:02:24|INFO|gpload session started 2017-04-10 07:02:24
 2017-04-10 07:02:24|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:02:24|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:02:24|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
-2017-04-10 07:02:24|INFO|did not find an external table to reuse. creating ext_gpload_reusable_a68c1c62_1dbb_11e7_a3b1_0242ac110005
+2017-04-10 07:02:24|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
+2017-04-10 07:02:24|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_a68c1c62_1dbb_11e7_a3b1_0242ac110005
 2017-04-10 07:02:24|INFO|running time: 0.08 seconds
 2017-04-10 07:02:24|INFO|rows Inserted          = 1
 2017-04-10 07:02:24|INFO|rows Updated           = 35
@@ -11,8 +11,8 @@
 2017-04-10 07:02:25|INFO|gpload session started 2017-04-10 07:02:25
 2017-04-10 07:02:25|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:02:25|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:02:25|INFO|reusing staging table staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
-2017-04-10 07:02:25|INFO|reusing external table ext_gpload_reusable_a68c1c62_1dbb_11e7_a3b1_0242ac110005
+2017-04-10 07:02:25|INFO|reusing staging table public.staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
+2017-04-10 07:02:25|INFO|reusing external table public.ext_gpload_reusable_a68c1c62_1dbb_11e7_a3b1_0242ac110005
 2017-04-10 07:02:25|INFO|running time: 0.08 seconds
 2017-04-10 07:02:25|INFO|rows Inserted          = 0
 2017-04-10 07:02:25|INFO|rows Updated           = 36

--- a/gpMgmt/bin/gpload_test/gpload2/query14.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query14.ans
@@ -1,8 +1,8 @@
 2017-04-10 07:07:11|INFO|gpload session started 2017-04-10 07:07:11
 2017-04-10 07:07:11|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:07:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:07:11|INFO|reusing staging table staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
-2017-04-10 07:07:11|INFO|reusing external table ext_gpload_reusable_51151d82_1dbc_11e7_bebd_0242ac110005
+2017-04-10 07:07:11|INFO|reusing staging table public.staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
+2017-04-10 07:07:11|INFO|reusing external table public.ext_gpload_reusable_51151d82_1dbc_11e7_bebd_0242ac110005
 2017-04-10 07:07:11|INFO|running time: 0.08 seconds
 2017-04-10 07:07:11|INFO|rows Inserted          = 0
 2017-04-10 07:07:11|INFO|rows Updated           = 36
@@ -11,8 +11,8 @@
 2017-04-10 07:07:11|INFO|gpload session started 2017-04-10 07:07:11
 2017-04-10 07:07:11|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:07:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:07:11|INFO|reusing staging table staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
-2017-04-10 07:07:11|INFO|reusing external table ext_gpload_reusable_51151d82_1dbc_11e7_bebd_0242ac110005
+2017-04-10 07:07:11|INFO|reusing staging table public.staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
+2017-04-10 07:07:11|INFO|reusing external table public.ext_gpload_reusable_51151d82_1dbc_11e7_bebd_0242ac110005
 2017-04-10 07:07:11|INFO|running time: 0.08 seconds
 2017-04-10 07:07:11|INFO|rows Inserted          = 0
 2017-04-10 07:07:11|INFO|rows Updated           = 36

--- a/gpMgmt/bin/gpload_test/gpload2/query15.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query15.ans
@@ -1,8 +1,8 @@
 2017-04-10 07:07:11|INFO|gpload session started 2017-04-10 07:07:11
 2017-04-10 07:07:11|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:07:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data/data_file.tbl" -t 30
-2017-04-10 07:07:11|INFO|reusing staging table staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
-2017-04-10 07:07:11|INFO|did not find an external table to reuse. creating ext_gpload_reusable_519611c6_1dbc_11e7_ba26_0242ac110005
+2017-04-10 07:07:11|INFO|reusing staging table public.staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
+2017-04-10 07:07:11|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_519611c6_1dbc_11e7_ba26_0242ac110005
 2017-04-10 07:07:11|INFO|running time: 0.08 seconds
 2017-04-10 07:07:11|INFO|rows Inserted          = 0
 2017-04-10 07:07:11|INFO|rows Updated           = 36
@@ -11,8 +11,8 @@
 2017-04-10 07:07:12|INFO|gpload session started 2017-04-10 07:07:12
 2017-04-10 07:07:12|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:07:12|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data/data_file.tbl" -t 30
-2017-04-10 07:07:12|INFO|reusing staging table staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
-2017-04-10 07:07:12|INFO|reusing external table ext_gpload_reusable_519611c6_1dbc_11e7_ba26_0242ac110005
+2017-04-10 07:07:12|INFO|reusing staging table public.staging_gpload_reusable_94d9ffba644dc6ed11f49b74844f842f
+2017-04-10 07:07:12|INFO|reusing external table public.ext_gpload_reusable_519611c6_1dbc_11e7_ba26_0242ac110005
 2017-04-10 07:07:12|INFO|running time: 0.08 seconds
 2017-04-10 07:07:12|INFO|rows Inserted          = 0
 2017-04-10 07:07:12|INFO|rows Updated           = 36

--- a/gpMgmt/bin/gpload_test/gpload2/query16.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query16.ans
@@ -1,7 +1,7 @@
 2017-04-11 04:39:06|INFO|gpload session started 2017-04-11 04:39:06
 2017-04-11 04:39:06|INFO|setting schema 'public' for table 'csvtable'
 2017-04-11 04:39:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2017-04-11 04:39:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_cc34dc6e_1e70_11e7_bb62_0242ac110005
+2017-04-11 04:39:06|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_cc34dc6e_1e70_11e7_bb62_0242ac110005
 2017-04-11 04:39:06|INFO|running time: 0.06 seconds
 2017-04-11 04:39:06|INFO|rows Inserted          = 4
 2017-04-11 04:39:06|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-04-11 04:39:07|INFO|gpload session started 2017-04-11 04:39:07
 2017-04-11 04:39:07|INFO|setting schema 'public' for table 'csvtable'
 2017-04-11 04:39:07|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2017-04-11 04:39:07|INFO|reusing external table ext_gpload_reusable_cc34dc6e_1e70_11e7_bb62_0242ac110005
+2017-04-11 04:39:07|INFO|reusing external table public.ext_gpload_reusable_cc34dc6e_1e70_11e7_bb62_0242ac110005
 2017-04-11 04:39:07|INFO|running time: 0.06 seconds
 2017-04-11 04:39:07|INFO|rows Inserted          = 4
 2017-04-11 04:39:07|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query17.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query17.ans
@@ -1,7 +1,7 @@
 2017-04-11 04:39:07|INFO|gpload session started 2017-04-11 04:39:07
 2017-04-11 04:39:07|INFO|setting schema 'public' for table 'csvtable'
 2017-04-11 04:39:07|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2017-04-11 04:39:07|INFO|did not find an external table to reuse. creating ext_gpload_reusable_cc6f8986_1e70_11e7_b7fc_0242ac110005
+2017-04-11 04:39:07|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_cc6f8986_1e70_11e7_b7fc_0242ac110005
 2017-04-11 04:39:07|INFO|running time: 0.06 seconds
 2017-04-11 04:39:07|INFO|rows Inserted          = 4
 2017-04-11 04:39:07|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-04-11 04:39:07|INFO|gpload session started 2017-04-11 04:39:07
 2017-04-11 04:39:07|INFO|setting schema 'public' for table 'csvtable'
 2017-04-11 04:39:07|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2017-04-11 04:39:07|INFO|reusing external table ext_gpload_reusable_cc6f8986_1e70_11e7_b7fc_0242ac110005
+2017-04-11 04:39:07|INFO|reusing external table public.ext_gpload_reusable_cc6f8986_1e70_11e7_b7fc_0242ac110005
 2017-04-11 04:39:07|INFO|running time: 0.06 seconds
 2017-04-11 04:39:07|INFO|rows Inserted          = 4
 2017-04-11 04:39:07|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query18.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query18.ans
@@ -1,7 +1,7 @@
 2017-04-11 04:39:07|INFO|gpload session started 2017-04-11 04:39:07
 2017-04-11 04:39:07|INFO|setting schema 'public' for table 'csvtable'
 2017-04-11 04:39:07|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2017-04-11 04:39:07|INFO|reusing external table ext_gpload_reusable_cc6f8986_1e70_11e7_b7fc_0242ac110005
+2017-04-11 04:39:07|INFO|reusing external table public.ext_gpload_reusable_cc6f8986_1e70_11e7_b7fc_0242ac110005
 2017-04-11 04:39:07|INFO|running time: 0.06 seconds
 2017-04-11 04:39:07|INFO|rows Inserted          = 4
 2017-04-11 04:39:07|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-04-11 04:39:07|INFO|gpload session started 2017-04-11 04:39:07
 2017-04-11 04:39:07|INFO|setting schema 'public' for table 'csvtable'
 2017-04-11 04:39:07|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2017-04-11 04:39:07|INFO|reusing external table ext_gpload_reusable_cc6f8986_1e70_11e7_b7fc_0242ac110005
+2017-04-11 04:39:07|INFO|reusing external table public.ext_gpload_reusable_cc6f8986_1e70_11e7_b7fc_0242ac110005
 2017-04-11 04:39:07|INFO|running time: 0.06 seconds
 2017-04-11 04:39:07|INFO|rows Inserted          = 4
 2017-04-11 04:39:07|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query19.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query19.ans
@@ -1,7 +1,7 @@
 2017-05-02 06:22:44|INFO|gpload session started 2017-05-02 06:22:44
 2017-05-02 06:22:44|INFO|setting schema 'public' for table 'texttable'
 2017-05-02 06:22:44|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpdb5/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-05-02 06:22:44|INFO|did not find an external table to reuse. creating ext_gpload_reusable_c0bc7546_2eff_11e7_a619_0242ac110005
+2017-05-02 06:22:44|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_c0bc7546_2eff_11e7_a619_0242ac110005
 2017-05-02 06:22:44|INFO|running time: 0.07 seconds
 2017-05-02 06:22:44|INFO|rows Inserted          = 16
 2017-05-02 06:22:44|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-05-02 06:22:44|INFO|gpload session started 2017-05-02 06:22:44
 2017-05-02 06:22:44|INFO|setting schema 'public' for table 'texttable'
 2017-05-02 06:22:44|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpdb5/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-05-02 06:22:44|INFO|reusing external table ext_gpload_reusable_c0bc7546_2eff_11e7_a619_0242ac110005
+2017-05-02 06:22:44|INFO|reusing external table public.ext_gpload_reusable_c0bc7546_2eff_11e7_a619_0242ac110005
 2017-05-02 06:22:44|INFO|running time: 0.06 seconds
 2017-05-02 06:22:44|INFO|rows Inserted          = 16
 2017-05-02 06:22:44|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query2.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query2.ans
@@ -1,7 +1,7 @@
 2017-03-28 09:21:42|INFO|gpload session started 2017-03-28 09:21:42
 2017-03-28 09:21:42|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:42|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
+2017-03-28 09:21:42|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
 2017-03-28 09:21:42|INFO|running time: 0.06 seconds
 2017-03-28 09:21:42|INFO|rows Inserted          = 16
 2017-03-28 09:21:42|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-03-28 09:21:42|INFO|gpload session started 2017-03-28 09:21:42
 2017-03-28 09:21:42|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:42|INFO|reusing external table ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
+2017-03-28 09:21:42|INFO|reusing external table public.ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
 2017-03-28 09:21:42|INFO|running time: 0.06 seconds
 2017-03-28 09:21:42|INFO|rows Inserted          = 16
 2017-03-28 09:21:42|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query20.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query20.ans
@@ -1,7 +1,7 @@
 2017-05-02 06:22:44|INFO|gpload session started 2017-05-02 06:22:44
 2017-05-02 06:22:44|INFO|setting schema 'public' for table 'texttable'
 2017-05-02 06:22:44|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpdb5/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-05-02 06:22:44|INFO|reusing external table ext_gpload_reusable_c0bc7546_2eff_11e7_a619_0242ac110005
+2017-05-02 06:22:44|INFO|reusing external table public.ext_gpload_reusable_c0bc7546_2eff_11e7_a619_0242ac110005
 2017-05-02 06:22:44|INFO|running time: 0.06 seconds
 2017-05-02 06:22:44|INFO|rows Inserted          = 16
 2017-05-02 06:22:44|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-05-02 06:22:44|INFO|gpload session started 2017-05-02 06:22:44
 2017-05-02 06:22:44|INFO|setting schema 'public' for table 'texttable'
 2017-05-02 06:22:44|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpdb5/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-05-02 06:22:44|INFO|reusing external table ext_gpload_reusable_c0bc7546_2eff_11e7_a619_0242ac110005
+2017-05-02 06:22:44|INFO|reusing external table public.ext_gpload_reusable_c0bc7546_2eff_11e7_a619_0242ac110005
 2017-05-02 06:22:44|INFO|running time: 0.06 seconds
 2017-05-02 06:22:44|INFO|rows Inserted          = 16
 2017-05-02 06:22:44|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query21.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query21.ans
@@ -1,7 +1,7 @@
 2017-05-02 06:24:56|INFO|gpload session started 2017-05-02 06:24:56
 2017-05-02 06:24:56|INFO|setting schema 'public' for table 'texttable'
 2017-05-02 06:24:56|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpdb5/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-05-02 06:24:56|INFO|reusing external table ext_gpload_reusable_0ed2b8bc_2f00_11e7_9485_0242ac110005
+2017-05-02 06:24:56|INFO|reusing external table public.ext_gpload_reusable_0ed2b8bc_2f00_11e7_9485_0242ac110005
 2017-05-02 06:24:56|INFO|running time: 0.06 seconds
 2017-05-02 06:24:56|INFO|rows Inserted          = 16
 2017-05-02 06:24:56|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-05-02 06:24:56|INFO|gpload session started 2017-05-02 06:24:56
 2017-05-02 06:24:56|INFO|setting schema 'public' for table 'texttable'
 2017-05-02 06:24:56|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpdb5/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-05-02 06:24:56|INFO|reusing external table ext_gpload_reusable_0ed2b8bc_2f00_11e7_9485_0242ac110005
+2017-05-02 06:24:56|INFO|reusing external table public.ext_gpload_reusable_0ed2b8bc_2f00_11e7_9485_0242ac110005
 2017-05-02 06:24:56|INFO|running time: 0.06 seconds
 2017-05-02 06:24:56|INFO|rows Inserted          = 16
 2017-05-02 06:24:56|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query23.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query23.ans
@@ -2,10 +2,10 @@
 2017-11-10 02:46:20|WARN|ERROR_TABLE is not supported. We will set LOG_ERRORS and REUSE_TABLES to True for compatibility.
 2017-11-10 02:46:20|INFO|setting schema 'public' for table 'csvtable'
 2017-11-10 02:46:20|INFO|started gpfdist -p 8081 -P 8082 -f "/usr/local/greenplum-db-devel/bin/gpload_test/gpload2/data_file.csv" -t 30
-2017-11-10 02:46:20|INFO|did not find an external table to reuse. creating ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003
+2017-11-10 02:46:20|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003
 2017-11-10 02:46:20|WARN|5000 bad rows
 2017-11-10 02:46:20|WARN|Please use following query to access the detailed error
-2017-11-10 02:46:20|WARN|select * from gp_read_error_log('ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003') where cmdtime > to_timestamp('1510281980.34')
+2017-11-10 02:46:20|WARN|select * from gp_read_error_log('public.ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003') where cmdtime > to_timestamp('1510281980.34')
 2017-11-10 02:46:20|INFO|running time: 0.34 seconds
 2017-11-10 02:46:20|INFO|rows Inserted          = 5000
 2017-11-10 02:46:20|INFO|rows Updated           = 0
@@ -15,10 +15,10 @@
 2017-11-10 02:46:20|WARN|ERROR_TABLE is not supported. We will set LOG_ERRORS and REUSE_TABLES to True for compatibility.
 2017-11-10 02:46:20|INFO|setting schema 'public' for table 'csvtable'
 2017-11-10 02:46:20|INFO|started gpfdist -p 8081 -P 8082 -f "/usr/local/greenplum-db-devel/bin/gpload_test/gpload2/data_file.csv" -t 30
-2017-11-10 02:46:20|INFO|reusing external table ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003
+2017-11-10 02:46:20|INFO|reusing external table public.ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003
 2017-11-10 02:46:21|WARN|5000 bad rows
 2017-11-10 02:46:21|WARN|Please use following query to access the detailed error
-2017-11-10 02:46:21|WARN|select * from gp_read_error_log('ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003') where cmdtime > to_timestamp('1510281980.77')
+2017-11-10 02:46:21|WARN|select * from gp_read_error_log('public.ext_gpload_reusable_54fd9764_c5c1_11e7_b31f_0242ac110003') where cmdtime > to_timestamp('1510281980.77')
 2017-11-10 02:46:21|INFO|running time: 0.31 seconds
 2017-11-10 02:46:21|INFO|rows Inserted          = 5000
 2017-11-10 02:46:21|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query25.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query25.ans
@@ -9,7 +9,7 @@
 2018-01-17 21:31:13|INFO|gpload session started 2018-01-17 21:31:13
 2018-01-17 21:31:13|INFO|setting schema 'public' for table 'csvtable'
 2018-01-17 21:31:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2018-01-17 21:31:13|INFO|reusing external staging table staging_table
+2018-01-17 21:31:13|INFO|reusing external staging table public.staging_table
 2018-01-17 21:31:13|INFO|running time: 0.08 seconds
 2018-01-17 21:31:13|INFO|rows Inserted          = 2
 2018-01-17 21:31:13|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query29.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query29.ans
@@ -1,7 +1,7 @@
 2018-02-23 09:54:40|INFO|gpload session started 2018-02-23 09:54:40
 2018-02-23 09:54:40|INFO|setting schema 'public' for table 'texttable'
 2018-02-23 09:54:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-02-23 09:54:40|INFO|did not find an external table to reuse. creating ext_gpload_reusable_90c9a812_187f_11e8_bd61_0242ac110002
+2018-02-23 09:54:40|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_90c9a812_187f_11e8_bd61_0242ac110002
 2018-02-23 09:54:40|INFO|running time: 0.16 seconds
 2018-02-23 09:54:40|INFO|rows Inserted          = 17
 2018-02-23 09:54:40|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2018-02-23 09:54:40|INFO|gpload session started 2018-02-23 09:54:40
 2018-02-23 09:54:40|INFO|setting schema 'public' for table 'texttable'
 2018-02-23 09:54:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-02-23 09:54:40|INFO|reusing external table ext_gpload_reusable_90c9a812_187f_11e8_bd61_0242ac110002
+2018-02-23 09:54:40|INFO|reusing external table public.ext_gpload_reusable_90c9a812_187f_11e8_bd61_0242ac110002
 2018-02-23 09:54:40|INFO|running time: 0.14 seconds
 2018-02-23 09:54:40|INFO|rows Inserted          = 17
 2018-02-23 09:54:40|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query3.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query3.ans
@@ -1,7 +1,7 @@
 2017-03-28 09:21:42|INFO|gpload session started 2017-03-28 09:21:42
 2017-03-28 09:21:42|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:42|INFO|reusing external table ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
+2017-03-28 09:21:42|INFO|reusing external table public.ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
 2017-03-28 09:21:42|INFO|running time: 0.06 seconds
 2017-03-28 09:21:42|INFO|rows Inserted          = 16
 2017-03-28 09:21:42|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-03-28 09:21:43|INFO|gpload session started 2017-03-28 09:21:43
 2017-03-28 09:21:43|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:43|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:43|INFO|reusing external table ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
+2017-03-28 09:21:43|INFO|reusing external table public.ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
 2017-03-28 09:21:43|INFO|running time: 0.06 seconds
 2017-03-28 09:21:43|INFO|rows Inserted          = 16
 2017-03-28 09:21:43|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query30.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query30.ans
@@ -1,8 +1,8 @@
 2017-04-10 07:07:08|INFO|gpload session started 2017-04-10 07:07:08
 2017-04-10 07:07:08|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:07:08|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:07:08|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2017-04-10 07:07:08|INFO|did not find an external table to reuse. creating ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
+2017-04-10 07:07:08|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2017-04-10 07:07:08|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
 2017-04-10 07:07:08|INFO|running time: 0.08 seconds
 2017-04-10 07:07:08|INFO|rows Inserted          = 0
 2017-04-10 07:07:08|INFO|rows Updated           = 32
@@ -11,8 +11,8 @@
 2017-04-10 07:07:08|INFO|gpload session started 2017-04-10 07:07:08
 2017-04-10 07:07:08|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:07:08|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:07:08|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2017-04-10 07:07:08|INFO|reusing external table ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
+2017-04-10 07:07:08|INFO|reusing staging table public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2017-04-10 07:07:08|INFO|reusing external table public.ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
 2017-04-10 07:07:09|INFO|running time: 0.08 seconds
 2017-04-10 07:07:09|INFO|rows Inserted          = 0
 2017-04-10 07:07:09|INFO|rows Updated           = 32

--- a/gpMgmt/bin/gpload_test/gpload2/query31.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query31.ans
@@ -1,12 +1,12 @@
 2018-07-20 09:06:30|INFO|gpload session started 2018-07-20 09:06:30
 2018-07-20 09:06:30|INFO|setting schema 'public' for table 'texttable'
 2018-07-20 09:06:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-07-20 09:06:30|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
-2018-07-20 09:06:30|INFO|reusing external table ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
+2018-07-20 09:06:30|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
+2018-07-20 09:06:30|INFO|reusing external table public.ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
 2018-07-20 09:06:30|ERROR|ERROR:  column "n8" does not exist
 LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
                                                              ^
- encountered while running INSERT INTO staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0 ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
+ encountered while running INSERT INTO public.staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0 ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM public.ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
 2018-07-20 09:06:30|INFO|rows Inserted          = 0
 2018-07-20 09:06:30|INFO|rows Updated           = 0
 2018-07-20 09:06:30|INFO|data formatting errors = 0
@@ -14,12 +14,12 @@ LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
 2018-07-20 09:06:30|INFO|gpload session started 2018-07-20 09:06:30
 2018-07-20 09:06:30|INFO|setting schema 'public' for table 'texttable'
 2018-07-20 09:06:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-07-20 09:06:30|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
-2018-07-20 09:06:30|INFO|reusing external table ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
+2018-07-20 09:06:30|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
+2018-07-20 09:06:30|INFO|reusing external table public.ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
 2018-07-20 09:06:30|ERROR|ERROR:  column "n8" does not exist
 LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
                                                              ^
- encountered while running INSERT INTO staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0 ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
+ encountered while running INSERT INTO public.staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0 ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM public.ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
 2018-07-20 09:06:30|INFO|rows Inserted          = 0
 2018-07-20 09:06:30|INFO|rows Updated           = 0
 2018-07-20 09:06:30|INFO|data formatting errors = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query33.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query33.ans
@@ -1,7 +1,7 @@
 2018-07-24 06:14:29|INFO|gpload session started 2018-07-24 06:14:29
 2018-07-24 06:14:29|INFO|setting schema 'public' for table 'texttable'
 2018-07-24 06:14:29|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-07-24 06:14:29|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-07-24 06:14:29|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
 2018-07-24 06:14:29|INFO|did not find an external table to reuse. creating test.ext_gpload_reusable_d2e95f76_8f08_11e8_8c76_0242ac110002
 2018-07-24 06:14:29|INFO|running time: 0.40 seconds
 2018-07-24 06:14:29|INFO|rows Inserted          = 16
@@ -11,7 +11,7 @@
 2018-07-24 06:14:30|INFO|gpload session started 2018-07-24 06:14:30
 2018-07-24 06:14:30|INFO|setting schema 'public' for table 'texttable'
 2018-07-24 06:14:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-07-24 06:14:30|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-07-24 06:14:30|INFO|reusing staging table public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
 2018-07-24 06:14:30|INFO|reusing external table test.ext_gpload_reusable_d2e95f76_8f08_11e8_8c76_0242ac110002
 2018-07-24 06:14:30|INFO|running time: 0.31 seconds
 2018-07-24 06:14:30|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query34.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query34.ans
@@ -1,8 +1,8 @@
 2018-11-05 19:14:10|INFO|gpload session started 2018-11-05 19:14:10
 2018-11-05 19:14:10|INFO|setting schema 'public' for table 'texttable'
 2018-11-05 19:14:10|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 19:14:10|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 19:14:11|INFO|did not find an external table to reuse. creating ext_gpload_reusable_eb932982_e0eb_11e8_9c10_00505698a2d7
+2018-11-05 19:14:10|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 19:14:11|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_eb932982_e0eb_11e8_9c10_00505698a2d7
 2018-11-05 19:14:11|INFO|running time: 0.57 seconds
 2018-11-05 19:14:11|INFO|rows Inserted          = 16
 2018-11-05 19:14:11|INFO|rows Updated           = 0
@@ -11,8 +11,8 @@
 2018-11-05 19:14:11|INFO|gpload session started 2018-11-05 19:14:11
 2018-11-05 19:14:11|INFO|setting schema 'public' for table 'texttable'
 2018-11-05 19:14:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 19:14:11|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 19:14:11|INFO|reusing external table ext_gpload_reusable_eb932982_e0eb_11e8_9c10_00505698a2d7
+2018-11-05 19:14:11|INFO|reusing staging table public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 19:14:11|INFO|reusing external table public.ext_gpload_reusable_eb932982_e0eb_11e8_9c10_00505698a2d7
 2018-11-05 19:14:12|INFO|running time: 0.50 seconds
 2018-11-05 19:14:12|INFO|rows Inserted          = 0
 2018-11-05 19:14:12|INFO|rows Updated           = 16

--- a/gpMgmt/bin/gpload_test/gpload2/query35.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query35.ans
@@ -1,8 +1,8 @@
 2018-11-05 19:39:49|INFO|gpload session started 2018-11-05 19:39:49
 2018-11-05 19:39:49|INFO|setting schema 'public' for table 'texttable'
 2018-11-05 19:39:49|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 19:39:49|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 19:39:49|INFO|did not find an external table to reuse. creating ext_gpload_reusable_8098fb6c_e0ef_11e8_a796_00505698a2d7
+2018-11-05 19:39:49|INFO|reusing staging table public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 19:39:49|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_8098fb6c_e0ef_11e8_a796_00505698a2d7
 2018-11-05 19:39:50|INFO|running time: 0.58 seconds
 2018-11-05 19:39:50|INFO|rows Inserted          = 0
 2018-11-05 19:39:50|INFO|rows Updated           = 16
@@ -11,8 +11,8 @@
 2018-11-05 19:39:50|INFO|gpload session started 2018-11-05 19:39:50
 2018-11-05 19:39:50|INFO|setting schema 'public' for table 'texttable'
 2018-11-05 19:39:50|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 19:39:50|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 19:39:50|INFO|reusing external table ext_gpload_reusable_8098fb6c_e0ef_11e8_a796_00505698a2d7
+2018-11-05 19:39:50|INFO|reusing staging table public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 19:39:50|INFO|reusing external table public.ext_gpload_reusable_8098fb6c_e0ef_11e8_a796_00505698a2d7
 2018-11-05 19:39:50|INFO|running time: 0.51 seconds
 2018-11-05 19:39:50|INFO|rows Inserted          = 0
 2018-11-05 19:39:50|INFO|rows Updated           = 16

--- a/gpMgmt/bin/gpload_test/gpload2/query36.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query36.ans
@@ -1,8 +1,8 @@
 2018-11-05 22:49:40|INFO|gpload session started 2018-11-05 22:49:40
 2018-11-05 22:49:40|INFO|setting schema 'public' for table 'texttable'
 2018-11-05 22:49:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 22:49:40|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 22:49:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_06670f3a_e10a_11e8_af7b_00505698a2d7
+2018-11-05 22:49:40|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 22:49:41|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_06670f3a_e10a_11e8_af7b_00505698a2d7
 2018-11-05 22:49:41|INFO|running time: 0.64 seconds
 2018-11-05 22:49:41|INFO|rows Inserted          = 16
 2018-11-05 22:49:41|INFO|rows Updated           = 0
@@ -11,8 +11,8 @@
 2018-11-05 22:49:41|INFO|gpload session started 2018-11-05 22:49:41
 2018-11-05 22:49:41|INFO|setting schema 'public' for table 'texttable'
 2018-11-05 22:49:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 22:49:41|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 22:49:41|INFO|reusing external table ext_gpload_reusable_06670f3a_e10a_11e8_af7b_00505698a2d7
+2018-11-05 22:49:41|INFO|reusing staging table public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 22:49:41|INFO|reusing external table public.ext_gpload_reusable_06670f3a_e10a_11e8_af7b_00505698a2d7
 2018-11-05 22:49:42|INFO|running time: 0.55 seconds
 2018-11-05 22:49:42|INFO|rows Inserted          = 0
 2018-11-05 22:49:42|INFO|rows Updated           = 16

--- a/gpMgmt/bin/gpload_test/gpload2/query37.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query37.ans
@@ -1,9 +1,9 @@
 2018-11-05 22:52:11|INFO|gpload session started 2018-11-05 22:52:11
 2018-11-05 22:52:11|INFO|setting schema 'public' for table 'texttable'
 2018-11-05 22:52:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 22:52:11|INFO|did not find an external table to reuse. creating ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7
-2018-11-05 22:52:11|ERROR|could not run SQL "create external table ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 22:52:11|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7
+2018-11-05 22:52:11|ERROR|could not run SQL "create external table public.ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
 
 2018-11-05 22:52:11|INFO|rows Inserted          = 0
 2018-11-05 22:52:11|INFO|rows Updated           = 0
@@ -12,9 +12,9 @@
 2018-11-05 22:52:11|INFO|gpload session started 2018-11-05 22:52:11
 2018-11-05 22:52:11|INFO|setting schema 'public' for table 'texttable'
 2018-11-05 22:52:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 22:52:12|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7
-2018-11-05 22:52:12|ERROR|could not run SQL "create external table ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2018-11-05 22:52:12|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7
+2018-11-05 22:52:12|ERROR|could not run SQL "create external table public.ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
 
 2018-11-05 22:52:12|INFO|rows Inserted          = 0
 2018-11-05 22:52:12|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query4.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query4.ans
@@ -1,7 +1,7 @@
 2017-03-28 09:21:43|INFO|gpload session started 2017-03-28 09:21:43
 2017-03-28 09:21:43|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:43|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:43|INFO|reusing external table ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
+2017-03-28 09:21:43|INFO|reusing external table public.ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
 2017-03-28 09:21:43|INFO|running time: 0.06 seconds
 2017-03-28 09:21:43|INFO|rows Inserted          = 16
 2017-03-28 09:21:43|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-03-28 09:21:43|INFO|gpload session started 2017-03-28 09:21:43
 2017-03-28 09:21:43|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:43|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:43|INFO|reusing external table ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
+2017-03-28 09:21:43|INFO|reusing external table public.ext_gpload_reusable_f4b7a56a_1397_11e7_b233_0242ac110005
 2017-03-28 09:21:43|INFO|running time: 0.06 seconds
 2017-03-28 09:21:43|INFO|rows Inserted          = 16
 2017-03-28 09:21:43|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query5.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query5.ans
@@ -1,7 +1,7 @@
 2017-03-28 09:21:43|INFO|gpload session started 2017-03-28 09:21:43
 2017-03-28 09:21:43|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:43|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:43|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f56904cc_1397_11e7_aad2_0242ac110005
+2017-03-28 09:21:43|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_f56904cc_1397_11e7_aad2_0242ac110005
 2017-03-28 09:21:43|INFO|running time: 0.06 seconds
 2017-03-28 09:21:43|INFO|rows Inserted          = 16
 2017-03-28 09:21:43|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-03-28 09:21:43|INFO|gpload session started 2017-03-28 09:21:43
 2017-03-28 09:21:43|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:43|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:43|INFO|reusing external table ext_gpload_reusable_f56904cc_1397_11e7_aad2_0242ac110005
+2017-03-28 09:21:43|INFO|reusing external table public.ext_gpload_reusable_f56904cc_1397_11e7_aad2_0242ac110005
 2017-03-28 09:21:43|INFO|running time: 0.06 seconds
 2017-03-28 09:21:43|INFO|rows Inserted          = 16
 2017-03-28 09:21:43|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query6.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query6.ans
@@ -1,7 +1,7 @@
 2017-03-28 09:21:44|INFO|gpload session started 2017-03-28 09:21:44
 2017-03-28 09:21:44|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:44|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:44|INFO|reusing external table ext_gpload_reusable_f56904cc_1397_11e7_aad2_0242ac110005
+2017-03-28 09:21:44|INFO|reusing external table public.ext_gpload_reusable_f56904cc_1397_11e7_aad2_0242ac110005
 2017-03-28 09:21:44|INFO|running time: 0.06 seconds
 2017-03-28 09:21:44|INFO|rows Inserted          = 16
 2017-03-28 09:21:44|INFO|rows Updated           = 0
@@ -10,7 +10,7 @@
 2017-03-28 09:21:44|INFO|gpload session started 2017-03-28 09:21:44
 2017-03-28 09:21:44|INFO|setting schema 'public' for table 'texttable'
 2017-03-28 09:21:44|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/source/gpdb/gpMgmt/bin/gpload_modules/data_file.txt" -t 30
-2017-03-28 09:21:44|INFO|reusing external table ext_gpload_reusable_f56904cc_1397_11e7_aad2_0242ac110005
+2017-03-28 09:21:44|INFO|reusing external table public.ext_gpload_reusable_f56904cc_1397_11e7_aad2_0242ac110005
 2017-03-28 09:21:44|INFO|running time: 0.06 seconds
 2017-03-28 09:21:44|INFO|rows Inserted          = 16
 2017-03-28 09:21:44|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query8.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query8.ans
@@ -1,8 +1,8 @@
 2017-04-10 07:07:08|INFO|gpload session started 2017-04-10 07:07:08
 2017-04-10 07:07:08|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:07:08|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:07:08|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2017-04-10 07:07:08|INFO|did not find an external table to reuse. creating ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
+2017-04-10 07:07:08|INFO|did not find a staging table to reuse. creating public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2017-04-10 07:07:08|INFO|did not find an external table to reuse. creating public.ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
 2017-04-10 07:07:08|INFO|running time: 0.08 seconds
 2017-04-10 07:07:08|INFO|rows Inserted          = 0
 2017-04-10 07:07:08|INFO|rows Updated           = 32
@@ -11,8 +11,8 @@
 2017-04-10 07:07:08|INFO|gpload session started 2017-04-10 07:07:08
 2017-04-10 07:07:08|INFO|setting schema 'public' for table 'texttable'
 2017-04-10 07:07:08|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/gpload/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2017-04-10 07:07:08|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2017-04-10 07:07:08|INFO|reusing external table ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
+2017-04-10 07:07:08|INFO|reusing staging table public.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2017-04-10 07:07:08|INFO|reusing external table public.ext_gpload_reusable_4fc43864_1dbc_11e7_a4b1_0242ac110005
 2017-04-10 07:07:09|INFO|running time: 0.08 seconds
 2017-04-10 07:07:09|INFO|rows Inserted          = 0
 2017-04-10 07:07:09|INFO|rows Updated           = 32


### PR DESCRIPTION
This is an attempt to mitigate CVE-2018-1058 for the gpload utility, by clearing the `search_path` for as many queries as possible.

Unlike the other utilities we've fixed so far, gpload makes explicit use of `search_path` to determine proper functionality, so we can't just set it to the empty string in all situations. We've instead unset `search_path` by default, and only restored its original value for queries that must have it (mostly those relying on `pg_table_is_visible()`).

Our first attempt at this correctly qualified functions and tables but forgot about operators, so we're not sure this implementation is maintainable -- the probability that the affected queries will remain properly schema-qualified into the future probably approaches zero. We may want to look into a approach where some of these queries are split in two: the main body of logic that does not rely on `search_path` can be safely run with it set to empty (which vastly reduces the amount of SQL that has to be properly qualified), and then a second query can be issued with the restored `search_path` to filter those results through `pg_table_is_visible()`.

Thoughts?