### PR TITLE
pg_upgrade: Output results of all GPDB-specific checks

### DIFF
--- a/contrib/pg_upgrade/Makefile
+++ b/contrib/pg_upgrade/Makefile
@@ -12,7 +12,11 @@ OBJS = check.o controldata.o dump.o exec.o file.o function.o info.o \
 
 # Source files specific to Greenplum
 OBJS += aotable.o gpdb4_heap_convert.o version_gp.o \
-        check_gp.o file_gp.o reporting.o aomd_filehandler.o
+        file_gp.o reporting.o aomd_filehandler.o
+
+# Source files specific to Greenplum from gp directory
+OBJS += gp/definitions_utilities.o gp/checks.o gp/definitions_checks_list.o \
+		gp/check_greenplum.o
 
 PG_CPPFLAGS  = -DFRONTEND -DDLSUFFIX=\"$(DLSUFFIX)\" -I$(srcdir) -I$(libpq_srcdir)
 PG_LIBS = $(libpq_pgport)

--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -12,6 +12,7 @@
 #include "mb/pg_wchar.h"
 #include "pg_upgrade.h"
 
+#include "gp/check_greenplum.h"
 
 static void set_locale_and_encoding(ClusterInfo *cluster);
 static void check_new_cluster_is_empty(void);
@@ -72,7 +73,6 @@ output_check_banner(bool live_check)
 		pg_log(PG_REPORT, "-----------------------------\n");
 	}
 }
-
 
 void
 check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)

--- a/contrib/pg_upgrade/check_gp.c
+++ b/contrib/pg_upgrade/check_gp.c
@@ -22,7 +22,31 @@ static void check_partition_indexes(void);
 static void check_orphaned_toastrels(void);
 static void check_online_expansion(void);
 static void check_gphdfs_external_tables(void);
-static void check_gphdfs_user_roles(void);
+static bool check_gphdfs_user_roles(void);
+
+static
+__attribute__((format(PG_PRINTF_ATTRIBUTE, 1, 2)))
+void
+gp_check_failure(const char *restrict fmt,...)
+{
+	report_status(PG_REPORT, "fatal\n");
+
+	va_list		args;
+
+	va_start(args, fmt);
+	vprintf(_(fmt), args);
+	va_end(args);
+
+	fflush(stdout);
+}
+
+static inline void
+__attribute__((nonnull(1, 2)))
+gp_conduct_check(bool (*f) (void), bool *failed)
+{
+	if (!f())
+		*failed = true;
+}
 
 /*
  *	check_greenplum
@@ -35,13 +59,18 @@ static void check_gphdfs_user_roles(void);
 void
 check_greenplum(void)
 {
+	bool		failed = false;
+
 	check_online_expansion();
 	check_external_partition();
 	check_covering_aoindex();
 	check_partition_indexes();
 	check_orphaned_toastrels();
 	check_gphdfs_external_tables();
-	check_gphdfs_user_roles();
+	gp_conduct_check(check_gphdfs_user_roles, &failed);
+
+	if (failed)
+		pg_log(PG_FATAL, "One or more checks failed. See output above.\n");
 }
 
 /*
@@ -544,7 +573,7 @@ check_gphdfs_external_tables(void)
  * Check if there are any remaining users with gphdfs roles.
  * We error if this is the case and let the users know how to proceed.
  */
-static void
+static bool
 check_gphdfs_user_roles(void)
 {
 	char		output_path[MAXPGPATH];
@@ -558,7 +587,7 @@ check_gphdfs_user_roles(void)
 
 	/* GPDB only supported gphdfs in this version range */
 	if (!(old_cluster.major_version >= 80215 && old_cluster.major_version < 80400))
-		return;
+		return true;
 
 	prep_status("Checking for users assigned the gphdfs role");
 
@@ -604,14 +633,16 @@ check_gphdfs_user_roles(void)
 	if (ntups > 0)
 	{
 		fclose(script);
-		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
-			   "| Your installation contains roles that have gphdfs privileges.\n"
-			   "| These privileges need to be revoked before upgrade.  A list\n"
-			   "| of roles and their corresponding gphdfs privileges that\n"
-			   "| must be revoked is provided in the file:\n"
-			   "| \t%s\n\n", output_path);
+		gp_check_failure("| Your installation contains roles that have gphdfs privileges.\n"
+						 "| These privileges need to be revoked before upgrade.  A list\n"
+						 "| of roles and their corresponding gphdfs privileges that\n"
+						 "| must be revoked is provided in the file:\n"
+						 "| \t%s\n\n", output_path);
+		return false;
 	}
 	else
