### PR TITLE
Include pg_config_manual.h for gpfdist

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -55,6 +55,7 @@
 #endif
 
 #include <pg_config.h>
+#include <pg_config_manual.h>
 #include "gpfdist_helper.h"
 #ifdef USE_SSL
 #include <openssl/ssl.h>


### PR DESCRIPTION
Commit 3b849ec changes USE_SSL macro to USE_OPENSSL, and provides
compatibility switch in pg_config_manual.h, but gpfdist doesn't
include it so USE_SSL macro is missing. Include pg_config_manual.h
to get it back.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
