### PR TITLE
docs - pxf content updates for s3 select support, misc related edits

### DIFF
--- a/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -34,7 +34,8 @@
                   </li>
                 </ul>
               </li>
-              <li><a href="/6-0/pxf/objstore_cfg.html" format="markdown">Configuring Connectors to Azure, Google Cloud Storage, Minio, and S3 Object Stores (Optional)</a> </li>
+              <li><a href="/6-0/pxf/s3_objstore_cfg.html" format="markdown">Configuring Connectors to Minio and S3 Object Stores (Optional)</a> </li>
+              <li><a href="/6-0/pxf/objstore_cfg.html" format="markdown">Configuring Connectors to Azure and Google Cloud Storage Object Stores (Optional)</a> </li>
               <li><a href="/6-0/pxf/jdbc_cfg.html" format="markdown">Configuring the JDBC Connector (Optional)</a> </li>
               <li><a href="/6-0/pxf/cfghostport.html" format="markdown">Configuring the PXF Agent Host and Port (Optional)</a> </li>
             </ul>
@@ -68,6 +69,7 @@
           <li><a href="/6-0/pxf/objstore_parquet.html" format="markdown">Reading and Writing Parquet Data</a></li>
           <li><a href="/6-0/pxf/objstore_seqfile.html" format="markdown">Reading and Writing SequenceFile Data</a></li>
           <li><a href="/6-0/pxf/objstore_fileasrow.html" format="markdown">Reading a Multi-Line Text File into a Single Table Row</a></li>
+          <li><a href="/6-0/pxf/access_s3.html" format="markdown">About Accessing the S3 Object Store</a></li>
         </ul>
       </li>
       <li><a href="/6-0/pxf/jdbc_pxf.html" format="markdown">Accessing an SQL Database with PXF (JDBC)</a></li>

--- a/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
@@ -28,7 +28,7 @@ PXF is installed with connectors to Azure Blob Storage, Azure Data Lake, Google 
 Before working with object store data using PXF, ensure that:
 
 - You have configured and initialized PXF, and PXF is running on each Greenplum Database segment host. See [Configuring PXF](instcfg_pxf.html) for additional information.
-- You have configured the PXF Object Store Connectors that you plan to use. Refer to [Configuring Connectors to Azure, Google Cloud Storage, Minio, and S3 Object Stores](objstore_cfg.html) for instructions.
+- You have configured the PXF Object Store Connectors that you plan to use. Refer to [Configuring Connectors to Azure and Google Cloud Storage Object Stores](objstore_cfg.html) and [Configuring Connectors to Minio and S3 Object Stores](s3_objstore_cfg.html) for instructions.
 - Time is synchronized between the Greenplum Database segment hosts and the external object store systems.
 
 
