### PR TITLE
[6X Backport] Fix `Explain Analyze` crash

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -772,8 +772,16 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 	/* Transfer worker counts to SliceSummary. */
 	showstatctx->slices[sliceIndex].dispatchSummary = ds;
 
-	/* Signal that we've gathered all the statistics */
-	showstatctx->stats_gathered = true;
+	/* Signal that we've gathered all the statistics
+	 * For some query, which has initplan on top of the plan,
+	 * its `ANALYZE EXPLAIN` invoke `cdbexplain_recvExecStats`
+	 * multi-times in different recursive routine to collect
+	 * metrics on both initplan and plan. Thus, this variable
+	 * should only assign on slice 0 after gather result done
+	 * to promise all slices information have been collected.
+	 */
+	if (sliceIndex == 0)
+		showstatctx->stats_gathered = true;
 
 	/* Clean up. */
 	if (ctx.msgptrs)

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -59,6 +59,44 @@ WHERE et like '%Memory: %';
 (1 row)
 
 reset explain_memory_verbosity;
+EXPLAIN ANALYZE SELECT id FROM 
+( SELECT id 
+	FROM explaintest
+	WHERE id > (
+		SELECT avg(id)
+		FROM explaintest
+	)
+) as foo
+ORDER BY id
+LIMIT 1;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=6.37..6.39 rows=1 width=4) (actual time=1.532..1.536 rows=1 loops=1)
+   InitPlan 1 (returns $0)  (slice3)
+     ->  Aggregate  (cost=3.19..3.20 rows=1 width=32) (actual time=1.498..1.498 rows=1 loops=1)
+           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=3.13..3.18 rows=1 width=32) (actual time=1.175..1.444 rows=3 loops=1)
+                 ->  Aggregate  (cost=3.13..3.14 rows=1 width=32) (actual time=0.036..0.036 rows=1 loops=1)
+                       ->  Seq Scan on explaintest explaintest_1  (cost=0.00..3.10 rows=4 width=4) (actual time=0.004..0.004 rows=5 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=3.17..3.19 rows=1 width=4) (actual time=1.530..1.530 rows=1 loops=1)
+         Merge Key: explaintest.id
+         ->  Limit  (cost=3.17..3.17 rows=1 width=4) (actual time=0.826..0.840 rows=1 loops=1)
+               ->  Sort  (cost=3.17..3.17 rows=2 width=4) (actual time=0.826..0.826 rows=1 loops=1)
+                     Sort Key: explaintest.id
+                     Sort Method:  top-N heapsort  Memory: 51kB
+                     ->  Seq Scan on explaintest  (cost=0.00..3.15 rows=2 width=4) (actual time=0.024..0.027 rows=3 loops=1)
+                           Filter: ((id)::numeric > $0)
+ Planning time: 1.221 ms
+   (slice0)    Executor memory: 156K bytes.
+ * (slice1)    Executor memory: 124K bytes avg x 3 workers, 124K bytes max (seg0).  Work_mem: 65K bytes max, 1K bytes wanted.
+ _ (slice2)    Workers: Workers: 3 not dispatched;.  
+ Executor memory: 75K bytes avg x 3 workers, 75K bytes max (seg0).
+   (slice3)    Executor memory: 147K bytes.
+ Memory used:  128000kB
+ Memory wanted:  801kB
+ Optimizer: Postgres query optimizer
+ Execution time: 4.772 ms
+(24 rows)
+
 -- Verify that the column references are OK. This tests for an old ORCA bug,
 -- where the Filter clause in the IndexScan of this query was incorrectly
 -- printed as something like:

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -58,6 +58,44 @@ WHERE et like '%Memory: %';
 (1 row)
 
 reset explain_memory_verbosity;
+EXPLAIN ANALYZE SELECT id FROM 
+( SELECT id 
+	FROM explaintest
+	WHERE id > (
+		SELECT avg(id)
+		FROM explaintest
+	)
+) as foo
+ORDER BY id
+LIMIT 1;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1324033.14 rows=1 width=4) (actual time=51.066..51.068 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324033.14 rows=1 width=4) (actual time=51.063..51.063 rows=1 loops=1)
+         Merge Key: explaintest.id
+         ->  Limit  (cost=0.00..1324033.14 rows=1 width=4) (actual time=16.459..16.468 rows=1 loops=1)
+               ->  Sort  (cost=0.00..1324033.14 rows=4 width=4) (actual time=16.456..16.456 rows=1 loops=1)
+                     Sort Key: explaintest.id
+                     Sort Method:  top-N heapsort  Memory: 51kB
+                     ->  Nested Loop  (cost=0.00..1324033.14 rows=4 width=4) (actual time=5.958..5.963 rows=3 loops=1)
+                           Join Filter: ((explaintest.id)::numeric > (pg_catalog.avg((avg(explaintest_1.id)))))
+                           ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8) (actual time=15.840..15.841 rows=1 loops=1)
+                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=4.496..4.496 rows=1 loops=1)
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.010..4.456 rows=3 loops=1)
+                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.057..0.057 rows=1 loops=1)
+                                                   ->  Seq Scan on explaintest explaintest_1  (cost=0.00..431.00 rows=4 width=4) (actual time=0.047..0.048 rows=5 loops=1)
+                           ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.003..0.017 rows=3 loops=2)
+ Planning time: 63.227 ms
+   (slice0)    Executor memory: 156K bytes.
+   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice2)    Executor memory: 167K bytes (entry db).
+ * (slice3)    Executor memory: 124K bytes avg x 3 workers, 124K bytes max (seg0).  Work_mem: 65K bytes max, 1K bytes wanted.
+ Memory used:  256000kB
+ Memory wanted:  1001kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.61.0
+ Execution time: 131.741 ms
+(24 rows)
+
 -- Verify that the column references are OK. This tests for an old ORCA bug,
 -- where the Filter clause in the IndexScan of this query was incorrectly
 -- printed as something like:

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -49,6 +49,17 @@ WHERE et like '%Memory: %';
 
 reset explain_memory_verbosity;
 
+EXPLAIN ANALYZE SELECT id FROM 
+( SELECT id 
+	FROM explaintest
+	WHERE id > (
+		SELECT avg(id)
+		FROM explaintest
+	)
+) as foo
+ORDER BY id
+LIMIT 1;
+
 
 -- Verify that the column references are OK. This tests for an old ORCA bug,
 -- where the Filter clause in the IndexScan of this query was incorrectly


### PR DESCRIPTION
We have a kind of query that its InitPlan execute in ExecutorStart.
If Explain Analyze this kind of query, as well as, some memory or disk
information requires to collect in the main plan, the QD will crash.
Since queryDesc->showstatctx->stats_gathered is assigned to true
in ExecSetParamPlan function before ExecutorRun, So we only gather
Initplan metrics and left other slices information over. Segment fault when
some execution node print out metrics message.

To fix this problem, variable stats_gathered only be assigned after slice 0
metrics information collection.

reproduce process:

create table t(a int);
explain analyze select a
from (
	select a
	from t
	where a > (
		select avg(a)
		from t
	)
) as foo
order by a
limit 1
fix issue:#6951
(cherry picked from commit 18f904a7e02a564a6a925a2704e1ae7e72c599b0)

