### PR TITLE
docs - Update of locking on partitioned tables for DELETE/INSERT/UPD…

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
@@ -168,6 +168,11 @@ name = 'Hannah';</codeblock>
                 a specific partition (child table) of a partitioned table is not supported. Instead,
                 these commands must be executed on the root partitioned table, the table created
                 with the <codeph>CREATE TABLE</codeph> command.</p>
+            <p>For a partitioned table, all the child tables are locked during the
+                    <codeph>DELETE</codeph> operation when the Global Deadlock Detector is not
+                enabled (the default). When the Global Deadlock Detector is enabled, only some of
+                the leaf child tables are locked. For information about the Global Deadlock
+                Detector, see <xref href="../../admin_guide/dml.xml#topic_gdd"/>.</p>
         </section>
         <section id="section7">
             <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
@@ -170,9 +170,9 @@ name = 'Hannah';</codeblock>
                 with the <codeph>CREATE TABLE</codeph> command.</p>
             <p>For a partitioned table, all the child tables are locked during the
                     <codeph>DELETE</codeph> operation when the Global Deadlock Detector is not
-                enabled (the default). When the Global Deadlock Detector is enabled, only some of
-                the leaf child tables are locked. For information about the Global Deadlock
-                Detector, see <xref href="../../admin_guide/dml.xml#topic_gdd"/>.</p>
+                enabled (the default). Only some of the leaf child tables are locked when the Global
+                Deadlock Detector is enabled. For information about the Global Deadlock Detector,
+                see <xref href="../../admin_guide/dml.xml#topic_gdd"/>.</p>
         </section>
         <section id="section7">
             <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
@@ -122,12 +122,18 @@ INSERT INTO <varname>table</varname> [( <varname>column</varname> [, ...] )]
         child table of a partitioned table is not supported. These commands must be executed on the
         root partitioned table, the table created with the <codeph>CREATE TABLE</codeph>
         command.</p>
+      <p>For a partitioned table, all the child tables are locked during the <codeph>INSERT</codeph>
+        operation when the Global Deadlock Detector is not enabled (the default). When the Global
+        Deadlock Detector is enabled, only some of the leaf child tables are locked. For information
+        about the Global Deadlock Detector, see <xref href="../../admin_guide/dml.xml#topic_gdd"
+        />.</p>
       <p>For append-optimized tables, Greenplum Database supports a maximum of 127 concurrent
           <codeph>INSERT</codeph> transactions into a single append-optimized table. </p>
       <p>For writable S3 external tables, the <codeph>INSERT</codeph> operation uploads to one or
         more files in the configured S3 bucket, as described in <xref
           href="../../admin_guide/external/g-s3-protocol.xml#amazon-emr"/>. Pressing
-          <codeph>Ctrl-c</codeph> cancels the <codeph>INSERT</codeph> and stops uploading to S3. </p>
+          <codeph>Ctrl-c</codeph> cancels the <codeph>INSERT</codeph> and stops uploading to S3.
+      </p>
     </section>
     <section id="section7">
       <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/INSERT.xml
@@ -111,30 +111,25 @@ INSERT INTO <varname>table</varname> [( <varname>column</varname> [, ...] )]
         </plentry>
       </parml>
     </section>
