### PR TITLE
Fix the panic when estimating cost for aggregation on Result path.

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4796,8 +4796,21 @@ cost_common_agg(PlannerInfo *root, MppGroupContext *ctx, AggPlanInfo *info, Plan
 
 	Assert(dummy != NULL);
 
-	input_rows = info->input_path->parent->rows;
-	input_width = info->input_path->parent->width;
+	/*
+	 * For Result pathnode, its parent would be set to NULL. In that case, we
+	 * can use the rows in the Path and use 0 as the width.
+	 */
+	if (info->input_path->parent)
+	{
+		input_rows = info->input_path->parent->rows;
+		input_width = info->input_path->parent->width;
+	}
+	else
+	{
+		input_rows = info->input_path->rows;
+		input_width = 0;
+	}
+
 	/* Path input width isn't correct for ctx->sub_tlist so we guess. */
 	n = 32 * list_length(ctx->sub_tlist);
 	input_width = (input_width < n) ? input_width : n;

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -328,3 +328,17 @@ select my_numeric_avg(n) from numerictesttab;
  5.5000000000000000
 (1 row)
 
+--- Test distinct on UDF which EXECUTE ON ALL SEGMENTS
+CREATE FUNCTION distinct_test() RETURNS SETOF boolean EXECUTE ON ALL SEGMENTS
+    LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY SELECT true;
+END
+$$;
+SELECT DISTINCT distinct_test();
+ distinct_test 
+---------------
+ t
+(1 row)
+
+DROP FUNCTION distinct_test();

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -134,3 +134,15 @@ CREATE AGGREGATE my_numeric_avg(numeric) (
 create temp table numerictesttab as select g::numeric as n from generate_series(1,10) g;
 
 select my_numeric_avg(n) from numerictesttab;
+
+--- Test distinct on UDF which EXECUTE ON ALL SEGMENTS
+CREATE FUNCTION distinct_test() RETURNS SETOF boolean EXECUTE ON ALL SEGMENTS
+    LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY SELECT true;
+END
+$$;
+
+SELECT DISTINCT distinct_test();
+
+DROP FUNCTION distinct_test();


### PR DESCRIPTION
For Result pathnode, its parent would be set to NULL. So we cannot
reference its parent in cost_common_agg() when estimating cost for
aggregation. Instead, we can use the rows in the Path and use 0 as the
width.

This patch fixes github issue #8357.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
