### PR TITLE
Make sure externalgettup_custom() doesn't reach an unexpected state

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -900,6 +900,7 @@ externalgettup_custom(FileScanDesc scan)
 	MemoryContext oldctxt = CurrentMemoryContext;
 
 	Assert(formatter);
+	Assert(pstate->raw_buf_len >= 0);
 
 	/* while didn't finish processing the entire file */
 	/* raw_buf_len was set to 0 in BeginCopyFrom() or external_rescan() */
@@ -922,7 +923,7 @@ externalgettup_custom(FileScanDesc scan)
 		}
 
 		/* while there is still data in our buffer */
-		while (pstate->raw_buf_len != 0)
+		while (pstate->raw_buf_len > 0)
 		{
 			bool		error_caught = false;
 


### PR DESCRIPTION
pstate->raw_buf_len should never be less than zero because it's the
length of unprocessed data in externalgettup_custom(). Add an assert to
make sure this.

This workarounds #8262 for now.
