### PR TITLE
6X: Avoid duplicated repeat node.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2203,33 +2203,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 											   &agg_costs,
 											   &group_context);
 
-			/* Add the Repeat node if needed. */
-			if (result_plan != NULL &&
-				canonical_grpsets != NULL &&
-				canonical_grpsets->grpset_counts != NULL)
-			{
-				bool		need_repeat_node = false;
-				int			grpset_no;
-				int			repeat_count = 0;
-
-				for (grpset_no = 0; grpset_no < canonical_grpsets->ngrpsets; grpset_no++)
-				{
-					if (canonical_grpsets->grpset_counts[grpset_no] > 1)
-					{
-						need_repeat_node = true;
-						break;
-					}
-				}
-
-				if (canonical_grpsets->ngrpsets == 1)
-					repeat_count = canonical_grpsets->grpset_counts[0];
-
-				if (need_repeat_node)
-				{
-					result_plan = add_repeat_node(result_plan, repeat_count, 0);
-				}
-			}
-
 			if (result_plan != NULL && querynode_changed)
 			{
 				/*

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6116,3 +6116,51 @@ select x, y, count(*), grouping(x,y) from generate_series(1,1) x, generate_serie
  1 |   |     1 |        1
 (1 row)
 
+-- test repeat node
+create table repeat_node_sale
+(
+    cn int not null,
+    vn int not null,
+    pn int not null,
+    dt date not null,
+    qty int not null,
+    prc float not null
+) distributed by (cn,vn,pn);
+insert into repeat_node_sale values
+  ( 2, 40, 100, '1401-1-1', 1100, 2400),
+  ( 1, 10, 200, '1401-3-1', 1, 0),
+  ( 3, 40, 200, '1401-4-1', 1, 0),
+  ( 1, 20, 100, '1401-5-1', 1, 0),
+  ( 1, 30, 300, '1401-5-2', 1, 0),
+  ( 1, 50, 400, '1401-6-1', 1, 0),
+  ( 2, 50, 400, '1401-6-1', 1, 0),
+  ( 1, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 600, '1401-6-1', 12, 5),
+  ( 4, 40, 700, '1401-6-1', 1, 1),
+  ( 4, 40, 800, '1401-6-1', 1, 1);
+set gp_eager_one_phase_agg to on;
+select cn,vn,sum(qty) from repeat_node_sale group by grouping sets ((cn,vn), cn, cn);
+ cn | vn | sum  
+----+----+------
+  1 | 30 |   13
+  1 | 50 |    1
+  1 | 10 |    1
+  3 | 30 |   24
+  2 | 50 |    1
+  2 | 40 | 1100
+  4 |    |    2
+  4 |    |    2
+  3 |    |   25
+  3 |    |   25
+  3 | 40 |    1
+  1 | 20 |    1
+  4 | 40 |    2
+  1 |    |   16
+  1 |    |   16
+  2 |    | 1101
+  2 |    | 1101
+(17 rows)
+
+reset gp_eager_one_phase_agg;
+drop table repeat_node_sale;

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6117,6 +6117,10 @@ select x, y, count(*), grouping(x,y) from generate_series(1,1) x, generate_serie
 (1 row)
 
 -- test repeat node
+-- Greenplum uses repeat node in plan to handle the case
+-- that duplicated groups in grouping sets. we have some
+-- bugs causing duplicated repeat node and wrong result.
+-- Fix it and add some tests.
 create table repeat_node_sale
 (
     cn int not null,

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -638,6 +638,10 @@ select i,n,count(*), grouping(i), grouping(n), grouping(i,n) from test_gsets gro
 select x, y, count(*), grouping(x,y) from generate_series(1,1) x, generate_series(1,1) y group by grouping sets(x,y) having x is not null;
 
 -- test repeat node
+-- Greenplum uses repeat node in plan to handle the case
+-- that duplicated groups in grouping sets. we have some
+-- bugs causing duplicated repeat node and wrong result.
+-- Fix it and add some tests.
 create table repeat_node_sale
 (
     cn int not null,

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -636,3 +636,36 @@ insert into test_gsets values (0, 0), (0, 1), (0,2);
 select i,n,count(*), grouping(i), grouping(n), grouping(i,n) from test_gsets group by grouping sets((), (i,n)) having n is null;
 
 select x, y, count(*), grouping(x,y) from generate_series(1,1) x, generate_series(1,1) y group by grouping sets(x,y) having x is not null;
+
+-- test repeat node
+create table repeat_node_sale
+(
+    cn int not null,
+    vn int not null,
+    pn int not null,
+    dt date not null,
+    qty int not null,
+    prc float not null
+) distributed by (cn,vn,pn);
+
+insert into repeat_node_sale values
+  ( 2, 40, 100, '1401-1-1', 1100, 2400),
+  ( 1, 10, 200, '1401-3-1', 1, 0),
+  ( 3, 40, 200, '1401-4-1', 1, 0),
+  ( 1, 20, 100, '1401-5-1', 1, 0),
+  ( 1, 30, 300, '1401-5-2', 1, 0),
+  ( 1, 50, 400, '1401-6-1', 1, 0),
+  ( 2, 50, 400, '1401-6-1', 1, 0),
+  ( 1, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 600, '1401-6-1', 12, 5),
+  ( 4, 40, 700, '1401-6-1', 1, 1),
+  ( 4, 40, 800, '1401-6-1', 1, 1);
+
+set gp_eager_one_phase_agg to on;
+
+select cn,vn,sum(qty) from repeat_node_sale group by grouping sets ((cn,vn), cn, cn);
+
+reset gp_eager_one_phase_agg;
+
+drop table repeat_node_sale;


### PR DESCRIPTION
Greenplum uses repeat node in plan to handle the case
that duplicated groups in grouping sets. Previously,
we add this node at two places:
  1. make_list_aggs_for_rollup, when is not twostage agg
  2. grouping_planner, when group-by keys are not collocated with dist-keys

But under some contitions, there are code paths that will add duplicated
repeat nodes. For example, when the GUC gp_eager_one_phase_agg is set to on,
, the grouping sets contains duplicated groups and group-by keys are not
collcated with dist-keys. In such case, repeate node is added both in 1 and
2.

This commit fixes the bug by:
  1. removing the code adding repeat node in grouping_planner
  2. let make_one_stage_agg_plan and make_two_stage_agg_plan handle adding
     repeat node

Co-authored-by: Zhenghua Lyu <zlv@pivotal.io>

----------------------

Since 9.5 is pushed into master and it removes the gpdb specific implementation of grouping sets. So this bug only exists in 6X and before.

This fix the issue : https://github.com/greenplum-db/gpdb/issues/8403

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
