### PR TITLE
6X Backport: Guard calls to cdbexplain_localExecStats with Gp_Role check

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -725,7 +725,7 @@ ExplainPrintPlan(ExplainState *es, QueryDesc *queryDesc)
 	 */
 	if (es->analyze && !es->showstatctx->stats_gathered)
 	{
-		if (!es->currentSlice || sliceRunsOnQD(es->currentSlice))
+		if (Gp_role == GP_ROLE_DISPATCH && (!es->currentSlice || sliceRunsOnQD(es->currentSlice)))
 			cdbexplain_localExecStats(queryDesc->planstate, es->showstatctx);
 
         /* Fill in the plan's Instrumentation with stats from qExecs. */

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1229,7 +1229,8 @@ PG_CATCH();
 	/* If EXPLAIN ANALYZE, collect local and distributed execution stats. */
 	if (planstate->instrument && planstate->instrument->need_cdb)
 	{
-		cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
+		if(Gp_role == GP_ROLE_DISPATCH)
+			cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
 		if (!explainRecvStats &&
 			shouldDispatch &&
 			queryDesc->estate->dispatcherState)
@@ -1278,7 +1279,7 @@ PG_END_TRY();
 	planstate->state->currentSubplanLevel--;
 
 	/* If EXPLAIN ANALYZE, collect local execution stats. */
-	if (planstate->instrument && planstate->instrument->need_cdb)
+	if (Gp_role == GP_ROLE_DISPATCH && planstate->instrument && planstate->instrument->need_cdb)
 		cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
 
 	/* Restore memory high-water mark for root slice of main query. */


### PR DESCRIPTION
`cdbexplain_localExecStats` has the assumption that it will always be run
on QD. However, there can be plans where InitPlan nodes are executed on
the QE as well. For example:

Consider the following query:

```
CREATE TEMP TABLE foo (a, b)
AS (VALUES (0, 1), (0, 2))
;

EXPLAIN
SELECT
(SELECT 1 +
	(SELECT abs(a)
	)
)
FROM foo;
```

```
                                 QUERY PLAN
----------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.07 rows=2 width=4)
   ->  Seq Scan on foo  (cost=0.00..1.07 rows=1 width=4)
         SubPlan 2  (slice1; segments: 1)
           ->  Result  (cost=0.01..0.03 rows=1 width=0)
                 InitPlan 1 (returns $1)  (slice2)
                   ->  Result  (cost=0.00..0.01 rows=1 width=0)
 Optimizer: Postgres query optimizer
(7 rows)
```

Clearly, the InitPlan is executed on the QE and eventually,
`ExecSetParamPlan`->`cdbexplain_localExecStats` is called, which
triggers the assertion `Assert(Gp_role != GP_ROLE_EXECUTE);` inside
`cdbexplain_localExecStats`. On a non-debug build, a SEGV would result
from showstatctx being trash.

Co-authored-by: Bhuvnesh Chaudhary <bchaudhary@pivotal.io>
Co-authored-by: Jesse Zhang <jzhang@pivotal.io>
(cherry picked from commit 74ba9915a394122c51284cdc6542cfa9393b361f)
