### PR TITLE
Prevent pushing down WHERE clauses into unsafe UNION/INTERSECT nests.

### DIFF
--- a/src/test/regress/expected/union_gp_optimizer.out
+++ b/src/test/regress/expected/union_gp_optimizer.out
@@ -247,7 +247,7 @@ union
                                              ->  Seq Scan on test1  (cost=0.00..1.01 rows=1 width=4)
                ->  Subquery Scan "*SELECT* 2"  (cost=0.00..0.01 rows=1 width=4)
                      ->  External Scan on test2  (cost=0.00..0.00 rows=1 width=4)
- Settings:  optimizer=off
+ Settings:  optimizer=on
  Optimizer status: legacy query optimizer
 (15 rows)
 
@@ -1974,16 +1974,16 @@ SELECT * FROM
 WHERE x < 4;
                          QUERY PLAN                         
 ------------------------------------------------------------
- Unique  (cost=0.05..0.07 rows=1 width=0)
-   Group By: "outer".t, "outer".x
-   ->  Sort  (cost=0.05..0.06 rows=1 width=0)
-         Sort Key (Distinct): "outer".t, "outer".x
-         ->  Append  (cost=0.00..0.04 rows=1 width=0)
-               ->  Result  (cost=0.00..0.01 rows=1 width=0)
-               ->  Result  (cost=0.00..0.01 rows=1 width=0)
-                     One-Time Filter: false
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
+ Append  (cost=0.00..0.00 rows=1 width=8)
+   ->  Result  (cost=0.00..0.00 rows=1 width=8)
+         Filter: x < 4
+         ->  Result  (cost=0.00..0.00 rows=1 width=8)
+               ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   ->  Result  (cost=0.00..0.00 rows=0 width=8)
+         ->  Result  (cost=0.00..0.00 rows=0 width=8)
+               One-Time Filter: false
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.65.0
 (10 rows)
 
  SELECT * FROM
@@ -2005,20 +2005,23 @@ WHERE x < 4
 ORDER BY x;
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
- Sort  (cost=0.10..0.11 rows=1 width=8)
-   Sort Key: ss.x
-   ->  Subquery Scan ss  (cost=0.05..0.09 rows=1 width=8)
-         Filter: ss.x < 4
-         ->  Unique  (cost=0.05..0.07 rows=1 width=0)
-               Group By: "outer".t, (generate_series(1, 10))
-               ->  Sort  (cost=0.05..0.06 rows=1 width=0)
-                     Sort Key (Distinct): "outer".t, (generate_series(1, 10))
-                     ->  Append  (cost=0.00..0.04 rows=1 width=0)
-                           ->  Result  (cost=0.00..0.01 rows=1 width=0)
-                           ->  Result  (cost=0.00..0.01 rows=1 width=0)
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
-(13 rows)
+ GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
+   Group By: t, (generate_series(1, 10))
+   ->  GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
+         Group By: t, (generate_series(1, 10))
+         ->  Sort  (cost=0.00..0.00 rows=1 width=8)
+               Sort Key: (generate_series(1, 10)), t
+               ->  Append  (cost=0.00..0.00 rows=1 width=8)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                           Filter: (generate_series(1, 10)) < 4
+                           ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                     ->  Result  (cost=0.00..0.00 rows=0 width=8)
+                           ->  Result  (cost=0.00..0.00 rows=0 width=8)
+                                 One-Time Filter: false
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.65.0
+(16 rows)
 
 SELECT * FROM
   (SELECT 1 AS t, generate_series(1,10) AS x
@@ -2052,7 +2055,7 @@ WHERE x > 3;
                            InitPlan
                              ->  Result  (cost=0.00..0.01 rows=1 width=0)
                      ->  Result  (cost=0.00..0.01 rows=1 width=0)
- Settings:  optimizer=off
+ Settings:  optimizer=on
  Optimizer status: legacy query optimizer
 (13 rows)
 
@@ -2086,40 +2089,40 @@ from
         FROM foo_union
 ) ABC
 where ABC.ss = 5;
