### PR TITLE
Remove unused variables from unittests

### DIFF
--- a/src/backend/cdb/test/cdbappendonlyxlog_test.c
+++ b/src/backend/cdb/test/cdbappendonlyxlog_test.c
@@ -32,7 +32,6 @@ ao_invalid_segment_file_test(uint8 xl_info)
 	xl_ao_target xlaotarget;
 	xl_ao_insert xlaoinsert;
 	xl_ao_truncate xlaotruncate;
-	char *buffer = NULL;
 
 	/* create mock transaction log */
 	relfilenode.spcNode = DEFAULTTABLESPACE_OID;

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -928,9 +928,6 @@ test__MemoryAccounting_CombinedAccountArrayToExplain__Validate(void **state)
 
 	MemoryAccounting_CombinedAccountArrayToExplain(serializedBytes.data, totalSerialized, es);
 
-	size_t newTopBalance = topAccount->allocated - topAccount->freed;
-	size_t newTopPeak = topAccount->peak;
-
 	assert_true(strcmp(es->str->data, buf) == 0);
 
     pfree(serializedBytes.data);


### PR DESCRIPTION
These variables were never used and caused (harmless) compiler warnings so remove to clean up the build.