### PR TITLE
Consistently use kB for kilobytes in EXPLAIN output

### DIFF
--- a/contrib/auto_explain/expected/auto_explain.out
+++ b/contrib/auto_explain/expected/auto_explain.out
@@ -32,7 +32,7 @@ Query Text: SELECT relname FROM pg_class WHERE relname='pg_class';
 Seq Scan on pg_class  (cost=0.00..12.46 rows=1 width=64) (actual rows=1 loops=1)
   Filter: (relname = 'pg_class'::name)
   Rows Removed by Filter: 438
-  (slice0)    Executor memory: 32K bytes.
+  (slice0)    Executor memory: 32kB.
 Memory used:  128000kB
  relname  
 ----------
@@ -51,9 +51,9 @@ Aggregate  (cost=10000035148.67..10000035148.68 rows=1 width=8) (actual rows=1 l
                     ->  Materialize  (cost=0.00..68.06 rows=1001 width=0) (actual rows=1001 loops=340)
                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..53.05 rows=1001 width=0) (actual rows=1001 loops=1)
                                 ->  Seq Scan on t2  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
-  (slice0)    Executor memory: 131K bytes.
-  (slice1)    Executor memory: 53K bytes avg x 3 workers, 58K bytes max (seg1).
-  (slice2)    Executor memory: 216K bytes avg x 3 workers, 216K bytes max (seg0).
+  (slice0)    Executor memory: 131kB.
+  (slice1)    Executor memory: 53kB avg x 3 workers, 58kB max (seg1).
+  (slice2)    Executor memory: 216kB avg x 3 workers, 216kB max (seg0).
 Memory used:  128000kB
   count  
 ---------
@@ -94,9 +94,9 @@ Aggregate  (cost=10000035148.67..10000035148.68 rows=1 width=8) (actual rows=1 l
                                 Output: t2.b
                                 ->  Seq Scan on auto_explain_test.t2  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
                                       Output: t2.b
-  (slice0)    Executor memory: 131K bytes.
-  (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg0).
-  (slice2)    Executor memory: 216K bytes avg x 3 workers, 216K bytes max (seg0).
+  (slice0)    Executor memory: 131kB.
+  (slice1)    Executor memory: 43kB avg x 3 workers, 43kB max (seg0).
+  (slice2)    Executor memory: 216kB avg x 3 workers, 216kB max (seg0).
 Memory used:  128000kB
   count  
 ---------

--- a/contrib/auto_explain/expected/auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/auto_explain_optimizer.out
@@ -33,7 +33,7 @@ Query Text: SELECT relname FROM pg_class WHERE relname='pg_class';
 Seq Scan on pg_class  (cost=0.00..12.46 rows=1 width=64) (actual rows=1 loops=1)
   Filter: (relname = 'pg_class'::name)
   Rows Removed by Filter: 438
-  (slice0)    Executor memory: 32K bytes.
+  (slice0)    Executor memory: 32kB.
 Memory used:  128000kB
  relname  
 ----------
@@ -52,9 +52,9 @@ Aggregate  (cost=0.00..1326086.34 rows=1 width=8) (actual rows=1 loops=1)
                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.02 rows=1001 width=1) (actual rows=1001 loops=1)
                           ->  Seq Scan on t1  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1)
                     ->  Seq Scan on t2  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1002)
-  (slice0)    Executor memory: 67K bytes.
-  (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-  (slice2)    Executor memory: 119K bytes avg x 3 workers, 119K bytes max (seg0).
+  (slice0)    Executor memory: 67kB.
+  (slice1)    Executor memory: 42kB avg x 3 workers, 42kB max (seg0).
+  (slice2)    Executor memory: 119kB avg x 3 workers, 119kB max (seg0).
 Memory used:  128000kB
   count  
 ---------
@@ -92,9 +92,9 @@ Aggregate  (cost=0.00..1326086.34 rows=1 width=8) (actual rows=1 loops=1)
                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.02 rows=1001 width=1) (actual rows=1001 loops=1)
                           ->  Seq Scan on auto_explain_test.t1  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1)
                     ->  Seq Scan on auto_explain_test.t2  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1002)
