### PR TITLE
Fix distribution policy for inherited tables

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5118,7 +5118,7 @@ atpxPart_validate_spec(
 															   RelationGetNamespace(rel)),
 											pstrdup(RelationGetRelationName(rel)), -1)),
 					false, true /* isPartitioned */,
-					&inheritOids, &old_constraints, &parentOidCount, NULL);
+					&inheritOids, &old_constraints, &parentOidCount);
 
 	pcxt->columns = schema;
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1599,26 +1599,7 @@ MergeAttributes(List *schema, List *supers, bool istemp, bool isPartitioned,
 				/* Default and other constraints are handled below */
 				newattno[parent_attno - 1] = exist_attno;
 
-				/*
-				 * Update GpPolicy
-				 */
-				if (policy != NULL)
-				{
-					int attr_ofst = 0;
-
-					Assert(policy->nattrs >= 0 && "the number of distribution attributes is not negative");
-
-					/* Iterate over all distribution attribute offsets */
-					for (attr_ofst = 0; attr_ofst < policy->nattrs; attr_ofst++)
-					{
-						/* Check if any distribution attribute has higher offset than the current */
-						if (policy->attrs[attr_ofst] > child_attno)
-						{
-							Assert(policy->attrs[attr_ofst] > 0 && "index should not become negative");
-							policy->attrs[attr_ofst]--;
-						}
-					}
-				}
+				Assert(policy->nattrs >= 0 && "the number of distribution attributes is not negative");
 
 			}
 			else

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -83,7 +83,6 @@ typedef struct
 	List	   *grants;			/* GRANT items */
 } CreateSchemaStmtContext;
 
-
 static void transformColumnDefinition(ParseState *pstate,
 						  CreateStmtContext *cxt,
 						  ColumnDef *column);
