### PR TITLE
Use updated pyOpenSSL for travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ python:
 
 install:
   - pip install --user --upgrade pip
+  - pip install --user "pyopenssl>=19.0.0"
   - pip install --user --pre psutil
   - pip install --user lockfile
   - pip install --user paramiko


### PR DESCRIPTION
Travis has been failing with
> AttributeError: 'module' object has no attribute 'SSL_ST_INIT'

This error is probably depended on the os packages used. However, since python
is the only demonstration of the dependency, be explicit in adding the
dependency there. Demand a version of pyOpenSSL greater or equal than the
current latest one early on in the pip installation chain.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
