### PR TITLE
6X: Restore default net.ipv4.ip_local_port_range

### DIFF
--- a/concourse/tasks/run_behave_on_ccp_cluster.yml
+++ b/concourse/tasks/run_behave_on_ccp_cluster.yml
@@ -21,7 +21,12 @@ run:
             sysctl -w kernel.shmmni=4096
             sysctl -w vm.overcommit_memory=2
             sysctl -w vm.overcommit_ratio=95
-            sysctl -w net.ipv4.ip_local_port_range=\"10000 65535\"
+
+            # the recommended port range overlaps with many testing ports, such
+            # as 15432, 25432, 20000, etc., until we have adjusted all of them
+            # to ports below 10000 we would skip this setting.
+            #sysctl -w net.ipv4.ip_local_port_range=\"10000 65535\"
+
             # additional settings
             sysctl -w kernel.sem=\"500 2048000 200 40960\"
             sysctl -w kernel.sysrq=1


### PR DESCRIPTION
In 42930ed126ddba205996ab7f407819950d712862 we set
net.ipv4.ip_local_port_range to "10000 65535" to match the official
recommendations, however it overlaps with many testing ports, such as
15432, 25432, 20000, etc., until we have adjusted all of them to ports
below 10000 we would skip this setting.

Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/fjF6OMzh2rQ/GbcmVvKlDAAJ

Reviewed-by: Jamie McAtamney <jmcatamney@pivotal.io>
Reviewed-by: Paul Guo <pguo@pivotal.io>
(cherry picked from commit f765a0ef9149b71e010afeff38e7abce9a59be85)

This is 6X version of https://github.com/greenplum-db/gpdb/pull/8450

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
