### PR TITLE
Turn on debug extensions by default

### DIFF
--- a/configure
+++ b/configure
@@ -1537,8 +1537,8 @@ Optional Features:
   --disable-strong-random do not use a strong random number source
   --disable-gpfdist       do not use gpfdist
   --disable-pxf           do not build pxf
-  --enable-debug-extensions
-                          include debug extensions in gpcontrib
+  --disable-debug-extensions
+                          exclude debug extensions in gpcontrib
   --enable-orafce         build with Oracle compatibility functions
   --enable-gpperfmon      build with gpperfmon
   --enable-debug          build with debugging symbols (-g)
@@ -3600,7 +3600,7 @@ if test "${enable_debug_extensions+set}" = set; then :
   esac
 
 else
-  enable_debug_extensions=no
+  enable_debug_extensions=yes
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -221,8 +221,8 @@ AC_SUBST(enable_pxf)
 #
 # include debug extensions in gpcontrib
 #
-PGAC_ARG_BOOL(enable, debug-extensions, no,
-              [include debug extensions in gpcontrib])
+PGAC_ARG_BOOL(enable, debug-extensions, yes,
+              [exclude debug extensions in gpcontrib])
 AC_SUBST(enable_debug_extensions)
 
 #


### PR DESCRIPTION
The debug extensions are required for developing and debugging GPDB, and are only not interesting for packaging. As packaging builds are more likely to be carefully managed than development builds which can be ad-hoc re-configurations (sometimes many time per day), make debug extensions an opt-out to save developer time.