### PR TITLE
Init plan with input param follow upstream execution flow

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -702,6 +702,7 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 	SubPlan    *splan;
 	ListCell   *lc;
 	Bitmapset  *tmpset;
+	Bitmapset  *plan_param_set;
 	int         paramid;
 
 	/*
@@ -726,6 +727,7 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 	splan->args = NIL;
 	splan->extParam = NIL;
 
+	plan_param_set  = NULL;
 	/*
 	 * Make parParam and args lists of param IDs and expressions that current
 	 * query level will pass to this child plan.
@@ -749,6 +751,7 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 
 		splan->parParam = lappend_int(splan->parParam, pitem->paramId);
 		splan->args = lappend(splan->args, arg);
+		plan_param_set = bms_add_member(plan_param_set, pitem->paramId);
 	}
 
 	/*
@@ -757,7 +760,8 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 	 */
 	if (plan->extParam)
 	{
-		tmpset = bms_copy(plan->extParam);
+		tmpset = bms_difference(plan->extParam, plan_param_set);
+
 		while ((paramid = bms_first_member(tmpset)) >= 0)
 			splan->extParam = lappend_int(splan->extParam, paramid);
 

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -2062,3 +2062,35 @@ select x from int8_tbl, extractq2_append(int8_tbl) f(x);
   4567890123456789
 (10 rows)
 
+create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$      
+  select (select extractq2(t))                                                  
+$$ language sql immutable;                                                      
+explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+                   QUERY PLAN                    
+-------------------------------------------------
+ Nested Loop
+   Output: ($1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: int8_tbl.*
+         ->  Seq Scan on public.int8_tbl
+               Output: int8_tbl.*
+   ->  Materialize
+         Output: ($1)
+         ->  Result
+               Output: $1
+               InitPlan 1 (returns $1)  (slice2)
+                 ->  Result
+                       Output: ($0).q2
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+         x         
+-------------------
+               123
+  4567890123456789
+ -4567890123456789
+               456
+  4567890123456789
+(5 rows)
+

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -2064,3 +2064,35 @@ select x from int8_tbl, extractq2_append(int8_tbl) f(x);
   4567890123456789
 (10 rows)
 
+create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$      
+  select (select extractq2(t))                                                  
+$$ language sql immutable;                                                      
+explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+                   QUERY PLAN                    
+-------------------------------------------------
+ Nested Loop
+   Output: ($1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: int8_tbl.*
+         ->  Seq Scan on public.int8_tbl
+               Output: int8_tbl.*
+   ->  Materialize
+         Output: ($1)
+         ->  Result
+               Output: $1
+               InitPlan 1 (returns $1)  (slice2)
+                 ->  Result
+                       Output: ($0).q2
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+         x         
+-------------------
+               123
+  4567890123456789
+ -4567890123456789
+               456
+  4567890123456789
+(5 rows)
+

--- a/src/test/regress/sql/rangefuncs.sql
+++ b/src/test/regress/sql/rangefuncs.sql
@@ -659,3 +659,11 @@ explain (verbose, costs off)
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
 
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
+
+create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$      
+  select (select extractq2(t))                                                  
+$$ language sql immutable;                                                      
+
+explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+
+select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);


### PR DESCRIPTION
In gpdb, we pre-execute init plan in ExecutorStart to reduce slice number.
However, for some initplan, which require params from same level node,
should follow upstream execution flow.

To recognize this initplan's pattern, record `extParam` when creating
`subplan` object.

Fix issue: #6953

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
