### PR TITLE
Fix compiler warning in xact_desc_prepare assertion

### DIFF
--- a/src/backend/access/rmgrdesc/xactdesc.c
+++ b/src/backend/access/rmgrdesc/xactdesc.c
@@ -208,7 +208,9 @@ xact_desc_assignment(StringInfo buf, xl_xact_assignment *xlrec)
 
 static void
 xact_desc_prepare(StringInfo buf, XLogRecord *record) {
+#ifdef USE_ASSERT_CHECKING
 	uint8		info = record->xl_info & ~XLR_INFO_MASK;
+#endif
 	char		*rec = XLogRecGetData(record);
 
 	Assert(info == XLOG_XACT_PREPARE);


### PR DESCRIPTION
Commit b74f174b6cde1c2bf2e1bf09129d9397cccb1c7b introduced an Assert backed by a variable, but since the variable was only used by the assertion it caused a compiler warning in non-cassert enabled builds. This fixes it by wrapping the variable declaration and assignment in `USE_ASSERT_CHECKING` guards.
