### PR TITLE
6X: Move assign_query_collations() forward

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1765,14 +1765,21 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 							   (LockingClause *) lfirst(l), false);
 	}
 
+	assign_query_collations(pstate, qry);
+
 	/*
 	 * If the query mixes window functions and aggregates, we need to
 	 * transform it such that the grouped query appears as a subquery
+	 *
+	 * This must be done after collations. Because it, specifically the
+	 * grouped_window_mutator() it called, will replace some expressions with
+	 * Var and set the varcollid with the replaced expressions' original
+	 * collations, which are from assign_query_collations().
+	 *
+	 * Note: assign_query_collations() doesn't handle Var's collation.
 	 */
 	if (qry->hasWindowFuncs && (qry->groupClause || qry->hasAggs))
 		transformGroupedWindows(pstate, qry);
-
-	assign_query_collations(pstate, qry);
 
 	return qry;
 }

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -2059,3 +2059,22 @@ select least_agg(variadic array[q1,q2]) from int8_tbl;
  -4567890123456789
 (1 row)
 
+-- check collation-sensitive matching between grouping expressions
+select v||'a', case v||'a' when 'aa' then 1 else 0 end, count(*)
+  from unnest(array['a','b']) u(v)
+ group by v||'a' order by 1;
+ ?column? | case | count 
+----------+------+-------
+ aa       |    1 |     1
+ ba       |    0 |     1
+(2 rows)
+
+select v||'a', case when v||'a' = 'aa' then 1 else 0 end, count(*)
+  from unnest(array['a','b']) u(v)
+ group by v||'a' order by 1;
+ ?column? | case | count 
+----------+------+-------
+ aa       |    1 |     1
+ ba       |    0 |     1
+(2 rows)
+

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -2274,3 +2274,22 @@ CONTEXT:  SQL function "least_accum" during startup
  -4567890123456789
 (1 row)
 
+-- check collation-sensitive matching between grouping expressions
+select v||'a', case v||'a' when 'aa' then 1 else 0 end, count(*)
+  from unnest(array['a','b']) u(v)
+ group by v||'a' order by 1;
+ ?column? | case | count 
+----------+------+-------
+ aa       |    1 |     1
+ ba       |    0 |     1
+(2 rows)
+
+select v||'a', case when v||'a' = 'aa' then 1 else 0 end, count(*)
+  from unnest(array['a','b']) u(v)
+ group by v||'a' order by 1;
+ ?column? | case | count 
+----------+------+-------
+ aa       |    1 |     1
+ ba       |    0 |     1
+(2 rows)
+

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -97,4 +97,10 @@ select * from v_sourcetable2;
 (10 rows)
 
 drop view v_sourcetable2;
+-- Greenplum divides the query if it mixes window functions with aggregate
+-- functions or grouping, test it here because creating view has a check
+-- related to the collation assigning process which is affected by the
+-- dividing.
+CREATE TEMP TABLE gp_create_view_t1 (f1 smallint, f2 text) DISTRIBUTED RANDOMLY;
+CREATE TEMP VIEW window_and_agg_v1 AS SELECT count(*) OVER (PARTITION BY f1), max(f2) FROM gp_create_view_t1 GROUP BY f1;
 reset optimizer;

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -788,3 +788,11 @@ drop view aggordview1;
 -- variadic aggregates
 select least_agg(q1,q2) from int8_tbl;
 select least_agg(variadic array[q1,q2]) from int8_tbl;
+
+-- check collation-sensitive matching between grouping expressions
+select v||'a', case v||'a' when 'aa' then 1 else 0 end, count(*)
+  from unnest(array['a','b']) u(v)
+ group by v||'a' order by 1;
+select v||'a', case when v||'a' = 'aa' then 1 else 0 end, count(*)
+  from unnest(array['a','b']) u(v)
+ group by v||'a' order by 1;

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -56,4 +56,12 @@ create view v_sourcetable2 as
 select * from v_sourcetable2;
 
 drop view v_sourcetable2;
+
+-- Greenplum divides the query if it mixes window functions with aggregate
+-- functions or grouping, test it here because creating view has a check
+-- related to the collation assigning process which is affected by the
+-- dividing.
+CREATE TEMP TABLE gp_create_view_t1 (f1 smallint, f2 text) DISTRIBUTED RANDOMLY;
+CREATE TEMP VIEW window_and_agg_v1 AS SELECT count(*) OVER (PARTITION BY f1), max(f2) FROM gp_create_view_t1 GROUP BY f1;
+
 reset optimizer;


### PR DESCRIPTION
If a query mixes window functions with aggregate functions or grouping,
transformGroupedWindows() divides it to a new query and a sub-query, and
replace some expressions with Var and set the varcollid with the
replaced expressions' original collations.

Because assign_query_collations() does not handle Var's collation,
transformGroupedWindows() should be called after it with the assigned
collations information. Otherwise the Var, which are replaced with, will
have no collations.

This is the 6X version of #8435, fixes #8376