### PR TITLE
Initialize member of SnapshotData in unittest

### DIFF
--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -89,6 +89,8 @@ test_write_read_shared_snapshot_for_cursor(void **state)
 
 	SnapshotData snapshot;
 	snapshot.xip = palloc(XCNT * sizeof(TransactionId));
+#define SUBXCNT 1
+	snapshot.subxip = palloc(SUBXCNT * sizeof(TransactionId));
 
 	/* read snapshot from the same file */
 	readSharedLocalSnapshot_forCursor(&snapshot, DTX_CONTEXT_QE_READER);


### PR DESCRIPTION
We need to initialize the value of subxip as there is a check inside
readSharedLocalSnapshot_forCursor that subxip is not NULL. We have
undefined behavior unless we initialize the field which can lead to test
failures.

Co-authored-by: Melanie Plageman <mplageman@pivotal.io>



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
