### PR TITLE
5X backport: Do additional cleanup when setting udp interconnect fails to avoid po…

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3204,7 +3204,30 @@ SetupUDPIFCInterconnect(EState *estate)
 	}
 	PG_CATCH();
 	{
+		/*
+		 * Remove connections from hash table to avoid packet handling in the
+		 * rx pthread, else the packet handling code could use memory whose
+		 * context (InterconnectContext) would be soon reset - that could
+		 * panic the process.
+		 */
+		ConnHashTable *ht = &ic_control_info.connHtab;
+
+		for (int i = 0; i < ht->size; i++)
+		{
+			struct ConnHtabBin *trash;
+			MotionConn *conn;
+
+			trash = ht->table[i];
+			while (trash != NULL)
+			{
+				conn = trash->conn;
+				/* Get trash at first as trash will be pfree-ed in connDelHash. */
+				trash = trash->next;
+				connDelHash(ht, conn);
+			}
+		}
 		pthread_mutex_unlock(&ic_control_info.lock);
+
 		PG_RE_THROW();
 	}
 	PG_END_TRY();

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/dispatch/interconnect/udp/test_udpic.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/dispatch/interconnect/udp/test_udpic.py
@@ -183,21 +183,7 @@ class UDPICFullTestCases(UDPICTestCases):
     def __init__(self, methodName):
         super(UDPICFullTestCases, self).__init__(methodName)
 
-        # these cases not run with 4.2.x 
-        cmdsql = 'SELECT version();'
-        ret = PSQL.run_sql_command(cmdsql)
-        #if ret.find('Greenplum Database 4.2 build') >= 0:
-        #    self.is_version_skip = 1
-
     def test_icudp_full(self):
-        if (self.is_version_skip):
-            self.skipTest('Test does not apply to the deployed GPDB version.')
-        try:
-            out = self.checkGUC(self.gp_udpic_fault_inject_percent)
-            self.assertTrue(len(out) > 4 and int(out[3].strip()) >= 0 )
-        except:
-            self.skipTest("GUC " + self.gp_udpic_fault_inject_percent + " not defined")
-
         start_time = time.strftime('%I:%M:%S',time.localtime(time.time()))
         tinctest.logger.debug('start time:%s ' % start_time)
 


### PR DESCRIPTION
…tential panic. (#8430)

We've seen occasional test failure of icudp/icudp_full due to an unexpected
panic of the QE process.  That happens when a QE main process elog(ERROR) in
SetupUDPIFCInterconnect_Internal() while its rx pthread is handling rx packets.
The memory (in memory context InterconnectContext) which is used to handle rx
packets is soon reset in resource owner ReleaseCallback function
destroy_interconnect_handle().

Fixing this by removing connection entries from hash table when
SetupUDPIFCInterconnect_Internal() errors out.

Cherry-picked from 10dba408a29c0aa7a20b3e4255c63d9b8fae64ed

In addition, enable test DPICFullTestCases.test_icudp_full test.
According to the error message it is really unreasonable to disable
the test case.