### PR TITLE
Unset optimizer_force_multistage_agg by default.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2440,7 +2440,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_multistage_agg,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -201,7 +201,7 @@ select count_operator('select count(*) from multi_stage_test group by b;','Group
 
 --CLEANUP
 reset optimizer_segments;
-set optimizer_force_multistage_agg = off;
+reset optimizer_force_multistage_agg;
 --
 -- Testing not picking HashAgg for aggregates without combine functions
 --

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -200,7 +200,7 @@ select count_operator('select count(*) from multi_stage_test group by b;','Group
 
 --CLEANUP
 reset optimizer_segments;
-set optimizer_force_multistage_agg = off;
+reset optimizer_force_multistage_agg;
 --
 -- Testing not picking HashAgg for aggregates without combine functions
 --

--- a/src/test/regress/expected/bfv_dd_multicolumn.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn.out
@@ -3,6 +3,7 @@
 --
 -- start_ignore
 set optimizer_log=on;
+set optimizer_force_multistage_agg=on;
 -- end_ignore
 set test_print_direct_dispatch_info=on; 
 set gp_autostats_mode = 'None';
@@ -266,3 +267,4 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  3 | 1
 (3 rows)
 
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
@@ -3,6 +3,7 @@
 --
 -- start_ignore
 set optimizer_log=on;
+set optimizer_force_multistage_agg=on;
 -- end_ignore
 set test_print_direct_dispatch_info=on; 
 set gp_autostats_mode = 'None';
@@ -272,3 +273,4 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  3 | 1
 (3 rows)
 
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -150,27 +150,26 @@ explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1134.51 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1134.51 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1134.51 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1134.51 rows=1 width=1)
-                     Hash Cond: (bfv_tab2_facttable1.wk_id = bfv_tab2_dimdate.wk_id)
-                     ->  Nested Loop  (cost=0.00..703.51 rows=1 width=2)
-                           Join Filter: true
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                 ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
-                           ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..272.51 rows=1 width=2)
-                                 Recheck Cond: (id = bfv_tab2_dimtabl1.id)
-                                 ->  Dynamic Bitmap Index Scan on bfv_tab2_facttable1_1_prt_dflt_id_idx  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (id = bfv_tab2_dimtabl1.id)
-                     ->  Hash  (cost=100.00..100.00 rows=34 width=4)
-                           ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=10 width=2)
-                                       ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.57.0
-(18 rows)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1134.51 rows=1 width=1)
+         ->  Hash Join  (cost=0.00..1134.51 rows=1 width=1)
+               Hash Cond: (bfv_tab2_facttable1.wk_id = bfv_tab2_dimdate.wk_id)
+               ->  Nested Loop  (cost=0.00..703.51 rows=1 width=2)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                           ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..272.51 rows=1 width=2)
+                           Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                           ->  Dynamic Bitmap Index Scan on bfv_tab2_facttable1_1_prt_dflt_id_idx  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (id = bfv_tab2_dimtabl1.id)
+               ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                     ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=10 width=2)
+                                 ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(17 rows)
 
 -- start_ignore
 create language plpythonu;

--- a/src/test/regress/expected/bitmapops_optimizer.out
+++ b/src/test/regress/expected/bitmapops_optimizer.out
@@ -58,8 +58,8 @@ EXPLAIN SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..6.35 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.35 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..6.35 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.35 rows=2 width=1)
+         ->  Result  (cost=0.00..6.35 rows=1 width=1)
                ->  Index Scan using i_bmtest2_c on bmscantest2  (cost=0.00..6.35 rows=1 width=1)
                      Index Cond: (c = 1)
                      Filter: ((a = 1) AND (b = 1))
@@ -115,24 +115,22 @@ CREATE INDEX i_bmtest_ao_b ON bmscantest_ao USING BITMAP(b);
 CREATE INDEX i_bmtest_ao_c ON bmscantest_ao(c);
 CREATE INDEX i_bmtest_ao_d ON bmscantest_ao(d);
 EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.00 rows=1 width=1)
-                     Recheck Cond: ((a = 1) AND (b = 1) AND (c = 1))
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.06 rows=2 width=1)
+         ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: ((a = 1) AND (b = 1) AND (c = 1))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (b = 1)
-                           ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (c = 1)
- Planning time: 44.164 ms
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(15 rows)
+                           ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (b = 1)
+                     ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: (c = 1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(13 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -141,27 +139,25 @@ SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
 (1 row)
 
 EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.00 rows=1 width=1)
-                     Recheck Cond: ((a = 1) AND ((b = 1) OR (c = 1)) AND (d = 1))
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.06 rows=3 width=1)
+         ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: ((a = 1) AND ((b = 1) OR (c = 1)) AND (d = 1))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
-                                 ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
-                                       ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
-                                             Index Cond: (b = 1)
-                                       ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
-                                             Index Cond: (c = 1)
-                           ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (d = 1)
- Planning time: 19.186 ms
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(18 rows)
+                           ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
+                           ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+                                 ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (b = 1)
+                                 ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (c = 1)
+                     ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: (d = 1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(16 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
  count 
@@ -236,24 +232,22 @@ CREATE INDEX i_bmtest_aocs_b ON bmscantest_aocs USING BITMAP(b);
 CREATE INDEX i_bmtest_aocs_c ON bmscantest_aocs(c);
 CREATE INDEX i_bmtest_aocs_d ON bmscantest_aocs(d);
 EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.00 rows=1 width=1)
-                     Recheck Cond: ((a = 1) AND (b = 1) AND (c = 1))
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.06 rows=2 width=1)
+         ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: ((a = 1) AND (b = 1) AND (c = 1))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (b = 1)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (c = 1)
- Planning time: 41.653 ms
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(15 rows)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (b = 1)
+                     ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: (c = 1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(13 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -262,27 +256,25 @@ SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
 (1 row)
 
 EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.00 rows=1 width=1)
-                     Recheck Cond: ((a = 1) AND ((b = 1) OR (c = 1)) AND (d = 1))
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.06 rows=3 width=1)
+         ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: ((a = 1) AND ((b = 1) OR (c = 1)) AND (d = 1))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
-                                 ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
-                                       ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
-                                             Index Cond: (b = 1)
-                                       ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
-                                             Index Cond: (c = 1)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (d = 1)
- Planning time: 22.854 ms
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(18 rows)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
+                           ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+                                 ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (b = 1)
+                                 ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (c = 1)
+                     ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: (d = 1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(16 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
  count 

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -529,7 +529,7 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
 ----------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <@ '(100,100),(0,0)'::box)
                      Filter: (f1 <@ '(100,100),(0,0)'::box)
@@ -548,7 +548,7 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
 ----------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <@ '(100,100),(0,0)'::box)
                      Filter: (f1 <@ '(100,100),(0,0)'::box)
@@ -567,7 +567,7 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
 ----------------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
                      Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
@@ -586,7 +586,7 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
 ----------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <@ '<(50,50),50>'::circle)
                      Filter: (f1 <@ '<(50,50),50>'::circle)
@@ -605,7 +605,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 << '(0,0)'::point)
                      Filter: (f1 << '(0,0)'::point)
@@ -624,7 +624,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 >> '(0,0)'::point)
                      Filter: (f1 >> '(0,0)'::point)
@@ -643,7 +643,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 <^ '(0,0)'::point)
                      Filter: (f1 <^ '(0,0)'::point)
@@ -662,7 +662,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 >^ '(0,0)'::point)
                      Filter: (f1 >^ '(0,0)'::point)
@@ -681,7 +681,7 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
 -----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using gpointind on point_tbl
                      Index Cond: (f1 ~= '(-5,-12)'::point)
                      Filter: (f1 ~= '(-5,-12)'::point)
@@ -3010,7 +3010,7 @@ SELECT count(*) FROM tenk1
 -------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
+         ->  Result
                ->  Index Scan using tenk1_hundred on tenk1
                      Index Cond: (hundred = 42)
                      Filter: ((thousand = 42) OR (thousand = 99))

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -1620,32 +1620,27 @@ select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) and fact1.code = 'OH
 --
 set gp_dynamic_partition_pruning=off;
 explain select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
-                                                                                                                QUERY PLAN                                                                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
    Merge Key: fact1.code
-   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-         Group Key: fact1.code
-         ->  Sort  (cost=0.00..862.00 rows=1 width=16)
-               Sort Key: fact1.code
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
-                     Hash Key: fact1.code
-                     ->  Result  (cost=0.00..862.00 rows=1 width=16)
-                           ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-                                 Group Key: fact1.code
-                                 ->  Sort  (cost=0.00..862.00 rows=1 width=8)
-                                       Sort Key: fact1.code
-                                       ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
-                                             Hash Cond: fact1.pid = dim1.pid
-                                             ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
-                                             ->  Hash  (cost=100.00..100.00 rows=34 width=4)
-                                                   ->  Partition Selector for fact1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                                         Filter: fact1.dist = dim1.pid
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                               ->  Seq Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=off; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
-(23 rows)
+   ->  Sort  (cost=0.00..862.00 rows=1 width=16)
+         Sort Key: fact1.code
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
+               Group Key: fact1.code
+               ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+                     Sort Key: fact1.code
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                           Hash Key: fact1.code
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                                 Hash Cond: (fact1.pid = dim1.pid)
+                                 ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                       ->  Partition Selector for fact1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                   ->  Seq Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(18 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
  code | count 
@@ -1656,32 +1651,27 @@ select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) g
 
 set gp_dynamic_partition_pruning=on;
 explain select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
