### PR TITLE
Fix external_table test failure.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4792,7 +4792,7 @@ NextCopyFrom(CopyState cstate, ExprContext *econtext,
 		for (;;)
 		{
 			bool		got_error = false;
-			bool		result;
+			bool		result = false;
 
 			PG_TRY();
 			{


### PR DESCRIPTION
Yesterday I saw it always fails on one of my dev environment with gcc 6.2.
Part of diff as below:

--- \/home\/gpadmin\/ws\/gpdb7\/src\/test\/regress\/expected\/external_table\.out   2019-08-21 11:58:21.533592943 +0800
+++ \/home\/gpadmin\/ws\/gpdb7\/src\/test\/regress\/results\/external_table\.out    2019-08-21 11:58:21.743592951 +0800
@@ -2610,9 +2689,12 @@
   LOG ERRORS SEGMENT REJECT LIMIT 20000;
   -- should fail with an appropriate error message
   SELECT COUNT(*) FROM exttab_first_reject_limit_1;
  -ERROR:  all 1000 first rows in this segment were rejected
  -DETAIL:  Aborting operation regardless of REJECT LIMIT value, last error was: invalid input syntax for integer: "error_0", column i
  -CONTEXT:  External table exttab_first_reject_limit_1, line 1000 of file://dev7/home/gpadmin/ws/gpdb7/src/test/regress/data/exttab_first_errors.data, column i
  +NOTICE:  found 5000 data formatting errors (5000 or more input rows), rejected related input data
  + count
  +-------
  +  5000
  +(1 row)
  +

Turn out that this is another variable initialization issue in the longjmp case.

Unfortunately gcc does not report a warning against this.
