### PR TITLE
[6X backport] Calculate memory for no spilling in bytes

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1955,8 +1955,17 @@ cdbexplain_showExecStatsEnd(struct PlannedStmt *stmt,
 		{
 			long mem_wanted;
 
-			mem_wanted = (long) PolicyAutoStatementMemForNoSpillKB(stmt,
-							(uint64) showstatctx->workmemwanted_max / 1024L);
+			mem_wanted = (long) PolicyAutoStatementMemForNoSpill(stmt,
+							(uint64) showstatctx->workmemwanted_max);
+
+			/*
+			 * Round up to a kilobyte in case we end up requiring less than
+			 * that.
+			 */
+			if (mem_wanted <= 1024L)
+				mem_wanted = 1L;
+			else
+				mem_wanted = mem_wanted / 1024L;
 
 			if (es->format == EXPLAIN_FORMAT_TEXT)
 				appendStringInfo(es->str, "Memory wanted:  %ldkB\n", mem_wanted);

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -446,16 +446,17 @@ void PolicyAutoAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memAvailableByte
 	 Assert(!result);
 }
 
-/**
- * What should be query mem such that memory intensive operators get a certain minimum amount of memory.
- * Return value is in KB.
+/*
+ * What should be query mem such that memory intensive operators get a certain
+ * minimum amount of memory.  Return value is in bytes.
  */
- uint64 PolicyAutoStatementMemForNoSpillKB(PlannedStmt *stmt, uint64 minOperatorMemKB)
- {
-	 Assert(stmt);
-	 Assert(minOperatorMemKB > 0);
+uint64
+PolicyAutoStatementMemForNoSpill(PlannedStmt *stmt, uint64 minOperatorMem)
+{
+	Assert(stmt);
+	Assert(minOperatorMem > 0);
 
-	 const uint64 nonMemIntenseOpMemKB = (uint64) (*gp_resmanager_memory_policy_auto_fixed_mem);
+	const uint64 nonMemIntenseOpMem = ((uint64) (*gp_resmanager_memory_policy_auto_fixed_mem) * 1024);
 
 	 PolicyAutoContext ctx;
 	 exec_init_plan_tree_base(&ctx.base, stmt);
@@ -472,15 +473,15 @@ void PolicyAutoAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memAvailableByte
 	 Assert(!result);
 	 Assert(ctx.numMemIntensiveOperators + ctx.numNonMemIntensiveOperators > 0);
 
-	 /**
-	  * Right now, the inverse is straightforward.
-	  * TODO: Siva - employ binary search to find the right value.
-	  */
-	 uint64 requiredStatementMemKB = ctx.numNonMemIntensiveOperators * nonMemIntenseOpMemKB
-			 + ctx.numMemIntensiveOperators * minOperatorMemKB;
+	/*
+	 * Right now, the inverse is straightforward.
+	 * TODO: Siva - employ binary search to find the right value.
+	 */
+	uint64 requiredStatementMem = ctx.numNonMemIntensiveOperators * nonMemIntenseOpMem
+									+ ctx.numMemIntensiveOperators * minOperatorMem;
 
-	 return requiredStatementMemKB;
- }
+	return requiredStatementMem;
+}
 
 /*
  * CreateOperatorGroup

--- a/src/include/cdb/memquota.h
+++ b/src/include/cdb/memquota.h
@@ -50,7 +50,7 @@ extern void PolicyEagerFreeAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memo
 /**
  * Inverse for explain analyze.
  */
-extern uint64 PolicyAutoStatementMemForNoSpillKB(PlannedStmt *stmt, uint64 minOperatorMemKB);
+extern uint64 PolicyAutoStatementMemForNoSpill(PlannedStmt *stmt, uint64 minOperatorMemKB);
 
 /**
  * Is result node memory intensive?


### PR DESCRIPTION
The calculation for the minimum amount of memory to memory-intensive
operators were using kB for both input and output, leading to an
assertion failure in case the minimum memory requirement was less
than a kB. Since we are using a full uint64 for calculating, we
have room for using just bytes instead leaving the formatting to
the caller (which is just EXPLAIN ANALYZE).

Reviewed-by: Weinan Wang <wewang@pivotal.io>
cherry-pick commit: b25022f152c402857f3ae882751ba2172e19aca9

