### PR TITLE
docs - SERVER is required when using pxf to access an object store

### DIFF
--- a/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
@@ -59,6 +59,8 @@ You provide the profile name when you specify the `pxf` protocol on a `CREATE EX
 
 ## <a id="sample_ddl"></a>Sample CREATE EXTERNAL TABLE Commands
 
+<div class="note">When you create an external table that references a file or directory in an object store, you must specify a `SERVER` in the `LOCATION` URI.</div>
+
 The following command creates an external table that references a text file on S3. It specifies the profile named `s3:text` and the server configuration named `s3srvcfg`:
 
 <pre>

--- a/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_objstore.html.md.erb
@@ -59,7 +59,7 @@ You provide the profile name when you specify the `pxf` protocol on a `CREATE EX
 
 ## <a id="sample_ddl"></a>Sample CREATE EXTERNAL TABLE Commands
 
-<div class="note">When you create an external table that references a file or directory in an object store, you must specify a `SERVER` in the `LOCATION` URI.</div>
+<div class="note">When you create an external table that references a file or directory in an object store, you must specify a <code>SERVER</code> in the <code>LOCATION</code> URI.</div>
 
 The following command creates an external table that references a text file on S3. It specifies the profile named `s3:text` and the server configuration named `s3srvcfg`:
 

--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -51,7 +51,7 @@ PXF may require additional information to read or write certain data formats. Yo
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | \<path&#8209;to&#8209;data\>        | A directory, file name, wildcard pattern, table name, etc. The syntax of \<path-to-data\> is dependent upon the external data source.                                                                                                                                                                                                                    |
 | PROFILE=\<profile_name\>  | The profile that PXF uses to access the data. PXF supports profiles that access text, Avro, JSON, RCFile, Parquet, SequenceFile, and ORC data in [Hadoop services](access_hdfs.html), [object stores](access_objstore.html), and [other SQL databases](jdbc_pxf.html).  |
-| SERVER=\<server_name\>   | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| SERVER=\<server_name\>   | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
 | \<custom&#8209;option\>=\<value\> | Additional options and their values supported by the profile or the server. |
 | FORMAT&nbsp;\<value\>| PXF profiles support the `TEXT`, `CSV`, and `CUSTOM` formats.  |
 | \<formatting&#8209;properties\> | Formatting properties supported by the profile; for example, the `FORMATTER` or `delimiter`.                                                                   |

--- a/gpdb-doc/markdown/pxf/objstore_avro.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_avro.html.md.erb
@@ -51,7 +51,7 @@ The following syntax creates a Greenplum Database readable external table that r
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:avro[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:avro&SERVER=<server_name>[&<custom-option>=<value>[...]]')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 ```
 
@@ -61,7 +61,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;file\>    | The absolute path to the directory or file in the object store. |
 | PROFILE=\<objstore\>:avro    | The `PROFILE` keyword must identify the specific object store. For example, `s3:avro`. |
-| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\> | Avro-specific custom options are described in the [PXF HDFS Avro documentation](hdfs_avro.html#customopts). |
 | FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `<objstore>:avro` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
 

--- a/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
@@ -29,7 +29,7 @@ The following syntax creates a Greenplum Database readable external table that r
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> text|json | LIKE <other_table> )
-  LOCATION ('pxf://<path-to-files>?PROFILE=<objstore>:text:multi[&SERVER=<server_name>]&FILE_AS_ROW=true')
+  LOCATION ('pxf://<path-to-files>?PROFILE=<objstore>:text:multi&SERVER=<server_name>&FILE_AS_ROW=true')
   FORMAT 'CSV');
 ```
 
@@ -39,7 +39,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;files\>    | The absolute path to the directory or files in the object store. |
 | PROFILE=\<objstore\>:text:multi    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text:multi`. |
-| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | FILE\_AS\_ROW=true    | The required option that instructs PXF to read each file into a single table row. |
 | FORMAT | The `FORMAT` must specify `'CSV'`.  |
 