-                                                                             QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=10.32..10.38 rows=1 width=4)
-   ->  Subquery Scan abc  (cost=10.32..10.38 rows=1 width=4)
-         Filter: abc.ss = 5
-         ->  Unique  (cost=10.32..10.34 rows=1 width=3)
-               Group By: "outer".ss
-               ->  Sort  (cost=10.32..10.33 rows=1 width=3)
-                     Sort Key (Distinct): "outer".ss
-                     ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..10.30 rows=1 width=3)
-                           Hash Key: "outer".ss
-                           ->  Append  (cost=0.00..10.30 rows=1 width=3)
-                                 ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.02 rows=1 width=0)
-                                       Hash Key: "outer".ss
-                                       ->  Result  (cost=0.00..0.01 rows=1 width=0)
-                                 ->  GroupAggregate  (cost=10.21..10.26 rows=1 width=4)
-                                       Group By: ((subplan))
-                                       ->  Sort  (cost=10.21..10.21 rows=1 width=4)
-                                             Sort Key: ((subplan))
-                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=6.08..10.20 rows=1 width=4)
-                                                   Hash Key: ((subplan))
-                                                   ->  GroupAggregate  (cost=6.08..10.16 rows=1 width=4)
-                                                         Group By: ((subplan))
-                                                         ->  Sort  (cost=6.08..6.08 rows=1 width=4)
-                                                               Sort Key: ((subplan))
-                                                               ->  Seq Scan on foo_union  (cost=0.00..6.07 rows=1 width=4)
-                                                                     SubPlan 1
-                                                                       ->  Result  (cost=2.03..2.04 rows=1 width=4)
-                                                                             Filter: bar_union.c = $0
-                                                                             ->  Materialize  (cost=2.03..2.04 rows=1 width=4)
-                                                                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..2.02 rows=1 width=4)
-                                                                                         ->  Seq Scan on bar_union  (cost=0.00..2.02 rows=1 width=4)
- Settings:  optimizer=off
- Optimizer status: legacy query optimizer
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324039.87 rows=1 width=4)
+   ->  GroupAggregate  (cost=0.00..1324039.87 rows=1 width=4)
+         Group By: "outer".ss
+         ->  Sort  (cost=0.00..1324039.87 rows=1 width=4)
+               Sort Key: "outer".ss
+               ->  Append  (cost=0.00..1324039.87 rows=1 width=4)
+                     ->  Result  (cost=0.00..0.00 rows=0 width=4)
+                           ->  Result  (cost=0.00..0.00 rows=0 width=4)
+                                 ->  Result  (cost=0.00..0.00 rows=0 width=4)
+                                       One-Time Filter: false
+                     ->  GroupAggregate  (cost=0.00..1324039.87 rows=1 width=4)
+                           Group By: ((subplan))
+                           ->  Sort  (cost=0.00..1324039.87 rows=1 width=4)
+                                 Sort Key: ((subplan))
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324039.87 rows=1 width=4)
+                                       Hash Key: ((subplan))
+                                       ->  GroupAggregate  (cost=0.00..1324039.87 rows=1 width=4)
+                                             Group By: ((subplan))
+                                             ->  Sort  (cost=0.00..1324039.87 rows=1 width=4)
+                                                   Sort Key: ((subplan))
+                                                   ->  Result  (cost=0.00..1324039.87 rows=1 width=4)
+                                                         Filter: ((subplan)) = 5
+                                                         ->  Result  (cost=0.00..1324039.87 rows=1 width=4)
+                                                               ->  Table Scan on foo_union  (cost=0.00..1324039.87 rows=334 width=4)
+                                                               SubPlan 1
+                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                       Filter: bar_union.c = $0
+                                                                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                                                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                                                                   ->  Table Scan on bar_union  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.65.0
 (32 rows)
 
 SELECT *


### PR DESCRIPTION
Approved for 4x, same commit. 

Ported from the upstream commit listed below:
     commit 964c0d0f80e485dd3a4073e073ddfd9bfdda90b2
     Author: Tom Lane <tgl@sss.pgh.pa.us>
     Date:   Wed Jun 5 23:44:02 2013 -0400

     Prevent pushing down WHERE clauses into unsafe UNION/INTERSECT nests.

     The planner is aware that it mustn't push down upper-level quals into
     subqueries if the quals reference subquery output columns that contain
     set-returning functions or volatile functions, or are non-DISTINCT outputs
     of a DISTINCT ON subquery.  However, it missed making this check when
     there were one or more levels of UNION or INTERSECT above the dangerous
     expression.  This could lead to "set-valued function called in context that
     cannot accept a set" errors, as seen in bug #8213 from Eric Soroos, or to
     silently wrong answers in the other cases.

     To fix, refactor the checks so that we make the column-is-unsafe checks
     during subquery_is_pushdown_safe(), which already has to recursively
     inspect all arms of a set-operation tree.  This makes
     qual_is_pushdown_safe() considerably simpler, at the cost that we will
     spend some cycles checking output columns that possibly aren't referenced
     in any upper qual.  But the cases where this code gets executed at all
     are already nontrivial queries, so it's unlikely anybody will notice any
     slowdown of planning.

     This has been broken since commit 05f916e6add9726bf4ee046e4060c1b03c9961f2,
     which makes the bug over ten years old.  A bit surprising nobody noticed it
     before now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
