### PR TITLE
Don't create tablespace test directories during make all

### DIFF
--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -127,7 +127,7 @@ installdirs-tests: installdirs
 
 # Get some extra C modules from contrib/spi
 
-all: refint$(DLSUFFIX) autoinc$(DLSUFFIX) tablespace-setup hooktest query_info_hook_test
+all: refint$(DLSUFFIX) autoinc$(DLSUFFIX) hooktest query_info_hook_test
 
 refint$(DLSUFFIX): $(top_builddir)/contrib/spi/refint$(DLSUFFIX)
 	cp $< $@
@@ -191,7 +191,7 @@ installcheck: installcheck-good
 installcheck-small: all
 	$(pg_regress_installcheck) $(REGRESS_OPTS) --schedule=$(srcdir)/parallel_schedule $(EXTRA_TESTS)
 
-installcheck-good: all twophase_pqexecparams hooktest query_info_hook_test
+installcheck-good: all twophase_pqexecparams hooktest query_info_hook_test tablespace-setup
 	$(pg_regress_installcheck) $(REGRESS_OPTS) --schedule=$(srcdir)/parallel_schedule --schedule=$(srcdir)/greenplum_schedule $(EXTRA_TESTS)
 
 installcheck-parallel: all tablespace-setup


### PR DESCRIPTION
The test directories for tablespaces need not to be created on the all target, as they are per-test artifacts and not compiled objects which are static per all test runs. Instead, make sure the target is executed on each invocation of installcheck.