### PR TITLE
Do not optimize select statement with locking clause when ORCA is enabled.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3806,6 +3806,13 @@ checkCanOptSelectLockingClause(SelectStmt *stmt)
 	if (!gp_enable_global_deadlock_detector)
 		return false;
 
+	/*
+	 * TODO: if future ORCA can emit LockRows plannode,
+	 * we should remove such restriction here.
+	 */
+	if (optimizer)
+		return false;
+
 	if (stmt->op != SETOP_NONE)
 		return false;
 


### PR DESCRIPTION
Currently, ORCA does not emit LockRows plannode. So when
ORCA is enabled, we do not consider the query a simple
select-for-locking case.

------------

No test cases added. Because the case `isolation2/sql/lockmodes.sql` has turned off ORCA at the first line. And we might consider to remove this restriction in future.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