@@ -1694,100 +1693,157 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 		policy->nattrs = 0;
 		if (!(distributedBy->length == 1 && linitial(distributedBy) == NULL))
 		{
+
+			typedef struct
+			{
+				char	   *columnName;
+				Oid			typeOid;
+			}			InheritColumn;
+
+			List	   *orderedColumns = NIL;
+
+
+			if (cxt->inhRelations)
+			{
+				/*
+				 * Get a list of unique columns in the right order from
+				 * inherited (parent) tables
+				 */
+				ListCell   *inher;
+
+				foreach(inher, cxt->inhRelations)
+				{
+					RangeVar   *inh = (RangeVar *) lfirst(inher);
+					Relation	rel;
+					int			count;
+
+					Assert(IsA(inh, RangeVar));
+					rel = heap_openrv(inh, AccessShareLock);
+					if (rel->rd_rel->relkind != RELKIND_RELATION)
+						ereport(ERROR,
+								(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+						   errmsg("inherited relation \"%s\" is not a table",
+								  inh->relname)));
+					for (count = 0; count < rel->rd_att->natts; count++)
+					{
+						Form_pg_attribute inhattr = rel->rd_att->attrs[count];
+						char	   *inhname = NameStr(inhattr->attname);
+						bool		found = false;
+
+						if (inhattr->attisdropped)
+							continue;
+
+						ListCell   *item;
+
+						foreach(item, orderedColumns)
+						{
+							InheritColumn *col = (InheritColumn *) lfirst(item);
+
+							if (strcmp(col->columnName, inhname) == 0)
+							{
+								found = true;
+								break;
+							}
+						}
+						if (!found)
+						{
+							InheritColumn *col = (InheritColumn *) palloc(sizeof(InheritColumn));
+
+							col->columnName = inhname;
+							col->typeOid = inhattr->atttypid;
+							orderedColumns = lappend(orderedColumns, col);
+							elog(DEBUG1, "Add inherited column \"%s\" of type %d to a column list",
+								 inhname, inhattr->atttypid);
+						}
+					}
+					heap_close(rel, NoLock);
+				}
+			}
+
+			/*
+			 * Add non-present columns from inheriting (child) table to a
+			 * column list with unique columns from interited (parent) tables.
+			 */
+			ListCell   *columns;
+
+			foreach(columns, cxt->columns)
+			{
+				ColumnDef  *column = (ColumnDef *) lfirst(columns);
+				ListCell   *inhColumn;
+				bool		found = false;
+
+				foreach(inhColumn, orderedColumns)
+				{
+					InheritColumn *col = (InheritColumn *) lfirst(inhColumn);
+
+					if (strcmp(col->columnName, column->colname) == 0)
+					{
+						found = true;
+						break;
+					}
+				}
+				if (!found)
+				{
+					int32		typmod;
+					Oid			typeOid = typenameTypeId(NULL, column->typeName, &typmod);
+					InheritColumn *col = (InheritColumn *) palloc(sizeof(InheritColumn));
+
+					col->columnName = column->colname;
+					col->typeOid = typeOid;
+					orderedColumns = lappend(orderedColumns, col);
+					elog(DEBUG1, "Add column \"%s\" of type %d to a column list",
+						 column->colname, typeOid);
+				}
+			}
+
+			/*
+			 * Find distribution keys in an ordered list of columns.
+			 */
 			foreach(keys, distributedBy)
 			{
 				char	   *key = strVal(lfirst(keys));
 				bool		found = false;
-				ColumnDef  *column = NULL;
-				ListCell   *columns;
+				ListCell   *item;
 
 				colindex = 0;
-
-				if (cxt->inhRelations)
+				foreach(item, orderedColumns)
 				{
-					/* try inherited tables */
-					ListCell   *inher;
+					InheritColumn *col = (InheritColumn *) lfirst(item);
 
-					foreach(inher, cxt->inhRelations)
+					colindex++;
+					elog(DEBUG1, "Iterating column list: column \"%s\", number %d",
+						 col->columnName, colindex);
+					if (strcmp(key, col->columnName) == 0)
 					{
-						RangeVar   *inh = (RangeVar *) lfirst(inher);
-						Relation	rel;
-						int			count;
-
-						Assert(IsA(inh, RangeVar));
-						rel = heap_openrv(inh, AccessShareLock);
-						if (rel->rd_rel->relkind != RELKIND_RELATION)
+						/*
+						 * To be a part of a distribution key, this type must
+						 * be supported for hashing internally in Greenplum
+						 * Database. We check if the base type is supported
+						 * for hashing or if it is an array type (we support
+						 * hashing on all array types).
+						 */
+						if (!isGreenplumDbHashable(col->typeOid))
+						{
 							ereport(ERROR,
-									(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-							   errmsg("inherited relation \"%s\" is not a table",
-									  inh->relname)));
-						for (count = 0; count < rel->rd_att->natts; count++)
-						{
-							Form_pg_attribute inhattr = rel->rd_att->attrs[count];
-							char	   *inhname = NameStr(inhattr->attname);
-
-							if (inhattr->attisdropped)
-								continue;
-							colindex++;
-							if (strcmp(key, inhname) == 0)
-							{
-								found = true;
-
-								break;
-							}
+								  (errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
+								   errmsg("type \"%s\" can't be a part of a "
+										  "distribution key",
+										  format_type_be(col->typeOid))));
 						}
-						heap_close(rel, NoLock);
-						if (found)
-							elog(DEBUG1, "DISTRIBUTED BY clause refers to columns of inherited table");
+						elog(DEBUG1, "Distribution key \"%s\" matched a column \"%s\" with number %d in a column list",
+							 key, col->columnName, colindex);
+						found = true;
 
-						if (found)
-							break;
-					}
-				}
-
-				if (!found)
-				{
-					foreach(columns, cxt->columns)
-					{
-						column = (ColumnDef *) lfirst(columns);
-						Assert(IsA(column, ColumnDef));
-						colindex++;
-
-						if (strcmp(column->colname, key) == 0)
-						{
-							Oid			typeOid;
-							int32		typmod;
-
-							typeOid = typenameTypeId(NULL, column->typeName, &typmod);
-							
-							/*
-							 * To be a part of a distribution key, this type must
-							 * be supported for hashing internally in Greenplum
-							 * Database. We check if the base type is supported
-							 * for hashing or if it is an array type (we support
-							 * hashing on all array types).
-							 */
-							if (!isGreenplumDbHashable(typeOid))
-							{
-								ereport(ERROR,
-										(errcode(ERRCODE_GP_FEATURE_NOT_SUPPORTED),
-										 errmsg("type \"%s\" can't be a part of a "
-												"distribution key",
-												format_type_be(typeOid))));
-							}
-
-							found = true;
-							break;
-						}
+						break;
 					}
 				}
 
 				/*
-				* In the ALTER TABLE case, don't complain about index keys
-				* not created in the command; they may well exist already.
-				* DefineIndex will complain about them if not, and will also
-				* take care of marking them NOT NULL.
-				*/
+				 * In the ALTER TABLE case, don't complain about index keys
+				 * not created in the command; they may well exist already.
+				 * DefineIndex will complain about them if not, and will also
+				 * take care of marking them NOT NULL.
+				 */
 				if (!found && !cxt->isalter)
 					ereport(ERROR,
 							(errcode(ERRCODE_UNDEFINED_COLUMN),
@@ -1801,7 +1857,6 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 
 
 	*policyp = policy;
-
 
 	if (cxt && cxt->pkey)		/* Primary key	specified.	Make sure
 								 * distribution columns match */

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -83,6 +83,7 @@ typedef struct
 	List	   *grants;			/* GRANT items */
 } CreateSchemaStmtContext;
 
+
 static void transformColumnDefinition(ParseState *pstate,
 						  CreateStmtContext *cxt,
 						  ColumnDef *column);
@@ -1839,11 +1840,11 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 				}
 
 				/*
-				 * In the ALTER TABLE case, don't complain about index keys
-				 * not created in the command; they may well exist already.
-				 * DefineIndex will complain about them if not, and will also
-				 * take care of marking them NOT NULL.
-				 */
+				* In the ALTER TABLE case, don't complain about index keys
+				* not created in the command; they may well exist already.
+				* DefineIndex will complain about them if not, and will also
+				* take care of marking them NOT NULL.
+				*/
 				if (!found && !cxt->isalter)
 					ereport(ERROR,
 							(errcode(ERRCODE_UNDEFINED_COLUMN),
@@ -1857,6 +1858,7 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 
 
 	*policyp = policy;
+
 
 	if (cxt && cxt->pkey)		/* Primary key	specified.	Make sure
 								 * distribution columns match */

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -118,7 +118,7 @@ extern Oid get_settable_tablespace_oid(char *tablespacename);
 
 extern List *
 MergeAttributes(List *schema, List *supers, bool istemp, bool isPartitioned,
-				List **supOids, List **supconstr, int *supOidCount, GpPolicy *policy);
+				List **supOids, List **supconstr, int *supOidCount);
 extern List *make_dist_clause(Relation rel);
 
 extern Oid transformFkeyCheckAttrs(Relation pkrel,

--- a/src/test/regress/expected/create_table_distpol.out
+++ b/src/test/regress/expected/create_table_distpol.out
@@ -161,3 +161,52 @@ select localoid::regclass, attrnums from gp_distribution_policy where localoid::
  distpol_ctas4 | {2,3}
 (4 rows)
 
+-- Check distribution keys for inherited tables with the same columns as in a parent table
+CREATE TABLE points (
+    p     point
+) distributed randomly;
+CREATE TABLE a_points (
+    p     point,
+    a     int
+) INHERITS (points) distributed by (a);
+NOTICE:  merging column "p" with inherited definition
+select attrnums from gp_distribution_policy where localoid = 'a_points'::regclass;
+ attrnums 
+----------
+ {2}
+(1 row)
+
+CREATE TABLE b_points (
+    b     int,
+    p     point,
+    c     int
+) INHERITS (points) distributed by (b, c);
+NOTICE:  merging column "p" with inherited definition
+select attrnums from gp_distribution_policy where localoid = 'b_points'::regclass;
+ attrnums 
+----------
+ {2,3}
+(1 row)
+
+CREATE TABLE c_points (
+    b     int,
+    p     point,
+    d     int,
+    c     int
+) INHERITS (points, b_points, a_points) distributed by (b, c);
+NOTICE:  merging multiple inherited definitions of column "p"
+NOTICE:  merging multiple inherited definitions of column "p"
+NOTICE:  merging column "b" with inherited definition
+NOTICE:  merging column "p" with inherited definition
+NOTICE:  merging column "c" with inherited definition
+select attrnums from gp_distribution_policy where localoid = 'c_points'::regclass;
+ attrnums 
+----------
+ {2,3}
+  (1 row)
+
+-- Check distribution on non-hashable column in a parent table
+CREATE TABLE c_points (
+    c     int
+) INHERITS (points) distributed by (p);
+ERROR:  type "point" can't be a part of a distribution key


### PR DESCRIPTION
Current parser algorithm for setting distribution key column numbers
in gp_distribution_policy relation for inherited tables in GP5X
is doing something wrong at the moment (for GP6X everything is ok).
Query planes with GPORCA caused segmentation fault because of
out of range column numbers, Postgres optimizer simply
returned error before current patch. For example:
```
create table ta (a int) distributed randomly;
create table tb (a int, b int) inherits (ta) distributed by (b);

set optimizer=on;
insert into tb values(0, 0);
-- Segmentation fault

set optimizer=off;
insert into tb values(0, 0);
-- ERROR: no tlist entry for key 3 (cdbmutate.c:1484)

select attrnums from gp_distribution_policy where localoid = 'tb'::regclass;
 attrnums
----------
{3}
(1 row)
```
Also a check for setting non-hashable distribution key from a
parent table in an inherited one didn't work.
```
create table tc (a point) distributed randomly;
create table td (b int) inherits (tc) distributed by (a);

select * from td;
ERROR:  could not find mergejoinable = operator for type 600 (pathkeys.c:1174)
```
Co-authored-by: Vasiliy Ivanov <ivi@arenadata.io>
