### PR TITLE
Fix up enable_hashagg when creating a UniquePath.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2421,7 +2421,7 @@ create_unique_rowid_path(PlannerInfo *root,
 	 * create_unique_path().
 	 */
 	all_btree = true;
-	all_hash = true;
+	all_hash = enable_hashagg;	/* don't consider hash if not enabled */
 
 	RowIdExpr *rowidexpr = makeNode(RowIdExpr);
 	rowidexpr->rowidexpr_id = rowidexpr_id;

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1387,3 +1387,86 @@ cross join lateral
 (6 rows)
 
 reset enable_bitmapscan;
+---
+--- Test that GUC enable_hashagg takes effect for SEMI join
+---
+drop table if exists foo;
+drop table if exists bar;
+create table foo(a int) distributed by (a);
+create table bar(b int) distributed by (b);
+insert into foo select i from generate_series(1,10)i;
+insert into bar select i from generate_series(1,1000)i;
+analyze foo;
+analyze bar;
+set enable_hashagg to on;
+explain (costs off)
+select * from foo where exists (select 1 from bar where foo.a = bar.b);
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: (RowIdExpr)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: (RowIdExpr)
+               ->  Hash Join
+                     Hash Cond: (bar.b = foo.a)
+                     ->  Seq Scan on bar
+                     ->  Hash
+                           ->  Seq Scan on foo
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from foo where exists (select 1 from bar where foo.a = bar.b);
+ a  
+----
+ 10
+  9
+  3
+  7
+  4
+  5
+  8
+  1
+  2
+  6
+(10 rows)
+
+set enable_hashagg to off;
+explain (costs off)
+select * from foo where exists (select 1 from bar where foo.a = bar.b);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Unique
+               Group Key: (RowIdExpr)
+               ->  Sort
+                     Sort Key (Distinct): (RowIdExpr)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: (RowIdExpr)
+                           ->  Hash Join
+                                 Hash Cond: (bar.b = foo.a)
+                                 ->  Seq Scan on bar
+                                 ->  Hash
+                                       ->  Seq Scan on foo
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select * from foo where exists (select 1 from bar where foo.a = bar.b);
+ a  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(10 rows)
+
+reset enable_hashagg;
+drop table foo;
+drop table bar;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1385,3 +1385,75 @@ cross join lateral
 (6 rows)
 
 reset enable_bitmapscan;
+---
+--- Test that GUC enable_hashagg takes effect for SEMI join
+---
+drop table if exists foo;
+drop table if exists bar;
+create table foo(a int) distributed by (a);
+create table bar(b int) distributed by (b);
+insert into foo select i from generate_series(1,10)i;
+insert into bar select i from generate_series(1,1000)i;
+analyze foo;
+analyze bar;
+set enable_hashagg to on;
+explain (costs off)
+select * from foo where exists (select 1 from bar where foo.a = bar.b);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (foo.a = bar.b)
+         ->  Seq Scan on foo
+         ->  Hash
+               ->  Seq Scan on bar
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select * from foo where exists (select 1 from bar where foo.a = bar.b);
+ a  
+----
+ 10
+  9
+  3
+  7
+  4
+  5
+  8
+  1
+  2
+  6
+(10 rows)
+
+set enable_hashagg to off;
+explain (costs off)
+select * from foo where exists (select 1 from bar where foo.a = bar.b);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (foo.a = bar.b)
+         ->  Seq Scan on foo
+         ->  Hash
+               ->  Seq Scan on bar
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select * from foo where exists (select 1 from bar where foo.a = bar.b);
+ a  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(10 rows)
+
+reset enable_hashagg;
+drop table foo;
+drop table bar;


### PR DESCRIPTION
In PostgreSQL, semi-joins are implemented with JOIN_SEMI join types, or
by first eliminating duplicates from the inner side, and then performing
normal inner join (that's JOIN_UNIQUE_OUTER and JOIN_UNIQUE_INNER).

GPDB has a third way to implement them: Perform an inner join first, and
then eliminate duplicates from the result. This is performed by a
UniquePath above the join. And there are two ways to implement the
UniquePath: sorting and hashing. But if hashing is not enabled, we
should not consider it.

This patch fixes github issue #8437.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