-                                                                                                                QUERY PLAN                                                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
    Merge Key: fact1.code
-   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-         Group Key: fact1.code
-         ->  Sort  (cost=0.00..862.00 rows=1 width=16)
-               Sort Key: fact1.code
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
-                     Hash Key: fact1.code
-                     ->  Result  (cost=0.00..862.00 rows=1 width=16)
-                           ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-                                 Group Key: fact1.code
-                                 ->  Sort  (cost=0.00..862.00 rows=1 width=8)
-                                       Sort Key: fact1.code
-                                       ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
-                                             Hash Cond: fact1.pid = dim1.pid
-                                             ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
-                                             ->  Hash  (cost=100.00..100.00 rows=34 width=4)
-                                                   ->  Partition Selector for fact1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                                         Filter: fact1.dist = dim1.pid
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                               ->  Seq Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_bitmapscan=off; enable_hashjoin=on; enable_indexscan=off; enable_mergejoin=off; enable_nestloop=off; enable_seqscan=on; gp_dynamic_partition_pruning=on; gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
-(23 rows)
+   ->  Sort  (cost=0.00..862.00 rows=1 width=16)
+         Sort Key: fact1.code
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
+               Group Key: fact1.code
+               ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+                     Sort Key: fact1.code
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                           Hash Key: fact1.code
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                                 Hash Cond: (fact1.pid = dim1.pid)
+                                 ->  Dynamic Seq Scan on fact1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                       ->  Partition Selector for fact1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                   ->  Seq Scan on dim1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(18 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
  code | count 

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -41,28 +41,25 @@ select d, count(*) from smallt group by d;
 (20 rows)
 
 explain analyze select d, count(*) from smallt group by d;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=2.560..2.577 rows=20 loops=1)
-   ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=2.007..2.039 rows=11 loops=1)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=1.785..1.787 rows=20 loops=1)
+   ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.513..1.522 rows=7 loops=1)
          Group Key: d
-         (seg1)   Hash chain length 1.4 avg, 3 max, using 8 of 32 buckets; total 0 expansions.
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=1.963..1.976 rows=11 loops=1)
-               Hash Key: d
-               ->  Result  (cost=0.00..431.01 rows=7 width=12) (actual time=0.081..0.108 rows=8 loops=1)
-                     ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.080..0.105 rows=8 loops=1)
-                           Group Key: d
-                           ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.073..0.080 rows=40 loops=1)
-                                 Sort Key: d
-                                 Sort Method:  quicksort  Memory: 99kB
-                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.018..0.033 rows=40 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 110K bytes avg x 3 workers, 110K bytes max (seg0).  Work_mem: 33K bytes max.
-   (slice2)    Executor memory: 138K bytes avg x 3 workers, 138K bytes max (seg0).
+         ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.510..1.513 rows=35 loops=1)
+               Sort Key: d
+               Sort Method:  quicksort  Memory: 99kB
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.342..1.481 rows=35 loops=1)
+                     Hash Key: d
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.004 rows=50 loops=1)
+ Planning time: 17.216 ms
+   (slice0)    Executor memory: 63K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
- Total runtime: 3.718 ms
-(19 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 2.061 ms
+(16 rows)
 
 set statement_mem=2560;
 select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
@@ -101,30 +98,22 @@ select count(distinct d) from smallt;
 (1 row)
 
 explain analyze select count(distinct d) from smallt;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.01 rows=1 width=8) (actual time=2.016..2.016 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=4) (actual time=1.988..2.001 rows=20 loops=1)
-         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=1.551..1.561 rows=11 loops=1)
-               Group Key: d
-               ->  Sort  (cost=0.00..431.01 rows=7 width=4) (actual time=1.547..1.554 rows=11 loops=1)
-                     Sort Key: d
-                     Sort Method:  quicksort  Memory: 99kB
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=7 width=4) (actual time=0.543..1.519 rows=11 loops=1)
-                           Hash Key: d
-                           ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=0.076..0.092 rows=8 loops=1)
-                                 Group Key: d
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.072..0.079 rows=40 loops=1)
-                                       Sort Key: d
-                                       Sort Method:  quicksort  Memory: 99kB
-                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.021..0.032 rows=40 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 110K bytes avg x 3 workers, 110K bytes max (seg0).  Work_mem: 33K bytes max.
-   (slice2)    Executor memory: 82K bytes avg x 3 workers, 82K bytes max (seg0).  Work_mem: 33K bytes max.
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.637..1.637 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=1.631..1.633 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.408..1.408 rows=1 loops=1)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=1.396..1.402 rows=35 loops=1)
+                     Hash Key: d
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.006 rows=50 loops=1)
+ Planning time: 19.307 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
- Total runtime: 3.325 ms
-(21 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 1.904 ms
+(13 rows)
 
 set statement_mem=2560;
 select count(distinct d) from bigt;
@@ -136,24 +125,21 @@ select count(distinct d) from bigt;
 explain analyze select count(distinct d) from bigt;
                                                                          QUERY PLAN                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..485.83 rows=1 width=8) (actual time=396.987..396.987 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.81 rows=49168 width=4) (actual time=352.946..386.854 rows=50000 loops=1)
-         ->  HashAggregate  (cost=0.00..485.08 rows=16390 width=4) (actual time=354.021..357.076 rows=16675 loops=1)
-               Group Key: d
-               (seg1)   Hash chain length 4.1 avg, 13 max, using 4021 of 4096 buckets; total 7 expansions.
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..483.07 rows=16390 width=4) (actual time=283.881..341.500 rows=27950 loops=1)
+ Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=394.139..394.139 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..446.60 rows=1 width=8) (actual time=388.126..394.130 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=393.902..393.903 rows=1 loops=1)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..446.45 rows=333334 width=4) (actual time=0.670..118.334 rows=334920 loops=1)
                      Hash Key: d
-                     ->  HashAggregate  (cost=0.00..482.86 rows=16390 width=4) (actual time=280.096..286.016 rows=28117 loops=1)
-                           Group Key: d
-                           (seg2)   Hash chain length 3.5 avg, 14 max, using 7925 of 8192 buckets; total 8 expansions.
-                           ->  Seq Scan on bigt  (cost=0.00..439.81 rows=333580 width=4) (actual time=0.024..168.014 rows=333530 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 1171K bytes avg x 3 workers, 1171K bytes max (seg0).
-   (slice2)    Executor memory: 1006K bytes avg x 3 workers, 1006K bytes max (seg0).
+                     ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.013..46.779 rows=334620 loops=1)
+ Planning time: 27.350 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 68K bytes avg x 3 workers, 68K bytes max (seg0).
+ * (slice2)    Executor memory: 2768K bytes avg x 3 workers, 2768K bytes max (seg0).  Work_mem: 2617K bytes max, 7876K bytes wanted.
  Memory used:  2560kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
- Total runtime: 397.691 ms
-(17 rows)
+ Memory wanted:  8275kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 394.389 ms
+(14 rows)
 
 set statement_mem=128000;
 set gp_enable_agg_distinct=on;
@@ -194,47 +180,38 @@ where t1.d = t2.d;
 explain analyze select t1.*, t2.* from
 (select d, count(*) from smallt group by d) as t1, (select d, sum(i) from smallt group by d) as t2
 where t1.d = t2.d;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=1.980..2.521 rows=10 loops=2)
-   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=1.317..1.752 rows=6 loops=2)
-         Hash Cond: smallt.d = smallt_1.d
-         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 11 of 131072 buckets.
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=1.873..1.922 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=1.498..1.631 rows=7 loops=1)
+         Hash Cond: (smallt.d = smallt_1.d)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 7 of 131072 buckets.Hash chain length 1.2 avg, 2 max, using 6 of 32 buckets; total 0 expansions.
  
-         ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.028..0.035 rows=6 loops=2)
+         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.032..0.038 rows=7 loops=1)
                Group Key: smallt.d
-               Extra Text: (seg1)   Hash chain length 1.4 avg, 3 max, using 8 of 32 buckets; total 0 expansions.
- 
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=0.005..0.009 rows=6 loops=2)
-                     Hash Key: smallt.d
-                     ->  Result  (cost=0.00..431.01 rows=7 width=12) (actual time=0.086..0.106 rows=4 loops=2)
-                           ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.084..0.103 rows=4 loops=2)
-                                 Group Key: smallt.d
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.080..0.088 rows=20 loops=2)
-                                       Sort Key: smallt.d
-                                       Sort Method:  quicksort  Memory: 99kB
-                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.023..0.032 rows=20 loops=2)
-         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=1.099..1.099 rows=6 loops=2)
-               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.076..1.091 rows=6 loops=2)
+               ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.029..0.032 rows=35 loops=1)
+                     Sort Key: smallt.d
+                     Sort Method:  quicksort  Memory: 99kB
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.011 rows=35 loops=1)
+                           Hash Key: smallt.d
+                           ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.018 rows=50 loops=1)
+         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=1.402..1.402 rows=7 loops=1)
+               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.388..1.398 rows=7 loops=1)
                      Group Key: smallt_1.d
