### PR TITLE
Change --psqldir to --bindir for gpfdist test in Windows

### DIFF
--- a/src/bin/gpfdist/remote_regress/Makefile
+++ b/src/bin/gpfdist/remote_regress/Makefile
@@ -31,7 +31,7 @@ installcheck_win: pre_installcheck
 	mkdir start_gpfdist_remote
 	cp -rf start_gpfdist_remote_win/* start_gpfdist_remote
 	scp -P ${REMOTE_PORT} start_gpfdist_remote/*.bat  ${REMOTE_USER}@${REMOTE_HOST}:
-	$(top_builddir)/src/test/regress/pg_regress --psqldir=$(PSQLDIR) --dbname=gpfdist_regression $(REGRESS) $(REGRESS_OPTS)
+	$(top_builddir)/src/test/regress/pg_regress --bindir=$(PSQLDIR) --dbname=gpfdist_regression $(REGRESS) $(REGRESS_OPTS)
 
 clean:
 	rm -rf regression.* sql results expected


### PR DESCRIPTION
PG9.5 changed the option '--psqldir' to '--bindir', we need
to let those GPDB specified callers using '--bindir'

This can fix the error in the job `test_gpdb_clients_windows`