### PR TITLE
5X BackPort Error out when locallock and proclock are not consistent.

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -781,53 +781,15 @@ LockAcquire(const LOCKTAG *locktag,
 	Assert((lock->nRequested > 0) && (lock->requested[lockmode] > 0));
 
 	/*
-	 * We shouldn't already hold the desired lock; else locallock table is
-	 * broken.
-	 */
-	if (Gp_role != GP_ROLE_UTILITY)
-	{
-		if (proclock->holdMask & LOCKBIT_ON(lockmode))
-		{
-			elog(LOG, "lock %s on object %u/%u/%u is already held",
-				 lock_mode_names[lockmode],
-				 lock->tag.locktag_field1, lock->tag.locktag_field2,
-				 lock->tag.locktag_field3);
-			if (MyProc == lockHolderProcPtr)
-			{
-				elog(LOG, "writer found lock %s on object %u/%u/%u that it didn't know it held",
-						 lock_mode_names[lockmode],
-						 lock->tag.locktag_field1, lock->tag.locktag_field2,
-						 lock->tag.locktag_field3);
-				GrantLock(lock, proclock, lockmode);
-				GrantLockLocal(locallock, owner);
-			}
-			else
-			{
-				if (MyProc != lockHolderProcPtr)
-				{
-					elog(LOG, "reader found lock %s on object %u/%u/%u which is already held by writer",
-						 lock_mode_names[lockmode],
-						 lock->tag.locktag_field1, lock->tag.locktag_field2,
-						 lock->tag.locktag_field3);
-				}
-				lock->nRequested--;
-				lock->requested[lockmode]--;
-			}
-			LWLockRelease(partitionLock);
-			return LOCKACQUIRE_ALREADY_HELD;
-		}
-		
-	}
-	else
-	if (proclock->holdMask & LOCKBIT_ON(lockmode))
-	{
-		elog(LOG, "lock %s on object %u/%u/%u is already held",
-			 lockMethodTable->lockModeNames[lockmode],
-			 lock->tag.locktag_field1, lock->tag.locktag_field2,
-			 lock->tag.locktag_field3);
-		Insist(false);
-	}
-
+     * We shouldn't already hold the desired lock; else locallock table is
+     * broken.
+     */
+    if (proclock->holdMask & LOCKBIT_ON(lockmode))
+        elog(ERROR, "lock %s on object %u/%u/%u is already held",
+             lockMethodTable->lockModeNames[lockmode],
+             lock->tag.locktag_field1, lock->tag.locktag_field2,
+             lock->tag.locktag_field3);
+	
 	if (MyProc == lockHolderProcPtr)
 	{
 		/*


### PR DESCRIPTION
When acquire a lock, there is a case where locallock doesn't hold
the lock but global lock treats we already held the lock. This
inconsistent state may be caused by broken of locallock or
global lock.

Upstream elog error for this case from the begining. If we already
know locallock or global lock is broken, there is no reason to
continue the queries.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
