### PR TITLE
6X: icw: run namespace_gp separately

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -35,9 +35,13 @@ test: gp_tablespace_with_faults
 test: temp_tablespaces
 test: default_tablespace
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views namespace_gp create_table_like_gp
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views create_table_like_gp
 
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
+
+# namespace_gp test will show diff if concurrent tests use temporary tables.
+# So run it separately.
+test: namespace_gp
 
 # test gpdb internal and segment connections
 test: gp_connections


### PR DESCRIPTION
namespace_gp test will show diff if concurrent tests use temporary
tables.  So run it separately.

(cherry picked from commit 56c5819110269ddf7f97397311968f66edd430c5)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
