### PR TITLE
Fix wrong results caused by NOT_EXISTS sublink elimination.

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -195,10 +195,8 @@ cdbsubselect_drop_orderby(Query *subselect)
  * safe_to_convert_NOT_EXISTS
  */
 static bool
-safe_to_convert_NOT_EXISTS(SubLink *sublink, ConvertSubqueryToJoinContext *ctx1)
+safe_to_convert_NOT_EXISTS(Query *subselect, ConvertSubqueryToJoinContext *ctx1)
 {
-	Query	   *subselect = (Query *) sublink->subselect;
-
 	if (subselect->jointree->fromlist == NULL)
 		return false;
 
@@ -241,6 +239,12 @@ safe_to_convert_NOT_EXISTS(SubLink *sublink, ConvertSubqueryToJoinContext *ctx1)
 	 * If there is a limit offset, then don't bother.
 	 */
 	if (subselect->limitOffset)
+		return false;
+
+	/**
+	 * If there is a limit count, then don't bother.
+	 */
+	if (subselect->limitCount)
 		return false;
 
 	ProcessSubqueryToJoin(subselect, ctx1);
@@ -786,38 +790,38 @@ convert_NOT_EXISTS_to_antijoin(PlannerInfo *root, List **rtrlist_inout, SubLink 
 	InitConvertSubqueryToJoinContext(&ctx1);
 	ctx1.considerNonEqualQual = true;
 
-	if (safe_to_convert_NOT_EXISTS(sublink, &ctx1))
+	/*
+	 * 'LIMIT n' makes NOT EXISTS true when n <= 0, and doesn't affect the
+	 * outcome when n > 0. Return true to be ANDed into the parent qual if n <=
+	 * 0. If there's a LIMIT with positive value (or NULL), though, just ignore
+	 * such clauses.
+	 *
+	 */
+	if (subselect->limitCount != NULL)
+	{
+
+		Node    *node = eval_const_expressions(root, subselect->limitCount);
+
+		subselect->limitCount = node;
+
+		if (IsA(node, Const))
+		{
+			Const   *limit = (Const *) node;
+
+			Assert(limit->consttype == INT8OID);
+			if (!limit->constisnull && DatumGetInt64(limit->constvalue) <= 0)
+				return makeBoolConst(true, false);
+
+			subselect->limitCount = NULL;
+		}
+	}
+
+	if (safe_to_convert_NOT_EXISTS(subselect, &ctx1))
 	{
 
 		/* Delete ORDER BY and DISTINCT. */
 		cdbsubselect_drop_orderby(subselect);
 		cdbsubselect_drop_distinct(subselect);
-
-		/*
-		 * 'LIMIT n' makes NOT EXISTS true when n <= 0, and doesn't affect the
-		 * outcome when n > 0. Return true to be ANDed into the parent qual if
-		 * n <= 0. If there's a LIMIT with anything else as argument, though,
-		 * just ignore such clauses.
-		 *
-		 */
-		if (subselect->limitCount != NULL)
-		{
-
-			Node    *node = eval_const_expressions(root, subselect->limitCount);
-
-			subselect->limitCount = node;
-
-			if (IsA(node, Const))
-			{
-				Const   *limit = (Const *) node;
-
-				Assert(limit->consttype == INT8OID);
-				if (!limit->constisnull && DatumGetInt64(limit->constvalue) <= 0)
-					return makeBoolConst(true, false);
-
-				subselect->limitCount = NULL;
-			}
-		}
 
 		/*
 		 * Trivial NOT EXISTS subquery without a LIMIT can be eliminated altogether.

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1795,3 +1795,106 @@ DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;
 DROP TABLE IF EXISTS dedup_test3;
 -- end_ignore
+--
+-- NOT EXISTS sublink with limit (issue 8396)
+--
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+NOTICE:  table "dedup_test1" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test2;
+NOTICE:  table "dedup_test2" does not exist, skipping
+-- end_ignore
+CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
+CREATE TABLE dedup_test2 ( e int, f int ) DISTRIBUTED BY (e);
+INSERT INTO dedup_test1 select i, i from generate_series(1,4)i;
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 0);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.04 rows=4 width=8)
+   ->  Seq Scan on dedup_test1  (cost=0.00..2.04 rows=2 width=8)
+ Optimizer status: legacy query optimizer
+(3 rows)
+
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 0);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+(4 rows)
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 1);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2036.17..2039.25 rows=17 width=8)
+   ->  Hash Left Anti Semi Join  (cost=2036.17..2039.25 rows=6 width=8)
+         Hash Cond: dedup_test1.a = dedup_test2.e
+         ->  Seq Scan on dedup_test1  (cost=0.00..2.04 rows=2 width=8)
+         ->  Hash  (cost=961.00..961.00 rows=28672 width=4)
+               ->  Seq Scan on dedup_test2  (cost=0.00..961.00 rows=28672 width=4)
+                     Filter: e IS NOT NULL
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 1);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+(4 rows)
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT NULL);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2036.17..2039.25 rows=17 width=8)
+   ->  Hash Left Anti Semi Join  (cost=2036.17..2039.25 rows=6 width=8)
+         Hash Cond: dedup_test1.a = dedup_test2.e
+         ->  Seq Scan on dedup_test1  (cost=0.00..2.04 rows=2 width=8)
+         ->  Hash  (cost=961.00..961.00 rows=28672 width=4)
+               ->  Seq Scan on dedup_test2  (cost=0.00..961.00 rows=28672 width=4)
+                     Filter: e IS NOT NULL
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT NULL);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+(4 rows)
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT ALL);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2036.17..2039.25 rows=17 width=8)
+   ->  Hash Left Anti Semi Join  (cost=2036.17..2039.25 rows=6 width=8)
+         Hash Cond: dedup_test1.a = dedup_test2.e
+         ->  Seq Scan on dedup_test1  (cost=0.00..2.04 rows=2 width=8)
+         ->  Hash  (cost=961.00..961.00 rows=28672 width=4)
+               ->  Seq Scan on dedup_test2  (cost=0.00..961.00 rows=28672 width=4)
+                     Filter: e IS NOT NULL
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT ALL);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+(4 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test2;
+-- end_ignore

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1893,3 +1893,115 @@ DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;
 DROP TABLE IF EXISTS dedup_test3;
 -- end_ignore
+--
+-- NOT EXISTS sublink with limit (issue 8396)
+--
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+NOTICE:  table "dedup_test1" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test2;
+NOTICE:  table "dedup_test2" does not exist, skipping
+-- end_ignore
+CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
+CREATE TABLE dedup_test2 ( e int, f int ) DISTRIBUTED BY (e);
+INSERT INTO dedup_test1 select i, i from generate_series(1,4)i;
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 0);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.10 rows=4 width=8)
+   ->  Nested Loop Left Anti Semi Join  (cost=0.00..882688.10 rows=2 width=8)
+         Join Filter: true
+         ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+         ->  Result  (cost=0.00..0.00 rows=0 width=1)
+               One-Time Filter: false
+ Optimizer status: PQO version 3.65.0
+(7 rows)
+
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 0);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+(4 rows)
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 1);
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.63 rows=4 width=8)
+   ->  Table Scan on dedup_test1  (cost=0.00..1324032.63 rows=2 width=8)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                   Filter: dedup_test2.e = $0
+                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                               ->  Table Scan on dedup_test2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer status: PQO version 3.65.0
+(13 rows)
+
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 1);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+(4 rows)
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT NULL);
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Hash Left Anti Semi Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: dedup_test1.a = dedup_test2.e
+         ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Table Scan on dedup_test2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer status: PQO version 3.65.0
+(8 rows)
+
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT NULL);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+(4 rows)
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT ALL);
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Hash Left Anti Semi Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: dedup_test1.a = dedup_test2.e
+         ->  Table Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Table Scan on dedup_test2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer status: PQO version 3.65.0
+(8 rows)
+
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT ALL);
+ a | b 
+---+---
+ 3 | 3
+ 4 | 4
+ 1 | 1
+ 2 | 2
+(4 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test2;
+-- end_ignore

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -769,3 +769,40 @@ DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;
 DROP TABLE IF EXISTS dedup_test3;
 -- end_ignore
+
+
+--
+-- NOT EXISTS sublink with limit (issue 8396)
+--
+
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test2;
+-- end_ignore
+
+CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
+CREATE TABLE dedup_test2 ( e int, f int ) DISTRIBUTED BY (e);
+
+INSERT INTO dedup_test1 select i, i from generate_series(1,4)i;
+
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 0);
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 0);
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 1);
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT 1);
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT NULL);
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT NULL);
+
+EXPLAIN
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT ALL);
+SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedup_test2.e = dedup_test1.a LIMIT ALL);
+
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test2;
+-- end_ignore


### PR DESCRIPTION
In GPDB 5X, we're trying to eliminate NOT_EXISTS sublink if there is
'limit 0' in the subquery. To do that, we delete subquery's LIMIT and
build (n <= 0) expr to be ANDed into the parent qual. In this way, the
limit can be evaluated at run-time. However, in the case of when n is a
positive number (or NULL), the expr (n <= 0) would be evaluated as
false, which causes the whole parent qual to become false. As a result,
we will get wrong results for query below:

```
create table foo(a int);
insert into foo values (1);

create table bar(b int);

select * from foo where not exists
		(select 1 from bar where bar.b = foo.a limit 1);
```

This patch fixes the wrong results by evaluating the limit at plan-time
and returning true to be ANDed into the parent qual if n <= 0. If n is a
positive value (or NULL), however, LIMIT doesn't affect the semantics of
EXISTS, so this patch just ignores it.

This patch fixes github issue #8396.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
