### PR TITLE
Mark temp_tablespaces GUC to be included in dispatch

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2829,7 +2829,7 @@ static struct config_string ConfigureNamesString[] =
 		{"temp_tablespaces", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Sets the tablespace(s) to use for temporary tables and sort files."),
 			NULL,
-			GUC_LIST_INPUT | GUC_LIST_QUOTE
+			GUC_LIST_INPUT | GUC_LIST_QUOTE | GUC_GPDB_ADDOPT
 		},
 		&temp_tablespaces,
 		"",


### PR DESCRIPTION
If temp_tablespaces GUC is set at session level and gang resets, the
newly created gang on segments has value different from master. This
causes the incorrect behavior where temp files will not be created in
desired location. Fix the same by having temp_tablespaces GUC marked
with GUC_GPDB_ADDOPT.

Till PR https://github.com/greenplum-db/gpdb/pull/7184 is not committed which for sure is not going to be in 6X, I think we need to manually go over all the existing GUCs and mark the relevant ones. Else such problems will be faced for most of new GUCs inherited from upstream.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
