### PR TITLE
PXF: FDW: Support config option

### DIFF
--- a/contrib/pxf_fdw/expected/pxf_fdw_foreign_table.out
+++ b/contrib/pxf_fdw/expected/pxf_fdw_foreign_table.out
@@ -22,6 +22,13 @@ CREATE FOREIGN TABLE pxf_fdw_test_table (id int, name text)
     OPTIONS ( resource '' );
 ERROR:  the resource option must be defined at the foreign table level
 --
+-- Table creation fails if config option is provided
+--
+CREATE FOREIGN TABLE pxf_fdw_test_table ()
+    SERVER pxf_fdw_test_server
+    OPTIONS ( config '/foo/bar' );
+ERROR:  the config option can only be defined at the pg_foreign_server level
+--
 -- Table creation succeeds if delimiter is provided with a single one-byte char
 --
 CREATE FOREIGN TABLE pxf_fdw_test_table_with_delim (id int, name text)
@@ -302,3 +309,9 @@ ERROR:  the log_errors option cannot be set without reject_limit
 ALTER FOREIGN TABLE pxf_fdw_test_table_log_errors
     OPTIONS ( SET log_errors 'no' );
 ERROR:  log_errors requires a Boolean value
+--
+-- Table alteration fails if config option is provided
+--
+ALTER FOREIGN TABLE pxf_fdw_test_table
+    OPTIONS ( ADD config '/foo/bar' );
+ERROR:  the config option can only be defined at the pg_foreign_server level

--- a/contrib/pxf_fdw/expected/pxf_fdw_server.out
+++ b/contrib/pxf_fdw/expected/pxf_fdw_server.out
@@ -122,6 +122,12 @@ ERROR:  the log_errors option can only be defined at the pg_foreign_table level
 CREATE SERVER pxf_fdw_test_server
     FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw;
 --
+-- Server creation succeeds if config option is provided
+--
+CREATE SERVER pxf_fdw_test_server_with_config
+    FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
+    OPTIONS ( config '/foo/bar' );
+--
 -- Server alteration fails if protocol option is added
 --
 ALTER SERVER pxf_fdw_test_server
@@ -221,3 +227,18 @@ ERROR:  the reject_limit_type option can only be defined at the pg_foreign_table
 ALTER SERVER pxf_fdw_test_server
     OPTIONS ( ADD log_errors 'true' );
 ERROR:  the log_errors option can only be defined at the pg_foreign_table level
+--
+-- Server alteration succeeds if config option is added
+--
+ALTER SERVER pxf_fdw_test_server
+    OPTIONS ( ADD config '/foo/bar' );
+--
+-- Server alteration succeeds if config option is modified
+--
+ALTER SERVER pxf_fdw_test_server
+    OPTIONS ( SET config '/foo/bar' );
+--
+-- Server alteration succeeds if config option is dropped
+--
+ALTER SERVER pxf_fdw_test_server
+    OPTIONS ( DROP config );

--- a/contrib/pxf_fdw/expected/pxf_fdw_user_mapping.out
+++ b/contrib/pxf_fdw/expected/pxf_fdw_user_mapping.out
@@ -124,6 +124,13 @@ CREATE USER MAPPING FOR pxf_fdw_user
     OPTIONS ( mpp_execute 'any' );
 ERROR:  the mpp_execute option cannot be defined at the user mapping level
 --
+-- User mapping creation fails if config option is provided
+--
+CREATE USER MAPPING FOR pxf_fdw_user
+    SERVER pxf_fdw_test_server
+    OPTIONS ( config '/foo/bar' );
+ERROR:  the config option can only be defined at the pg_foreign_server level
+--
 -- User mapping creation succeeds if protocol option is not provided
 --
 CREATE USER MAPPING FOR pxf_fdw_user
@@ -250,3 +257,10 @@ ALTER USER MAPPING FOR pxf_fdw_user
     SERVER pxf_fdw_test_server
     OPTIONS ( ADD mpp_execute 'any' );
 ERROR:  the mpp_execute option cannot be defined at the user mapping level
+--
+-- User mapping alteration fails if config option is added
+--
+ALTER USER MAPPING FOR pxf_fdw_user
+    SERVER pxf_fdw_test_server
+    OPTIONS ( ADD config '/foo/bar' );
+ERROR:  the config option can only be defined at the pg_foreign_server level

--- a/contrib/pxf_fdw/expected/pxf_fdw_wrapper.out
+++ b/contrib/pxf_fdw/expected/pxf_fdw_wrapper.out
@@ -146,6 +146,14 @@ CREATE FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
     OPTIONS ( protocol 'pxf_fdw_test', log_errors 'true' );
 ERROR:  the log_errors option can only be defined at the pg_foreign_table level
 --