-    <section id="section6">
-      <title>Notes</title>
-      <p>To insert data into a partitioned table, you specify the root partitioned table, the table
-        created with the <codeph>CREATE TABLE</codeph> command. You also can specify a leaf child
-        table of the partitioned table in an <codeph>INSERT</codeph> command. An error is returned
-        if the data is not valid for the specified leaf child table. Specifying a child table that
-        is not a leaf child table in the <codeph>INSERT</codeph> command is not supported. Execution
-        of other DML commands such as <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> on any
-        child table of a partitioned table is not supported. These commands must be executed on the
-        root partitioned table, the table created with the <codeph>CREATE TABLE</codeph>
-        command.</p>
-      <p>For a partitioned table, all the child tables are locked during the <codeph>INSERT</codeph>
-        operation when the Global Deadlock Detector is not enabled (the default). When the Global
-        Deadlock Detector is enabled, only some of the leaf child tables are locked. For information
-        about the Global Deadlock Detector, see <xref href="../../admin_guide/dml.xml#topic_gdd"
-        />.</p>
-      <p>For append-optimized tables, Greenplum Database supports a maximum of 127 concurrent
-          <codeph>INSERT</codeph> transactions into a single append-optimized table. </p>
-      <p>For writable S3 external tables, the <codeph>INSERT</codeph> operation uploads to one or
-        more files in the configured S3 bucket, as described in <xref
-          href="../../admin_guide/external/g-s3-protocol.xml#amazon-emr"/>. Pressing
-          <codeph>Ctrl-c</codeph> cancels the <codeph>INSERT</codeph> and stops uploading to S3.
-      </p>
-    </section>
+    <section id="section6"><title>Notes</title><p>To insert data into a partitioned table, you
+        specify the root partitioned table, the table created with the <codeph>CREATE TABLE</codeph>
+        command. You also can specify a leaf child table of the partitioned table in an
+          <codeph>INSERT</codeph> command. An error is returned if the data is not valid for the
+        specified leaf child table. Specifying a child table that is not a leaf child table in the
+          <codeph>INSERT</codeph> command is not supported. Execution of other DML commands such as
+          <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> on any child table of a partitioned
+        table is not supported. These commands must be executed on the root partitioned table, the
+        table created with the <codeph>CREATE TABLE</codeph> command.</p>For a partitioned table,
+      all the child tables are locked during the <codeph>INSERT</codeph> operation when the Global
+      Deadlock Detector is not enabled (the default). Only some of the leaf child tables are locked
+      when the Global Deadlock Detector is enabled. For information about the Global Deadlock
+      Detector, see <xref href="../../admin_guide/dml.xml#topic_gdd"/>.<p>For append-optimized
+        tables, Greenplum Database supports a maximum of 127 concurrent <codeph>INSERT</codeph>
+        transactions into a single append-optimized table. </p><p>For writable S3 external tables,
+        the <codeph>INSERT</codeph> operation uploads to one or more files in the configured S3
+        bucket, as described in <xref href="../../admin_guide/external/g-s3-protocol.xml#amazon-emr"
+        />. Pressing <codeph>Ctrl-c</codeph> cancels the <codeph>INSERT</codeph> and stops uploading
+        to S3. </p></section>
     <section id="section7">
       <title>Examples</title>
       <p>Insert a single row into table <codeph>films</codeph>: </p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
@@ -175,8 +175,8 @@ UPDATE [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
         these commands on the root partitioned table, the table created with the <codeph>CREATE
           TABLE</codeph> command.</p>
       <p>For a partitioned table, all the child tables are locked during the <codeph>UPDATE</codeph>
-        operation when the Global Deadlock Detector is not enabled (the default). When the Global
-        Deadlock Detector is enabled, only some of the leaf child tables are locked. For information
+        operation when the Global Deadlock Detector is not enabled (the default). Only some of the
+        leaf child tables are locked when the Global Deadlock Detector is enabled. For information
         about the Global Deadlock Detector, see <xref href="../../admin_guide/dml.xml#topic_gdd"
         />.</p>
     </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
@@ -174,6 +174,11 @@ UPDATE [ONLY] <varname>table</varname> [[AS] <varname>alias</varname>]
         specific partition (child table) of a partitioned table is not supported. Instead, execute
         these commands on the root partitioned table, the table created with the <codeph>CREATE
           TABLE</codeph> command.</p>
+      <p>For a partitioned table, all the child tables are locked during the <codeph>UPDATE</codeph>
+        operation when the Global Deadlock Detector is not enabled (the default). When the Global
+        Deadlock Detector is enabled, only some of the leaf child tables are locked. For information
+        about the Global Deadlock Detector, see <xref href="../../admin_guide/dml.xml#topic_gdd"
+        />.</p>
     </section>
     <section id="section7">
       <title>Examples</title>


### PR DESCRIPTION
…ATE operations.

This will be backported to 6X_STABLE

Dev change https://github.com/greenplum-db/gpdb/pull/8133
