### PR TITLE
6X Back port: Remove old fault injector

### DIFF
--- a/gpcontrib/gp_inject_fault/expected/inject_fault_test.out
+++ b/gpcontrib/gp_inject_fault/expected/inject_fault_test.out
@@ -4,59 +4,53 @@ CREATE EXTENSION gp_inject_fault;
 begin;
 -- inject fault of type sleep on all primaries
 select gp_inject_fault('finish_prepared_after_record_commit_prepared',
-       'sleep', '', '', '', 1, 2, dbid) from gp_segment_configuration
+       'sleep', '', '', '', 1, 2, 0, dbid) from gp_segment_configuration
        where role = 'p' and content > -1;
-NOTICE:  Success:
-NOTICE:  Success:
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 -- check fault status
 select gp_inject_fault('finish_prepared_after_record_commit_prepared',
-       'status', '', '', '', 1, 2, dbid) from gp_segment_configuration
+       'status', '', '', '', 1, 2, 0, dbid) from gp_segment_configuration
        where role = 'p' and content > -1;
-NOTICE:  Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'2' fault injection state:'set'  num times hit:'0'
-NOTICE:  Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'2' fault injection state:'set'  num times hit:'0'
-NOTICE:  Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'2' fault injection state:'set'  num times hit:'0'
- gp_inject_fault 
------------------
- t
- t
- t
+                                                                                                               gp_inject_fault                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'2' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
+ Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'2' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
+ Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'2' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
 (3 rows)
 
 -- commit transaction should trigger the fault
 end;
 -- fault status should indicate it's triggered
 select gp_inject_fault('finish_prepared_after_record_commit_prepared',
-       'status', '', '', '', 1, 2, dbid) from gp_segment_configuration
+       'status', '', '', '', 1, 2, 0, dbid) from gp_segment_configuration
        where role = 'p' and content > -1;
-NOTICE:  Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'2' fault injection state:'completed'  num times hit:'1'
-NOTICE:  Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'2' fault injection state:'completed'  num times hit:'1'
-NOTICE:  Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'2' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
- t
- t
+                                                                                                               gp_inject_fault                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'2' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
+ Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'2' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
+ Success: fault name:'finish_prepared_after_record_commit_prepared' fault type:'sleep' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'2' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
 (3 rows)
 
 -- reset the fault on all primaries
 select gp_inject_fault('finish_prepared_after_record_commit_prepared',
-       'reset', '', '', '', 1, 2, dbid) from gp_segment_configuration
+       'reset', '', '', '', 1, 2, 0, dbid) from gp_segment_configuration
        where role = 'p' and content > -1;
-NOTICE:  Success:
-NOTICE:  Success:
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 

--- a/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
@@ -56,9 +56,7 @@ CREATE FUNCTION gp_inject_fault2(
   start_occurrence int4,
   end_occurrence int4,
   extra_arg int4,
-  db_id int4,
-  hostname text,
-  port int4)
+  db_id int4)
 RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C VOLATILE STRICT NO SQL;
@@ -68,22 +66,18 @@ LANGUAGE C VOLATILE STRICT NO SQL;
 CREATE FUNCTION gp_inject_fault2(
   faultname text,
   type text,
-  db_id int4,
-  hostname text,
-  port int4)
+  db_id int4)
 RETURNS text
-AS $$ select gp_inject_fault2($1, $2, '', '', '', 1, 1, 0, $3, $4, $5) $$
+AS $$ select gp_inject_fault2($1, $2, '', '', '', 1, 1, 0, $3) $$
 LANGUAGE SQL;
 
 -- Simpler version, always trigger until fault is reset.
 CREATE FUNCTION gp_inject_fault_infinite2(
   faultname text,
   type text,
-  db_id int4,
-  hostname text,
-  port int4)
+  db_id int4)
 RETURNS text
-AS $$ select gp_inject_fault2($1, $2, '', '', '', 1, -1, 0, $3, $4, $5) $$
+AS $$ select gp_inject_fault2($1, $2, '', '', '', 1, -1, 0, $3) $$
 LANGUAGE SQL;
 
 -- Simpler version to avoid confusion for wait_until_triggered fault.
@@ -92,9 +86,7 @@ LANGUAGE SQL;
 CREATE FUNCTION gp_wait_until_triggered_fault2(
   faultname text,
   numtimestriggered int4,
-  db_id int4,
-  hostname text,
-  port int4)
+  db_id int4)
 RETURNS text
-AS $$ select gp_inject_fault2($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3, $4, $5) $$
+AS $$ select gp_inject_fault2($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3) $$
 LANGUAGE SQL;

--- a/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
@@ -13,7 +13,7 @@ CREATE FUNCTION gp_inject_fault(
   end_occurrence int4,
   extra_arg int4,
   db_id int4)
-RETURNS boolean
+RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C VOLATILE STRICT NO SQL;
 
@@ -23,7 +23,7 @@ CREATE FUNCTION gp_inject_fault(
   faultname text,
   type text,
   db_id int4)
-RETURNS boolean
+RETURNS text
 AS $$ select gp_inject_fault($1, $2, '', '', '', 1, 1, 0, $3) $$
 LANGUAGE SQL;
 
@@ -32,7 +32,7 @@ CREATE FUNCTION gp_inject_fault_infinite(
   faultname text,
   type text,
   db_id int4)
-RETURNS boolean
+RETURNS text
 AS $$ select gp_inject_fault($1, $2, '', '', '', 1, -1, 0, $3) $$
 LANGUAGE SQL;
 
@@ -43,50 +43,6 @@ CREATE FUNCTION gp_wait_until_triggered_fault(
   faultname text,
   numtimestriggered int4,
   db_id int4)
-RETURNS boolean
+RETURNS text
 AS $$ select gp_inject_fault($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3) $$
-LANGUAGE SQL;
-
-CREATE FUNCTION gp_inject_fault2(
-  faultname text,
-  type text,
-  ddl text,
-  database text,
-  tablename text,
-  start_occurrence int4,
-  end_occurrence int4,
-  extra_arg int4,
-  db_id int4)
-RETURNS text
-AS 'MODULE_PATHNAME'
-LANGUAGE C VOLATILE STRICT NO SQL;
-
--- Simpler version, trigger only one time, occurrence start at 1 and
--- end at 1, no sleep and no ddl/database/tablename.
-CREATE FUNCTION gp_inject_fault2(
-  faultname text,
-  type text,
-  db_id int4)
-RETURNS text
-AS $$ select gp_inject_fault2($1, $2, '', '', '', 1, 1, 0, $3) $$
-LANGUAGE SQL;
-
--- Simpler version, always trigger until fault is reset.
-CREATE FUNCTION gp_inject_fault_infinite2(
-  faultname text,
-  type text,
-  db_id int4)
-RETURNS text
-AS $$ select gp_inject_fault2($1, $2, '', '', '', 1, -1, 0, $3) $$
-LANGUAGE SQL;
-
--- Simpler version to avoid confusion for wait_until_triggered fault.
--- occurrence in call below defines wait until number of times the
--- fault hits.
-CREATE FUNCTION gp_wait_until_triggered_fault2(
-  faultname text,
-  numtimestriggered int4,
-  db_id int4)
-RETURNS text
-AS $$ select gp_inject_fault2($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3) $$
 LANGUAGE SQL;

--- a/gpcontrib/gp_inject_fault/gp_inject_fault.c
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault.c
@@ -19,75 +19,6 @@
 PG_MODULE_MAGIC;
 
 extern Datum gp_inject_fault(PG_FUNCTION_ARGS);
-extern Datum gp_inject_fault2(PG_FUNCTION_ARGS);
-
-PG_FUNCTION_INFO_V1(gp_inject_fault);
-Datum
-gp_inject_fault(PG_FUNCTION_ARGS)
-{
-	char	*faultName = TextDatumGetCString(PG_GETARG_DATUM(0));
-	char	*type = TextDatumGetCString(PG_GETARG_DATUM(1));
-	char	*ddlStatement = TextDatumGetCString(PG_GETARG_DATUM(2));
-	char	*databaseName = TextDatumGetCString(PG_GETARG_DATUM(3));
-	char	*tableName = TextDatumGetCString(PG_GETARG_DATUM(4));
-	int		startOccurrence = PG_GETARG_INT32(5);
-	int		endOccurrence = PG_GETARG_INT32(6);
-	int		extraArg = PG_GETARG_INT32(7);
-	int		dbid = PG_GETARG_INT32(8);
-
-	/* Fast path if injecting fault in our postmaster. */
-	if (GpIdentity.dbid == dbid)
-	{
-		char	   *response;
-
-		response = InjectFault(
-			faultName, type, ddlStatement, databaseName,
-			tableName, startOccurrence, endOccurrence, extraArg);
-		if (!response)
-			elog(ERROR, "failed to inject fault locally (dbid %d)", dbid);
-		if (strncmp(response, "Success:",  strlen("Success:")) != 0)
-			elog(ERROR, "%s", response);
-
-		elog(NOTICE, "%s", response);
-	}
-	else if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		/*
-		 * Otherwise, relay the command to executor nodes.
-		 *
-		 * We'd only really need to dispatch it to the one that it's meant for,
-		 * but for now, just send it everywhere. The other nodes will just
-		 * ignore it.
-		 *
-		 * (Perhaps this function should be defined as EXECUTE ON SEGMENTS,
-		 * instead of dispatching manually here? But then it wouldn't run on
-		 * QD. There is no EXECUTE ON SEGMENTS AND MASTER options, at the
-		 * moment...)
-		 *
-		 * NOTE: Because we use the normal dispatcher to send this query,
-		 * if a fault has already been injected to the dispatcher code,
-		 * this will trigger it. That means that if you wish to inject
-		 * faults on both the dispatcher and an executor in the same test,
-		 * you need to be careful with the order you inject the faults!
-		 */
-		char	   *sql;
-
-		sql = psprintf("select gp_inject_fault(%s, %s, %s, %s, %s, %d, %d, %d, %d)",
-					   quote_literal_cstr(faultName),
-					   quote_literal_cstr(type),
-					   quote_literal_cstr(ddlStatement),
-					   quote_literal_cstr(databaseName),
-					   quote_literal_cstr(tableName),
-					   startOccurrence,
-					   endOccurrence,
-					   extraArg,
-					   dbid);
-
-		CdbDispatchCommand(sql, DF_CANCEL_ON_ERROR, NULL);
-	}
-	PG_RETURN_DATUM(BoolGetDatum(true));
-}
-
 
 static void
 getHostnameAndPort(int dbid, char **hostname, int *port)
@@ -128,10 +59,9 @@ getHostnameAndPort(int dbid, char **hostname, int *port)
 	heap_close(configrel, NoLock);
 }
 
-
-PG_FUNCTION_INFO_V1(gp_inject_fault2);
+PG_FUNCTION_INFO_V1(gp_inject_fault);
 Datum
-gp_inject_fault2(PG_FUNCTION_ARGS)
+gp_inject_fault(PG_FUNCTION_ARGS)
 {
 	char	*faultName = TextDatumGetCString(PG_GETARG_DATUM(0));
 	char	*type = TextDatumGetCString(PG_GETARG_DATUM(1));

--- a/gpcontrib/gp_inject_fault/gp_inject_fault.c
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault.c
@@ -88,6 +88,47 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 	PG_RETURN_DATUM(BoolGetDatum(true));
 }
 
+
+static void
+getHostnameAndPort(int dbid, char **hostname, int *port)
+{
+	HeapTuple	tuple;
+	Relation    configrel;
+	ScanKeyData scankey[1];
+	SysScanDesc scan;
+	Datum       attr;
+	bool        isNull;
+
+	configrel = heap_open(GpSegmentConfigRelationId, AccessShareLock);
+	ScanKeyInit(&scankey[0],
+				Anum_gp_segment_configuration_dbid,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(dbid));
+	scan = systable_beginscan(configrel, GpSegmentConfigDbidIndexId, true,
+							  NULL, 1, scankey);
+
+	tuple = systable_getnext(scan);
+
+	if (HeapTupleIsValid(tuple))
+	{
+		attr = heap_getattr(tuple, Anum_gp_segment_configuration_hostname,
+							RelationGetDescr(configrel), &isNull);
+		Assert(!isNull);
+		*hostname = TextDatumGetCString(attr);
+
+		attr = heap_getattr(tuple, Anum_gp_segment_configuration_port,
+							RelationGetDescr(configrel), &isNull);
+		Assert(!isNull);
+		*port = DatumGetInt16(attr);
+	}
+	else
+		elog(ERROR, "dbid %d not found", dbid);
+
+	systable_endscan(scan);
+	heap_close(configrel, NoLock);
+}
+
+
 PG_FUNCTION_INFO_V1(gp_inject_fault2);
 Datum
 gp_inject_fault2(PG_FUNCTION_ARGS)
@@ -101,8 +142,8 @@ gp_inject_fault2(PG_FUNCTION_ARGS)
 	int		endOccurrence = PG_GETARG_INT32(6);
 	int		extraArg = PG_GETARG_INT32(7);
 	int		dbid = PG_GETARG_INT32(8);
-	char	*hostname = TextDatumGetCString(PG_GETARG_DATUM(9));
-	int		port = PG_GETARG_INT32(10);
+	char	*hostname;
+	int		port;
 	char	*response;
 
 
@@ -124,6 +165,7 @@ gp_inject_fault2(PG_FUNCTION_ARGS)
 		PGconn *conn;
 		PGresult *res;
 
+		getHostnameAndPort(dbid, &hostname, &port);
 		snprintf(conninfo, 1024, "host=%s port=%d %s=%s",
 				 hostname, port, GPCONN_TYPE, GPCONN_TYPE_FAULT);
 		conn = PQconnectdb(conninfo);

--- a/gpcontrib/gp_inject_fault/sql/inject_fault_test.sql
+++ b/gpcontrib/gp_inject_fault/sql/inject_fault_test.sql
@@ -5,19 +5,19 @@ CREATE EXTENSION gp_inject_fault;
 begin;
 -- inject fault of type sleep on all primaries
 select gp_inject_fault('finish_prepared_after_record_commit_prepared',
-       'sleep', '', '', '', 1, 2, dbid) from gp_segment_configuration
+       'sleep', '', '', '', 1, 2, 0, dbid) from gp_segment_configuration
        where role = 'p' and content > -1;
 -- check fault status
 select gp_inject_fault('finish_prepared_after_record_commit_prepared',
-       'status', '', '', '', 1, 2, dbid) from gp_segment_configuration
+       'status', '', '', '', 1, 2, 0, dbid) from gp_segment_configuration
        where role = 'p' and content > -1;
 -- commit transaction should trigger the fault
 end;
 -- fault status should indicate it's triggered
 select gp_inject_fault('finish_prepared_after_record_commit_prepared',
-       'status', '', '', '', 1, 2, dbid) from gp_segment_configuration
+       'status', '', '', '', 1, 2, 0, dbid) from gp_segment_configuration
        where role = 'p' and content > -1;
 -- reset the fault on all primaries
 select gp_inject_fault('finish_prepared_after_record_commit_prepared',
-       'reset', '', '', '', 1, 2, dbid) from gp_segment_configuration
+       'reset', '', '', '', 1, 2, 0, dbid) from gp_segment_configuration
        where role = 'p' and content > -1;

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2369,6 +2369,11 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 
 	gp_expand_protect_catalog_changes(relation);
 