--- a/gpdb-doc/markdown/pxf/objstore_json.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_json.html.md.erb
@@ -50,7 +50,7 @@ The following syntax creates a Greenplum Database readable external table that r
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:json[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:json&SERVER=<server_name>[&<custom-option>=<value>[...]]')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 ```
 
@@ -60,7 +60,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;file\>    | The absolute path to the directory or file in the object store. |
 | PROFILE=\<objstore\>:json    | The `PROFILE` keyword must identify the specific object store. For example, `s3:json`. |
-| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\> | JSON supports the custom option named `IDENTIFIER` as described in the [PXF HDFS JSON documentation](hdfs_json.html#customopts). |
 | FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `<objstore>:json` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
 

--- a/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
@@ -55,7 +55,7 @@ Use the following syntax to create a Greenplum Database external table that refe
 CREATE [WRITABLE] EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<path-to-dir>
-    ?PROFILE=<objstore>:parquet[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+    ?PROFILE=<objstore>:parquet&SERVER=<server_name>[&<custom-option>=<value>[...]]')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import'|'pxfwritable_export');
 [DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
 ```
@@ -66,7 +66,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;dir\>    | The absolute path to the directory in the object store. |
 | PROFILE=\<objstore\>:parquet    | The `PROFILE` keyword must identify the specific object store. For example, `s3:parquet`. |
-| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\> | Parquet-specific custom write options are described in the [PXF HDFS Parquet documentation](hdfs_parquet.html#customopts). |
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
 | DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |

--- a/gpdb-doc/markdown/pxf/objstore_seqfile.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_seqfile.html.md.erb
@@ -48,7 +48,7 @@ Use the following syntax to create a Greenplum Database external table that refe
 CREATE [WRITABLE] EXTERNAL TABLE <table_name> 
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<path-to-dir>
-    ?PROFILE=<objstore>:SequenceFile[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+    ?PROFILE=<objstore>:SequenceFile&SERVER=<server_name>[&<custom-option>=<value>[...]]')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import'|'pxfwritable_export')
 [DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
 ```
@@ -59,7 +59,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;dir\>    | The absolute path to the directory in the object store. |
 | PROFILE=\<objstore\>:SequenceFile    | The `PROFILE` keyword must identify the specific object store. For example, `s3:SequenceFile`. |
-| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\> | SequenceFile-specific custom options are described in the [PXF HDFS SequenceFile documentation](hdfs_seqfile.html#customopts). |
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
 | DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |

--- a/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
@@ -46,7 +46,7 @@ The following syntax creates a Greenplum Database readable external table that r
 ``` sql
 CREATE EXTERNAL TABLE <table_name> 
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text&SERVER=<server_name>[&<custom-option>=<value>[...]]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 ```
 
@@ -56,7 +56,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;file\>    | The absolute path to the directory or file in the S3 object store. |
 | PROFILE=\<objstore\>:text    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text`. |
-| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'`  when \<path-to-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 
@@ -153,7 +153,7 @@ Use the `<objstore>:text:multi` profile to read plain text data with delimited s
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text:multi[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text:multi&SERVER=<server_name>[&<custom-option>=<value>[...]]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 ```
 
@@ -163,7 +163,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;file\>    | The absolute path to the directory or file in the S3 data store. |
 | PROFILE=\<objstore\>:text:multi    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text:multi`. |
-| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'` when \<path-to-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 
@@ -252,7 +252,7 @@ Use the following syntax to create a Greenplum Database writable external table 
 CREATE WRITABLE EXTERNAL TABLE <table_name> 
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<path-to-dir>
-    ?PROFILE=<objstore>:text[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+    ?PROFILE=<objstore>:text&SERVER=<server_name>[&<custom-option>=<value>[...]]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 [DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
 ```
@@ -263,7 +263,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;dir\>    | The absolute path to the directory in the S3 data store. |
 | PROFILE=\<objstore\>:text    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text`. |
-| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\>  | \<custom-option\>s are described below.|
 | FORMAT | Use `FORMAT` `'TEXT'` to write plain, delimited text to \<path-to-dir\>.<br> Use `FORMAT` `'CSV'` to write comma-separated value text to \<path-to-dir\>. |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |

--- a/gpdb-doc/markdown/pxf/read_s3_s3select.html.md.erb
+++ b/gpdb-doc/markdown/pxf/read_s3_s3select.html.md.erb
@@ -55,7 +55,7 @@ Use the following syntax to create a Greenplum Database external table that refe
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-  LOCATION ('pxf://<path-to-file>?PROFILE=s3:parquet[&SERVER=<server_name>]&S3_SELECT=ON|AUTO[&<other-custom-option>=<value>[...]]')
+  LOCATION ('pxf://<path-to-file>?PROFILE=s3:parquet&SERVER=<server_name>&S3_SELECT=ON|AUTO[&<other-custom-option>=<value>[...]]')
 FORMAT 'CSV';
 ```
 
@@ -113,7 +113,7 @@ Use the following syntax to create a Greenplum Database external table that refe
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<path-to-file>
-    ?PROFILE=s3:text[&SERVER=<server_name>]&S3_SELECT=ON|AUTO[&FILE_HEADER=IGNORE|USE][&COMPRESSION_CODEC=gzip|bzip2][&<other-custom-option>=<value>[...]]')
+    ?PROFILE=s3:text&SERVER=<server_name>&S3_SELECT=ON|AUTO[&FILE_HEADER=IGNORE|USE][&COMPRESSION_CODEC=gzip|bzip2][&<other-custom-option>=<value>[...]]')
 FORMAT 'CSV' [(delimiter '<delim_char>')];
 ```
 


### PR DESCRIPTION
in this PR:
- removed optionality of SERVER from all object store topics.
- add a note in object store intro that SERVER is required

all object store CREATE EXTERNAL TABLE examples already specified a SERVER option, so no updates required there.

i retained the optionality of SERVER in the hadoop topics, since the default server was originally Hadoop, and must be Hadoop if it is kerberized.

question - should this PR be backported to 5X_STABLE?

