### PR TITLE
Consider predicate of type <cast(ident)> array cmp <const array>

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.66.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.67.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.66.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.67.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.66.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.67.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.66.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.67.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.66.0@gpdb/stable
+orca/v3.67.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.66.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.67.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11136,3 +11136,53 @@ SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_p
 (1 row)
  
 RESET optimizer_enforce_subplans;
+-- implied predicate must be generated for the type cast(ident) scalar array cmp const array
+CREATE TABLE varchar_sc_array_cmp(a varchar);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO varchar_sc_array_cmp VALUES ('a'), ('b'), ('c'), ('d');
+EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and t1.a in ('b', 'c');
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=3.07..6.17 rows=4 width=4)
+   ->  Hash Join  (cost=3.07..6.17 rows=2 width=4)
+         Hash Cond: ((t1.a)::text = (t2.a)::text)
+         ->  Seq Scan on varchar_sc_array_cmp t1  (cost=0.00..3.05 rows=1 width=2)
+               Filter: ((a)::text = ANY ('{b,c}'::text[]))
+         ->  Hash  (cost=3.05..3.05 rows=1 width=2)
+               ->  Seq Scan on varchar_sc_array_cmp t2  (cost=0.00..3.05 rows=1 width=2)
+                     Filter: ((a)::text = ANY ('{b,c}'::text[]))
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and t1.a in ('b', 'c');
+ a | a 
+---+---
+ c | c
+ b | b
+(2 rows)
+
+SET optimizer_array_constraints=on;
+EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.09..6.18 rows=4 width=4)
+   ->  Hash Join  (cost=3.09..6.18 rows=2 width=4)
+         Hash Cond: ((t2.a)::text = (t1.a)::text)
+         ->  Seq Scan on varchar_sc_array_cmp t2  (cost=0.00..3.04 rows=2 width=2)
+         ->  Hash  (cost=3.06..3.06 rows=1 width=2)
+               ->  Seq Scan on varchar_sc_array_cmp t1  (cost=0.00..3.06 rows=1 width=2)
+                     Filter: (((a)::text = ANY ('{b,c}'::text[])) OR ((a)::text = 'a'::text))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
+ a | a 
+---+---
+ b | b
+ a | a
+ c | c
+(3 rows)
+
+DROP TABLE varchar_sc_array_cmp;
+--

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11203,3 +11203,154 @@ SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_p
 (1 row)
  
 RESET optimizer_enforce_subplans;
