### PR TITLE
Correct memory unit

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2782,7 +2782,7 @@ initial_cost_hashjoin(PlannerInfo *root, JoinCostWorkspace *workspace,
 	ExecChooseHashTableSize(inner_path_rows,
 							inner_path->parent->width,
 							true,		/* useskew */
-							global_work_mem(root),
+							global_work_mem(root) / 1024L,
 							&numbuckets,
 							&numbatches,
 							&num_skew_mcvs);
@@ -4691,7 +4691,7 @@ Cost incremental_hashjoin_cost(double rows, int inner_width, int outer_width, Li
 	ExecChooseHashTableSize(rows,
 							inner_width,
 							true /* useSkew */,
-							global_work_mem(root),
+							global_work_mem(root) / 1024L,
 							&numbuckets,
 							&numbatches,
 							&num_skew_mcvs);


### PR DESCRIPTION
ExecChooseHashTableSize takes KB as parameter while global_work_mem returns bytes

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
