### PR TITLE
Fix crash when the qual under DynamicTableScan has a subplan

### DIFF
--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -49,6 +49,14 @@ ExecInitDynamicSeqScan(DynamicSeqScan *node, EState *estate, int eflags)
 
 	state->scan_state = SCAN_INIT;
 
+	/* Initialize child expressions. This is needed to find subplans. */
+	state->ss.ps.qual = (List *)
+		ExecInitExpr((Expr *) node->seqscan.plan.qual,
+					 (PlanState *) state);
+	state->ss.ps.targetlist = (List *)
+		ExecInitExpr((Expr *) node->seqscan.plan.targetlist,
+					 (PlanState *) state);
+
 	/* Initialize result tuple type. */
 	ExecInitResultTupleSlot(estate, &state->ss.ps);
 	ExecAssignResultTypeFromTL(&state->ss.ps);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11296,3 +11296,90 @@ SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinne
   8 | 2 |   |  
 (10 rows)
 
+-- test subplan in a qual under dynamic scan
+CREATE TABLE ds_part ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_deflt" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_2" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_3" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_4" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_5" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_6" for table "ds_part"
+CREATE TABLE non_part1 (c INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part2 (e INT, f INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'e' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO ds_part SELECT i, i, i FROM generate_series (1, 1000)i; 
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i; 
+INSERT INTO non_part2 SELECT i, i FROM generate_series(1, 100)i;
+SET optimizer_enforce_subplans TO ON;
+analyze ds_part;
+analyze non_part1;
+analyze non_part2;
+SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+ a | b | c | e | f 
+---+---+---+---+---
+(0 rows)
+
+explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000004.33..10000000039.13 rows=7 width=20)
+   ->  Nested Loop Semi Join  (cost=10000000004.33..10000000039.13 rows=3 width=20)
+         ->  Hash Join  (cost=4.33..28.40 rows=2 width=20)
+               Hash Cond: (ds_part_1_prt_deflt.c = non_part2.e)
+               ->  Append  (cost=0.00..24.00 rows=2 width=12)
+                     ->  Result  (cost=0.00..17.87 rows=1 width=12)
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on ds_part_1_prt_deflt  (cost=0.00..17.87 rows=1 width=12)
+                                 Filter: (a = (b + 1))
+                     ->  Result  (cost=0.00..2.03 rows=1 width=12)
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on ds_part_1_prt_2  (cost=0.00..2.03 rows=1 width=12)
+                                 Filter: (a = (b + 1))
+                     ->  Result  (cost=0.00..1.03 rows=1 width=12)
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on ds_part_1_prt_3  (cost=0.00..1.03 rows=1 width=12)
+                                 Filter: (a = (b + 1))
+                     ->  Result  (cost=0.00..1.03 rows=1 width=12)
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on ds_part_1_prt_4  (cost=0.00..1.03 rows=1 width=12)
+                                 Filter: (a = (b + 1))
+                     ->  Result  (cost=0.00..1.03 rows=1 width=12)
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on ds_part_1_prt_5  (cost=0.00..1.03 rows=1 width=12)
+                                 Filter: (a = (b + 1))
+                     ->  Result  (cost=0.00..1.01 rows=1 width=12)
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on ds_part_1_prt_6  (cost=0.00..1.01 rows=1 width=12)
+                                 Filter: (a = (b + 1))
+               ->  Hash  (cost=4.29..4.29 rows=1 width=8)
+                     ->  Partition Selector for ds_part (dynamic scan id: 1)  (cost=0.00..4.29 rows=1 width=8)
+                           Filter: non_part2.e
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4.29 rows=1 width=8)
+                                 ->  Seq Scan on non_part2  (cost=0.00..4.25 rows=1 width=8)
+                                       Filter: (f = 10)
+         ->  Materialize  (cost=0.00..9.50 rows=100 width=0)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..8.00 rows=100 width=0)
+                     ->  Seq Scan on non_part1  (cost=0.00..4.00 rows=34 width=0)
+ Optimizer: Postgres query optimizer
+(39 rows)
+
+SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
+ a  | b  | c  | e  | f  | ?column? 
+----+----+----+----+----+----------
+ 10 | 10 | 10 | 10 | 10 | f
+(1 row)
+
+CREATE INDEX ds_idx ON ds_part(a);
+analyze ds_part;
+SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
+ a  | b  | c  | e  | f  | ?column? 
+----+----+----+----+----+----------
+ 10 | 10 | 10 | 10 | 10 | f
+(1 row)
+
+RESET optimizer_enforce_subplans;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11417,6 +11417,72 @@ SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinne
   8 | 2 |   |  
 (10 rows)
 