-                     Extra Text: (seg1)   Hash chain length 1.4 avg, 3 max, using 8 of 32 buckets; total 0 expansions.
+                     Extra Text: (seg1)   Hash chain length 1.2 avg, 2 max, using 6 of 32 buckets; total 0 expansions.
  
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=1.042..1.047 rows=6 loops=2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=8) (actual time=0.245..1.337 rows=35 loops=1)
                            Hash Key: smallt_1.d
-                           ->  Result  (cost=0.00..431.01 rows=7 width=12) (actual time=0.109..0.139 rows=4 loops=2)
-                                 ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.107..0.137 rows=4 loops=2)
-                                       Group Key: smallt_1.d
-                                       Extra Text: (seg0)   Hash chain length 1.3 avg, 3 max, using 6 of 32 buckets; total 0 expansions.
- 
-                                       ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=0.034..0.042 rows=20 loops=2)
-   (slice0)    Executor memory: 514K bytes.
-   (slice1)    Executor memory: 110K bytes avg x 3 workers, 110K bytes max (seg0).  Work_mem: 33K bytes max.
-   (slice2)    Executor memory: 166K bytes avg x 3 workers, 166K bytes max (seg0).
-   (slice3)    Executor memory: 1226K bytes avg x 3 workers, 1226K bytes max (seg0).  Work_mem: 1K bytes max.
+                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=0.003..0.018 rows=50 loops=1)
+ Planning time: 64.498 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 1192K bytes avg x 3 workers, 1192K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 7.014 ms
-(38 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 2.226 ms
+(29 rows)
 
 set enable_nestloop=off;
 set enable_hashjoin=on;
@@ -305,29 +282,27 @@ select d, count(*) from smallt group by d limit 5; --ignore
 (5 rows)
 
 explain analyze select d, count(*) from smallt group by d limit 5;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=2.452..2.455 rows=5 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=2.449..2.450 rows=5 loops=1)
-         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=2.021..2.025 rows=5 loops=1)
-               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=2.021..2.024 rows=5 loops=1)
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.700..1.702 rows=5 loops=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=1.698..1.700 rows=5 loops=1)
+         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.456..1.464 rows=5 loops=1)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.455..1.460 rows=5 loops=1)
                      Group Key: d
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=1.063..1.985 rows=11 loops=1)
-                           Hash Key: d
-                           ->  Result  (cost=0.00..431.01 rows=7 width=12) (actual time=0.422..0.448 rows=8 loops=1)
-                                 ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.421..0.445 rows=8 loops=1)
-                                       Group Key: d
-                                       ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.415..0.421 rows=40 loops=1)
-                                             Sort Key: d
-                                             Sort Method:  quicksort  Memory: 131kB
-                                             ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.015..0.028 rows=40 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).  Work_mem: 65K bytes max.
-   (slice2)    Executor memory: 170K bytes avg x 3 workers, 170K bytes max (seg0).
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.449..1.453 rows=26 loops=1)
+                           Sort Key: d
+                           Sort Method:  quicksort  Memory: 99kB
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.413..1.428 rows=35 loops=1)
+                                 Hash Key: d
+                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.006 rows=50 loops=1)
+ Planning time: 16.802 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
- Total runtime: 4.148 ms
-(20 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 2.024 ms
+(18 rows)
 
 -- HashJoin
 select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i order by 1,2,3;

--- a/src/test/regress/expected/gang_reuse.out
+++ b/src/test/regress/expected/gang_reuse.out
@@ -15,6 +15,7 @@ set gp_log_gang to 'debug';
 set gp_cached_segworkers_threshold to 10;
 set gp_vmem_idle_resource_timeout to '60s';
 set optimizer_enable_motion_broadcast to off;
+set optimizer_force_multistage_agg to on;
 create table test_gang_reuse_t1 (c1 int, c2 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -147,3 +148,4 @@ explain analyze select count(*) from test_gang_reuse_t1 a
  Execution time: 6.223 ms
 (20 rows)
 
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/gang_reuse_optimizer.out
+++ b/src/test/regress/expected/gang_reuse_optimizer.out
@@ -15,6 +15,7 @@ set gp_log_gang to 'debug';
 set gp_cached_segworkers_threshold to 10;
 set gp_vmem_idle_resource_timeout to '60s';
 set optimizer_enable_motion_broadcast to off;
+set optimizer_force_multistage_agg to on;
 create table test_gang_reuse_t1 (c1 int, c2 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -147,3 +148,4 @@ explain analyze select count(*) from test_gang_reuse_t1 a
  Execution time: 4.820 ms
 (20 rows)
 
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -302,6 +302,7 @@ create aggregate mysum_prefunc(int4) (
   stype=bigint,
   prefunc=int8pl_with_notice
 );
+set optimizer_force_multistage_agg = on;
 select mysum_prefunc(a::int4) from aggtest;
 NOTICE:  combinefunc called
 NOTICE:  combinefunc called
@@ -310,6 +311,7 @@ NOTICE:  combinefunc called
            198
 (1 row)
 
+reset optimizer_force_multistage_agg;
 -- Test an aggregate with 'internal' transition type, and a combine function,
 -- but no serial/deserial functions. This is valid, but we have no use for
 -- the combine function in GPDB in that case.

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -318,26 +318,23 @@ select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d gr
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d group by dqa_t2.dt;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Result
-         ->  HashAggregate
+         ->  GroupAggregate
                Group Key: dqa_t2.dt
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: dqa_t2.dt
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: dqa_t2.dt
-                                 ->  Sort
-                                       Sort Key: dqa_t2.dt
-                                       ->  Hash Join
-                                             Hash Cond: (dqa_t2.d = dqa_t1.d)
-                                             ->  Seq Scan on dqa_t2
-                                             ->  Hash
-                                                   ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
-(17 rows)
+               ->  Sort
+                     Sort Key: dqa_t2.dt
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: dqa_t2.dt
+                           ->  Hash Join
+                                 Hash Cond: (dqa_t2.d = dqa_t1.d)
+                                 ->  Seq Scan on dqa_t2
+                                 ->  Hash
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(14 rows)
 
 -- Distinct keys are not distribution keys
 select count(distinct c) from dqa_t1;
@@ -347,23 +344,16 @@ select count(distinct c) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct c) from dqa_t1;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice2; segments: 3)
-         ->  GroupAggregate
-               Group Key: c
-               ->  Sort
-                     Sort Key: c
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: c
-                           ->  GroupAggregate
-                                 Group Key: c
-                                 ->  Sort
-                                       Sort Key: c
-                                       ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
-(14 rows)
+         ->  Aggregate
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: c
+                     ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(7 rows)
 
 select count(distinct c) from dqa_t1 group by dt;
  count 
@@ -405,24 +395,19 @@ select count(distinct c) from dqa_t1 group by dt;
 (34 rows)
 
 explain (costs off) select count(distinct c) from dqa_t1 group by dt;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
    ->  Result
-         ->  HashAggregate
+         ->  GroupAggregate
                Group Key: dt
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: dt
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: dt
-                                 ->  Sort
-                                       Sort Key: dt, c
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                             Hash Key: dt, c
-                                             ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
-(15 rows)
+               ->  Sort
+                     Sort Key: dt
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: dt
+                           ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(10 rows)
 
 select count(distinct c) from dqa_t1 group by d;
  count 
@@ -606,29 +591,24 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
 (1 row)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice4; segments: 3)
-         ->  GroupAggregate
-               Group Key: dqa_t1.dt
-               ->  Sort
-                     Sort Key: dqa_t1.dt
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: dqa_t1.dt
-                           ->  HashAggregate
-                                 Group Key: dqa_t1.dt
-                                 ->  Hash Join
-                                       Hash Cond: (dqa_t1.c = dqa_t2.c)
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                             Hash Key: dqa_t1.c
-                                             ->  Seq Scan on dqa_t1
-                                       ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                                   Hash Key: dqa_t2.c
-                                                   ->  Seq Scan on dqa_t2
- Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
-(20 rows)
+         ->  Aggregate
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: dqa_t1.dt
+                     ->  Hash Join
+                           Hash Cond: (dqa_t1.c = dqa_t2.c)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: dqa_t1.c
+                                 ->  Seq Scan on dqa_t1
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: dqa_t2.c
+                                       ->  Seq Scan on dqa_t2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(15 rows)
 
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
  count 
@@ -692,32 +672,27 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c g
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
    ->  Result
-         ->  HashAggregate
+         ->  GroupAggregate
                Group Key: dqa_t2.dt
-               ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                     Hash Key: dqa_t2.dt
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: dqa_t2.dt
-                                 ->  Sort
-                                       Sort Key: dqa_t2.dt
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                             Hash Key: dqa_t2.dt, dqa_t1.dt
-                                             ->  Hash Join
-                                                   Hash Cond: (dqa_t1.c = dqa_t2.c)
-                                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                                         Hash Key: dqa_t1.c
-                                                         ->  Seq Scan on dqa_t1
-                                                   ->  Hash
-                                                         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                                               Hash Key: dqa_t2.c
-                                                               ->  Seq Scan on dqa_t2
- Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
-(23 rows)
+               ->  Sort
+                     Sort Key: dqa_t2.dt
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: dqa_t2.dt
+                           ->  Hash Join
+                                 Hash Cond: (dqa_t1.c = dqa_t2.c)
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                       Hash Key: dqa_t1.c
+                                       ->  Seq Scan on dqa_t1
+                                 ->  Hash
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                             Hash Key: dqa_t2.c
+                                             ->  Seq Scan on dqa_t2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(18 rows)
 
 -- MPP-19037
 drop table if exists fact_route_aggregation;

