### PR TITLE
docs - Fix UUID data type size documentation

### DIFF
--- a/gpdb-doc/dita/ref_guide/data_types.xml
+++ b/gpdb-doc/dita/ref_guide/data_types.xml
@@ -299,7 +299,7 @@
             <row>
               <entry colname="col1">uuid</entry>
               <entry colname="col2"/>
-              <entry colname="col3">32 bytes</entry>
+              <entry colname="col3">16 bytes</entry>
               <entry colname="col4"/>
               <entry colname="col5">Universally Unique Identifiers according to RFC 4122, ISO/IEC
                 9834-8:2005</entry>


### PR DESCRIPTION
The UUID data type is actually 16 bytes (128 bits) in size as
described in `src/include/utils/uuid.h` and in Postgres documentation
(https://www.postgresql.org/docs/9.4/datatype-uuid.html). Most likely
it was confused for its 32 digit representation.

Reported by Evgeny Ermakov on OSS Greenplum Slack.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
