### PR TITLE
6X_BACKPORT: Behave stop segments: Add -w flag to pg_ctl stop

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -849,7 +849,7 @@ def stop_segments(context, segment_type):
         # For demo_cluster tests that run on the CI gives the error 'bash: pg_ctl: command not found'
         # Thus, need to add pg_ctl to the path when ssh'ing to a demo cluster.
         subprocess.check_call(['ssh', seg.getSegmentHostName(),
-                               'source %s/greenplum_path.sh && pg_ctl stop -m fast -D %s' % (
+                               'source %s/greenplum_path.sh && pg_ctl stop -m fast -D %s -w' % (
                                    pipes.quote(os.environ.get("GPHOME")), pipes.quote(seg.getSegmentDataDirectory()))
                                ])
 


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/8327.

When reading the Behave test code for stopping segments, it is not obvious that
we are waiting for the segment to stop. Therefore we are explicitly adding the
`-w` flag to show the blocking behavior.

Co-authored-by: Nikolaos Kalampalikis <nkalampalikis@pivotal.io>
(cherry picked from commit 1e946005f0f8acc4b2aebab5ae685bef792b135a)