--- a/src/test/regress/expected/gpdiffcheck_optimizer.out
+++ b/src/test/regress/expected/gpdiffcheck_optimizer.out
@@ -140,37 +140,36 @@ set optimizer_nestloop_factor = 1.0;
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                                     QUERY PLAN                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=0.984..1.439 rows=8 loops=2)
-   Hash Cond: gpd1.c1 = (max((max(gpd1_2.c1))))
+ Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=1.743..2.097 rows=16 loops=1)
+   Hash Cond: (gpd1.c1 = (max(gpd1_2.c1)))
    Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
- 
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.011..0.029 rows=32 loops=2)
-         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.333..0.377 rows=16 loops=2)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.282..0.291 rows=64 loops=1)
+         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.949..1.287 rows=32 loops=1)
                Join Filter: true
-               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.015..0.015 rows=2 loops=2)
-               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.105..0.106 rows=6 loops=6)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=0.202..0.280 rows=4 loops=2)
-                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.015..0.017 rows=2 loops=2)
-   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=0.893..0.893 rows=0 loops=2)
+               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.005..0.006 rows=4 loops=1)
+               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.187..0.253 rows=7 loops=5)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=0.897..1.264 rows=8 loops=1)
+                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.012..0.134 rows=4 loops=1)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=0.137..0.137 rows=1 loops=1)
          Buckets: 262144  Batches: 1  Memory Usage: 1kB
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.891..0.891 rows=0 loops=2)
-               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.611..0.871 rows=2 loops=2)
-                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.021..0.021 rows=0 loops=2)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.007..0.009 rows=2 loops=2)
-   (slice0)    Executor memory: 2218K bytes.  Work_mem: 1K bytes max.
-   (slice1)    Executor memory: 62K bytes avg x 3 workers, 62K bytes max (seg0).
-   (slice2)    Executor memory: 126K bytes avg x 3 workers, 126K bytes max (seg0).
-   (slice3)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.133..0.133 rows=1 loops=1)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2) (actual time=0.004..0.097 rows=8 loops=1)
+                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.008..0.009 rows=4 loops=1)
+ Planning time: 109.024 ms
+   (slice0)    Executor memory: 2216K bytes.  Work_mem: 1K bytes max.
+   (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice2)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
+   (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 19.681 ms
-(24 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 17.954 ms
+(23 rows)
 
 explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
  Hash Join  (cost=0.00..1724.00 rows=1 width=12)
-   Hash Cond: gpd1.c1 = (max((max(gpd1_2.c1))))
+   Hash Cond: (gpd1.c1 = (max(gpd1_2.c1)))
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=14)
          ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14)
                Join Filter: true
@@ -180,11 +179,10 @@ explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from 
                            ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
    ->  Hash  (cost=431.00..431.00 rows=1 width=8)
          ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(15 rows)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2)
+                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(14 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
  c1 | c2 | c3 

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -668,17 +668,13 @@ explain (costs off) select even.i from even right outer join odd on (even.i = od
                Sort Key: even.i
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
                      Hash Key: even.i
-                     ->  GroupAggregate
-                           Group Key: even.i
-                           ->  Sort
-                                 Sort Key: even.i
-                                 ->  Hash Left Join
-                                       Hash Cond: (odd.i = even.i)
-                                       ->  Seq Scan on odd
-                                       ->  Hash
-                                             ->  Seq Scan on even
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(17 rows)
+                     ->  Hash Left Join
+                           Hash Cond: (odd.i = even.i)
+                           ->  Seq Scan on odd
+                           ->  Hash
+                                 ->  Seq Scan on even
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(13 rows)
 
 -- Check that we can track the distribution through multiple FULL OUTER JOINs.
 -- This query should not need Redistribute Motion.

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10276,44 +10276,42 @@ WHERE tq.sym = tt.symbol AND
       tt.event_ts <  tq.end_ts
 GROUP BY 1
 ORDER BY 1 asc ;
-                                                                                           QUERY PLAN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate  (cost=0.00..1305.01 rows=1 width=16)
-   Group Key: (share0_ref2.event_ts / 100000 / 5 * 5)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1305.01 rows=1 width=16)
-         Merge Key: (share0_ref2.event_ts / 100000 / 5 * 5)
-         ->  Result  (cost=0.00..1305.01 rows=1 width=16)
-               ->  GroupAggregate  (cost=0.00..1305.01 rows=1 width=16)
-                     Group Key: (share0_ref2.event_ts / 100000 / 5 * 5)
-                     ->  Sort  (cost=0.00..1305.01 rows=1 width=8)
-                           Sort Key: (share0_ref2.event_ts / 100000 / 5 * 5)
-                           ->  Result  (cost=0.00..1305.01 rows=1 width=8)
-                                 ->  Sequence  (cost=0.00..1305.01 rows=1 width=8)
-                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=1)
-                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-                                                   ->  Seq Scan on my_tt_agg_opt  (cost=0.00..431.00 rows=1 width=62)
-                                       ->  Sequence  (cost=0.00..874.01 rows=1 width=8)
-                                             ->  Partition Selector for my_tq_agg_opt_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                                   Partitions selected: 2 (out of 2)
-                                             ->  Append  (cost=0.00..874.00 rows=1 width=8)
-                                                   ->  Nested Loop  (cost=0.00..437.00 rows=1 width=8)
-                                                         Join Filter: true
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=24)
-                                                               ->  Result  (cost=0.00..431.00 rows=1 width=24)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=24)
-                                                         ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=1)
-                                                               Index Cond: ((ets <= share0_ref2.event_ts) AND (end_ts > share0_ref2.event_ts))
-                                                               Filter: (((sym)::bpchar = share0_ref2.symbol) AND (plusone(bid_price) < share0_ref2.trade_price))
-                                                   ->  Nested Loop  (cost=0.00..437.00 rows=1 width=8)
-                                                         Join Filter: true
-                                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=24)
-                                                               ->  Result  (cost=0.00..431.00 rows=1 width=24)
-                                                                     ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=24)
-                                                         ->  Dynamic Index Scan on my_tq_agg_opt_part my_tq_agg_opt_part_1 (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=1)
-                                                               Index Cond: (ets <= share0_ref3.event_ts)
-                                                               Filter: (((sym)::bpchar = share0_ref3.symbol) AND (plusone(bid_price) < share0_ref3.trade_price) AND (share0_ref3.event_ts < end_ts))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.35.0
-(35 rows)
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=0.00..1305.00 rows=1 width=16)
+   Sort Key: ((((share0_ref2.event_ts / 100000) / 5) * 5))
+   ->  GroupAggregate  (cost=0.00..1305.00 rows=1 width=16)
+         Group Key: ((((share0_ref2.event_ts / 100000) / 5) * 5))
+         ->  Sort  (cost=0.00..1305.00 rows=1 width=8)
+               Sort Key: ((((share0_ref2.event_ts / 100000) / 5) * 5))
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1305.00 rows=1 width=8)
+                     ->  Result  (cost=0.00..1305.00 rows=1 width=8)
+                           ->  Sequence  (cost=0.00..1305.00 rows=1 width=8)
+                                 ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=1)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Seq Scan on my_tt_agg_opt  (cost=0.00..431.00 rows=1 width=54)
+                                 ->  Sequence  (cost=0.00..874.00 rows=1 width=8)
+                                       ->  Partition Selector for my_tq_agg_opt_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                             Partitions selected: 2 (out of 2)
+                                       ->  Append  (cost=0.00..874.00 rows=1 width=8)
+                                             ->  Nested Loop  (cost=0.00..437.00 rows=1 width=8)
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=24)
+                                                         ->  Result  (cost=0.00..431.00 rows=1 width=24)
+                                                               ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=24)
+                                                   ->  Dynamic Index Scan on my_tq_agg_opt_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=1)
+                                                         Index Cond: ((ets <= share0_ref2.event_ts) AND (end_ts > share0_ref2.event_ts))
+                                                         Filter: (((sym)::bpchar = share0_ref2.symbol) AND (plusone(bid_price) < share0_ref2.trade_price))
+                                             ->  Nested Loop  (cost=0.00..437.00 rows=1 width=8)
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=24)
+                                                         ->  Result  (cost=0.00..431.00 rows=1 width=24)
+                                                               ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=24)
+                                                   ->  Dynamic Index Scan on my_tq_agg_opt_part my_tq_agg_opt_part_1 (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=1)
+                                                         Index Cond: (ets <= share0_ref3.event_ts)
+                                                         Filter: (((sym)::bpchar = share0_ref3.symbol) AND (plusone(bid_price) < share0_ref3.trade_price) AND (share0_ref3.event_ts < end_ts))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(33 rows)
 
 reset optimizer_segments;
 reset optimizer_enable_constant_expression_evaluation;
