### PR TITLE
Add debugging utilities for trace "cached plan must not change result type"

### DIFF
--- a/src/backend/access/common/tupdesc.c
+++ b/src/backend/access/common/tupdesc.c
@@ -429,6 +429,71 @@ equalTupleDescs(TupleDesc tupdesc1, TupleDesc tupdesc2, bool strict)
 	return true;
 }
 
+void
+printTupleDescs(TupleDesc tupdesc)
+{
+	int			i,
+			n;
+
+	if (tupdesc == NULL)
+	{
+		elog(WARNING, "TupleDesc is NULL");
+		return;
+	}
+
+	StringInfoData buf;
+	initStringInfo(&buf);
+
+	appendStringInfo(&buf, "tupdesc->natts: %d, ", tupdesc->natts);
+	appendStringInfo(&buf, "tupdesc->tdtypeid: %u, ", tupdesc->tdtypeid);
+	appendStringInfo(&buf, "tupdesc->tdhasoid: %d, ", tupdesc->tdhasoid);
+
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		Form_pg_attribute attr = tupdesc->attrs[i];
+
+		appendStringInfo(&buf, "attr->attrelid: %u, ", attr->attrelid);
+		appendStringInfo(&buf, "attr->attname: %s, ", NameStr(attr->attname));
+		appendStringInfo(&buf, "attr->atttypid: %u, ", attr->atttypid);
+		appendStringInfo(&buf, "attr->attstattarget: %d, ", attr->attstattarget);
+		appendStringInfo(&buf, "attr->attlen: %d, ", attr->attlen);
+		appendStringInfo(&buf, "attr->attndims: %d, ", attr->attndims);
+		appendStringInfo(&buf, "attr->atttypmod: %d, ", attr->atttypmod);
+		appendStringInfo(&buf, "attr->attbyval: %d, ", attr->attbyval);
+		appendStringInfo(&buf, "attr->attstorage: %c, ", attr->attstorage);
+		appendStringInfo(&buf, "attr->attalign: %c, ", attr->attalign);
+		appendStringInfo(&buf, "attr->attnotnull: %d, ", attr->attnotnull);
+		appendStringInfo(&buf, "attr->atthasdef: %d, ", attr->atthasdef);
+		appendStringInfo(&buf, "attr->attisdropped: %d, ", attr->attisdropped);
+		appendStringInfo(&buf, "attr->attislocal: %d, ", attr->attislocal);
+		appendStringInfo(&buf, "attr->attinhcount: %d, ", attr->attinhcount);
+	}
+
+	if (tupdesc->constr != NULL)
+	{
+		TupleConstr *constr = tupdesc->constr;
+		appendStringInfo(&buf, "constr->has_not_null: %d, ", constr->has_not_null);
+		appendStringInfo(&buf, "constr->num_defval: %d, ", constr->num_defval);
+		n = constr->num_defval;
+		for (i = 0; i < n; i++)
+		{
+			AttrDefault *defval = constr->defval + i;
+			appendStringInfo(&buf, "defval->adnum: %d, ", defval->adnum);
+			appendStringInfo(&buf, "defval->adbin: %s, ", defval->adbin);
+		}
+		n = constr->num_check;
+		appendStringInfo(&buf, "constr->num_check: %d, ", constr->num_check);
+		for (i = 0; i < n; i++)
+		{
+			ConstrCheck *check = constr->check + i;
+			appendStringInfo(&buf, "check->ccname: %s, ", check->ccname);
+			appendStringInfo(&buf, "check->ccbin: %s, ", check->ccbin);
+		}
+	}
+
+	elog(WARNING, "TupleDesc %s ", buf.data);
+	pfree(buf.data);
+}
 /*
  * TupleDescInitEntry
  *		This function initializes a single attribute structure in

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -4296,10 +4296,9 @@ is_log_level_output(int elevel, int log_min_level)
  * elog_debug_linger
  */
 void
-elog_debug_linger(ErrorData *edata)
-{
-	int			seconds_to_linger = gp_debug_linger;
-	int			seconds_lingered = 0;
+elog_debug_linger(ErrorData *edata) {
+	int seconds_to_linger = gp_debug_linger;
+	int seconds_lingered = 0;
 
 	/* Don't linger again in the event of another error. */
 	gp_debug_linger = 0;
@@ -4320,6 +4319,14 @@ elog_debug_linger(ErrorData *edata)
 	/* Terminate the client connection. */
 	pq_comm_close_fatal();
 
+	debug_linger(seconds_to_linger, "error exit in");
+}
+
+void
+debug_linger(int seconds_to_linger, char *ps_msg)
+{
+	int			seconds_lingered = 0;
+
 	while (seconds_lingered < seconds_to_linger)
 	{
 		int			seconds_left = seconds_to_linger - seconds_lingered;
@@ -4332,7 +4339,8 @@ elog_debug_linger(ErrorData *edata)
 
 		/* Update 'ps' display. */
 		snprintf(buf, sizeof(buf)-1,
-				 "error exit in %dm %ds",
+				 "%s %dm %ds",
+				 ps_msg,
 				 minutes_left,
 				 seconds_left - minutes_left * 60);
 		set_ps_display(buf, true);

--- a/src/include/access/tupdesc.h
+++ b/src/include/access/tupdesc.h
@@ -121,6 +121,7 @@ extern void DecrTupleDescRefCount(TupleDesc tupdesc);
 	} while (0)
 
 extern bool equalTupleDescs(TupleDesc tupdesc1, TupleDesc tupdesc2, bool strict);
+extern void printTupleDescs(TupleDesc tupdesc);
 
 extern void TupleDescInitEntry(TupleDesc desc,
 				   AttrNumber attributeNumber,

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -221,6 +221,7 @@ extern int	errcode_for_socket_access(void);
 
 extern int sqlstate_to_errcode(const char *sqlstate);
 extern char *errcode_to_sqlstate(int errcode, char outbuf[6]);
+extern void debug_linger(int seconds_to_linger, char *ps_msg);
 
 extern int
 errmsg(const char *fmt,...)


### PR DESCRIPTION
Note: This is targeted on top of 5.20.1 and will not be merged in 5X_STABLE.

This commit is to add some debugging utilites to assist in
troubleshooting the error "cached plan must not change result type"

1. Add Method to print the tupledesc
2. Add Method to allow the process to be halted so that we can attach it
via gdb. Set the value of gp_debug_linger to desired sleep time, once we
hit the issue, the system will be sleeping at that stage so that we can
debug the state of the variables etc.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
