### PR TITLE
Don't fix up Flow's hashExpr if it's a non-var in the target list

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -596,12 +596,17 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
     {
         indexed_tlist  *plan_itlist = build_tlist_index(plan->targetlist);
 
-		plan->flow->hashExprs =
-			(List *) fix_upper_expr(root,
+		/* skip the fixup because non-Var could not be matched. */
+		if (!plan_itlist->has_non_vars)
+		{
+			plan->flow->hashExprs =
+				(List *) fix_upper_expr(root,
 									(Node *) plan->flow->hashExprs,
 									plan_itlist,
 									OUTER_VAR,
 									rtoffset);
+		}
+
         pfree(plan_itlist);
     }
 

--- a/src/test/regress/expected/gpdist.out
+++ b/src/test/regress/expected/gpdist.out
@@ -736,3 +736,48 @@ select * from xidtab group by x;
  5
 (5 rows)
 
+--
+-- Use a non-Var entry as the hashExpr and relabel it. In this case the
+-- hashExpr could not refer to the RelabelType entry in the target list.
+-- Test we handled it.
+--
+CREATE TEMPORARY TABLE a (c1 numeric(38,10), c2 character varying(16)) DISTRIBUTED BY (c1);
+CREATE TEMPORARY TABLE b (c3 character varying(16), c4 numeric(22,0)) DISTRIBUTED BY (c3);
+SELECT
+   CASE
+      WHEN
+         a.c2 IS NULL
+      THEN
+         '-1'::text
+      ELSE
+         btrim(a.c2::text)
+   END
+   ::character varying AS foo, 'Undefined'::character varying AS bar
+FROM
+   a
+   LEFT JOIN
+      b
+      ON b.c3::text =
+      CASE
+         WHEN
+            a.c2 IS NULL
+         THEN
+            '-1'::text
+         ELSE
+            btrim(a.c2::text)
+      END
+GROUP BY
+   CASE
+      WHEN
+         a.c2 IS NULL
+      THEN
+         '-1'::text
+      ELSE
+         btrim(a.c2::text)
+   END
+   ::character varying, 'Undefined'::character varying
+;
+ foo | bar 
+-----+-----
+(0 rows)
+

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -744,3 +744,48 @@ select * from xidtab group by x;
  3
 (5 rows)
 
+--
+-- Use a non-Var entry as the hashExpr and relabel it. In this case the
+-- hashExpr could not refer to the RelabelType entry in the target list.
+-- Test we handled it.
+--
+CREATE TEMPORARY TABLE a (c1 numeric(38,10), c2 character varying(16)) DISTRIBUTED BY (c1);
+CREATE TEMPORARY TABLE b (c3 character varying(16), c4 numeric(22,0)) DISTRIBUTED BY (c3);
+SELECT
+   CASE
+      WHEN
+         a.c2 IS NULL
+      THEN
+         '-1'::text
+      ELSE
+         btrim(a.c2::text)
+   END
+   ::character varying AS foo, 'Undefined'::character varying AS bar
+FROM
+   a
+   LEFT JOIN
+      b
+      ON b.c3::text =
+      CASE
+         WHEN
+            a.c2 IS NULL
+         THEN
+            '-1'::text
+         ELSE
+            btrim(a.c2::text)
+      END
+GROUP BY
+   CASE
+      WHEN
+         a.c2 IS NULL
+      THEN
+         '-1'::text
+      ELSE
+         btrim(a.c2::text)
+   END
+   ::character varying, 'Undefined'::character varying
+;
+ foo | bar 
+-----+-----
+(0 rows)
+


### PR DESCRIPTION
If the planner converts a non-Var target entry to the flow node's
hashExpr and relabels it in the target list, then the hashExpr could not
easily refer to the RelabelType entry in the target list. This would
report error "variable not found in subplan target list".

Check the plan's target list and skip the fixup to fix this.

### Not sure if this makes much sense... Drop here first to trigger the PR pipeline 