### PR TITLE
Fix aocs table block version mismatch (#8202)

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14662,11 +14662,11 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 					/* bound of -1 are fine because this has no effect on data */
 					tname->arrayBounds = lappend(tname->arrayBounds,
 												 makeInteger(-1));
-
-				/* Per column encoding settings */
-				if (col_encs)
-					cd->encoding = col_encs[attno];
 			}
+
+			/* Per column encoding settings */
+			if (col_encs)
+				cd->encoding = col_encs[attno];
 
 			tname->location = -1;
 			cd->typeName = tname;

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -770,3 +770,14 @@ reset enable_indexscan;
 -- (e.g. column_compression).
 set client_min_messages='WARNING';
 drop schema aocs_addcol cascade;
+-- Test case: alter column on a table after reorganize
+-- For an AOCS table with columns using rle_type compression, the
+-- implementation of 'reorganize' at 62d66c063fd did not set compression type
+-- for dropped columns. This led to an error 'Bad datum stream Dense block
+-- version'.
+create table aocs_with_compress(a smallint, b smallint, c smallint) with (appendonly=true, orientation=column, compresstype=rle_type);
+insert into aocs_with_compress values (1, 1, 1), (2, 2, 2);
+alter table aocs_with_compress drop column b;
+alter table aocs_with_compress set with (reorganize=true);
+-- The following operation must not fail
+alter table aocs_with_compress alter column c type integer;


### PR DESCRIPTION
(Cherry-picked from master without conflicts)

ALTER TABLE DROP COLUMN followed by reorganize leads to loss of column
encoding settings of the dropped column. When the column's compresstype
encoding is incorrect, we can encounter block version mismatch error
later during block info validation check of the dropped column.

One idea was to skip dropped columns when constructing AOCSScanDesc.
However, dropping all columns is a special case that is not easily handled
because it is not equivalent to deleted rows. Instead, the fix is to preserve
column encoding settings even for dropped columns.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
Co-authored-by: Ivan Leskin <leskin.in@arenadata.io>