### PR TITLE
Correct a minor error in gpMgmt Makefile

### DIFF
--- a/gpMgmt/bin/stream/Makefile
+++ b/gpMgmt/bin/stream/Makefile
@@ -19,7 +19,7 @@ installdirs:
 install: stream installdirs
 	$(INSTALL_PROGRAM) stream$(X) '$(DESTDIR)$(bindir)/lib/stream$(X)'
 	# Symlink bin/lib/stream to bin/stream to maintain backward compatibility
-	if [[ ! -f $(DESTDIR)$(bindir)/stream/stream$(X) && ! -L $(DESTDIR)$(bindir)/stream/stream$(X) ]]; then \
+	if [ ! -f $(DESTDIR)$(bindir)/stream/stream$(X) ] && [ ! -L $(DESTDIR)$(bindir)/stream/stream$(X) ]; then \
 		$(LN_S) $(DESTDIR)$(bindir)/lib/stream$(X) $(DESTDIR)$(bindir)/stream/stream$(X); \
 	fi
 


### PR DESCRIPTION
Makefiles use sh as shell by default unless ${SHELL} is set. This leads to
conditionals expressed in '[[...]]' to not be portable. For example in ubuntu
the following error is emitted during install:
	/bin/sh: 1: [[: not found

Use the more portable yet more cumbersome '[...] && [...]' syntax.
