### PR TITLE
docs - update from upstream sgml for psql pset command

### DIFF
--- a/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
+++ b/gpdb-doc/dita/utility_guide/client_utilities/psql.xml
@@ -997,7 +997,7 @@ lo_import 152801</codeblock>
                   <codeph>unaligned</codeph>, <codeph>aligned</codeph>, <codeph>html</codeph>,
                   <codeph>latex</codeph> (uses <codeph>tabular</codeph>),
                   <codeph>latex-longtable</codeph>, <codeph>troff-ms</codeph>, or
-                  <codeph>wrapped</codeph>. Unique abbreviations, including one letter, are allowed.
+                  <codeph>wrapped</codeph>. Unique abbreviations are allowed.
                       <p><b><codeph>unaligned</codeph></b> format writes all columns of a row on one
                   line, separated by the currently active field separator. This is useful for
                   creating output that might be intended to be read in by other programs (for


### PR DESCRIPTION
One-letter abbreviations stopped working in 9.3 when "latex-longtable" was added.



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
