### PR TITLE
Set Plan::allParam correctly in CTranslatorDXLToPlStmt

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -400,7 +400,7 @@ CTranslatorDXLToPlStmt::SetInitPlanSliceInformation(SubPlan * subplan)
 void
 CTranslatorDXLToPlStmt::SetParamIds(Plan* plan)
 {
-	List *params_node_list = gpdb::ExtractNodesPlan(plan, T_Param, true);
+	List *params_node_list = gpdb::ExtractNodesPlan(plan, T_Param, true /* descend_into_subqueries */);
 
 	ListCell *lc = NULL;
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10898,6 +10898,27 @@ select c1 from t_outer where not c1 =all (select c2 from t_inner);
 (10 rows)
 
 reset optimizer_enable_streaming_material;
+-- Ensure that ORCA rescans the subquery in case of skip-level correlation with
+-- materialization
+drop table if exists wst0, wst1, wst2;
+NOTICE:  table "wst0" does not exist, skipping
+NOTICE:  table "wst1" does not exist, skipping
+NOTICE:  table "wst2" does not exist, skipping
+create table wst0(a0 int, b0 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a0' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table wst1(a1 int, b1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table wst2(a2 int, b2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into wst0 select i, i from generate_series(1,10) i;
+insert into wst1 select i, i from generate_series(1,10) i;
+insert into wst2 select i, i from generate_series(1,10) i;
+-- NB: the rank() is need to force materialization (via Sort) in the subplan
+select count(*) from wst0 where exists (select 1, rank() over (order by wst1.a1) from wst1 where a1 = (select b2 from wst2 where a0=a2+5));
+ERROR:  correlated subquery with skip-level correlations is not supported
 --
 -- Test to ensure sane behavior when DML queries are optimized by ORCA by
 -- enforcing a non-master gather motion, controlled by

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11012,6 +11012,31 @@ select c1 from t_outer where not c1 =all (select c2 from t_inner);
 (10 rows)
 
 reset optimizer_enable_streaming_material;
+-- Ensure that ORCA rescans the subquery in case of skip-level correlation with
+-- materialization
+drop table if exists wst0, wst1, wst2;
+NOTICE:  table "wst0" does not exist, skipping
+NOTICE:  table "wst1" does not exist, skipping
+NOTICE:  table "wst2" does not exist, skipping
+create table wst0(a0 int, b0 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a0' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table wst1(a1 int, b1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table wst2(a2 int, b2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into wst0 select i, i from generate_series(1,10) i;
+insert into wst1 select i, i from generate_series(1,10) i;
+insert into wst2 select i, i from generate_series(1,10) i;
+-- NB: the rank() is need to force materialization (via Sort) in the subplan
+select count(*) from wst0 where exists (select 1, rank() over (order by wst1.a1) from wst1 where a1 = (select b2 from wst2 where a0=a2+5));
+ count 
+-------
+     5
+(1 row)
+
 --
 -- Test to ensure sane behavior when DML queries are optimized by ORCA by
 -- enforcing a non-master gather motion, controlled by


### PR DESCRIPTION
ExecRescanMaterial uses Plan::allParam bitset to determine the param
changes it should watch for when determining whether it needs to destroy
the tuplestore and re-execute the subtree. ORCA sets allParam by
extracting PARAMs from the plan tree using extract_nodes_walker().

However, the function logic not descend into sub-queries via SUBPLAN
nodes, even if descendIntoSubqueries option is set to true (in case of
ORCA, this is sometimes not even possible because the base node is not
available during dxl to plstmt translation as it is done bottom-up).
But, because of this, extract_nodes_walker() may miss PARAMs present in
SubPlan::testexpr and SubPlan::args.

This commit fixes the logic in extract_nodes_walker() to examine the
SubPlan node, no matter if descendIntoSubqueries is set or unset.

This fix was motivated by a wrong results bug in skip-level correlated
subqueries (see test case in the commit). Because allParam was left
empty, any Materialize in the intermediate subplan would retain it's
contents even if there was an changed outerref, causing wrong results.

For the purpose for retrieving PARAMs in such cases, it is not
really necessary to descend into subqueries. It should be sufficient to
look at the args list of the SUBPLAN, since any PARAM that would affect
the materialized results in the intermediate subplan must be passed into
the lowest subplan using SubPlan::args.

In the example below, the PARAM may be an outer ref to either subtrees:
subtree (1):
  It will be passed into the subplan via SubPlan 2 args and so
  will be captured in allParams. Thus, Materialize's results are discarded
  at every rescan of Subplan 2, as is expected.
subtree (2):
  It will not capture the PARAM. The Materialize's results need
  not be discarded, since there is not relevant outer ref under it.

-> Result
   Filter: x = (subplan 2)
     -> subtree (1)
   Subplan 2
     -> Material
       -> Result
          Filter: x = (subplan 2)
            -> subtree (2)
          Subplan 1
            -> PARAM used somewhere

This PR replaces PR #8297. 

The earlier PR was closed because it didn't handle two cases. After digging into that further, I found that it didn't really need to be handled because ORCA does not produce those operators anymore. However, instead of relying on that, it's probably better to the fix logic here in extract_nodes_walker() anyway, in case we decide to use those operators in the future.