-  (slice0)    Executor memory: 67K bytes.
-  (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-  (slice2)    Executor memory: 119K bytes avg x 3 workers, 119K bytes max (seg0).
+  (slice0)    Executor memory: 67kB.
+  (slice1)    Executor memory: 42kB avg x 3 workers, 42kB max (seg0).
+  (slice2)    Executor memory: 119kB avg x 3 workers, 119kB max (seg0).
 Memory used:  128000kB
   count  
 ---------

--- a/gpdb-doc/dita/admin_guide/query/topics/query-profiling.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-profiling.xml
@@ -141,8 +141,8 @@ Gather Motion 2:1 (slice1) (cost=0.00..20.88 rows=1 width=13)
           used by the operation. If the <codeph>work_mem</codeph> was insufficient to perform the
           operation in memory, the plan shows the amount of data spilled to disk for the
           lowest-performing segment. For example:<p>
-            <codeblock>Work_mem used: 64K bytes avg, 64K bytes max (seg0).
-Work_mem wanted: 90K bytes avg, 90K byes max (seg0) to lessen 
+            <codeblock>Work_mem used: 64kB avg, 64kB max (seg0).
+Work_mem wanted: 90kB avg, 90K byes max (seg0) to lessen 
 workfile I/O affecting 2 workers.
 </codeblock>
           </p></li>
@@ -169,12 +169,12 @@ Gather Motion 2:1 (slice1; segments: 2) (cost=0.00..20.88 rows=1 width=13)
                  Filter: name = 'Joelle'::text
  Slice statistics:
 
-      (slice0) Executor memory: 135K bytes.
+      (slice0) Executor memory: 135kB.
 
-    (slice1) Executor memory: 151K bytes avg x 2 workers, 151K bytes max (seg0).
+    (slice1) Executor memory: 151kB avg x 2 workers, 151kB max (seg0).
 
 <b>Statement statistics:</b>
- <b>Memory used: 128000K bytes</b>
+ <b>Memory used: 128000kB</b>
  <b>Total runtime: 22.548 ms</b>
 </codeblock>
         <p>Read the plan from the bottom to the top. The total elapsed time to run this query was
@@ -285,9 +285,9 @@ Gather Motion 2:1 (slice1; segments: 2) (cost=0.00..20.88 rows=1 width=13)
           memory to improve performance for a query. If possible, run an <codeph>EXPLAIN
             ANALYZE</codeph> for the query to show which plan operations spilled to disk, how much
           work memory they used, and how much memory was required to avoid spilling to disk. For
-              example:<p><codeph>Work_mem used: 23430K bytes avg, 23430K bytes max (seg0). Work_mem
-              wanted: 33649K bytes avg, 33649K bytes max (seg0) to lessen workfile I/O affecting 2
-              workers.</codeph></p><p>The "bytes wanted" message from <codeph>EXPLAIN
+              example:<p><codeph>Work_mem used: 23430kB avg, 23430kB max (seg0). Work_mem
+              wanted: 33649kB avg, 33649kB max (seg0) to lessen workfile I/O affecting 2
+              workers.</codeph></p><p>The "kB wanted" message from <codeph>EXPLAIN
               ANALYZE</codeph> is based on the amount of data written to work files and is not
             exact. The minimum <codeph>work_mem</codeph> needed can differ from the suggested
             value.</p></li>

--- a/gpdb-doc/dita/ref_guide/sql_commands/EXPLAIN.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/EXPLAIN.xml
@@ -73,8 +73,8 @@ EXPLAIN [ANALYZE] [VERBOSE] <varname>statement</varname></codeblock>
           operation. If <codeph>work_mem</codeph> was not sufficient to perform the operation in
           memory, the plan will show how much data was spilled to disk and how many passes over the
           data were required for the lowest performing segment. For
-          example:<codeblock>Work_mem used: 64K bytes avg, 64K bytes max (seg0).
-Work_mem wanted: 90K bytes avg, 90K bytes max (seg0) to abate workfile 
+          example:<codeblock>Work_mem used: 64kB avg, 64kB max (seg0).
+Work_mem wanted: 90kB avg, 90kB max (seg0) to abate workfile 
 I/O affecting 2 workers.
 [seg0] pass 0: 488 groups made from 488 rows; 263 rows written to 
 workfile

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1379,7 +1379,7 @@ cdbexplain_formatMemory(char *outbuf, int bufsize, double bytes)
 #ifdef USE_ASSERT_CHECKING
 	int			nchars_written =
 #endif							/* USE_ASSERT_CHECKING */
-	snprintf(outbuf, bufsize, "%.0fK bytes", kb(bytes));
+	snprintf(outbuf, bufsize, "%.0fkB", kb(bytes));
 
 	Assert(nchars_written < bufsize &&
 		   "CDBEXPLAIN:  size of char buffer is smaller than the required number of chars");
@@ -2332,13 +2332,11 @@ gpexplain_formatSlicesOutput(struct CdbExplain_ShowStatCtx *showstatctx,
     if (total_memory_across_slices > 0)
     {
         if (es->format == EXPLAIN_FORMAT_TEXT)
-        {
-            appendStringInfo(es->str, "Total memory used across slices: %.0fK bytes \n", total_memory_across_slices);
-        }
+			appendStringInfo(es->str, "Total memory used across slices: %.0fkB\n",
+							 total_memory_across_slices);
         else
-        {
-            ExplainPropertyInteger("Total memory used across slices", total_memory_across_slices, es);
-        }
+			ExplainPropertyInteger("Total memory used across slices",
+								   total_memory_across_slices, es);
     }
 }
 

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -1718,13 +1718,11 @@ ExecHashTableExplainBatches(HashJoinTable   hashtable,
     /* Inner bytes read from workfile */
     if (irdbytes.vcnt > 0)
     {
-        appendStringInfo(buf,
-                         "  Read %.0fK bytes from inner workfile",
+        appendStringInfo(buf, "  Read %.0fkB from inner workfile",
                          ceil(irdbytes.vsum / 1024));
         if (irdbytes.vcnt > 1)
             appendStringInfo(buf,
-                             ": %.0fK avg x %d nonempty batches"
-                             ", %.0fK max",
+                             ": %.0fkB avg x %d nonempty batches, %.0fkB max",
                              ceil(cdbexplain_agg_avg(&irdbytes)/1024),
                              irdbytes.vcnt,
                              ceil(irdbytes.vmax / 1024));
@@ -1734,13 +1732,11 @@ ExecHashTableExplainBatches(HashJoinTable   hashtable,
     /* Inner rel bytes spilled to workfile */
     if (iwrbytes.vcnt > 0)
     {
-        appendStringInfo(buf,
-                         "  Wrote %.0fK bytes to inner workfile",
+        appendStringInfo(buf, "  Wrote %.0fkB to inner workfile",
                          ceil(iwrbytes.vsum / 1024));
         if (iwrbytes.vcnt > 1)
             appendStringInfo(buf,
-                             ": %.0fK avg x %d overflowing batches"
-                             ", %.0fK max",
+                             ": %.0fkB avg x %d overflowing batches, %.0fkB max",
                              ceil(cdbexplain_agg_avg(&iwrbytes)/1024),
                              iwrbytes.vcnt,
                              ceil(iwrbytes.vmax / 1024));
@@ -1750,13 +1746,11 @@ ExecHashTableExplainBatches(HashJoinTable   hashtable,
     /* Outer bytes read from workfile */
     if (ordbytes.vcnt > 0)
     {
-        appendStringInfo(buf,
-                         "  Read %.0fK bytes from outer workfile",
+        appendStringInfo(buf, "  Read %.0fkB from outer workfile",
                          ceil(ordbytes.vsum / 1024));
         if (ordbytes.vcnt > 1)
             appendStringInfo(buf,
-                             ": %.0fK avg x %d nonempty batches"
-                             ", %.0fK max",
+                             ": %.0fkB avg x %d nonempty batches, %.0fkB max",
                              ceil(cdbexplain_agg_avg(&ordbytes)/1024),
                              ordbytes.vcnt,
                              ceil(ordbytes.vmax / 1024));
@@ -1766,13 +1760,11 @@ ExecHashTableExplainBatches(HashJoinTable   hashtable,
     /* Outer rel bytes spilled to workfile */
     if (owrbytes.vcnt > 0)
     {
-        appendStringInfo(buf,
-                         "  Wrote %.0fK bytes to outer workfile",
+        appendStringInfo(buf, "  Wrote %.0fkB to outer workfile",
                          ceil(owrbytes.vsum / 1024));
         if (owrbytes.vcnt > 1)
             appendStringInfo(buf,
-                             ": %.0fK avg x %d overflowing batches"
-                             ", %.0fK max",
+                             ": %.0fkB avg x %d overflowing batches, %.0fkB max",
                              ceil(cdbexplain_agg_avg(&owrbytes)/1024),
                              owrbytes.vcnt,
                              ceil(owrbytes.vmax / 1024));

--- a/src/test/regress/atmsort.pl
+++ b/src/test/regress/atmsort.pl
@@ -149,9 +149,9 @@ explain analyze select * from customer;
          Rows out:  Avg 75000.0 rows x 2 workers.  Max 75001 rows (seg0) 
          with 0.056 ms to first row, 26 ms to end, start offset by 7.332 ms.
  Slice statistics:
-   (slice0)    Executor memory: 186K bytes.
-   (slice1)    Executor memory: 130K bytes avg x 2 workers, 
-               130K bytes max (seg0).
+   (slice0)    Executor memory: 186kB.
+   (slice1)    Executor memory: 130kB avg x 2 workers, 
+               130kB max (seg0).
  Total runtime: 413.401 ms
 (8 rows)
 

--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -1195,8 +1195,8 @@ explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
                      ->  Seq Scan on mpp8031_1_prt_2 b_1  (cost=0.00..811.00 rows=23700 width=4) (never executed)
                      ->  Seq Scan on mpp8031_1_prt_3 b_2  (cost=0.00..811.00 rows=23700 width=4) (never executed)
                      ->  Seq Scan on mpp8031_1_prt_4 b_3  (cost=0.00..811.00 rows=23700 width=4) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 142K bytes avg x 3 workers, 142K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 142kB avg x 3 workers, 142kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.237 ms

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -1196,8 +1196,8 @@ explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
                            Partitions selected: 4 (out of 4)
                      ->  Dynamic Seq Scan on mpp8031 mpp8031_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.957 rows=0 loops=1)
                            Partitions scanned:  Avg 4.0 (out of 4) x 3 workers.  Max 4 parts (seg0).
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 4234kB avg x 3 workers, 4234kB max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 5.260 ms

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -1104,9 +1104,9 @@ explain analyze select * from t, pt where tid = ptid;
                      Filter: t.tid
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.08 rows=2 width=19) (actual time=0.013..1.782 rows=1 loops=2)
                            ->  Seq Scan on t  (cost=0.00..2.02 rows=1 width=19) (actual time=0.028..0.031 rows=0 loops=2)
-   (slice0)    Executor memory: 540K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4406K bytes avg x 3 workers, 4406K bytes max (seg0).  Work_mem: 1K bytes max.
+   (slice0)    Executor memory: 540kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4406kB avg x 3 workers, 4406kB max (seg0).  Work_mem: 1kB max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 15.697 ms

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -826,9 +826,9 @@ explain analyze select * from t, pt where tid = ptid;
                ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31) (actual time=0.046..0.073 rows=4 loops=2)
                      Index Cond: ptid = $0
                      Partitions scanned:  Avg 6.0 (out of 6) x 3 workers of 2 scans.  Max 6 parts (seg0).
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 62K bytes max (seg0).
-   (slice2)    Executor memory: 155K bytes avg x 3 workers, 155K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 60kB avg x 3 workers, 62kB max (seg0).
+   (slice2)    Executor memory: 155kB avg x 3 workers, 155kB max (seg0).
    (slice3)    
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21

--- a/src/test/regress/expected/eagerfree.out
+++ b/src/test/regress/expected/eagerfree.out
@@ -53,9 +53,9 @@ explain analyze select d, count(*) from smallt group by d;
                      Group Key: smallt.d
                      (seg1)   Hash chain length 1.1 avg, 2 max, using 9 of 32 buckets; total 0 expansions.
                      ->  Seq Scan on smallt  (cost=0.00..4.00 rows=34 width=4) (actual time=0.020..0.055 rows=50 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 166K bytes avg x 3 workers, 166K bytes max (seg0).
-   (slice2)    Executor memory: 138K bytes avg x 3 workers, 138K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 166kB avg x 3 workers, 166kB max (seg0).
+   (slice2)    Executor memory: 138kB avg x 3 workers, 138kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 2.162 ms
@@ -80,8 +80,8 @@ explain analyze select count(*) from (select i, t, d, count(*) from bigt group b
                            (seg0)   44568 groups total in 32 batches; 1 overflows; 44568 spill groups.
                            (seg0)   Hash chain length 3.3 avg, 14 max, using 23361 of 24576 buckets; total 1 expansions.
                            ->  Seq Scan on bigt  (cost=0.00..11615.78 rows=334160 width=18) (actual time=0.042..59.788 rows=333490 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)  * Executor memory: 3004K bytes avg x 3 workers, 3004K bytes max (seg0).  Work_mem: 2361K bytes max, 4738K bytes wanted.
+   (slice0)    Executor memory: 386kB.
+   (slice1)  * Executor memory: 3004kB avg x 3 workers, 3004kB max (seg0).  Work_mem: 2361kB max, 4738kB wanted.
  Memory used:  2560kB
  Memory wanted:  5237kB
  Optimizer: Postgres query optimizer
@@ -104,8 +104,8 @@ explain analyze select count(distinct d) from smallt;
  Aggregate  (cost=8.25..8.26 rows=1 width=8) (actual time=0.782..0.783 rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4) (actual time=0.338..0.651 rows=100 loops=1)
          ->  Seq Scan on smallt  (cost=0.00..4.00 rows=34 width=4) (actual time=0.012..0.033 rows=50 loops=1)
-   (slice0)    Executor memory: 322K bytes.  Work_mem: 33K bytes max.
-   (slice1)    Executor memory: 46K bytes avg x 3 workers, 46K bytes max (seg0).
+   (slice0)    Executor memory: 322kB.  Work_mem: 33kB max.
+   (slice1)    Executor memory: 46kB avg x 3 workers, 46kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.348 ms
@@ -124,8 +124,8 @@ explain analyze select count(distinct d) from bigt;
  Aggregate  (cost=54221.10..54221.11 rows=1 width=8) (actual time=4936.204..4936.205 rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..51714.90 rows=1002478 width=4) (actual time=1.474..1249.805 rows=1000000 loops=1)
          ->  Seq Scan on bigt  (cost=0.00..11615.78 rows=334160 width=4) (actual time=0.037..141.126 rows=333490 loops=1)
-   (slice0)  * Executor memory: 2966K bytes.  Work_mem: 2649K bytes max, 23514K bytes wanted.
-   (slice1)    Executor memory: 70K bytes avg x 3 workers, 70K bytes max (seg0).
+   (slice0)  * Executor memory: 2966kB.  Work_mem: 2649kB max, 23514kB wanted.
+   (slice1)    Executor memory: 70kB avg x 3 workers, 70kB max (seg0).
  Memory used:  2560kB
  Memory wanted:  23713kB
  Optimizer: Postgres query optimizer
@@ -195,10 +195,10 @@ where t1.d = t2.d;
                                  Group Key: public.smallt.d
                                  (seg1)   Hash chain length 1.1 avg, 2 max, using 9 of 32 buckets; total 0 expansions.
                                  ->  Seq Scan on smallt smallt_1  (cost=0.00..4.00 rows=34 width=8) (actual time=0.017..0.043 rows=50 loops=1)
-   (slice0)    Executor memory: 514K bytes.
-   (slice1)    Executor memory: 166K bytes avg x 3 workers, 166K bytes max (seg0).
-   (slice2)    Executor memory: 166K bytes avg x 3 workers, 166K bytes max (seg0).
-   (slice3)    Executor memory: 218K bytes avg x 3 workers, 218K bytes max (seg0).
+   (slice0)    Executor memory: 514kB.
+   (slice1)    Executor memory: 166kB avg x 3 workers, 166kB max (seg0).
+   (slice2)    Executor memory: 166kB avg x 3 workers, 166kB max (seg0).
+   (slice3)    Executor memory: 218kB avg x 3 workers, 218kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.272 ms
@@ -246,8 +246,8 @@ where t1.i = t2.i;
                      Group Key: public.smallt.i
                      (seg1)   Hash chain length 1.0 avg, 1 max, using 5 of 32 buckets; total 0 expansions.
                      ->  Seq Scan on smallt smallt_1  (cost=0.00..4.00 rows=34 width=4) (actual time=0.012..0.030 rows=50 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 278K bytes avg x 3 workers, 278K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 278kB avg x 3 workers, 278kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.614 ms
@@ -280,9 +280,9 @@ explain analyze select d, count(*) from smallt group by d limit 5;
                                  Group Key: smallt.d
                                  (seg1)   Hash chain length 1.1 avg, 2 max, using 9 of 32 buckets; total 0 expansions.
                                  ->  Seq Scan on smallt  (cost=0.00..4.00 rows=34 width=4) (actual time=0.018..0.044 rows=50 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 166K bytes avg x 3 workers, 166K bytes max (seg0).
-   (slice2)    Executor memory: 170K bytes avg x 3 workers, 170K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 166kB avg x 3 workers, 166kB max (seg0).
+   (slice2)    Executor memory: 170kB avg x 3 workers, 170kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.057 ms
@@ -1304,8 +1304,8 @@ explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i;
          ->  Seq Scan on smallt t1  (cost=0.00..4.00 rows=34 width=15) (actual time=0.010..0.023 rows=50 loops=1)
          ->  Hash  (cost=4.00..4.00 rows=34 width=4) (actual time=0.054..0.054 rows=50 loops=1)
                ->  Seq Scan on smallt t2  (cost=0.00..4.00 rows=34 width=4) (actual time=0.008..0.029 rows=50 loops=1)
-   (slice0)    Executor memory: 322K bytes.
-   (slice1)    Executor memory: 4202K bytes avg x 3 workers, 4206K bytes max (seg0).  Work_mem: 2K bytes max.
+   (slice0)    Executor memory: 322kB.
+   (slice1)    Executor memory: 4202kB avg x 3 workers, 4206kB max (seg0).  Work_mem: 2kB max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 7.932 ms
@@ -1616,8 +1616,8 @@ explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i an
                Sort Method:  quicksort  Memory: 33kB
                ->  Seq Scan on smallt t2  (cost=0.00..4.25 rows=7 width=4) (actual time=0.007..0.018 rows=20 loops=1)
                      Filter: i < 2
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 120K bytes avg x 3 workers, 142K bytes max (seg0).  Work_mem: 33K bytes max.
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 120kB avg x 3 workers, 142kB max (seg0).  Work_mem: 33kB max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.433 ms
@@ -1745,9 +1745,9 @@ explain analyze select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d an
                Sort Key: t2.d
                Sort Method:  quicksort  Memory: 99kB
                ->  Seq Scan on smallt t2  (cost=0.00..4.00 rows=34 width=4) (actual time=0.012..0.033 rows=50 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 62K bytes max (seg0).
-   (slice2)    Executor memory: 158K bytes avg x 3 workers, 158K bytes max (seg0).  Work_mem: 33K bytes max.
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 60kB avg x 3 workers, 62kB max (seg0).
+   (slice2)    Executor memory: 158kB avg x 3 workers, 158kB max (seg0).  Work_mem: 33kB max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 2.362 ms
@@ -1811,8 +1811,8 @@ and smallt.d = '2011-01-04'::date;
          ->  Materialize  (cost=0.00..990.53 rows=2 width=4) (actual time=0.019..0.021 rows=4 loops=5)
                ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..990.51 rows=2 width=4) (actual time=0.007..0.011 rows=4 loops=1)
                      Index Cond: d = '01-04-2011'::date
-   (slice0)    Executor memory: 437K bytes.
-   (slice1)    Executor memory: 128K bytes avg x 3 workers, 149K bytes max (seg1).
+   (slice0)    Executor memory: 437kB.
+   (slice1)    Executor memory: 128kB avg x 3 workers, 149kB max (seg1).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.672 ms
@@ -1831,7 +1831,7 @@ explain analyze select *, exists(select 1 from pg_class where oid = c.oid) as du
      ->  Materialize  (cost=0.29..15397.73 rows=14872 width=4) (actual time=3.828..4.157 rows=3030 loops=2)
            ->  Index Only Scan using pg_class_oid_index on pg_class pg_class_1  (cost=0.29..15323.36 rows=14872 width=4) (actual time=0.024..3.218 rows=3030 loops=2)
                  Heap Fetches: 13752
- * (slice0)    Executor memory: 1118K bytes.  Work_mem: 96K bytes max, 64K bytes wanted.
+ * (slice0)    Executor memory: 1118kB.  Work_mem: 96kB max, 64kB wanted.
  Memory used:  128000kB
  Memory wanted:  364kB
  Optimizer: Postgres query optimizer
@@ -1886,8 +1886,8 @@ and smallt.d = '2011-01-04'::date;
                      Recheck Cond: d = '01-04-2011'::date
                      ->  Bitmap Index Scan on smallt2_d_idx  (cost=0.00..800.38 rows=2 width=0) (actual time=0.006..0.006 rows=1 loops=1)
                            Index Cond: d = '01-04-2011'::date
-   (slice0)    Executor memory: 437K bytes.
-   (slice1)    Executor memory: 480K bytes avg x 3 workers, 678K bytes max (seg1).  Work_mem: 9K bytes max.
+   (slice0)    Executor memory: 437kB.
+   (slice1)    Executor memory: 480kB avg x 3 workers, 678kB max (seg1).  Work_mem: 9kB max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.456 ms

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -53,9 +53,9 @@ explain analyze select d, count(*) from smallt group by d;
                      Hash Key: d
                      ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.004 rows=50 loops=1)
  Planning time: 17.216 ms
-   (slice0)    Executor memory: 63K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
+   (slice0)    Executor memory: 63kB.
+   (slice1)    Executor memory: 42kB avg x 3 workers, 42kB max (seg0).
+   (slice2)    Executor memory: 64kB avg x 3 workers, 64kB max (seg0).  Work_mem: 33kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 2.061 ms
@@ -79,8 +79,8 @@ explain analyze select count(*) from (select i, t, d, count(*) from bigt group b
                      (seg0)   44435 groups total in 32 batches; 1 overflows; 44435 spill groups.
                      (seg0)   Hash chain length 2.8 avg, 10 max, using 30315 of 32768 buckets; total 9 expansions.
                      ->  Seq Scan on bigt  (cost=0.00..439.81 rows=333580 width=18) (actual time=0.026..49.692 rows=333530 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)  * Executor memory: 3180K bytes avg x 3 workers, 3180K bytes max (seg0).  Work_mem: 2461K bytes max, 4866K bytes wanted.
+   (slice0)    Executor memory: 386kB.
+   (slice1)  * Executor memory: 3180kB avg x 3 workers, 3180kB max (seg0).  Work_mem: 2461kB max, 4866kB wanted.
  Memory used:  2560kB
  Memory wanted:  5265kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
@@ -107,9 +107,9 @@ explain analyze select count(distinct d) from smallt;
                      Hash Key: d
                      ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.006 rows=50 loops=1)
  Planning time: 19.307 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
+   (slice0)    Executor memory: 59kB.
+   (slice1)    Executor memory: 42kB avg x 3 workers, 42kB max (seg0).
+   (slice2)    Executor memory: 64kB avg x 3 workers, 64kB max (seg0).  Work_mem: 33kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 1.904 ms
@@ -132,9 +132,9 @@ explain analyze select count(distinct d) from bigt;
                      Hash Key: d
                      ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.013..46.779 rows=334620 loops=1)
  Planning time: 27.350 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 68K bytes avg x 3 workers, 68K bytes max (seg0).
- * (slice2)    Executor memory: 2768K bytes avg x 3 workers, 2768K bytes max (seg0).  Work_mem: 2617K bytes max, 7876K bytes wanted.
+   (slice0)    Executor memory: 59kB.
+   (slice1)    Executor memory: 68kB avg x 3 workers, 68kB max (seg0).
+ * (slice2)    Executor memory: 2768kB avg x 3 workers, 2768kB max (seg0).  Work_mem: 2617kB max, 7876kB wanted.
  Memory used:  2560kB
  Memory wanted:  8275kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
@@ -204,10 +204,10 @@ where t1.d = t2.d;
                            Hash Key: smallt_1.d
                            ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=0.003..0.018 rows=50 loops=1)
  Planning time: 64.498 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 1192K bytes avg x 3 workers, 1192K bytes max (seg0).  Work_mem: 33K bytes max.
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 1192kB avg x 3 workers, 1192kB max (seg0).  Work_mem: 33kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 2.226 ms
@@ -261,8 +261,8 @@ where t1.i = t2.i;
                            Sort Key: smallt_1.i
                            Sort Method:  quicksort  Memory: 99kB
                            ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.012..0.022 rows=20 loops=2)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 1238K bytes avg x 3 workers, 1238K bytes max (seg0).  Work_mem: 33K bytes max.
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 1238kB avg x 3 workers, 1238kB max (seg0).  Work_mem: 33kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 2.471 ms
@@ -296,9 +296,9 @@ explain analyze select d, count(*) from smallt group by d limit 5;
                                  Hash Key: d
                                  ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.006 rows=50 loops=1)
  Planning time: 16.802 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
+   (slice0)    Executor memory: 59kB. 
+   (slice1)    Executor memory: 42kB avg x 3 workers, 42kB max (seg0).
+   (slice2)    Executor memory: 64kB avg x 3 workers, 64kB max (seg0).  Work_mem: 33kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 2.024 ms
@@ -1321,8 +1321,8 @@ explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i;
          ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=15) (actual time=0.002..0.008 rows=20 loops=2)
          ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.034..0.034 rows=20 loops=2)
                ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.019..0.023 rows=20 loops=2)
-   (slice0)    Executor memory: 322K bytes.
-   (slice1)    Executor memory: 4198K bytes avg x 3 workers, 4206K bytes max (seg0).  Work_mem: 1K bytes max.
+   (slice0)    Executor memory: 322kB.
+   (slice1)    Executor memory: 4198kB avg x 3 workers, 4206kB max (seg0).  Work_mem: 1kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 4.129 ms
@@ -1632,8 +1632,8 @@ explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i an
          ->  Hash  (cost=431.00..431.00 rows=7 width=4) (actual time=0.049..0.049 rows=5 loops=2)
                ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=7 width=4) (actual time=0.037..0.044 rows=5 loops=2)
                      Filter: i < 2
-   (slice0)    Executor memory: 322K bytes.
-   (slice1)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).  Work_mem: 1K bytes max.
+   (slice0)    Executor memory: 322kB.
+   (slice1)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).  Work_mem: 1kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 3.631 ms
@@ -1761,10 +1761,10 @@ explain analyze select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d an
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.032..0.153 rows=28 loops=2)
                      Hash Key: smallt_1.d
                      ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.022..0.036 rows=20 loops=2)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4186K bytes avg x 3 workers, 4186K bytes max (seg0).  Work_mem: 2K bytes max.
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4186kB avg x 3 workers, 4186kB max (seg0).  Work_mem: 2kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 5.688 ms
@@ -1829,8 +1829,8 @@ and smallt.d = '2011-01-04'::date;
          ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.034..0.034 rows=4 loops=1)
                ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.023..0.027 rows=4 loops=1)
                      Index Cond: d = '01-04-2011'::date
