### PR TITLE
Remove lockmode ExclusiveLock upgrade for non-partitioned tables

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1540,7 +1540,8 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
 		 * root table info in resultRelations. Similarly, INSERT plans
 		 * produced by planner only has the root table info as well.
 		 */
-		if (!is_child_partition && (operation == CMD_UPDATE || operation == CMD_DELETE || operation == CMD_INSERT))
+		if ((operation == CMD_UPDATE || operation == CMD_DELETE || operation == CMD_INSERT) &&
+			rel_is_partitioned(relid) && !is_child_partition)
 		{
 			// On QD, the lockmode is RowExclusiveLock
 			Assert(lockmode == RowExclusiveLock);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1505,13 +1505,12 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
 	{
 		List 	*all_relids = NIL;
 		Oid		relid = getrelid(linitial_int(plannedstmt->resultRelations), rangeTable);
-		bool	is_child_partition = false;
+		bool	is_root_table = false;
 
 		if (rel_is_child_partition(relid))
-		{
 			relid = rel_partition_get_master(relid);
-			is_child_partition = true;
-		}
+		else if (rel_is_partitioned(relid))
+			is_root_table = true;
 
 		estate->es_result_partitions = BuildPartitionNodeFromRoot(relid);
 		
@@ -1540,8 +1539,7 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
 		 * root table info in resultRelations. Similarly, INSERT plans
 		 * produced by planner only has the root table info as well.
 		 */
-		if ((operation == CMD_UPDATE || operation == CMD_DELETE || operation == CMD_INSERT) &&
-			rel_is_partitioned(relid) && !is_child_partition)
+		if (is_root_table && (operation == CMD_UPDATE || operation == CMD_DELETE || operation == CMD_INSERT))
 		{
 			// On QD, the lockmode is RowExclusiveLock
 			Assert(lockmode == RowExclusiveLock);

--- a/src/test/isolation2/expected/dml_on_root_locks_all_parts.out
+++ b/src/test/isolation2/expected/dml_on_root_locks_all_parts.out
@@ -90,3 +90,25 @@ t
 COMMIT
 DROP TABLE part_tbl;
 DROP
+
+-- Above scenarios do not affect non-partitioned tables, as there is no
+-- root/child partitions so we should not take ExclusiveLock.
+CREATE TABLE a_table_in_pgclass(a int);
+CREATE
+1: BEGIN;
+BEGIN
+1: SET allow_system_table_mods=DML;
+SET
+1: UPDATE pg_class SET relpages = 42 WHERE oid='a_table_in_pgclass'::regclass::oid;
+UPDATE 1
+
+-- If we had taken a lock on pg_class then subsequent CREATE TABLE statements
+-- would block until lock is released. Check to ensure we do not block.
+CREATE TABLE another_table_in_pgclass(a int);
+CREATE
+1: COMMIT;
+COMMIT
+DROP TABLE a_table_in_pgclass;
+DROP
+DROP TABLE another_table_in_pgclass;
+DROP


### PR DESCRIPTION
Issue is that on UPDATE/DELETE statements we are taking ExclusiveLock
even on non-paritioned tables. Variable is_child_partition was not
enough to distinguish between partitioned/non-partitioned tables. For
that we can use rel_is_partitioned(). This patch also updates to align
closer to 6X_STABLE code.

This issue does not exist on 6X_STABLE as it already uses `rel_is_partitioned()` function.