### PR TITLE
6X: Init plan with input param follow upstream execution flow

### DIFF
--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -2087,3 +2087,35 @@ select x from int8_tbl, extractq2_append(int8_tbl) f(x);
   4567890123456789
 (10 rows)
 
+create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$      
+  select (select extractq2(t))                                                  
+$$ language sql immutable;                                                      
+explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+                   QUERY PLAN                    
+-------------------------------------------------
+ Nested Loop
+   Output: ($1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: int8_tbl.*
+         ->  Seq Scan on public.int8_tbl
+               Output: int8_tbl.*
+   ->  Materialize
+         Output: ($1)
+         ->  Result
+               Output: $1
+               InitPlan 1 (returns $1)  (slice2)
+                 ->  Result
+                       Output: ($0).q2
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+         x         
+-------------------
+               123
+  4567890123456789
+ -4567890123456789
+               456
+  4567890123456789
+(5 rows)
+

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -2089,3 +2089,35 @@ select x from int8_tbl, extractq2_append(int8_tbl) f(x);
   4567890123456789
 (10 rows)
 
+create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$      
+  select (select extractq2(t))                                                  
+$$ language sql immutable;                                                      
+explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+                   QUERY PLAN                    
+-------------------------------------------------
+ Nested Loop
+   Output: ($1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: int8_tbl.*
+         ->  Seq Scan on public.int8_tbl
+               Output: int8_tbl.*
+   ->  Materialize
+         Output: ($1)
+         ->  Result
+               Output: $1
+               InitPlan 1 (returns $1)  (slice2)
+                 ->  Result
+                       Output: ($0).q2
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+         x         
+-------------------
+               123
+  4567890123456789
+ -4567890123456789
+               456
+  4567890123456789
+(5 rows)
+

--- a/src/test/regress/sql/rangefuncs.sql
+++ b/src/test/regress/sql/rangefuncs.sql
@@ -674,3 +674,11 @@ explain (verbose, costs off)
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
 
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
+
+create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$      
+  select (select extractq2(t))                                                  
+$$ language sql immutable;                                                      
+
+explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
+
+select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);


### PR DESCRIPTION
gpdb, we pre-execute init plan in ExecutorStart to reduce slice number.
However, for some initplans, which require params from the same level node,
should follow upstream execution flow.

To recognize this initplan's pattern, record `extParam` when creating
`subplan` object.

Fix issue: #6953
cherry-pick by: f6f1f9bbc750618d2559cb004ad6154d73731abd