-   (slice0)    Executor memory: 450K bytes.
-   (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
+   (slice0)    Executor memory: 450kB.
+   (slice1)    Executor memory: 4234kB avg x 3 workers, 4234kB max (seg0).  Work_mem: 1kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
  Total runtime: 3.325 ms
@@ -1849,7 +1849,7 @@ explain analyze select *, exists(select 1 from pg_class where oid = c.oid) as du
      ->  Materialize  (cost=0.15..1027.89 rows=1387 width=4) (actual time=0.327..0.345 rows=222 loops=2)
            ->  Index Only Scan using pg_class_oid_index on pg_class pg_class_1  (cost=0.15..1020.96 rows=1387 width=4) (actual time=0.036..0.258 rows=222 loops=2)
                  Heap Fetches: 1252
-   (slice0)    Executor memory: 382K bytes.
+   (slice0)    Executor memory: 382kB.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.681 ms
@@ -1900,8 +1900,8 @@ and smallt.d = '2011-01-04'::date;
          ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.031..0.031 rows=4 loops=1)
                ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.020..0.024 rows=4 loops=1)
                      Index Cond: d = '01-04-2011'::date
-   (slice0)    Executor memory: 450K bytes.
-   (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
+   (slice0)    Executor memory: 450kB.
+   (slice1)    Executor memory: 4234kB avg x 3 workers, 4234kB max (seg0).  Work_mem: 1kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
  Total runtime: 5.131 ms

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -1,12 +1,12 @@
 -- start_matchsubs
 -- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
 -- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
--- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
--- m/Work_mem: \d+\w bytes max\./
--- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
+-- m/\(slice\d+\)    Executor memory: (\d+)kB\./
+-- s/Executor memory: (\d+)\wkB\./Executor memory: (#####)kB./
+-- m/\(slice\d+\)    Executor memory: (\d+)kB avg x \d+ workers, \d+kB max \(seg\d+\)\./
+-- s/Executor memory: (\d+)kB avg x \d+ workers, \d+kB max \(seg\d+\)\./Executor memory: ####kB avg x #### workers, ####kB max (seg#)./
+-- m/Work_mem: \d+kB max\./
+-- s/Work_mem: \d+kB max\. */Work_mem: ###kB max./
 -- m/Execution time: \d+\.\d+ ms/
 -- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
 -- m/Planning time: \d+\.\d+ ms/
@@ -67,10 +67,10 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
          ->  Hash  (cost=596.00..596.00 rows=16534 width=36) (never executed)
                ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36) (never executed)
  Planning time: 0.791 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice2)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).  Work_mem: 2048K bytes max.
