### PR TITLE
Add stats warning to gpsd and minirepro

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -147,7 +147,7 @@ def dumpStats(cur, inclHLL):
 
 
 def parseCmdLine():
-    p = OptionParser(usage='Usage: %prog [options] <database>', version=gpsd_version, conflict_handler="resolve")
+    p = OptionParser(usage='Usage: %prog [options] <database>', version=gpsd_version, conflict_handler="resolve", epilog="WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file. Please review output file to ensure it is within corporate policy to transport the output file.")
     p.add_option('-?', '--help', action='help', help='Show this help message and exit')
     p.add_option('-h', '--host', action='store',
                  dest='host', help='Specify a remote host')
@@ -239,6 +239,10 @@ def main():
             with closing(connection.cursor()) as cursor:
                 dumpTupleCount(cursor)
                 dumpStats(cursor, inclHLL)
+        # Upon success, leave a warning message about data collected
+        sys.stderr.writelines(['WARNING: This tool collects statistics about your data, including most common values, '
+                               'which requires some data elements to be included in the output file.\n',
+                               'Please review output file to ensure it is within corporate policy to transport the output file.\n'])
 
     except pgdb.DatabaseError, err:  # catch *all* exceptions
         sys.stderr.write('Error while dumping statistics:\n')

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -104,7 +104,7 @@ def get_server_version(cursor):
         sys.exit(1)
 
 def parse_cmd_line():
-    p = OptionParser(usage='Usage: %prog <database> [options]', version='%prog '+version, conflict_handler="resolve")
+    p = OptionParser(usage='Usage: %prog <database> [options]', version='%prog '+version, conflict_handler="resolve", epilog="WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file. Please review output file to ensure it is within corporate policy to transport the output file.")
     p.add_option('-?', '--help', action='help', help='Show this help message and exit')
     p.add_option('-h', '--host', action='store',
                  dest='host', help='Specify a remote host')
@@ -414,6 +414,10 @@ def main():
     f_out.close()
 
     print "--- MiniRepro completed! ---"
+
+    # upon success, leave a warning message about data collected
+    print 'WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file.'
+    print 'Please review output file to ensure it is within corporate policy to transport the output file.'
 
 if __name__ == "__main__":
         main()


### PR DESCRIPTION
This commit adds a warning regarding the data elements collected when
creating the output file.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
