### PR TITLE
Support FIPS mode operation in pgcrypto

### DIFF
--- a/contrib/pgcrypto/internal.c
+++ b/contrib/pgcrypto/internal.c
@@ -677,3 +677,17 @@ px_add_entropy(const uint8 *data, unsigned count)
 	fortuna_add_entropy(data, count);
 	return 0;
 }
+
+void
+px_disable_fipsmode(void)
+{
+	ereport(ERROR,
+			(errmsg("pgcrypto FIPS mode is only supported in OpenSSL enabled builds")));
+}
+
+void
+px_enable_fipsmode(bool strict)
+{
+	ereport(ERROR,
+			(errmsg("pgcrypto FIPS mode is only supported in OpenSSL enabled builds")));
+}

--- a/contrib/pgcrypto/openssl.c
+++ b/contrib/pgcrypto/openssl.c
@@ -40,6 +40,10 @@
 #include <openssl/rand.h>
 #include <openssl/err.h>
 
+#ifdef OPENSSL_FIPS
+#include <openssl/fips.h>
+#endif
+
 #include "utils/memutils.h"
 #include "utils/resowner.h"
 
@@ -197,6 +201,16 @@ compat_find_digest(const char *name, PX_MD **res)
 #else
 #define compat_find_digest(name, res)  (PXE_NO_HASH)
 #endif
+
+/*
+ * Fips mode
+ */
+static bool fips = false;
+
+#define NOT_FIPS_CERTIFIED \
+	if (fips) \
+		ereport(ERROR, \
+				(errmsg("requested functionality not allowed in FIPS mode")));
 
 /*
  * Hashes
@@ -928,7 +942,7 @@ ossl_aes_cbc_decrypt(PX_Cipher *c, const uint8 *data, unsigned dlen,
  * aliases
  */
 
