### PR TITLE
Calculate memory for no spilling in bytes

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9177,9 +9177,9 @@ RecoveryRestartPoint(const CheckPoint *checkPoint)
 	volatile XLogCtlData *xlogctl = XLogCtl;
 
 	/* Update the shared RedoRecPtr */
-	 SpinLockAcquire(&xlogctl->info_lck);
-	 xlogctl->Insert.RedoRecPtr = checkPoint->redo;
-	 SpinLockRelease(&xlogctl->info_lck);
+	SpinLockAcquire(&xlogctl->info_lck);
+	xlogctl->Insert.RedoRecPtr = checkPoint->redo;
+	SpinLockRelease(&xlogctl->info_lck);
 
 	/*
 	 * Also refrain from creating a restartpoint if we have seen any

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -339,7 +339,7 @@ restrict_and_check_grant(bool is_grant, AclMode avail_goptions, bool all_privs,
 	 */
 	this_privileges = privileges & ACL_OPTION_TO_PRIVS(avail_goptions);
 	
-	 /*
+	/*
 	 * GPDB: don't do this if we're an execute node. Let the QD handle the
 	 * WARNING.
 	 */

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -1988,7 +1988,7 @@ make_plan_for_one_dqa(PlannerInfo *root, MppGroupContext *ctx, int dqa_index,
 	 * GroupClause node for the DQA argument.  This is where the sort operator
 	 * for the DQA argument is selected.
 	 */
-	 {
+	{
 		SortGroupClause *gc;
 		TargetEntry *tle;
 		Oid			dqaArg_orderingop;

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1947,8 +1947,17 @@ cdbexplain_showExecStatsEnd(struct PlannedStmt *stmt,
 		{
 			long mem_wanted;
 
-			mem_wanted = (long) PolicyAutoStatementMemForNoSpillKB(stmt,
-							(uint64) showstatctx->workmemwanted_max / 1024L);
+			mem_wanted = (long) PolicyAutoStatementMemForNoSpill(stmt,
+							(uint64) showstatctx->workmemwanted_max);
+
+			/*
+			 * Round up to a kilobyte in case we end up requiring less than
+			 * that.
+			 */
+			if (mem_wanted <= 1024L)
+				mem_wanted = 1L;
+			else
+				mem_wanted = mem_wanted / 1024L;
 
 			if (es->format == EXPLAIN_FORMAT_TEXT)
 				appendStringInfo(es->str, "Memory wanted:  %ldkB\n", mem_wanted);

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2422,7 +2422,7 @@ SubPlanFinderWalker(Plan *node,
 			ctx->bms_subplans = bms_add_member(ctx->bms_subplans, i);
 		else
 			return false;
-	 }
+	}
 
 	/* Continue walking */
 	return plan_tree_walker((Node*)node, SubPlanFinderWalker, ctx);

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -4671,15 +4671,19 @@ Cost incremental_hashjoin_cost(double rows, int inner_width, int outer_width, Li
 	Selectivity innerbucketsize;
 	int num_hashclauses = list_length(hashclauses);
 
-	/* Each inner row joins to a single outer row and vice versa, 
-	 * no selectivity issues. */
-	 startup_cost = 0;
-	 run_cost = 0;
+	/*
+	 * Each inner row joins to a single outer row and vice versa, no
+	 * selectivity issues.
+	 */
+	startup_cost = 0;
+	run_cost = 0;
 	
-	/* Cost of computing hash function: must do it once per input tuple. We
+	/*
+	 * Cost of computing hash function: must do it once per input tuple. We
 	 * charge one cpu_operator_cost for each column's hash function.  Also,
 	 * tack on one cpu_tuple_cost per inner row, to model the costs of
-	 * inserting the row into the hashtable. */
+	 * inserting the row into the hashtable.
+	 */
 	startup_cost += (cpu_operator_cost * num_hashclauses + cpu_tuple_cost) * rows;
 	run_cost += cpu_operator_cost * num_hashclauses * rows;
 

--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -113,9 +113,9 @@ gp_hll_unpack(GpHLLCounter hloglog){
 	}
 
 	/*
-	 allocate and zero an array large enough to hold all the decompressed
-	 bins
-	*/
+	 * Allocate and zero an array large enough to hold all the decompressed
+	 * bins
+	 */
 	m = POW2(hloglog->b);
 	htemp = palloc(sizeof(GpHLLData) + m);
 	memcpy(htemp, hloglog, sizeof(GpHLLData));
@@ -477,7 +477,6 @@ gp_hll_add_element(GpHLLCounter hloglog, const char * element, int elen)
 static GpHLLCounter
 gp_hll_add_hash_dense(GpHLLCounter hloglog, uint64_t hash)
 {
-
     uint64_t idx;
     uint8_t rho,entry,addn;
 
@@ -496,15 +495,17 @@ gp_hll_add_hash_dense(GpHLLCounter hloglog, uint64_t hash)
      * which is currently supported nor really necessary due to 2^(2^8) ~ 
      * 1.16E77 a number so large its not feasible to have that many unique 
      * elements. */
-    if (rho == HASH_LENGTH){
-	    addn = HASH_LENGTH;
-	    rho = (HASH_LENGTH - hloglog->b);
-	    while (addn == HASH_LENGTH && rho < POW2(hloglog->binbits)){
+	if (rho == HASH_LENGTH)
+	{
+		addn = HASH_LENGTH;
+		rho = (HASH_LENGTH - hloglog->b);
+		while (addn == HASH_LENGTH && rho < POW2(hloglog->binbits))
+		{
 		    hash = GpMurmurHash64A((const char * )&hash, HASH_LENGTH/8, HASH_SEED);
             /* zero length runs should be 1 so counter gets set */
 		    addn = __builtin_clzll(hash) + 1;
 		    rho += addn;
-	    }
+		}
     }
 
     /* keep the highest value */
@@ -514,7 +515,6 @@ gp_hll_add_hash_dense(GpHLLCounter hloglog, uint64_t hash)
     }
     
     return hloglog;
-
 }
 
 /* Just reset the counter (set all the counters to 0). We do this by

--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -205,13 +205,12 @@ typedef struct AllocBlockData
  */
 typedef struct AllocChunkData
 {
-	 /*
-	  * SharedChunkHeader stores all the "shared" details
-	  * among multiple chunks, such as memoryAccount to charge,
-	  * generation of memory account, memory context that owns this
-	  * chunk etc. However, in case of a free chunk, this pointer
-	  * actually refers to the next chunk in the free list.
-	  */
+	/*
+	 * SharedChunkHeader stores all the "shared" details among multiple chunks,
+	 * such as memoryAccount to charge, generation of memory account, memory
+	 * context that owns this chunk etc. However, in case of a free chunk, this
+	 * pointer actually refers to the next chunk in the free list.
+	 */
 	struct SharedChunkHeader* sharedHeader;
 
 	Size		size;			/* size of data space allocated in chunk */

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -448,14 +448,15 @@ void PolicyAutoAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memAvailableByte
 
 /*
  * What should be query mem such that memory intensive operators get a certain
- * minimum amount of memory.  Return value is in KB.
+ * minimum amount of memory.  Return value is in bytes.
  */
-uint64 PolicyAutoStatementMemForNoSpillKB(PlannedStmt *stmt, uint64 minOperatorMemKB)
+uint64
+PolicyAutoStatementMemForNoSpill(PlannedStmt *stmt, uint64 minOperatorMem)
 {
 	Assert(stmt);
-	Assert(minOperatorMemKB > 0);
+	Assert(minOperatorMem > 0);
 
-	const uint64 nonMemIntenseOpMemKB = (uint64) (*gp_resmanager_memory_policy_auto_fixed_mem);
+	const uint64 nonMemIntenseOpMem = ((uint64) (*gp_resmanager_memory_policy_auto_fixed_mem) * 1024);
 
 	PolicyAutoContext ctx;
 	exec_init_plan_tree_base(&ctx.base, stmt);
@@ -476,10 +477,10 @@ uint64 PolicyAutoStatementMemForNoSpillKB(PlannedStmt *stmt, uint64 minOperatorM
 	 * Right now, the inverse is straightforward.
 	 * TODO: Siva - employ binary search to find the right value.
 	 */
-	uint64 requiredStatementMemKB = ctx.numNonMemIntensiveOperators * nonMemIntenseOpMemKB
-									+ ctx.numMemIntensiveOperators * minOperatorMemKB;
+	uint64 requiredStatementMem = ctx.numNonMemIntensiveOperators * nonMemIntenseOpMem
+									+ ctx.numMemIntensiveOperators * minOperatorMem;
 
-	return requiredStatementMemKB;
+	return requiredStatementMem;
 }
 
 /*

--- a/src/include/cdb/memquota.h
+++ b/src/include/cdb/memquota.h
@@ -50,7 +50,7 @@ extern void PolicyEagerFreeAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memo
 /**
  * Inverse for explain analyze.
  */
-extern uint64 PolicyAutoStatementMemForNoSpillKB(PlannedStmt *stmt, uint64 minOperatorMemKB);
+extern uint64 PolicyAutoStatementMemForNoSpill(PlannedStmt *stmt, uint64 minOperatorMemKB);
 
 /**
  * Is result node memory intensive?


### PR DESCRIPTION
The calculation for minimum amount of memory to memory intensive operators was using kB for both input and output, leading to an assertion failure in case the minimum memory requirement was less than a kB. Since we are using a full uint64 for calculating, we have room for using just bytes instead leaving the formatting to the caller (which is just EXPLAIN ANALYZE).

This came up from a hunk in #8281. 

The first commit is just whitespace cleanup, as there was tab+space indentation that couldn't be unseen once observed.