### PR TITLE
Only link with libbz2 when available from autoconf

### DIFF
--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -13,7 +13,10 @@ OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o
 GPFDIST_LIBS =-levent
 
 ifeq ($(PORTNAME),aix)
-  GPFDIST_LIBS += -lbz2 -lbsd
+  ifeq ($(with_libbz2),yes)
+    GPFDIST_LIBS += -lbz2
+  endif
+  GPFDIST_LIBS += -lbsd
 endif
 
 ifeq ($(have_yaml),yes)


### PR DESCRIPTION
The gpfdist Makefile was explicitly linking with libbz2 regardless of whether it was identified as available by autoconf. Fix by by linking only if the library is specified to exist.

Why this is done this way for just AIX is another question, but as I don't have an AIX box to test on this will have to do for now.