### PR TITLE
Expand Preamble improvement - #168158510

### DIFF
--- a/gpdb-doc/dita/admin_guide/expand/expand-main.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-main.xml
@@ -4,7 +4,8 @@
 <topic id="topic1" xml:lang="en">
   <title>Expanding a Greenplum System</title>
   <shortdesc>To scale up performance and storage capacity, expand your Greenplum Database system by
-    adding hosts to the system.</shortdesc>
+    adding hosts to the system. In general, adding nodes to a Greenplum cluster achieves a linear scaling 
+    of performance and storage capacity. </shortdesc>
   <body>
     <p>Data warehouses typically grow over time as additional data is gathered and the retention
       periods increase for existing data. At times, it is necessary to increase database capacity to

--- a/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-overview.xml
@@ -4,7 +4,8 @@
 <topic id="topic3" xml:lang="en">
   <title>System Expansion Overview</title>
   <shortdesc>You can perform a Greenplum Database expansion to add segment instances and segment
-    hosts with minimal downtime.</shortdesc>
+    hosts with minimal downtime. In general, adding nodes to a Greenplum cluster achieves a linear scaling 
+    of performance and storage capacity. </shortdesc>
   <body>
     <p>Data warehouses typically grow over time, often at a continuous pace, as additional data is
       gathered and the retention period increases for existing data. At times, it is necessary to


### PR DESCRIPTION
Discussed with Ivan. Main purpose was to highlight "linear" growth, somewhere in the page. 
I felt it was best adding it at the top, where we mention the host addition. It felt out of context in the middle of the second paragraph. Ivan is flexible, as long as it's there.