+	{
 		check_ok();
+		return true;
+	}
 }

--- a/contrib/pg_upgrade/check_gp.c
+++ b/contrib/pg_upgrade/check_gp.c
@@ -41,11 +41,16 @@ gp_check_failure(const char *restrict fmt,...)
 }
 
 static inline void
-__attribute__((nonnull(1, 2)))
-gp_conduct_check(bool (*f) (void), bool *failed)
+__attribute__((nonnull(1)))
+conduct_check(bool (*check_function) (void))
 {
-	if (!f())
-		*failed = true;
+	if (check_function())
+	{
+		check_ok();
+		return;
+	}
+
+	pg_log(PG_FATAL, "One or more checks failed. See output above.\n");
 }
 
 /*
@@ -59,18 +64,13 @@ gp_conduct_check(bool (*f) (void), bool *failed)
 void
 check_greenplum(void)
 {
-	bool		failed = false;
-
-	gp_conduct_check(check_online_expansion, &failed);
-	gp_conduct_check(check_external_partition, &failed);
-	gp_conduct_check(check_covering_aoindex, &failed);
-	gp_conduct_check(check_partition_indexes, &failed);
-	gp_conduct_check(check_orphaned_toastrels, &failed);
-	gp_conduct_check(check_gphdfs_external_tables, &failed);
-	gp_conduct_check(check_gphdfs_user_roles, &failed);
-
-	if (failed)
-		pg_log(PG_FATAL, "One or more checks failed. See output above.\n");
+	conduct_check(check_online_expansion);
+	conduct_check(check_external_partition);
+	conduct_check(check_covering_aoindex);
+	conduct_check(check_partition_indexes);
+	conduct_check(check_orphaned_toastrels);
+	conduct_check(check_gphdfs_external_tables);
+	conduct_check(check_gphdfs_user_roles);
 }
 
 /*
@@ -138,7 +138,6 @@ check_online_expansion(void)
 		return false;
 	}
 
-	check_ok();
 	return true;
 }
 
@@ -221,7 +220,6 @@ check_external_partition(void)
 		return false;
 	}
 
-	check_ok();
 	return true;
 }
 
@@ -332,7 +330,6 @@ check_covering_aoindex(void)
 
 	}
 
-	check_ok();
 	return true;
 }
 
@@ -394,7 +391,6 @@ check_orphaned_toastrels(void)
 		return false;
 	}
 
-	check_ok();
 	return true;
 }
 
@@ -490,7 +486,6 @@ check_partition_indexes(void)
 		return false;
 	}
 
-	check_ok();
 	return true;
 }
 
@@ -568,7 +563,6 @@ check_gphdfs_external_tables(void)
 		return false;
 	}
 
-	check_ok();
 	return true;
 }
 
@@ -646,6 +640,5 @@ check_gphdfs_user_roles(void)
 		return false;
 	}
 
-	check_ok();
 	return true;
 }

--- a/contrib/pg_upgrade/gp/Makefile
+++ b/contrib/pg_upgrade/gp/Makefile
@@ -1,0 +1,6 @@
+# top_builddir = ../../..
+#
+# OBJS = check_greenplum.o checks.o checks_list.o checks_utilities.o
+#
+# include $(top_builddir)/src/Makefile.global
+# include $(top_srcdir)/contrib/contrib-global.mk

--- a/contrib/pg_upgrade/gp/check_greenplum.c
+++ b/contrib/pg_upgrade/gp/check_greenplum.c
@@ -1,0 +1,21 @@
+/*
+ * contrib/pg_upgrade/gp/check_greenplum.c
+ *
+ * Definition of an interface function to conduct Greenplum-specific pg_upgrade
+ * checks
+ */
+
+#include "check_greenplum.h"
+#include "definitions.h"
+
+
+void
+check_greenplum(void)
+{
+	size_t i;
+
+	for (i = 0; i < GP_CHECKS_LIST_LENGTH; i++)
+	{
+		conduct_check(GP_CHECKS_LIST[i]);
+	}
+}