-static PX_Alias ossl_aliases[] = {
+static PX_Alias ossl_aliases_all[] = {
 	{"bf", "bf-cbc"},
 	{"blowfish", "bf-cbc"},
 	{"blowfish-cbc", "bf-cbc"},
@@ -945,6 +959,8 @@ static PX_Alias ossl_aliases[] = {
 	{"rijndael-ecb", "aes-ecb"},
 	{NULL}
 };
+
+static PX_Alias *ossl_aliases = ossl_aliases_all;
 
 static const struct ossl_cipher ossl_bf_cbc = {
 	bf_init, bf_cbc_encrypt, bf_cbc_decrypt,
@@ -1010,7 +1026,7 @@ struct ossl_cipher_lookup
 	const struct ossl_cipher *ciph;
 };
 
-static const struct ossl_cipher_lookup ossl_cipher_types[] = {
+static const struct ossl_cipher_lookup ossl_cipher_types_all[] = {
 	{"bf-cbc", &ossl_bf_cbc},
 	{"bf-ecb", &ossl_bf_ecb},
 	{"bf-cfb", &ossl_bf_cfb},
@@ -1025,6 +1041,8 @@ static const struct ossl_cipher_lookup ossl_cipher_types[] = {
 	{NULL}
 };
 
+static const struct ossl_cipher_lookup *ossl_cipher_types = ossl_cipher_types_all;
+
 /* PUBLIC functions */
 
 int
@@ -1033,6 +1051,8 @@ px_find_cipher(const char *name, PX_Cipher **res)
 	const struct ossl_cipher_lookup *i;
 	PX_Cipher  *c = NULL;
 	ossldata   *od;
+
+	NOT_FIPS_CERTIFIED
 
 	name = px_resolve_alias(ossl_aliases, name);
 	for (i = ossl_cipher_types; i->name; i++)
@@ -1103,4 +1123,112 @@ px_add_entropy(const uint8 *data, unsigned count)
 	 */
 	RAND_add(data, count, 0);
 	return 0;
+}
+
+void
+px_disable_fipsmode(void)
+{
+#ifndef OPENSSL_FIPS
+	/*
+	 * If this build doesn't support FIPS mode at all, we shouldn't be able
+	 * to reach this point, so Assert that and return to handle production
+	 * builds gracefully.
+	 */
+	Assert(!fips);
+#else
+	ossl_aliases = ossl_aliases_all;
+	ossl_cipher_types = ossl_cipher_types_all;
+	fips = false;
+
+	if (!FIPS_mode_set)
+		return;
+
+	FIPS_mode_set(0);
+#endif
+
+	return;
+}
+
+void
+px_enable_fipsmode(bool strict)
+{
+#ifndef OPENSSL_FIPS
+	ereport(ERROR,
+			(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),
+			 errhint("Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.")));
+#else
+
+	/*
+	 * While AES and 3DES are allowed ciphers under FIPS-140 level 2, pgcrypto
+	 * is calling the lowlevel API for these which is disallowed under FIPS.
+	 * However, rather than returning NULL as is done when calling the high
+	 * level functions, the lowlevel API throws a SIGABORT so we need to avoid
+	 * calling this altogether.
+	 */
+	ossl_aliases = NULL;
+	ossl_cipher_types = NULL;
+
+	/* Make sure that we are linked against a FIPS enabled OpenSSL */
+	if (!FIPS_mode_set)
+	{
+		ereport(ERROR,
+				(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),
+				 errhint("Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.")));
+	}
+
+	/*
+	 * In strict mode, we also require that the underlying operating system
+	 * has been set in FIPS mode.
+	 */
+	if (strict)
+	{
+#ifndef __linux__
+		/*
+		 * Strict FIPS mode is only available on Linux, and require the kernel
+		 * crypto.fips_enabled sysctl to be set.
+		 */
+		ereport(ERROR,
+				(errmsg("strict FIPS mode not supported on this platform")));
+#else
+		FILE	   *proc;
+		char		buf;
+
+		/*
+		 * Since the _sysctl interface isn't specifying an enum for sys/crypto
+		 * we have to read the value by looking at the correspondig procfs
+		 * entry. fread'ing from procfs is generally not recommended due to
+		 * the risk of race conditions, but since this value can be expected
+		 * to be stable across a runtime the risk should be quite minimal.
+		 */
+		proc = fopen("/proc/sys/crypto/fips_enabled", "r");
+		fread(&buf, sizeof(char), 1, proc);
+		fclose(proc);
+
+		if (buf != '1')
+			ereport(ERROR,
+					(errmsg("strict FIPS mode require kernel support"),
+					 errhint("Turn on FIPS mode in the kernel by enabling crypto.fips_enabled via sysctl.")));
+#endif
+	}
+
+	/*
+	 * A non-zero return value means that FIPS mode was enabled, but the
+	 * full range of possible non-zero return values is not documented so
+	 * rather than checking for success we check for failure.
+	 */
+	if (FIPS_mode_set(1) == 0)
+	{
+		char		errbuf[128];
+
+		ERR_load_crypto_strings();
+		ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
+		ERR_free_strings();
+
+		ereport(ERROR,
+				(errmsg("unable to enable FIPS mode: %lx, %s",
+						ERR_get_error(), errbuf)));
+	}
+
+	fips = true;
+#endif
 }

--- a/contrib/pgcrypto/pgp.c
+++ b/contrib/pgcrypto/pgp.c
@@ -65,7 +65,7 @@ struct cipher_info
 	int			block_len;
 };
 