-   (slice3)    Executor memory: 1104K bytes avg x 3 workers, 1104K bytes max (seg0).  Work_mem: 1024K bytes max.
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice2)    Executor memory: 2128kB avg x 3 workers, 2128kB max (seg0).  Work_mem: 2048kB max.
+   (slice3)    Executor memory: 1104kB avg x 3 workers, 1104kB max (seg0).  Work_mem: 1024kB max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 29.929 ms

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -1,12 +1,12 @@
 -- start_matchsubs
 -- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
 -- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
--- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
--- m/Work_mem: \d+\w bytes max\./
--- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
+-- m/\(slice\d+\)    Executor memory: (\d+)kB\./
+-- s/Executor memory: (\d+)\wkB\./Executor memory: (#####)kB./
+-- m/\(slice\d+\)    Executor memory: (\d+)kB avg x \d+ workers, \d+kB max \(seg\d+\)\./
+-- s/Executor memory: (\d+)kB avg x \d+ workers, \d+kB max \(seg\d+\)\./Executor memory: ####kB avg x #### workers, ####kB max (seg#)./
+-- m/Work_mem: \d+kB max\./
+-- s/Work_mem: \d+kB max\. */Work_mem: ###kB max./
 -- m/Execution time: \d+\.\d+ ms/
 -- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
 -- m/Planning time: \d+\.\d+ ms/
@@ -67,10 +67,10 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
          ->  Index Scan using box_locations_pkey on box_locations  (cost=0.00..12.00 rows=1 width=12) (never executed)
                Index Cond: (id = boxes.location_id)
  Planning time: 14.784 ms
-   (slice0)    Executor memory: 192K bytes.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice2)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
-   (slice3)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
+   (slice0)    Executor memory: 192kB.
+   (slice1)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice2)    Executor memory: 96kB avg x 3 workers, 96kB max (seg0).
+   (slice3)    Executor memory: 96kB avg x 3 workers, 96kB max (seg0).
    (slice4)    
    (slice5)    
  Memory used:  128000kB

--- a/src/test/regress/expected/gang_reuse.out
+++ b/src/test/regress/expected/gang_reuse.out
@@ -46,11 +46,11 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                  Hash Key: c.c2
                                  ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (never executed)
  Planning time: 3.415 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice4)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice2)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice3)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice4)    Executor memory: 2128kB avg x 3 workers, 2128kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 19.418 ms
@@ -75,10 +75,10 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                  Hash Key: b.c2
                                  ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
  Planning time: 1.300 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4176kB avg x 3 workers, 4176kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 8.568 ms
@@ -110,11 +110,11 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                  Hash Key: c.c2
                                  ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (never executed)
  Planning time: 1.931 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice4)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice4)    Executor memory: 2128kB avg x 3 workers, 2128kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 5.753 ms
@@ -139,10 +139,10 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                  Hash Key: b.c2
                                  ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
  Planning time: 1.231 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4176kB avg x 3 workers, 4176kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 6.223 ms

--- a/src/test/regress/expected/gang_reuse_optimizer.out
+++ b/src/test/regress/expected/gang_reuse_optimizer.out
@@ -46,11 +46,11 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                              Hash Key: test_gang_reuse_t1_2.c2
                                              ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (never executed)
  Planning time: 82.403 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice4)    Executor memory: 4192K bytes avg x 3 workers, 4192K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice2)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice3)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice4)    Executor memory: 4192kB avg x 3 workers, 4192kB max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
  Execution time: 26.149 ms
@@ -75,10 +75,10 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                  Hash Key: test_gang_reuse_t1_1.c2
                                  ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
  Planning time: 12.168 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4176kB avg x 3 workers, 4176kB max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
  Execution time: 5.858 ms
@@ -110,11 +110,11 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                              Hash Key: test_gang_reuse_t1_2.c2
                                              ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (never executed)
  Planning time: 44.030 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice4)    Executor memory: 4192K bytes avg x 3 workers, 4192K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice4)    Executor memory: 4192kB avg x 3 workers, 4192kB max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
  Execution time: 6.743 ms
