### PR TITLE
Replication slots behave test: wait for segments to be in-sync after recovery

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
+++ b/gpMgmt/test/behave/mgmt_utils/replication_slots.feature
@@ -7,19 +7,26 @@ Feature: Replication Slots
     Then the primaries and mirrors should be replicating using replication slots
 
     Given a preferred primary has failed
-    When primary and mirror switch to non-preferred roles
+    When the user runs "gprecoverseg -a"
+    And gprecoverseg should return a return code of 0
+    And the segments are synchronized
+    And primary and mirror switch to non-preferred roles
     Then the primaries and mirrors should be replicating using replication slots
     And the mirrors should not have replication slots
 
     When the user runs "gprecoverseg -ra"
     Then gprecoverseg should return a return code of 0
+    And the segments are synchronized
     And the primaries and mirrors should be replicating using replication slots
 
     When a mirror has crashed
-    And I fully recover a mirror
+    And the user runs "gprecoverseg -aFv"
+    And gprecoverseg should return a return code of 0
+    And the segments are synchronized
     Then the primaries and mirrors should be replicating using replication slots
 
     When I add a segment to the cluster
+    And the segments are synchronized
     Then the primaries and mirrors should be replicating using replication slots
 
   Scenario: A adding mirrors to a cluster after the primaries have been initialized

--- a/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
@@ -6,8 +6,6 @@ from test.behave_utils.utils import (
     stop_database,
     run_command,
     stop_primary,
-    trigger_fts_probe,
-    run_gprecoverseg,
     execute_sql,
     wait_for_unblocked_transactions,
 )
@@ -19,11 +17,6 @@ from mirrors_mgmt_utils import (add_three_mirrors)
 def assert_successful_command(context):
     if context.ret_code != 0:
         raise Exception('%s : %s' % (context.error_message, context.stdout_message))
-
-
-def run_recovery_for_segments(context):
-    run_command(context, "gprecoverseg -aFv")
-    assert_successful_command(context)
 
 
 def create_cluster(context, with_mirrors=True):
@@ -135,11 +128,7 @@ def step_impl(context):
 
 @when('primary and mirror switch to non-preferred roles')
 def step_impl(context):
-    trigger_fts_probe()
-    run_gprecoverseg()
-
     ensure_primary_mirror_switched_roles()
-
 
 
 @given("I cluster with no mirrors")
@@ -155,11 +144,6 @@ def step_impl(context):
 @given("I create a cluster")
 def step_impl(context):
     create_cluster(context, with_mirrors=True)
-
-
-@when("I fully recover a mirror")
-def step_impl(context):
-    run_recovery_for_segments(context)
 
 
 @when("I add a segment to the cluster")


### PR DESCRIPTION
The replication_slots test brings down segments in various ways and performs incremental as well as full recovery.  After gprecoverseg returns success, the segments may still be marked as down or not in-sync.  The test must, therefore, wait until the segments are up and in sync before moving on.  Especially when the subsequent steps include rebalance or checking replication slots status, which may fail if invoked when segments are not in-sync.  CI results indicate that such failures have happened several times.

@pengzhout made me aware of the failures in CI and then we worked on this together.  I was not able to reproduce the failures seen in CI but the changed test has passed when run several times on my Mac.