@@ -10927,23 +10925,22 @@ FROM   (SELECT *
         SELECT region,
                code
         FROM   tab_3)a;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-               ->  Append  (cost=0.00..1293.00 rows=2 width=1)
-                     ->  Result  (cost=0.00..862.00 rows=1 width=1)
-                           ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
-                                 Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
-                                 ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=7)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
-                                             ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
-                     ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                           ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.70.2
-(17 rows)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=4 width=1)
+         ->  Append  (cost=0.00..1293.00 rows=2 width=1)
+               ->  Result  (cost=0.00..862.00 rows=1 width=1)
+                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
+                           Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
+                           ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=7)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
+                                       ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
+               ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(13 rows)
 
 SELECT Count(*)
 FROM   (SELECT *

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1211,30 +1211,23 @@ create or replace function abseq (absint, absint) returns bool as $$ select isze
 create operator = (PROCEDURE = abseq, leftarg=absint, rightarg=absint);
 explain select c1 from t1 where c1::absint not in
 	(select c1n::absint from t1n);
-                                                                                                                                              QUERY PLAN                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324035.89 rows=10 width=4)
+                                                                                                                            QUERY PLAN                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324035.89 rows=10 width=4)
    ->  Result  (cost=0.00..1324035.89 rows=4 width=4)
-         Filter: (NOT CASE WHEN ((count((count("inner".ColRef_0017)))) > 0::bigint) THEN CASE WHEN ((pg_catalog.sum((sum((CASE WHEN (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NULL) THEN 1 ELSE 0 END))))) = (count((count("inner".ColRef_0017))))) THEN NULL::boolean ELSE true END ELSE false END)
-         ->  GroupAggregate  (cost=0.00..1324035.89 rows=4 width=20)
+         Filter: (NOT CASE WHEN ((count("inner".ColRef_0017)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0017))) THEN NULL::boolean ELSE true END ELSE false END)
+         ->  HashAggregate  (cost=0.00..1324035.89 rows=4 width=20)
                Group Key: t1.c1, t1.ctid, t1.gp_segment_id
-               ->  Sort  (cost=0.00..1324035.89 rows=4 width=30)
-                     Sort Key: t1.ctid, t1.gp_segment_id
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324035.89 rows=4 width=30)
-                           Hash Key: t1.ctid, t1.gp_segment_id
-                           ->  Result  (cost=0.00..1324035.89 rows=4 width=30)
-                                 ->  HashAggregate  (cost=0.00..1324035.89 rows=4 width=30)
-                                       Group Key: t1.c1, t1.ctid, t1.gp_segment_id
-                                       ->  Result  (cost=0.00..1324035.88 rows=11 width=19)
-                                             ->  Nested Loop Left Join  (cost=0.00..1324035.88 rows=11 width=19)
-                                                   Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
-                                                   ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
-                                                   ->  Result  (cost=0.00..431.00 rows=7 width=5)
-                                                         ->  Materialize  (cost=0.00..431.00 rows=7 width=4)
-                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                                                     ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
-(21 rows)
+               ->  Result  (cost=0.00..1324035.88 rows=11 width=19)
+                     ->  Nested Loop Left Join  (cost=0.00..1324035.88 rows=11 width=19)
+                           Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
+                           ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
+                           ->  Result  (cost=0.00..431.00 rows=7 width=5)
+                                 ->  Materialize  (cost=0.00..431.00 rows=7 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                             ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(14 rows)
 
 select c1 from t1 where c1::absint not in
 	(select c1n::absint from t1n);

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7681,18 +7681,16 @@ order by 1,2,3;
 -- Once upon a time, there was a bug in deparsing a WindowAgg node with EXPLAIN
 -- that this query triggered (MPP-4840)
 explain select n from ( select row_number() over () from (values (0)) as t(x) ) as r(n) group by n;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
-   Group By: row_number
-   ->  GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
-         Group By: row_number
-         ->  Sort  (cost=0.00..0.00 rows=1 width=8)
-               Sort Key: row_number
-               ->  WindowAgg  (cost=0.00..0.00 rows=1 width=8)
-                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on; optimizer_segments=3
-(9 rows)
+   Group Key: (row_number() OVER (?))
+   ->  Sort  (cost=0.00..0.00 rows=1 width=8)
+         Sort Key: (row_number() OVER (?))
+         ->  WindowAgg  (cost=0.00..0.00 rows=1 width=8)
+               ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(7 rows)
 
 -- Test for MPP-11645
 create table olap_window_r (a int, b int, x int,  y int,  z int ) distributed by (b);

--- a/src/test/regress/expected/pg_lsn_optimizer.out
+++ b/src/test/regress/expected/pg_lsn_optimizer.out
@@ -72,28 +72,26 @@ SELECT DISTINCT (i || '/' || j)::pg_lsn f
        generate_series(1, 5) k
   WHERE i <= 10 AND j > 0 AND j <= 10
   ORDER BY f;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Group Key: (((((generate_series_1.generate_series)::text || '/'::text) || (generate_series_2.generate_series)::text))::pg_lsn)
-   ->  Sort
-         Sort Key: (((((generate_series_1.generate_series)::text || '/'::text) || (generate_series_2.generate_series)::text))::pg_lsn)
-         ->  HashAggregate
-               Group Key: ((((generate_series_1.generate_series)::text || '/'::text) || (generate_series_2.generate_series)::text))::pg_lsn
-               ->  Result
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (((((generate_series_1.generate_series)::text || '/'::text) || (generate_series_2.generate_series)::text))::pg_lsn)
+   ->  HashAggregate
+         Group Key: ((((generate_series_1.generate_series)::text || '/'::text) || (generate_series_2.generate_series)::text))::pg_lsn
+         ->  Result
+               ->  Nested Loop
+                     Join Filter: true
                      ->  Nested Loop
                            Join Filter: true
-                           ->  Nested Loop
-                                 Join Filter: true
-                                 ->  Result
-                                       Filter: ((generate_series_2.generate_series > 0) AND (generate_series_2.generate_series <= 10))
-                                       ->  Function Scan on generate_series generate_series_2
-                                 ->  Result
-                                       Filter: (generate_series_1.generate_series <= 10)
-                                       ->  Function Scan on generate_series generate_series_1
-                           ->  Function Scan on generate_series
- Optimizer: Pivotal Optimizer (GPORCA) version 3.8.0
-(21 rows)
+                           ->  Result
+                                 Filter: ((generate_series_2.generate_series > 0) AND (generate_series_2.generate_series <= 10))
+                                 ->  Function Scan on generate_series generate_series_2
+                           ->  Result
+                                 Filter: (generate_series_1.generate_series <= 10)
+                                 ->  Function Scan on generate_series generate_series_1
+                     ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(17 rows)
 
 SELECT DISTINCT (i || '/' || j)::pg_lsn f
   FROM generate_series(1, 10) i,

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -824,47 +824,43 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
 (4 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..1389709666335.39 rows=4 width=12)
-   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1389709666335.39 rows=10 width=12)
+                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1389709665858.46 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1389709665858.46 rows=10 width=12)
          Merge Key: a.i, b.i, c.j
-         ->  Limit  (cost=0.00..1389709666335.39 rows=4 width=12)
-               ->  Sort  (cost=0.00..1389709666335.39 rows=90 width=12)
+         ->  Limit  (cost=0.00..1389709665858.46 rows=4 width=12)
+               ->  Sort  (cost=0.00..1389709665858.46 rows=90 width=12)
                      Sort Key: a.i, b.i, c.j
-                     ->  Nested Loop  (cost=0.00..1389709666335.35 rows=90 width=12)
+                     ->  Nested Loop  (cost=0.00..1389709665858.42 rows=90 width=12)
                            Join Filter: true
-                           ->  Nested Loop  (cost=0.00..1357137484.03 rows=10 width=8)
+                           ->  Nested Loop  (cost=0.00..1357137483.56 rows=10 width=8)
                                  Join Filter: true
                                  ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324467.57 rows=5 width=4)
                                        ->  Hash Join  (cost=0.00..1324467.57 rows=2 width=4)
-                                             Hash Cond: (pg_catalog.sum((sum(c_1.j)))) = a.j::bigint AND c_1.j = a.j
+                                             Hash Cond: (((sum(c_1.j)) = (a.j)::bigint) AND (c_1.j = a.j))
                                              ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
                                                    Group Key: c_1.j
-                                                   ->  Sort  (cost=0.00..1324036.57 rows=3 width=12)
+                                                   ->  Sort  (cost=0.00..1324036.57 rows=3 width=4)
                                                          Sort Key: c_1.j
-                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.57 rows=3 width=12)
+                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.57 rows=3 width=4)
                                                                Hash Key: c_1.j