@@ -139,10 +139,10 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                  Hash Key: test_gang_reuse_t1_1.c2
                                  ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
  Planning time: 9.705 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB avg x 3 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4176kB avg x 3 workers, 4176kB max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
  Execution time: 4.820 ms

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -38,10 +38,10 @@ EXPLAIN ANALYZE SELECT * FROM explaintest;
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4)
    ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4)
  Slice statistics:
-   (slice0)    Executor memory: 318K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice0)    Executor memory: 318kB.
+   (slice1)    Executor memory: 50kB avg x 3 workers, 50kB max (seg0).
  Statement statistics:
-   Memory used: 128000K bytes
+   Memory used: 128000kB
  Total runtime: 0.998 ms
 (10 rows)
 
@@ -86,11 +86,11 @@ LIMIT 1;
                      ->  Seq Scan on explaintest  (cost=0.00..3.15 rows=2 width=4) (actual time=0.024..0.027 rows=3 loops=1)
                            Filter: ((id)::numeric > $0)
  Planning time: 1.221 ms
-   (slice0)    Executor memory: 156K bytes.
- * (slice1)    Executor memory: 124K bytes avg x 3 workers, 124K bytes max (seg0).  Work_mem: 65K bytes max, 1K bytes wanted.
+   (slice0)    Executor memory: 156kB.
+ * (slice1)    Executor memory: 124kB avg x 3 workers, 124kB max (seg0).  Work_mem: 65kB max, 1kB wanted.
  _ (slice2)    Workers: Workers: 3 not dispatched;.  
- Executor memory: 75K bytes avg x 3 workers, 75K bytes max (seg0).
-   (slice3)    Executor memory: 147K bytes.
+ Executor memory: 75kB avg x 3 workers, 75kB max (seg0).
+   (slice3)    Executor memory: 147kB.
  Memory used:  128000kB
  Memory wanted:  801kB
  Optimizer: Postgres query optimizer
@@ -323,8 +323,8 @@ explain analyze SELECT * FROM explaintest;
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=10 width=4) (actual time=0.266..0.384 rows=5 loops=2)
    ->  Seq Scan on explaintest  (cost=0.00..3.10 rows=4 width=4) (actual time=0.011..0.013 rows=2 loops=2)
          allstat: seg_firststart_total_ntuples/seg0_0.745 ms_0.028 ms_3/seg1_0.640 ms_0.025 ms_5/seg2_0.997 ms_0.019 ms_2//end
-   (slice0)    Executor memory: 322K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice0)    Executor memory: 322kB.
+   (slice1)    Executor memory: 50kB avg x 3 workers, 50kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 2.600 ms

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -37,8 +37,8 @@ EXPLAIN ANALYZE SELECT * FROM explaintest;
 --------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4) (actual time=0.365..0.380 rows=10 loops=1)
    ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.019..0.021 rows=5 loops=1)
-   (slice0)    Executor memory: 290K bytes.
-   (slice1)    Executor memory: 135K bytes avg x 3 workers, 135K bytes max (seg0).
+   (slice0)    Executor memory: 290kB.
+   (slice1)    Executor memory: 135kB avg x 3 workers, 135kB max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
  Total runtime: 0.710 ms
@@ -86,10 +86,10 @@ LIMIT 1;
                                                    ->  Seq Scan on explaintest explaintest_1  (cost=0.00..431.00 rows=4 width=4) (actual time=0.047..0.048 rows=5 loops=1)
                            ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.003..0.017 rows=3 loops=2)
  Planning time: 63.227 ms
-   (slice0)    Executor memory: 156K bytes.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice2)    Executor memory: 167K bytes (entry db).
- * (slice3)    Executor memory: 124K bytes avg x 3 workers, 124K bytes max (seg0).  Work_mem: 65K bytes max, 1K bytes wanted.
+   (slice0)    Executor memory: 156kB.
+   (slice1)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice2)    Executor memory: 167kB (entry db).
+ * (slice3)    Executor memory: 124kB avg x 3 workers, 124kB max (seg0).  Work_mem: 65kB max, 1kB wanted.
  Memory used:  256000kB
  Memory wanted:  1001kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.61.0
@@ -354,8 +354,8 @@ explain analyze SELECT * FROM explaintest;
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4) (actual time=0.298..0.302 rows=5 loops=2)
    ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.013..0.015 rows=2 loops=2)
          allstat: seg_firststart_total_ntuples/seg0_0.938 ms_0.027 ms_3/seg1_0.880 ms_0.029 ms_5/seg2_0.866 ms_0.029 ms_2//end
-   (slice0)    Executor memory: 290K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice0)    Executor memory: 290kB.
+   (slice1)    Executor memory: 50kB avg x 3 workers, 50kB max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.2.0
  Total runtime: 1.577 ms

--- a/src/test/regress/expected/gpdiffcheck.out
+++ b/src/test/regress/expected/gpdiffcheck.out
@@ -158,12 +158,12 @@ explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c
                            ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.01..1.07 rows=1 width=32) (actual time=1.524..2.512 rows=3 loops=1)
                                  ->  Aggregate  (cost=1.01..1.02 rows=1 width=32) (actual time=0.212..0.212 rows=1 loops=1)
                                        ->  Seq Scan on gpd1  (cost=0.00..1.01 rows=1 width=2) (actual time=0.108..0.113 rows=4 loops=1)
-   (slice0)    Executor memory: 518K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 126K bytes avg x 3 workers, 126K bytes max (seg0).
-   (slice3)    Executor memory: 86K bytes avg x 3 workers, 86K bytes max (seg0).
-   (slice4)    Executor memory: 66K bytes (seg2).
-   (slice5)    Executor memory: 1103K bytes avg x 3 workers, 1114K bytes max (seg2).  Work_mem: 1K bytes max.
+   (slice0)    Executor memory: 518kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 126kB avg x 3 workers, 126kB max (seg0).
+   (slice3)    Executor memory: 86kB avg x 3 workers, 86kB max (seg0).
+   (slice4)    Executor memory: 66kB (seg2).
+   (slice5)    Executor memory: 1103kB avg x 3 workers, 1114kB max (seg2).  Work_mem: 1kB max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4571.552 ms
@@ -281,12 +281,12 @@ explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c
                            ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.01..1.43 rows=1 width=32) (actual time=0.017..0.023 rows=3 loops=1)
                                  ->  Aggregate  (cost=1.01..1.02 rows=1 width=32) (actual time=0.093..0.093 rows=1 loops=1)
                                        ->  Seq Scan on gpd1  (cost=0.00..1.01 rows=1 width=2) (actual time=0.055..0.061 rows=4 loops=1)
-   (slice0)    Executor memory: 518K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 126K bytes avg x 3 workers, 126K bytes max (seg0).
-   (slice3)    Executor memory: 86K bytes avg x 3 workers, 86K bytes max (seg0).
-   (slice4)    Executor memory: 65K bytes (seg2).
-   (slice5)    Executor memory: 1103K bytes avg x 3 workers, 1114K bytes max (seg2).  Work_mem: 1K bytes max.
+   (slice0)    Executor memory: 518kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 126kB avg x 3 workers, 126kB max (seg0).
+   (slice3)    Executor memory: 86kB avg x 3 workers, 86kB max (seg0).
+   (slice4)    Executor memory: 65kB (seg2).
+   (slice5)    Executor memory: 1103kB avg x 3 workers, 1114kB max (seg2).  Work_mem: 1kB max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1507.339 ms

--- a/src/test/regress/expected/gpdiffcheck_optimizer.out
+++ b/src/test/regress/expected/gpdiffcheck_optimizer.out
@@ -156,10 +156,10 @@ explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c
                ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2) (actual time=0.004..0.097 rows=8 loops=1)
                      ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.008..0.009 rows=4 loops=1)
  Planning time: 109.024 ms
-   (slice0)    Executor memory: 2216K bytes.  Work_mem: 1K bytes max.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice2)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
-   (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice0)    Executor memory: 2216kB.  Work_mem: 1kB max.
+   (slice1)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice2)    Executor memory: 96kB avg x 3 workers, 96kB max (seg0).
+   (slice3)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 17.954 ms
@@ -270,11 +270,11 @@ explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c
                      ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=14 width=12) (actual time=0.009..0.013 rows=4 loops=2)
                            ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=12) (actual time=0.008..0.009 rows=2 loops=2)
                      ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.003..0.005 rows=3 loops=10)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 161K bytes (entry db).
-   (slice3)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice4)    Executor memory: 4198K bytes avg x 3 workers, 4198K bytes max (seg0).  Work_mem: 2K bytes max.
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 161kB (entry db).
+   (slice3)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice4)    Executor memory: 4198kB avg x 3 workers, 4198kB max (seg0).  Work_mem: 2kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 6.345 ms

--- a/src/test/regress/expected/instr_in_shmem.out
+++ b/src/test/regress/expected/instr_in_shmem.out
@@ -120,10 +120,10 @@ EXPLAIN ANALYZE SELECT count(*) FROM a a1, a a2, a a3;
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..5.50 rows=50 width=0) (actual time=1.877..2.315 rows=25 loops=2)
                                  ->  Seq Scan on a a3  (cost=0.00..3.50 rows=17 width=0) (actual time=0.023..0.029 rows=10 loops=2)
  Planning time: 1.016 ms
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 63K bytes avg x 3 workers, 66K bytes max (seg1).
-   (slice2)    Executor memory: 62K bytes avg x 3 workers, 62K bytes max (seg0).
-   (slice3)    Executor memory: 158K bytes avg x 3 workers, 158K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 63kB avg x 3 workers, 66kB max (seg1).
+   (slice2)    Executor memory: 62kB avg x 3 workers, 62kB max (seg0).
+   (slice3)    Executor memory: 158kB avg x 3 workers, 158kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 73.541 ms

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -304,10 +304,10 @@ begin;
                ->  Hash  (cost=2.00..2.00 rows=34 width=16) (actual time=0.000..0.056 rows=0 loops=1)
                      ->  Seq Scan on t1 d  (cost=0.00..2.00 rows=34 width=16) (actual time=0.009..0.022 rows=50 loops=2)
  Planning time: 1.964 ms
