### PR TITLE
docs - updates and corrections to ALTER PARTITION clause of ALTER TABLE

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
@@ -479,7 +479,8 @@ Filter: "date"=01-07-12::date AND region='USA'::text
   <topic id="topic76" xml:lang="en">
     <title>Viewing Your Partition Design</title>
     <body>
-      <p>You can look up information about your partition design using the <i>pg_partitions</i>
+      <p>You can look up information about your partition design using the <i><xref
+            href="../../ref_guide/system_catalogs/pg_partitions.xml">pg_partitions</xref></i> system
         view. For example, to see the partition design of the <i>sales</i> table:</p>
       <p>
         <codeblock>SELECT partitionboundary, partitiontablename, partitionname, 
@@ -488,17 +489,21 @@ FROM pg_partitions
 WHERE tablename='sales';
 </codeblock>
       </p>
-      <p>The following table and views show information about partitioned tables.</p>
+      <p>The following table and views also show information about partitioned tables.</p>
       <ul id="ul_ycd_2wy_sp">
-        <li id="im211944"><i>pg_partition </i>- Tracks partitioned tables and their inheritance
-          level relationships. </li>
-        <li id="im156096"><i>pg_partition_templates</i> - Shows the subpartitions created using a
+        <li id="im211944"><i><xref href="../../ref_guide/system_catalogs/pg_partition.xml"
+              >pg_partition</xref></i>- Tracks partitioned tables and their inheritance level
+          relationships. </li>
+        <li id="im156096"><i><xref
+              href="../../ref_guide/system_catalogs/pg_partition_templates.xml#topic1"
+              >pg_partition_templates</xref></i>- Shows the subpartitions created using a
           subpartition template.</li>
-        <li id="im156103"><i>pg_partition_columns</i> - Shows the partition key columns used in a
-          partition design.</li>
+        <li id="im156103"><i><xref href="../../ref_guide/system_catalogs/pg_partition_columns.xml"
+              >pg_partition_columns</xref></i> - Shows the partition key columns used in a partition
+          design.</li>
       </ul>
-      <p>For information about Greenplum Database system catalog tables and views, see the
-          <i>Greenplum Database Reference Guide</i>. </p>
+      <p otherprops="op-print">For information about Greenplum Database system catalog tables and
+        views, see the <i>Greenplum Database Reference Guide</i>. </p>
     </body>
   </topic>
   <topic id="topic77" xml:lang="en">
@@ -540,12 +545,25 @@ WHERE tablename='sales';
         </li>
       </ul>
       <note type="important">When defining and altering partition designs, use the given partition