-static const struct digest_info digest_list[] = {
+static const struct digest_info digest_list_all[] = {
 	{"md5", PGP_DIGEST_MD5},
 	{"sha1", PGP_DIGEST_SHA1},
 	{"sha-1", PGP_DIGEST_SHA1},
@@ -76,7 +76,18 @@ static const struct digest_info digest_list[] = {
 	{NULL, 0}
 };
 
-static const struct cipher_info cipher_list[] = {
+static const struct digest_info digest_list_fips[] = {
+	{"sha1", PGP_DIGEST_SHA1},
+	{"sha-1", PGP_DIGEST_SHA1},
+	{"sha256", PGP_DIGEST_SHA256},
+	{"sha384", PGP_DIGEST_SHA384},
+	{"sha512", PGP_DIGEST_SHA512},
+	{NULL, 0}
+};
+
+static const struct digest_info *digest_list = digest_list_all;
+
+static const struct cipher_info cipher_list_all[] = {
 	{"3des", PGP_SYM_DES3, "3des-ecb", 192 / 8, 64 / 8},
 	{"cast5", PGP_SYM_CAST5, "cast5-ecb", 128 / 8, 64 / 8},
 	{"bf", PGP_SYM_BLOWFISH, "bf-ecb", 128 / 8, 64 / 8},
@@ -88,6 +99,17 @@ static const struct cipher_info cipher_list[] = {
 	{"twofish", PGP_SYM_TWOFISH, "twofish-ecb", 256 / 8, 128 / 8},
 	{NULL, 0, NULL}
 };
+
+static const struct cipher_info cipher_list_fips[] = {
+	{"3des", PGP_SYM_DES3, "3des-ecb", 192 / 8, 64 / 8},
+	{"aes", PGP_SYM_AES_128, "aes-ecb", 128 / 8, 128 / 8},
+	{"aes128", PGP_SYM_AES_128, "aes-ecb", 128 / 8, 128 / 8},
+	{"aes192", PGP_SYM_AES_192, "aes-ecb", 192 / 8, 128 / 8},
+	{"aes256", PGP_SYM_AES_256, "aes-ecb", 256 / 8, 128 / 8},
+	{NULL, 0, NULL}
+};
+
+static const struct cipher_info *cipher_list = cipher_list_all;
 
 static const struct cipher_info *
 get_cipher_info(int code)
@@ -356,4 +378,18 @@ pgp_set_symkey(PGP_Context *ctx, const uint8 *key, int len)
 	ctx->sym_key = key;
 	ctx->sym_key_len = len;
 	return 0;
+}
+
+void
+pgp_disable_fipsmode(void)
+{
+	cipher_list = cipher_list_all;
+	digest_list = digest_list_all;
+}
+
+void
+pgp_enable_fipsmode(bool strict)
+{
+	cipher_list = cipher_list_fips;
+	digest_list = digest_list_fips;
 }

--- a/contrib/pgcrypto/pgp.h
+++ b/contrib/pgcrypto/pgp.h
@@ -316,3 +316,6 @@ int			pgp_rsa_encrypt(PGP_PubKey *pk, PGP_MPI *m, PGP_MPI **c);
 int			pgp_rsa_decrypt(PGP_PubKey *pk, PGP_MPI *c, PGP_MPI **m);
 
 extern struct PullFilterOps pgp_decrypt_filter;
+
+void		pgp_disable_fipsmode(void);
+void		pgp_enable_fipsmode(bool strict);

--- a/contrib/pgcrypto/px.h
+++ b/contrib/pgcrypto/px.h
@@ -202,6 +202,9 @@ void		px_set_debug_handler(void (*handler) (const char *));
 
 void		px_memset(void *ptr, int c, size_t len);
 
+void		px_enable_fipsmode(bool strict);
+void		px_disable_fipsmode(void);
+
 #ifdef PX_DEBUG
 void
 px_debug(const char *fmt,...)

--- a/src/backend/libpq/sha2.h
+++ b/src/backend/libpq/sha2.h
@@ -39,6 +39,9 @@
 #define _SHA2_H
 
 /* avoid conflict with OpenSSL */
+#define SHA224_Init pg_SHA224_Init
+#define SHA224_Update pg_SHA224_Update
+#define SHA224_Final pg_SHA224_Final
 #define SHA256_Init pg_SHA256_Init
 #define SHA256_Update pg_SHA256_Update
 #define SHA256_Final pg_SHA256_Final


### PR DESCRIPTION
In Greenplum 4.3 there was a GUC in pgcrypto controlling FIPS mode
operation which was deprecated. This brings the GUC back, as there
has been requests from production instances.

To enable the GUC, Greenplum must be dynamically linked against an
OpenSSL installation which is compiled with the FIPS module (1.0.2
with FIPS 2.0 is tested and supported, no FIPS module exist for
later versions of OpenSSL as of yet). There is an additional strict
mode as well which requires both OpenSSL to be FIPS capable as well
as the operating system kernel to be running in FIPS mode (this is
only supported on Linux for now).

Some ciphers will be disallowed in this mode even though they are
defined as legal by FIPS-140 level 2, due to the fact that pgcrypto
is using the lowlevel API for these and this is not certified for
FIPS operation.