### PR TITLE
Check for --with-libcurl in gpcloud configuration

### DIFF
--- a/configure
+++ b/configure
@@ -8236,6 +8236,10 @@ if test "$with_libcurl" = "no" && test "$enable_pxf" = "yes"; then
   as_fn_error $? "libcurl is required by PXF" "$LINENO" 5
 fi
 
+if test "$with_libcurl" = "no" && test "$enable_gpcloud" = "yes"; then
+  as_fn_error $? "libcurl is required by gpcloud" "$LINENO" 5
+fi
+
 #
 # libapr. Used for gpfdist and gpperfmon
 #

--- a/configure.in
+++ b/configure.in
@@ -1127,6 +1127,10 @@ if test "$with_libcurl" = "no" && test "$enable_pxf" = "yes"; then
   AC_MSG_ERROR([libcurl is required by PXF])
 fi
 
+if test "$with_libcurl" = "no" && test "$enable_gpcloud" = "yes"; then
+  AC_MSG_ERROR([libcurl is required by gpcloud])
+fi
+
 #
 # libapr. Used for gpfdist and gpperfmon
 #


### PR DESCRIPTION
libcurl is required by gpcloud, but there was no explicit dependency on it in autoconf which would cause compiler errors in a build with gpcloud but without libcurl. Fix by adding a similar dependency check that we have for PXF.