### PR TITLE
Backport 6X: Removes enable_partition_rules guc.

### DIFF
--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -40,9 +40,6 @@
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
-/* temporary rule to control whether we generate RULEs or not -- for testing */
-bool		enable_partition_rules = false;
-
 
 typedef struct
 {
@@ -740,10 +737,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 					pL1 = lappend(pL1, relname);		/* child name */
 					pL1 = lappend(pL1, cxt->relation->relname); /* parent name */
 
-					if (enable_partition_rules)
-						pPostCreate = (Node *) list_make2(lfirst(lc_rule), pL1);
-					else
-						pPostCreate = NULL;
+					pPostCreate = NULL;
 				}
 			}
 		}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -93,8 +93,6 @@ static bool check_gp_resource_group_bypass(bool *newval, void **extra, GucSource
 
 extern struct config_generic *find_option(const char *name, bool create_placeholders, int elevel);
 
-extern bool enable_partition_rules;
-
 extern int listenerBacklog;
 
 /* GUC lists for gp_guc_list_show().  (List of struct config_generic) */
@@ -1586,17 +1584,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_local_distributed_cache_stats,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"enable_partition_rules", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Enable creation of RULEs to implement partitioning"),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&enable_partition_rules,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -1,4 +1,3 @@
-set enable_partition_rules = false;
 drop table if exists d;
 drop table if exists c;
 drop table if exists b;

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -1,4 +1,3 @@
-set enable_partition_rules = false;
 drop table if exists d;
 drop table if exists c;
 drop table if exists b;

--- a/src/test/regress/expected/partition_indexing.out
+++ b/src/test/regress/expected/partition_indexing.out
@@ -1,4 +1,3 @@
-set enable_partition_rules = off;
 -- partition_list_index.sql
 -- Test partition with CREATE INDEX
 DROP TABLE if exists mpp3033a;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -1,4 +1,3 @@
-set enable_partition_rules = false;
 drop table if exists d;
 NOTICE:  table "d" does not exist, skipping
 drop table if exists c;

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -3,7 +3,6 @@ set timezone to '+07:00';
 DROP SCHEMA IF EXISTS partition_ddl2 CASCADE;
 CREATE SCHEMA partition_ddl2;
 set search_path to partition_ddl2;
-set enable_partition_rules = off;
 
 CREATE TABLE rank (
                 id int,
@@ -14,16 +13,14 @@ CREATE TABLE rank (
 
         DISTRIBUTED BY (id, gender, year);
 
-set enable_partition_rules = off;
 
-create table rank2 (LIKE rank) 
+create table rank2 (LIKE rank)
 PARTITION BY LIST (gender) 
 SUBPARTITION BY RANGE (year) 
 SUBPARTITION TEMPLATE (start ('2000') end ('2006') every (interval '1')) 
 (PARTITION girls VALUES ('F'), PARTITION boys VALUES ('M'));
 
 drop table rank;
-set enable_partition_rules = off;
 
 create table ggg (a char(1), b char(2), d char(3))
 distributed by (a)
@@ -695,7 +692,6 @@ partition by range (a)
 alter table mpp3241 add partition zz start (-1) end (0);
 DROP TABLE mpp3241;
 
-set enable_partition_rules = off;
 
 CREATE TABLE mpp3438 (
         unique1         int4,
@@ -729,7 +725,6 @@ alter table mpp3438 alter partition aa add default partition def3;
 \d mpp3438*
 
 drop table mpp3438;
-set enable_partition_rules = false;
 
 CREATE TABLE mpp3261 (
         unique1         int4,

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -3,7 +3,6 @@ set timezone to '+07:00';
 DROP SCHEMA IF EXISTS partition_ddl2 CASCADE;
 CREATE SCHEMA partition_ddl2;
 set search_path to partition_ddl2;
-set enable_partition_rules = off;
 CREATE TABLE rank (
                 id int,
                 rank int,
@@ -11,8 +10,7 @@ CREATE TABLE rank (
                 gender char(1),
                 count int )
         DISTRIBUTED BY (id, gender, year);
-set enable_partition_rules = off;
-create table rank2 (LIKE rank) 
+create table rank2 (LIKE rank)
 PARTITION BY LIST (gender) 
 SUBPARTITION BY RANGE (year) 
 SUBPARTITION TEMPLATE (start ('2000') end ('2006') every (interval '1')) 
@@ -22,7 +20,6 @@ LINE 4: SUBPARTITION TEMPLATE (start ('2000') end ('2006') every (in...
                                       ^
 HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
 drop table rank;
-set enable_partition_rules = off;
 create table ggg (a char(1), b char(2), d char(3))
 distributed by (a)
 partition by LIST (b)
@@ -2365,7 +2362,6 @@ partition by range (a)
 ( partition aa start (1) end (5) every (1) );
 alter table mpp3241 add partition zz start (-1) end (0);
 DROP TABLE mpp3241;
-set enable_partition_rules = off;
 CREATE TABLE mpp3438 (
         unique1         int4,
         unique2         int4,
@@ -2642,7 +2638,6 @@ Inherits: mpp3438_1_prt_default_part
 Distributed by: (unique1)
 
 drop table mpp3438;
-set enable_partition_rules = false;
 CREATE TABLE mpp3261 (
         unique1         int4,
         unique2         int4,

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -1,4 +1,3 @@
-set enable_partition_rules = false;
 
 drop table if exists d;
 drop table if exists c;

--- a/src/test/regress/sql/partition1.sql
+++ b/src/test/regress/sql/partition1.sql
@@ -1,4 +1,3 @@
-set enable_partition_rules = false;
 
 drop table if exists d;
 drop table if exists c;

--- a/src/test/regress/sql/partition_indexing.sql
+++ b/src/test/regress/sql/partition_indexing.sql
@@ -1,4 +1,3 @@
-set enable_partition_rules = off;
 
 -- partition_list_index.sql
 


### PR DESCRIPTION
- before this change, the guc would setup a pPostCreate hook to be run
  after the creation of a partition table, but we never actually read
  from that hook setting, so it is dead code.

(cherry picked from commit 738d919e7315581e1548e4eed38e823d183d6a38)