+-- Foreign-data wrapper creation fails if config option is provided
+--
+CREATE FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
+    HANDLER pxf_fdw_handler
+    VALIDATOR pxf_fdw_validator
+    OPTIONS ( protocol 'pxf_fdw_test', config '/foo/bar' );
+ERROR:  the config option can only be defined at the pg_foreign_server level
+--
 -- Foreign-data wrapper succeeds when protocol is provided
 --
 CREATE FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
@@ -258,3 +266,9 @@ ERROR:  the reject_limit_type option can only be defined at the pg_foreign_table
 ALTER FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
     OPTIONS ( ADD log_errors 'true' );
 ERROR:  the log_errors option can only be defined at the pg_foreign_table level
+--
+-- Foreign-data wrapper alteration fails if config option is added
+--
+ALTER FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
+    OPTIONS ( ADD config '/foo/bar' );
+ERROR:  the config option can only be defined at the pg_foreign_server level

--- a/contrib/pxf_fdw/pxf_option.c
+++ b/contrib/pxf_fdw/pxf_option.c
@@ -25,16 +25,17 @@
 #define FDW_OPTION_REJECT_LIMIT_ROWS "rows"
 #define FDW_OPTION_REJECT_LIMIT_PERCENT "percent"
 
-#define FDW_OPTION_PROTOCOL "protocol"
-#define FDW_OPTION_RESOURCE "resource"
+#define FDW_OPTION_CONFIG "config"
 #define FDW_OPTION_FORMAT "format"
 #define FDW_OPTION_LOG_ERRORS "log_errors"
-#define FDW_OPTION_REJECT_LIMIT_TYPE "reject_limit_type"
-#define FDW_OPTION_REJECT_LIMIT "reject_limit"
-#define FDW_OPTION_PXF_PORT "pxf_port"
-#define FDW_OPTION_PXF_HOST "pxf_host"
-#define FDW_OPTION_PXF_PROTOCOL "pxf_protocol"
 #define FDW_OPTION_MPP_EXECUTE "mpp_execute"
+#define FDW_OPTION_PROTOCOL "protocol"
+#define FDW_OPTION_PXF_HOST "pxf_host"
+#define FDW_OPTION_PXF_PORT "pxf_port"
+#define FDW_OPTION_PXF_PROTOCOL "pxf_protocol"
+#define FDW_OPTION_REJECT_LIMIT "reject_limit"
+#define FDW_OPTION_REJECT_LIMIT_TYPE "reject_limit_type"
+#define FDW_OPTION_RESOURCE "resource"
 
 #define FDW_COPY_OPTION_HEADER "header"
 #define FDW_COPY_OPTION_DELIMITER "delimiter"