+-- implied predicate must be generated for the type cast(ident) scalar array cmp const array
+CREATE TABLE varchar_sc_array_cmp(a varchar);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO varchar_sc_array_cmp VALUES ('a'), ('b'), ('c'), ('d');
+EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and t1.a in ('b', 'c');
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: orca.varchar_sc_array_cmp.a::text = orca.varchar_sc_array_cmp.a::text
+         ->  Table Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=2)
+               Filter: (a::text = ANY ('{b,c}'::text[])) AND (a::text = 'b'::text OR a::text = 'c'::text)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=2)
+               ->  Table Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=2)
+                     Filter: a::text = 'b'::text OR a::text = 'c'::text
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 3.67.0
+(10 rows)
+
+SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and t1.a in ('b', 'c');
+ a | a 
+---+---
+ b | b
+ c | c
+(2 rows)
+
+SET optimizer_array_constraints=on;
+EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: orca.varchar_sc_array_cmp.a::text = orca.varchar_sc_array_cmp.a::text
+         ->  Table Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=2)
+               Filter: a = ANY ('{a,b,c}'::character varying[])
+         ->  Hash  (cost=431.00..431.00 rows=1 width=2)
+               ->  Table Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=2)
+                     Filter: a = ANY ('{a,b,c}'::character varying[])
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 3.67.0
+(10 rows)
+
+SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
+ a | a 
+---+---
+ a | a
+ c | c
+ b | b
+(3 rows)
+
+DROP TABLE varchar_sc_array_cmp;
+-- 
+-- start_ignore
+DROP SCHEMA orca CASCADE;
+NOTICE:  drop cascades to 92 other objects
+DETAIL:  drop cascades to table bar1
+drop cascades to table bar2
+drop cascades to table r
+drop cascades to table s
+drop cascades to table m
+drop cascades to table m1
+drop cascades to table rcte
+drop cascades to table onek
+drop cascades to table pp
+drop cascades to table multilevel_p
+drop cascades to table t
+drop cascades to table t_date
+drop cascades to table t_text
+drop cascades to type employee
+drop cascades to function emp_equal(employee,employee)
+drop cascades to operator =(employee,employee)
+drop cascades to operator family employee_op_class for access method btree
+drop cascades to table t_employee
+drop cascades to table t_ceeval_ints
+drop cascades to function csq_f(integer)
+drop cascades to table csq_r
+drop cascades to table fooh1
+drop cascades to table fooh2
+drop cascades to append only table t77
+drop cascades to table prod9
+drop cascades to table toanalyze
+drop cascades to table ur
+drop cascades to table us
+drop cascades to table ut
+drop cascades to table uu
+drop cascades to table twf1
+drop cascades to table twf2
+drop cascades to table tab1
+drop cascades to table tab2
+drop cascades to function sum_sfunc(anyelement,anyelement)
+drop cascades to function sum_combinefunc(anyelement,anyelement)
+drop cascades to function myagg1(anyelement)
+drop cascades to function sum_sfunc2(anyelement,anyelement,anyelement)
+drop cascades to function myagg2(anyelement,anyelement)
+drop cascades to function gptfp(anyarray,anyelement)
+drop cascades to function gpffp(anyarray)
+drop cascades to function myagg3(anyelement)
+drop cascades to table array_table
+drop cascades to table mpp22453
+drop cascades to table mpp22791
+drop cascades to table p1
+drop cascades to append only table tmp_verd_s_pp_provtabs_agt_0015_extract1
+drop cascades to table arrtest
+drop cascades to table foo_missing_stats
+drop cascades to table bar_missing_stats
+drop cascades to table cust
+drop cascades to table datedim
+drop cascades to table sales
+drop cascades to function plusone(integer)
+drop cascades to table bm_test
+drop cascades to table bm_dyn_test
+drop cascades to table bm_dyn_test_onepart
+drop cascades to table my_tt_agg_opt
+drop cascades to table my_tq_agg_opt_part
+drop cascades to function plusone(numeric)
+drop cascades to table ggg
+drop cascades to table t3
+drop cascades to table index_test
+drop cascades to table btree_test
+drop cascades to table bitmap_test
+drop cascades to type rainbow
+drop cascades to table foo
+drop cascades to table foo_ctas
+drop cascades to table input_tab1
+drop cascades to table input_tab2
+drop cascades to table tab_1
+drop cascades to table tab_2
+drop cascades to table tab_3
+drop cascades to table t_outer
+drop cascades to table t_inner
+drop cascades to table test1
+drop cascades to table t_new
+drop cascades to table x_tab
+drop cascades to table y_tab
+drop cascades to table z_tab
+drop cascades to function test_func_pg_stats()
+drop cascades to table bar
+drop cascades to type myint
+drop cascades to function myintout(myint)
+drop cascades to function myintin(cstring)
+drop cascades to function myint_int8(myint)
+drop cascades to table csq_cast_param_outer
+drop cascades to table csq_cast_param_inner
+drop cascades to function myint_numeric(myint)
+drop cascades to cast from myint to numeric
+drop cascades to table onetimefilter1
+drop cascades to table onetimefilter2
+drop cascades to table ffoo
+drop cascades to table fbar
+-- end_ignore

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1799,6 +1799,17 @@ CREATE INDEX ds_idx ON ds_part(a);
 analyze ds_part;
 SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
 RESET optimizer_enforce_subplans;
+-- implied predicate must be generated for the type cast(ident) scalar array cmp const array
+CREATE TABLE varchar_sc_array_cmp(a varchar);
+INSERT INTO varchar_sc_array_cmp VALUES ('a'), ('b'), ('c'), ('d');
+EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and t1.a in ('b', 'c');
+SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and t1.a in ('b', 'c');
+SET optimizer_array_constraints=on;
+EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
+SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
+DROP TABLE varchar_sc_array_cmp;
+-- 
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
While processing constraint interval, also consider predicate of type
<cast(ident)> array cmp else we lose the opportunity
to generate implied quals. This is corresponding to the ORCA changes.

ORCA PR: greenplum-db/gporca#522

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