+#ifdef FAULT_INJECTOR
+	FaultInjector_InjectFaultIfSet("heap_insert", DDLNotSpecified, "",
+								   RelationGetRelationName(relation));
+#endif
+
 	/*
 	 * Fill in tuple header fields, assign an OID, and toast the tuple if
 	 * necessary.

--- a/src/test/fsync/expected/bgwriter_checkpoint.out
+++ b/src/test/fsync/expected/bgwriter_checkpoint.out
@@ -67,20 +67,16 @@ end;
 -- the following gp_inject_fault_infinite don't dirty the
 -- buffer again.
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
-NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
-NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
 (8 rows)
 
 -- Start with a clean slate (no dirty buffers).
@@ -88,27 +84,21 @@ checkpoint;
 -- Skip checkpoints.
 select gp_inject_fault_infinite('checkpoint', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
-NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
-NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 -- Suspend bgwriter.
 select gp_inject_fault_infinite('fault_in_background_writer_main', 'suspend', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
-NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
-NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 -- Ensure no buffers are dirty before we start.
@@ -146,27 +136,21 @@ select sum(num_dirty('fsync_test2'::regclass)) > 0 as passed
 -- Flush all dirty pages by BgBufferSync()
 select gp_inject_fault_infinite('bg_buffer_sync_default_logic', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
-NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
-NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 -- Resume bgwriter.
 select gp_inject_fault('fault_in_background_writer_main', 'resume', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
-NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
-NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
  gp_inject_fault 
 -----------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 -- Wait until bgwriter sweeps through and writes out dirty buffers.
@@ -188,27 +172,21 @@ select wait_for_bgwriter('fsync_test2'::regclass, 25) as passed;
 -- Inject fault to count relfiles fsync'ed by checkpointer.
 select gp_inject_fault_infinite('fsync_counter', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
-NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
-NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 -- Resume checkpoints.
 select gp_inject_fault('checkpoint', 'reset', dbid)
 from gp_segment_configuration where role = 'p' and content > -1;
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
-NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
-NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
  gp_inject_fault 
 -----------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 checkpoint;
@@ -224,27 +202,23 @@ select dirty_buffers() from gp_dist_random('gp_id')
 -- fsync_test1 and fsync_test2 tables. `num times hit` is corresponding
 -- to the number of files synced by `fsync_counter` fault type.
 select gp_inject_fault('fsync_counter', 'status', 2::smallint);
-NOTICE:  Success: fault name:'fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'5'  (seg0 127.0.1.1:25432 pid=24489)
- gp_inject_fault 
------------------
- t
+                                                                                                  gp_inject_fault                                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'6' +
+ 
 (1 row)
 
 -- Reset all faults.
 select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=24489)
-NOTICE:  Success:  (seg1 127.0.1.1:25433 pid=24490)
-NOTICE:  Success:  (seg2 127.0.1.1:25434 pid=24491)
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
 (8 rows)
 

--- a/src/test/heap_checksum/expected/heap_checksum_corruption.out
+++ b/src/test/heap_checksum/expected/heap_checksum_corruption.out
@@ -105,10 +105,9 @@ SHOW data_checksums;
 
 -- skip FTS probes always
 SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
+ Success:
 (1 row)
 
 SELECT gp_request_fts_probe_scan();
@@ -118,10 +117,9 @@ SELECT gp_request_fts_probe_scan();
 (1 row)
 
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
-NOTICE:  Success:
  gp_wait_until_triggered_fault 
 -------------------------------
- t
+ Success:
 (1 row)
 
 --  Corrupt a heap table
@@ -247,13 +245,12 @@ set gp_disable_tuple_hints=off;
 checkpoint;
 -- skip all further checkpoint
 select gp_inject_fault_infinite('checkpoint', 'skip', dbid) from gp_segment_configuration where role = 'p';
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 -- set the hint bit on (the buffer will be marked dirty)
@@ -292,13 +289,12 @@ WARNING:  page verification failed, calculated checksum 18239 but expected 58815
 ERROR:  invalid page in block 0 of relation base/81967/81939  (seg0 slice1 127.0.0.1:25432 pid=27287)
 -- trigger recovery on primaries with multiple retries and ignore warning/notice messages
 select gp_inject_fault_infinite('finish_prepared_after_record_commit_prepared', 'panic', dbid) from gp_segment_configuration where role = 'p';
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 set client_min_messages='ERROR';
@@ -316,23 +312,21 @@ select count(*) from corrupt_heap_checksum.mark_buffer_dirty_hint;
 
 -- reset the fault injector
 select gp_inject_fault('checkpoint', 'reset', dbid) from gp_segment_configuration where role = 'p';
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 select gp_inject_fault('finish_prepared_after_record_commit_prepared', 'reset', dbid) from gp_segment_configuration where role = 'p';
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 -- Clean up. We don't want to leave the corrupt tables lying around!
@@ -341,9 +335,8 @@ DROP SCHEMA corrupt_heap_checksum CASCADE;
 NOTICE:  drop cascades to 13 other objects
 -- resume fts
 SELECT gp_inject_fault('fts_probe', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 

--- a/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
+++ b/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
@@ -7,7 +7,7 @@ CREATE
 select gp_inject_fault_infinite('before_xlog_xact_commit_prepared', 'suspend', 3);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 
 -- trigger a 2PC, and it will block at commit;
@@ -23,7 +23,7 @@ CREATE
 select gp_wait_until_triggered_fault('before_xlog_xact_commit_prepared', 1, 3);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- do checkpoint on segment content 1 in utility mode, and it should block
@@ -33,7 +33,7 @@ select gp_wait_until_triggered_fault('before_xlog_xact_commit_prepared', 1, 3);
 select gp_inject_fault('before_xlog_xact_commit_prepared', 'reset', 3);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 2<:  <... completed>
 COMMIT
@@ -47,7 +47,7 @@ CHECKPOINT
 select gp_inject_fault_infinite('onephase_transaction_commit', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 
 -- trigger a 2PC, and it will block at commit;
@@ -63,7 +63,7 @@ DROP
 select gp_wait_until_triggered_fault('onephase_transaction_commit', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- do checkpoint on master in utility mode, and it should block
@@ -73,7 +73,7 @@ select gp_wait_until_triggered_fault('onephase_transaction_commit', 1, 1);
 select gp_inject_fault('onephase_transaction_commit', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 2<:  <... completed>
 COMMIT

--- a/src/test/isolation2/expected/concurrent_index_creation_should_not_deadlock.out
+++ b/src/test/isolation2/expected/concurrent_index_creation_should_not_deadlock.out
@@ -10,7 +10,7 @@ CREATE
 SELECT gp_inject_fault('before_acquire_lock_during_create_ao_blkdir_table', 'suspend', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- Attempt to concurrently create an index
@@ -18,13 +18,13 @@ SELECT gp_inject_fault('before_acquire_lock_during_create_ao_blkdir_table', 'sus
 SELECT gp_wait_until_triggered_fault('before_acquire_lock_during_create_ao_blkdir_table', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 2>: CREATE INDEX index_deadlocking_test_table_idx2 ON index_deadlocking_test_table (value);  <waiting ...>
 SELECT gp_inject_fault('before_acquire_lock_during_create_ao_blkdir_table', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- Both index creation attempts should succeed

--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -19,7 +19,7 @@ CREATE
 1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 2&:insert into crash_test_table values (1), (11), (111), (1111);  <waiting ...>
 3&:create table crash_test_ddl(c1 int);  <waiting ...>
@@ -28,7 +28,7 @@ CREATE
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 2, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 1:CHECKPOINT;
 CHECKPOINT
@@ -40,14 +40,14 @@ CHECKPOINT
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 3, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- transaction of session 5 didn't insert 'COMMIT' record
 1:select gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 5&:INSERT INTO crash_test_table VALUES (3), (33), (333), (3333);  <waiting ...>
 
@@ -55,26 +55,28 @@ CHECKPOINT
 1:select gp_wait_until_triggered_fault('transaction_abort_after_distributed_prepared', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- check injector status
 1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'status', 1);
- gp_inject_fault 
------------------
- t               
+ gp_inject_fault                                                                                                                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'dtm_broadcast_commit_prepared' fault type:'suspend' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'3' 
+ 
 (1 row)
 1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'status', 1);
- gp_inject_fault 
------------------
- t               
+ gp_inject_fault                                                                                                                                                                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'transaction_abort_after_distributed_prepared' fault type:'suspend' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1' 
+ 
 (1 row)
 
 -- trigger crash
 1:select gp_inject_fault('before_read_command', 'panic', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1:select 1;
 PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -48,10 +48,10 @@ CREATE
 1: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE
 -- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault_infinite2( 'finish_prepared_start_of_function', 'error', dbid, hostname, port) from gp_segment_configuration where content=0 and role='p';
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
 -- Start looping in background, till master panics and closes the session
 3&: SELECT wait_till_master_shutsdown();  <waiting ...>
@@ -63,10 +63,10 @@ server closed the connection unexpectedly
 	before or while processing the request.
 -- Reset the fault in utility mode because normal mode connection will
 -- not be accepted until DTX recovery is finished.
--1U: SELECT gp_inject_fault2( 'finish_prepared_start_of_function', 'reset', dbid, hostname, port) from gp_segment_configuration where content=0 and role='p';
- gp_inject_fault2 
-------------------
- Success:         
+-1U: SELECT gp_inject_fault('finish_prepared_start_of_function', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 -- Join back to know master has completed postmaster reset.
 3<:  <... completed>
@@ -96,10 +96,10 @@ INSERT 10
 -- Start looping in background, till master panics and closes the
 -- session
 5&: SELECT wait_till_master_shutsdown();  <waiting ...>
-6: SELECT gp_inject_fault2( 'dtm_broadcast_commit_prepared', 'fatal', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
- gp_inject_fault2 
-------------------
- Success:         
+6: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'fatal', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 6: CREATE TABLE commit_fatal_fault_test_table(a int, b int);
 PANIC:  fault triggered, fault name:'dtm_broadcast_commit_prepared' fault type:'fatal'
@@ -120,10 +120,10 @@ server closed the connection unexpectedly
  transaction | gid | prepared | owner | database 
 -------------+-----+----------+-------+----------
 (0 rows)
-7: SELECT gp_inject_fault2( 'dtm_broadcast_commit_prepared', 'reset', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
- gp_inject_fault2 
-------------------
- Success:         
+7: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 -- Scenario 3: Inject ERROR after prepare phase has completed to
@@ -137,15 +137,15 @@ server closed the connection unexpectedly
 -- Start looping in background, till master panics and closes the
 -- session
 8&: SELECT wait_till_master_shutsdown();  <waiting ...>
-9: SELECT gp_inject_fault2( 'transaction_abort_after_distributed_prepared', 'error', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
- gp_inject_fault2 
-------------------
- Success:         
+9: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'error', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
-9: SELECT gp_inject_fault2('dtm_broadcast_abort_prepared', 'fatal', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
- gp_inject_fault2 
-------------------
- Success:         
+9: SELECT gp_inject_fault('dtm_broadcast_abort_prepared', 'fatal', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 9: CREATE TABLE abort_fatal_fault_test_table(a int, b int);
 ERROR:  fault triggered, fault name:'transaction_abort_after_distributed_prepared' fault type:'error'
@@ -165,15 +165,15 @@ LINE 1: SELECT count(*) from abort_fatal_fault_test_table;
  transaction | gid | prepared | owner | database 
 -------------+-----+----------+-------+----------
 (0 rows)
-10: SELECT gp_inject_fault2( 'transaction_abort_after_distributed_prepared', 'reset', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
- gp_inject_fault2 
-------------------
- Success:         
+10: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
-10: SELECT gp_inject_fault2('dtm_broadcast_abort_prepared', 'reset', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
- gp_inject_fault2 
-------------------
- Success:         
+10: SELECT gp_inject_fault('dtm_broadcast_abort_prepared', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 -- Scenario 4: QE panics after writing prepare xlog record. This
@@ -197,32 +197,32 @@ ALTER
  t              
 (1 row)
 -- skip FTS probes always
-11: SELECT gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+11: SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
 11: SELECT gp_request_fts_probe_scan();
  gp_request_fts_probe_scan 
 ---------------------------
  t                         
 (1 row)
-11: select gp_wait_until_triggered_fault2('fts_probe', 1, dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+11: select gp_wait_until_triggered_fault('fts_probe', 1, dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
-11: SELECT gp_inject_fault2( 'end_prepare_two_phase', 'infinite_loop', dbid, hostname, port) from gp_segment_configuration where role='p' and content=0;
- gp_inject_fault2 
-------------------
- Success:         
+11: SELECT gp_inject_fault('end_prepare_two_phase', 'infinite_loop', dbid) from gp_segment_configuration where role='p' and content=0;
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 -- statement to trigger fault after writing prepare record
 12&: DELETE FROM QE_panic_test_table;  <waiting ...>
-11: SELECT gp_wait_until_triggered_fault2( 'end_prepare_two_phase', 1, dbid, hostname, port) from gp_segment_configuration where role='p' and content=0;
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+11: SELECT gp_wait_until_triggered_fault('end_prepare_two_phase', 1, dbid) from gp_segment_configuration where role='p' and content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 11: SELECT pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 0;
  pg_ctl                                                                                               
@@ -247,10 +247,10 @@ DETAIL:
  transaction | gid | prepared | owner | database 
 -------------+-----+----------+-------+----------
 (0 rows)
-13: SELECT gp_inject_fault2('fts_probe', 'reset', dbid, hostname, port) from gp_segment_configuration where role='p' and content=-1;
- gp_inject_fault2 
-------------------
- Success:         
+13: SELECT gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 13: alter system reset dtx_phase2_retry_count;
 ALTER

--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -19,13 +19,13 @@ CREATE
 1:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 -- checkpoint suspend before scanning proc array
 1:select gp_inject_fault_infinite('checkpoint_dtx_info', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 1&:CHECKPOINT;  <waiting ...>
 
@@ -33,7 +33,7 @@ CREATE
 2:select gp_wait_until_triggered_fault('checkpoint_dtx_info', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 -- the 'COMMIT' record is logically after REDO pointer
 2&:insert into crash_test_redundant values (1);  <waiting ...>
@@ -42,7 +42,7 @@ CREATE
 3:select gp_inject_fault('checkpoint_dtx_info', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1<:  <... completed>
 CHECKPOINT
@@ -51,13 +51,13 @@ CHECKPOINT
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 -- trigger crash
 1:select gp_inject_fault('before_read_command', 'panic', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 -- start_ignore
 -- We ignore the output here because PANIC output is intermittent and is

--- a/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
+++ b/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
@@ -41,12 +41,12 @@ CREATE
 select gp_inject_fault('transaction_start_under_entry_db_singleton', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 select gp_inject_fault_infinite('transaction_start_under_entry_db_singleton', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 
 -- The QD should already hold RowExclusiveLock and ExclusiveLock on
@@ -56,9 +56,10 @@ select gp_inject_fault_infinite('transaction_start_under_entry_db_singleton', 's
 
 -- verify the fault hit
 select gp_inject_fault('transaction_start_under_entry_db_singleton', 'status', 1);
- gp_inject_fault 
------------------
- t               
+ gp_inject_fault                                                                                                                                                                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'transaction_start_under_entry_db_singleton' fault type:'suspend' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1' 
+ 
 (1 row)
 
 -- This session will wait for ExclusiveLock on
@@ -74,12 +75,12 @@ select gp_inject_fault('transaction_start_under_entry_db_singleton', 'status', 1
 select gp_inject_fault('transaction_start_under_entry_db_singleton', 'resume', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 select gp_inject_fault('transaction_start_under_entry_db_singleton', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- verify the deadlock across multiple pids with same mpp session id

--- a/src/test/isolation2/expected/distributed_snapshot.out
+++ b/src/test/isolation2/expected/distributed_snapshot.out
@@ -37,13 +37,13 @@ INSERT 1
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend', '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 3&:@db_name postgres: SELECT count(*) > 0 from gp_dist_random('gp_id');  <waiting ...>
 1: SELECT gp_wait_until_triggered_fault('distributedlog_advance_oldest_xmin', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 2: COMMIT;
 COMMIT
@@ -55,7 +55,7 @@ INSERT 1
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 3<:  <... completed>
  ?column? 

--- a/src/test/isolation2/expected/fts_dns_error.out
+++ b/src/test/isolation2/expected/fts_dns_error.out
@@ -59,7 +59,7 @@ select gp_request_fts_probe_scan();
 select gp_inject_fault_infinite('get_dns_cached_address', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 select gp_request_fts_probe_scan();
  gp_request_fts_probe_scan 
@@ -69,7 +69,7 @@ select gp_request_fts_probe_scan();
 select gp_inject_fault_infinite('get_dns_cached_address', 'reset', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 
 -- verify a fts failover happens

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -100,7 +100,7 @@ server stopped
 select gp_inject_fault_infinite('get_dns_cached_address', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 
 -- trigger failover
@@ -129,7 +129,7 @@ select gp_request_fts_probe_scan();
 select gp_inject_fault('get_dns_cached_address', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- session 1: in no transaction and no temp table created, it's safe to

--- a/src/test/isolation2/expected/gdd/avoid-qd-deadlock.out
+++ b/src/test/isolation2/expected/gdd/avoid-qd-deadlock.out
@@ -16,12 +16,12 @@ INSERT 10
 SELECT gp_inject_fault('upgrade_row_lock', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 SELECT gp_inject_fault('upgrade_row_lock', 'sleep', '', '', '', 1, -1, 10, 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 3&: SELECT * FROM func1(1);  <waiting ...>
@@ -42,5 +42,5 @@ SELECT gp_inject_fault('upgrade_row_lock', 'sleep', '', '', '', 1, -1, 10, 1);
 SELECT gp_inject_fault('upgrade_row_lock', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)

--- a/src/test/isolation2/expected/gdd/planner_insert_while_vacuum_drop.out
+++ b/src/test/isolation2/expected/gdd/planner_insert_while_vacuum_drop.out
@@ -5,17 +5,17 @@
 -- partition so it keeps waiting and the deadlock is not observed.
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
- gp_inject_fault2 
-------------------
- Success:         
- Success:         
- Success:         
- Success:         
- Success:         
- Success:         
- Success:         
- Success:         
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
 (8 rows)
 
 -- Helper function
@@ -39,17 +39,17 @@ show gp_enable_global_deadlock_detector;
 (1 row)
 
 -- VACUUM drop phase is blocked before it opens the child relation on the primary
-SELECT gp_inject_fault2('vacuum_relation_open_relation_during_drop_phase', 'suspend', dbid, hostname, port) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_inject_fault2 
-------------------
- Success:         
+SELECT gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 -- VACUUM takes AccessExclusiveLock on the leaf partition on QD
 1&: VACUUM ao_part_tbl;  <waiting ...>
-SELECT gp_wait_until_triggered_fault2('vacuum_relation_open_relation_during_drop_phase', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+SELECT gp_wait_until_triggered_fault('vacuum_relation_open_relation_during_drop_phase', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
 -- And INSERT is blocked until it acquires the RowExclusiveLock on the child relation
@@ -64,10 +64,10 @@ SELECT wait_until_acquired_lock_on_rel('ao_part_tbl_1_prt_1', 'RowExclusiveLock'
 (1 row)
 
 -- Reset the fault on VACUUM.
-SELECT gp_inject_fault2('vacuum_relation_open_relation_during_drop_phase', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_inject_fault2 
-------------------
- Success:         
+SELECT gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 -- VACUUM waits for AccessExclusiveLock on the leaf table on QE
 1<:  <... completed>

--- a/src/test/isolation2/expected/pg_terminate_backend.out
+++ b/src/test/isolation2/expected/pg_terminate_backend.out
@@ -5,7 +5,7 @@ CREATE
 select gp_inject_fault('heap_insert', 'infinite_loop', '', '', 'terminate_backend_t', 1, 1, 0, dbid) from gp_segment_configuration where content = 1 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- expect this command to be terminated by 'test pg_terminate_backend'
@@ -14,7 +14,7 @@ select gp_inject_fault('heap_insert', 'infinite_loop', '', '', 'terminate_backen
 select gp_wait_until_triggered_fault('heap_insert', 1, dbid) from gp_segment_configuration where content = 1 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- extract the pid for the previous query
@@ -35,7 +35,7 @@ server closed the connection unexpectedly
 select gp_inject_fault('heap_insert', 'reset', dbid) from gp_segment_configuration where content = 1 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- the table should be empty if insert was terminated

--- a/src/test/isolation2/expected/pg_terminate_backend.out
+++ b/src/test/isolation2/expected/pg_terminate_backend.out
@@ -1,11 +1,24 @@
-create table foo as select i a, i b from generate_series(1, 10) i;
-CREATE 10
+1:create table terminate_backend_t (a int) distributed by (a);
+CREATE
 
--- expect this query terminated by 'test pg_terminate_backend'
-1&:create temp table t as select count(*) from foo where pg_sleep(20) is null;  <waiting ...>
+-- fault on seg1 to block insert command into terminate_backend_t table
+select gp_inject_fault('heap_insert', 'infinite_loop', '', '', 'terminate_backend_t', 1, 1, 0, dbid) from gp_segment_configuration where content = 1 and role = 'p';
+ gp_inject_fault 
+-----------------
+ t               
+(1 row)
+
+-- expect this command to be terminated by 'test pg_terminate_backend'
+1&: insert into terminate_backend_t values (1);  <waiting ...>
+
+select gp_wait_until_triggered_fault('heap_insert', 1, dbid) from gp_segment_configuration where content = 1 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ t                             
+(1 row)
 
 -- extract the pid for the previous query
-SELECT pg_terminate_backend(pid,'test pg_terminate_backend') FROM pg_stat_activity WHERE query like 'create temp table t as select%' ORDER BY pid LIMIT 1;
+SELECT pg_terminate_backend(pid,'test pg_terminate_backend') FROM pg_stat_activity WHERE query like 'insert into terminate_backend_t%' ORDER BY pid LIMIT 1;
  pg_terminate_backend 
 ----------------------
  t                    
@@ -19,8 +32,14 @@ server closed the connection unexpectedly
 	before or while processing the request.
 
 -- query backend to ensure no PANIC on postmaster
-select count(*) from foo;
- count 
--------
- 10    
+select gp_inject_fault('heap_insert', 'reset', dbid) from gp_segment_configuration where content = 1 and role = 'p';
+ gp_inject_fault 
+-----------------
+ t               
 (1 row)
+
+-- the table should be empty if insert was terminated
+select * from terminate_backend_t;
+ a 
+---
+(0 rows)

--- a/src/test/isolation2/expected/reindex.out
+++ b/src/test/isolation2/expected/reindex.out
@@ -7,7 +7,7 @@ CREATE
 SELECT gp_inject_fault_infinite('reindex_db', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 1:@db_name reindexdb1: CREATE TABLE heap1(a INT, b INT);
 CREATE
@@ -15,14 +15,14 @@ CREATE
 SELECT gp_wait_until_triggered_fault('reindex_db', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 2:@db_name reindexdb1:DROP TABLE heap1;
 DROP
 SELECT gp_inject_fault('reindex_db', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 -- reindex should complete fine
 1<:  <... completed>
@@ -45,13 +45,13 @@ COMMIT
 SELECT gp_inject_fault_infinite('reindex_relation', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 3&: REINDEX TABLE reindex_index1;  <waiting ...>
 SELECT gp_wait_until_triggered_fault('reindex_relation', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 -- create one more index
 CREATE INDEX reindex_index1_idx2 on reindex_index1 (a);
@@ -59,7 +59,7 @@ CREATE
 SELECT gp_inject_fault('reindex_relation', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 3<:  <... completed>
 REINDEX

--- a/src/test/isolation2/expected/reindex_gpfastsequence.out
+++ b/src/test/isolation2/expected/reindex_gpfastsequence.out
@@ -13,7 +13,7 @@ CREATE
 select gp_inject_fault_infinite('reindex_relation', 'suspend', 2);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 
 -- The reindex_relation fault should be hit
@@ -21,7 +21,7 @@ select gp_inject_fault_infinite('reindex_relation', 'suspend', 2);
 2: select gp_wait_until_triggered_fault('reindex_relation', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 -- The insert should for reindex in session 1
 2&: insert into test_fastseqence select i , 'aa'||i from generate_series(1,100) i;  <waiting ...>
@@ -29,7 +29,7 @@ select gp_inject_fault_infinite('reindex_relation', 'suspend', 2);
 select gp_inject_fault('reindex_relation', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 1<:  <... completed>

--- a/src/test/isolation2/expected/resgroup/resgroup_assign_slot_fail.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_assign_slot_fail.out
@@ -24,12 +24,12 @@ SET
 SELECT gp_inject_fault('resgroup_assigned_on_master', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 SELECT gp_inject_fault('resgroup_assigned_on_master', 'error', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 -- end_ignore
 2: BEGIN;

--- a/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
+++ b/src/test/isolation2/expected/segwalrep/cancel_commit_pending_replication.out
@@ -4,12 +4,12 @@ CREATE
 select gp_inject_fault('sync_rep_query_cancel', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 select gp_inject_fault('wal_sender_loop', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 create or replace function wait_for_replication(iterations int) returns bool as $$ begin /* in func */ for i in 1 .. iterations loop /* in func */ if exists (select waiting_reason from pg_stat_activity where sess_id in (select sess_id from store_session_id) and waiting_reason = 'replication') then /* in func */ return true; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ end loop; /* in func */ return false; /* in func */ end; /* in func */ $$ language plpgsql VOLATILE;
