### PR TITLE
Bump ORCA to v3.63.0

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.62.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.63.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.62.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.63.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.62.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.63.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.62.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.63.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.62.0@gpdb/stable
+orca/v3.63.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.62.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.63.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/executor/execDynamicScan.c
+++ b/src/backend/executor/execDynamicScan.c
@@ -240,7 +240,7 @@ static bool
 DynamicScan_InitNextPartition(ScanState *scanState, PartitionInitMethod *partitionInitMethod, PartitionEndMethod *partitionEndMethod, PartitionReScanMethod *partitionReScanMethod)
 {
 	Assert(isDynamicScan((Scan *)scanState->ps.plan));
-	AssertImply(scanState->scan_state != SCAN_INIT, NULL != scanState->ss_currentRelation);
+	AssertImply(scanState->scan_state != SCAN_INIT && scanState->scan_state != SCAN_RESCAN, NULL != scanState->ss_currentRelation);
 
 	Scan *scan = (Scan *)scanState->ps.plan;
 	DynamicTableScanInfo *partitionInfo = scanState->ps.state->dynamicTableScanInfo;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10805,3 +10805,222 @@ SELECT d FROM ffoo FULL OUTER JOIN fbar ON a = c WHERE b BETWEEN 5 and 9;
    
 (3 rows)
 
+-- test index left outer joins on bitmap and btree indexes on partitioned tables with and without select clause
+DROP TABLE IF EXISTS touter, tinnerbitmap, tinnerbtree;
+NOTICE:  table "touter" does not exist, skipping
+NOTICE:  table "tinnerbitmap" does not exist, skipping
+NOTICE:  table "tinnerbtree" does not exist, skipping
+CREATE TABLE touter(a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE tinnerbitmap(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+NOTICE:  CREATE TABLE will create partition "tinnerbitmap_1_prt_1" for table "tinnerbitmap"
+NOTICE:  CREATE TABLE will create partition "tinnerbitmap_1_prt_2" for table "tinnerbitmap"
+CREATE TABLE tinnerbtree(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+NOTICE:  CREATE TABLE will create partition "tinnerbtree_1_prt_1" for table "tinnerbtree"
+NOTICE:  CREATE TABLE will create partition "tinnerbtree_1_prt_2" for table "tinnerbtree"
+INSERT INTO touter SELECT i, i%6 FROM generate_series(1,10) i;
+INSERT INTO tinnerbitmap select i, i%6 FROM generate_series(1,1000) i;
+INSERT INTO tinnerbtree select i, i%6 FROM generate_series(1,1000) i;
+CREATE INDEX tinnerbitmap_ix ON tinnerbitmap USING bitmap(a);
+NOTICE:  building index for child partition "tinnerbitmap_1_prt_1"
+NOTICE:  building index for child partition "tinnerbitmap_1_prt_2"
+CREATE INDEX tinnerbtree_ix ON tinnerbtree USING btree(a);
+NOTICE:  building index for child partition "tinnerbtree_1_prt_1"
+NOTICE:  building index for child partition "tinnerbtree_1_prt_2"
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a;
+ a  | b | a  | b 
+----+---+----+---
+  8 | 2 |  8 | 2
+  9 | 3 |  9 | 3
+ 10 | 4 | 10 | 4
+  1 | 1 |  1 | 1
+  2 | 2 |  2 | 2
+  3 | 3 |  3 | 3
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |  6 | 0
+  7 | 1 |  7 | 1
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b=10;
+ a  | b | a | b 
+----+---+---+---
+  8 | 2 |   |  
+  9 | 3 |   |  
+ 10 | 4 |   |  
+  3 | 3 |   |  
+  4 | 4 |   |  
+  5 | 5 |   |  
+  6 | 0 |   |  
+  7 | 1 |   |  
+  1 | 1 |   |  
+  2 | 2 |   |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b>3;
+ a  | b | a  | b 
+----+---+----+---
+  8 | 2 |    |  
+  9 | 3 |    |  
+ 10 | 4 | 10 | 4
+  1 | 1 |    |  
+  2 | 2 |    |  
+  3 | 3 |    |  
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |    |  
+  7 | 1 |    |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |  1 | 1
+  2 | 2 |  2 | 2
+  3 | 3 |  3 | 3
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |  6 | 0
+  7 | 1 |  7 | 1
+  8 | 2 |  8 | 2
+  9 | 3 |  9 | 3
+ 10 | 4 | 10 | 4
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b=10;
+ a  | b | a | b 
+----+---+---+---
+  8 | 2 |   |  
+  9 | 3 |   |  
+ 10 | 4 |   |  
+  1 | 1 |   |  
+  2 | 2 |   |  
+  3 | 3 |   |  
+  4 | 4 |   |  
+  5 | 5 |   |  
+  6 | 0 |   |  
+  7 | 1 |   |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b>3;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |    |  
+  2 | 2 |    |  
+  8 | 2 |    |  
+  9 | 3 |    |  
+ 10 | 4 | 10 | 4
+  3 | 3 |    |  
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |    |  
+  7 | 1 |    |  
+(10 rows)
+
+-- test index left outer joins on bitmap and btree indexes on ao partitioned tables with and without select clause
+DROP TABLE IF EXISTS touter, tinnerbitmap, tinnerbtree;
+CREATE TABLE touter(a int, b int) with (appendonly=true) DISTRIBUTED BY (a);
+CREATE TABLE tinnerbitmap(a int, b int) with (appendonly=true) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+NOTICE:  CREATE TABLE will create partition "tinnerbitmap_1_prt_1" for table "tinnerbitmap"
+NOTICE:  CREATE TABLE will create partition "tinnerbitmap_1_prt_2" for table "tinnerbitmap"
+CREATE TABLE tinnerbtree(a int, b int) with (appendonly=true) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+NOTICE:  CREATE TABLE will create partition "tinnerbtree_1_prt_1" for table "tinnerbtree"
+NOTICE:  CREATE TABLE will create partition "tinnerbtree_1_prt_2" for table "tinnerbtree"
+INSERT INTO touter SELECT i, i%6 FROM generate_series(1,10) i;
+INSERT INTO tinnerbitmap select i, i%6 FROM generate_series(1,1000) i;
+INSERT INTO tinnerbtree select i, i%6 FROM generate_series(1,1000) i;
+CREATE INDEX tinnerbitmap_ix ON tinnerbitmap USING bitmap(a);
+NOTICE:  building index for child partition "tinnerbitmap_1_prt_1"
+NOTICE:  building index for child partition "tinnerbitmap_1_prt_2"
+CREATE INDEX tinnerbtree_ix ON tinnerbtree USING btree(a);
+NOTICE:  building index for child partition "tinnerbtree_1_prt_1"
+NOTICE:  building index for child partition "tinnerbtree_1_prt_2"
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a;
+ a  | b | a  | b 
+----+---+----+---
+  3 | 3 |  3 | 3
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |  6 | 0
+  7 | 1 |  7 | 1
+  8 | 2 |  8 | 2
+  9 | 3 |  9 | 3
+ 10 | 4 | 10 | 4
+  1 | 1 |  1 | 1
+  2 | 2 |  2 | 2
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b=10;
+ a  | b | a | b 
+----+---+---+---
+  1 | 1 |   |  
+  2 | 2 |   |  
+  8 | 2 |   |  
+  9 | 3 |   |  
+ 10 | 4 |   |  
+  3 | 3 |   |  
+  4 | 4 |   |  
+  5 | 5 |   |  
+  6 | 0 |   |  
+  7 | 1 |   |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b>3;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |    |  
+  2 | 2 |    |  
+  8 | 2 |    |  
+  9 | 3 |    |  
+ 10 | 4 | 10 | 4
+  3 | 3 |    |  
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |    |  
+  7 | 1 |    |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |  1 | 1
+  2 | 2 |  2 | 2
+  8 | 2 |  8 | 2
+  9 | 3 |  9 | 3
+ 10 | 4 | 10 | 4
+  3 | 3 |  3 | 3
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |  6 | 0
+  7 | 1 |  7 | 1
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b=10;
+ a  | b | a | b 
+----+---+---+---
+  3 | 3 |   |  
+  4 | 4 |   |  
+  5 | 5 |   |  
+  6 | 0 |   |  
+  7 | 1 |   |  
+  8 | 2 |   |  
+  9 | 3 |   |  
+ 10 | 4 |   |  
+  1 | 1 |   |  
+  2 | 2 |   |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b>3;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |    |  
+  2 | 2 |    |  
+  8 | 2 |    |  
+  9 | 3 |    |  
+ 10 | 4 | 10 | 4
+  3 | 3 |    |  
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |    |  
+  7 | 1 |    |  
+(10 rows)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10892,3 +10892,222 @@ SELECT d FROM ffoo FULL OUTER JOIN fbar ON a = c WHERE b BETWEEN 5 and 9;
    
 (3 rows)
 
+-- test index left outer joins on bitmap and btree indexes on partitioned tables with and without select clause
+DROP TABLE IF EXISTS touter, tinnerbitmap, tinnerbtree;
+NOTICE:  table "touter" does not exist, skipping
+NOTICE:  table "tinnerbitmap" does not exist, skipping
+NOTICE:  table "tinnerbtree" does not exist, skipping
+CREATE TABLE touter(a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE tinnerbitmap(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+NOTICE:  CREATE TABLE will create partition "tinnerbitmap_1_prt_1" for table "tinnerbitmap"
+NOTICE:  CREATE TABLE will create partition "tinnerbitmap_1_prt_2" for table "tinnerbitmap"
+CREATE TABLE tinnerbtree(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+NOTICE:  CREATE TABLE will create partition "tinnerbtree_1_prt_1" for table "tinnerbtree"
+NOTICE:  CREATE TABLE will create partition "tinnerbtree_1_prt_2" for table "tinnerbtree"
+INSERT INTO touter SELECT i, i%6 FROM generate_series(1,10) i;
+INSERT INTO tinnerbitmap select i, i%6 FROM generate_series(1,1000) i;
+INSERT INTO tinnerbtree select i, i%6 FROM generate_series(1,1000) i;
+CREATE INDEX tinnerbitmap_ix ON tinnerbitmap USING bitmap(a);
+NOTICE:  building index for child partition "tinnerbitmap_1_prt_1"
+NOTICE:  building index for child partition "tinnerbitmap_1_prt_2"
+CREATE INDEX tinnerbtree_ix ON tinnerbtree USING btree(a);
+NOTICE:  building index for child partition "tinnerbtree_1_prt_1"
+NOTICE:  building index for child partition "tinnerbtree_1_prt_2"
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a;
+ a  | b | a  | b 
+----+---+----+---
+  8 | 2 |  8 | 2
+  9 | 3 |  9 | 3
+ 10 | 4 | 10 | 4
+  1 | 1 |  1 | 1
+  2 | 2 |  2 | 2
+  3 | 3 |  3 | 3
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |  6 | 0
+  7 | 1 |  7 | 1
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b=10;
+ a  | b | a | b 
+----+---+---+---
+  8 | 2 |   |  
+  9 | 3 |   |  
+ 10 | 4 |   |  
+  3 | 3 |   |  
+  4 | 4 |   |  
+  5 | 5 |   |  
+  6 | 0 |   |  
+  7 | 1 |   |  
+  1 | 1 |   |  
+  2 | 2 |   |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b>3;
+ a  | b | a  | b 
+----+---+----+---
+  8 | 2 |    |  
+  9 | 3 |    |  
+ 10 | 4 | 10 | 4
+  1 | 1 |    |  
+  2 | 2 |    |  
+  3 | 3 |    |  
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |    |  
+  7 | 1 |    |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |  1 | 1
+  2 | 2 |  2 | 2
+  3 | 3 |  3 | 3
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |  6 | 0
+  7 | 1 |  7 | 1
+  8 | 2 |  8 | 2
+  9 | 3 |  9 | 3
+ 10 | 4 | 10 | 4
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b=10;
+ a  | b | a | b 
+----+---+---+---
+  8 | 2 |   |  
+  9 | 3 |   |  
+ 10 | 4 |   |  
+  1 | 1 |   |  
+  2 | 2 |   |  
+  3 | 3 |   |  
+  4 | 4 |   |  
+  5 | 5 |   |  
+  6 | 0 |   |  
+  7 | 1 |   |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b>3;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |    |  
+  2 | 2 |    |  
+  8 | 2 |    |  
+  9 | 3 |    |  
+ 10 | 4 | 10 | 4
+  3 | 3 |    |  
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |    |  
+  7 | 1 |    |  
+(10 rows)
+
+-- test index left outer joins on bitmap and btree indexes on ao partitioned tables with and without select clause
+DROP TABLE IF EXISTS touter, tinnerbitmap, tinnerbtree;
+CREATE TABLE touter(a int, b int) with (appendonly=true) DISTRIBUTED BY (a);
+CREATE TABLE tinnerbitmap(a int, b int) with (appendonly=true) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+NOTICE:  CREATE TABLE will create partition "tinnerbitmap_1_prt_1" for table "tinnerbitmap"
+NOTICE:  CREATE TABLE will create partition "tinnerbitmap_1_prt_2" for table "tinnerbitmap"
+CREATE TABLE tinnerbtree(a int, b int) with (appendonly=true) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+NOTICE:  CREATE TABLE will create partition "tinnerbtree_1_prt_1" for table "tinnerbtree"
+NOTICE:  CREATE TABLE will create partition "tinnerbtree_1_prt_2" for table "tinnerbtree"
+INSERT INTO touter SELECT i, i%6 FROM generate_series(1,10) i;
+INSERT INTO tinnerbitmap select i, i%6 FROM generate_series(1,1000) i;
+INSERT INTO tinnerbtree select i, i%6 FROM generate_series(1,1000) i;
+CREATE INDEX tinnerbitmap_ix ON tinnerbitmap USING bitmap(a);
+NOTICE:  building index for child partition "tinnerbitmap_1_prt_1"
+NOTICE:  building index for child partition "tinnerbitmap_1_prt_2"
+CREATE INDEX tinnerbtree_ix ON tinnerbtree USING btree(a);
+NOTICE:  building index for child partition "tinnerbtree_1_prt_1"
+NOTICE:  building index for child partition "tinnerbtree_1_prt_2"
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a;
+ a  | b | a  | b 
+----+---+----+---
+  3 | 3 |  3 | 3
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |  6 | 0
+  7 | 1 |  7 | 1
+  8 | 2 |  8 | 2
+  9 | 3 |  9 | 3
+ 10 | 4 | 10 | 4
+  1 | 1 |  1 | 1
+  2 | 2 |  2 | 2
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b=10;
+ a  | b | a | b 
+----+---+---+---
+  1 | 1 |   |  
+  2 | 2 |   |  
+  8 | 2 |   |  
+  9 | 3 |   |  
+ 10 | 4 |   |  
+  3 | 3 |   |  
+  4 | 4 |   |  
+  5 | 5 |   |  
+  6 | 0 |   |  
+  7 | 1 |   |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b>3;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |    |  
+  2 | 2 |    |  
+  8 | 2 |    |  
+  9 | 3 |    |  
+ 10 | 4 | 10 | 4
+  3 | 3 |    |  
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |    |  
+  7 | 1 |    |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |  1 | 1
+  2 | 2 |  2 | 2
+  8 | 2 |  8 | 2
+  9 | 3 |  9 | 3
+ 10 | 4 | 10 | 4
+  3 | 3 |  3 | 3
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |  6 | 0
+  7 | 1 |  7 | 1
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b=10;
+ a  | b | a | b 
+----+---+---+---
+  3 | 3 |   |  
+  4 | 4 |   |  
+  5 | 5 |   |  
+  6 | 0 |   |  
+  7 | 1 |   |  
+  8 | 2 |   |  
+  9 | 3 |   |  
+ 10 | 4 |   |  
+  1 | 1 |   |  
+  2 | 2 |   |  
+(10 rows)
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b>3;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |    |  
+  2 | 2 |    |  
+  8 | 2 |    |  
+  9 | 3 |    |  
+ 10 | 4 | 10 | 4
+  3 | 3 |    |  
+  4 | 4 |  4 | 4
+  5 | 5 |  5 | 5
+  6 | 0 |    |  
+  7 | 1 |    |  
+(10 rows)
+

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1724,6 +1724,44 @@ CREATE TABLE fbar (c, d) AS (VALUES (1, 42), (2, 43), (4, 45), (5, 46)) DISTRIBU
 
 SELECT d FROM ffoo FULL OUTER JOIN fbar ON a = c WHERE b BETWEEN 5 and 9;
 
+-- test index left outer joins on bitmap and btree indexes on partitioned tables with and without select clause
+DROP TABLE IF EXISTS touter, tinnerbitmap, tinnerbtree;
+CREATE TABLE touter(a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE tinnerbitmap(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+CREATE TABLE tinnerbtree(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+
+INSERT INTO touter SELECT i, i%6 FROM generate_series(1,10) i;
+INSERT INTO tinnerbitmap select i, i%6 FROM generate_series(1,1000) i;
+INSERT INTO tinnerbtree select i, i%6 FROM generate_series(1,1000) i;
+CREATE INDEX tinnerbitmap_ix ON tinnerbitmap USING bitmap(a);
+CREATE INDEX tinnerbtree_ix ON tinnerbtree USING btree(a);
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a;
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b=10;
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b>3;
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a;
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b=10;
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b>3;
+
+-- test index left outer joins on bitmap and btree indexes on ao partitioned tables with and without select clause
+DROP TABLE IF EXISTS touter, tinnerbitmap, tinnerbtree;
+CREATE TABLE touter(a int, b int) with (appendonly=true) DISTRIBUTED BY (a);
+CREATE TABLE tinnerbitmap(a int, b int) with (appendonly=true) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+CREATE TABLE tinnerbtree(a int, b int) with (appendonly=true) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
+INSERT INTO touter SELECT i, i%6 FROM generate_series(1,10) i;
+INSERT INTO tinnerbitmap select i, i%6 FROM generate_series(1,1000) i;
+INSERT INTO tinnerbtree select i, i%6 FROM generate_series(1,1000) i;
+CREATE INDEX tinnerbitmap_ix ON tinnerbitmap USING bitmap(a);
+CREATE INDEX tinnerbtree_ix ON tinnerbtree USING btree(a);
+
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a;
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b=10;
+SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tinnerbitmap.b>3;
+
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a;
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b=10;
+SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b>3;
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
ICG changes for ORCA commit "Add 4 xforms for LOJ index apply on dynamic table
scan"

These transforms existed for non-partition tables, but not for partition
tables. These transforms are disabled in 5X at this time.

Authored-by: Chris Hajas <chajas@pivotal.io>