-        name, not the table object name. Although you can query and load any table (including
-        partitioned tables) directly using SQL commands, you can only modify the structure of a
-        partitioned table using the <codeph>ALTER TABLE...PARTITION</codeph> clauses.<p>Partitions
-          are not required to have names. If a partition does not have a name, use one of the
-          following expressions to specify a part: <codeph>PARTITION FOR (value)</codeph> or
-            )<codeph>PARTITION FOR(RANK(number)</codeph>.</p></note>
+        name, not the table object name. The given partition name is the
+          <codeph>partitionname</codeph> column value in the <i><xref
+            href="../../ref_guide/system_catalogs/pg_partitions.xml">pg_partitions</xref></i> system
+        view. Although you can query and load any table (including partitioned tables) directly
+        using SQL commands, you can only modify the structure of a partitioned table using the
+          <codeph>ALTER TABLE...PARTITION</codeph> clauses.<p>Partitions are not required to have
+          names. If a partition does not have a name, use one of the following expressions to
+          specify a part: <codeph>PARTITION FOR (value)</codeph> or ) <codeph>PARTITION
+            FOR(RANK(number)</codeph>. </p></note>
+      <p>For a multi-level partitioned table, you identify a specific partition to change with
+          <codeph>ALTER PARTITION</codeph> clauses. The clauses specify the child partition in each
+        level of the partitioned table hierarchy that is above and is linked to the target
+        partition. For example, if you have a partitioned table that consists of three levels, year,
+        quarter, and region, this <codeph>ALTER TABLE</codeph> command exchanges a leaf partition
+          <codeph>region4</codeph> with the table <codeph>region4_new</codeph>. </p>
+      <codeblock>ALTER TABLE sales <b>ALTER PARTITION yr_1 ALTER PARTITION qtr_4</b> EXCHANGE PARTITION region4 WITH TABLE region4_new ;</codeblock>
+      <p>The two <codeph>ALTER PARTITION</codeph> clauses identify which <codeph>region4</codeph>
+        partition to exchange. Both clauses are required to identify the specific partition to
+        exchange.</p>
     </body>
     <topic id="topic78" xml:lang="en">
       <title id="im172625">Adding a Partition</title>

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
@@ -552,17 +552,18 @@ WHERE tablename='sales';
         using SQL commands, you can only modify the structure of a partitioned table using the
           <codeph>ALTER TABLE...PARTITION</codeph> clauses.<p>Partitions are not required to have
           names. If a partition does not have a name, use one of the following expressions to
-          specify a part: <codeph>PARTITION FOR (value)</codeph> or ) <codeph>PARTITION
-            FOR(RANK(number)</codeph>. </p></note>
+          specify a partition: <codeph>PARTITION FOR (<varname>value</varname>)</codeph> or
+            <codeph>PARTITION FOR (RANK(<varname>number</varname>))</codeph>. </p></note>
       <p>For a multi-level partitioned table, you identify a specific partition to change with
-          <codeph>ALTER PARTITION</codeph> clauses. The clauses specify the child partition in each
-        level of the partitioned table hierarchy that is above and is linked to the target
-        partition. For example, if you have a partitioned table that consists of three levels, year,
-        quarter, and region, this <codeph>ALTER TABLE</codeph> command exchanges a leaf partition
-          <codeph>region4</codeph> with the table <codeph>region4_new</codeph>. </p>
-      <codeblock>ALTER TABLE sales <b>ALTER PARTITION yr_1 ALTER PARTITION qtr_4</b> EXCHANGE PARTITION region4 WITH TABLE region4_new ;</codeblock>
-      <p>The two <codeph>ALTER PARTITION</codeph> clauses identify which <codeph>region4</codeph>
-        partition to exchange. Both clauses are required to identify the specific partition to
+          <codeph>ALTER PARTITION</codeph> clauses. For each partition level in the table hierarchy
+        that is above the target partition, specify the partition that is related to the target
+        partition in an <codeph>ALTER PARTITION</codeph> clause. For example, if you have a
+        partitioned table that consists of three levels, year, quarter, and region, this
+          <codeph>ALTER TABLE</codeph> command exchanges a leaf partition <codeph>region</codeph>
+        with the table <codeph>region_new</codeph>. </p>
+      <codeblock>ALTER TABLE sales <b>ALTER PARTITION year_1 ALTER PARTITION quarter_4</b> EXCHANGE PARTITION region WITH TABLE region_new ;</codeblock>
+      <p>The two <codeph>ALTER PARTITION</codeph> clauses identify which <codeph>region</codeph>
+        partition to exchange. Both clauses are required to identify the specific leaf partition to
         exchange.</p>
     </body>
     <topic id="topic78" xml:lang="en">

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -662,10 +662,11 @@ where <varname>action</varname> is one of:
                                         <pd>If altering a partition deeper than the first level of
                                                 partitions, use <codeph>ALTER PARTITION</codeph>
                                                 clauses to specify which subpartition in the
-                                                hierarchy you want to alter. The clauses specify the
-                                                child partition in each level of the partitioned
-                                                table hierarchy that is above and is linked to the
-                                                target partition.</pd>
+                                                hierarchy you want to alter. For each partition
+                                                level in the table hierarchy that is above the
+                                                target partition, specify the partition that is
+                                                related to the target partition in an <codeph>ALTER
+                                                  PARTITION</codeph> clause.</pd>
                                 </plentry>
                                 <plentry>
                                         <pt>DROP [DEFAULT] PARTITION</pt>
@@ -1066,11 +1067,11 @@ AT ('2016-01-16')
 INTO (PARTITION jan081to15, PARTITION jan0816to31);</codeblock>
                         <p>For a multi-level partitioned table that consists of three levels, year,
                                 quarter, and region, exchange a leaf partition
-                                        <codeph>region4</codeph> with the table
-                                        <codeph>region4_new</codeph>. </p>
-                        <codeblock>ALTER TABLE sales ALTER PARTITION yr_1 ALTER PARTITION qtr_4 EXCHANGE PARTITION region4 WITH TABLE region4_new ;</codeblock>
+                                        <codeph>region</codeph> with the table
+                                        <codeph>region_new</codeph>. </p>
+                        <codeblock>ALTER TABLE sales ALTER PARTITION year_1 ALTER PARTITION quarter_4 EXCHANGE PARTITION region WITH TABLE region_new ;</codeblock>
                         <p>In the previous command, the two <codeph>ALTER PARTITION</codeph> clauses
-                                identify which <codeph>region4</codeph> partition to exchange. Both
+                                identify which <codeph>region</codeph> partition to exchange. Both
                                 clauses are required to identify the specific partition to
                                 exchange.</p>
                         <p> To recreate a primary key constraint, without blocking updates while the

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -33,8 +33,7 @@ ALTER TABLE [IF EXISTS] [ONLY] <varname>name</varname> SET
 
 ALTER TABLE <varname>name</varname>
    [ ALTER PARTITION { <varname>partition_name</varname> | FOR (RANK(<varname>number</varname>)) 
-   | FOR (<varname>value</varname>) } <varname>partition_action</varname> [...] ] 
-   <varname>partition_action</varname>
+   | FOR (<varname>value</varname>) } [...] ] <varname>partition_action</varname>
 
 where <varname>action</varname> is one of:
                         
