### PR TITLE
Fix more flakey gp_tablespace_with_faults tests.

### DIFF
--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -54,6 +54,15 @@ create or replace function setup_tablespace_location_dir_for_test(tablespace_loc
 $$ LANGUAGE plpythonu;
 
 
+create or replace function disable_fts() returns void as $$
+	begin
+		-- intentionally skip fts during these tests
+		-- we know we're going to be inducing errors and panics on primaries
+		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = -1 and role = 'p';
+	end;
+$$ language plpgsql;
+
+
 create or replace function setup(content_id integer, fault_name text, fault_action_type text, tablespace_dir text) returns void as $$
 	begin
 		-- reset tablespace directories
@@ -64,10 +73,7 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 		-- setup faults
 		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
 		perform gp_inject_fault2(fault_name, fault_action_type, dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
-
-		-- intentionally skip fts during these tests
-		-- we know we're going to be inducing errors and panics on primaries
-		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = -1 and role = 'p';
+		perform disable_fts();
 	end;
 $$ LANGUAGE plpgsql;
 
@@ -411,6 +417,7 @@ select remove_tablespace_location_directory(:'tablespace_location');
 select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
 select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
+select disable_fts();
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
@@ -434,6 +441,7 @@ select remove_tablespace_location_directory(:'tablespace_location');
 select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
 select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
+select disable_fts();
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
@@ -458,6 +466,7 @@ select remove_tablespace_location_directory(:'tablespace_location');
 select remove_tablespace_location_directory(:'tablespace_location') from gp_dist_random('gp_id');
 select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
+select disable_fts();
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -52,6 +52,13 @@ create or replace function setup_tablespace_location_dir_for_test(tablespace_loc
 	import os;
 	os.mkdir(tablespace_location_dir);
 $$ LANGUAGE plpythonu;
+create or replace function disable_fts() returns void as $$
+	begin
+		-- intentionally skip fts during these tests
+		-- we know we're going to be inducing errors and panics on primaries
+		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = -1 and role = 'p';
+	end;
+$$ language plpgsql;
 create or replace function setup(content_id integer, fault_name text, fault_action_type text, tablespace_dir text) returns void as $$
 	begin
 		-- reset tablespace directories
@@ -62,10 +69,7 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 		-- setup faults
 		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
 		perform gp_inject_fault2(fault_name, fault_action_type, dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
-
-		-- intentionally skip fts during these tests
-		-- we know we're going to be inducing errors and panics on primaries
-		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where content = -1 and role = 'p';
+		perform disable_fts();
 	end;
 $$ LANGUAGE plpgsql;
 create or replace function cleanup(content_id integer, tablespace_location_dir text) returns void as $$
@@ -848,6 +852,12 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
  
 (1 row)
 
+select disable_fts();
+ disable_fts 
+-------------
+ 
+(1 row)
+
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
 select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
  gp_inject_fault2 
@@ -925,6 +935,12 @@ select remove_tablespace_location_directory(:'tablespace_location') from gp_dist
 select setup_tablespace_location_dir_for_test(:'tablespace_location');
  setup_tablespace_location_dir_for_test 
 ----------------------------------------
+ 
+(1 row)
+
+select disable_fts();
+ disable_fts 
+-------------
  
 (1 row)
 
@@ -1010,6 +1026,12 @@ select remove_tablespace_location_directory(:'tablespace_location') from gp_dist
 select setup_tablespace_location_dir_for_test(:'tablespace_location');
  setup_tablespace_location_dir_for_test 
 ----------------------------------------
+ 
+(1 row)
+
+select disable_fts();
+ disable_fts 
+-------------
  
 (1 row)
 


### PR DESCRIPTION
The drop tablespace tests that introduce panics were not disabling
fts, which is a source of flakey tests.

Introduce a disable_fts() function that we can call before each
test. The fault reset at the end of each test will reenable fts for
the next test.

This needs to go back to 6X_STABLE.