--- a/contrib/pg_upgrade/gp/check_greenplum.h
+++ b/contrib/pg_upgrade/gp/check_greenplum.h
@@ -1,0 +1,20 @@
+#ifndef GPDB_CHECK_GREENPLUM_H
+#define GPDB_CHECK_GREENPLUM_H
+
+/*
+ * contrib/pg_upgrade/gp/check_greenplum.h
+ *
+ * Declaration of an interface function to conduct Greenplum-specific pg_upgrade
+ * checks
+ */
+
+
+/*
+ * Conduct all greenplum checks, defined in GP_CHECKS_LIST
+ *
+ * This function should be executed after all PostgreSQL checks. The order of the checks should not matter.
+ */
+void check_greenplum(void);
+
+
+#endif //GPDB_CHECK_GREENPLUM_H

--- a/contrib/pg_upgrade/gp/checks.c
+++ b/contrib/pg_upgrade/gp/checks.c
@@ -1,77 +1,12 @@
 /*
- *	check_gp.c
+ * contrib/pg_upgrade/gp/checks.h
  *
- *	Greenplum specific server checks and output routines
- *
- *	Any compatibility checks which are version dependent (testing for issues in
- *	specific versions of Greenplum) should be placed in their respective
- *	version_old_gpdb{MAJORVERSION}.c file.  The checks in this file supplement
- *	the checks present in check.c, which is the upstream file for performing
- *	checks against a PostgreSQL cluster.
- *
- *	Copyright (c) 2010, PostgreSQL Global Development Group
- *	Copyright (c) 2017-Present Pivotal Software, Inc
- *	contrib/pg_upgrade/check_gp.c
+ * Definitions of Greenplum-specific check functions
  */
 
-#include "pg_upgrade.h"
+#include "checks.h"
+#include "definitions.h"
 
-static bool check_external_partition(void);
-static bool check_covering_aoindex(void);
-static bool check_partition_indexes(void);
-static bool check_orphaned_toastrels(void);
-static bool check_online_expansion(void);
-static bool check_gphdfs_external_tables(void);
-static bool check_gphdfs_user_roles(void);
-
-static
-__attribute__((format(PG_PRINTF_ATTRIBUTE, 1, 2)))
-void
-gp_check_failure(const char *restrict fmt,...)
-{
-	report_status(PG_REPORT, "fatal\n");
-
-	va_list		args;
-
-	va_start(args, fmt);
-	vprintf(_(fmt), args);
-	va_end(args);
-
-	fflush(stdout);
-}
-
-static inline void
-__attribute__((nonnull(1)))
-conduct_check(bool (*check_function) (void))
-{
-	if (check_function())
-	{
-		check_ok();
-		return;
-	}
-
-	pg_log(PG_FATAL, "One or more checks failed. See output above.\n");
-}
-
-/*
- *	check_greenplum
- *
- *	Rather than exporting all checks, we export a single API function which in
- *	turn is responsible for running Greenplum checks. This function should be
- *	executed after all PostgreSQL checks. The order of the checks should not
- *	matter.
- */
-void
-check_greenplum(void)
-{
-	conduct_check(check_online_expansion);
-	conduct_check(check_external_partition);
-	conduct_check(check_covering_aoindex);
-	conduct_check(check_partition_indexes);
-	conduct_check(check_orphaned_toastrels);
-	conduct_check(check_gphdfs_external_tables);
-	conduct_check(check_gphdfs_user_roles);
-}
 
 /*
  *	check_online_expansion
@@ -79,7 +14,7 @@ check_greenplum(void)
  *	Check for online expansion status and refuse the upgrade if online
  *	expansion is in progress.
  */