+-- test subplan in a qual under dynamic scan
+CREATE TABLE ds_part ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_deflt" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_2" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_3" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_4" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_5" for table "ds_part"
+NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_6" for table "ds_part"
+CREATE TABLE non_part1 (c INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part2 (e INT, f INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'e' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO ds_part SELECT i, i, i FROM generate_series (1, 1000)i; 
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i; 
+INSERT INTO non_part2 SELECT i, i FROM generate_series(1, 100)i;
+SET optimizer_enforce_subplans TO ON;
+analyze ds_part;
+analyze non_part1;
+analyze non_part2;
+SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+ a | b | c | e | f 
+---+---+---+---+---
+(0 rows)
+
+explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324481.28 rows=1000 width=20)
+   ->  Hash Join  (cost=0.00..1324481.20 rows=334 width=20)
+         Hash Cond: (ds_part.c = non_part2.e)
+         ->  Dynamic Seq Scan on ds_part (dynamic scan id: 1)  (cost=0.00..1324050.11 rows=334 width=12)
+               Filter: ((a = (b + 1)) AND (SubPlan 1))
+               SubPlan 1  (slice4; segments: 3)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=4)
+                             ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                         ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                                               ->  Seq Scan on non_part1  (cost=0.00..431.00 rows=34 width=4)
+         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+               ->  Partition Selector for ds_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Seq Scan on non_part2  (cost=0.00..431.00 rows=1 width=8)
+                                 Filter: (f = 10)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.65.0
+(18 rows)
+
+SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
+ a  | b  | c  | e  | f  | ?column? 
+----+----+----+----+----+----------
+ 10 | 10 | 10 | 10 | 10 | f
+(1 row)
+
+CREATE INDEX ds_idx ON ds_part(a);
+analyze ds_part;
+SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
+ a  | b  | c  | e  | f  | ?column? 
+----+----+----+----+----+----------
+ 10 | 10 | 10 | 10 | 10 | f
+(1 row)
+
+RESET optimizer_enforce_subplans;
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 NOTICE:  drop cascades to 92 other objects

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2162,6 +2162,29 @@ SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a AND tin
 SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a;
 SELECT * FROM touter LEFT JOIN tinnerbtree ON touter.a = tinnerbtree.a AND tinnerbtree.b=10;
 
+-- test subplan in a qual under dynamic scan
+CREATE TABLE ds_part ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
+CREATE TABLE non_part1 (c INT);
+CREATE TABLE non_part2 (e INT, f INT);
+
+INSERT INTO ds_part SELECT i, i, i FROM generate_series (1, 1000)i; 
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i; 
+INSERT INTO non_part2 SELECT i, i FROM generate_series(1, 100)i;
+
+SET optimizer_enforce_subplans TO ON;
+analyze ds_part;
+analyze non_part1;
+analyze non_part2;
+SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+
+SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
+CREATE INDEX ds_idx ON ds_part(a);
+analyze ds_part;
+SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
+
+RESET optimizer_enforce_subplans;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Consider the query below:

```
test=# explain select * from foo, jazz where foo.c = jazz.e and jazz.f = 10 and a in (select b+1 from bar);
						 QUERY PLAN
--------------------------------------------------------------------------------------------------------------------
Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324469.30 rows=1 width=20)
->  Hash Join  (cost=0.00..1324469.30 rows=1 width=20)
     Hash Cond: foo.c = jazz.e
     ->  Dynamic Table Scan on foo (dynamic scan id: 1)  (cost=0.00..1324038.29 rows=34 width=12)
	   Filter: a = (b + 1) AND ((subplan))
	   SubPlan 1
	     ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
		   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=4)
			 ->  Limit  (cost=0.00..431.00 rows=1 width=4)
			       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
				     ->  Limit  (cost=0.00..431.00 rows=1 width=4)
					   ->  Table Scan on bar  (cost=0.00..431.00 rows=34 width=4)
     ->  Hash  (cost=100.00..100.00 rows=34 width=4)
	   ->  Partition Selector for foo (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
		 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
		       ->  Table Scan on jazz  (cost=0.00..431.00 rows=1 width=8)
			     Filter: f = 10
Optimizer status: PQO version 3.65.0
(18 rows)
```

Previously, since the subplan was in a qual, we did not populate the
qual properly when executing a dynamic table scan node. Thus the
subplan attribute in PlanState of the dynamic table scan was incorrectly
set to NULL, causing a later crash.

We now populate this similarly to how we do it for dynamic index/bitmap
scans.

Co-authored-by: Sambitesh Dash <sdash@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>