@@ -661,9 +660,12 @@ where <varname>action</varname> is one of:
                                 <plentry>
                                         <pt>ALTER [DEFAULT] PARTITION</pt>
                                         <pd>If altering a partition deeper than the first level of
-                                                partitions, the <codeph>ALTER PARTITION</codeph>
-                                                clause is used to specify which subpartition in the
-                                                hierarchy you want to alter.</pd>
+                                                partitions, use <codeph>ALTER PARTITION</codeph>
+                                                clauses to specify which subpartition in the
+                                                hierarchy you want to alter. The clauses specify the
+                                                child partition in each level of the partitioned
+                                                table hierarchy that is above and is linked to the
+                                                target partition.</pd>
                                 </plentry>
                                 <plentry>
                                         <pt>DROP [DEFAULT] PARTITION</pt>
@@ -864,7 +866,11 @@ where <varname>action</varname> is one of:
                                         <pt>
                                                 <varname>partition_name</varname>
                                         </pt>
-                                        <pd>The given name of a partition. </pd>
+                                        <pd>The given name of a partition. The given partition name
+                                                is the <codeph>partitionname</codeph> column value
+                                                in the <i><xref
+                                                  href="../../ref_guide/system_catalogs/pg_partitions.xml"
+                                                  >pg_partitions</xref></i> system view.</pd>
                                 </plentry>
                                 <plentry>
                                         <pt>FOR (RANK(number))</pt>
@@ -1058,6 +1064,15 @@ INTO (PARTITION jan09, PARTITION other);</codeblock>
                         <codeblock>ALTER TABLE sales SPLIT PARTITION FOR ('2016-01-01')
 AT ('2016-01-16')
 INTO (PARTITION jan081to15, PARTITION jan0816to31);</codeblock>
+                        <p>For a multi-level partitioned table that consists of three levels, year,
+                                quarter, and region, exchange a leaf partition
+                                        <codeph>region4</codeph> with the table
+                                        <codeph>region4_new</codeph>. </p>
+                        <codeblock>ALTER TABLE sales ALTER PARTITION yr_1 ALTER PARTITION qtr_4 EXCHANGE PARTITION region4 WITH TABLE region4_new ;</codeblock>
+                        <p>In the previous command, the two <codeph>ALTER PARTITION</codeph> clauses
+                                identify which <codeph>region4</codeph> partition to exchange. Both
+                                clauses are required to identify the specific partition to
+                                exchange.</p>
                         <p> To recreate a primary key constraint, without blocking updates while the
                                 index is rebuilt: </p>
                         <codeblock>CREATE UNIQUE INDEX CONCURRENTLY dist_id_temp_idx ON distributors (dist_id);


### PR DESCRIPTION
The ALTER PARTITION clause of the ALTER TABLE command and the Admin. Guide information on changing partitions of a partitioned table needs to be corrected/updated for multi-level partitioned tables.

-- Corrected ALTER PARTITION clause syntax
-- Clarified description of ALTER PARTITION clause.
-- Clarified information about altering partitions in Admin. Guide
-- Added example in Ref. Guide and Admin. Guide
-- Other minor edits.

To be backported to 6X_STABLE and 5X_STABLE