@@ -37,7 +37,7 @@ INSERT 1
 select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', 2);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 -- Expect: `create table` should be blocked until reset
 -- `wal_sender_loop`. We also verify the `sync_rep_query_cancel` is
@@ -46,19 +46,19 @@ select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', 
 select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 -- now pause the wal sender on primary for content 0
 select gp_inject_fault_infinite('wal_sender_loop', 'suspend', 2);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 -- let the transaction move forward with the commit
 select gp_inject_fault('finish_prepared_start_of_function', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 -- loop to reach waiting_reason=replication
 0U: select wait_for_replication(200);
@@ -70,7 +70,7 @@ select gp_inject_fault('finish_prepared_start_of_function', 'reset', 2);
 select gp_inject_fault_infinite('sync_rep_query_cancel', 'skip', 2);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 0U: select pg_cancel_backend(pid) from pg_stat_activity where waiting_reason='replication' and sess_id in (select sess_id from store_session_id);
  pg_cancel_backend 
@@ -81,7 +81,7 @@ select gp_inject_fault_infinite('sync_rep_query_cancel', 'skip', 2);
 select gp_wait_until_triggered_fault('sync_rep_query_cancel', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 -- EXPECT: the query is still in waiting mode, to verify the cancel is ignored.
 0U: select waiting_reason from pg_stat_activity where sess_id in (select sess_id from store_session_id);
@@ -93,7 +93,7 @@ select gp_wait_until_triggered_fault('sync_rep_query_cancel', 1, 2);
 select gp_inject_fault('wal_sender_loop', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1<:  <... completed>
 CREATE
@@ -101,5 +101,5 @@ CREATE
 select gp_inject_fault('sync_rep_query_cancel', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -36,12 +36,12 @@ CREATE
 select gp_inject_fault('fts_probe', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 select gp_inject_fault_infinite('fts_probe', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 -- force scan to trigger the fault
 select gp_request_fts_probe_scan();
@@ -53,7 +53,7 @@ select gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- stop a mirror and show commit on dbid 2 will block
@@ -121,7 +121,7 @@ COMMIT
 select gp_inject_fault('fts_probe', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- everything should be back to normal

--- a/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
@@ -15,10 +15,10 @@ select application_name, state, sync_state from pg_stat_replication;
 (1 row)
 
 -- Inject fault on standby to skip WAL flush.
-select gp_inject_fault_infinite2('walrecv_skip_flush', 'skip', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='m';
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segment_configuration where content=-1 and role='m';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
 
 begin;
@@ -30,10 +30,10 @@ CREATE
 checkpoint;
 CHECKPOINT
 
-select gp_wait_until_triggered_fault2('walrecv_skip_flush', 1, dbid, hostname, port) from gp_segment_configuration where content=-1 and role='m';
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+select gp_wait_until_triggered_fault('walrecv_skip_flush', 1, dbid) from gp_segment_configuration where content=-1 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
 -- Should block in commit (SyncrepWaitForLSN()), waiting for commit
@@ -53,10 +53,10 @@ select datname, waiting_reason, query from pg_stat_activity where waiting_reason
  isolation2test | replication    | create table commit_blocking_on_standby_t1 (a int) distributed by (a); 
 (1 row)
 
-select gp_inject_fault2('walrecv_skip_flush', 'reset', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='m';
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('walrecv_skip_flush', 'reset', dbid) from gp_segment_configuration where content=-1 and role='m';
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 -- Ensure that commits are no longer blocked.
@@ -84,17 +84,17 @@ INSERT 1
 
 -- Suspend WAL sender in main loop.  "infinite_loop" fault type does
 -- not block signals.
-select gp_inject_fault_infinite2('wal_sender_loop', 'infinite_loop', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+select gp_inject_fault_infinite('wal_sender_loop', 'infinite_loop', dbid) from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
 
 -- Inject fault on standby to skip WAL flush.
-select gp_inject_fault_infinite2('walrecv_skip_flush', 'skip', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='m';
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segment_configuration where content=-1 and role='m';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
 
 -- Kill existing walsender.  WAL sender and WAL receiver processes
@@ -130,10 +130,10 @@ select wait_until_standby_in_state('catchup');
                              
 (1 row)
 
-select gp_wait_until_triggered_fault2('wal_sender_loop', 1, dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+select gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid) from gp_segment_configuration where content=-1 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
 -- WAL sender should be stuck in CATCHUP state.
@@ -149,25 +149,25 @@ select application_name, state, sync_state from pg_stat_replication;
 commit;
 COMMIT
 
-select gp_inject_fault2('wal_sender_after_caughtup_within_range', 'suspend', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('wal_sender_after_caughtup_within_range', 'suspend', dbid) from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
-select gp_inject_fault2('wal_sender_loop', 'reset', dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('wal_sender_loop', 'reset', dbid) from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 -- Once this fault is triggered, WAL sender should have set
 -- caughtup_within_range to true because difference between
 -- sent_location and flush_location is within 1 WAL segment (64) MB.
-select gp_wait_until_triggered_fault2( 'wal_sender_after_caughtup_within_range', 1, dbid, hostname, port) from gp_segment_configuration where content=-1 and role='p';
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+select gp_wait_until_triggered_fault( 'wal_sender_after_caughtup_within_range', 1, dbid) from gp_segment_configuration where content=-1 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
 -- Should block because standby is considered to have caughtup within
@@ -187,11 +187,11 @@ select datname, waiting_reason, query from pg_stat_activity where waiting_reason
 (1 row)
 
 -- Reset faults on primary as well as mirror.
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where content=-1;
- gp_inject_fault2 
-------------------
- Success:         
- Success:         
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
 (2 rows)
 
 1<:  <... completed>

--- a/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
@@ -21,7 +21,7 @@ select application_name, state, sync_state from pg_stat_replication;
 select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', dbid) from gp_segment_configuration where content = -1 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 1&: create table committed_by_standby(a int, b int);  <waiting ...>
@@ -29,7 +29,7 @@ select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', dbid) from gp
 select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 1, dbid) from gp_segment_configuration where content = -1 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- Scenario2: standby broadcasts abort-prepared for a transaction that
@@ -40,12 +40,12 @@ select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 1, dbid) f
 select gp_inject_fault('transaction_abort_after_distributed_prepared', 'error', dbid) from gp_segment_configuration where content = -1 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 select gp_inject_fault('transaction_abort_failure', 'suspend', dbid) from gp_segment_configuration where content = -1 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 2&: create table aborted_by_standby(a int, b int);  <waiting ...>
@@ -53,7 +53,7 @@ select gp_inject_fault('transaction_abort_failure', 'suspend', dbid) from gp_seg
 select gp_wait_until_triggered_fault('transaction_abort_failure', 1, dbid) from gp_segment_configuration where content = -1 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- Promote standby
@@ -89,7 +89,7 @@ LINE 1: select count(*) from aborted_by_standby;
 select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = -1 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1<:  <... completed>
 CREATE

--- a/src/test/isolation2/expected/segwalrep/failover_with_many_records.out
+++ b/src/test/isolation2/expected/segwalrep/failover_with_many_records.out
@@ -26,7 +26,7 @@ CREATE
 1:SELECT gp_inject_fault_infinite('checkpoint_after_redo_calculated', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 2&:CHECKPOINT;  <waiting ...>
 3:INSERT INTO t VALUES (1, 0);
@@ -42,7 +42,7 @@ INSERT 25
 1:SELECT gp_inject_fault_infinite('checkpoint_after_redo_calculated', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 2<:  <... completed>
 CHECKPOINT

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -50,12 +50,12 @@ CREATE
 select gp_inject_fault('fts_probe', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 select gp_inject_fault_infinite('fts_probe', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 -- force scan to trigger the fault
 select gp_request_fts_probe_scan();
@@ -67,7 +67,7 @@ select gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- stop a mirror
@@ -94,7 +94,7 @@ INSERT 1
 select gp_inject_fault('fts_probe', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- trigger fts probe and check to see primary marked n/u and mirror still n/u as
@@ -155,7 +155,7 @@ COMMIT
 select gp_inject_fault_infinite('initialize_wal_sender', 'suspend', dbid) from gp_segment_configuration where role='p' and content=2;
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 
 -- bring the mirror back up and see primary s/u and mirror s/u
@@ -168,7 +168,7 @@ select gp_inject_fault_infinite('initialize_wal_sender', 'suspend', dbid) from g
 select gp_wait_until_triggered_fault('initialize_wal_sender', 1, dbid) from gp_segment_configuration where role='p' and content=2;
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 -- make sure the walsender on primary is in startup
 select state from gp_stat_replication where gp_segment_id=2;
@@ -193,7 +193,7 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
 select gp_inject_fault('initialize_wal_sender', 'reset', dbid) from gp_segment_configuration where role='p' and content=2;
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 select wait_for_streaming(2::smallint);
  wait_for_streaming 

--- a/src/test/isolation2/expected/segwalrep/master_xlog_switch.out
+++ b/src/test/isolation2/expected/segwalrep/master_xlog_switch.out
@@ -8,7 +8,7 @@ CREATE
 SELECT gp_inject_fault('base_backup_post_create_checkpoint', 'suspend', dbid) FROM gp_segment_configuration WHERE content=-1 and role='p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- Run pg_basebackup which should trigger and suspend at the fault
@@ -18,7 +18,7 @@ SELECT gp_inject_fault('base_backup_post_create_checkpoint', 'suspend', dbid) FR
 SELECT gp_wait_until_triggered_fault('base_backup_post_create_checkpoint', 1, dbid) FROM gp_segment_configuration WHERE content=-1 and role='p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- See that pg_basebackup is still running
@@ -54,7 +54,7 @@ CHECKPOINT
 SELECT gp_inject_fault('base_backup_post_create_checkpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=-1 and role='p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- Wait until basebackup finishes

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -106,7 +106,7 @@ select dbid from gp_segment_configuration where content = 0 and role = 'p';
 select gp_inject_fault_infinite('fts_handle_message', 'infinite_loop', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 
 -- trigger failover

--- a/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
@@ -63,18 +63,18 @@ SET
 1:SELECT gp_inject_fault_infinite('start_prepare', 'infinite_loop', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 1&:CREATE TABLE tolerance_test_table(an_int int);  <waiting ...>
 2:SELECT gp_wait_until_triggered_fault('start_prepare', 1, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 2:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 -- do fts probe request twice to guarantee the fault is triggered
 2:SELECT gp_request_fts_probe_scan();
@@ -93,12 +93,12 @@ ERROR:  FTS detected connection lost during dispatch to seg0 127.0.0.1:25432 pid
 1:SELECT gp_inject_fault('start_prepare', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1:SELECT gp_inject_fault('fts_handle_message', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1:SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 0;
  role | preferred_role 
@@ -117,18 +117,18 @@ LINE 1: INSERT INTO tolerance_test_table VALUES(42);
 1:SELECT gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 1&:CREATE TABLE tolerance_test_table(an_int int);  <waiting ...>
 3:SELECT gp_wait_until_triggered_fault('transaction_abort_after_distributed_prepared', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 3:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 -- do fts probe request twice to guarantee the fault is triggered
 3:SELECT gp_request_fts_probe_scan();
@@ -144,7 +144,7 @@ LINE 1: INSERT INTO tolerance_test_table VALUES(42);
 3:SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'resume', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1<:  <... completed>
 CREATE
@@ -152,12 +152,12 @@ CREATE
 1:SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1:SELECT gp_inject_fault('fts_handle_message', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1:SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 1;
  role | preferred_role 
@@ -173,18 +173,18 @@ INSERT 1
 1:SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'infinite_loop', dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 1&:DROP TABLE tolerance_test_table;  <waiting ...>
 4:SELECT gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 4:SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 -- do fts probe request twice to guarantee the fault is triggered
 4:SELECT gp_request_fts_probe_scan();

--- a/src/test/isolation2/expected/terminate_in_gang_creation.out
+++ b/src/test/isolation2/expected/terminate_in_gang_creation.out
@@ -31,12 +31,12 @@ BEGIN
 SELECT gp_inject_fault('create_gang_in_progress', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 SELECT gp_inject_fault('create_gang_in_progress', 'suspend', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 10&: SELECT * FROM foo a JOIN foo b USING (c2);  <waiting ...>
@@ -44,7 +44,7 @@ SELECT gp_inject_fault('create_gang_in_progress', 'suspend', 1);
 SELECT gp_wait_until_triggered_fault('create_gang_in_progress', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT * FROM foo a JOIN foo b USING (c2);';
@@ -56,7 +56,7 @@ SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT * F
 SELECT gp_inject_fault('create_gang_in_progress', 'resume', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 10<:  <... completed>

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -75,18 +75,18 @@ UPDATE 10
 3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 2&:VACUUM crash_before_segmentfile_drop;  <waiting ...>
 3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 1, -1, 0, 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- VACUUM on crash_before_cleanup_phase will end up skipping the drop
@@ -97,7 +97,7 @@ UPDATE 10
 3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 1, -1, 0, 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 3:BEGIN;
 BEGIN
@@ -110,7 +110,7 @@ BEGIN
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 3:END;
 END
@@ -143,17 +143,17 @@ DETAIL:
 1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1:SELECT gp_inject_fault('appendonly_insert', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- perform post crash validation checks
@@ -381,13 +381,13 @@ DELETE 3
 2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1&:VACUUM crash_master_before_cleanup_phase;  <waiting ...>
 SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- wait for suspend faults to trigger and then proceed to run next
@@ -396,7 +396,7 @@ SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 2:VACUUM crash_master_before_segmentfile_drop;
 PANIC:  fault triggered, fault name:'compaction_before_segmentfile_drop' fault type:'panic'
@@ -412,12 +412,12 @@ server closed the connection unexpectedly
 4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- perform post crash validation checks
@@ -572,7 +572,7 @@ UPDATE 1
 4:SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 4:SELECT gp_request_fts_probe_scan();
  gp_request_fts_probe_scan 
@@ -582,7 +582,7 @@ UPDATE 1
 4:SELECT gp_wait_until_triggered_fault('fts_probe', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 4:SET gp_default_storage_options="appendonly=true,orientation=column";
 SET
@@ -601,7 +601,7 @@ UPDATE 10
 4:SELECT gp_inject_fault('xlog_ao_insert', 'infinite_loop', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 -- This will cause file to be created on primary for segno 2 but crash
 -- just before creating the xlog record. Hence, primary will have the
@@ -610,7 +610,7 @@ UPDATE 10
 5:SELECT gp_wait_until_triggered_fault('xlog_ao_insert', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 -- to make sure xlog gets flushed till this point to persist the
 -- changes to pg_aocsseg.
@@ -658,5 +658,5 @@ VACUUM
 6:SELECT gp_inject_fault('fts_probe', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -70,25 +70,25 @@ UPDATE 10
 3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 1, -1, 0, 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1&:VACUUM crash_before_cleanup_phase;  <waiting ...>
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 2&:VACUUM crash_before_segmentfile_drop;  <waiting ...>
 3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- we already waited for suspend faults to trigger and hence we can proceed to
@@ -97,7 +97,7 @@ UPDATE 10
 3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 1, -1, 0, 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21369)
@@ -123,17 +123,17 @@ DETAIL:
 1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1:SELECT gp_inject_fault('appendonly_insert', 'reset', 2);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- perform post crash validation checks
@@ -325,13 +325,13 @@ DELETE 3
 2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1&:VACUUM crash_master_before_cleanup_phase;  <waiting ...>
 2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- wait for suspend faults to trigger and then proceed to run next
@@ -340,7 +340,7 @@ DELETE 3
 SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 2:VACUUM crash_master_before_segmentfile_drop;
 PANIC:  fault triggered, fault name:'compaction_before_segmentfile_drop' fault type:'panic'
@@ -356,12 +356,12 @@ server closed the connection unexpectedly
 4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- perform post crash validation checks

--- a/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
+++ b/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
@@ -46,7 +46,7 @@ CREATE
 SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 SELECT gp_request_fts_probe_scan();
  gp_request_fts_probe_scan 
@@ -56,7 +56,7 @@ SELECT gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 CREATE OR REPLACE FUNCTION test_excep (arg INTEGER) RETURNS INTEGER AS $$ DECLARE res INTEGER; /* in func */ BEGIN /* in func */ res := 100 / arg; /* in func */ RETURN res; /* in func */ EXCEPTION /* in func */ WHEN division_by_zero /* in func */ THEN  RETURN 999; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE
@@ -245,5 +245,5 @@ LINE 1: select * from employees;
 SELECT gp_inject_fault('fts_probe', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)

--- a/src/test/isolation2/expected/unlogged_appendonly_tables.out
+++ b/src/test/isolation2/expected/unlogged_appendonly_tables.out
@@ -12,7 +12,7 @@ CREATE
 SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 SELECT gp_request_fts_probe_scan();
  gp_request_fts_probe_scan 
@@ -27,7 +27,7 @@ SELECT gp_request_fts_probe_scan();
 SELECT gp_wait_until_triggered_fault('fts_probe', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- expect: insert/update/select works
@@ -105,5 +105,5 @@ DROP
 SELECT gp_inject_fault('fts_probe', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)

--- a/src/test/isolation2/expected/unlogged_heap_tables.out
+++ b/src/test/isolation2/expected/unlogged_heap_tables.out
@@ -12,7 +12,7 @@ CREATE
 SELECT gp_inject_fault_infinite('fts_probe', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 SELECT gp_request_fts_probe_scan();
  gp_request_fts_probe_scan 
@@ -27,7 +27,7 @@ SELECT gp_request_fts_probe_scan();
 SELECT gp_wait_until_triggered_fault('fts_probe', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- expect: insert/update/select works
@@ -85,5 +85,5 @@ DROP
 SELECT gp_inject_fault('fts_probe', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)

--- a/src/test/isolation2/input/fts_manual_probe.source
+++ b/src/test/isolation2/input/fts_manual_probe.source
@@ -22,7 +22,7 @@
 
 include: helpers/server_helpers.sql;
 
-select gp_inject_fault2('all', 'reset', 1, hostname, port) from master();
+select gp_inject_fault('all', 'reset', 1) from master();
 
 create temp table fts_probe_results(seq serial, seq_name varchar(20),
                                     current_started int, expected_start_delta int,
@@ -75,56 +75,56 @@ select insert_expected_stats('initial', 0, 0);
 select * from get_stats;
 
 -- piggyback test: start multiple probes
-select gp_inject_fault_infinite2('ftsNotify_before', 'suspend', 1, hostname, port) from master();
-select gp_inject_fault_infinite2('ftsLoop_after_latch', 'suspend', 1, hostname, port) from master();
-select gp_inject_fault_infinite2('ftsLoop_before_probe', 'suspend', 1, hostname, port) from master();
+select gp_inject_fault_infinite('ftsNotify_before', 'suspend', 1) from master();
+select gp_inject_fault_infinite('ftsLoop_after_latch', 'suspend', 1) from master();
+select gp_inject_fault_infinite('ftsLoop_before_probe', 'suspend', 1) from master();
 
 1&: select gp_request_fts_probe_scan();
 2&: select gp_request_fts_probe_scan();
 3&: select gp_request_fts_probe_scan();
 
 -- piggyback: ensure the probe requests are at a known starting location
-select gp_wait_until_triggered_fault2('ftsNotify_before', 3, 1, hostname, port) from master();
+select gp_wait_until_triggered_fault('ftsNotify_before', 3, 1) from master();
 
 -- piggyback: ensure the ftsLoop is triggered only once
-select gp_wait_until_triggered_fault2('ftsLoop_after_latch', 1, 1, hostname, port) from master();
-select gp_inject_fault2('ftsLoop_after_latch', 'resume', 1, hostname, port) from master();
+select gp_wait_until_triggered_fault('ftsLoop_after_latch', 1, 1) from master();
+select gp_inject_fault('ftsLoop_after_latch', 'resume', 1) from master();
 
 -- piggyback: ensure the ftsLoop is at a known starting location
-select gp_wait_until_triggered_fault2('ftsLoop_before_probe', 1, 1, hostname, port) from master();
+select gp_wait_until_triggered_fault('ftsLoop_before_probe', 1, 1) from master();
 select insert_expected_stats('top_of_ftsLoop', 0, 0);
 select * from get_stats;
-select gp_inject_fault2('ftsNotify_before', 'resume', 1, hostname, port) from master();
+select gp_inject_fault('ftsNotify_before', 'resume', 1) from master();
 
 -- piggyback: trap the probe requests inside the ftsLoop
-select gp_inject_fault_infinite2('ftsLoop_after_probe', 'suspend', 1, hostname, port) from master();
-select gp_inject_fault2('ftsLoop_before_probe', 'resume', 1, hostname, port) from master();
-select gp_wait_until_triggered_fault2('ftsLoop_after_probe', 1, 1, hostname, port) from master();
+select gp_inject_fault_infinite('ftsLoop_after_probe', 'suspend', 1) from master();
+select gp_inject_fault('ftsLoop_before_probe', 'resume', 1) from master();
+select gp_wait_until_triggered_fault('ftsLoop_after_probe', 1, 1) from master();
 
 select insert_expected_stats('bottom_of_ftsLoop', 1, 0);
 select * from get_stats;
 
 -- fresh result test: issue a new probe request during the in progress piggyback ftsLoop
-select gp_inject_fault2('ftsLoop_before_probe', 'reset', 1, hostname, port) from master();
-select gp_inject_fault_infinite2('ftsLoop_before_probe', 'suspend', 1, hostname, port) from master();
+select gp_inject_fault('ftsLoop_before_probe', 'reset', 1) from master();
+select gp_inject_fault_infinite('ftsLoop_before_probe', 'suspend', 1) from master();
 4&: select gp_request_fts_probe_scan();
 
 -- piggyback: resume the suspended piggyback ftsLoop
-select gp_inject_fault2('ftsLoop_after_probe', 'resume', 1, hostname, port) from master();
+select gp_inject_fault('ftsLoop_after_probe', 'resume', 1) from master();
 
 1<:
 2<:
 3<:
 
 -- fresh result: ensure the next ftsLoop iteration is at a known starting location
-select gp_wait_until_triggered_fault2('ftsLoop_before_probe', 1, 1, hostname, port) from master();
+select gp_wait_until_triggered_fault('ftsLoop_before_probe', 1, 1) from master();
 
 -- piggyback: query the probe stats before the start of the 'fresh result' ftsLoop
 select insert_expected_stats('piggyback_result', 1, 1);
 select * from get_stats;
 
 -- fresh result: resume the suspended ftsLoop
-select gp_inject_fault2('ftsLoop_before_probe', 'resume', 1, hostname, port) from master();
+select gp_inject_fault('ftsLoop_before_probe', 'resume', 1) from master();
 
 4<:
 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -35,7 +35,12 @@ test: gdd/dml_locks_only_targeted_table_in_query
 # gdd end
 test: gdd/end
 
-test: pg_terminate_backend deadlock_under_entry_db_singleton starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc
+# The following test injects a fault at a generic location
+# (StartTransaction).  The fault can be easily triggered by a
+# concurrent test, so run the test by itself.
+test: deadlock_under_entry_db_singleton
+
+test: pg_terminate_backend starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/output/fts_manual_probe.source
+++ b/src/test/isolation2/output/fts_manual_probe.source
@@ -23,10 +23,10 @@
 include: helpers/server_helpers.sql;
 CREATE
 
-select gp_inject_fault2('all', 'reset', 1, hostname, port) from master();
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('all', 'reset', 1) from master();
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 create temp table fts_probe_results(seq serial, seq_name varchar(20), current_started int, expected_start_delta int, current_done int, expected_done_delta int);
@@ -84,20 +84,20 @@ select * from get_stats;
 (1 row)
 
 -- piggyback test: start multiple probes
-select gp_inject_fault_infinite2('ftsNotify_before', 'suspend', 1, hostname, port) from master();
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+select gp_inject_fault_infinite('ftsNotify_before', 'suspend', 1) from master();
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
-select gp_inject_fault_infinite2('ftsLoop_after_latch', 'suspend', 1, hostname, port) from master();
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+select gp_inject_fault_infinite('ftsLoop_after_latch', 'suspend', 1) from master();
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
-select gp_inject_fault_infinite2('ftsLoop_before_probe', 'suspend', 1, hostname, port) from master();
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+select gp_inject_fault_infinite('ftsLoop_before_probe', 'suspend', 1) from master();
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
 
 1&: select gp_request_fts_probe_scan();  <waiting ...>
@@ -105,29 +105,29 @@ select gp_inject_fault_infinite2('ftsLoop_before_probe', 'suspend', 1, hostname,
 3&: select gp_request_fts_probe_scan();  <waiting ...>
 
 -- piggyback: ensure the probe requests are at a known starting location
-select gp_wait_until_triggered_fault2('ftsNotify_before', 3, 1, hostname, port) from master();
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+select gp_wait_until_triggered_fault('ftsNotify_before', 3, 1) from master();
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
 -- piggyback: ensure the ftsLoop is triggered only once
-select gp_wait_until_triggered_fault2('ftsLoop_after_latch', 1, 1, hostname, port) from master();
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+select gp_wait_until_triggered_fault('ftsLoop_after_latch', 1, 1) from master();
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
-select gp_inject_fault2('ftsLoop_after_latch', 'resume', 1, hostname, port) from master();
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('ftsLoop_after_latch', 'resume', 1) from master();
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 -- piggyback: ensure the ftsLoop is at a known starting location
-select gp_wait_until_triggered_fault2('ftsLoop_before_probe', 1, 1, hostname, port) from master();
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+select gp_wait_until_triggered_fault('ftsLoop_before_probe', 1, 1) from master();
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 select insert_expected_stats('top_of_ftsLoop', 0, 0);
  insert_expected_stats 
@@ -139,27 +139,27 @@ select * from get_stats;
 -----+----------------+----------------------+--------------------+---------------------+-------------------
  2   | top_of_ftsLoop | 0                    | 0                  | 0                   | 0                 
 (1 row)
-select gp_inject_fault2('ftsNotify_before', 'resume', 1, hostname, port) from master();
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('ftsNotify_before', 'resume', 1) from master();
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 -- piggyback: trap the probe requests inside the ftsLoop
-select gp_inject_fault_infinite2('ftsLoop_after_probe', 'suspend', 1, hostname, port) from master();
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+select gp_inject_fault_infinite('ftsLoop_after_probe', 'suspend', 1) from master();
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
-select gp_inject_fault2('ftsLoop_before_probe', 'resume', 1, hostname, port) from master();
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('ftsLoop_before_probe', 'resume', 1) from master();
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
-select gp_wait_until_triggered_fault2('ftsLoop_after_probe', 1, 1, hostname, port) from master();
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+select gp_wait_until_triggered_fault('ftsLoop_after_probe', 1, 1) from master();
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
 select insert_expected_stats('bottom_of_ftsLoop', 1, 0);
@@ -174,23 +174,23 @@ select * from get_stats;
 (1 row)
 
 -- fresh result test: issue a new probe request during the in progress piggyback ftsLoop
-select gp_inject_fault2('ftsLoop_before_probe', 'reset', 1, hostname, port) from master();
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('ftsLoop_before_probe', 'reset', 1) from master();
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
-select gp_inject_fault_infinite2('ftsLoop_before_probe', 'suspend', 1, hostname, port) from master();
- gp_inject_fault_infinite2 
----------------------------
- Success:                  
+select gp_inject_fault_infinite('ftsLoop_before_probe', 'suspend', 1) from master();
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
 4&: select gp_request_fts_probe_scan();  <waiting ...>
 
 -- piggyback: resume the suspended piggyback ftsLoop
-select gp_inject_fault2('ftsLoop_after_probe', 'resume', 1, hostname, port) from master();
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('ftsLoop_after_probe', 'resume', 1) from master();
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 1<:  <... completed>
@@ -210,10 +210,10 @@ select gp_inject_fault2('ftsLoop_after_probe', 'resume', 1, hostname, port) from
 (1 row)
 
 -- fresh result: ensure the next ftsLoop iteration is at a known starting location
-select gp_wait_until_triggered_fault2('ftsLoop_before_probe', 1, 1, hostname, port) from master();
- gp_wait_until_triggered_fault2 
---------------------------------
- Success:                       
+select gp_wait_until_triggered_fault('ftsLoop_before_probe', 1, 1) from master();
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
 -- piggyback: query the probe stats before the start of the 'fresh result' ftsLoop
@@ -229,10 +229,10 @@ select * from get_stats;
 (1 row)
 
 -- fresh result: resume the suspended ftsLoop
-select gp_inject_fault2('ftsLoop_before_probe', 'resume', 1, hostname, port) from master();
- gp_inject_fault2 
-------------------
- Success:         
+select gp_inject_fault('ftsLoop_before_probe', 'resume', 1) from master();
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 4<:  <... completed>

--- a/src/test/isolation2/output/gp_collation.source
+++ b/src/test/isolation2/output/gp_collation.source
@@ -12,7 +12,7 @@ CREATE
 SELECT gp_inject_fault('collate_locale_os_lookup', 'error', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- The fault injector should prevent all collations from being created by
@@ -33,7 +33,7 @@ select count(*) from pg_collation where collnamespace = (select oid from pg_name
 SELECT gp_inject_fault('collate_locale_os_lookup', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 --
@@ -159,7 +159,7 @@ DROP
 SELECT gp_inject_fault('collate_locale_os_lookup', 'error', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 select gp_segment_id, collname from gp_dist_random('pg_collation') where oid=(select oid from pg_collation where collname='locale_missing_on_one_segment');
@@ -182,7 +182,7 @@ select gp_segment_id, collname from gp_dist_random('pg_collation') where collnam
 SELECT gp_inject_fault('collate_locale_os_lookup', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 
@@ -221,7 +221,7 @@ INSERT 2
 SELECT gp_inject_fault('collate_locale_os_lookup', 'error', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- This should error out
@@ -231,6 +231,6 @@ ERROR:  fault triggered, fault name:'collate_locale_os_lookup' fault type:'error
 SELECT gp_inject_fault('collate_locale_os_lookup', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 

--- a/src/test/isolation2/output/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpuset.source
@@ -270,7 +270,7 @@ SELECT check_rules();
 SELECT gp_inject_fault('create_resource_group_fail', 'error', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 CREATE RESOURCE GROUP rg1_test_group WITH (memory_limit=10, cpuset='0');
 ERROR:  fault triggered, fault name:'create_resource_group_fail' fault type:'error'
@@ -286,7 +286,7 @@ SELECT check_rules();
 SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 REVOKE ALL ON busy FROM role1_cpuset_test;

--- a/src/test/isolation2/output/uao/insert_should_not_use_awaiting_drop.source
+++ b/src/test/isolation2/output/uao/insert_should_not_use_awaiting_drop.source
@@ -12,7 +12,7 @@ CREATE
 select gp_inject_fault('all', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- Given an append only table that is ready to be compacted
@@ -35,7 +35,7 @@ select gp_toolkit.__gp_remove_ao_entry_from_cache('test_table_@orientation@'::re
 select gp_inject_fault('before_creating_an_ao_hash_entry', 'suspend', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- And an insert transaction is blocked before assigning a segment
@@ -45,20 +45,20 @@ select gp_inject_fault('before_creating_an_ao_hash_entry', 'suspend', 1);
 select gp_wait_until_triggered_fault('before_creating_an_ao_hash_entry', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 2&: VACUUM test_table_@orientation@;  <waiting ...>
 
 select gp_wait_until_triggered_fault('vacuum_relation_open_relation_during_drop_phase', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- Then vacuum should have completed compaction leaving segment file 1
@@ -96,7 +96,7 @@ select gp_toolkit.__gp_remove_ao_entry_from_cache('test_table_@orientation@'::re
 select gp_inject_fault('before_creating_an_ao_hash_entry', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 1<:  <... completed>
 INSERT 1
@@ -115,7 +115,7 @@ select segno, state from gp_toolkit.__gp_get_ao_entry_from_cache('test_table_@or
 select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 2<:  <... completed>
 VACUUM

--- a/src/test/isolation2/output/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/output/uao/vacuum_cleanup.source
@@ -76,7 +76,7 @@ DELETE 100
 1: select gp_inject_fault_infinite('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
- t                        
+ Success:                 
 (1 row)
 1&: vacuum ao_@orientation@_vacuum_cleanup3;  <waiting ...>
 
@@ -97,7 +97,7 @@ BEGIN
 2: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 1);
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 1<:  <... completed>

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -46,8 +46,7 @@ $$ LANGUAGE plpgsql;
 -- after querying in-doubt prepared transactions from segments.
 1: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault_infinite2(
-   'finish_prepared_start_of_function', 'error', dbid, hostname, port)
+1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', dbid)
    from gp_segment_configuration where content=0 and role='p';
 -- Start looping in background, till master panics and closes the session
 3&: SELECT wait_till_master_shutsdown();
@@ -55,8 +54,7 @@ $$ LANGUAGE plpgsql;
 1: CREATE TABLE commit_phase1_panic(a int, b int);
 -- Reset the fault in utility mode because normal mode connection will
 -- not be accepted until DTX recovery is finished.
--1U: SELECT gp_inject_fault2(
-     'finish_prepared_start_of_function', 'reset', dbid, hostname, port)
+-1U: SELECT gp_inject_fault('finish_prepared_start_of_function', 'reset', dbid)
      from gp_segment_configuration where content=0 and role='p';
 -- Join back to know master has completed postmaster reset.
 3<:
@@ -75,16 +73,14 @@ $$ LANGUAGE plpgsql;
 -- Start looping in background, till master panics and closes the
 -- session
 5&: SELECT wait_till_master_shutsdown();
-6: SELECT gp_inject_fault2(
-   'dtm_broadcast_commit_prepared', 'fatal', dbid, hostname, port)
+6: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'fatal', dbid)
    from gp_segment_configuration where role='p' and content=-1;
 6: CREATE TABLE commit_fatal_fault_test_table(a int, b int);
 5<:
 -- Start a session on master which would complete the DTM recovery and hence COMMIT PREPARED
 7: SELECT count(*) from commit_fatal_fault_test_table;
 7: SELECT * FROM gp_dist_random('pg_prepared_xacts');
-7: SELECT gp_inject_fault2(
-   'dtm_broadcast_commit_prepared', 'reset', dbid, hostname, port)
+7: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'reset', dbid)
    from gp_segment_configuration where role='p' and content=-1;
 
 -- Scenario 3: Inject ERROR after prepare phase has completed to
@@ -98,19 +94,17 @@ $$ LANGUAGE plpgsql;
 -- Start looping in background, till master panics and closes the
 -- session
 8&: SELECT wait_till_master_shutsdown();
-9: SELECT gp_inject_fault2(
-   'transaction_abort_after_distributed_prepared', 'error', dbid, hostname, port)
+9: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'error', dbid)
    from gp_segment_configuration where role='p' and content=-1;
-9: SELECT gp_inject_fault2('dtm_broadcast_abort_prepared', 'fatal', dbid, hostname, port)
+9: SELECT gp_inject_fault('dtm_broadcast_abort_prepared', 'fatal', dbid)
    from gp_segment_configuration where role='p' and content=-1;
 9: CREATE TABLE abort_fatal_fault_test_table(a int, b int);
 8<:
 10: SELECT count(*) from abort_fatal_fault_test_table;
 10: SELECT * FROM gp_dist_random('pg_prepared_xacts');
-10: SELECT gp_inject_fault2(
-    'transaction_abort_after_distributed_prepared', 'reset', dbid, hostname, port)
+10: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'reset', dbid)
     from gp_segment_configuration where role='p' and content=-1;
-10: SELECT gp_inject_fault2('dtm_broadcast_abort_prepared', 'reset', dbid, hostname, port)
+10: SELECT gp_inject_fault('dtm_broadcast_abort_prepared', 'reset', dbid)
     from gp_segment_configuration where role='p' and content=-1;
 
 -- Scenario 4: QE panics after writing prepare xlog record. This
@@ -126,24 +120,22 @@ $$ LANGUAGE plpgsql;
 11: alter system set dtx_phase2_retry_count to 1500;
 11: select pg_reload_conf();
 -- skip FTS probes always
-11: SELECT gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port)
+11: SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid)
     from gp_segment_configuration where role='p' and content=-1;
 11: SELECT gp_request_fts_probe_scan();
-11: select gp_wait_until_triggered_fault2('fts_probe', 1, dbid, hostname, port)
+11: select gp_wait_until_triggered_fault('fts_probe', 1, dbid)
     from gp_segment_configuration where role='p' and content=-1;
-11: SELECT gp_inject_fault2(
-    'end_prepare_two_phase', 'infinite_loop', dbid, hostname, port)
+11: SELECT gp_inject_fault('end_prepare_two_phase', 'infinite_loop', dbid)
     from gp_segment_configuration where role='p' and content=0;
 -- statement to trigger fault after writing prepare record
 12&: DELETE FROM QE_panic_test_table;
-11: SELECT gp_wait_until_triggered_fault2(
-    'end_prepare_two_phase', 1, dbid, hostname, port)
+11: SELECT gp_wait_until_triggered_fault('end_prepare_two_phase', 1, dbid)
     from gp_segment_configuration where role='p' and content=0;
 11: SELECT pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 0;
 12<:
 13: SELECT count(*) from QE_panic_test_table;
 13: SELECT * FROM gp_dist_random('pg_prepared_xacts');
-13: SELECT gp_inject_fault2('fts_probe', 'reset', dbid, hostname, port)
+13: SELECT gp_inject_fault('fts_probe', 'reset', dbid)
     from gp_segment_configuration where role='p' and content=-1;
 13: alter system reset dtx_phase2_retry_count;
 13: select pg_reload_conf();

--- a/src/test/isolation2/sql/gdd/planner_insert_while_vacuum_drop.sql
+++ b/src/test/isolation2/sql/gdd/planner_insert_while_vacuum_drop.sql
@@ -4,7 +4,7 @@
 -- leaf partition but Vacuum already has AccessExclusiveLock on the leaf
 -- partition so it keeps waiting and the deadlock is not observed.
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 
 -- Helper function
 CREATE or REPLACE FUNCTION wait_until_acquired_lock_on_rel (rel_name text, lmode text, segment_id integer) RETURNS /*in func*/
@@ -39,10 +39,10 @@ DELETE FROM ao_part_tbl;
 show gp_enable_global_deadlock_detector;
 
 -- VACUUM drop phase is blocked before it opens the child relation on the primary 
-SELECT gp_inject_fault2('vacuum_relation_open_relation_during_drop_phase', 'suspend', dbid, hostname, port) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 -- VACUUM takes AccessExclusiveLock on the leaf partition on QD
 1&: VACUUM ao_part_tbl;
-SELECT gp_wait_until_triggered_fault2('vacuum_relation_open_relation_during_drop_phase', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('vacuum_relation_open_relation_during_drop_phase', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 
 -- And INSERT is blocked until it acquires the RowExclusiveLock on the child relation
 2: set optimizer to off;
@@ -51,7 +51,7 @@ SELECT gp_wait_until_triggered_fault2('vacuum_relation_open_relation_during_drop
 SELECT wait_until_acquired_lock_on_rel('ao_part_tbl_1_prt_1', 'RowExclusiveLock', content) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 
 -- Reset the fault on VACUUM. 
-SELECT gp_inject_fault2('vacuum_relation_open_relation_during_drop_phase', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 -- VACUUM waits for AccessExclusiveLock on the leaf table on QE
 1<:
 -- INSERT watis for AccessShareLock on the leaf table on QD, hence deadlock

--- a/src/test/isolation2/sql/pg_terminate_backend.sql
+++ b/src/test/isolation2/sql/pg_terminate_backend.sql
@@ -1,14 +1,28 @@
-create table foo as select i a, i b from generate_series(1, 10) i;
+1:create table terminate_backend_t (a int) distributed by (a);
 
--- expect this query terminated by 'test pg_terminate_backend'
-1&:create temp table t as select count(*) from foo where pg_sleep(20) is null;
+-- fault on seg1 to block insert command into terminate_backend_t table
+select gp_inject_fault('heap_insert', 'infinite_loop', '', '',
+   'terminate_backend_t', 1, 1, 0, dbid) from gp_segment_configuration
+   where content = 1 and role = 'p';
+
+-- expect this command to be terminated by 'test pg_terminate_backend'
+1&: insert into terminate_backend_t values (1);
+
+select gp_wait_until_triggered_fault('heap_insert', 1, dbid)
+from gp_segment_configuration where content = 1 and role = 'p';
 
 -- extract the pid for the previous query
 SELECT pg_terminate_backend(pid,'test pg_terminate_backend')
-FROM pg_stat_activity WHERE query like 'create temp table t as select%' ORDER BY pid LIMIT 1;
+FROM pg_stat_activity WHERE query like 'insert into terminate_backend_t%'
+ORDER BY pid LIMIT 1;
 
 -- EXPECT: session 1 terminated with 'test pg_terminate_backend'
 1<:
 
 -- query backend to ensure no PANIC on postmaster
-select count(*) from foo;
+select gp_inject_fault('heap_insert', 'reset', dbid)
+   from gp_segment_configuration
+   where content = 1 and role = 'p';
+
+-- the table should be empty if insert was terminated
+select * from terminate_backend_t;

--- a/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
@@ -11,7 +11,7 @@
 select application_name, state, sync_state from pg_stat_replication;
 
 -- Inject fault on standby to skip WAL flush.
-select gp_inject_fault_infinite2('walrecv_skip_flush', 'skip', dbid, hostname, port)
+select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid)
 from gp_segment_configuration where content=-1 and role='m';
 
 begin;
@@ -39,7 +39,7 @@ $$ language plpgsql;
 -- Flush WAL to trigger the fault on standby.
 checkpoint;
 
-select gp_wait_until_triggered_fault2('walrecv_skip_flush', 1, dbid, hostname, port)
+select gp_wait_until_triggered_fault('walrecv_skip_flush', 1, dbid)
 from gp_segment_configuration where content=-1 and role='m';
 
 -- Should block in commit (SyncrepWaitForLSN()), waiting for commit
@@ -52,7 +52,7 @@ select wait_for_pg_stat_activity(60);
 select datname, waiting_reason, query from pg_stat_activity
 where waiting_reason = 'replication';
 
-select gp_inject_fault2('walrecv_skip_flush', 'reset', dbid, hostname, port)
+select gp_inject_fault('walrecv_skip_flush', 'reset', dbid)
 from gp_segment_configuration where content=-1 and role='m';
 
 -- Ensure that commits are no longer blocked.
@@ -77,13 +77,11 @@ insert into commit_blocking_on_standby_t1 values (1);
 
 -- Suspend WAL sender in main loop.  "infinite_loop" fault type does
 -- not block signals.
-select gp_inject_fault_infinite2('wal_sender_loop', 'infinite_loop',
-       dbid, hostname, port)
+select gp_inject_fault_infinite('wal_sender_loop', 'infinite_loop', dbid)
        from gp_segment_configuration where content=-1 and role='p';
 
 -- Inject fault on standby to skip WAL flush.
-select gp_inject_fault_infinite2('walrecv_skip_flush', 'skip',
-       dbid, hostname, port)
+select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid)
        from gp_segment_configuration where content=-1 and role='m';
 
 -- Kill existing walsender.  WAL sender and WAL receiver processes
@@ -116,8 +114,7 @@ $$ language plpgsql;
 
 select wait_until_standby_in_state('catchup');
 
-select gp_wait_until_triggered_fault2('wal_sender_loop', 1,
-       dbid, hostname, port)
+select gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid)
        from gp_segment_configuration where content=-1 and role='p';
 
 -- WAL sender should be stuck in CATCHUP state.
@@ -128,18 +125,17 @@ select application_name, state, sync_state from pg_stat_replication;
 -- main loop.
 commit;
 
-select gp_inject_fault2('wal_sender_after_caughtup_within_range', 'suspend',
-       dbid, hostname, port) from gp_segment_configuration
-       where content=-1 and role='p';
+select gp_inject_fault('wal_sender_after_caughtup_within_range', 'suspend', dbid)
+       from gp_segment_configuration where content=-1 and role='p';
 
-select gp_inject_fault2('wal_sender_loop', 'reset', dbid, hostname, port)
+select gp_inject_fault('wal_sender_loop', 'reset', dbid)
        from gp_segment_configuration where content=-1 and role='p';
 
 -- Once this fault is triggered, WAL sender should have set
 -- caughtup_within_range to true because difference between
 -- sent_location and flush_location is within 1 WAL segment (64) MB.
-select gp_wait_until_triggered_fault2(
-       'wal_sender_after_caughtup_within_range', 1, dbid, hostname, port)
+select gp_wait_until_triggered_fault(
+       'wal_sender_after_caughtup_within_range', 1, dbid)
        from gp_segment_configuration where content=-1 and role='p';
 
 -- Should block because standby is considered to have caughtup within
@@ -152,7 +148,7 @@ select datname, waiting_reason, query from pg_stat_activity
 where waiting_reason = 'replication';
 
 -- Reset faults on primary as well as mirror.
-select gp_inject_fault2('all', 'reset', dbid, hostname, port)
+select gp_inject_fault('all', 'reset', dbid)
        from gp_segment_configuration where content=-1;
 
 1<:

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -637,28 +637,22 @@ INSERT INTO bm_test_update SELECT i,i FROM generate_series (1, 10000) i;
 CHECKPOINT;
 -- skip all further checkpoint
 SELECT gp_inject_fault_infinite('checkpoint', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
-NOTICE:  Success:  (seg0 172.17.0.10:25435 pid=355751)
-NOTICE:  Success:  (seg1 172.17.0.10:25433 pid=355752)
-NOTICE:  Success:  (seg2 172.17.0.10:25434 pid=355753)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 INSERT INTO bm_test_insert SELECT generate_series (1, 10000);
 UPDATE bm_test_update SET b=b+1;
 -- trigger recovery on primaries 
 SELECT gp_inject_fault_infinite('finish_prepared_after_record_commit_prepared', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
-NOTICE:  Success:  (seg0 172.17.0.10:25435 pid=355751)
-NOTICE:  Success:  (seg1 172.17.0.10:25433 pid=355752)
-NOTICE:  Success:  (seg2 172.17.0.10:25434 pid=355753)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 SET client_min_messages='ERROR';
@@ -667,25 +661,19 @@ RESET client_min_messages;
 -- reconnect to the database after restart
 \c
 SELECT gp_inject_fault('checkpoint', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
-NOTICE:  Success:  (seg1 172.17.0.10:25433 pid=355829)
-NOTICE:  Success:  (seg2 172.17.0.10:25434 pid=355830)
-NOTICE:  Success:  (seg0 172.17.0.10:25435 pid=355828)
  gp_inject_fault 
 -----------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 SELECT gp_inject_fault('finish_prepared_after_record_commit_prepared', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
-NOTICE:  Success:  (seg1 172.17.0.10:25433 pid=355829)
-NOTICE:  Success:  (seg2 172.17.0.10:25434 pid=355830)
-NOTICE:  Success:  (seg0 172.17.0.10:25435 pid=355828)
  gp_inject_fault 
 -----------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 SET enable_seqscan=off;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -639,28 +639,22 @@ INSERT INTO bm_test_update SELECT i,i FROM generate_series (1, 10000) i;
 CHECKPOINT;
 -- skip all further checkpoint
 SELECT gp_inject_fault_infinite('checkpoint', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
-NOTICE:  Success:  (seg0 172.17.0.10:25435 pid=69866)
-NOTICE:  Success:  (seg1 172.17.0.10:25433 pid=69867)
-NOTICE:  Success:  (seg2 172.17.0.10:25434 pid=69868)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 INSERT INTO bm_test_insert SELECT generate_series (1, 10000);
 UPDATE bm_test_update SET b=b+1;
 -- trigger recovery on primaries 
 SELECT gp_inject_fault_infinite('finish_prepared_after_record_commit_prepared', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
-NOTICE:  Success:  (seg0 172.17.0.10:25435 pid=69866)
-NOTICE:  Success:  (seg1 172.17.0.10:25433 pid=69867)
-NOTICE:  Success:  (seg2 172.17.0.10:25434 pid=69868)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 SET client_min_messages='ERROR';
@@ -669,25 +663,19 @@ RESET client_min_messages;
 -- reconnect to the database after restart
 \c
 SELECT gp_inject_fault('checkpoint', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
-NOTICE:  Success:  (seg1 172.17.0.10:25433 pid=69945)
-NOTICE:  Success:  (seg2 172.17.0.10:25434 pid=69946)
-NOTICE:  Success:  (seg0 172.17.0.10:25435 pid=69944)
  gp_inject_fault 
 -----------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 SELECT gp_inject_fault('finish_prepared_after_record_commit_prepared', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
-NOTICE:  Success:  (seg1 172.17.0.10:25433 pid=69945)
-NOTICE:  Success:  (seg2 172.17.0.10:25434 pid=69946)
-NOTICE:  Success:  (seg0 172.17.0.10:25435 pid=69944)
  gp_inject_fault 
 -----------------
- t
- t
- t
+ Success:
+ Success:
+ Success:
 (3 rows)
 
 SET enable_seqscan=off;

--- a/src/test/regress/expected/cursor.out
+++ b/src/test/regress/expected/cursor.out
@@ -81,27 +81,24 @@ CREATE TABLE cursor_writer_reader (a int, b int) DISTRIBUTED BY (a);
 BEGIN;
 INSERT INTO cursor_writer_reader VALUES(1, 666);
 select gp_inject_fault_infinite('qe_got_snapshot_and_interconnect', 'suspend', 2);
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
+ Success:
 (1 row)
 
 DECLARE cursor_c2 CURSOR FOR SELECT * FROM cursor_writer_reader WHERE b=666 ORDER BY 1;
 SAVEPOINT x;
 UPDATE cursor_writer_reader SET b=333 WHERE b=666;
 select gp_wait_until_triggered_fault('qe_got_snapshot_and_interconnect', 1, 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=31091)
  gp_wait_until_triggered_fault 
 -------------------------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('qe_got_snapshot_and_interconnect', 'resume', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 FETCH cursor_c2;
@@ -117,10 +114,9 @@ SELECT * FROM cursor_writer_reader WHERE b=666 ORDER BY 1;
 
 END;
 select gp_inject_fault('qe_got_snapshot_and_interconnect', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- start_ignore

--- a/src/test/regress/expected/dtm_retry.out
+++ b/src/test/regress/expected/dtm_retry.out
@@ -14,10 +14,9 @@ set dtx_phase2_retry_count = 11;
 create extension if not exists gp_inject_fault;
 select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 begin;
@@ -47,17 +46,16 @@ WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one 
 NOTICE:  Releasing segworker group to retry broadcast.
 -- Reset all faults.
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
 (8 rows)
 
 -- Verify that the table got created properly on all segments.
@@ -69,10 +67,9 @@ insert into dtm_retry_table select * from generate_series(1,12);
 -- abort_some_prepared broadcast in 2nd phase.
 select gp_inject_fault('start_prepare', 'error', dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Let content 1 primary, which had successfully prepared the
@@ -80,10 +77,9 @@ NOTICE:  Success:
 -- abort_some_prepared request.
 select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 1;
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 begin;
@@ -112,17 +108,16 @@ select count(*) = 12 from dtm_retry_table;
 
 -- Reset all faults.
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
 (8 rows)
 
 --
@@ -132,19 +127,17 @@ NOTICE:  Success:
 -- abort_prepared broadcast in 2nd phase.
 select gp_inject_fault('dtm_broadcast_prepare', 'error', dbid)
 from gp_segment_configuration where role = 'p' and content = -1;
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Let content 0 primary error out 10 times during second phase.
 select gp_inject_fault('finish_prepared_start_of_function', 'error', '', '', '', 1, 10, 0, dbid)
 from gp_segment_configuration where role = 'p' and status = 'u' and content = 0;
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 begin;
@@ -173,16 +166,15 @@ select count(*) = 12 from dtm_retry_table;
 
 -- Reset all faults.
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
 (8 rows)
 

--- a/src/test/regress/expected/fts_error.out
+++ b/src/test/regress/expected/fts_error.out
@@ -11,45 +11,40 @@ where content = 0 and mode = 's';
 -- Once this fault is hit, FTS process should abort current
 -- transaction and exit.
 select gp_inject_fault_infinite('fts_update_config', 'error', 1);
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
+ Success:
 (1 row)
 
 -- FTS probe connection should encounter an error due to this fault,
 -- injected on content 0 primary.
 select gp_inject_fault_infinite('fts_handle_message', 'error', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=23250)
  gp_inject_fault_infinite 
 --------------------------
- t
+ Success:
 (1 row)
 
 -- Upon failure to probe content 0 primary, FTS will try to update the
 -- configuration.  The update to configuration will hit error due to
 -- the "fts_update_config" fault.
 select gp_wait_until_triggered_fault('fts_update_config', 1, 1);
-NOTICE:  Success:
  gp_wait_until_triggered_fault 
 -------------------------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('fts_handle_message', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=23250)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('fts_update_config', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Postmaster should have restarted FTS by now. Trigger a scan and

--- a/src/test/regress/expected/fts_recovery_in_progress.out
+++ b/src/test/regress/expected/fts_recovery_in_progress.out
@@ -12,10 +12,10 @@ select role, preferred_role, mode, status from gp_segment_configuration where co
  m    | m              | s    | u
 (2 rows)
 
-select gp_inject_fault_infinite2('fts_conn_startup_packet', 'skip', dbid, hostname, port)
+select gp_inject_fault_infinite('fts_conn_startup_packet', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
- gp_inject_fault_infinite2 
----------------------------
+ gp_inject_fault_infinite 
+--------------------------
  Success:
 (1 row)
 
@@ -51,10 +51,10 @@ select gp_request_fts_probe_scan();
  t
 (1 row)
 
-select gp_wait_until_triggered_fault2('fts_conn_startup_packet', 3, dbid, hostname, port)
+select gp_wait_until_triggered_fault('fts_conn_startup_packet', 3, dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
- gp_wait_until_triggered_fault2 
---------------------------------
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
 (1 row)
 
@@ -68,10 +68,10 @@ select role, preferred_role, mode, status from gp_segment_configuration where co
 -- test other scenario where recovery on primary is hung and hence FTS marks
 -- primary down and promotes mirror. When 'fts_recovery_in_progress' is set to
 -- skip it mimics the behavior of hung recovery on primary.
-select gp_inject_fault_infinite2('fts_recovery_in_progress', 'skip', dbid, hostname, port)
+select gp_inject_fault_infinite('fts_recovery_in_progress', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
- gp_inject_fault_infinite2 
----------------------------
+ gp_inject_fault_infinite 
+--------------------------
  Success:
 (1 row)
 
@@ -168,10 +168,10 @@ select role, preferred_role, mode, status from gp_segment_configuration where co
 \!gpstop -u
 -- end_ignore
 -- cleanup steps
-select gp_inject_fault2('all', 'reset', dbid, hostname, port)
+select gp_inject_fault('all', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
- gp_inject_fault2 
-------------------
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 

--- a/src/test/regress/expected/gporca_faults.out
+++ b/src/test/regress/expected/gporca_faults.out
@@ -12,17 +12,15 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 INSERT INTO foo VALUES (1,1);
 -- test interruption requests to optimization
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select count(*) from foo;
@@ -53,17 +51,15 @@ EXPLAIN SELECT * FROM func1_nosql_vol(5), foo;
 (8 rows)
 
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 SELECT * FROM func1_nosql_vol(5), foo;
@@ -74,9 +70,8 @@ SELECT * FROM func1_nosql_vol(5), foo;
 
 -- The fault should *not* be hit above when optimizer = off, to reset it now.
 SELECT gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 

--- a/src/test/regress/expected/gporca_faults_optimizer.out
+++ b/src/test/regress/expected/gporca_faults_optimizer.out
@@ -12,17 +12,15 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 INSERT INTO foo VALUES (1,1);
 -- test interruption requests to optimization
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select count(*) from foo;
@@ -49,26 +47,23 @@ EXPLAIN SELECT * FROM func1_nosql_vol(5), foo;
 (8 rows)
 
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('opt_relcache_translator_catalog_access', 'interrupt', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 SELECT * FROM func1_nosql_vol(5), foo;
 ERROR:  canceling statement due to user request
 -- The fault should *not* be hit above when optimizer = off, to reset it now.
 SELECT gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 

--- a/src/test/regress/expected/ic.out
+++ b/src/test/regress/expected/ic.out
@@ -465,17 +465,15 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 begin;
 declare ic_test_cursor_c1 cursor for select * from ic_test_1;
 select gp_inject_fault('interconnect_stop_ack_is_lost', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('interconnect_stop_ack_is_lost', 'skip', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 commit;
@@ -488,20 +486,18 @@ drop table ic_test_1;
 CREATE TABLE a (i INT, j INT) DISTRIBUTED BY (i);
 INSERT INTO a (SELECT i, i * i FROM generate_series(1, 10) as i);
 SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 SELECT * FROM a;
 ERROR:  fault triggered, fault name:'interconnect_setup_palloc' fault type:'error'
 DROP TABLE a;
 SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Use WITH RECURSIVE to construct a one-time filter result node that executed

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -14,18 +14,14 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 (1 row)
 
 \dx+ gp_inject*
-                              Objects in extension "gp_inject_fault"
-                                        Object Description                                        
---------------------------------------------------------------------------------------------------
+                       Objects in extension "gp_inject_fault"
+                                 Object Description                                 
+------------------------------------------------------------------------------------
  function gp_inject_fault(text,text,integer)
  function gp_inject_fault(text,text,text,text,text,integer,integer,integer,integer)
- function gp_inject_fault2(text,text,integer,text,integer)
- function gp_inject_fault2(text,text,text,text,text,integer,integer,integer,integer,text,integer)
  function gp_inject_fault_infinite(text,text,integer)
- function gp_inject_fault_infinite2(text,text,integer,text,integer)
  function gp_wait_until_triggered_fault(text,integer,integer)
- function gp_wait_until_triggered_fault2(text,integer,integer,text,integer)
-(8 rows)
+(4 rows)
 
 --
 -- Test extended \du flags

--- a/src/test/regress/expected/python_processed64bit.out
+++ b/src/test/regress/expected/python_processed64bit.out
@@ -39,16 +39,12 @@ SELECT COUNT(*) AS count
 SELECT gp_inject_fault('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 192.168.0.65:25432 pid=121194)
-NOTICE:  Success:  (seg1 192.168.0.65:25433 pid=121196)
-NOTICE:  Success:  (seg2 192.168.0.65:25434 pid=121195)
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 -- and insert another 30k rows, this time overflowing the 2^32 counter
@@ -62,16 +58,12 @@ SELECT public.test_bigint_python();
 SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 192.168.0.65:25432 pid=121194)
-NOTICE:  Success:  (seg1 192.168.0.65:25433 pid=121196)
-NOTICE:  Success:  (seg2 192.168.0.65:25434 pid=121195)
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 SELECT COUNT(*) AS count

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -1,7 +1,3 @@
--- start_ignore
-CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
--- end_ignore
-NOTICE:  extension "gp_inject_fault" already exists, skipping
 drop table if exists _tmp_table;
 NOTICE:  table "_tmp_table" does not exist, skipping
 create table _tmp_table (i1 int, i2 int, i3 int, i4 int);
@@ -13,18 +9,16 @@ set statement_mem="2MB";
 set gp_enable_mk_sort=on;
 set gp_cte_sharing=on;
 select gp_inject_fault('execsort_mksort_mergeruns', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- set QueryFinishPending=true in sort mergeruns. This will stop sort and set result_tape to NULL
 select gp_inject_fault('execsort_mksort_mergeruns', 'finish_pending', 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- return results although sort will be interrupted in one of the segments 
@@ -35,10 +29,10 @@ select DISTINCT S from (select row_number() over(partition by i1 order by i2) AS
 (1 row)
 
 select gp_inject_fault('execsort_mksort_mergeruns', 'status', 2);
-NOTICE:  Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                             gp_inject_fault                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'execsort_mksort_mergeruns' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 -- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
@@ -59,19 +53,17 @@ set gp_enable_mk_sort=off;
 -- planner on the other hand does not.
 set optimizer=off;
 select gp_inject_fault('execshare_input_next', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
 -- This will eagerly free the memory context of shared input scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 with cte as (select i2 from testsisc order by i2)
@@ -83,29 +75,27 @@ select * from cte c1, cte c2 limit 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                          gp_inject_fault                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 -- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node and sort_mk algorithm is used
 set gp_enable_mk_sort=on;
 select gp_inject_fault('execshare_input_next', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
 -- This will eagerly free the memory context of shared input scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 with cte as (select i2 from testsisc order by i2)
@@ -117,26 +107,24 @@ select * from cte c1, cte c2 limit 2;
 (2 rows)
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
-NOTICE:  Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                          gp_inject_fault                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 reset gp_enable_mk_sort;
 -- Disable faultinjectors
 select gp_inject_fault('execsort_mksort_mergeruns', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('execshare_input_next', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- test if a query can be canceled when cancel signal arrives fast than the query dispatched.
@@ -151,10 +139,9 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 -- triggered immediately, rather that waiting until the next probe
 -- interval.
 select gp_inject_fault_infinite('fts_probe', 'skip', 1);
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
+ Success:
 (1 row)
 
 select gp_request_fts_probe_scan();
@@ -164,35 +151,31 @@ select gp_request_fts_probe_scan();
 (1 row)
 
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
-NOTICE:  Success:
  gp_wait_until_triggered_fault 
 -------------------------------
- t
+ Success:
 (1 row)
 
 -- make one QE sleep before reading command
 select gp_inject_fault('before_read_command', 'sleep', '', '', '', 1, 1, 50, 2::smallint);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;
 ERROR:  division by zero  (seg0 slice1 127.0.1.1:25432 pid=15478)
 select gp_inject_fault('before_read_command', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.1.1:25432 pid=15470)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Resume FTS probes starting from the next probe interval.
 select gp_inject_fault('fts_probe', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 drop table _tmp_table1;

--- a/src/test/regress/expected/segspace.out
+++ b/src/test/regress/expected/segspace.out
@@ -32,17 +32,15 @@ ANALYZE segspace_test_hj_skew;
 ------------ Interrupting SELECT query that spills -------------------
 -- enable the fault injector
 select gp_inject_fault('exec_hashjoin_new_batch', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('exec_hashjoin_new_batch', 'interrupt', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 set statement_mem=2048;
@@ -52,10 +50,10 @@ SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE 
 ERROR:  canceling MPP operation  (seg0 slice2 127.0.0.1:25432 pid=26876)
 rollback;
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                         gp_inject_fault                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 -- check used segspace after test
@@ -92,17 +90,15 @@ set statement_mem=2048;
 set gp_autostats_mode = none;
 -- enable the fault injector
 select gp_inject_fault('exec_hashjoin_new_batch', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('exec_hashjoin_new_batch', 'interrupt', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 begin;
@@ -111,10 +107,10 @@ SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE 
 ERROR:  canceling MPP operation  (seg0 127.0.0.1:25432 pid=26876)
 rollback;
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                         gp_inject_fault                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 -- check used segspace after test
@@ -147,17 +143,15 @@ set statement_mem=2048;
 set gp_autostats_mode = none;
 -- enable the fault injector
 select gp_inject_fault('exec_hashjoin_new_batch', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('exec_hashjoin_new_batch', 'interrupt', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 begin;
@@ -168,10 +162,10 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 ERROR:  canceling MPP operation  (seg0 127.0.0.1:25432 pid=26876)
 rollback;
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                         gp_inject_fault                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 -- check used segspace after test
@@ -216,17 +210,15 @@ set gp_enable_mk_sort=on;
 set gp_cte_sharing=on;
 -- enable the fault injector
 select gp_inject_fault('workfile_write_failure', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('workfile_write_failure', 'error', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- LEAK in UPDATE: update with sisc xslice sort
@@ -238,10 +230,10 @@ update foo set j=m.cc1 from (
   where t1.i1 = t2.i2 ) as m;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice3 127.0.0.1:25432 pid=3175)
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                         gp_inject_fault                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;
@@ -287,17 +279,15 @@ insert into foo select i, i % 1000 from
 set statement_mem=1024; -- 1mb for 3 segment to get leak.
 -- enable the fault injector
 select gp_inject_fault('workfile_write_failure', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('workfile_write_failure', 'error', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- LEAK in DELETE with APPEND ONLY tables
@@ -307,10 +297,10 @@ delete from testsisc using (
 ) src  where testsisc.i1 = src.i;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 127.0.0.1:25432 pid=3143)
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                         gp_inject_fault                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;
@@ -347,17 +337,15 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- enable the fault injector
 select gp_inject_fault('workfile_write_failure', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('workfile_write_failure', 'error', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- expect to see leak if we hit error
@@ -371,10 +359,10 @@ select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used
 (1 row)
 
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                         gp_inject_fault                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 -- Run the test without fault injection
@@ -403,17 +391,15 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 -- expect to see leak if we hit error
 -- enable the fault injector
 select gp_inject_fault('workfile_write_failure', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('workfile_write_failure', 'error', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 update foo set d = i1 from (with ctesisc as (select * from testsisc order by i2)
@@ -422,10 +408,10 @@ select * from
 where x.a = ctesisc.i1) y;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice1 127.0.0.1:25432 pid=3175)
 select gp_inject_fault('exec_hashjoin_new_batch', 'status', 2);
-NOTICE:  Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                         gp_inject_fault                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 -- check counter leak

--- a/src/test/regress/expected/spi_processed64bit.out
+++ b/src/test/regress/expected/spi_processed64bit.out
@@ -14,32 +14,24 @@ CREATE TABLE public.spi64bittest (id BIGSERIAL PRIMARY KEY, data BIGINT);
 SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
-NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
-NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 -- insert enough rows to trigger the fault injector
 SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
-NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
-NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 -- Insert 1 ~ 40000 here can guarantee each segment's processing more than 10000 rows
@@ -62,16 +54,12 @@ NOTICE:  Inserted 12884901855 rows
 SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
-NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
-NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 SELECT COUNT(*) AS count
@@ -85,16 +73,12 @@ SELECT COUNT(*) AS count
 SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
-NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
-NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 DO $$
@@ -113,16 +97,12 @@ NOTICE:  Updated 12884901855 rows
 SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
-NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
-NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 SELECT COUNT(*) AS count
@@ -136,16 +116,12 @@ SELECT COUNT(*) AS count
 SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
-NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
-NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 DO $$
@@ -163,16 +139,12 @@ NOTICE:  Deleted 12884901855 rows
 SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
-NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
-NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 SELECT COUNT(*) AS count
@@ -221,16 +193,12 @@ SELECT sql_exec_stmt('INSERT INTO public.spi64bittest_2 (id) SELECT generate_ser
 SELECT gp_inject_fault_infinite('executor_run_high_processed', 'skip', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
-NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
-NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
  gp_inject_fault_infinite 
 --------------------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 -- double the data
@@ -261,16 +229,12 @@ SELECT sql_exec_stmt('INSERT INTO public.spi64bittest_2 (id) SELECT id FROM publ
 SELECT gp_inject_fault('executor_run_high_processed', 'reset', dbid)
   FROM pg_catalog.gp_segment_configuration
  WHERE role = 'p';
-NOTICE:  Success:
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=24141)
-NOTICE:  Success:  (seg1 127.0.0.1:40001 pid=24142)
-NOTICE:  Success:  (seg2 127.0.0.1:40002 pid=24143)
  gp_inject_fault 
 -----------------
- t
- t
- t
- t
+ Success:
+ Success:
+ Success:
+ Success:
 (4 rows)
 
 SELECT COUNT(*) AS count

--- a/src/test/regress/expected/toast.out
+++ b/src/test/regress/expected/toast.out
@@ -98,20 +98,18 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 SELECT DISTINCT gp_inject_fault('decrease_toast_max_chunk_size', 'skip', dbid)
 	   FROM pg_catalog.gp_segment_configuration
 	   WHERE role = 'p';
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 INSERT INTO toast_chunk_test VALUES (repeat('abcdefghijklmnopqrstuvwxyz', 1000)::bytea);
 SELECT DISTINCT gp_inject_fault('decrease_toast_max_chunk_size', 'reset', dbid)
 	   FROM pg_catalog.gp_segment_configuration
 	   WHERE role = 'p';
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- The toasted value should still be read correctly.

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -23,26 +23,24 @@ INSERT INTO test_zlib_hashjoin SELECT i,i,i,i,i,i,i,i FROM
 SET statement_mem=5000;
 --Fail after workfile creation and before add it to workfile set
 select gp_inject_fault('workfile_creation_failure', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('workfile_creation_failure', 'error', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 SELECT COUNT(t1.*) FROM test_zlib_hashjoin AS t1, test_zlib_hashjoin AS t2 WHERE t1.i1=t2.i2;
 ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=2829)
 select gp_inject_fault('workfile_creation_failure', 'status', 2);
-NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                        gp_inject_fault                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 RESET statement_mem;
@@ -57,34 +55,31 @@ INSERT INTO test_zlib_hagg SELECT i,i,i,i FROM
 SET statement_mem=2000;
 --Fail after workfile creation and before add it to workfile set
 select gp_inject_fault('workfile_creation_failure', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('workfile_creation_failure', 'error', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 SELECT MAX(i1) FROM test_zlib_hagg GROUP BY i2;
 ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=2829)
 select gp_inject_fault('workfile_creation_failure', 'status', 2);
-NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                        gp_inject_fault                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 -- Reset faultinjectors
 select gp_inject_fault('workfile_creation_failure', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 create table test_zlib (i int, j text);
@@ -109,17 +104,15 @@ end
 $body$ language plpgsql;
 -- Inject fault before we close workfile in ExecHashJoinNewBatch
 select gp_inject_fault('workfile_creation_failure', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('workfile_creation_failure', 'error', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select FuncA();
@@ -139,19 +132,18 @@ select * from test_zlib_t1;
 (0 rows)
 
 select gp_inject_fault('workfile_creation_failure', 'status', 2);
-NOTICE:  Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1'
- gp_inject_fault 
------------------
- t
+                                                                                                        gp_inject_fault                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'completed'  num times hit:'1' +
+ 
 (1 row)
 
 drop function FuncA();
 drop table test_zlib;
 drop table test_zlib_t1;
 select gp_inject_fault('workfile_creation_failure', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 

--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -32,10 +32,10 @@ $$LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
 BEGIN
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
 END;
 $$ LANGUAGE plpgsql;
 
@@ -73,7 +73,7 @@ BEGIN
     PERFORM setup_tablespace_location_dir_for_test(adst_destination_tablespace_location);
 
     -- setup faults
-    PERFORM gp_inject_fault2('all', 'reset', dbid, hostname, port) FROM gp_segment_configuration;
+    PERFORM gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -210,7 +210,7 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
 -- And we track the removal of the dboid dir under the source tablespace by the mirrors.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db.
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -219,7 +219,7 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 SELECT * FROM list_db_tablespace('alter_db', 'adst_destination_tablespace');
 
 -- Ensure that the mirrors have removed the dboid dir under the source tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
 
 -- Then all the files of the database should now be in the dboid directory in the target tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_destination_tablespace');
@@ -267,10 +267,10 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
 -- And we track the removal of the dboid dir by the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE content=-1 AND role='m';
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE content=-1 AND role='m';
 
 -- And introduce an error on the master directly after the XLOG_DBASE_CREATE is written by the master and before the master dispatches the ALTER command.
-SELECT gp_inject_fault2('inside_move_db_transaction', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('inside_move_db_transaction', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the fault is triggered.
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -279,7 +279,7 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
 -- Ensure that the standby master has removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE content=-1 AND role='m';
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE content=-1 AND role='m';
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -330,10 +330,10 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
 
 -- And introduce an error on a primary directly after the XLOG_DBASE_CREATE is written by the primary during dispatch of the ALTER command.
-SELECT gp_inject_fault2('inside_move_db_transaction', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+SELECT gp_inject_fault('inside_move_db_transaction', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the fault is triggered.
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -342,7 +342,7 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -393,13 +393,13 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
 
 -- And introduce an error on a primary directly after the XLOG_DBASE_CREATE is written by the primary during dispatch of the ALTER command.
-SELECT gp_inject_fault2('inside_move_db_transaction', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+SELECT gp_inject_fault('inside_move_db_transaction', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 
 -- And introduce an error on the master after dispatch of the ALTER command and before XLOG_XACT_ABORT is written by the master.
-SELECT gp_inject_fault2('transaction_abort_failure', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('transaction_abort_failure', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the faults are triggered.
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -408,7 +408,7 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -458,10 +458,10 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
 
 -- And introduce an error on a primary directly before the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
-SELECT gp_inject_fault2('start_prepare', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+SELECT gp_inject_fault('start_prepare', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the fault is triggered.
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -470,7 +470,7 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -521,13 +521,13 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
 
 -- And introduce an error on a primary directly before the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
-SELECT gp_inject_fault2('start_prepare', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+SELECT gp_inject_fault('start_prepare', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 
 -- And introduce an error on the master after dispatch of the ALTER command and before XLOG_XACT_ABORT is written by the master.
-SELECT gp_inject_fault2('transaction_abort_failure', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('transaction_abort_failure', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the faults are triggered.
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -536,7 +536,7 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -586,10 +586,10 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
 
 -- And introduce an error on the master after dispatch of the PREPARE TRANSACTION command and before XLOG_XACT_DISTRIBUTED_COMMIT is written by the master.
-SELECT gp_inject_fault2('transaction_abort_after_distributed_prepared', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the fault is triggered.
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -598,7 +598,7 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -649,13 +649,13 @@ SELECT force_mirrors_to_catch_up();
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
 -- And we track the removal of the dboid dir by all mirrors including the standby master, except the mirror of the primary about to panic.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m' AND content!=0;
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m' AND content!=0;
 
 -- And introduce a panic on a primary directly before the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
-SELECT gp_inject_fault2('start_prepare', 'panic', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+SELECT gp_inject_fault('start_prepare', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 
 -- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
-SELECT gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the panic is triggered
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -664,7 +664,7 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace, except the mirror of the panicked primary.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m' AND content!=0;
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m' AND content!=0;
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 -- Note: Sometimes the pg_internal.init is not yet formed on the recovering primary. It is not important for our test.
@@ -714,13 +714,13 @@ SELECT force_mirrors_to_catch_up();
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
 
 -- And introduce a panic on a primary directly after the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
-SELECT gp_inject_fault2('after_xlog_xact_prepare_flushed', 'panic', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+SELECT gp_inject_fault('after_xlog_xact_prepare_flushed', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 
 -- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
-SELECT gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the panic is triggered
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -729,7 +729,7 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace, except the mirror of the panicked primary.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m' AND content!=0;
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m' AND content!=0;
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 -- Note: Sometimes the pg_internal.init is not yet formed on the recovering primary. It is not important for our test.
@@ -750,7 +750,7 @@ SELECT force_mirrors_to_catch_up();
 -- Final cleanup
 DROP SCHEMA adst CASCADE;
 
-SELECT gp_inject_fault2('all', 'reset', dbid, hostname, port) FROM gp_segment_configuration;
+SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
 
 \!rm -rf @testtablespace@/adst_source
 \!rm -rf @testtablespace@/adst_dest

--- a/src/test/regress/input/createdb.source
+++ b/src/test/regress/input/createdb.source
@@ -27,10 +27,10 @@ END;
 $$LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
 BEGIN
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
 END;
 $$ LANGUAGE plpgsql;
 
@@ -55,10 +55,10 @@ drop database dowell;
 --CASE 1: error in segment after db file physically created
 --
 --reset status
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 -- inject fault on content0 primary to error out after copying
 -- template db directory
-select gp_inject_fault2('create_db_after_file_copy', 'error', dbid, hostname, port)
+select gp_inject_fault('create_db_after_file_copy', 'error', dbid)
 from gp_segment_configuration where content=0 and role='p';
 
 -- should fail
@@ -80,8 +80,8 @@ set gp_select_invisible=off;
 --
 --CASE 2: error after XLOG_DBASE_CREATE on master
 --
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
-select gp_inject_fault2('after_xlog_create_database', 'error', dbid, hostname, port)
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+select gp_inject_fault('after_xlog_create_database', 'error', dbid)
 from gp_segment_configuration where content=-1 and role='p';
 -- should fail
 create database db2;
@@ -100,8 +100,8 @@ set gp_select_invisible=off;
 --
 --CASE 3: error after XLOG_DBASE_CREATE on segment
 --
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
-select gp_inject_fault2('after_xlog_create_database', 'error', dbid, hostname, port)
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+select gp_inject_fault('after_xlog_create_database', 'error', dbid)
 from gp_segment_configuration where content=0 and role='p';
 -- should fail
 create database db3;
@@ -120,10 +120,10 @@ set gp_select_invisible=off;
 --
 --CASE 4: panic after XLOG_XACT_PREPARE on segment
 --
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
-select gp_inject_fault2('end_prepare_two_phase', 'panic', dbid, hostname, port)
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+select gp_inject_fault('end_prepare_two_phase', 'panic', dbid)
 from gp_segment_configuration where content=0 and role='p';
-select gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port)
+select gp_inject_fault_infinite('fts_probe', 'skip', dbid)
 from gp_segment_configuration where content=0 and role='p';
 -- should fail
 create database db4;
@@ -137,6 +137,6 @@ select db_dirs(oid) from pg_database where datname = 'db4';
 
 set gp_select_invisible=off;
 -- start_ignore
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 select force_mirrors_to_catch_up();
 -- end_ignore

--- a/src/test/regress/input/gp_tablespace.source
+++ b/src/test/regress/input/gp_tablespace.source
@@ -57,10 +57,10 @@ $$LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
 BEGIN
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
 END;
 $$ LANGUAGE plpgsql;
 

--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -61,7 +61,7 @@ create or replace function disable_fts() returns void as $$
 	begin
 		-- intentionally skip fts during these tests
 		-- we know we're going to be inducing errors and panics on primaries
-		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port)
+		perform gp_inject_fault_infinite('fts_probe', 'skip', dbid)
 			from gp_segment_configuration
 			where content = master_content_id
 			and role = master_primary_role;
@@ -71,7 +71,7 @@ create or replace function disable_fts() returns void as $$
 		-- also, ensure that the fts loop observes the probe being skipped before
 		-- continuing with the test because it could still be in the middle of a
 		-- previous probe
-		perform gp_wait_until_triggered_fault2('fts_probe', 1, dbid, hostname, port)
+		perform gp_wait_until_triggered_fault('fts_probe', 1, dbid)
 			from gp_segment_configuration
 			where content = master_content_id
 			and role = master_primary_role;
@@ -87,8 +87,8 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 		perform setup_tablespace_location_dir_for_test(tablespace_dir);
 
 		-- setup faults
-		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
-		perform gp_inject_fault2(fault_name, fault_action_type, dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
+		perform gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = content_id and role = 'p';
+		perform gp_inject_fault(fault_name, fault_action_type, dbid) from gp_segment_configuration where content = content_id and role = 'p';
 		perform disable_fts();
 	end;
 $$ LANGUAGE plpgsql;
@@ -98,7 +98,7 @@ create or replace function cleanup(content_id integer, tablespace_location_dir t
 	begin
 		CHECKPOINT; -- ensure primary/master xlogs do not leak into following test
 		perform force_mirrors_to_catch_up();
-		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
+		perform gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 		perform remove_tablespace_location_directory(tablespace_location_dir);
 	end;
 $$ LANGUAGE plpgsql;
@@ -147,10 +147,10 @@ $$LANGUAGE plpgsql;
 
 create or replace function force_mirrors_to_catch_up() returns void as $$
 begin
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
 end;
 $$ language plpgsql;
 
@@ -366,12 +366,12 @@ select remove_tablespace_location_directory(:'tablespace_location') from gp_dist
 select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_inject_fault('after_xlog_tblspc_drop', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 DROP TABLESPACE my_tablespace_for_testing;
 select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(8, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 DROP TABLESPACE my_tablespace_for_testing;
 select force_mirrors_to_catch_up();
 select cleanup(0, :'tablespace_location');
@@ -390,12 +390,12 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault('after_xlog_tblspc_drop', 'error', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(8, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespace should still exist in the catalog
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select force_mirrors_to_catch_up();
 select cleanup(:content_id_under_test, :'tablespace_location');
@@ -435,13 +435,13 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
 select disable_fts();
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault(:'fault_name', :'fault_type', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select wait_for_primaries_to_restart();
 select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(0, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespace should no longer exist in the catalog
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 select cleanup(:content_id_under_test, :'tablespace_location');
 
 
@@ -459,13 +459,13 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
 select disable_fts();
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault(:'fault_name', :'fault_type', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select wait_for_primaries_to_restart();
 select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(8, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select cleanup(:content_id_under_test, :'tablespace_location');
 
@@ -484,12 +484,12 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
 select disable_fts();
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault(:'fault_name', :'fault_type', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select cleanup(:content_id_under_test, :'tablespace_location');
 
@@ -507,12 +507,12 @@ select remove_tablespace_location_directory(:'tablespace_location') from gp_dist
 select setup_tablespace_location_dir_for_test(:'tablespace_location');
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault(:'fault_name', :'fault_type', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select force_mirrors_to_catch_up();
 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
 select * from list_tablespace_catalog_without_oid(); -- the tablespaces should exist in the catalog
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
 DROP TABLESPACE my_tablespace_for_testing;
 select cleanup(:content_id_under_test, :'tablespace_location');
 

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -25,10 +25,10 @@ END;
 $$LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
 BEGIN
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
 END;
 $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
@@ -61,7 +61,7 @@ BEGIN
     PERFORM setup_tablespace_location_dir_for_test(adst_destination_tablespace_location);
 
     -- setup faults
-    PERFORM gp_inject_fault2('all', 'reset', dbid, hostname, port) FROM gp_segment_configuration;
+    PERFORM gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
 END;
 $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION list_db_tablespace(database_name text, tablespace_name text) RETURNS TABLE(gp_segment_id int, db_name name, tablespace_name name) AS $$
@@ -193,9 +193,9 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- And we track the removal of the dboid dir under the source tablespace by the mirrors.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -215,9 +215,9 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_destination_tablespace');
 (4 rows)
 
 -- Ensure that the mirrors have removed the dboid dir under the source tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
- gp_wait_until_triggered_fault2 
---------------------------------
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
  Success:
  Success:
@@ -310,16 +310,16 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- And we track the removal of the dboid dir by the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE content=-1 AND role='m';
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE content=-1 AND role='m';
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
 -- And introduce an error on the master directly after the XLOG_DBASE_CREATE is written by the master and before the master dispatches the ALTER command.
-SELECT gp_inject_fault2('inside_move_db_transaction', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('inside_move_db_transaction', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -337,9 +337,9 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 (4 rows)
 
 -- Ensure that the standby master has removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE content=-1 AND role='m';
- gp_wait_until_triggered_fault2 
---------------------------------
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE content=-1 AND role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
 (1 row)
 
@@ -432,9 +432,9 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -442,9 +442,9 @@ SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.ho
 (4 rows)
 
 -- And introduce an error on a primary directly after the XLOG_DBASE_CREATE is written by the primary during dispatch of the ALTER command.
-SELECT gp_inject_fault2('inside_move_db_transaction', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('inside_move_db_transaction', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -462,9 +462,9 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 (4 rows)
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
- gp_wait_until_triggered_fault2 
---------------------------------
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
  Success:
  Success:
@@ -560,9 +560,9 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -570,16 +570,16 @@ SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.ho
 (4 rows)
 
 -- And introduce an error on a primary directly after the XLOG_DBASE_CREATE is written by the primary during dispatch of the ALTER command.
-SELECT gp_inject_fault2('inside_move_db_transaction', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('inside_move_db_transaction', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
 -- And introduce an error on the master after dispatch of the ALTER command and before XLOG_XACT_ABORT is written by the master.
-SELECT gp_inject_fault2('transaction_abort_failure', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('transaction_abort_failure', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -598,9 +598,9 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 (4 rows)
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
- gp_wait_until_triggered_fault2 
---------------------------------
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
  Success:
  Success:
@@ -695,9 +695,9 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -705,9 +705,9 @@ SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.ho
 (4 rows)
 
 -- And introduce an error on a primary directly before the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
-SELECT gp_inject_fault2('start_prepare', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('start_prepare', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -725,9 +725,9 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 (4 rows)
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
- gp_wait_until_triggered_fault2 
---------------------------------
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
  Success:
  Success:
@@ -823,9 +823,9 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -833,16 +833,16 @@ SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.ho
 (4 rows)
 
 -- And introduce an error on a primary directly before the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
-SELECT gp_inject_fault2('start_prepare', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('start_prepare', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
 -- And introduce an error on the master after dispatch of the ALTER command and before XLOG_XACT_ABORT is written by the master.
-SELECT gp_inject_fault2('transaction_abort_failure', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('transaction_abort_failure', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -861,9 +861,9 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 (4 rows)
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
- gp_wait_until_triggered_fault2 
---------------------------------
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
  Success:
  Success:
@@ -958,9 +958,9 @@ SELECT force_mirrors_to_catch_up();
 CREATE TEMPORARY TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -968,9 +968,9 @@ SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.ho
 (4 rows)
 
 -- And introduce an error on the master after dispatch of the PREPARE TRANSACTION command and before XLOG_XACT_DISTRIBUTED_COMMIT is written by the master.
-SELECT gp_inject_fault2('transaction_abort_after_distributed_prepared', 'error', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -988,9 +988,9 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 (4 rows)
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
- gp_wait_until_triggered_fault2 
---------------------------------
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
  Success:
  Success:
@@ -1086,25 +1086,25 @@ SELECT force_mirrors_to_catch_up();
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- And we track the removal of the dboid dir by all mirrors including the standby master, except the mirror of the primary about to panic.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m' AND content!=0;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m' AND content!=0;
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
 (3 rows)
 
 -- And introduce a panic on a primary directly before the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
-SELECT gp_inject_fault2('start_prepare', 'panic', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('start_prepare', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
 -- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
-SELECT gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) FROM gp_segment_configuration WHERE role='p' AND content=-1;
- gp_inject_fault_infinite2 
----------------------------
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault_infinite 
+--------------------------
  Success:
 (1 row)
 
@@ -1123,9 +1123,9 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 (4 rows)
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace, except the mirror of the panicked primary.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m' AND content!=0;
- gp_wait_until_triggered_fault2 
---------------------------------
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m' AND content!=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
  Success:
  Success:
@@ -1213,9 +1213,9 @@ SELECT force_mirrors_to_catch_up();
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
-SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.hostname, c.port) FROM gp_segment_configuration c WHERE role='m';
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -1223,16 +1223,16 @@ SELECT gp_inject_fault2('after_drop_database_directories', 'sleep', c.dbid, c.ho
 (4 rows)
 
 -- And introduce a panic on a primary directly after the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
-SELECT gp_inject_fault2('after_xlog_xact_prepare_flushed', 'panic', dbid, hostname, port) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('after_xlog_xact_prepare_flushed', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
 -- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
-SELECT gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port) FROM gp_segment_configuration WHERE role='p' AND content=-1;
- gp_inject_fault_infinite2 
----------------------------
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault_infinite 
+--------------------------
  Success:
 (1 row)
 
@@ -1251,9 +1251,9 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 (4 rows)
 
 -- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace, except the mirror of the panicked primary.
-SELECT gp_wait_until_triggered_fault2('after_drop_database_directories', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m' AND content!=0;
- gp_wait_until_triggered_fault2 
---------------------------------
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m' AND content!=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
  Success:
  Success:
  Success:
@@ -1322,9 +1322,9 @@ drop cascades to function setup_tablespace_location_dir_for_test(text)
 drop cascades to function setup()
 drop cascades to function list_db_tablespace(text,text)
 drop cascades to function stat_db_objects(text,text)
-SELECT gp_inject_fault2('all', 'reset', dbid, hostname, port) FROM gp_segment_configuration;
- gp_inject_fault2 
-------------------
+SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1162,7 +1162,7 @@ select gp_inject_fault('appendonly_skip_compression', 'skip', '', '',
 from gp_segment_configuration where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 insert into aocs_small_and_dense_content select i,i from
@@ -1172,7 +1172,7 @@ from gp_segment_configuration where
 role = 'p' and content = 0;
  gp_wait_until_triggered_fault 
 -------------------------------
- t
+ Success:
 (1 row)
 
 -- This should not fail if small content or bulk dense content headers
@@ -1187,6 +1187,6 @@ select gp_inject_fault('appendonly_skip_compression', 'reset', dbid)
 from gp_segment_configuration where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 

--- a/src/test/regress/output/autovacuum-template0.source
+++ b/src/test/regress/output/autovacuum-template0.source
@@ -14,19 +14,17 @@ select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='templat
 
 -- track that we've updated the row in pg_database for template0
 SELECT gp_inject_fault_infinite('vacuum_update_dat_frozen_xid', 'skip', 1);
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
+ Success:
 (1 row)
 
 -- Suspend the autovacuum worker from vacuuming before
 -- ShmemVariableCache->latestCompletedXid is expected to be updated
 SELECT gp_inject_fault_infinite('auto_vac_worker_before_do_autovacuum', 'suspend', 1);
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
+ Success:
 (1 row)
 
 select test_consume_xids(100 * 1000000);
@@ -49,32 +47,28 @@ select test_consume_xids(10 * 1000000);
 
 -- Wait until autovacuum is triggered
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, 1);
-NOTICE:  Success:
  gp_wait_until_triggered_fault 
 -------------------------------
- t
+ Success:
 (1 row)
 
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- wait until autovacuum worker updates pg_database
 SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
-NOTICE:  Success:
  gp_wait_until_triggered_fault 
 -------------------------------
- t
+ Success:
 (1 row)
 
 SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- template0 should be young

--- a/src/test/regress/output/createdb.source
+++ b/src/test/regress/output/createdb.source
@@ -32,10 +32,10 @@ END;
 $$LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
 BEGIN
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
 END;
 $$ LANGUAGE plpgsql;
 --
@@ -74,9 +74,9 @@ drop database dowell;
 --CASE 1: error in segment after db file physically created
 --
 --reset status
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -89,10 +89,10 @@ select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_co
 
 -- inject fault on content0 primary to error out after copying
 -- template db directory
-select gp_inject_fault2('create_db_after_file_copy', 'error', dbid, hostname, port)
+select gp_inject_fault('create_db_after_file_copy', 'error', dbid)
 from gp_segment_configuration where content=0 and role='p';
- gp_inject_fault2 
-------------------
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -119,9 +119,9 @@ set gp_select_invisible=off;
 --
 --CASE 2: error after XLOG_DBASE_CREATE on master
 --
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -132,10 +132,10 @@ select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_co
  Success:
 (8 rows)
 
-select gp_inject_fault2('after_xlog_create_database', 'error', dbid, hostname, port)
+select gp_inject_fault('after_xlog_create_database', 'error', dbid)
 from gp_segment_configuration where content=-1 and role='p';
- gp_inject_fault2 
-------------------
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -160,9 +160,9 @@ set gp_select_invisible=off;
 --
 --CASE 3: error after XLOG_DBASE_CREATE on segment
 --
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -173,10 +173,10 @@ select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_co
  Success:
 (8 rows)
 
-select gp_inject_fault2('after_xlog_create_database', 'error', dbid, hostname, port)
+select gp_inject_fault('after_xlog_create_database', 'error', dbid)
 from gp_segment_configuration where content=0 and role='p';
- gp_inject_fault2 
-------------------
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -201,9 +201,9 @@ set gp_select_invisible=off;
 --
 --CASE 4: panic after XLOG_XACT_PREPARE on segment
 --
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:
@@ -214,17 +214,17 @@ select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_co
  Success:
 (8 rows)
 
-select gp_inject_fault2('end_prepare_two_phase', 'panic', dbid, hostname, port)
+select gp_inject_fault('end_prepare_two_phase', 'panic', dbid)
 from gp_segment_configuration where content=0 and role='p';
- gp_inject_fault2 
-------------------
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
-select gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port)
+select gp_inject_fault_infinite('fts_probe', 'skip', dbid)
 from gp_segment_configuration where content=0 and role='p';
- gp_inject_fault_infinite2 
----------------------------
+ gp_inject_fault_infinite 
+--------------------------
  Success:
 (1 row)
 
@@ -247,9 +247,9 @@ select db_dirs(oid) from pg_database where datname = 'db4';
 
 set gp_select_invisible=off;
 -- start_ignore
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
  Success:
  Success:
  Success:

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -13,10 +13,9 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- end_matchsubs
 -- skip FTS probes always
 select gp_inject_fault_infinite('fts_probe', 'skip', 1);
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
+ Success:
 (1 row)
 
 select gp_request_fts_probe_scan();
@@ -26,10 +25,9 @@ select gp_request_fts_probe_scan();
 (1 row)
 
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
-NOTICE:  Success:
  gp_wait_until_triggered_fault 
 -------------------------------
- t
+ Success:
 (1 row)
 
 -- Test quoting of GUC values and database names when they're sent to segments
@@ -105,18 +103,16 @@ HINT:  Size controlled by gp_max_plan_size
 -- during backend initialization
 --
 select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11034)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- inject a 'skip' fault before QE sends its motion_listener
 select gp_inject_fault('send_qe_details_init_backend', 'skip', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11034)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- terminate exiting QEs first
@@ -127,10 +123,9 @@ ERROR:  failed to acquire resources on one or more segments
 DETAIL:  Internal error: No motion listener port (seg0 127.0.0.1:40000)
 -- reset fault injector
 select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11048)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 --
@@ -188,10 +183,9 @@ select cleanupAllGangs();
 
 -- trigger fault and report segment 0 in recovery for 5 times
 select gp_inject_fault('process_startup_packet', 'skip', '', 'dispatch_test_db', '', 1, 5, 0, 2::smallint);
-NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=373785)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select cleanupAllGangs();
@@ -209,10 +203,9 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 (1 row)
 
 select gp_inject_fault('process_startup_packet', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11092)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Case 1.2
@@ -229,10 +222,9 @@ select cleanupAllGangs();
 
 -- trigger fault and put segment 0 into recovery mode
 select gp_inject_fault('process_startup_packet', 'skip', '', 'dispatch_test_db', '', 1, 5, 0, 2::smallint);
-NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=373867)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select cleanupAllGangs();
@@ -256,10 +248,9 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 (1 row)
 
 select gp_inject_fault('process_startup_packet', 'reset', 2);
-NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=373925)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 --start_ignore
@@ -310,10 +301,9 @@ select cleanupAllGangs();
 
 -- segment 0 report an error when get a request 
 select gp_inject_fault('send_qe_details_init_backend', 'error', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11221)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select cleanupAllGangs();
@@ -350,18 +340,16 @@ select cleanupAllGangs();
 (1 row)
 
 select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11272)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- segment 0 report an error when get the second request (reader gang creation request)
 select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11272)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select cleanupAllGangs();
@@ -391,10 +379,9 @@ select sum(case when hasBackendsExist(0)='t' then 1 else 0 end) > 0 as hasbacken
 (1 row)
 
 select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11284)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Case 1.4
@@ -403,10 +390,9 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11284)
 -- gp_segment_connect_timeout = 1 : wait 1 second
 set gp_segment_connect_timeout to 1;
 select gp_inject_fault('process_startup_packet', 'suspend', '', 'dispatch_test_db', '', 1, 1, 0, 2::smallint);
-NOTICE:  Success:  (seg0 10.153.101.106:25432 pid=374053)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select cleanupAllGangs();
@@ -422,25 +408,22 @@ ERROR:  failed to acquire resources on one or more segments
 DETAIL:  timeout expired
  (seg0 127.0.0.1:40000)
 select gp_inject_fault('process_startup_packet', 'resume', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('process_startup_packet', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11314)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 set gp_segment_connect_timeout to 0;
 select gp_inject_fault('process_startup_packet', 'sleep', '', '', '', 1, 1, 2, 2::smallint);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11337)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select cleanupAllGangs();
@@ -458,10 +441,9 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 (1 row)
 
 select gp_inject_fault('process_startup_packet', 'reset', 2);
-NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11337)
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Case 1.5
@@ -470,10 +452,9 @@ NOTICE:  Success:  (seg0 127.0.0.1:40000 pid=11337)
 -- must set log_min_messages to default when using interrupt, there is a bug in fault injection.
 set log_min_messages to default;
 select gp_inject_fault('after_one_slice_dispatched', 'interrupt', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- should fail and report error
@@ -481,10 +462,9 @@ select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 ERROR:  canceling statement due to user request
 select gp_inject_fault('after_one_slice_dispatched', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Case 1.6
@@ -492,20 +472,18 @@ NOTICE:  Success:
 -- dispatched, the query can be cancelled correctly.
 -- 
 select gp_inject_fault('before_one_slice_dispatched', 'error', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 update dispatch_test_t1 set c2 = 3 from dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 ERROR:  fault triggered, fault name:'before_one_slice_dispatched' fault type:'error'
 select gp_inject_fault('before_one_slice_dispatched', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- test logging of gang management
@@ -584,17 +562,15 @@ select cleanupAllGangs();
 (1 row)
 
 select gp_inject_fault('gang_created', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_inject_fault('gang_created', 'error', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select 1 from gp_dist_random('gp_id') limit 1;
@@ -607,30 +583,27 @@ select 1 from gp_dist_random('gp_id') limit 1;
 (1 row)
 
 select gp_inject_fault('gang_created', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 --
 -- Test that an error happens after a big command is dispatched.
 --
 select gp_inject_fault('after_one_slice_dispatched', 'error', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select * from gp_dist_random('gp_id')
 	where gpname > (select * from repeat('sssss', 10000000));
 ERROR:  fault triggered, fault name:'after_one_slice_dispatched' fault type:'error'
 select gp_inject_fault('after_one_slice_dispatched', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select * from gp_dist_random('gp_id')
@@ -667,10 +640,9 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into disp_temp_test1 values (1, 2);
 -- Let cleanupSegdb() return false and writer gang be destroyed
 select gp_inject_fault('cleanup_qe', 'skip', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select * from disp_temp_test1 where c1 / 0 = 9;
@@ -691,18 +663,16 @@ LINE 1: select * from disp_temp_test1;
                       ^
 -- reset fault
 select gp_inject_fault('cleanup_qe', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- resume FTS probes
 select gp_inject_fault('fts_probe', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 --

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -51,10 +51,10 @@ END;
 $$LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
 BEGIN
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
 END;
 $$ LANGUAGE plpgsql;
 -- create tablespaces we can use

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -59,7 +59,7 @@ create or replace function disable_fts() returns void as $$
 	begin
 		-- intentionally skip fts during these tests
 		-- we know we're going to be inducing errors and panics on primaries
-		perform gp_inject_fault_infinite2('fts_probe', 'skip', dbid, hostname, port)
+		perform gp_inject_fault_infinite('fts_probe', 'skip', dbid)
 			from gp_segment_configuration
 			where content = master_content_id
 			and role = master_primary_role;
@@ -69,7 +69,7 @@ create or replace function disable_fts() returns void as $$
 		-- also, ensure that the fts loop observes the probe being skipped before
 		-- continuing with the test because it could still be in the middle of a
 		-- previous probe
-		perform gp_wait_until_triggered_fault2('fts_probe', 1, dbid, hostname, port)
+		perform gp_wait_until_triggered_fault2('fts_probe', 1, dbid)
 			from gp_segment_configuration
 			where content = master_content_id
 			and role = master_primary_role;
@@ -83,8 +83,8 @@ create or replace function setup(content_id integer, fault_name text, fault_acti
 		perform setup_tablespace_location_dir_for_test(tablespace_dir);
 
 		-- setup faults
-		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
-		perform gp_inject_fault2(fault_name, fault_action_type, dbid, hostname, port) from gp_segment_configuration where content = content_id and role = 'p';
+		perform gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = content_id and role = 'p';
+		perform gp_inject_fault(fault_name, fault_action_type, dbid) from gp_segment_configuration where content = content_id and role = 'p';
 		perform disable_fts();
 	end;
 $$ LANGUAGE plpgsql;
@@ -92,7 +92,7 @@ create or replace function cleanup(content_id integer, tablespace_location_dir t
 	begin
 		CHECKPOINT; -- ensure primary/master xlogs do not leak into following test
 		perform force_mirrors_to_catch_up();
-		perform gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration;
+		perform gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 		perform remove_tablespace_location_directory(tablespace_location_dir);
 	end;
 $$ LANGUAGE plpgsql;
@@ -131,10 +131,10 @@ END;
 $$LANGUAGE plpgsql;
 create or replace function force_mirrors_to_catch_up() returns void as $$
 begin
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'sleep', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault2('after_xlog_redo_noop', 1, dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault2('after_xlog_redo_noop', 'reset', dbid, hostname, port) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
 end;
 $$ language plpgsql;
 create or replace function wait_for_primaries_to_restart() returns boolean as $$
@@ -635,9 +635,9 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('after_xlog_tblspc_drop', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -672,9 +672,9 @@ select * from list_tablespace_catalog_without_oid(); -- the tablespace should st
             -1 | pg_global
 (12 rows)
 
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = 0;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -718,9 +718,9 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2('after_xlog_tblspc_drop', 'error', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('after_xlog_tblspc_drop', 'error', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -755,9 +755,9 @@ select * from list_tablespace_catalog_without_oid(); -- the tablespace should st
             -1 | pg_global
 (12 rows)
 
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -875,9 +875,9 @@ select disable_fts();
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault(:'fault_name', :'fault_type', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -915,9 +915,9 @@ select * from list_tablespace_catalog_without_oid(); -- the tablespace should no
             -1 | pg_global
 (8 rows)
 
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -961,9 +961,9 @@ select disable_fts();
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault(:'fault_name', :'fault_type', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -1004,9 +1004,9 @@ select * from list_tablespace_catalog_without_oid(); -- the tablespaces should e
              2 | pg_global
 (12 rows)
 
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -1052,9 +1052,9 @@ select disable_fts();
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault(:'fault_name', :'fault_type', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -1089,9 +1089,9 @@ select * from list_tablespace_catalog_without_oid(); -- the tablespaces should e
             -1 | pg_global
 (12 rows)
 
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -1131,9 +1131,9 @@ select setup_tablespace_location_dir_for_test(:'tablespace_location');
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-select gp_inject_fault2(:'fault_name', :'fault_type', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault(:'fault_name', :'fault_type', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -1168,9 +1168,9 @@ select * from list_tablespace_catalog_without_oid(); -- the tablespaces should e
             -1 | pg_global
 (12 rows)
 
-select gp_inject_fault2('all', 'reset', dbid, hostname, port) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
- gp_inject_fault2 
-------------------
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = :content_id_under_test;
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -69,7 +69,7 @@ create or replace function disable_fts() returns void as $$
 		-- also, ensure that the fts loop observes the probe being skipped before
 		-- continuing with the test because it could still be in the middle of a
 		-- previous probe
-		perform gp_wait_until_triggered_fault2('fts_probe', 1, dbid)
+		perform gp_wait_until_triggered_fault('fts_probe', 1, dbid)
 			from gp_segment_configuration
 			where content = master_content_id
 			and role = master_primary_role;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1440,17 +1440,15 @@ COMMIT;
 -- number of rows in the lineitem table.
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'interrupt', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 COPY lineitem TO '/tmp/aborted.data';
@@ -1465,10 +1463,9 @@ SELECT count(*) < 57190 FROM lineitem_aborted;
 (1 row)
 
 SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 -- Test external partition

--- a/src/test/regress/sql/fts_recovery_in_progress.sql
+++ b/src/test/regress/sql/fts_recovery_in_progress.sql
@@ -6,7 +6,7 @@
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- end_ignore
 select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
-select gp_inject_fault_infinite2('fts_conn_startup_packet', 'skip', dbid, hostname, port)
+select gp_inject_fault_infinite('fts_conn_startup_packet', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 -- to make test deterministic and fast
 -- start_ignore
@@ -26,14 +26,14 @@ from gp_segment_configuration where content = 0 and role = 'p';
 select pg_sleep(5);
 show gp_fts_probe_retries;
 select gp_request_fts_probe_scan();
-select gp_wait_until_triggered_fault2('fts_conn_startup_packet', 3, dbid, hostname, port)
+select gp_wait_until_triggered_fault('fts_conn_startup_packet', 3, dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 select role, preferred_role, mode, status from gp_segment_configuration where content = 0;
 
 -- test other scenario where recovery on primary is hung and hence FTS marks
 -- primary down and promotes mirror. When 'fts_recovery_in_progress' is set to
 -- skip it mimics the behavior of hung recovery on primary.
-select gp_inject_fault_infinite2('fts_recovery_in_progress', 'skip', dbid, hostname, port)
+select gp_inject_fault_infinite('fts_recovery_in_progress', 'skip', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';
 -- We call gp_request_fts_probe_scan twice to guarantee that the scan happens
 -- after the fts_recovery_in_progress fault has been injected. If periodic fts
@@ -107,5 +107,5 @@ select role, preferred_role, mode, status from gp_segment_configuration where co
 -- end_ignore
 
 -- cleanup steps
-select gp_inject_fault2('all', 'reset', dbid, hostname, port)
+select gp_inject_fault('all', 'reset', dbid)
 from gp_segment_configuration where content = 0 and role = 'p';

--- a/src/test/walrep/expected/missing_xlog.out
+++ b/src/test/walrep/expected/missing_xlog.out
@@ -138,10 +138,9 @@ create extension if not exists gp_inject_fault;
 -- triggered immediately, rather that waiting until the next probe
 -- interval.
 select gp_inject_fault_infinite('fts_probe', 'skip', 1);
-NOTICE:  Success:
  gp_inject_fault_infinite 
 --------------------------
- t
+ Success:
 (1 row)
 
 select gp_request_fts_probe_scan();
@@ -151,10 +150,9 @@ select gp_request_fts_probe_scan();
 (1 row)
 
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
-NOTICE:  Success:
  gp_wait_until_triggered_fault 
 -------------------------------
- t
+ Success:
 (1 row)
 
 -- stop a mirror
@@ -225,10 +223,9 @@ select sync_error from gp_stat_replication where gp_segment_id = 0;
 
 -- Resume FTS probes and perform a probe scan.
 select gp_inject_fault('fts_probe', 'reset', 1);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 select gp_request_fts_probe_scan();


### PR DESCRIPTION
This is a back port of PR #8343 to 6X.  All except the warning to disable FTS have been cherry-picked.  The warning change has not been back ported to 6X.

Relying on PR pipeline to provide verdict.

