### PR TITLE
6X Backport: Do additional cleanup when setting udp interconnect fails to avoid po…

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3191,7 +3191,30 @@ SetupUDPIFCInterconnect(EState *estate)
 	}
 	PG_CATCH();
 	{
+		/*
+		 * Remove connections from hash table to avoid packet handling in the
+		 * rx pthread, else the packet handling code could use memory whose
+		 * context (InterconnectContext) would be soon reset - that could
+		 * panic the process.
+		 */
+		ConnHashTable *ht = &ic_control_info.connHtab;
+
+		for (int i = 0; i < ht->size; i++)
+		{
+			struct ConnHtabBin *trash;
+			MotionConn *conn;
+
+			trash = ht->table[i];
+			while (trash != NULL)
+			{
+				conn = trash->conn;
+				/* Get trash at first as trash will be pfree-ed in connDelHash. */
+				trash = trash->next;
+				connDelHash(ht, conn);
+			}
+		}
 		pthread_mutex_unlock(&ic_control_info.lock);
+
 		PG_RE_THROW();
 	}
 	PG_END_TRY();


### PR DESCRIPTION
…tential panic. (#8430)

We've seen occasional test failure of icudp/icudp_full due to an unexpected
panic of the QE process.  That happens when a QE main process elog(ERROR) in
SetupUDPIFCInterconnect_Internal() while its rx pthread is handling rx packets.
The memory (in memory context InterconnectContext) which is used to handle rx
packets is soon reset in resource owner ReleaseCallback function
destroy_interconnect_handle().

Fixing this by removing connection entries from hash table when
SetupUDPIFCInterconnect_Internal() errors out.

Reviewed-by: Ning Yu <nyu@pivotal.io>
Reviewed-by: Melanie Plageman <mplageman@pivotal.io>
