### PR TITLE
Fix the panic when rollup() meets subplan.

### DIFF
--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -136,6 +136,7 @@ typedef struct GroupExtContext
 
 typedef struct SubqueryScanWalkerContext
 {
+	plan_tree_base_prefix base;
 	SubqueryScan *firstSubqueryScan;
 } SubqueryScanWalkerContext;
 
@@ -227,10 +228,11 @@ subqueryScanWalker(Plan *node,
 }
 
 static SubqueryScan*
-findFirstSubqueryScan(Plan *node)
+findFirstSubqueryScan(PlannerInfo *root, Plan *node)
 {
 	SubqueryScanWalkerContext ctx;
 	ctx.firstSubqueryScan = NULL;
+	ctx.base.node = (Node*)root;
 	subqueryScanWalker(node, &ctx);
 	return ctx.firstSubqueryScan;
 }
@@ -788,7 +790,7 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 			}
 
 			/* update subplan if current_lefttree has been modified */
-			splan = findFirstSubqueryScan(current_lefttree);
+			splan = findFirstSubqueryScan(root, current_lefttree);
 			if (splan != NULL && splan->subplan != root->simple_rel_array[1]->subplan)
 				root->simple_rel_array[1]->subplan = splan->subplan;
 
@@ -2501,7 +2503,7 @@ plan_list_rollup_plans(PlannerInfo *root,
 				root->simple_rte_array[1] != NULL &&
 				root->simple_rte_array[1]->rtekind == RTE_SUBQUERY)
 			{
-				rollup_subplan = findFirstSubqueryScan(rollup_plan);
+				rollup_subplan = findFirstSubqueryScan(root, rollup_plan);
 				list_nth_replace(rollup_subplans, 0, rollup_subplan);
 			}
 		}

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6168,3 +6168,30 @@ select cn,vn,sum(qty) from repeat_node_sale group by grouping sets ((cn,vn), cn,
 
 reset gp_eager_one_phase_agg;
 drop table repeat_node_sale;
+-- GROUPING SETS meets subplan [issue 8342]
+create table foo_gset(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar_gset(b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo_gset select i from generate_series(1,10)i;
+insert into bar_gset select i from generate_series(1,10)i;
+select a, (select b from bar_gset where foo_gset.a = bar_gset.b) from foo_gset group by rollup(a) order by 1,2;
+ a  | b  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+    |   
+(11 rows)
+
+drop table foo_gset;
+drop table bar_gset;

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -673,3 +673,15 @@ select cn,vn,sum(qty) from repeat_node_sale group by grouping sets ((cn,vn), cn,
 reset gp_eager_one_phase_agg;
 
 drop table repeat_node_sale;
+
+-- GROUPING SETS meets subplan [issue 8342]
+create table foo_gset(a int);
+create table bar_gset(b int);
+
+insert into foo_gset select i from generate_series(1,10)i;
+insert into bar_gset select i from generate_series(1,10)i;
+
+select a, (select b from bar_gset where foo_gset.a = bar_gset.b) from foo_gset group by rollup(a) order by 1,2;
+
+drop table foo_gset;
+drop table bar_gset;


### PR DESCRIPTION
For GPDB, to use the general plan tree walker/mutator, structure
plan_tree_base_prefix needs to be prefixed with in the context structure
and initialized appropriately. It is needed by function plan_tree_walker
to recur into the subplan in case of visiting a SubPlan node.

However, context structure SubqueryScanWalkerContext fails to do that.
So when we are trying to recurse through a plan tree to find a subquery
scan node, if there is a subplan there, we will crash.

This patch fixes that. Also it fixes github issue #8342 as well as the
panic in github issue #7279.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
