### PR TITLE
Clean up created ROLE in privileges test

### DIFF
--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -17,6 +17,7 @@ DROP ROLE IF EXISTS regressuser3;
 DROP ROLE IF EXISTS regressuser4;
 DROP ROLE IF EXISTS regressuser5;
 DROP ROLE IF EXISTS regressuser6;
+DROP ROLE IF EXISTS non_superuser_schema;
 -- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata WHERE oid >= 1000 AND oid < 3000 ORDER BY oid;
  lo_unlink 
@@ -1755,6 +1756,8 @@ DROP OWNED BY regressuser1;
 -- regression test: superuser create a schema and authorize it to a non-superuser
 CREATE ROLE "non_superuser_schema";
 CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
+DROP SCHEMA test_non_superuser_schema;
+DROP USER non_superuser_schema;
 DROP USER regressuser1;
 DROP USER regressuser2;
 DROP USER regressuser3;

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -21,6 +21,7 @@ DROP ROLE IF EXISTS regressuser3;
 DROP ROLE IF EXISTS regressuser4;
 DROP ROLE IF EXISTS regressuser5;
 DROP ROLE IF EXISTS regressuser6;
+DROP ROLE IF EXISTS non_superuser_schema;
 
 -- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata WHERE oid >= 1000 AND oid < 3000 ORDER BY oid;
@@ -1063,6 +1064,8 @@ DROP OWNED BY regressuser1;
 -- regression test: superuser create a schema and authorize it to a non-superuser
 CREATE ROLE "non_superuser_schema";
 CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
+DROP SCHEMA test_non_superuser_schema;
+DROP USER non_superuser_schema;
 
 DROP USER regressuser1;
 DROP USER regressuser2;


### PR DESCRIPTION
As roles are global objects, failure to clean up a created role will
cause subsequent testruns to fail as the role already exists (only
the database is dropped between testtruns of installcheck). Fix by
dropping the role explicitly along with dependant objects.

Longer term this should probably become a privileges_gp test to keep
upstream tests unmodified as much as we can, but for now lets fix
the immediate issue.