### PR TITLE
Treat cursors as extended queries but nothing else.

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -2263,7 +2263,14 @@ exec_bind_message(StringInfo input_message)
 	else
 		portal = CreatePortal(portal_name, false, false);
 
-	portal->is_extended_query = true;
+	/*
+	 * GPDB specific: upstream does not have such field for the
+	 * struct Portal. In Greenplum, this field is used for cursor.
+	 * For `exec_bind_message` we should not consider it as cursor.
+	 * More details please refer the gpdb-dev mailing list:
+	 * https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/ugsZca1qLXU
+	 */
+	portal->is_extended_query = false;
 
 	/*
 	 * Prepare to copy stuff into the portal's memory context.  We do all this

--- a/src/test/isolation2/.gitignore
+++ b/src/test/isolation2/.gitignore
@@ -1,5 +1,6 @@
 regression.diffs
 regression.out
+extended_protocol_test
 */dummy.sql
 */dummy.out
 

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -17,7 +17,10 @@ endif
 override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPFLAGS)
 override LDLIBS := $(libpq_pgport) $(LDLIBS)
 
-all: test_python pg_isolation2_regress$(X) all-lib
+all: test_python pg_isolation2_regress$(X) all-lib extended_protocol_test
+
+extended_protocol_test: extended_protocol_test.c
+	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq  -o $@ $< -lpq
 
 test_python:
 	python helpers_test.py

--- a/src/test/isolation2/expected/gdd/extended_protocol.out
+++ b/src/test/isolation2/expected/gdd/extended_protocol.out
@@ -1,0 +1,9 @@
+show gp_enable_global_deadlock_detector;
+ gp_enable_global_deadlock_detector 
+------------------------------------
+ on                                 
+(1 row)
+! ./extended_protocol_test dbname=isolation2test;
+extended_protocol_test test ok!
+
+

--- a/src/test/isolation2/extended_protocol_test.c
+++ b/src/test/isolation2/extended_protocol_test.c
@@ -1,0 +1,80 @@
+/*
+ * extended_protocol_test.c
+ *
+ * This program is to test whether exetend-queries run on reader gang
+ * or writer gang.
+ *
+ * More details please refer:
+ * https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/ugsZca1qLXU
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include "libpq-fe.h"
+
+/* for ntohl/htonl */
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+
+static void
+exit_nicely(PGconn *conn)
+{
+	PQfinish(conn);
+	exit(1);
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *conninfo;
+	PGconn	   *conn;
+	PGresult   *res;
+	const char *paramValues[1];
+
+	/*
+	 * If the user supplies a parameter on the command line, use it as the
+	 * conninfo string; otherwise default to setting dbname=postgres and using
+	 * environment variables or defaults for all other connection parameters.
+	 */
+	if (argc > 1)
+		conninfo = argv[1];
+	else
+		conninfo = "dbname = postgres";
+
+	/* Make a connection to the database */
+	conn = PQconnectdb(conninfo);
+
+	/* Check to see that the backend connection was successfully made */
+	if (PQstatus(conn) != CONNECTION_OK)
+	{
+		fprintf(stderr, "Connection to database failed: %s",
+				PQerrorMessage(conn));
+		exit_nicely(conn);
+	}
+
+	PQexec(conn, "create table t_extended_protocol_test(c int) distributed randomly;");
+	PQexec(conn, "insert into t_extended_protocol_test select * from generate_series(1, 10);");
+
+	PQprepare(conn, "select_forupdate",
+			  "select * from t_extended_protocol_test where c > $1 for update",
+			  1, NULL);
+
+	paramValues[0] = "1";
+	res = PQexecPrepared(conn, "select_forupdate", 1,
+						 paramValues, NULL, NULL, 0);
+
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		printf("%s", PQresultErrorMessage(res));
+	else
+		printf("%s", "extended_protocol_test test ok!\n");
+	
+	PQclear(res);
+
+	PQfinish(conn);
+
+	return 0;
+}

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -22,6 +22,7 @@ test: udf_exception_blocks_panic_scenarios
 
 # Tests on global deadlock detector
 test: gdd/prepare
+test: gdd/extended_protocol
 test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/non-lock-105
 # until we can improve below flaky case please keep it disabled
 ignore: gdd/non-lock-107

--- a/src/test/isolation2/sql/gdd/extended_protocol.sql
+++ b/src/test/isolation2/sql/gdd/extended_protocol.sql
@@ -1,0 +1,3 @@
+show gp_enable_global_deadlock_detector;
+! ./extended_protocol_test dbname=isolation2test;
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -38,7 +38,6 @@ test: default_tablespace
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views replication_slots create_table_like_gp gp_constraints
 
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
-
 # namespace_gp test will show diff if concurrent tests use temporary tables.
 # So run it separately.
 test: namespace_gp


### PR DESCRIPTION
In Portal struct, Greenplum add a field is_extended_query. This
field is used for CURSOR. We should not consider it CURSOR for
exec_bind_message.

More details: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/ugsZca1qLXU

Co-authored-by: Jinbao Chen <jinchen@pivotal.io>

----------------

Related issue: https://github.com/greenplum-db/gpdb/issues/8365

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