-   (slice0)    Executor memory: 518K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 3244K bytes avg x 2 workers, 4270K bytes max (seg0).
+   (slice0)    Executor memory: 518kB.
+   (slice1)    Executor memory: 66kB avg x 2 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 2 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 3244kB avg x 2 workers, 4270kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 9.956 ms
@@ -336,10 +336,10 @@ begin;
                            Hash Key: d.c2
                            ->  Seq Scan on t2 d  (cost=0.00..3.00 rows=34 width=16) (actual time=0.006..0.013 rows=28 loops=2)
  Planning time: 1.493 ms
-   (slice0)    Executor memory: 518K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 3232K bytes avg x 2 workers, 4258K bytes max (seg0).
+   (slice0)    Executor memory: 518kB.
+   (slice1)    Executor memory: 66kB avg x 2 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 2 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 3232kB avg x 2 workers, 4258kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 3.839 ms
@@ -407,11 +407,11 @@ select gp_debug_reset_create_table_default_numsegments();
                                          ->  Materialize  (cost=0.00..989.11 rows=24 width=4) (never executed)
                                                ->  Broadcast Motion 1:2  (slice2; segments: 1)  (cost=0.00..988.75 rows=24 width=4) (never executed)
                                                      ->  Seq Scan on t1 t1_1  (cost=0.00..988.75 rows=24 width=4) (actual time=0.000..0.174 rows=0 loops=1)
-   (slice0)    Executor memory: 514K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
-   (slice4)    Executor memory: 129K bytes avg x 3 workers, 129K bytes max (seg0).
+   (slice0)    Executor memory: 514kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
+   (slice4)    Executor memory: 129kB avg x 3 workers, 129kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 14.189 ms
@@ -776,9 +776,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.088 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4170kB avg x 3 workers, 4170kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 6.541 ms
@@ -793,8 +793,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes avg x 3 workers, 78K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB avg x 3 workers, 78kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.148 ms
@@ -809,8 +809,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.205 ms
@@ -825,8 +825,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.027 ms
@@ -841,9 +841,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4170kB avg x 3 workers, 4170kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.919 ms
@@ -858,9 +858,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.182 ms
@@ -875,8 +875,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.103 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.165 ms
@@ -891,8 +891,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.223 ms
@@ -907,8 +907,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.053 ms
@@ -923,8 +923,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.028 ms
@@ -939,8 +939,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.135 ms
@@ -955,8 +955,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.070 ms
@@ -971,9 +971,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4170kB avg x 3 workers, 4170kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 6.008 ms
@@ -988,9 +988,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.148 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.638 ms
@@ -1005,8 +1005,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.094 ms
@@ -1021,8 +1021,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.031 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.085 ms
@@ -1037,9 +1037,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4170kB avg x 3 workers, 4170kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.583 ms
@@ -1054,9 +1054,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4170kB avg x 3 workers, 4170kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.447 ms
@@ -1073,9 +1073,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.055 rows=0 loops=1)
                ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.053 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.039 ms
@@ -1092,9 +1092,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..2.286 rows=0 loops=1)
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4170kB avg x 3 workers, 4170kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 5.340 ms
@@ -1109,8 +1109,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.370 ms
@@ -1125,8 +1125,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.071 ms
@@ -1142,9 +1142,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.028 rows=0 loops=1)
                ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.588 ms
@@ -1161,9 +1161,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.042 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.040 rows=0 loops=1)
                ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.038 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 5.159 ms
@@ -1183,10 +1183,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on t2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 0.895 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 4.332 ms
@@ -1203,9 +1203,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.031 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.030 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.289 ms
@@ -1220,8 +1220,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.036 ms
@@ -1236,8 +1236,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.005 ms
@@ -1257,10 +1257,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 0.754 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 2.734 ms
@@ -1280,10 +1280,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.075 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.174 ms
@@ -1299,9 +1299,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.025 rows=0 loops=1)
                ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.024 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.490 ms
@@ -1318,9 +1318,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.029 rows=0 loops=1)
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.184 ms
@@ -1335,8 +1335,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.073 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.169 ms
@@ -1351,8 +1351,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.995 ms
@@ -1368,9 +1368,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
                ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.364 ms
@@ -1386,9 +1386,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.029 rows=0 loops=1)
                ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.028 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.899 ms
@@ -1405,9 +1405,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.025 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.164 ms
@@ -1424,9 +1424,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.633 rows=0 loops=1)
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4170kB avg x 3 workers, 4170kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.722 ms
@@ -1446,10 +1446,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 0.956 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 4.686 ms
@@ -1466,9 +1466,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.008 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
                ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.025 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.357 ms
@@ -1484,9 +1484,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.008 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.030 rows=0 loops=1)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.029 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.651 ms
@@ -1503,9 +1503,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.012 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.034 rows=0 loops=1)
                ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.546 ms
@@ -1520,8 +1520,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.190 ms
@@ -1536,8 +1536,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.001 ms
@@ -1552,8 +1552,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.951 ms
@@ -1568,8 +1568,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.969 ms
@@ -1584,8 +1584,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.075 ms
@@ -1600,8 +1600,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.028 ms
@@ -1617,9 +1617,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.647 ms
@@ -1636,9 +1636,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.034 rows=0 loops=1)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.610 ms
@@ -1658,10 +1658,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 0.786 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 3.907 ms
@@ -1681,10 +1681,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.124 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.281 ms
@@ -1700,9 +1700,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.497 ms
@@ -1718,9 +1718,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.035 rows=0 loops=1)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.561 ms
@@ -1740,10 +1740,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..3.167 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.024 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 12.201 ms
@@ -1758,8 +1758,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes avg x 3 workers, 78K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB avg x 3 workers, 78kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.957 ms
@@ -1774,8 +1774,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.908 ms
@@ -1790,8 +1790,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.960 ms
@@ -1810,10 +1810,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.203 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.328 ms
@@ -1830,9 +1830,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
                ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.556 ms
@@ -1847,8 +1847,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.972 ms
@@ -1863,8 +1863,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.972 ms
@@ -1879,8 +1879,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.893 ms
@@ -1895,8 +1895,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.869 ms
@@ -1911,8 +1911,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.103 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.087 ms
@@ -1927,8 +1927,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.019 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.045 ms
@@ -1947,10 +1947,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.271 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.302 ms
@@ -1967,9 +1967,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.039 rows=0 loops=1)
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.037 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.654 ms
@@ -1984,8 +1984,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.075 ms
@@ -2000,8 +2000,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.943 ms
@@ -2020,10 +2020,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.526 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.498 ms
@@ -2042,10 +2042,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.377 rows=0 loops=1)
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.819 ms
@@ -2061,9 +2061,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.543 ms
@@ -2078,8 +2078,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes avg x 3 workers, 78K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB avg x 3 workers, 78kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.907 ms
@@ -2094,8 +2094,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.952 ms
@@ -2110,8 +2110,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.076 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.982 ms
@@ -2126,9 +2126,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.448 ms
@@ -2143,9 +2143,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.552 ms
@@ -2165,10 +2165,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on t1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 0.900 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 4.234 ms
@@ -2186,9 +2186,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.369 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes (seg0).
-   (slice2)    Executor memory: 4176K bytes (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 42kB (seg0).
+   (slice2)    Executor memory: 4176kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 2.750 ms
@@ -2203,8 +2203,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.985 ms
@@ -2219,8 +2219,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.906 ms
@@ -2240,10 +2240,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on r1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 0.909 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.618 ms
@@ -2263,10 +2263,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on r1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.502 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.723 ms
@@ -2281,9 +2281,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.114 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.601 ms
@@ -2298,9 +2298,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.023 ms
@@ -2315,8 +2315,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.015 ms
@@ -2331,8 +2331,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.101 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.979 ms
@@ -2347,9 +2347,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.549 ms
@@ -2364,9 +2364,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.448 ms
@@ -2383,9 +2383,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
                ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.737 ms
@@ -2402,9 +2402,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.195 rows=0 loops=1)
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.268 ms
@@ -2419,8 +2419,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.104 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.996 ms
@@ -2435,8 +2435,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.024 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.024 ms
@@ -2452,9 +2452,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.057 rows=0 loops=1)
                ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.056 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.685 ms
@@ -2471,9 +2471,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.024 rows=0 loops=1)
                ->  Seq Scan on t1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.813 ms
@@ -2493,10 +2493,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on t2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.058 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 4.414 ms
@@ -2514,9 +2514,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
                ->  Seq Scan on t2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.537 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes (seg0).
-   (slice2)    Executor memory: 4176K bytes avg x 2 workers, 4176K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 42kB (seg0).
+   (slice2)    Executor memory: 4176kB avg x 2 workers, 4176kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.583 ms
@@ -2531,8 +2531,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.013 ms
@@ -2547,8 +2547,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.973 ms
@@ -2568,10 +2568,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 0.878 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.500 ms
@@ -2591,10 +2591,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.383 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.357 ms
@@ -2610,9 +2610,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.050 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
                ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.531 ms
@@ -2629,9 +2629,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.034 rows=0 loops=1)
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.228 ms
@@ -2646,8 +2646,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.921 ms
@@ -2662,8 +2662,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.033 ms
@@ -2679,9 +2679,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.037 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.028 rows=0 loops=1)
                ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.668 ms
