### PR TITLE
Align constraints tests with upstream

### DIFF
--- a/src/test/regress/expected/gp_constraints.out
+++ b/src/test/regress/expected/gp_constraints.out
@@ -95,3 +95,31 @@ SELECT '' AS five, * FROM UNIQUE_TBL;
 (5 rows)
 
 DROP TABLE UNIQUE_TBL;
+--
+-- Test foreign key constraints
+--
+BEGIN;
+-- Test with two heap tables
+CREATE TABLE fkc_primary_table1(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
+CREATE TABLE fkc_foreign_table1(a int REFERENCES fkc_primary_table1 ON DELETE RESTRICT ON UPDATE RESTRICT, b text) DISTRIBUTED BY (a);
+-- the following should succeed
+INSERT INTO fkc_primary_table1 VALUES (1, 'bar');
+INSERT INTO fkc_primary_table1 VALUES (2, 'bar');
+INSERT INTO fkc_foreign_table1 VALUES (1, 'bar');
+INSERT INTO fkc_foreign_table1 VALUES (2, 'bar');
+UPDATE fkc_foreign_table1 SET b = 'foo';
+DELETE FROM fkc_primary_table1 WHERE a = 1;
+COMMIT;
+BEGIN;
+-- Test with an ao table and heap table
+CREATE TABLE fkc_primary_table2(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
+CREATE TABLE fkc_foreign_table2(a int REFERENCES fkc_primary_table2 ON DELETE RESTRICT ON UPDATE RESTRICT,
+                                b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
+-- the following should succeed
+INSERT INTO fkc_primary_table2 VALUES (1, 'bar');
+INSERT INTO fkc_primary_table2 VALUES (2, 'bar');
+INSERT INTO fkc_foreign_table2 VALUES (1, 'bar');
+INSERT INTO fkc_foreign_table2 VALUES (2, 'bar');
+UPDATE fkc_foreign_table2 SET b = 'foo';
+DELETE FROM fkc_primary_table2 WHERE a = 1;
+COMMIT;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -35,7 +35,7 @@ test: gp_tablespace_with_faults
 test: temp_tablespaces
 test: default_tablespace
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp replication_slots create_table_like_gp
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp replication_slots create_table_like_gp gp_constraints
 
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
 

--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -215,7 +215,7 @@ DELETE FROM INSERT_TBL;
 
 ALTER SEQUENCE INSERT_SEQ RESTART WITH 4;
 
-CREATE TABLE tmp (xd INT, yd TEXT, zd INT) distributed by (xd);
+CREATE TABLE tmp (xd INT, yd TEXT, zd INT);
 
 INSERT INTO tmp VALUES (null, 'Y', null);
 INSERT INTO tmp VALUES (5, '!check failed', null);
@@ -276,7 +276,7 @@ SELECT * FROM COPY_TBL;
 -- Primary keys
 --
 
-CREATE TABLE PRIMARY_TBL (i int PRIMARY KEY, t text) DISTRIBUTED BY (i);
+CREATE TABLE PRIMARY_TBL (i int PRIMARY KEY, t text);
 
 INSERT INTO PRIMARY_TBL VALUES (1, 'one');
 INSERT INTO PRIMARY_TBL VALUES (2, 'two');
@@ -290,7 +290,7 @@ SELECT '' AS four, * FROM PRIMARY_TBL;
 DROP TABLE PRIMARY_TBL;
 
 CREATE TABLE PRIMARY_TBL (i int, t text,
-	PRIMARY KEY(i,t)) DISTRIBUTED BY (i);
+	PRIMARY KEY(i,t));
 
 INSERT INTO PRIMARY_TBL VALUES (1, 'one');
 INSERT INTO PRIMARY_TBL VALUES (2, 'two');
@@ -307,7 +307,7 @@ DROP TABLE PRIMARY_TBL;
 -- Unique keys
 --
 
-CREATE TABLE UNIQUE_TBL (i int UNIQUE, t text) DISTRIBUTED BY (i);
+CREATE TABLE UNIQUE_TBL (i int UNIQUE, t text);
 
 INSERT INTO UNIQUE_TBL VALUES (1, 'one');
 INSERT INTO UNIQUE_TBL VALUES (2, 'two');
@@ -322,7 +322,7 @@ SELECT '' AS five, * FROM UNIQUE_TBL;
 DROP TABLE UNIQUE_TBL;
 
 CREATE TABLE UNIQUE_TBL (i int, t text,
-	UNIQUE(i,t)) DISTRIBUTED BY (i);
+	UNIQUE(i,t));
 
 INSERT INTO UNIQUE_TBL VALUES (1, 'one');
 INSERT INTO UNIQUE_TBL VALUES (2, 'two');
@@ -525,32 +525,3 @@ ALTER TABLE deferred_excl ADD EXCLUDE (f1 WITH =);
 DROP TABLE deferred_excl;
 -- end_ignore
 
---
--- Test foreign key constraints
---
-BEGIN;
--- Test with two heap tables
-CREATE TABLE fkc_primary_table1(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
-CREATE TABLE fkc_foreign_table1(a int REFERENCES fkc_primary_table1 ON DELETE RESTRICT ON UPDATE RESTRICT, b text) DISTRIBUTED BY (a);
--- the following should succeed
-INSERT INTO fkc_primary_table1 VALUES (1, 'bar');
-INSERT INTO fkc_primary_table1 VALUES (2, 'bar');
-INSERT INTO fkc_foreign_table1 VALUES (1, 'bar');
-INSERT INTO fkc_foreign_table1 VALUES (2, 'bar');
-UPDATE fkc_foreign_table1 SET b = 'foo';
-DELETE FROM fkc_primary_table1 WHERE a = 1;
-COMMIT;
-
-BEGIN;
--- Test with an ao table and heap table
-CREATE TABLE fkc_primary_table2(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
-CREATE TABLE fkc_foreign_table2(a int REFERENCES fkc_primary_table2 ON DELETE RESTRICT ON UPDATE RESTRICT,
-                                b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
--- the following should succeed
-INSERT INTO fkc_primary_table2 VALUES (1, 'bar');
-INSERT INTO fkc_primary_table2 VALUES (2, 'bar');
-INSERT INTO fkc_foreign_table2 VALUES (1, 'bar');
-INSERT INTO fkc_foreign_table2 VALUES (2, 'bar');
-UPDATE fkc_foreign_table2 SET b = 'foo';
-DELETE FROM fkc_primary_table2 WHERE a = 1;
-COMMIT;

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -301,7 +301,7 @@ NOTICE:  drop cascades to table atacc2
 --
 DELETE FROM INSERT_TBL;
 ALTER SEQUENCE INSERT_SEQ RESTART WITH 4;
-CREATE TABLE tmp (xd INT, yd TEXT, zd INT) distributed by (xd);
+CREATE TABLE tmp (xd INT, yd TEXT, zd INT);
 INSERT INTO tmp VALUES (null, 'Y', null);
 INSERT INTO tmp VALUES (5, '!check failed', null);
 INSERT INTO tmp VALUES (null, 'try again', null);
@@ -389,7 +389,7 @@ SELECT * FROM COPY_TBL;
 --
 -- Primary keys
 --
-CREATE TABLE PRIMARY_TBL (i int PRIMARY KEY, t text) DISTRIBUTED BY (i);
+CREATE TABLE PRIMARY_TBL (i int PRIMARY KEY, t text);
 INSERT INTO PRIMARY_TBL VALUES (1, 'one');
 INSERT INTO PRIMARY_TBL VALUES (2, 'two');
 INSERT INTO PRIMARY_TBL VALUES (1, 'three');
@@ -411,7 +411,7 @@ SELECT '' AS four, * FROM PRIMARY_TBL;
 
 DROP TABLE PRIMARY_TBL;
 CREATE TABLE PRIMARY_TBL (i int, t text,
-	PRIMARY KEY(i,t)) DISTRIBUTED BY (i);
+	PRIMARY KEY(i,t));
 INSERT INTO PRIMARY_TBL VALUES (1, 'one');
 INSERT INTO PRIMARY_TBL VALUES (2, 'two');
 INSERT INTO PRIMARY_TBL VALUES (1, 'three');
@@ -434,7 +434,7 @@ DROP TABLE PRIMARY_TBL;
 --
 -- Unique keys
 --
-CREATE TABLE UNIQUE_TBL (i int UNIQUE, t text) DISTRIBUTED BY (i);
+CREATE TABLE UNIQUE_TBL (i int UNIQUE, t text);
 INSERT INTO UNIQUE_TBL VALUES (1, 'one');
 INSERT INTO UNIQUE_TBL VALUES (2, 'two');
 INSERT INTO UNIQUE_TBL VALUES (1, 'three');
@@ -457,7 +457,7 @@ SELECT '' AS five, * FROM UNIQUE_TBL;
 
 DROP TABLE UNIQUE_TBL;
 CREATE TABLE UNIQUE_TBL (i int, t text,
-	UNIQUE(i,t)) DISTRIBUTED BY (i);
+	UNIQUE(i,t));
 INSERT INTO UNIQUE_TBL VALUES (1, 'one');
 INSERT INTO UNIQUE_TBL VALUES (2, 'two');
 INSERT INTO UNIQUE_TBL VALUES (1, 'three');
@@ -696,31 +696,3 @@ ERROR:  could not create exclusion constraint "deferred_excl_f1_excl"
 DETAIL:  Key (f1)=(3) conflicts with key (f1)=(3).
 DROP TABLE deferred_excl;
 -- end_ignore
---
--- Test foreign key constraints
---
-BEGIN;
--- Test with two heap tables
-CREATE TABLE fkc_primary_table1(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
-CREATE TABLE fkc_foreign_table1(a int REFERENCES fkc_primary_table1 ON DELETE RESTRICT ON UPDATE RESTRICT, b text) DISTRIBUTED BY (a);
--- the following should succeed
-INSERT INTO fkc_primary_table1 VALUES (1, 'bar');
-INSERT INTO fkc_primary_table1 VALUES (2, 'bar');
-INSERT INTO fkc_foreign_table1 VALUES (1, 'bar');
-INSERT INTO fkc_foreign_table1 VALUES (2, 'bar');
-UPDATE fkc_foreign_table1 SET b = 'foo';
-DELETE FROM fkc_primary_table1 WHERE a = 1;
-COMMIT;
-BEGIN;
--- Test with an ao table and heap table
-CREATE TABLE fkc_primary_table2(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
-CREATE TABLE fkc_foreign_table2(a int REFERENCES fkc_primary_table2 ON DELETE RESTRICT ON UPDATE RESTRICT,
-                                b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
--- the following should succeed
-INSERT INTO fkc_primary_table2 VALUES (1, 'bar');
-INSERT INTO fkc_primary_table2 VALUES (2, 'bar');
-INSERT INTO fkc_foreign_table2 VALUES (1, 'bar');
-INSERT INTO fkc_foreign_table2 VALUES (2, 'bar');
-UPDATE fkc_foreign_table2 SET b = 'foo';
-DELETE FROM fkc_primary_table2 WHERE a = 1;
-COMMIT;


### PR DESCRIPTION
This removes unnecessary table distribution clauses (as they match the default), and moves Greenplum specific tests to gp_constraints to further reduce differences with upstream.

This was spurred by the discussion in #1139 which led me to look closer at the actual test in this file.