### PR TITLE
gpMgmt: make remaining utilities search_path-safe

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -311,16 +311,22 @@ def parseCommandLine():
 def connect(user=None, password=None, host=None, port=None,
             database=None, utilityMode=False):
     '''Connect to DB using parameters in GV'''
-    options = utilityMode and '-c gp_session_role=utility' or None
+    # unset search path due to CVE-2018-1058
+    options = '-c search_path='
+    if utilityMode:
+        options += ' -c gp_session_role=utility'
+
     if not user: user = GV.opt['-U']
     if not password: password = GV.opt['-P']
     if not host: host = GV.opt['-h']
     if not port: port = GV.opt['-p']
     if not database: database = GV.dbname
+
     try:
         logger.debug('connecting to %s:%s %s' % (host, port, database))
         db = pg.connect(host=host, port=port, user=user,
                         passwd=password, dbname=database, opt=options)
+
     except pg.InternalError, ex:
         logger.fatal('could not connect to %s: "%s"' %
                      (database, str(ex).strip()))

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -5,7 +5,7 @@ from gppylib.db import dbconn
 import pygresql.pg
 
 
-FTS_PROBE_QUERY = 'SELECT gp_request_fts_probe_scan()'
+FTS_PROBE_QUERY = 'SELECT pg_catalog.gp_request_fts_probe_scan()'
 
 class SegmentReconfigurer:
     def __init__(self, logger, worker_pool, timeout):

--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -17,7 +17,8 @@ gpsd_version = '%prog 1.0'
 
 sysnslist = "('pg_toast', 'pg_bitmapindex', 'pg_temp_1', 'pg_catalog', 'information_schema')"
 orca = False
-pgoptions = '-c gp_session_role=utility'
+# unset search path due to CVE-2018-1058
+pgoptions = '-c gp_session_role=utility -c search_path='
 
 
 def ResultIter(cursor, arraysize=1000):
@@ -238,6 +239,7 @@ def main():
             with closing(connection.cursor()) as cursor:
                 dumpTupleCount(cursor)
                 dumpStats(cursor, inclHLL)
+
     except pgdb.DatabaseError, err:  # catch *all* exceptions
         sys.stderr.write('Error while dumping statistics:\n')
         sys.stderr.write(err.message)

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -68,7 +68,8 @@ version = '1.13'
 PATH_PREFIX = '/tmp/'
 PGDUMP_FILE = 'pg_dump_out.sql'
 sysnslist = "('pg_toast', 'pg_bitmapindex', 'pg_catalog', 'information_schema', 'gp_toolkit')"
-pgoptions = '-c gp_session_role=utility'
+# unset search path due to CVE-2018-1058
+pgoptions = '-c gp_session_role=utility -c search_path='
 
 class MRQuery(object):
     def __init__(self):


### PR DESCRIPTION
As a continued follow-up in the CVE-2018-1058 work, ensure that the utilities that connect using PyGreSQL primitives also have `search_path` protection.

We set an empty `search_path` for the connection in all cases except for `segment_reconfigurer.py`, where a fully-qualified SELECT statement seemed sufficient (there is only one query being performed on the connection, and that seems unlikely to change).