@@ -2697,9 +2697,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
                ->  Seq Scan on r1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.031 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.610 ms
@@ -2719,10 +2719,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..2.151 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 5.593 ms
@@ -2739,9 +2739,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 1:2  (slice1; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.942 rows=0 loops=1)
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.922 ms
@@ -2761,10 +2761,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.779 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.335 ms
@@ -2781,9 +2781,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.036 rows=0 loops=1)
                ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.034 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.554 ms
@@ -2802,10 +2802,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..2.930 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.019 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 5.554 ms
@@ -2822,9 +2822,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.027 rows=0 loops=1)
                ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.026 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.969 ms
@@ -2844,10 +2844,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on t1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.162 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.865 ms
@@ -2865,9 +2865,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
                ->  Seq Scan on t1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.665 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes (seg0).
-   (slice2)    Executor memory: 4176K bytes (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 42kB (seg0).
+   (slice2)    Executor memory: 4176kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.733 ms
@@ -2882,8 +2882,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.074 ms
@@ -2898,8 +2898,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.015 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.981 ms
@@ -2919,10 +2919,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on r1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.078 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.369 ms
@@ -2942,10 +2942,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on r1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.779 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.473 ms
@@ -2964,10 +2964,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.285 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 6.261 ms
@@ -2984,9 +2984,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
                ->  Seq Scan on t1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.031 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.018 ms
@@ -3006,10 +3006,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.055 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.679 ms
@@ -3029,10 +3029,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 2.872 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes (seg0).
-   (slice3)    Executor memory: 4184K bytes (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice2)    Executor memory: 44kB (seg0).
+   (slice3)    Executor memory: 4184kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 4.259 ms
@@ -3051,10 +3051,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.634 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.749 ms
@@ -3073,10 +3073,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 1:1  (slice2; segments: 1)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..0.808 rows=0 loops=1)
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on r1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.073 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 5.359 ms
@@ -3096,10 +3096,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.505 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.784 ms
@@ -3114,8 +3114,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes avg x 3 workers, 78K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB avg x 3 workers, 78kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.954 ms
@@ -3130,8 +3130,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.063 ms
@@ -3146,8 +3146,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.968 ms
@@ -3166,10 +3166,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.251 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 6.142 ms
@@ -3186,9 +3186,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.022 rows=0 loops=1)
                ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 3.862 ms
@@ -3208,10 +3208,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on t2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.171 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4184K bytes avg x 2 workers, 4184K bytes max (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4184kB avg x 2 workers, 4184kB max (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 4.948 ms
@@ -3229,9 +3229,9 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
                ->  Seq Scan on t2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.640 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes (seg0).
-   (slice2)    Executor memory: 4176K bytes avg x 2 workers, 4176K bytes max (seg0).
+   (slice0)    Executor memory: 127kB.
+   (slice1)    Executor memory: 42kB (seg0).
+   (slice2)    Executor memory: 4176kB avg x 2 workers, 4176kB max (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 3.890 ms
@@ -3246,8 +3246,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.016 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.946 ms
@@ -3262,8 +3262,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on d2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 78K bytes (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 78kB (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.883 ms
@@ -3283,10 +3283,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1
                      ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.036 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4184K bytes avg x 2 workers, 4184K bytes max (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4184kB avg x 2 workers, 4184kB max (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 5.514 ms
@@ -3306,10 +3306,10 @@ select gp_debug_reset_create_table_default_numsegments();
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (never executed)
  Planning time: 1.516 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 44K bytes (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 4184K bytes avg x 2 workers, 4184K bytes max (seg0).
+   (slice0)    Executor memory: 135kB.
+   (slice1)    Executor memory: 44kB (seg0).
+   (slice2)    Executor memory: 44kB avg x 2 workers, 44kB max (seg0).
+   (slice3)    Executor memory: 4184kB avg x 2 workers, 4184kB max (seg0).
  Memory used:  128000kB
  Optimizer: legacy query optimizer
  Execution time: 3.948 ms
@@ -3328,10 +3328,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..2.099 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.011 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 5.253 ms
@@ -3348,9 +3348,9 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.000..0.033 rows=0 loops=1)
                ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.032 rows=0 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 4182kB avg x 3 workers, 4182kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.098 ms
@@ -3365,8 +3365,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 1.022 ms
@@ -3381,8 +3381,8 @@ select gp_debug_reset_create_table_default_numsegments();
          ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
          ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (never executed)
                ->  Seq Scan on d2 b  (cost=0.00..811.00 rows=23700 width=16) (never executed)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 98K bytes avg x 3 workers, 98K bytes max (seg0).
+   (slice0)    Executor memory: 386kB.
+   (slice1)    Executor memory: 98kB avg x 3 workers, 98kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 0.923 ms
@@ -3401,10 +3401,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..3.141 rows=0 loops=1)
                      Hash Key: b.c1
                      ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.012 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 6.083 ms
@@ -3423,10 +3423,10 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..2233.00 rows=23700 width=16) (actual time=0.000..1.444 rows=0 loops=1)
                      Hash Key: b.c1, b.c2
                      ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
-   (slice0)    Executor memory: 390K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4174K bytes avg x 3 workers, 4174K bytes max (seg0).
+   (slice0)    Executor memory: 390kB.
+   (slice1)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice2)    Executor memory: 66kB avg x 3 workers, 66kB max (seg0).
+   (slice3)    Executor memory: 4174kB avg x 3 workers, 4174kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Total runtime: 4.955 ms

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -4476,10 +4476,10 @@ explain analyze select reltablespace  from pg_class where oid = (select reltoast
      ->  Index Scan using pg_class_relname_nsp_index on pg_class pg_class_1  (cost=0.00..200.27 rows=1 width=4)
            Index Cond: relname = 'tbl_8205'::name
  Slice statistics:
-   (slice0)    Executor memory: 113K bytes.
-   (slice1)    Executor memory: 113K bytes.
+   (slice0)    Executor memory: 113kB.
+   (slice1)    Executor memory: 113kB.
  Statement statistics:
-   Memory used: 1000K bytes
+   Memory used: 1000kB
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=off; optimizer_segments=3
  Optimizer status: Postgres query optimizer
  Total runtime: 0.068 ms
@@ -5166,10 +5166,10 @@ explain analyze select count(*) from qp_misc_jiras.test_heap;
                ->  Seq Scan on test_heap  (cost=0.00..961.00 rows=28700 width=0)
                      allstat: seg_firststart_total_ntuples/seg0_0.622 ms_7.878 ms_33350/seg1_0.622 ms_7.850 ms_33336/seg2_0.634 ms_7.866 ms_33315//end
  Slice statistics:
-   (slice0)    Executor memory: 382K bytes.
-   (slice1)    Executor memory: 163K bytes avg x 3 workers, 163K bytes max (seg0).
+   (slice0)    Executor memory: 382kB.
+   (slice1)    Executor memory: 163kB avg x 3 workers, 163kB max (seg0).
  Statement statistics:
-   Memory used: 128000K bytes
+   Memory used: 128000kB
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer_segments=3
  Total runtime: 15.974 ms
 (17 rows)
@@ -5291,8 +5291,8 @@ explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
  Gather Motion 3:1  (slice2; segments: 3)  (cost=25.50..73.50 rows=1000 width=16)
    ->  Hash Join  (cost=25.50..73.50 rows=334 width=16)
          Hash Cond: s.b = r.a
-         Executor memory:  11K bytes avg, 11K bytes max (seg1).
-         Work_mem used:  11K bytes avg, 11K bytes max (seg1). Workfile: (0 spilling, 0 reused)
+         Executor memory:  11kB avg, 11kB max (seg1).
+         Work_mem used:  11kB avg, 11kB max (seg1). Workfile: (0 spilling, 0 reused)
          (seg1)   Hash chain length 1.0 avg, 1 max, using 342 of 8388619 buckets.
          allstat: seg_firststart_total_ntuples/seg0_0.408 ms_116 ms_321/seg1_0.434 ms_126 ms_342/seg2_0.446 ms_119 ms_337//end
          ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..33.00 rows=334 width=8)
@@ -5306,11 +5306,11 @@ explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
                ->  Seq Scan on r  (cost=0.00..13.00 rows=334 width=8)
                      allstat: seg_firststart_total_ntuples/seg0_78 ms_0.073 ms_321/seg1_86 ms_0.099 ms_342/seg2_80 ms_0.065 ms_337//end
  Slice statistics:
-   (slice0)    Executor memory: 267K bytes.
-   (slice1)    Executor memory: 193K bytes avg x 3 workers, 193K bytes max (seg0).
-   (slice2)    Executor memory: 131366K bytes avg x 3 workers, 131387K bytes max (seg1).  Work_mem: 11K bytes max.
+   (slice0)    Executor memory: 267kB.
+   (slice1)    Executor memory: 193kB avg x 3 workers, 193kB max (seg0).
+   (slice2)    Executor memory: 131366kB avg x 3 workers, 131387kB max (seg1).  Work_mem: 11kB max.
  Statement statistics:
-   Memory used: 1945600K bytes
+   Memory used: 1945600kB
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=off; optimizer_segments=3
  Optimizer status: Postgres query optimizer
  Total runtime: 127.268 ms

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -4460,10 +4460,10 @@ explain analyze select reltablespace  from pg_class where oid = (select reltoast
      ->  Index Scan using pg_class_relname_nsp_index on pg_class pg_class_1  (cost=0.00..200.27 rows=1 width=4)
            Index Cond: relname = 'tbl_8205'::name
  Slice statistics:
-   (slice0)    Executor memory: 113K bytes.
-   (slice1)    Executor memory: 113K bytes.
+   (slice0)    Executor memory: 113kB.
+   (slice1)    Executor memory: 113kB.
  Statement statistics:
-   Memory used: 1000K bytes
+   Memory used: 1000kB
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
  Optimizer status: Postgres query optimizer
  Total runtime: 0.085 ms
@@ -5150,8 +5150,8 @@ explain analyze select count(*) from qp_misc_jiras.test_heap;
          ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=1) (actual time=0.022..2.438 rows=33462 loops=1)
                allstat: seg_firststart_total_ntuples/seg0_0.235 ms_2.438 ms_33462/seg1_0.235 ms_2.363 ms_33329/seg2_0.225 ms_2.381 ms_33210//end
  Planning time: 2.804 ms
-   (slice0)    Executor memory: 567K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice0)    Executor memory: 567kB.
+   (slice1)    Executor memory: 50kB avg x 3 workers, 50kB max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 16.835 ms
@@ -5274,8 +5274,8 @@ explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.26 rows=1000 width=16)
    ->  Hash Join  (cost=0.00..862.20 rows=334 width=16)
          Hash Cond: r.a = s.b
-         Executor memory:  11K bytes avg, 11K bytes max (seg1).
-         Work_mem used:  11K bytes avg, 11K bytes max (seg1). Workfile: (0 spilling, 0 reused)
+         Executor memory:  11kB avg, 11kB max (seg1).
+         Work_mem used:  11kB avg, 11kB max (seg1). Workfile: (0 spilling, 0 reused)
          (seg1)   Hash chain length 1.0 avg, 1 max, using 342 of 8388619 buckets.
          allstat: seg_firststart_total_ntuples/seg0_0.559 ms_86 ms_321/seg1_0.527 ms_86 ms_342/seg2_0.576 ms_86 ms_337//end
          ->  Seq Scan on r  (cost=0.00..431.01 rows=334 width=8)
@@ -5289,11 +5289,11 @@ explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
                      ->  Seq Scan on s  (cost=0.00..431.01 rows=334 width=8)
                            allstat: seg_firststart_total_ntuples/seg0_2.222 ms_2.232 ms_321/seg1_2.265 ms_2.069 ms_342/seg2_2.286 ms_1.974 ms_337//end
  Slice statistics:
-   (slice0)    Executor memory: 267K bytes.
-   (slice1)    Executor memory: 193K bytes avg x 3 workers, 193K bytes max (seg0).
-   (slice2)    Executor memory: 131378K bytes avg x 3 workers, 131399K bytes max (seg1).  Work_mem: 11K bytes max.
+   (slice0)    Executor memory: 267kB.
+   (slice1)    Executor memory: 193kB avg x 3 workers, 193kB max (seg0).
+   (slice2)    Executor memory: 131378kB avg x 3 workers, 131399kB max (seg1).  Work_mem: 11kB max.
  Statement statistics:
-   Memory used: 1945600K bytes
+   Memory used: 1945600kB
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
  Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
  Total runtime: 87.064 ms

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1804,9 +1804,9 @@ order by 1,2;
                ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..28.00 rows=500 width=4) (actual time=0.034..0.319 rows=250 loops=2)
                      ->  Seq Scan on mergeappend_test r_1  (cost=0.00..8.00 rows=167 width=4) (actual time=0.008..0.041 rows=150 loops=2)
  Planning time: 0.793 ms
-   (slice0)    Executor memory: 380K bytes.  Work_mem: 33K bytes max.
-   (slice1)    Executor memory: 121K bytes avg x 3 workers, 140K bytes max (seg0).  Work_mem: 49K bytes max.
-   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+   (slice0)    Executor memory: 380kB.  Work_mem: 33kB max.
+   (slice1)    Executor memory: 121kB avg x 3 workers, 140kB max (seg0).  Work_mem: 49kB max.
+   (slice2)    Executor memory: 42kB avg x 3 workers, 42kB max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 2.496 ms

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1826,10 +1826,10 @@ order by 1,2;
                                  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=500 width=4) (actual time=0.140..0.645 rows=250 loops=2)
                                        ->  Seq Scan on mergeappend_test mergeappend_test_1  (cost=0.00..431.00 rows=167 width=4) (actual time=0.006..0.042 rows=150 loops=2)
  Planning time: 21.621 ms
