### PR TITLE
Fix COPY FROM SEGMENT segment rows completed count

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -440,7 +440,7 @@ processCopyEndResults(CdbCopy *c,
 	PGresult   *res;
 	struct pollfd	*pollRead = (struct pollfd *) palloc(sizeof(struct pollfd));
 	int			segment_rows_rejected = 0;	/* num of rows rejected by this QE */
-	int			segment_rows_completed = 0; /* num of rows completed by this
+	int64			segment_rows_completed = 0; /* num of rows completed by this
 											 * QE */
 
 	for (seg = 0; seg < size; seg ++)

--- a/src/backend/cdb/test/Makefile
+++ b/src/backend/cdb/test/Makefile
@@ -7,7 +7,8 @@ TARGETS=cdbtm \
 	cdbbackup \
 	cdbfilerep \
 	cdbsrlz \
-	cdbdistributedsnapshot
+	cdbdistributedsnapshot \
+	cdbcopy
 
 include $(top_builddir)/src/backend/mock.mk
 cdbtm.t: $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o
@@ -17,3 +18,8 @@ cdbfilerep.t: \
 	$(MOCK_DIR)/backend/utils/mmgr/redzone_handler_mock.o
 
 cdbdistributedsnapshot.t: $(MOCK_DIR)/backend/access/transam/distributedlog_mock.o
+
+cdbcopy.t: \
+	$(MOCK_DIR)/backend/libpq/fe-exec_mock.o \
+	$(MOCK_DIR)/backend/libpq/fe-connect_mock.o \
+	$(MOCK_DIR)/backend/cdb/dispatcher/cdbdispatchresult_mock.o

--- a/src/backend/cdb/test/cdbcopy_test.c
+++ b/src/backend/cdb/test/cdbcopy_test.c
@@ -1,0 +1,100 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../cdbcopy.c"
+
+void
+test__processCopyEndResults_handles_int64_aggregation(void **state)
+{
+	/* Initialize mock variables for the function call */
+	CdbCopy *c;
+	SegmentDatabaseDescriptor *db_descriptors;
+	int *results;
+	int size;
+	SegmentDatabaseDescriptor *failedSegDBs;
+	bool err_header;
+	bool first_error;
+	int failed_count;
+	int total_rows_rejected;
+	int64 total_rows_completed;
+
+	/* Set up mock variables for the function call */
+	SegDbState *segdb_state = malloc(sizeof(SegDbState));
+	c = malloc(sizeof(CdbCopy));
+	c->segdb_state = &segdb_state;
+	db_descriptors = malloc(sizeof(SegmentDatabaseDescriptor));
+	size = 1; /* just loop once */
+	results = malloc(size * sizeof(int));
+	results[0] = 1; /* skip "if (result == 0)" part */
+	total_rows_rejected = 0;
+	total_rows_completed = 0; /* we'll be asserting against this one */
+
+	/* Set up PGresult mock as QE COPY response */
+	PGresult *mock_result = malloc(sizeof(PGresult));
+	mock_result->numRejected = 0;
+	mock_result->numCompleted = PG_INT64_MAX;
+	mock_result->aotupcounts = malloc(sizeof(PQaoRelTupCount));
+
+	/* Mock out uninteresting function calls in processCopyEndResults*/
+	expect_any(PQsocket, conn);
+	will_return(PQsocket, -1);
+
+	expect_any(PQisBusy, conn);
+	will_return(PQisBusy, false);
+
+	expect_any(PQgetResult, conn);
+	will_return(PQgetResult, mock_result); /* dispatcher gets mock QE result */
+
+	expect_any(PQstatus, conn);
+	will_return(PQstatus, CONNECTION_OK);
+
+	expect_any_count(PQresultStatus, res, -1);
+	will_return_count(PQresultStatus, PGRES_TUPLES_OK, -1);
+
+	expect_any(PQprocessAoTupCounts, parts);
+	expect_any(PQprocessAoTupCounts, ht);
+	expect_any(PQprocessAoTupCounts, aotupcounts);
+	expect_any(PQprocessAoTupCounts, naotupcounts);
+	will_return(PQprocessAoTupCounts, 0);
+
+	expect_any(PQclear, res);
+	will_be_called(PQclear);
+
+	expect_any(PQgetResult, conn);
+	will_return(PQgetResult, NULL); /* exit loop */
+
+	expect_any(PQstatus, conn);
+	will_return(PQstatus, CONNECTION_OK);
+
+	/* Call the function of interest with our mock arguments */
+	processCopyEndResults(c, db_descriptors, results, size, &failedSegDBs,
+			      &err_header, &first_error, &failed_count,
+			      &total_rows_rejected, &total_rows_completed);
+
+	/* Assert that the dispatcher aggregated the QE values correctly */
+	assert_true(total_rows_completed == PG_INT64_MAX);
+
+	/* Cleanup malloc calls */
+	free(mock_result->aotupcounts);
+	free(mock_result);
+	free(results);
+	free(db_descriptors);
+	free(c);
+	free(segdb_state);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test__processCopyEndResults_handles_int64_aggregation)
+	};
+
+	MemoryContextInit();
+
+	return run_tests(tests);
+}


### PR DESCRIPTION
The primary segment backends return an int64 count back to the
dispatcher but the dispatcher temporarily stores that int64 count in
an int32 variable.

You can clearly see this in a debugger:
```
-> 609                          if (res->numCompleted > 0)
                                    ^
   610                                  segment_rows_completed = res->numCompleted;
(lldb) p res->numCompleted
(int64) $3 = 2000
(lldb) p segment_rows_completed
(int) $4 = 0
```

If res->numCompleted is bigger than INT32_MAX, segment_rows_completed
will become negative and a check later in this function will reject
this negative number from being added to the total rows completed
count.

Co-authored-by: Shivram Mani <shivram.mani@gmail.com>
