### PR TITLE
Comment the divergence with regards to upstream on tableOid

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6502,8 +6502,6 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 				 * Constraints might reference the tableoid column, so
 				 * initialize t_tableOid before evaluating them.
 				 */
-				// GPDB_94_MERGE_FIXME: tableoid removed. should we put it back? It's used
-				// in a lot more places in 9.4
 #if 0
 				tuple->t_tableOid = RelationGetRelid(oldrel);
 #endif

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -407,7 +407,11 @@ ExecInsert(TupleTableSlot *parentslot,
 
 #if 0
 		/* FDW might have changed tuple */
-		tuple = ExecMaterializeSlot(slot); //GPDB_94_STABLE_MERGE_FIXME: Why GPDB removes this?
+		/*
+		 * GPDB: Greenplum does not allow triggers/contraints to reference
+		 * system columns which makes the t_tableOid initialization reduntant.
+		 */
+		tuple = ExecMaterializeSlot(slot);
 
 		/*
 		 * AFTER ROW Triggers or RETURNING expressions might reference the
@@ -425,6 +429,10 @@ ExecInsert(TupleTableSlot *parentslot,
 		 * t_tableOid before evaluating them.
 		 */
 #if 0
+		/*
+		 * GPDB: Greenplum does not allow triggers/contraints to reference
+		 * system columns which makes the t_tableOid initialization reduntant.
+		 */
 		tuple->t_tableOid = RelationGetRelid(resultRelationDesc);
 #endif
 
@@ -688,11 +696,11 @@ ExecDelete(ItemPointer tupleid,
 		if (slot->PRIVATE_tts_flags & TTS_ISEMPTY)
 			ExecStoreAllNullTuple(slot);
 
-		/*
-		 * GPDB_94_MERGE_FIXME: gpdb does not use tableoid. Do we need to bring
-		 * the related code back?
-		 */
 #if 0
+		/*
+		 * GPDB: Greenplum does not allow triggers/contraints to reference
+		 * system columns which makes the t_tableOid initialization reduntant.
+		 */
 		tuple = ExecMaterializeSlot(slot);
 		tuple->t_tableOid = RelationGetRelid(resultRelationDesc);
 #endif
@@ -1301,7 +1309,11 @@ ExecUpdate(ItemPointer tupleid,
 
 #if 0
 		/* FDW might have changed tuple */
-		tuple = ExecMaterializeSlot(slot); //GPDB_94_STABLE_MERGE_FIXME: Why GPDB removes this?
+		/*
+		 * GPDB: Greenplum does not allow triggers/contraints to reference
+		 * system columns which makes the t_tableOid initialization reduntant.
+		 */
+		tuple = ExecMaterializeSlot(slot);
 
 		/*
 		 * AFTER ROW Triggers or RETURNING expressions might reference the
@@ -1319,6 +1331,10 @@ ExecUpdate(ItemPointer tupleid,
 		 * t_tableOid before evaluating them.
 		 */
 #if 0
+		/*
+		 * GPDB: Greenplum does not allow triggers/contraints to reference
+		 * system columns which makes the t_tableOid initialization reduntant.
+		 */
 		tuple->t_tableOid = RelationGetRelid(resultRelationDesc);
 #endif
 


### PR DESCRIPTION
Upstream on commits 9418d79a7 and ba3d39c96 initialized the member t_tableOid of
heaptuple in order to address triggers and/or constraints on modify table
expressions. Greenplum does not support system columns to be referenced in
triggers and/or contraints. Additionally it has removed t_tableOid from the
heap tuple structure.

Since the feature is not currently supported, there is no need to re-introduce
t_tableOid and the related code. Instead explain the diversion and remove the
relative MERGE_FIXME comments.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
