### PR TITLE
Fix compiler warnings in unittests

### DIFF
--- a/gpcontrib/pxf/test/libchurl_test.c
+++ b/gpcontrib/pxf/test/libchurl_test.c
@@ -41,7 +41,8 @@ test_set_curl_option(void **state)
 {
 	/* set up context with a curl_handle */
 	churl_context *context = palloc0(sizeof(churl_context));
-	context->curl_handle = palloc0(sizeof(CURL));
+	/* mock a curl_easy_init call which returns a calloced CURL handle */
+	context->curl_handle = palloc0(1);
 
 	/* set mock behavior for curl_easy_setopt */
 	curl_easy_setopt_test_helper(context->curl_handle, CURLOPT_URL);
@@ -58,8 +59,14 @@ test_set_curl_option(void **state)
 static CURL *
 test_churl_init()
 {
-	/* set mock behavior for curl handle initialization */
-	CURL	   *mock_curl_handle = palloc0(sizeof(CURL));
+	/*
+	 * Set mock behavior for curl handle initialization. curl_easy_init will
+	 * return a calloced CURL handle, but since the CURL struct is opaque we
+	 * cannot allocate a sizeof(CURL) chunk here. Since these tests never use
+	 * the mocked handle for anything but non-NULL checks, settle for
+	 * allocating a small buffer.
+	 */
+	CURL	   *mock_curl_handle = palloc0(1);
 	will_return(curl_easy_init, mock_curl_handle);
 
 	/* set mock behavior for all the curl_easy_setopt calls */
@@ -95,8 +102,13 @@ test_churl_init_upload(void **state)
 	curl_slist_append_test_helper(mock_curl_slist, "Transfer-Encoding: chunked");
 	curl_slist_append_test_helper(mock_curl_slist, "Expect: 100-continue");
 
-	/* setup_multi_handle mock setup */
-	CURLM	   *mock_multi_handle = palloc0(sizeof(CURLM));
+	/*
+	 * setup_multi_handle mock setup. curl_multi_init will return a calloced
+	 * CURLM handle, but since the CURL struct is opaque we cannot allocate a
+	 * sizeof(CURLM) chunk here. Since these tests never use the mocked handle
+	 * for anything but non-NULL checks, settle for allocating a small buffer.
+	 */
+	CURLM	   *mock_multi_handle = palloc0(1);
 	will_return(curl_multi_init, mock_multi_handle);
 
 	expect_value(curl_multi_add_handle, multi_handle, mock_multi_handle);
@@ -132,8 +144,13 @@ test_churl_init_download(void **state)
 	CHURL_HEADERS headers = palloc0(sizeof(CHURL_HEADERS));
 	CURL	   *mock_curl_handle = test_churl_init();
 
-	/* setup_multi_handle mock setup */
-	CURLM	   *mock_multi_handle = palloc0(sizeof(CURLM));
+	/*
+	 * setup_multi_handle mock setup. curl_multi_init will return a calloced
+	 * CURLM handle, but since the CURL struct is opaque we cannot allocate a
+	 * sizeof(CURLM) chunk here. Since these tests never use the mocked handle
+	 * for anything but non-NULL checks, settle for allocating a small buffer.
+	 */
+	CURLM	   *mock_multi_handle = palloc0(1);
 	will_return(curl_multi_init, mock_multi_handle);
 
 	expect_value(curl_multi_add_handle, multi_handle, mock_multi_handle);
@@ -177,7 +194,8 @@ test_churl_read(void **state)
 	/* context setup */
 	CHURL_HANDLE handle = palloc0(sizeof(CHURL_HANDLE));
 	churl_context *context = (churl_context *) handle;
-	CURLM	   *mock_multi_handle = palloc0(sizeof(CURLM));
+	/* mock curl_multi_init */
+	CURLM	   *mock_multi_handle = palloc0(1);
 
 	/* buffer to read into */
 	int			READ_LEN = 32;

--- a/gpcontrib/pxf/test/mock/pxffragment_mock.c
+++ b/gpcontrib/pxf/test/mock/pxffragment_mock.c
@@ -16,24 +16,6 @@ get_fragments(GPHDUri *uri,
 	mock();
 }
 
-static void
-call_rest(GPHDUri* hadoop_uri, ClientContext* client_context, char* rest_msg)
-{
-	check_expected(hadoop_uri);
-	check_expected(client_context);
-	check_expected(rest_msg);
-	optional_assignment(hadoop_uri);
-	optional_assignment(client_context);
-	optional_assignment(rest_msg);
-	mock();
-}
-
-static void
-process_request(ClientContext* client_context, char* uri)
-{
-	mock();
-}
-
 void
 free_fragment(FragmentData *data)
 {

--- a/gpcontrib/pxf/test/mock/pxfuriparser_mock.c
+++ b/gpcontrib/pxf/test/mock/pxfuriparser_mock.c
@@ -35,11 +35,3 @@ GPHDUri_verify_core_options_exist(GPHDUri *uri, List *coreoptions)
     check_expected(coreoptions);
     mock();
 }
-
-void
-GPHDUri_verify_cluster_exists(GPHDUri *uri, char* cluster)
-{
-    check_expected(uri);
-    check_expected(cluster);
-    mock();
-}

--- a/gpcontrib/pxf/test/pxfbridge_test.c
+++ b/gpcontrib/pxf/test/pxfbridge_test.c
@@ -179,7 +179,7 @@ test_gpbridge_read_one_fragment_less_than_buffer(void **state)
 	gphadoop_context *context = (gphadoop_context *) palloc0(sizeof(gphadoop_context));
 
 	context->gphd_uri = (GPHDUri *) palloc0(sizeof(GPHDUri));
-	context->gphd_uri->fragments = (FragmentData *) palloc0(sizeof(FragmentData));
+	context->gphd_uri->fragments = list_make1((FragmentData *) palloc0(sizeof(FragmentData)));
 	CHURL_HANDLE handle = (CHURL_HANDLE) palloc0(sizeof(CHURL_HANDLE));
 
 	context->churl_handle = handle;
@@ -218,7 +218,7 @@ test_gpbridge_read_one_fragment_buffer(void **state)
 	gphadoop_context *context = (gphadoop_context *) palloc0(sizeof(gphadoop_context));
 
 	context->gphd_uri = (GPHDUri *) palloc0(sizeof(GPHDUri));
-	context->gphd_uri->fragments = (FragmentData *) palloc0(sizeof(FragmentData));
+	context->gphd_uri->fragments = list_make1((FragmentData *) palloc0(sizeof(FragmentData)));
 	CHURL_HANDLE handle = (CHURL_HANDLE) palloc0(sizeof(CHURL_HANDLE));
 
 	context->churl_handle = handle;
@@ -424,7 +424,7 @@ test_gpbridge_read_last_fragment_finished(void **state)
 	gphadoop_context *context = (gphadoop_context *) palloc0(sizeof(gphadoop_context));
 
 	context->gphd_uri = (GPHDUri *) palloc0(sizeof(GPHDUri));
-	context->gphd_uri->fragments = (FragmentData *) palloc0(sizeof(FragmentData));
+	context->gphd_uri->fragments =  list_make1((FragmentData *) palloc0(sizeof(FragmentData)));
 	CHURL_HANDLE handle = (CHURL_HANDLE) palloc0(sizeof(CHURL_HANDLE));
 
 	context->churl_handle = handle;

--- a/gpcontrib/pxf/test/pxffilters_test.c
+++ b/gpcontrib/pxf/test/pxffilters_test.c
@@ -64,10 +64,10 @@ test__supported_filter_type(void **state)
 
 	int array_size = sizeof(oids) / sizeof(Oid);
 	bool result = false;
-	int i = 0;
+	int i;
 
 	/* supported types */
-	for (; i < array_size-1; ++i)
+	for (i = 0; i < array_size-1; ++i)
 	{
 		result = supported_filter_type(oids[i]);
 		assert_true(result);
@@ -109,10 +109,10 @@ test__supported_operator_type_op_expr(void **state)
 
 	int array_size = sizeof(operator_oids) / sizeof(dbop_pxfop_map);
 	bool result = false;
-	int i = 0;
+	int i;
 
 	/* supported types */
-	for (; i < array_size-1; ++i)
+	for (i = 0; i < array_size-1; ++i)
 	{
 		result = supported_operator_type_op_expr(operator_oids[i][0], filter);
 		assert_true(result);
@@ -456,7 +456,8 @@ build_filter(char lopcode, int lattnum, char* lconststr,
 }
 
 static Var *
-build_var(Oid oid, int attno) {
+build_var(Oid oid, int attno)
+{
 	Var *arg_var = (Var*) palloc0(sizeof(Var));
 	arg_var->xpr.type = T_Var;
 	arg_var->vartype = oid;
@@ -541,7 +542,8 @@ build_qualifier(int lattnum, Oid lattrtype, char* rconststr, Oid rattrtype, int 
 }
 
 static FuncExpr *
-build_func_expr_operand(List *args, CoercionForm funcformat) {
+build_func_expr_operand(List *args, CoercionForm funcformat)
+{
 	FuncExpr* operand = palloc0(sizeof(FuncExpr));
 	((Node*) operand)->type = T_FuncExpr;
 	operand->args = args;
@@ -558,7 +560,8 @@ build_func_expr_operand(List *args, CoercionForm funcformat) {
  * where Var holds actual arguments - column1, column2,...,columnk
  */
 static FuncExpr *
-build_nested_func_expr_operand(List *columnsOids, List *attrsIndices) {
+build_nested_func_expr_operand(List *columnsOids, List *attrsIndices)
+{
 	assert_int_equal(columnsOids->length, attrsIndices->length);
 	ListCell *columnOidLc = NULL, *attrIndexLc = NULL;
 	Var *var = NULL;
@@ -628,8 +631,7 @@ test__opexpr_to_pxffilter__attributeEqualsNull(void **state)
 {
 	PxfFilterDesc *filter = (PxfFilterDesc*) palloc0(sizeof(PxfFilterDesc));
 	Var *arg_var = build_var(INT2OID, 1);
-	Const* arg_const = build_const(INT2OID, NULL, true
-			);
+	Const* arg_const = build_const(INT2OID, NULL, true);
 	OpExpr *expr = build_op_expr(arg_var, arg_const, 94 /* int2eq */);
 
 	PxfFilterDesc* expected = build_filter(

--- a/gpcontrib/pxf/test/pxffilters_test.c
+++ b/gpcontrib/pxf/test/pxffilters_test.c
@@ -508,7 +508,7 @@ build_null_expression_item(int attnum, Oid attrtype, NullTestType nullType)
 {
 	ExpressionItem *expressionItem = (ExpressionItem*) palloc0(sizeof(ExpressionItem));
 	Var *vararg = build_var(attrtype, attnum);
-	OpExpr *operationExpression = build_null_expr(vararg, nullType);
+	NullTest *operationExpression = build_null_expr((Expr *) vararg, nullType);
 
 	expressionItem->node = (Node *) operationExpression;
 	expressionItem->processed = false;
@@ -652,7 +652,7 @@ static void
 test__opexpr_to_pxffilter__attributeIsNull(void **state)
 {
 	Var *arg_var = build_var(INT2OID, 1);
-	NullTest *expr = build_null_expr(arg_var, IS_NULL);
+	NullTest *expr = build_null_expr((Expr *) arg_var, IS_NULL);
 
 	pfree(expr->arg);
 	pfree(expr);

--- a/gpcontrib/pxf/test/pxffilters_test.c
+++ b/gpcontrib/pxf/test/pxffilters_test.c
@@ -131,57 +131,6 @@ test__supported_operator_type_op_expr(void **state)
 		assert_true(supported_operator_type_op_expr(pxf_supported_opr_op_expr[i].dbop, filter));
 		assert_true(pxf_supported_opr_op_expr[i].pxfop == filter->op);
 	}
-
-}
-
-static void
-test__supported_operator_type_scalar_array_op_expr(void **state)
-{
-	Oid operator_oids[15][2] = {
-			{Int2EqualOperator, PXFOP_IN},
-			{Int4EqualOperator, PXFOP_IN},
-			{Int8EqualOperator, PXFOP_IN},
-			{TextEqualOperator, PXFOP_IN},
-			{Int24EqualOperator, PXFOP_IN},
-			{Int42EqualOperator, PXFOP_IN},
-			{Int84EqualOperator, PXFOP_IN},
-			{Int48EqualOperator, PXFOP_IN},
-			{Int28EqualOperator, PXFOP_IN},
-			{Int82EqualOperator, PXFOP_IN},
-			{DateEqualOperator, PXFOP_IN},
-			{Float8EqualOperator, PXFOP_IN},
-			{1120 , PXFOP_IN},
-			{BPCharEqualOperator, PXFOP_IN},
-			{BooleanEqualOperator, PXFOP_IN},
-	};
-
-	PxfFilterDesc *filter = (PxfFilterDesc*) palloc0(sizeof(PxfFilterDesc));
-
-	int array_size = sizeof(operator_oids) / sizeof(operator_oids[0]);
-	bool result = false;
-	int i = 0;
-
-	/* supported types */
-	for (; i < array_size-1; ++i)
-	{
-		result = supported_operator_type_scalar_array_op_expr(operator_oids[i][0], filter, true);
-		assert_true(result);
-		assert_true(operator_oids[i][1] == filter->op);
-	}
-
-	/* unsupported type */
-	result = supported_operator_type_op_expr(InvalidOid, filter);
-	assert_false(result);
-
-	/* go over pxf_supported_opr_scalar_array_op_expr array */
-	int nargs = sizeof(pxf_supported_opr_scalar_array_op_expr) / sizeof(dbop_pxfop_array_map);
-	assert_int_equal(nargs, 15);
-	for (i = 0; i < nargs; ++i)
-	{
-		assert_true(supported_operator_type_scalar_array_op_expr(pxf_supported_opr_op_expr[i].dbop, filter, pxf_supported_opr_scalar_array_op_expr[i].useOr));
-		assert_true(pxf_supported_opr_scalar_array_op_expr[i].pxfop == filter->op);
-	}
-
 }
 
 /*

--- a/gpcontrib/pxf/test/pxffragment_test.c
+++ b/gpcontrib/pxf/test/pxffragment_test.c
@@ -359,8 +359,6 @@ test_call_rest(void **state)
 
 	expect_value(print_http_headers, headers, client_context->http_headers);
 	will_be_called(print_http_headers);
-	(client_context->http_headers);
-
 
 	StringInfoData expected_url;
 

--- a/gpcontrib/pxf/test/pxfheaders_test.c
+++ b/gpcontrib/pxf/test/pxfheaders_test.c
@@ -328,7 +328,7 @@ test_add_tuple_desc_httpheader(void **state)
 	attrs_ptr[0] = &attrs[0];
 	char		data0[10] = "name0";
 
-	snprintf(NameStr(attrs[0].attname), sizeof(data0), data0);
+	snprintf(NameStr(attrs[0].attname), sizeof(data0), "%s", data0);
 	char		typename0[12] = "NUMERICOID";
 
 	attrs[0].atttypid = NUMERICOID;
@@ -355,7 +355,7 @@ test_add_tuple_desc_httpheader(void **state)
 	attrs_ptr[1] = &attrs[1];
 	char		data1[10] = "name1";
 
-	snprintf(NameStr(attrs[1].attname), sizeof(data1), data1);
+	snprintf(NameStr(attrs[1].attname), sizeof(data1), "%s", data1);
 	char		typename1[12] = "CHAROID";
 
 	attrs[1].atttypid = CHAROID;
@@ -378,7 +378,7 @@ test_add_tuple_desc_httpheader(void **state)
 	attrs_ptr[2] = &attrs[2];
 	char		data2[10] = "name2";
 
-	snprintf(NameStr(attrs[2].attname), sizeof(data2), data2);
+	snprintf(NameStr(attrs[2].attname), sizeof(data2), "%s", data2);
 	char		typename2[12] = "TIMEOID";
 
 	attrs[2].atttypid = TIMEOID;
@@ -401,7 +401,7 @@ test_add_tuple_desc_httpheader(void **state)
 	attrs_ptr[3] = &attrs[3];
 	char		data3[10] = "name3";
 
-	snprintf(NameStr(attrs[3].attname), sizeof(data3), data3);
+	snprintf(NameStr(attrs[3].attname), sizeof(data3), "%s", data3);
 	char		typename3[12] = "INTERVALOID";
 
 	attrs[3].atttypid = INTERVALOID;

--- a/src/backend/access/transam/test/xact_test.c
+++ b/src/backend/access/transam/test/xact_test.c
@@ -151,7 +151,7 @@ helper_ExpectLWLock()
 static void
 test_IsCurrentTransactionIdForReader(void **state)
 {
-	PGPROC testProc = {0};
+	PGPROC testProc = {{0}};
 	PGXACT testXAct = {0};
 	LWLock localslotLock;
 

--- a/src/backend/utils/misc/test/pg_mkdir_p_test.c
+++ b/src/backend/utils/misc/test/pg_mkdir_p_test.c
@@ -34,7 +34,8 @@
  *
  *     # wait for them to finish and check for the error
  *     wait
- *     grep 'could not create directory' $testdir/*.log
+ *     cd $testdir
+ *     grep 'could not create directory' *.log
  *
  * The fail rate is not 100% but should be large enough to happen in 5 tries.
  *

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -74,7 +74,7 @@ elog_mock(int passed_elevel, const char *fmt, ...)
 
 	vsnprintf(buf, sizeof(buf), fmt, ap);
 
-	appendStringInfo(&outputBuffer, buf);
+	appendStringInfoString(&outputBuffer, buf);
 
 	elevel = passed_elevel;
 
@@ -98,7 +98,7 @@ write_stderr_mock(const char *fmt, ...)
 
 	vsnprintf(buf, sizeof(buf), fmt, ap);
 
-	appendStringInfo(&outputBuffer, buf);
+	appendStringInfoString(&outputBuffer, buf);
 
 	va_end(ap);
 }
@@ -110,7 +110,7 @@ write_stderr_mock(const char *fmt, ...)
 int
 fwrite_mock(const char *data, Size size, Size count, FILE *file)
 {
-	appendStringInfo(&outputBuffer, data);
+	appendStringInfoString(&outputBuffer, data);
 
 	return count;
 }


### PR DESCRIPTION
When hacking on the extended Travis CI pipeline I noticed that we had a ton of compiler warnings in the unittest code. Normally the compilation flies off the screen very fast due to the very excessive linking, so it sort of requires `make -s` to be visible.

This PR fixes a set of the warnings, not all of them. See individual commit messages for context.