-   (slice0)    Executor memory: 384K bytes.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice2)    Executor memory: 215K bytes (entry db).
-   (slice3)    Executor memory: 229K bytes avg x 3 workers, 244K bytes max (seg0).  Work_mem: 49K bytes max.
+   (slice0)    Executor memory: 384kB.
+   (slice1)    Executor memory: 60kB avg x 3 workers, 60kB max (seg0).
+   (slice2)    Executor memory: 215kB (entry db).
+   (slice3)    Executor memory: 229kB avg x 3 workers, 244kB max (seg0).  Work_mem: 49kB max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.18.0
  Execution time: 3.142 ms

--- a/src/test/regress/explain.pm
+++ b/src/test/regress/explain.pm
@@ -16,8 +16,8 @@ use IO::File;
 # The final statistics look like this:
 #
 #  Slice statistics:
-#    (slice0)    Executor memory: 472K bytes.
-#    (slice1)    Executor memory: 464K bytes avg x 2 workers, 464K bytes max (seg0).
+#    (slice0)    Executor memory: 472kB.
+#    (slice1)    Executor memory: 464kB avg x 2 workers, 464kB max (seg0).
 #  Settings:
 #
 #  Total runtime: 52347.493 ms
@@ -419,15 +419,15 @@ sub analyze_node
             # NOTE: the final statistics look something like this:
 
             # Slice statistics:
-            #   (slice0)    Executor memory: 472K bytes.
-            #   (slice1)    Executor memory: 464K bytes avg x 2 workers, 464K bytes max (seg0).
+            #   (slice0)    Executor memory: 472kB.
+            #   (slice1)    Executor memory: 464kB avg x 2 workers, 464kB max (seg0).
             # Settings:
             # Total runtime: 52347.493 ms
 
             # (we've actually added some vertical bars so it might look
             # like this):
             # || Slice statistics:
-            # ||   (slice0)    Executor memory: 472K bytes.
+            # ||   (slice0)    Executor memory: 472kB.
 
             # NB: the "Settings" entry is optional, so
             # add Settings if they are missing

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -2015,12 +2015,12 @@ explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hell
                            ->  Aggregate  (cost=2.13..2.14 rows=1 width=8)
                                  ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=0)
  Slice statistics:
-   (slice0)    Executor memory: 258K bytes.
-   (slice1)    Executor memory: 210K bytes avg x 2 workers, 210K bytes max (seg0).
-   (slice2)    Executor memory: 274K bytes (seg0).
-   (slice3)    Executor memory: 254K bytes avg x 2 workers, 266K bytes max (seg1).
+   (slice0)    Executor memory: 258kB.
+   (slice1)    Executor memory: 210kB avg x 2 workers, 210kB max (seg0).
+   (slice2)    Executor memory: 274kB (seg0).
+   (slice3)    Executor memory: 254kB avg x 2 workers, 266kB max (seg1).
  Statement statistics:
-   Memory used: 128000K bytes
+   Memory used: 128000kB
  Settings:  gp_segments_for_planner=8
  Total runtime: 5.296 ms
 (23 rows)

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -2016,12 +2016,12 @@ explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hell
                            ->  Aggregate  (cost=2.13..2.14 rows=1 width=8)
                                  ->  Seq Scan on example_r  (cost=0.00..2.10 rows=5 width=0)
  Slice statistics:
-   (slice0)    Executor memory: 258K bytes.
-   (slice1)    Executor memory: 210K bytes avg x 2 workers, 210K bytes max (seg0).
-   (slice2)    Executor memory: 274K bytes (seg0).
-   (slice3)    Executor memory: 254K bytes avg x 2 workers, 266K bytes max (seg1).
+   (slice0)    Executor memory: 258kB.
+   (slice1)    Executor memory: 210kB avg x 2 workers, 210kB max (seg0).
+   (slice2)    Executor memory: 274kB (seg0).
+   (slice3)    Executor memory: 254kB avg x 2 workers, 266kB max (seg1).
  Statement statistics:
-   Memory used: 128000K bytes
+   Memory used: 128000kB
  Settings:  gp_segments_for_planner=8
  Total runtime: 5.296 ms
 (23 rows)

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -1,12 +1,12 @@
 -- start_matchsubs
 -- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
 -- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
--- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
--- m/Work_mem: \d+\w bytes max\./
--- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
+-- m/\(slice\d+\)    Executor memory: (\d+)kB\./
+-- s/Executor memory: (\d+)\wkB\./Executor memory: (#####)kB./
+-- m/\(slice\d+\)    Executor memory: (\d+)kB avg x \d+ workers, \d+kB max \(seg\d+\)\./
+-- s/Executor memory: (\d+)kB avg x \d+ workers, \d+kB max \(seg\d+\)\./Executor memory: ####kB avg x #### workers, ####kB max (seg#)./
+-- m/Work_mem: \d+kB max\./
+-- s/Work_mem: \d+kB max\. */Work_mem: ###kB max./
 -- m/Execution time: \d+\.\d+ ms/
 -- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
 -- m/Planning time: \d+\.\d+ ms/


### PR DESCRIPTION
EXPLAIN ANALYZE output was using both 'kB' and 'K bytes' to denote sizes in kilobytes. The correct unit for kilo is k, and 'kB' is a universally accepted unit. This consistently makes us use kB for EXPLAIN output rather than mixing the two.

A little bit of tidying up of the code which had to changed as part of this is also performed.