### PR TITLE
Add optimizer_penalize_skew to unsync_guc_name

### DIFF
--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -395,6 +395,7 @@
 		"optimizer_nestloop_factor",
 		"optimizer_parallel_union",
 		"optimizer_penalize_broadcast_threshold",
+		"optimizer_penalize_skew",
 		"optimizer_print_expression_properties",
 		"optimizer_print_group_properties",
 		"optimizer_print_job_scheduler",


### PR DESCRIPTION
This will make the pipeline go green

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
