### PR TITLE
Handle jumps from sigusr1 handler to sigterm handler

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -90,6 +90,8 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 	 */
 	if (AmIInSIGUSR1Handler())
 	{
+		elogif(debug_walrepl_syncrep, LOG,
+				"canceling wait for synchronous replication as we are in SIGUSR1 handler");
 		return;
 	}
 


### PR DESCRIPTION
Any temporary tables created in a session are cleaned up while exiting.
However, consider the below actions being performed:
1. A temporary table table is created. (Backend is used for this session)
2. Backend for temp table recieves SIGUSR1 signal -> it invokes procsignal_sigusr1_handler
3. Immediately, a SIGTERM is recieved by the backend before anything is
processed in procsignal_sigusr1_handler.

Here, SIGTERM will invoke die and it will attemp to remove the temp relations and commit
the transaction. While committing the transaction, SyncRepWaitForLSN will be invoked and if the
Commit LSN for the temp table session is greater than then LSN shipped to the Standby, the backend
will wait for a byte to be written on the fd in WaitLatch and keep on polling until it recieves
a byte on the pipe. However, Walsender will not be able to wake the process up, as it uses
SIGUSR1 signal to communiate with the backend process and since the signal handler are not
re-entrant the backend will not terminate.

Before this commit as well, if we are in SIGUSR1 handler, SyncRepWaitForLSN will exit early,
however, if the jump to die happened without setting the flag InSIGUSR1Handler, SyncRepWaitForLSN
will not realize that its already in SIGUSR1 handler and will hit the issue as described above.
In this commit, instead of using the flag we use pthread_sigmask to identify if we are already in
SIGUSR1 handler.

Repro Steps:
 Session1:   Create a temporary table
    create temp table t1 ( a int);

 GDB Session1: Attach to the walsender process to stop it.
    Or put a breakpoint in the WalSndLoop around foo(;;)

 GDB Session2:Attach to the backend pid for the psql session creating the temp table.
    Put a breakpoint:
    b procsignal_sigusr1_handler
    
Send a SIGUSR1 signal to the backend_pid
    kill -10 <backend pid>
    GDB Session2: Press continue (c), you will enter procsignal_sigusr1_handler

Send a SIGTERM signal to the backend_pid
    kill -15 <backend pid>
    GDB Session2: Press continue (c), you will go to SyncRepWaitForLSN and it will be stuck at WaitLatch -> WaitLatchOrSocket -> poll

Now if you check the pg_stat_activity, it will be waiting for replication.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
Co-authored-by: Jesse Zhang <jzhang@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
