### PR TITLE
Single set command failed, rollback guc value

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3449,7 +3449,9 @@ AbortTransaction(void)
 
 		AtAbort_TablespaceStorage();
 		AtEOXact_AppendOnly();
+		gp_guc_need_restore = true;
 		AtEOXact_GUC(false, 1);
+		gp_guc_need_restore = false;
 		AtEOXact_SPI(false);
 		AtEOXact_on_commit_actions(false);
 		AtEOXact_Namespace(false, is_parallel_worker);

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5046,6 +5046,11 @@ PostgresMain(int argc, char *argv[],
 		if (ignore_till_sync && firstchar != EOF)
 			continue;
 
+		/* last txn abort, try to synchronize guc to cached QE */
+		if(Gp_role == GP_ROLE_DISPATCH && gp_guc_restore_list)
+			restore_guc_to_QE();
+
+
 		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
 				(errmsg_internal("First char: '%c'; gp_role = '%s'.", firstchar, role_to_string(Gp_role))));
 
@@ -5073,13 +5078,7 @@ PostgresMain(int argc, char *argv[],
 					else if (IsFaultHandler)
 						HandleFaultMessage(query_string);
 					else
-					{
-						/* last txn abort, try to synchronize guc to cached QE */
-						if(Gp_role == GP_ROLE_DISPATCH && gp_guc_restore_list)
-							restore_guc_to_QE();
-
 						exec_simple_query(query_string);
-					}
 
 					send_ready_for_query = true;
 				}

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -255,6 +255,10 @@ typedef enum
 extern List    *gp_guc_list_for_explain;
 extern List    *gp_guc_list_for_no_plan;
 
+/* Changed GUC which need to be pass to QE from QD */
+extern List *gp_guc_restore_list;
+extern bool gp_guc_need_restore;
+
 /* GUC vars that are actually declared in guc.c, rather than elsewhere */
 extern bool log_duration;
 extern bool Debug_print_plan;
@@ -807,5 +811,6 @@ extern bool gpvars_check_statement_mem(int *newval, void **extra, GucSource sour
 extern bool gpvars_check_gp_enable_gpperfmon(bool *newval, void **extra, GucSource source);
 extern bool gpvars_check_gp_gpperfmon_send_interval(int *newval, void **extra, GucSource source);
 extern int guc_name_compare(const char *namea, const char *nameb);
+extern void DispatchSyncPGVariable(struct config_generic * gconfig);
 
 #endif   /* GUC_H */

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -167,16 +167,6 @@ BEGIN TRANSACTION ISOLATION LEVEL serializable;
 COMMIT;
 DROP TABLE test_serializable;
 -- Test single query guc rollback
-CREATE FUNCTION t() RETURNS text
-AS $$
-DECLARE
-c TEXT;
-BEGIN
-EXECUTE 'show datestyle;' INTO c;
-RETURN c;
-END;
-$$
-language plpgsql;
 set allow_segment_DML to on;
 set datestyle='german';
 select gp_inject_fault('set_variable_fault', 'error', dbid)
@@ -187,7 +177,23 @@ from gp_segment_configuration where content=0 and role='p';
 (1 row)
 
 set datestyle='sql, mdy';
-ERROR:  fault triggered, fault name:'set_variable_fault' fault type:'error'  (seg0 10.34.49.105:25432 pid=84455)
+ERROR:  fault triggered, fault name:'set_variable_fault' fault type:'error'  (seg0 10.34.58.103:25432 pid=31389)
+-- after guc set failed, before next query handle, qd will sync guc
+-- to qe. using `select 1` trigger guc reset.
+select 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+select current_setting('datestyle') from gp_dist_random('gp_id');
+ current_setting 
+-----------------
+ German, DMY
+ German, DMY
+ German, DMY
+(3 rows)
+
 select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
  gp_inject_fault 
 -----------------
@@ -201,13 +207,4 @@ select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
  Success:
 (8 rows)
 
-select t() from gp_dist_random('gp_id');
-      t      
--------------
- German, DMY
- German, DMY
- German, DMY
-(3 rows)
-
 set allow_segment_DML to off;
-DROP FUNCTION t();

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -166,3 +166,48 @@ BEGIN TRANSACTION ISOLATION LEVEL serializable;
 
 COMMIT;
 DROP TABLE test_serializable;
+-- Test single query guc rollback
+CREATE FUNCTION t() RETURNS text
+AS $$
+DECLARE
+c TEXT;
+BEGIN
+EXECUTE 'show datestyle;' INTO c;
+RETURN c;
+END;
+$$
+language plpgsql;
+set allow_segment_DML to on;
+set datestyle='german';
+select gp_inject_fault('set_variable_fault', 'error', dbid)
+from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+set datestyle='sql, mdy';
+ERROR:  fault triggered, fault name:'set_variable_fault' fault type:'error'  (seg0 10.34.49.105:25432 pid=84455)
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
+select t() from gp_dist_random('gp_id');
+      t      
+-------------
+ German, DMY
+ German, DMY
+ German, DMY
+(3 rows)
+
+set allow_segment_DML to off;
+DROP FUNCTION t();


### PR DESCRIPTION
In gpdb, guc set flow is that:
	1. QD set guc
	2. QD dispatch job to all QE
	3. QE set guc

For single set command, in gpdb, it is not 2pc safe. If the `set command`
failed in QE, only QD guc value can rollback. For the guc which has
**GUC_GPDB_NEED_SYNC** flag, it requires guc value is same in whole session-level.

To deal with it, record rollback guc in AbortTransaction to a restore
guc list. Re-set this guc when next query coming.
However, if it failed again, destroy all QE, since we can not have the same
value in that session. Hopefully, guc value can synchronize success in
later creategang stage using `-c` command.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