-                                                               ->  Result  (cost=0.00..1324036.57 rows=3 width=12)
-                                                                     ->  GroupAggregate  (cost=0.00..1324036.57 rows=3 width=12)
-                                                                           Group Key: c_1.j
-                                                                           ->  Sort  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                                 Sort Key: c_1.j
-                                                                                 ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                                       Filter: (SubPlan 1)
-                                                                                       SubPlan 1  (slice3; segments: 3)
+                                                               ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                     ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                           Filter: (SubPlan 1)
+                                                                           SubPlan 1  (slice3; segments: 3)
+                                                                             ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                         Filter: ((CASE WHEN ((sum((CASE WHEN (c_1.i <> b_1.i) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (b_1.i IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (c_1.i IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (c_1.i <> b_1.i) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
                                                                                          ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                                     Filter: (CASE WHEN (sum((CASE WHEN c_1.i <> b_1.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN b_1.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN c_1.i IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN c_1.i <> b_1.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
-                                                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                                                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                                                                                             Filter: c_1.i = b_1.i
-                                                                                                                             ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                                         ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
-                                                                                                                                               Filter: i <> 10
+                                                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                                                 Filter: (c_1.i = b_1.i)
+                                                                                                                 ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                             ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                                                   Filter: (i <> 10)
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=8)
                                                    ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
                                                          Hash Key: a.j
@@ -873,8 +869,8 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(48 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(44 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -2355,8 +2355,8 @@ select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a
 (2 rows)
 
 explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
-                                                                                            QUERY PLAN                                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=4)
    ->  Sequence  (cost=0.00..1293.00 rows=1 width=4)
          ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=1)
@@ -2364,30 +2364,21 @@ explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping 
                      ->  Seq Scan on tbl7553_test  (cost=0.00..431.00 rows=1 width=4)
          ->  Append  (cost=0.00..862.00 rows=1 width=4)
                ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                     Group By: share0_ref2.j
+                     Group Key: share0_ref2.j
                      ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                            Sort Key: share0_ref2.j
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                  Hash Key: share0_ref2.j
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                       Group By: share0_ref2.j
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                             Sort Key: share0_ref2.j
-                                             ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
                ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                     Group By: share0_ref3.j, share0_ref3.j
+                     Group Key: share0_ref3.j, share0_ref3.j
                      ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                            Sort Key: share0_ref3.j, share0_ref3.j
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                  Hash Key: share0_ref3.j, share0_ref3.j
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                       Group By: share0_ref3.j, share0_ref3.j
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                             Sort Key: share0_ref3.j, share0_ref3.j
-                                             ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=4)
- Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; gp_enable_agg_distinct=off; gp_enable_agg_distinct_pruning=off; optimizer=on; optimizer_force_three_stage_scalar_dqa=off
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.51.0
-(30 rows)
+                                 ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(21 rows)
 
 select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
  a | b 
@@ -2983,108 +2974,84 @@ reset gp_enable_agg_distinct_pruning;
 set enable_groupagg=off;
 -- both queries should use hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..862.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
                Group Key: tbl5994_test.j
-               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                     Group Key: tbl5994_test.j
-                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                           Sort Key: tbl5994_test.j
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Key: tbl5994_test.j
-                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                       Group Key: tbl5994_test.j
-                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                                             Sort Key: tbl5994_test.j
-                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: tbl5994_test.j = tbl5994_test_1.j
-                                                   ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                               ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(21 rows)
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(15 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..862.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
                Group Key: tbl5994_test.j
-               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                     Group Key: tbl5994_test.j
-                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                           Sort Key: tbl5994_test.j
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Key: tbl5994_test.j
-                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                       Group Key: tbl5994_test.j
-                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                                             Sort Key: tbl5994_test.j
-                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: tbl5994_test.i = tbl5994_test_1.i
-                                                   ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                                         ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(20 rows)
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(14 rows)
 
 set enable_groupagg=on;
 -- first query should use groupagg, and second one - hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..862.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
                Group Key: tbl5994_test.j
-               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                     Group Key: tbl5994_test.j
-                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                           Sort Key: tbl5994_test.j
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Key: tbl5994_test.j
-                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                       Group Key: tbl5994_test.j
-                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                                             Sort Key: tbl5994_test.j
-                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: tbl5994_test.j = tbl5994_test_1.j
-                                                   ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                               ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(21 rows)
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(15 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..862.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
                Group Key: tbl5994_test.j
-               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                     Group Key: tbl5994_test.j
-                     ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                           Sort Key: tbl5994_test.j
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Key: tbl5994_test.j
-                                 ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                       Group Key: tbl5994_test.j
-                                       ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                                             Sort Key: tbl5994_test.j
-                                             ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: tbl5994_test.i = tbl5994_test_1.i
-                                                   ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                                   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                                         ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(20 rows)
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(14 rows)
 
 drop table qp_misc_jiras.tbl5994_test;
 CREATE TABLE qp_misc_jiras.tbl_8205 (
@@ -3531,25 +3498,20 @@ then 'MO' else 'foo' end
 case when ir_call_type_group_code in ('H', 'VH', 'PCB') then 'Thailland'
 else 'Unidentify' end
 ;
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                     QUERY PLAN                                                                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
    ->  Result  (cost=0.00..431.00 rows=1 width=8)
          ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
-               Group By: "?column?", "?column?"
+               Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
                ->  Sort  (cost=0.00..431.00 rows=1 width=16)
-                     Sort Key: "?column?", "?column?"
+                     Sort Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-                           Hash Key: "?column?", "?column?"
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                                 Group By: "?column?", "?column?"
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=16)
-                                       Sort Key: "?column?", "?column?"
-                                       ->  Result  (cost=0.00..431.00 rows=1 width=16)
-                                             ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
- Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
-(16 rows)
+                           Hash Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=16)
+                                 ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(11 rows)
 
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
 create table qp_misc_jiras.r
@@ -3799,23 +3761,19 @@ select  * from qp_misc_jiras.test_co where ctid='(33554432,1)' and gp_segment_id
 set gp_enable_explain_allstat=on;
 insert into qp_misc_jiras.test_heap select i, i from generate_series(0, 99999) i;
 explain analyze select count(*) from qp_misc_jiras.test_heap;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               allstat: seg_firststart_total_ntuples/seg0_0.638 ms_10 ms_1/seg1_0.636 ms_10 ms_1/seg2_0.637 ms_10 ms_1//end
-               ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=1)
-                     allstat: seg_firststart_total_ntuples/seg0_0.638 ms_5.346 ms_33350/seg1_0.636 ms_5.368 ms_33336/seg2_0.637 ms_5.264 ms_33315//end
- Slice statistics:
-   (slice0)    Executor memory: 382K bytes.
-   (slice1)    Executor memory: 163K bytes avg x 3 workers, 163K bytes max (seg0).
- Statement statistics:
-   Memory used: 128000K bytes
- Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.684
- Total runtime: 10.892 ms
-(18 rows)
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=16.682..16.682 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1) (actual time=0.666..11.222 rows=100001 loops=1)
+         ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=1) (actual time=0.022..2.438 rows=33462 loops=1)
+               allstat: seg_firststart_total_ntuples/seg0_0.235 ms_2.438 ms_33462/seg1_0.235 ms_2.363 ms_33329/seg2_0.225 ms_2.381 ms_33210//end
+ Planning time: 2.804 ms
+   (slice0)    Executor memory: 567K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 16.835 ms
+(10 rows)
 
 -- start_ignore
 -- This is to verify MPP-8946

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -521,16 +521,15 @@ explain select count(*) from mpp7638 where a =1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Result  (cost=0.00..431.00 rows=1 width=1)
                ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
                      ->  Partition Selector for mpp7638 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                            Partitions selected: 9 (out of 9)
                      ->  Dynamic Seq Scan on mpp7638 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
                            Filter: (a = 1)
- Planning time: 101.741 ms
- Optimizer: Pivotal Optimizer (GPORCA) version 3.6.0
-(10 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(9 rows)
 
 alter table mpp7638 set distributed by (a, b, c);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -771,18 +770,16 @@ explain select a0 from table_a where a0 in (select max(a1) from table_a);
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: "outer".max = public.table_a.a0
+         Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
-               Hash Key: max
+               Hash Key: (max(table_a.a1))
                ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
-(13 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(11 rows)
 
 select a0 from table_a where a0 in (select max(a1) from table_a);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -811,19 +808,17 @@ explain select a0 from table_a where a0 in (select max(a1) from table_a where a0
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: "outer".max = public.table_a.a0
+         Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
-               Hash Key: max
+               Hash Key: (max(table_a.a1))
                ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
-                                       Filter: a0 = 1
+                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: (a0 = 1)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
-(14 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(12 rows)
 
 reset test_print_direct_dispatch_info;
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -195,30 +195,25 @@ select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
 (20 rows)
 
 explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
-                                                                                                                                                   QUERY PLAN                                                                                                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.02 rows=20 width=4)
+                                                                                                                                 QUERY PLAN                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.02 rows=20 width=4)
    ->  Result  (cost=0.00..1293.02 rows=7 width=4)
-         Filter: (CASE WHEN ((count((count("inner".ColRef_0017)))) > 0::bigint) THEN CASE WHEN ((pg_catalog.sum((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))))) = (count((count("inner".ColRef_0017))))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
-         ->  HashAggregate  (cost=0.00..1293.02 rows=7 width=20)
+         Filter: (CASE WHEN ((count("inner".ColRef_0017)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0017))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
+         ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=20)
                Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.02 rows=7 width=30)
-                     Hash Key: mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                     ->  Result  (cost=0.00..1293.02 rows=7 width=30)
-                           ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=30)
-                                 Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                                 ->  Result  (cost=0.00..1293.02 rows=56 width=19)
-                                       ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
-                                             Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
-                                             ->  Sort  (cost=0.00..431.00 rows=7 width=14)
-                                                   Sort Key: mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                                                   ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
-                                             ->  Result  (cost=0.00..431.00 rows=20 width=5)
-                                                   ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
-                                                               ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
-(21 rows)
+               ->  Result  (cost=0.00..1293.02 rows=56 width=19)
+                     ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
+                           Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
+                           ->  Sort  (cost=0.00..431.00 rows=7 width=14)
+                                 Sort Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
+                                 ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
+                           ->  Result  (cost=0.00..431.00 rows=20 width=5)
+                                 ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
+                                             ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(16 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
  x 
@@ -410,32 +405,25 @@ select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
 -- outer plan node is master-only and CSQ has distributed relation
 --
 explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- broadcast motion
-                                                                                                                                               QUERY PLAN                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+                                                                                                                             QUERY PLAN                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
-         Filter: (CASE WHEN ((count((count("inner".ColRef_0016)))) > 0::bigint) THEN CASE WHEN ((pg_catalog.sum((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))))) = (count((count("inner".ColRef_0016))))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < (-100)))
+         Filter: (CASE WHEN ((count("inner".ColRef_0016)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0016))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < (-100)))
          ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-               ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
-                     Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
-                           Hash Key: csq_d1.ctid, csq_d1.gp_segment_id
-                           ->  Result  (cost=0.00..1293.00 rows=1 width=30)
-                                 ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
-                                       Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-                                       ->  Result  (cost=0.00..1293.00 rows=2 width=19)
-                                             ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
-                                                   Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
-                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=14)
-                                                         Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                                                         ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                                                   ->  Result  (cost=0.00..431.00 rows=3 width=5)
-                                                         ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
-                                                               ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=9 width=4)
-                                                                     ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
-(23 rows)
+               ->  Result  (cost=0.00..1293.00 rows=2 width=19)
+                     ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
+                           Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+                                 Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
+                                 ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
+                           ->  Result  (cost=0.00..431.00 rows=3 width=5)
+                                 ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                                       ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=9 width=4)
+                                             ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(16 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
  x 
@@ -681,30 +669,25 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 -- text, varchar
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: 1 = COALESCE((count((count()))), 0::bigint)
+         Filter: (1 = COALESCE((count()), 0::bigint))
          ->  Result  (cost=0.00..862.00 rows=1 width=36)
                ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: csq_pullup.t = csq_pullup_1.v::text
+                     Hash Cond: (csq_pullup.t = (csq_pullup_1.v)::text)
                      ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                            ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                                  Group Key: csq_pullup_1.v
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                                        Sort Key: csq_pullup_1.v
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                              Hash Key: csq_pullup_1.v
-                                             ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                                                   ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                                         Group Key: csq_pullup_1.v
-                                                         ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                                               Sort Key: csq_pullup_1.v
-                                                               ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(21 rows)
+                                             ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(16 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
   t  | n | i |  v  
@@ -718,10 +701,10 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 -- numeric, numeric
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=1 width=17)
-   Filter: (1 = COALESCE((count((count()))), 0::bigint))
+   Filter: (1 = COALESCE((count()), 0::bigint))
    ->  Result  (cost=0.00..862.00 rows=1 width=36)
          ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
                Hash Cond: (csq_pullup.n = csq_pullup_1.n)
@@ -732,18 +715,13 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                            ->  Result  (cost=0.00..431.00 rows=1 width=13)
                                  ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
                                        Group Key: csq_pullup_1.n
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=13)
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=5)
                                              Sort Key: csq_pullup_1.n
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
                                                    Hash Key: csq_pullup_1.n
-                                                   ->  Result  (cost=0.00..431.00 rows=1 width=13)
-                                                         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
-                                                               Group Key: csq_pullup_1.n
-                                                               ->  Sort  (cost=0.00..431.00 rows=1 width=5)
-                                                                     Sort Key: csq_pullup_1.n
-                                                                     ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
+                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(23 rows)
+(18 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
   t  | n | i |  v  
@@ -921,18 +899,17 @@ select * from subselect_t1 where x in (select y from subselect_t2 union all sele
 (2 rows)
 
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..862.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8)
-               ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
-                     Hash Cond: subselect_t1.x = subselect_t2.y
-                     ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
-(9 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
+               Hash Cond: (subselect_t1.x = subselect_t2.y)
+               ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(8 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2);
  count 
@@ -944,24 +921,23 @@ select count(*) from subselect_t1 where x in (select y from subselect_t2);
 -- Known_opt_diff: MPP-21351
 -- end_ignore
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
-                     Hash Cond: subselect_t2.y = subselect_t1.x
-                     ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
-                           Group Key: subselect_t2.y
-                           ->  Sort  (cost=0.00..862.00 rows=2 width=4)
-                                 Sort Key: subselect_t2.y
-                                 ->  Append  (cost=0.00..862.00 rows=2 width=4)
-                                       ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(15 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=1)
+         ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
+               Hash Cond: (subselect_t2.y = subselect_t1.x)
+               ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
+                     Group Key: subselect_t2.y
+                     ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+                           Sort Key: subselect_t2.y
+                           ->  Append  (cost=0.00..862.00 rows=2 width=4)
+                                 ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(14 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
  count 
@@ -1245,14 +1221,14 @@ CASE
 	ELSE 'Q2'::text END  AS  cc,  1 AS nn
 FROM t_mpp_20470 b;
 explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  WindowAgg  (cost=0.00..862.00 rows=1 width=16)
    ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=12)
          ->  Result  (cost=0.00..862.00 rows=1 width=12)
                ->  Result  (cost=0.00..862.00 rows=1 width=16)
                      ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
-                           Hash Cond: t_mpp_20470.col_name::text = t_mpp_20470_1.col_name::text
+                           Hash Cond: ((t_mpp_20470.col_name)::text = (t_mpp_20470_1.col_name)::text)
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                  Hash Key: t_mpp_20470.col_name
                                  ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
@@ -1262,21 +1238,16 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                            ->  Hash  (cost=431.00..431.00 rows=1 width=16)
                                  ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
                                        Group Key: t_mpp_20470_1.col_name
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                                              Sort Key: t_mpp_20470_1.col_name
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                                                    Hash Key: t_mpp_20470_1.col_name
-                                                   ->  Result  (cost=0.00..431.00 rows=1 width=16)
-                                                         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                               Group Key: t_mpp_20470_1.col_name
-                                                               ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                                                                     Sort Key: t_mpp_20470_1.col_name
-                                                                     ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
-                                                                           ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                                                                 Partitions selected: 2 (out of 2)
-                                                                           ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(29 rows)
+                                                   ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                                                         ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                                               Partitions selected: 2 (out of 2)
+                                                         ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(24 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;
@@ -1631,35 +1602,28 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..864.11 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.11 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.11 rows=4 width=4)
-               Group Key: tenk1.ten
-               ->  Sort  (cost=0.00..864.11 rows=4 width=4)
-                     Sort Key: tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=4 width=4)
-                           Hash Key: tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.11 rows=4 width=4)
-                                 Group Key: tenk1.ten
-                                 ->  Sort  (cost=0.00..864.11 rows=34 width=4)
-                                       Sort Key: tenk1.ten
-                                       ->  Hash Join  (cost=0.00..864.11 rows=34 width=4)
-                                             Hash Cond: tenk1.unique1 = tenk1_1.hundred
-                                             ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.11 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
+                     Hash Key: tenk1.ten
+                     ->  Hash Join  (cost=0.00..864.11 rows=34 width=4)
+                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
+                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                       Group Key: tenk1_1.hundred
+                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                             Sort Key: tenk1_1.hundred
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                   Hash Key: tenk1_1.hundred
+                                                   ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: tenk1_1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                                     Hash Key: tenk1_1.hundred
-                                                                     ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                                           Group Key: tenk1_1.hundred
-                                                                           ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
-(26 rows)
+                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(19 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
@@ -1688,35 +1652,28 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..864.11 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.11 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.11 rows=4 width=4)
-               Group Key: tenk1.ten
-               ->  Sort  (cost=0.00..864.11 rows=4 width=4)
-                     Sort Key: tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=4 width=4)
-                           Hash Key: tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.11 rows=4 width=4)
-                                 Group Key: tenk1.ten
-                                 ->  Sort  (cost=0.00..864.11 rows=34 width=4)
-                                       Sort Key: tenk1.ten
-                                       ->  Hash Semi Join  (cost=0.00..864.11 rows=34 width=4)
-                                             Hash Cond: tenk1.unique1 = tenk1_1.hundred
-                                             ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.11 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
+                     Hash Key: tenk1.ten
+                     ->  Hash Semi Join  (cost=0.00..864.11 rows=34 width=4)
+                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
+                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                       Group Key: tenk1_1.hundred
+                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                             Sort Key: tenk1_1.hundred
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                   Hash Key: tenk1_1.hundred
+                                                   ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: tenk1_1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                                     Hash Key: tenk1_1.hundred
-                                                                     ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                                           Group Key: tenk1_1.hundred
-                                                                           ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
-(26 rows)
+                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(19 rows)
 
 --
 -- In case of simple exists query, planner can generate alternative
