### PR TITLE
Print more details when a behave test fails

### DIFF
--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -670,10 +670,12 @@ def check_user_permissions(file_name, access_mode):
 def are_segments_running():
     gparray = GpArray.initFromCatalog(dbconn.DbURL())
     segments = gparray.getDbList()
+    result = True
     for seg in segments:
         if seg.status != 'u':
-            return False
-    return True
+            print "segment is not up - %s" % seg
+            result = False
+    return result
 
 
 def modify_sql_file(file, hostport):


### PR DESCRIPTION
I came across a behave test failure that looked like this:

    And all the segments are running
      Traceback (most recent call last):
        ...
        File "gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py", line 947, in impl
          raise Exception("all segments are not currently running")
      Exception: all segments are not currently running

It would have been very helpful to know which segment was not running.  This patch adds segment details to the exception messages so that such failures are easier to debug in future.

I've not tested this change locally, relying on PR pipeline.