@@ -60,6 +61,7 @@ static const struct PxfFdwOption valid_options[] = {
 	{FDW_OPTION_PROTOCOL, ForeignDataWrapperRelationId},
 	{FDW_OPTION_RESOURCE, ForeignTableRelationId},
 	{FDW_OPTION_FORMAT, ForeignTableRelationId},
+	{FDW_OPTION_CONFIG, ForeignServerRelationId},
 
 	/* Error handling */
 	{FDW_OPTION_REJECT_LIMIT, ForeignTableRelationId},

--- a/contrib/pxf_fdw/sql/pxf_fdw_foreign_table.sql
+++ b/contrib/pxf_fdw/sql/pxf_fdw_foreign_table.sql
@@ -23,6 +23,13 @@ CREATE FOREIGN TABLE pxf_fdw_test_table (id int, name text)
     OPTIONS ( resource '' );
 
 --
+-- Table creation fails if config option is provided
+--
+CREATE FOREIGN TABLE pxf_fdw_test_table ()
+    SERVER pxf_fdw_test_server
+    OPTIONS ( config '/foo/bar' );
+
+--
 -- Table creation succeeds if delimiter is provided with a single one-byte char
 --
 CREATE FOREIGN TABLE pxf_fdw_test_table_with_delim (id int, name text)
@@ -330,3 +337,9 @@ ALTER FOREIGN TABLE pxf_fdw_test_table
 --
 ALTER FOREIGN TABLE pxf_fdw_test_table_log_errors
     OPTIONS ( SET log_errors 'no' );
+
+--
+-- Table alteration fails if config option is provided
+--
+ALTER FOREIGN TABLE pxf_fdw_test_table
+    OPTIONS ( ADD config '/foo/bar' );

--- a/contrib/pxf_fdw/sql/pxf_fdw_server.sql
+++ b/contrib/pxf_fdw/sql/pxf_fdw_server.sql
@@ -114,6 +114,13 @@ CREATE SERVER pxf_fdw_test_server
     FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw;
 
 --
+-- Server creation succeeds if config option is provided
+--
+CREATE SERVER pxf_fdw_test_server_with_config
+    FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
+    OPTIONS ( config '/foo/bar' );
+
+--
 -- Server alteration fails if protocol option is added
 --
 ALTER SERVER pxf_fdw_test_server
@@ -202,4 +209,22 @@ ALTER SERVER pxf_fdw_test_server
 --
 ALTER SERVER pxf_fdw_test_server
     OPTIONS ( ADD log_errors 'true' );
+
+--
+-- Server alteration succeeds if config option is added
+--
+ALTER SERVER pxf_fdw_test_server
+    OPTIONS ( ADD config '/foo/bar' );
+
+--
+-- Server alteration succeeds if config option is modified
+--
+ALTER SERVER pxf_fdw_test_server
+    OPTIONS ( SET config '/foo/bar' );
+
+--
+-- Server alteration succeeds if config option is dropped
+--
+ALTER SERVER pxf_fdw_test_server
+    OPTIONS ( DROP config );
 

--- a/contrib/pxf_fdw/sql/pxf_fdw_user_mapping.sql
+++ b/contrib/pxf_fdw/sql/pxf_fdw_user_mapping.sql
@@ -115,6 +115,13 @@ CREATE USER MAPPING FOR pxf_fdw_user
     OPTIONS ( mpp_execute 'any' );
 
 --
+-- User mapping creation fails if config option is provided
+--
+CREATE USER MAPPING FOR pxf_fdw_user
+    SERVER pxf_fdw_test_server
+    OPTIONS ( config '/foo/bar' );
+
+--
 -- User mapping creation succeeds if protocol option is not provided
 --
 CREATE USER MAPPING FOR pxf_fdw_user
@@ -231,4 +238,11 @@ ALTER USER MAPPING FOR pxf_fdw_user
 ALTER USER MAPPING FOR pxf_fdw_user
     SERVER pxf_fdw_test_server
     OPTIONS ( ADD mpp_execute 'any' );
+
+--
+-- User mapping alteration fails if config option is added
+--
+ALTER USER MAPPING FOR pxf_fdw_user
+    SERVER pxf_fdw_test_server
+    OPTIONS ( ADD config '/foo/bar' );
 

--- a/contrib/pxf_fdw/sql/pxf_fdw_wrapper.sql
+++ b/contrib/pxf_fdw/sql/pxf_fdw_wrapper.sql
@@ -139,6 +139,14 @@ CREATE FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
     OPTIONS ( protocol 'pxf_fdw_test', log_errors 'true' );
 
 --
+-- Foreign-data wrapper creation fails if config option is provided
+--
+CREATE FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
+    HANDLER pxf_fdw_handler
+    VALIDATOR pxf_fdw_validator
+    OPTIONS ( protocol 'pxf_fdw_test', config '/foo/bar' );
+
+--
 -- Foreign-data wrapper succeeds when protocol is provided
 --
 CREATE FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
@@ -242,3 +250,8 @@ ALTER FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
 ALTER FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
     OPTIONS ( ADD log_errors 'true' );
 
+--
+-- Foreign-data wrapper alteration fails if config option is added
+--
+ALTER FOREIGN DATA WRAPPER pxf_fdw_test_pxf_fdw
+    OPTIONS ( ADD config '/foo/bar' );


### PR DESCRIPTION
Access to Hadoop clusters is nuanced, because with a single set of configurations
users are able to access HDFS, Hive, HBase and other services.

Suppose an enterprise user has a Hortonworks hadoop installation that includes
HDFS, Hive, and HBase. We would configure one server per technology we access,
for example:

     CREATE SERVER hdfs_hdp
          FOREIGN DATA WRAPPER hdfs_pxf_fdw
          OPTIONS ( config 'hdp_1' );

     CREATE SERVER hive_hdp
          FOREIGN DATA WRAPPER hive_pxf_fdw
          OPTIONS ( config 'hdp_1' );

     CREATE SERVER hbase_hdp
          FOREIGN DATA WRAPPER hbase_pxf_fdw
          OPTIONS ( config 'hdp_1' );

To reduce the amount of configuration required for each server, we introduce a
new option `config`. This new option provides the name of the server directory where
the configuration files reside. In the example above, configuration files live
in the `$PXF_CONF/servers/hdp_1` directory, and all three servers share the same
configuration directory.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
