### PR TITLE
6X_BACKPORT: set_config_by_name(): dispatch all values correctly

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7519,16 +7519,17 @@ set_config_by_name(PG_FUNCTION_ARGS)
 							 true,
 							 0);
 
-    if (Gp_role == GP_ROLE_DISPATCH && !IsBootstrapProcessingMode())
-    {
-			StringInfoData buffer;
-			initStringInfo(&buffer);
-			appendStringInfo(&buffer, "SET ");
-			if (is_local)
-					appendStringInfo(&buffer, "LOCAL ");
-			appendStringInfo(&buffer, "%s TO '%s'", name, value);
-			CdbDispatchSetCommand(buffer.data, false /* cancelOnError */);
-    }
+	if (Gp_role == GP_ROLE_DISPATCH && !IsBootstrapProcessingMode())
+	{
+		StringInfoData buffer;
+
+		initStringInfo(&buffer);
+		appendStringInfo(&buffer, "SET ");
+		if (is_local)
+			appendStringInfo(&buffer, "LOCAL ");
+		appendStringInfo(&buffer, "%s TO '%s'", name, value);
+		CdbDispatchSetCommand(buffer.data, false /* cancelOnError */ );
+	}
 
 	/* get the new current value */
 	new_value = GetConfigOptionByName(name, NULL);

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7521,13 +7521,25 @@ set_config_by_name(PG_FUNCTION_ARGS)
 
 	if (Gp_role == GP_ROLE_DISPATCH && !IsBootstrapProcessingMode())
 	{
-		StringInfoData buffer;
+		StringInfoData	buffer;
+		char		   *quoted_name;
+		char		   *quoted_value = NULL;
 
 		initStringInfo(&buffer);
-		appendStringInfo(&buffer, "SET ");
-		if (is_local)
-			appendStringInfo(&buffer, "LOCAL ");
-		appendStringInfo(&buffer, "%s TO '%s'", name, value);
+
+		quoted_name = quote_literal_cstr(name);
+		if (value)
+			quoted_value = quote_literal_cstr(value);
+
+		appendStringInfo(&buffer, "SELECT pg_catalog.set_config(%s, %s, %s)",
+						 quoted_name,
+						 quoted_value ? quoted_value : "NULL",
+						 is_local ? "true" : "false");
+
+		if (quoted_value)
+			pfree(quoted_value);
+		pfree(quoted_name);
+
 		CdbDispatchSetCommand(buffer.data, false /* cancelOnError */ );
 	}
 

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -34,6 +34,32 @@ ALTER DATABASE "funny""db'with\\quotes" SET search_path="funny""schema'with\\quo
 -- reach commit a2385cac13, which was backported to PostgreSQL 9.1.
 DROP DATABASE "funny""db'with\\quotes";
 
+-- set_config() used to have quoting problems as well when dispatching to
+-- segments.
+CREATE TABLE IF NOT EXISTS should_be_visible();
+CREATE OR REPLACE FUNCTION visible_to_segments(tbl oid)
+    RETURNS SETOF boolean
+    EXECUTE ON ALL SEGMENTS
+    LANGUAGE plpgsql AS
+$$
+BEGIN
+    RETURN NEXT pg_catalog.pg_table_is_visible(tbl);
+END
+$$;
+
+-- Spin up any gangs necessary to handle the SELECT DISTINCT so that they
+-- receive the new search_path setting from the set_config() dispatch.
+SELECT DISTINCT visible_to_segments('public.should_be_visible'::regclass);
+
+-- Now change search_path. This setting should not affect the visibility of the
+-- public schema if it's dispatched correctly.
+SELECT set_config('search_path', 'pg_catalog,public', false);
+
+-- Check that our test table is still visible.
+SELECT DISTINCT visible_to_segments('public.should_be_visible'::regclass);
+
+RESET search_path;
+
 -- There used to be a bug in the quoting when the search_path setting was sent
 -- to the segment. It was not easily visible when search_path was set with a
 -- SET command, only when the setting was sent as part of the startup packet.

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -42,6 +42,42 @@ ALTER DATABASE "funny""db'with\\quotes" SET search_path="funny""schema'with\\quo
 -- Remove this DROP DATABASE once it's fixed. That should happen when we
 -- reach commit a2385cac13, which was backported to PostgreSQL 9.1.
 DROP DATABASE "funny""db'with\\quotes";
+-- set_config() used to have quoting problems as well when dispatching to
+-- segments.
+CREATE TABLE IF NOT EXISTS should_be_visible();
+CREATE OR REPLACE FUNCTION visible_to_segments(tbl oid)
+    RETURNS SETOF boolean
+    EXECUTE ON ALL SEGMENTS
+    LANGUAGE plpgsql AS
+$$
+BEGIN
+    RETURN NEXT pg_catalog.pg_table_is_visible(tbl);
+END
+$$;
+-- Spin up any gangs necessary to handle the SELECT DISTINCT so that they
+-- receive the new search_path setting from the set_config() dispatch.
+SELECT DISTINCT visible_to_segments('public.should_be_visible'::regclass);
+ visible_to_segments 
+---------------------
+ t
+(1 row)
+
+-- Now change search_path. This setting should not affect the visibility of the
+-- public schema if it's dispatched correctly.
+SELECT set_config('search_path', 'pg_catalog,public', false);
+    set_config     
+-------------------
+ pg_catalog,public
+(1 row)
+
+-- Check that our test table is still visible.
+SELECT DISTINCT visible_to_segments('public.should_be_visible'::regclass);
+ visible_to_segments 
+---------------------
+ t
+(1 row)
+
+RESET search_path;
 -- There used to be a bug in the quoting when the search_path setting was sent
 -- to the segment. It was not easily visible when search_path was set with a
 -- SET command, only when the setting was sent as part of the startup packet.


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/8371.

Fixes #8354.

The dispatch code for set_config() incorrectly quoted the GUC value by surrounding it in single quotes. Not only does this not handle more "interesting" values containing embedded single quotes, but GUCs with the GUC_LIST_QUOTE flag, such as search_path, ended up with different values on the segments compared to the master. For example,

SELECT set_config('search_path', 'my_schema,public', false);
was dispatched as

SET search_path TO 'my_schema,public';
instead of

SET search_path TO my_schema,public;
The two are not equivalent; the latter correctly sets search_path to a list of two elements, my_schema and public, whereas the former sets search_path to a list containing a single my_schema,public element.

Rather than trying to parse apart the list value, dispatch the set_config() call to the QEs as well. This lets us pass through the (quoted) arguments directly and guarantees that we run the same code in both places.

This PR includes a whitespace-cleanup commit that should not affect the semantics.