-static bool
+bool
 check_online_expansion(void)
 {
 	bool		expansion = false;
@@ -155,7 +90,7 @@ check_online_expansion(void)
  *	Check for the existence of external partitions and refuse the upgrade if
  *	found.
  */
-static bool
+bool
 check_external_partition(void)
 {
 	char		output_path[MAXPGPATH];
@@ -262,7 +197,7 @@ check_external_partition(void)
  *	creates the current state, but for the time being we disallow upgrades on
  *	cluster which exhibits this.
  */
-static bool
+bool
 check_covering_aoindex(void)
 {
 	char		output_path[MAXPGPATH];
@@ -333,7 +268,7 @@ check_covering_aoindex(void)
 	return true;
 }
 
-static bool
+bool
 check_orphaned_toastrels(void)
 {
 	bool		found = false;
@@ -403,7 +338,7 @@ check_orphaned_toastrels(void)
  *	invalidate the indexes forcing a REINDEX, there is little to be gained by
  *	handling them for the end-user.
  */
-static bool
+bool
 check_partition_indexes(void)
 {
 	int			dbnum;
@@ -496,7 +431,7 @@ check_partition_indexes(void)
  * We error if any gphdfs external tables remain and let the users know that,
  * any remaining gphdfs external tables have to be removed.
  */
-static bool
+bool
 check_gphdfs_external_tables(void)
 {
 	char		output_path[MAXPGPATH];
@@ -572,7 +507,7 @@ check_gphdfs_external_tables(void)
  * Check if there are any remaining users with gphdfs roles.
  * We error if this is the case and let the users know how to proceed.
  */
-static bool
+bool
 check_gphdfs_user_roles(void)
 {
 	char		output_path[MAXPGPATH];

--- a/contrib/pg_upgrade/gp/checks.h
+++ b/contrib/pg_upgrade/gp/checks.h
@@ -1,0 +1,22 @@
+#ifndef GPDB_CHECKS_H
+#define GPDB_CHECKS_H
+
+/*
+ * contrib/pg_upgrade/gp/checks.h
+ *
+ * Declarations of Greenplum-specific check functions
+ */
+
+#include "definitions.h"
+
+
+bool check_external_partition(void);
+bool check_covering_aoindex(void);
+bool check_partition_indexes(void);
+bool check_orphaned_toastrels(void);
+bool check_online_expansion(void);
+bool check_gphdfs_external_tables(void);
+bool check_gphdfs_user_roles(void);
+
+
+#endif //GPDB_CHECKS_H

--- a/contrib/pg_upgrade/gp/definitions.h
+++ b/contrib/pg_upgrade/gp/definitions.h
@@ -1,0 +1,425 @@
+#ifndef GPDB_CHECK_UTILS_H
+#define GPDB_CHECK_UTILS_H
+
+/*
+ * contrib/pg_upgrade/gp/definitions.h
+ *
+ * Objects required to run Greenplum-specific checks.
+ *
+ * This file redeclares functions from pg_upgrade. Original versions are not
+ * used in order to:
+ * 1. Eliminate dependency of checks on utilities implementation;
+ * 2. Facilitate unit test conduction;
+ * 3. Preserve pg_upgrade functions originating from upstream.
+ */
+
+
+/*
+ * Common upgrade-specific stuff. These are redefinitions in case upgrade is
+ * not included
+ */
+#ifndef PG_UPGRADE_H
+
+#include <unistd.h>
+#include <assert.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+
+#include "postgres.h"
+#include "libpq-fe.h"
+#include "pqexpbuffer.h"
+
+/* Use port in the private/dynamic port number range */
+#define DEF_PGUPORT			50432
+
+/* Allocate for null byte */
+#define USER_NAME_SIZE		128
+
+#define MAX_STRING			1024
+#define LINE_ALLOC			4096
+#define QUERY_ALLOC			8192
+
+#define NUMERIC_ALLOC 100
+
+#define MIGRATOR_API_VERSION	1
+
+#define MESSAGE_WIDTH		60
+
+#define GET_MAJOR_VERSION(v)	((v) / 100)
+
+
+/* needs to be kept in sync with pg_class.h */
+#define RELSTORAGE_EXTERNAL	'x'
+#define RELSTORAGE_AOROWS	'a'
+#define RELSTORAGE_AOCOLS	'c'
+
+
+#define CLUSTER_NAME(cluster)	((cluster) == &old_cluster ? "old" : \
+								 (cluster) == &new_cluster ? "new" : "none")
+
+#define atooid(x)  ((Oid) strtoul((x), NULL, 10))
+
+/* OID system catalog preservation added during PG 9.0 development */
+#define TABLE_SPACE_SUBDIRS_CAT_VER 201001111
+/* postmaster/postgres -b (binary_upgrade) flag added during PG 9.1 development */
+/* In GPDB, it was introduced during GPDB 5.0 development. */
+#define BINARY_UPGRADE_SERVER_FLAG_CAT_VER 301607301
+/*
+ *	Visibility map changed with this 9.2 commit,
+ *	8f9fe6edce358f7904e0db119416b4d1080a83aa; pick later catalog version.
+ */
+#define VISIBILITY_MAP_CRASHSAFE_CAT_VER 201107031
+
+/*
+ * change in JSONB format during 9.4 beta
+ */
+#define JSONB_FORMAT_CHANGE_CAT_VER 201409291
+
+/*
+ * pg_multixact format changed in 9.3 commit 0ac5ad5134f2769ccbaefec73844f85,
+ * ("Improve concurrency of foreign key locking") which also updated catalog
+ * version to this value.  pg_upgrade behavior depends on whether old and new
+ * server versions are both newer than this, or only the new one is.
+ *
+ * In GPDB: that upstream change was merged into GPDB in the big 9.3 merge
+ * commit.
+ */
+#define MULTIXACT_FORMATCHANGE_CAT_VER 301809211
+
+/*
+ * Extra information stored for each Append-only table.
+ * This is used to transfer the information from the auxiliary
+ * AO table to the new cluster.
+ */
+
+/* To hold contents of pg_visimap_<oid> */
+typedef struct
+{
+	int			segno;
+	int64		first_row_no;
+	char	   *visimap;		/* text representation of the "bit varying" field */
+} AOVisiMapInfo;
+
+typedef struct
+{
+	int			segno;
+	int			columngroup_no;
+	int64		first_row_no;
+	char	   *minipage;		/* text representation of the "bit varying" field */
+} AOBlkDir;
+
+/* To hold contents of pg_aoseg_<oid> */
+typedef struct
+{
+	int			segno;
+	int64		eof;
+	int64		tupcount;
+	int64		varblockcount;
+	int64		eofuncompressed;
+	int64		modcount;
+	int16		version;
+	int16		state;
+} AOSegInfo;
+
+/* To hold contents of pf_aocsseg_<oid> */
+typedef struct
+{
+	int         segno;
+	int64		tupcount;
+	int64		varblockcount;
+	char       *vpinfo;
+	int64		modcount;
+	int16		state;
+	int16		version;
+} AOCSSegInfo;
+
+typedef struct
+{
+	int16		attlen;
+	char		attalign;
+	bool		is_numeric;
+} AttInfo;
+
+typedef enum
+{
+	HEAP,
+	AO,
+	AOCS,
+	FSM
+} RelType;
+
+/*
+ * Each relation is represented by a relinfo structure.
+ */
+typedef struct
+{
+	/* Can't use NAMEDATALEN;  not guaranteed to fit on client */
+	char	   *nspname;		/* namespace name */
+	char	   *relname;		/* relation name */
+	Oid			reloid;			/* relation oid */
+	char		relstorage;
+	Oid			relfilenode;	/* relation relfile node */
+	/* GPDB_96_MERGE_FIXME: indtable and toastheap are backported from 9.6. */
+	Oid			indtable;		/* if index, OID of its table, else 0 */
+	Oid			toastheap;		/* if toast table, OID of base table, else 0 */
+	/* relation tablespace path, or "" for the cluster default */
+	char	   *tablespace;
+	bool		nsp_alloc;
+	bool		tblsp_alloc;
+
+	RelType		reltype;
+
+	/* Extra information for append-only tables */
+	AOSegInfo  *aosegments;
+	AOCSSegInfo *aocssegments;
+	int			naosegments;
+	AOVisiMapInfo *aovisimaps;
+	int			naovisimaps;
+	AOBlkDir   *aoblkdirs;
+	int			naoblkdirs;
+
+	/* Extra information for heap tables */
+	bool		gpdb4_heap_conversion_needed;
+	bool		has_numerics;
+	AttInfo	   *atts;
+	int			natts;
+} RelInfo;
+
+typedef struct
+{
+	RelInfo    *rels;
+	int			nrels;
+} RelInfoArr;
+
+/*
+ * Structure to store database information
+ */
+typedef struct
+{
+	Oid			db_oid;			/* oid of the database */
+	char	   *db_name;		/* database name */
+	char		db_tablespace[MAXPGPATH];		/* database default tablespace
+												 * path */
+	RelInfoArr	rel_arr;		/* array of all user relinfos */
+
+	char	   *reserved_oids;	/* as a string */
+} DbInfo;
+
+typedef struct
+{
+	DbInfo	   *dbs;			/* array of db infos */
+	int			ndbs;			/* number of db infos */
+} DbInfoArr;
+
+/*
+ * The following structure is used to hold pg_control information.
+ * Rather than using the backend's control structure we use our own
+ * structure to avoid pg_control version issues between releases.
+ */
+typedef struct
+{
+	uint32		ctrl_ver;
+	uint32		cat_ver;
+	char		nextxlogfile[25];
+	uint32		chkpnt_nxtxid;
+	uint32		chkpnt_nxtepoch;
+	uint32		chkpnt_nxtoid;
+	uint32		chkpnt_nxtmulti;
+	uint32		chkpnt_nxtmxoff;
+	uint32		chkpnt_oldstMulti;
+	uint32		align;
+	uint32		blocksz;
+	uint32		largesz;
+	uint32		walsz;
+	uint32		walseg;
+	uint32		ident;
+	uint32		index;
+	uint32		toast;
+	bool		date_is_int;
+	bool		float8_pass_by_value;
+	bool		data_checksum_version;
+	char	   *lc_collate;
+	char	   *lc_ctype;
+	char	   *encoding;
+} ControlData;
+
+/*
+ * cluster
+ *
+ *	information about each cluster
+ */
+typedef struct
+{
+	ControlData controldata;	/* pg_control information */
+	DbInfoArr	dbarr;			/* dbinfos array */
+	char	   *pgdata;			/* pathname for cluster's $PGDATA directory */
+	char	   *pgconfig;		/* pathname for cluster's config file
+								 * directory */
+	char	   *bindir;			/* pathname for cluster's executable directory */
+	char	   *pgopts;			/* options to pass to the server, like pg_ctl
+								 * -o */
+	char	   *sockdir;		/* directory for Unix Domain socket, if any */
+	unsigned short port;		/* port number where postmaster is waiting */
+	uint32		major_version;	/* PG_VERSION of cluster */
+	char		major_version_str[64];	/* string PG_VERSION of cluster */
+	uint32		bin_version;	/* version returned from pg_ctl */
+	Oid			pg_database_oid;	/* OID of pg_database relation */
+	Oid			install_role_oid;		/* OID of connected role */
+	Oid			role_count;		/* number of roles defined in the cluster */
+	const char *tablespace_suffix;		/* directory specification */
+
+	char	   *global_reserved_oids; /* OID preassign calls for shared objects */
+} ClusterInfo;
+
+/*
+ * Enumeration to denote link modes
+ */
+typedef enum
+{
+	TRANSFER_MODE_COPY,
+	TRANSFER_MODE_LINK
+} transferMode;
+
+/*
+ * Enumeration to denote checksum modes
+ */
+typedef enum
+{
+	CHECKSUM_NONE = 0,
+	CHECKSUM_ADD,
+	CHECKSUM_REMOVE
+} checksumMode;
+
+typedef enum
+{
+	DISPATCHER = 0,
+	SEGMENT
+} segmentMode;
+
+/*
+ *	UserOpts
+*/
+typedef struct
+{
+	bool		check;			/* TRUE -> ask user for permission to make
+								 * changes */
+	transferMode transfer_mode; /* copy files or link them? */
+	int			jobs;			/* number of processes/threads to use */
+	char	   *socketdir;		/* directory to use for Unix sockets */
+
+	bool		progress;
+	segmentMode	segment_mode;
+	checksumMode checksum_mode;
+
+} UserOpts;
+
+ClusterInfo old_cluster;
+
+extern UserOpts user_opts;
+
+/*
+ * Enumeration to denote pg_log modes
+ */
+typedef enum
+{
+	PG_VERBOSE,
+	PG_STATUS,
+	PG_REPORT,
+	PG_WARNING,
+	PG_FATAL
+} eLogType;
+
+/*
+ * connectToServer()
+ *
+ *	Connects to the desired database on the designated server.
+ *	If the connection attempt fails, this function logs an error
+ *	message and calls exit() to kill the program.
+ */
+PGconn *
+connectToServer(ClusterInfo *cluster, const char *db_name);
+
+/*
+ * executeQueryOrDie()
+ *
+ *	Formats a query string from the given arguments and executes the
+ *	resulting query.  If the query fails, this function logs an error
+ *	message and calls exit() to kill the program.
+ */
+PGresult *
+executeQueryOrDie(PGconn *conn, const char *fmt,...)
+__attribute__((format(PG_PRINTF_ATTRIBUTE, 2, 3)));
+
+void
+report_status(eLogType type, const char *fmt,...)
+__attribute__((format(PG_PRINTF_ATTRIBUTE, 2, 3)));
+
+void
+pg_log(eLogType type, const char *fmt,...)
+__attribute__((format(PG_PRINTF_ATTRIBUTE, 2, 3)));
+
+void
+pg_fatal(const char *fmt,...)
+__attribute__((format(PG_PRINTF_ATTRIBUTE, 1, 2), noreturn));
+
+/*
+ * prep_status
+ *
+ *	Displays a message that describes an operation we are about to begin.
+ *	We pad the message out to MESSAGE_WIDTH characters so that all of the "ok" and
+ *	"failed" indicators line up nicely.
+ *
+ *	A typical sequence would look like this:
+ *		prep_status("about to flarb the next %d files", fileCount );
+ *
+ *		if(( message = flarbFiles(fileCount)) == NULL)
+ *		  report_status(PG_REPORT, "ok" );
+ *		else
+ *		  pg_log(PG_FATAL, "failed - %s\n", message );
+ */
+void
+prep_status(const char *fmt,...)
+__attribute__((format(PG_PRINTF_ATTRIBUTE, 1, 2)));
+
+/*
+ * Set the current check as "successful"
+ */
+void		check_ok(void);
+
+#endif /* PG_UPGRADE_H */
+
+
+/*
+ * Greenplum-specific stuff
+ */
+
+/*
+ * Check function definition.
+ * Such functions actually perform checks on Greenplum
+ */
+typedef bool (*check_function)(void);
+
+/*
+ * A list of functions to be run to conduct tests
+ */
+extern check_function GP_CHECKS_LIST[];
+extern size_t GP_CHECKS_LIST_LENGTH;
+
+/*
+ * gp_check_failure()
+ *
+ * Check if failure happened during check execution
+ */
+void
+gp_check_failure(const char *restrict fmt,...)
+__attribute__((format(PG_PRINTF_ATTRIBUTE, 1, 2)));
+
+/*
+ * Conducts check using provided check function
+ */
+void
+conduct_check(bool (*check_function) (void))
+__attribute__((nonnull(1)));
+
+
+#endif //GPDB_CHECK_UTILS_H

--- a/contrib/pg_upgrade/gp/definitions_checks_list.c
+++ b/contrib/pg_upgrade/gp/definitions_checks_list.c
@@ -1,0 +1,25 @@
+/*
+ * contrib/pg_upgrade/gp/check_gp_support.c
+ *
+ * A configuration file for actual check execution.
+ *
+ * Declarations of checks *normally* executed by Greenplum pg_upgrade
+ */
+
+#include "definitions.h"
+#include "checks.h"
+
+
+/* Check functions */
+
+check_function GP_CHECKS_LIST[] = {
+	check_online_expansion,
+	check_external_partition,
+	check_covering_aoindex,
+	check_partition_indexes,
+	check_orphaned_toastrels,
+	check_gphdfs_external_tables,
+	check_gphdfs_user_roles
+};
+
+size_t GP_CHECKS_LIST_LENGTH = sizeof(GP_CHECKS_LIST) / sizeof(GP_CHECKS_LIST[0]);

--- a/contrib/pg_upgrade/gp/definitions_utilities.c
+++ b/contrib/pg_upgrade/gp/definitions_utilities.c
@@ -1,0 +1,33 @@
+#include "definitions.h"
+
+/*
+ * contrib/pg_upgrade/check_gp/check_gp_support.c
+ *
+ * Definitions of utility functions *normally* used to conduct pg_upgrade checks
+ */
+
+void
+gp_check_failure(const char *restrict fmt,...)
+{
+	report_status(PG_REPORT, "fatal\n");
+
+	va_list		args;
+
+	va_start(args, fmt);
+	vprintf(_(fmt), args);
+	va_end(args);
+
+	fflush(stdout);
+}
+
+void
+conduct_check(bool (*check_function) (void))
+{
+	if (check_function())
+	{
+		check_ok();
+		return;
+	}
+
+	pg_log(PG_FATAL, "One or more checks failed. See output above.\n");
+}

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -94,6 +94,7 @@ main(int argc, char **argv)
 	char	   *deletion_script_file_name = NULL;
 	bool		live_check = false;
 
+
 	/* Ensure that all files created by pg_upgrade are non-world-readable */
 	umask(S_IRWXG | S_IRWXO);
 

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -689,10 +689,6 @@ void new_gpdb_invalidate_bitmap_indexes(void);
 Oid *get_numeric_types(PGconn *conn);
 void old_GPDB5_check_for_unsupported_distribution_key_data_types(void);
 
-/* check_gp.c */
-
-void check_greenplum(void);
-
 /* reporting.c */
 
 void report_progress(ClusterInfo *cluster, progress_type op, char *fmt,...)


### PR DESCRIPTION
Introduce `gp_conduct_check()` and `gp_check_failure()` functions. These enable `pg_upgrade` to store its "state" and do not fail on the first error it encounters. Errors are printed after each check.

##### Before:
```
Performing Consistency Checks
-----------------------------
Checking cluster versions                                   ok
Checking database user is a superuser                       ok
Checking database connection settings                       ok
Checking for prepared transactions                          ok
Checking for reg* system OID user data types                ok
Checking for contrib/isn with bigint-passing mismatch       ok
Checking array types derived from partitions                ok
Checking for external tables used in partitioning           fatal

| Your installation contains partitioned tables with external
| tables as partitions.  These partitions need to be removed
| from the partition hierarchy before the upgrade.  A list of
| external partitions to remove is in the file:
|     external_partitions.txt

Failure, exiting
```

##### After:
```
Performing Consistency Checks
-----------------------------
Checking cluster versions                                   ok
Checking database user is a superuser                       ok
Checking database connection settings                       ok
Checking for prepared transactions                          ok
Checking for reg* system OID user data types                ok
Checking for contrib/isn with bigint-passing mismatch       ok
Checking array types derived from partitions                ok
Checking for external tables used in partitioning           fatal

| Your installation contains partitioned tables with external
| tables as partitions.  These partitions need to be removed
| from the partition hierarchy before the upgrade.  A list of
| external partitions to remove is in the file:
|     external_partitions.txt

Checking for non-covering indexes on partitioned AO tables  ok
Checking for indexes on partitioned tables                  fatal

| Your installation contains partitioned tables with
| indexes defined on them.  Indexes on partition parents,
| as well as children, must be dropped before upgrade.
| A list of the problem tables is in the file:
|     partitioned_tables_indexes.txt

Checking for orphaned TOAST relations                       ok
Checking for gphdfs external tables                         ok
Checking for users assigned the gphdfs role                 fatal

| Your installation contains roles that have gphdfs privileges.
| These privileges need to be revoked before upgrade.  A list
| of roles and their corresponding gphdfs privileges that
| must be revoked is provided in the file:
|     gphdfs_user_roles.txt


One or more checks failed. See output above.
Failure, exiting
```