@@ -90,24 +90,4 @@ CREATE EXTERNAL TABLE pxf_gsc_json(location text, month text, num_orders int, to
   LOCATION ('pxf://dir/subdir/file.json?<b>PROFILE=gs:json&SERVER=gcssrvcfg</b>')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 </pre>
-
-## <a id="s3_override"></a>Overriding the S3 Server Configuration with DDL
-
-If you are accessing an S3 object store, you can override the S3 server configuration by directly specifying the S3 access ID and secret key via these custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause:
-
-| Custom Option  | Value Description |
-|-------|-------------------------------------|
-| accesskey    | The AWS account access key ID. |
-| secretkey    | The secret key associated with the AWS access key ID. |
-
-For example:
-<pre>CREATE EXTERNAL TABLE pxf_ext_tbl(name text, orders int)
-  LOCATION ('pxf://S3_BUCKET/dir/file.txt?PROFILE=s3:text&SERVER=s3srvcfg<b>&accesskey=YOURKEY&secretkey=YOURSECRET</b>')
-FORMAT 'TEXT' (delimiter=E',');</pre>
-
-<div class="note warning">Credentials that you provide in this manner are visible as part of the external table definition. Do not use this method of passing credentials in a production environment.</div>
-
-PXF does not support overriding Azure, Google Cloud Storage, and Minio server credentials in this manner at this time.
-
-Refer to [Configuration Property Precedence](cfg_server.html#override) for detailed information about the precedence rules that PXF uses to obtain configuration property settings for a Greenplum Database user.
 

--- a/gpdb-doc/markdown/pxf/access_s3.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_s3.html.md.erb
@@ -1,0 +1,33 @@
+---
+title: About Accessing the S3 Object Store
+---
+
+PXF is installed with a connector to the S3 object store. PXF supports the following additional runtime features with this connector:
+
+- Overriding the S3 credentials specified in the server configuration by providing them in the `CREATE EXTERNAL TABLE` command DDL.
+- Using the Amazon S3 Select service to read certain CSV and Parquet data from S3.
+
+## <a id="s3_override"></a>Overriding the S3 Server Configuration with DDL
+
+If you are accessing an S3-compatible object store, you can override the credentials in an S3 server configuration by directly specifying the S3 access ID and secret key via these custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause:
+
+| Custom Option  | Value Description |
+|-------|-------------------------------------|
+| accesskey    | The AWS account access key ID. |
+| secretkey    | The secret key associated with the AWS access key ID. |
+
+For example:
+<pre>CREATE EXTERNAL TABLE pxf_ext_tbl(name text, orders int)
+  LOCATION ('pxf://S3_BUCKET/dir/file.txt?PROFILE=s3:text&SERVER=s3srvcfg<b>&accesskey=YOURKEY&secretkey=YOURSECRET</b>')
+FORMAT 'TEXT' (delimiter=E',');</pre>
+
+<div class="note warning">Credentials that you provide in this manner are visible as part of the external table definition. Do not use this method of passing credentials in a production environment.</div>
+
+PXF does not support overriding Azure, Google Cloud Storage, and Minio server credentials in this manner at this time.
+
+Refer to [Configuration Property Precedence](cfg_server.html#override) for detailed information about the precedence rules that PXF uses to obtain configuration property settings for a Greenplum Database user.
+
+
+## <a id="s3_select"></a>Using the Amazon S3 Select Service
+
+Refer to [Reading CSV and Parquet Data From S3 Using S3 Select](read_s3_s3select.html) for specific information on how PXF can use the Amazon S3 Select service to read CSV and Parquet files stored on S3.

--- a/gpdb-doc/markdown/pxf/col_project.html.md.erb
+++ b/gpdb-doc/markdown/pxf/col_project.html.md.erb
@@ -11,6 +11,7 @@ Column projection is automatically enabled for the `pxf` external table protocol
 - PXF Hive Connector, `HiveORC` profile
 - PXF JDBC Connector, `Jdbc` profile
 - PXF Hadoop and Object Store Connectors, `hdfs:parquet`, `adl:parquet`, `gs:parquet`,`s3:parquet`, and `wasbs:parquet` profiles
+- PXF S3 Connector using Amazon S3 Select service, `s3:parquet` and `s3:text` profiles
 
 **Note:** PXF may disable column projection in cases where it cannot successfully serialize a query filter; for example, when the `WHERE` clause resolves to a `boolean` type.
 

--- a/gpdb-doc/markdown/pxf/filter_push.html.md.erb
+++ b/gpdb-doc/markdown/pxf/filter_push.html.md.erb
@@ -37,21 +37,22 @@ PXF accesses data sources using different connectors, and filter pushdown suppor
 - Hive Connector, all profiles
 - HBase Connector
 - JDBC Connector
+- S3 Connector using the Amazon S3 Select service to access CSV and Parquet data
 
 PXF filter pushdown can be used with these data types (connector-specific):
 
 - `INT2`, `INT4`, `INT8`
 - `CHAR`, `TEXT`
 - `FLOAT`
-- `NUMERIC`
+- `NUMERIC` (not the S3 connector using S3 Select)
 - `BOOL`
-- `DATE`, `TIMESTAMP` (JDBC connector only)
+- `DATE`, `TIMESTAMP` (JDBC connector and S3 connector using S3 Select only)
 
 You can use PXF filter pushdown with these operators:
 
 - `<`, `<=`, `>=`, `>`
 - `<>`, `=`
-- `AND`, `OR`
+- `AND`, `OR`, `NOT`
 - `IN` operator on arrays of `INT` and `TEXT` (JDBC connector only)
 - `LIKE` (`TEXT` fields, JDBC connector only)
 

--- a/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hive_pxf.html.md.erb
@@ -183,7 +183,7 @@ Use the following syntax to create a Greenplum Database external table that refe
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<hive-db-name>.<hive-table-name>
-    ?PROFILE=Hive|HiveText|HiveRC|HiveORC|HiveVectorizedORC[&SERVER=<server_name>][&DELIMITER=<delim>'])
+    ?PROFILE=Hive|HiveText|HiveRC|HiveORC|HiveVectorizedORC[&SERVER=<server_name>]'])
 FORMAT 'CUSTOM|TEXT' (FORMATTER='pxfwritable_import' | delimiter='<delim>')
 ```
 
@@ -195,16 +195,13 @@ Hive connector-specific keywords and values used in the [CREATE EXTERNAL TABLE](
 | \<hive&#8209;table&#8209;name\>    | The name of the Hive table. |
 | PROFILE    | The `PROFILE` keyword must specify one of the values `Hive`, `HiveText`, `HiveRC`, `HiveORC`, or `HiveVectorizedORC`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
-| DELIMITER    | The custom options `DELIMITER` clause is required for both the `HiveText` and `HiveRC` profiles and identifies the field delimiter used in the Hive data set.  \<delim\> must be a single ascii character or specified in hexadecimal representation. |
 | FORMAT (`Hive`, `HiveORC`, and `HiveVectorizedORC` profiles)   | The `FORMAT` clause must specify `'CUSTOM'`. The `CUSTOM` format requires the built-in `pxfwritable_import` `formatter`.   |
-| FORMAT (`HiveText` and `HiveRC` profiles) | The `FORMAT` clause must specify `TEXT`. The `delimiter` must be specified a second time in the '\<delim\>' formatting option. |
+| FORMAT (`HiveText` and `HiveRC` profiles) | The `FORMAT` clause must specify `TEXT`. Specify the single ascii character field delimiter in the `delimiter='<delim>'` formatting option. |
 
 
 ## <a id="hive_text"></a>Accessing TextFile-Format Hive Tables
 
 You can use the `Hive` and `HiveText` profiles to access Hive table data stored in TextFile format.
-
-**Note**: When you use the `HiveText` profile, you **must** specify a delimiter option in both the `LOCATION` and `FORMAT` clauses.
 
 ### <a id="hive_hive_example" class="no-quick-link"></a>Example: Using the Hive Profile
 
@@ -241,13 +238,11 @@ Use the PXF `HiveText` profile to create a readable Greenplum Database external 
 
     ``` sql
     postgres=# CREATE EXTERNAL TABLE salesinfo_hivetextprofile(location text, month text, num_orders int, total_sales float8)
-                 LOCATION ('pxf://default.sales_info?PROFILE=HiveText&DELIMITER=\x2c')
+                 LOCATION ('pxf://default.sales_info?PROFILE=HiveText')
                FORMAT 'TEXT' (delimiter=E',');
     ```
 
-    Notice that:
-    - The `LOCATION` subclause `DELIMITER` value is specified in hexadecimal format. The `\x` prefix instructs PXF to interpret the following characters as hexadecimal. `2c` is the hex value for the comma character.
-    - The `FORMAT` subclause `delimiter` value is specified as the single ascii comma character `','`. `E` escapes the character.
+    Notice that the `FORMAT` subclause `delimiter` value is specified as the single ascii comma character `','`. `E` escapes the character.
 
 2. Query the external table:
 
@@ -268,7 +263,6 @@ Use the PXF `HiveText` profile to create a readable Greenplum Database external 
 
 The RCFile Hive table format is used for row columnar formatted data. The PXF `HiveRC` profile provides access to RCFile data.
 
-**Note**: When you use the `HiveRC` profile, you **must** specify a delimiter option in both the `LOCATION` and `FORMAT` clauses.
 
 ### <a id="hive_hiverc_example" class="no-quick-link"></a>Example: Using the HiveRC Profile
 
@@ -301,11 +295,11 @@ Use the `HiveRC` profile to query RCFile-formatted data in a Hive table.
     hive> SELECT * FROM sales_info_rcfile;
     ```
 
-4. Use the PXF `HiveRC` profile to create a readable Greenplum Database external table that references the Hive `sales_info_rcfile` table that you created in the previous steps. You *must* specify a delimiter option in both the `LOCATION` and `FORMAT` clauses.:
+4. Use the PXF `HiveRC` profile to create a readable Greenplum Database external table that references the Hive `sales_info_rcfile` table that you created in the previous steps. For example:
 
     ``` sql
     postgres=# CREATE EXTERNAL TABLE salesinfo_hivercprofile(location text, month text, num_orders int, total_sales float8)
-                 LOCATION ('pxf://default.sales_info_rcfile?PROFILE=HiveRC&DELIMITER=\x2c')
+                 LOCATION ('pxf://default.sales_info_rcfile?PROFILE=HiveRC')
                FORMAT 'TEXT' (delimiter=E',');
     ```
 

--- a/gpdb-doc/markdown/pxf/objstore_avro.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_avro.html.md.erb
@@ -65,7 +65,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<custom&#8209;option\>=\<value\> | Avro-specific custom options are described in the [PXF HDFS Avro documentation](hdfs_avro.html#customopts). |
 | FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `<objstore>:avro` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
 
-If you are accessing an S3 object store, you can provide S3 credentials directly in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_objstore.html#s3_override).
+If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 
 ## <a id="example"></a>Example
 

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -1,10 +1,10 @@
 ---
-title: Configuring Connectors to Azure, Google Cloud Storage, Minio, and S3 Object Stores (Optional)
+title: Configuring Connectors to Azure and Google Cloud Storage Object Stores (Optional)
 ---
 
-You can use PXF to access Azure Data Lake, Azure Blob Storage, Google Cloud Storage, and S3-compatible object stores. This topic describes how to configure the PXF connectors to these external data sources.
+You can use PXF to access Azure Data Lake, Azure Blob Storage, and Google Cloud Storage object stores. This topic describes how to configure the PXF connectors to these external data sources.
 
-*If you do not plan to use the PXF object store connectors, then you do not need to perform this procedure.*
+*If you do not plan to use these PXF object store connectors, then you do not need to perform this procedure.*
 
 ## <a id="about_cfg"></a>About Object Store Configuration
 
@@ -45,133 +45,6 @@ The template configuration file for Google Cloud Storage is `$PXF_CONF/templates
 | google.cloud.auth.service.account.enable | Enable service account authorization. | Must specify `true`. |
 | google.cloud.auth.service.account.json.keyfile | The Google Storage key file. | Path to your key file. |
 | fs.AbstractFileSystem.gs.impl | The file system class name. | Must specify `com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS`. |
-
-### <a id="minio_cfg"></a>Minio Server Configuration
-
-The template configuration file for Minio is `$PXF_CONF/templates/minio-site.xml`. When you configure a Minio server, you must provide the following server configuration properties and replace the template values with your credentials:
-
-| Property       | Description                                | Value |
-|----------------|--------------------------------------------|------ |
-| fs.s3a.endpoint | The Minio S3 endpoint to which to connect. | Your endpoint. |
-| fs.s3a.access.key | The Minio account access key ID. | Your access key. |
-| fs.s3a.secret.key | The secret key associated with the Minio access key ID. | Your secret key. |
-
-### <a id="s3_cfg"></a>S3 Server Configuration
-
-The template configuration file for S3 is `$PXF_CONF/templates/s3-site.xml`. When you configure an S3 server, you must provide the following server configuration properties and replace the template values with your credentials:
-
-| Property       | Description                                | Value |
-|----------------|--------------------------------------------|-------|
-| fs.s3a.access.key | The AWS account access key ID. | Your access key. |
-| fs.s3a.secret.key | The secret key associated with the AWS access key ID. | Your secret key. |
-
-If required, fine-tune PXF S3 connectivity by specifying properties identified in the [S3A](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html#S3A) section of the Hadoop-AWS module documentation in your `s3-site.xml` server configuration file.
-
-You can override an S3 server configuration by directly specifying the S3 access ID and secret key via custom options in the CREATE EXTERNAL TABLE command LOCATION clause. Refer to [Overriding the S3 Server Configuration with DDL](access_objstore.html#s3_override) for additional information.
-
-
-#### <a id="s3-sse"></a>Configuring S3 Server-Side Encryption
-
-PXF supports Amazon Web Service S3 Server-Side Encryption (SSE) for S3 files that you access with readable and writable Greenplum Database external tables that specify the `pxf` protocol and an `s3:*` profile. AWS S3 server-side encryption protects your data at rest; it encrypts your object data as it writes to disk, and transparently decrypts the data for you when you access it.
-
-PXF supports the following AWS SSE encryption key management schemes:
-
-- SSE with S3-Managed Keys (SSE-S3) - Amazon manages the data and master encryption keys.
-- SSE with Key Management Service Managed Keys (SSE-KMS) - Amazon manages the data key, and you manage the encryption key in AWS KMS.
-- SSE with Customer-Provided Keys (SSE-C) - You set and manage the encryption key.
-
-Your S3 access key and secret key govern your access to all S3 bucket objects, whether the data is encrypted or not.
-
-S3 transparently decrypts data during a read operation of an encrypted file that you access via a readable external table that is created by specifying the `pxf` protocol and an `s3:*` profile. No additional configuration is required.
-
-To encrypt data that you write to S3 via this type of external table, you have two options:
-
-- Configure the default SSE encryption key management scheme on a per-S3-bucket basis via the AWS console or command line tools (recommended).
-- Configure SSE encryption options in your PXF S3 server `s3-site.xml` configuration file.
-
-##### <a id="s3-sse-bucket"></a>Configuring SSE via an S3 Bucket Policy (Recommended)
-
-You can create S3 <i>Bucket Policy</i>(s) that identify the objects that you want to encrypt, the encryption key management scheme, and the write actions permitted on those objects. Refer to [Protecting Data Using Server-Side Encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html) in the AWS S3 documentation for more information about the SSE encryption key management schemes. [How Do I Enable Default Encryption for an S3 Bucket?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/default-bucket-encryption.html) describes how to set default encryption bucket policies.
-
-
-##### <a id="s3-sse-pxfs3cfg"></a>Specifying SSE Options in a PXF S3 Server Configuration
-
-You must include certain properties in `s3-site.xml` to configure server-side encryption in a PXF S3 server configuration. The properties and values that you add to the file are dependent upon the SSE encryption key management scheme.
-
-**SSE-S3**
-
-To enable SSE-S3 on any file that you write to any S3 bucket, set the following encryption algorithm property and value in the `s3-site.xml` file:
-
-``` xml
-<property>
-  <name>fs.s3a.server-side-encryption-algorithm</name>
-  <value>AES256</value>
-</property>
-```
-
-To enable SSE-S3 for a specific S3 bucket, use the property name variant that includes the bucket name. For example:
-
-``` xml
-<property>
-  <name>fs.s3a.bucket.YOUR_BUCKET1_NAME.server-side-encryption-algorithm</name>
-  <value>AES256</value>
-</property>
-```
-
-Replace `YOUR_BUCKET1_NAME` with the name of the S3 bucket.
-
-**SSE-KMS**
-
-To enable SSE-KMS on any file that you write to any S3 bucket, set both the encryption algorithm and encryption key ID. To set these properties in the `s3-site.xml` file:
-
-``` xml
-<property>
-  <name>fs.s3a.server-side-encryption-algorithm</name>
-  <value>SSE-KMS</value>
-</property>
-<property>
-  <name>fs.s3a.server-side-encryption.key</name>
-  <value>YOUR_AWS_SSE_KMS_KEY_ARN</value>
-</property>
-```
-
-Substitute `YOUR_AWS_SSE_KMS_KEY_ARN` with your key resource name. If you do not specify an encryption key, the default key defined in the Amazon KMS is used. Example KMS key: `arn:aws:kms:us-west-2:123456789012:key/1a23b456-7890-12cc-d345-6ef7890g12f3`.
-
-**Note**: Be sure to create the bucket and the key in the same Amazon Availability Zone.
-
-To enable SSE-KMS for a specific S3 bucket, use property name variants that include the bucket name. For example:
-
-``` xml
-<property>
-  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption-algorithm</name>
-  <value>SSE-KMS</value>
-</property>
-<property>
-  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption.key</name>
-  <value>YOUR_AWS_SSE_KMS_KEY_ARN</value>
-</property>
-```
-
-Replace `YOUR_BUCKET2_NAME` with the name of the S3 bucket.
-
-**SSE-C**
-
-To enable SSE-C on any file that you write to any S3 bucket, set both the encryption algorithm and the encryption key (base-64 encoded). All clients must share the same key.
-
-To set these properties in the `s3-site.xml` file:
-
-``` xml
-<property>
-  <name>fs.s3a.server-side-encryption-algorithm</name>
-  <value>SSE-C</value>
-</property>
-<property>
-  <name>fs.s3a.server-side-encryption.key</name>
-  <value>YOUR_BASE64-ENCODED_ENCRYPTION_KEY</value>
-</property>
-```
-
-To enable SSE-C for a specific S3 bucket, use the property name variants that include the bucket name as described in the SSE-KMS example.
 
 
 ## <a id="cfg_proc"></a>Example Server Configuration Procedure

--- a/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
@@ -43,7 +43,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | FILE\_AS\_ROW=true    | The required option that instructs PXF to read each file into a single table row. |
 | FORMAT | The `FORMAT` must specify `'CSV'`.  |
 
-If you are accessing an S3 object store, you can provide S3 credentials directly in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_objstore.html#s3_override).
+If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 
 ## <a id="example"></a>Example
 

--- a/gpdb-doc/markdown/pxf/objstore_json.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_json.html.md.erb
@@ -64,7 +64,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<custom&#8209;option\>=\<value\> | JSON supports the custom option named `IDENTIFIER` as described in the [PXF HDFS JSON documentation](hdfs_json.html#customopts). |
 | FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `<objstore>:json` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
 
-If you are accessing an S3 object store, you can provide S3 credentials directly in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_objstore.html#s3_override).
+If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 
 ## <a id="example"></a>Example
 

--- a/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
@@ -71,7 +71,10 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
 | DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
 
-If you are accessing an S3 object store, you can provide S3 credentials directly in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_objstore.html#s3_override).
+If you are accessing an S3 object store:
+
+- You can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
+- If you are reading Parquet data from S3, you can direct PXF to use the S3 Select Amazon service to retrieve the data. Refer to [Using the Amazon S3 Select Service](access_s3.html#s3_select) for more information about the PXF custom option used for this purpose.
 
 ## <a id="example"></a> Example
 

--- a/gpdb-doc/markdown/pxf/objstore_seqfile.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_seqfile.html.md.erb
@@ -64,7 +64,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
 | DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
 
-If you are accessing an S3 object store, you can provide S3 credentials directly in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_objstore.html#s3_override).
+If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 
 ## <a id="example"></a>Example
 

--- a/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
@@ -60,7 +60,11 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'`  when \<path-to-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 
-If you are accessing an S3 object store, you can provide S3 credentials directly in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_objstore.html#s3_override).
+If you are accessing an S3 object store:
+
+- You can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
+
+- If you are reading CSV-format data from S3, you can direct PXF to use the S3 Select Amazon service to retrieve the data. Refer to [Using the Amazon S3 Select Service](access_s3.html#s3_select) for more information about the PXF custom option used for this purpose.
 
 ### <a id="profile_text_query"></a>Example: Reading Text Data from S3
 
@@ -163,7 +167,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'` when \<path-to-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 
-If you are accessing an S3 object store, you can provide S3 credentials directly in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_objstore.html#s3_override).
+If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 
 ### <a id="profile_textmulti_query"></a>Example: Reading Multi-Line Text Data from S3
 
@@ -279,7 +283,7 @@ You specify the compression codec via custom options in the `CREATE EXTERNAL TAB
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | THREAD-SAFE | Boolean value determining if a table query can run in multi-threaded mode. The default value is `TRUE`. Set this option to `FALSE` to handle all requests in a single thread for operations that are not thread-safe (for example, compression). |
 
-If you are accessing an S3 object store, you can provide S3 credentials directly in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_objstore.html#s3_override).
+If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 
 ### <a id="write_s3textsimple_example"></a>Example: Writing Text Data to S3
 

--- a/gpdb-doc/markdown/pxf/read_s3_s3select.html.md.erb
+++ b/gpdb-doc/markdown/pxf/read_s3_s3select.html.md.erb
@@ -1,0 +1,126 @@
+---
+title: Reading CSV and Parquet Data From S3 Using S3 Select
+---
+
+The PXF S3 connector supports reading certain CSV- and Parquet-format data from S3 using the Amazon S3 Select service. S3 Select provides direct query-in-place features on data stored in Amazon S3.
+
+When you enable it, PXF uses S3 Select to filter the contents of S3 objects to retrieve the subset of data that you request. This typically reduces both the amount of data transferred to Greenplum Database and the query time.
+
+You can use the PXF S3 Connector with S3 Select to read:
+
+- `gzip`- or `bzip2`-compressed `CSV` files
+- `Parquet` files with `gzip`- or `snappy`-compressed columns
+
+The data must be `UTF-8`-encoded, and may be server-side encrypted.
+
+PXF supports column projection as well as predicate pushdown for `AND`, `OR`, and `NOT` operators when using S3 Select.
+
+<div class="note"> Using the Amazon S3 Select service may increase the cost of data access and retrieval. Be sure to consider the associated costs before you enable PXF to use the S3 Select service.</div>
+
+## <a id="s3_select_enable"></a>Enabling PXF to Use S3 Select
+
+The `S3_SELECT` external table custom option governs PXF's use of S3 Select when accessing the S3 object store. You can provide the following values when you set the `S3_SELECT` option:
+
+| S3-SELECT Value  | Description |
+|-------|-------------------------------------|
+| OFF    | PXF does not use S3 Select; the default. |
+| ON    | PXF always uses S3 Select. |
+| AUTO    | PXF uses S3 Select when it will benefit access or performance. |
+
+By default, PXF does not use S3 Select (`S3_SELECT=OFF`). You can enable PXF to always use S3 Select, or to use S3 Select only when PXF determines that it would be beneficial for performance. For example, when `S3_SELECT=AUTO`, PXF automatically uses S3 Select when a query on the external table utilizes column projection or predicate pushdown, or when the referenced CSV file has a header row.
+
+
+## <a id="s3_select_parquet"></a>Reading Parquet Data with S3 Select
+
+PXF supports reading Parquet data from S3 as described in [Reading and Writing Parquet Data in an Object Store](objstore_parquet.html). If you want PXF to use S3 Select when reading the Parquet data, you add the `S3_SELECT` custom option and value to the `CREATE EXTERNAL TABLE` `LOCATION` URI.
+
+### <a id="parquet_compress"></a>Specifying the Parquet Column Compression Type
+
+If columns in the Parquet file are `gzip`- or `snappy`-compressed, use the `COMPRESSION_CODEC` custom option in the `LOCATION` URI to identify the compression codec alias. For example:
+
+``` pre
+&COMPRESSION_CODEC=gzip
+```
+
+Or,
+
+``` pre
+&COMPRESSION_CODEC=snappy
+```
+
+### <a id="parquet_cet"></a>Creating the External Table
+
+Use the following syntax to create a Greenplum Database external table that references a Parquet file on S3 that you want PXF to access with the S3 Select service:
+
+``` sql
+CREATE EXTERNAL TABLE <table_name>
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+  LOCATION ('pxf://<path-to-file>?PROFILE=s3:parquet[&SERVER=<server_name>]&S3_SELECT=ON|AUTO[&<other-custom-option>=<value>[...]]')
+FORMAT 'CSV';
+```
+
+<div class="note">You <i>must</i> specify <code>FORMAT 'CSV'</code> when you enable PXF to use S3 Select on an external table that accesses a Parquet file on S3.</div>
+
+For example, use the following command to have PXF use S3 Select to access a Parquet file on S3 when optimal:
+
+``` sql
+CREATE EXTERNAL TABLE parquet_on_s3 ( LIKE table1 )
+  LOCATION ('pxf://bucket/file.parquet?PROFILE=s3:parquet&SERVER=s3srvcfg&S3_SELECT=AUTO')
+FORMAT 'CSV';
+```
+
+## <a id="s3_select_csv"></a>Reading CSV files with S3 Select
+
+PXF supports reading CSV data from S3 as described in [Reading and Writing Text Data in an Object Store](objstore_text.html). If you want PXF to use S3 Select when reading the CSV data, you add the `S3_SELECT` custom option and value to the `CREATE EXTERNAL TABLE` `LOCATION` URI. You may also specify the delimiter and file header and compression custom options.
+
+### <a id="csv_header"></a>Handling the CSV File Header
+
+When you enable PXF to use S3 Select to access a CSV-format file, you use the `FILE_HEADER` custom option in the `LOCATION` URI to identify whether or not the CSV file has a header row, and, if so, how you want PXF to handle the header. The `FILE_HEADER` option takes the following values:
+
+| FILE_HEADER Value  | Description |
+|-------|-------------------------------------|
+| NONE    | The file has no header row; the default. |
+| IGNORE  | The file has a header row; ignore the header. |
+| USE    | The file has a header row; read the header. |
+
+The default `FILE_HEADER` value is `NONE`. You can also instruct PXF to ignore, or read, the file header. For example, to have PXF ignore the header, add the following to the `CREATE EXTERNAL TABLE` `LOCATION` URI:
+
+``` pre
+&FILE_HEADER=IGNORE
+```
+
+<div class="note">PXF can read a CSV file with a header row <i>only</i> when the S3 Connector uses the Amazon S3 Select service to access the file on S3. PXF does not support reading a CSV file that includes a header row from any other external data store.</div>
+
+### <a id="csv_compress"></a>Specifying the CSV File Compression Type
+
+If the CSV file is `gzip`- or `bzip2`-compressed, use the `COMPRESSION_CODEC` custom option in the `LOCATION` URI to identify the compression codec alias. For example:
+
+``` pre
+&COMPRESSION_CODEC=gzip
+```
+
+Or,
+
+``` pre
+&COMPRESSION_CODEC=bzip2
+```
+
+### <a id="csv_cet"></a>Creating the External Table
+
+Use the following syntax to create a Greenplum Database external table that references a CSV file on S3 that you want PXF to access with the S3 Select service:
+
+``` sql
+CREATE EXTERNAL TABLE <table_name>
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<path-to-file>
+    ?PROFILE=s3:text[&SERVER=<server_name>]&S3_SELECT=ON|AUTO[&FILE_HEADER=IGNORE|USE][&COMPRESSION_CODEC=gzip|bzip2][&<other-custom-option>=<value>[...]]')
+FORMAT 'CSV' [(delimiter '<delim_char>')];
+```
+
+For example, use the following command to have PXF always use S3 Select to access a `gzip`-compressed file on S3, where the field delimiter is a pipe ('|') character and you want to read the header row:
+
+``` sql
+CREATE EXTERNAL TABLE gzippedcsv_on_s3 ( LIKE table2 )
+  LOCATION ('pxf://bucket/file.csv.gz?PROFILE=s3:text&SERVER=s3srvcfg&S3_SELECT=ON&FILE_HEADER=USE')
+FORMAT 'CSV' (delimiter '|');
+```

--- a/gpdb-doc/markdown/pxf/s3_objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/s3_objstore_cfg.html.md.erb
@@ -1,0 +1,196 @@
+---
+title: Configuring Connectors to Minio and S3 Object Stores (Optional)
+---
+
+You can use PXF to access S3-compatible object stores. This topic describes how to configure the PXF connectors to these external data sources.
+
+*If you do not plan to use these PXF object store connectors, then you do not need to perform this procedure.*
+
+## <a id="about_cfg"></a>About Object Store Configuration
+
+To access data in an object store, you must provide a server location and client credentials. When you configure a PXF object store connector, you add at least one named PXF server configuration for the connector as described in [Configuring PXF Servers](cfg_server.html).
+
+PXF provides a template configuration file for each object store connector. These template files are located in the `$PXF_CONF/templates/` directory.
+
+
+## <a id="minio_cfg"></a>Minio Server Configuration
+
+The template configuration file for Minio is `$PXF_CONF/templates/minio-site.xml`. When you configure a Minio server, you must provide the following server configuration properties and replace the template values with your credentials:
+
+| Property       | Description                                | Value |
+|----------------|--------------------------------------------|------ |
+| fs.s3a.endpoint | The Minio S3 endpoint to which to connect. | Your endpoint. |
+| fs.s3a.access.key | The Minio account access key ID. | Your access key. |
+| fs.s3a.secret.key | The secret key associated with the Minio access key ID. | Your secret key. |
+
+## <a id="s3_cfg"></a>S3 Server Configuration
+
+The template configuration file for S3 is `$PXF_CONF/templates/s3-site.xml`. When you configure an S3 server, you must provide the following server configuration properties and replace the template values with your credentials:
+
+| Property       | Description                                | Value |
+|----------------|--------------------------------------------|-------|
+| fs.s3a.access.key | The AWS account access key ID. | Your access key. |
+| fs.s3a.secret.key | The secret key associated with the AWS access key ID. | Your secret key. |
+
+If required, fine-tune PXF S3 connectivity by specifying properties identified in the [S3A](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html#S3A) section of the Hadoop-AWS module documentation in your `s3-site.xml` server configuration file.
+
+You can override the credentials an S3 server configuration by directly specifying the S3 access ID and secret key via custom options in the CREATE EXTERNAL TABLE command LOCATION clause. Refer to [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override) for additional information.
+
+
+### <a id="s3-sse"></a>Configuring S3 Server-Side Encryption
+
+PXF supports Amazon Web Service S3 Server-Side Encryption (SSE) for S3 files that you access with readable and writable Greenplum Database external tables that specify the `pxf` protocol and an `s3:*` profile. AWS S3 server-side encryption protects your data at rest; it encrypts your object data as it writes to disk, and transparently decrypts the data for you when you access it.
+
+PXF supports the following AWS SSE encryption key management schemes:
+
+- SSE with S3-Managed Keys (SSE-S3) - Amazon manages the data and master encryption keys.
+- SSE with Key Management Service Managed Keys (SSE-KMS) - Amazon manages the data key, and you manage the encryption key in AWS KMS.
+- SSE with Customer-Provided Keys (SSE-C) - You set and manage the encryption key.
+
+Your S3 access key and secret key govern your access to all S3 bucket objects, whether the data is encrypted or not.
+
+S3 transparently decrypts data during a read operation of an encrypted file that you access via a readable external table that is created by specifying the `pxf` protocol and an `s3:*` profile. No additional configuration is required.
+
+To encrypt data that you write to S3 via this type of external table, you have two options:
+
+- Configure the default SSE encryption key management scheme on a per-S3-bucket basis via the AWS console or command line tools (recommended).
+- Configure SSE encryption options in your PXF S3 server `s3-site.xml` configuration file.
+
+#### <a id="s3-sse-bucket"></a>Configuring SSE via an S3 Bucket Policy (Recommended)
+
+You can create S3 <i>Bucket Policy</i>(s) that identify the objects that you want to encrypt, the encryption key management scheme, and the write actions permitted on those objects. Refer to [Protecting Data Using Server-Side Encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html) in the AWS S3 documentation for more information about the SSE encryption key management schemes. [How Do I Enable Default Encryption for an S3 Bucket?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/default-bucket-encryption.html) describes how to set default encryption bucket policies.
+
+
+#### <a id="s3-sse-pxfs3cfg"></a>Specifying SSE Options in a PXF S3 Server Configuration
+
+You must include certain properties in `s3-site.xml` to configure server-side encryption in a PXF S3 server configuration. The properties and values that you add to the file are dependent upon the SSE encryption key management scheme.
+
+**SSE-S3**
+
+To enable SSE-S3 on any file that you write to any S3 bucket, set the following encryption algorithm property and value in the `s3-site.xml` file:
+
+``` xml
+<property>
+  <name>fs.s3a.server-side-encryption-algorithm</name>
+  <value>AES256</value>
+</property>
+```
+
+To enable SSE-S3 for a specific S3 bucket, use the property name variant that includes the bucket name. For example:
+
+``` xml
+<property>
+  <name>fs.s3a.bucket.YOUR_BUCKET1_NAME.server-side-encryption-algorithm</name>
+  <value>AES256</value>
+</property>
+```
+
+Replace `YOUR_BUCKET1_NAME` with the name of the S3 bucket.
+
+**SSE-KMS**
+
+To enable SSE-KMS on any file that you write to any S3 bucket, set both the encryption algorithm and encryption key ID. To set these properties in the `s3-site.xml` file:
+
+``` xml
+<property>
+  <name>fs.s3a.server-side-encryption-algorithm</name>
+  <value>SSE-KMS</value>
+</property>
+<property>
+  <name>fs.s3a.server-side-encryption.key</name>
+  <value>YOUR_AWS_SSE_KMS_KEY_ARN</value>
+</property>
+```
+
+Substitute `YOUR_AWS_SSE_KMS_KEY_ARN` with your key resource name. If you do not specify an encryption key, the default key defined in the Amazon KMS is used. Example KMS key: `arn:aws:kms:us-west-2:123456789012:key/1a23b456-7890-12cc-d345-6ef7890g12f3`.
+
+**Note**: Be sure to create the bucket and the key in the same Amazon Availability Zone.
+
+To enable SSE-KMS for a specific S3 bucket, use property name variants that include the bucket name. For example:
+
+``` xml
+<property>
+  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption-algorithm</name>
+  <value>SSE-KMS</value>
+</property>
+<property>
+  <name>fs.s3a.bucket.YOUR_BUCKET2_NAME.server-side-encryption.key</name>
+  <value>YOUR_AWS_SSE_KMS_KEY_ARN</value>
+</property>
+```
+
+Replace `YOUR_BUCKET2_NAME` with the name of the S3 bucket.
+
+**SSE-C**
+
+To enable SSE-C on any file that you write to any S3 bucket, set both the encryption algorithm and the encryption key (base-64 encoded). All clients must share the same key.
+
+To set these properties in the `s3-site.xml` file:
+
+``` xml
+<property>
+  <name>fs.s3a.server-side-encryption-algorithm</name>
+  <value>SSE-C</value>
+</property>
+<property>
+  <name>fs.s3a.server-side-encryption.key</name>
+  <value>YOUR_BASE64-ENCODED_ENCRYPTION_KEY</value>
+</property>
+```
+
+To enable SSE-C for a specific S3 bucket, use the property name variants that include the bucket name as described in the SSE-KMS example.
+
+
+## <a id="cfg_proc"></a>Example Server Configuration Procedure
+
+Ensure that you have initialized PXF before you configure an object store connector server.
+
+In this procedure, you name and add a PXF server configuration in the `$PXF_CONF/servers` directory on the Greenplum Database master host for the S3 Cloud Storage connector. You then use the `pxf cluster sync` command to sync the server configuration(s) to the Greenplum Database cluster.
+
+1. Log in to your Greenplum Database master node:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    ```
+
+2. Choose a name for the server. You will provide the name to end users that need to reference files in the object store.
+
+3. Create the `$PXF_HOME/servers/<server_name>` directory. For example, use the following command to create a server configuration for an S3 server named `s3_user1cfg`:
+
+    ``` shell
+    gpadmin@gpmaster$ mkdir $PXF_CONF/servers/s3_user1cfg
+    ````
+
+3. Copy the PXF template file for S3 to the server configuration directory. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ cp $PXF_CONF/templates/s3-site.xml $PXF_CONF/servers/s3_user1cfg/
+    ```
+        
+4. Open the template server configuration file in the editor of your choice, and provide appropriate property values for your environment. For example:
+
+    ``` pre
+    <?xml version="1.0" encoding="UTF-8"?>
+    <configuration>
+        <property>
+            <name>fs.s3a.access.key</name>
+            <value>access_key_for_user1</value>
+        </property>
+        <property>
+            <name>fs.s3a.secret.key</name>
+            <value>secret_key_for_user1</value>
+        </property>
+        <property>
+            <name>fs.s3a.fast.upload</name>
+            <value>true</value>
+        </property>
+    </configuration>
+    ```
+5. Save your changes and exit the editor.
+
+4. Use the `pxf cluster sync` command to copy the new server configuration to the Greenplum Database cluster. For example:
+    
+    ``` shell
+    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
+    ```
+

--- a/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf.html.md.erb
@@ -74,7 +74,7 @@ After you upgrade to the new version of Greenplum Database, perform the followin
     5. Starting in Greenplum Database version 5.15, PXF requires that the Hadoop configuration files reside in the `$PXF_CONF/servers/default` directory. If you configured PXF Hadoop connectors in your *PXF.from* installation, copy the Hadoop configuration files in `/etc/<hadoop_service>/conf` to `$PXF_CONF/servers/default` on the Greenplum Database master host.
     5. Starting in Greenplum Database version 5.15, the default Kerberos keytab file location for PXF is `$PXF_CONF/keytabs`. If you previously configured PXF for secure HDFS and the PXF keytab file is located in a *PXF.from* installation directory (for example, `$GPHOME/pxf/conf`), consider relocating the keytab file to `$PXF_CONF/keytabs`. Alternatively, update the `PXF_KEYTAB` property setting in the `$PXF_CONF/conf/pxf-env.sh` file to reference your keytab file.
 
-5. **If you are upgrading to Greenplum Database version 5.19**:
+5. **If you are upgrading from Greenplum Database version 5.18 or earlier**:
 
     1. PXF now bundles Hadoop version 2.9.2 dependent JAR files. If you registered additional Hadoop-related JAR files in `$PXF_CONF/lib`, ensure that these libraries are compatible with Hadoop version 2.9.2.
 
@@ -83,6 +83,8 @@ After you upgrade to the new version of Greenplum Database, perform the followin
     2. The PXF JDBC connector now supports statement query timeouts. This feature requires explicit support from the JDBC driver. The default query timeout is `0`, wait forever. Some JDBC drivers support a `0` timeout value without fully supporting the statement query timeout feature. Ensure that any JDBC driver that you have registered supports the default timeout, or better yet, fully supports this feature. You may need to update your JDBC driver version to obtain this support. Refer to the configuration instructions in [JDBC Driver JAR Registration](jdbc_cfg.html#cfg_jar) for information about registering JAR files with PXF.
 
     3. If you plan to use Hive partition filtering with integral types, you must set the `hive.metastore.integral.jdo.pushdown` Hive property in your Hadoop cluster's `hive-site.xml` and in your PXF user configuration `$PXF_CONF/servers/default/hive-site.xml` file. See [Updating Hadoop Configuration](client_instcfg.html#client-cfg-update).
+
+5. **If you are upgrading from Greenplum Database version 5.21 or earlier**: PXF no longer supports providing a `DELIMITER=<delim>` option in the `LOCATION` URI when you create an external table that specifies the `HiveText` or `HiveRC` profiles. If you have previously created an external table(s) specifying a `DELIMITER` in the URI, you must drop the table, and recreate it omitting the `DELIMITER`.
 
 5. Synchronize the PXF configuration from the master host to the standby master and each Greenplum Database segment host. For example:
 


### PR DESCRIPTION
pxf doc updates for https://github.com/greenplum-db/pxf/pull/187, https://github.com/greenplum-db/pxf/pull/202, https://github.com/greenplum-db/pxf/pull/206 (note: there are other pxf PRs related to this feature.) 

in this PR:
- move s3 and minio config to its own page/topic
- add new topic "About Accessing the S3 Object Store" - describes the "overriding server config" and "using amazon s3 select service" s3-specific runtime features
- moved the "overriding s3 server config" topic from general object store page to new page above
- add new topic "Reading CSV and Parquet Data from S3 Using S3 Select" - identifies s3-select-specific considerations when accessing parquet and csv data on s3
- update column projection and filter pushdown topics to include s3 select
- doc updates related to pxf no longer supporting reading an external table created with a DELIMITER formatting option in the LOCATION URI - affects HiveText and HiveRC profiles - also has upgrade considerations

doc review site links:
- new page for s3/minio config:  http://docs-lisa-s3select.cfapps.io/6-0/pxf/s3_objstore_cfg.html
- new about s3 page:  http://docs-lisa-s3select.cfapps.io/6-0/pxf/access_s3.html
- new s3 select page:  http://docs-lisa-s3select.cfapps.io/6-0/pxf/read_s3_s3select.html