@@ -1725,23 +1682,22 @@ EXPLAIN select count(distinct ss.ten) from
 -- we should see 2 subplans in the explain
 --
 EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
-                                               QUERY PLAN                                                
+                                                QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..865.44 rows=1 width=1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..865.44 rows=1 width=1)
          ->  Limit  (cost=0.00..865.44 rows=1 width=1)
-               ->  Result  (cost=0.00..865.44 rows=3361 width=1)
-                     ->  Result  (cost=0.00..865.44 rows=3361 width=8)
-                           ->  Hash Left Join  (cost=0.00..865.41 rows=3361 width=8)
-                                 Hash Cond: tenk2.unique1 = tenk1.unique1
-                                 ->  Seq Scan on tenk2  (cost=0.00..431.51 rows=3361 width=4)
-                                 ->  Hash  (cost=431.96..431.96 rows=3319 width=12)
-                                       ->  HashAggregate  (cost=0.00..431.96 rows=3319 width=12)
+               ->  Result  (cost=0.00..865.44 rows=3334 width=1)
+                     ->  Result  (cost=0.00..865.44 rows=3334 width=8)
+                           ->  Hash Left Join  (cost=0.00..865.41 rows=3334 width=8)
+                                 Hash Cond: (tenk2.unique1 = tenk1.unique1)
+                                 ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=4)
+                                 ->  Hash  (cost=431.96..431.96 rows=3334 width=12)
+                                       ->  HashAggregate  (cost=0.00..431.96 rows=3334 width=12)
                                              Group Key: tenk1.unique1
-                                             ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3319 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.36.0
-(14 rows)
+                                             ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(13 rows)
 
 SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
  exists 
@@ -1882,11 +1838,7 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b 
                                        Sort Key: dedup_test1_2.b
                                        ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                              Hash Key: dedup_test1_2.b
-                                             ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
-                                                   Group Key: dedup_test1_2.b
-                                                   ->  Sort  (cost=0.00..431.00 rows=2 width=4)
-                                                         Sort Key: dedup_test1_2.b
-                                                         ->  Seq Scan on dedup_test1 dedup_test1_2  (cost=0.00..431.00 rows=2 width=4)
+                                             ->  Seq Scan on dedup_test1 dedup_test1_2  (cost=0.00..431.00 rows=2 width=4)
                            ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
                                  ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=1)
                                        ->  Limit  (cost=0.00..431.00 rows=1 width=1)
@@ -1894,7 +1846,7 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b 
                                                    ->  Limit  (cost=0.00..431.00 rows=1 width=1)
                                                          ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=1)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(34 rows)
+(30 rows)
 
 -- start_ignore
 DROP TABLE IF EXISTS dedup_test1;

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -504,21 +504,17 @@ explain (costs off)
          Group Key: ((t1.a || t1.b))
          ->  Sort
                Sort Key: ((t1.a || t1.b))
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: ((t1.a || t1.b))
-                     ->  GroupAggregate
-                           Group Key: ((t1.a || t1.b))
-                           ->  Sort
-                                 Sort Key: ((t1.a || t1.b))
-                                 ->  Append
-                                       ->  Result
-                                             Filter: (((t1.a || t1.b)) = 'ab'::text)
-                                             ->  Result
-                                                   ->  Seq Scan on t1
-                                       ->  Index Scan using t2_pkey on t2
-                                             Index Cond: (ab = 'ab'::text)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(19 rows)
+               ->  Append
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: ((t1.a || t1.b))
+                           ->  Result
+                                 Filter: (((t1.a || t1.b)) = 'ab'::text)
+                                 ->  Result
+                                       ->  Seq Scan on t1
+                     ->  Index Scan using t2_pkey on t2
+                           Index Cond: (ab = 'ab'::text)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(15 rows)
 
 --
 -- Test that ORDER BY for UNION ALL can be pushed down to inheritance
@@ -662,12 +658,12 @@ WHERE x < 4
 ORDER BY x;
                             QUERY PLAN                            
 ------------------------------------------------------------------
- GroupAggregate
-   Group Key: t, (generate_series(1, 10))
+ Sort
+   Sort Key: (generate_series(1, 10))
    ->  GroupAggregate
          Group Key: t, (generate_series(1, 10))
          ->  Sort
-               Sort Key: (generate_series(1, 10)), t
+               Sort Key: t, (generate_series(1, 10))
                ->  Append
                      ->  Result
                            Filter: ((generate_series(1, 10)) < 4)

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -152,14 +152,13 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                                                                        Assert Cond: ((row_number() OVER (?)) = 1)
                                                                                        ->  WindowAgg
                                                                                              ->  Hash Join
-                                                                                                   Hash Cond: ((keo4.keo_para_budget_date)::text = (min((min((keo4_1.keo_para_budget_date)::text)))))
+                                                                                                   Hash Cond: ((keo4.keo_para_budget_date)::text = (min((keo4_1.keo_para_budget_date)::text)))
                                                                                                    ->  Gather Motion 3:1  (slice3; segments: 3)
                                                                                                          ->  Seq Scan on keo4
                                                                                                    ->  Hash
                                                                                                          ->  Aggregate
                                                                                                                ->  Gather Motion 3:1  (slice4; segments: 3)
-                                                                                                                     ->  Aggregate
-                                                                                                                           ->  Seq Scan on keo4 keo4_1
+                                                                                                                     ->  Seq Scan on keo4 keo4_1
                                  ->  Hash
                                        ->  Broadcast Motion 3:3  (slice6; segments: 3)
                                              ->  Seq Scan on keo2

--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -3,6 +3,8 @@ set search_path to hashagg_spill;
 -- start_ignore
 create language plpythonu;
 -- end_ignore
+-- force multistage to increase likelihood of spilling
+set optimizer_force_multistage_agg = on;
 -- set workfile is created to true if all segment did it.
 create or replace function hashagg_spill.is_workfile_created(explain_query text)
 returns setof int as
@@ -147,6 +149,7 @@ select count(*) from (select a, avg(b), avg(c) from aggspill_numeric_avg group b
  500000
 (1 row)
 
+reset optimizer_force_multistage_agg;
 drop schema hashagg_spill cascade;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function hashagg_spill.is_workfile_created(text)

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -125,7 +125,7 @@ select count_operator('select count(*) from multi_stage_test group by b;','Group
 
 --CLEANUP
 reset optimizer_segments;
-set optimizer_force_multistage_agg = off;
+reset optimizer_force_multistage_agg;
 
 --
 -- Testing not picking HashAgg for aggregates without combine functions

--- a/src/test/regress/sql/bfv_dd_multicolumn.sql
+++ b/src/test/regress/sql/bfv_dd_multicolumn.sql
@@ -3,6 +3,7 @@
 --
 -- start_ignore
 set optimizer_log=on;
+set optimizer_force_multistage_agg=on;
 -- end_ignore
 
 set test_print_direct_dispatch_info=on; 
@@ -90,3 +91,4 @@ select * from dd_multicol_1 where a>80 and b=1;
 
 select * from dd_multicol_1 where a<=5 and b>0;
 
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/sql/gang_reuse.sql
+++ b/src/test/regress/sql/gang_reuse.sql
@@ -16,6 +16,7 @@ set gp_log_gang to 'debug';
 set gp_cached_segworkers_threshold to 10;
 set gp_vmem_idle_resource_timeout to '60s';
 set optimizer_enable_motion_broadcast to off;
+set optimizer_force_multistage_agg to on;
 
 create table test_gang_reuse_t1 (c1 int, c2 int);
 
@@ -41,3 +42,5 @@ explain analyze select count(*) from test_gang_reuse_t1 a
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
+
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -117,7 +117,9 @@ create aggregate mysum_prefunc(int4) (
   stype=bigint,
   prefunc=int8pl_with_notice
 );
+set optimizer_force_multistage_agg = on;
 select mysum_prefunc(a::int4) from aggtest;
+reset optimizer_force_multistage_agg;
 
 
 -- Test an aggregate with 'internal' transition type, and a combine function,

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -5,6 +5,9 @@ set search_path to hashagg_spill;
 create language plpythonu;
 -- end_ignore
 
+-- force multistage to increase likelihood of spilling
+set optimizer_force_multistage_agg = on;
+
 -- set workfile is created to true if all segment did it.
 create or replace function hashagg_spill.is_workfile_created(explain_query text)
 returns setof int as
@@ -103,4 +106,5 @@ select count(*) from (select i, count(*) from aggspill group by i,j,t having cou
 select count(*) from (select i, count(*) from aggspill group by i,j,t having count(*) = 3) g;
 select count(*) from (select a, avg(b), avg(c) from aggspill_numeric_avg group by a) g;
 
+reset optimizer_force_multistage_agg;
 drop schema hashagg_spill cascade;


### PR DESCRIPTION
ORCA will now choose between one-stage and two-stage agg based on cost.

Note: A number of ICG tests needed updates. In most cases, the plans
changed from two-stage to one-stage agg. Some of the tests, e.g
workfile/hashagg_spill, are testing some other functionality or
otherwise would benefit from forced two-stage aggs. I have added
set/reset commands in such cases, to keep the testing unchanged.

This PR stems from the discussion on the mailing list: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/5eapR7_pA0g