### PR TITLE
Port from 5X_STABLE: aee8cac

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -461,23 +461,15 @@ AOCSDrop(Relation aorel,
 		}
 
 		/*
-		 * Try to get the transaction write-lock for the Append-Only segment
-		 * file.
+		 * Get the transaction write-lock for the Append-Only segment file.
 		 *
 		 * NOTE: This is a transaction scope lock that must be held until
 		 * commit / abort.
 		 */
-		acquireResult = LockRelationAppendOnlySegmentFile(
-														  &aorel->rd_node,
-														  segfile_array[i]->segno,
-														  AccessExclusiveLock,
-														   /* dontWait */ true);
-		if (acquireResult == LOCKACQUIRE_NOT_AVAIL)
-		{
-			elog(DEBUG5, "drop skips AOCS segfile %d, "
-				 "relation %s", segfile_array[i]->segno, relname);
-			continue;
-		}
+		LockRelationAppendOnlySegmentFile(&aorel->rd_node,
+										  segfile_array[i]->segno,
+										  AccessExclusiveLock,
+										  /* dontWait */ false);
 
 		/* Re-fetch under the write lock to get latest committed eof. */
 		fsinfo = GetAOCSFileSegInfo(aorel, appendOnlyMetaDataSnapshot, segno);

--- a/src/test/isolation2/expected/vacuum_drop_phase_ao.out
+++ b/src/test/isolation2/expected/vacuum_drop_phase_ao.out
@@ -1,0 +1,77 @@
+-- @Description Assert that QEs don't skip a vacuum drop phase (unless we have
+-- an abort) and thus guarantees that seg file states are consistent across QD/QE.
+
+-- Given we have an AO table
+1: CREATE TABLE ao_test_drop_phase (a INT, b INT) WITH (appendonly=true);
+CREATE
+-- And the AO table has all tuples on primary with content = 0
+1: INSERT INTO ao_test_drop_phase SELECT 2,i from generate_series(1, 5)i;
+INSERT 5
+
+-- We should see 1 pg_aoseg catalog table tuple in state 1 (AVAILABLE) for
+-- segno = 1
+0U: SELECT * FROM gp_toolkit.__gp_aoseg('ao_test_drop_phase');
+ segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+-------+-----+----------+---------------+------------------+----------+---------------+-------
+ 1     | 128 | 5        | 1             | 128              | 1        | 3             | 1     
+(1 row)
+
+-- And with a utility mode session on the primary with content = 0, we simulate
+-- an access shared lock that would exist on the QE but not on the QD.
+0U: BEGIN;
+BEGIN
+0U: SELECT COUNT(*) FROM ao_test_drop_phase;
+ count 
+-------
+ 5     
+(1 row)
+
+-- And we delete 4/5 rows to trigger vacuum's compaction phase.
+1: DELETE FROM ao_test_drop_phase where b != 5;
+DELETE 4
+-- We should see that VACUUM blocks while the QE holds the access shared lock
+1&: VACUUM ao_test_drop_phase;  <waiting ...>
+
+0U: END;
+END
+1<:  <... completed>
+VACUUM
+
+-- We should see that the one visible tuple left after the DELETE gets compacted
+-- from segno = 1 to segno = 2.
+-- Also, segno = 1 should be empty and in state 1 (AVAILABLE)
+0U: SELECT * FROM gp_toolkit.__gp_aoseg('ao_test_drop_phase');
+ segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+-------+-----+----------+---------------+------------------+----------+---------------+-------
+ 1     | 0   | 0        | 0             | 0                | 1        | 3             | 1     
+ 2     | 40  | 1        | 1             | 40               | 1        | 3             | 1     
+(2 rows)
+
+-- We should see that the QD's hash table matches content = 0's pg_aoseg catalog
+1: SELECT segno, total_tupcount, state FROM gp_toolkit.__gp_get_ao_entry_from_cache('ao_test_drop_phase'::regclass::oid) WHERE segno IN (1, 2);
+ segno | total_tupcount | state 
+-------+----------------+-------
+ 1     | 0              | 1     
+ 2     | 1              | 1     
+(2 rows)
+
+-- We should see that a subsequent insert succeeds and lands on segno = 1
+1: INSERT INTO ao_test_drop_phase SELECT 2,i from generate_series(11, 15)i;
+INSERT 5
+0U: SELECT * FROM gp_toolkit.__gp_aoseg('ao_test_drop_phase');
+ segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+-------+-----+----------+---------------+------------------+----------+---------------+-------
+ 1     | 128 | 5        | 1             | 128              | 2        | 3             | 1     
+ 2     | 40  | 1        | 1             | 40               | 1        | 3             | 1     
+(2 rows)
+
+1: SELECT * FROM ao_test_drop_phase;
+ a | b  
+---+----
+ 2 | 11 
+ 2 | 12 
+ 2 | 13 
+ 2 | 14 
+ 2 | 15 
+ 2 | 5  
+(6 rows)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -43,7 +43,7 @@ test: gdd/end
 # concurrent test, so run the test by itself.
 test: deadlock_under_entry_db_singleton
 
-test: pg_terminate_backend starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc
+test: pg_terminate_backend starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc vacuum_drop_phase_ao
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/sql/vacuum_drop_phase_ao.sql
+++ b/src/test/isolation2/sql/vacuum_drop_phase_ao.sql
@@ -1,0 +1,40 @@
+-- @Description Assert that QEs don't skip a vacuum drop phase (unless we have
+-- an abort) and thus guarantees that seg file states are consistent across QD/QE.
+
+-- Given we have an AO table
+1: CREATE TABLE ao_test_drop_phase (a INT, b INT) WITH (appendonly=true);
+-- And the AO table has all tuples on primary with content = 0
+1: INSERT INTO ao_test_drop_phase SELECT 2,i from generate_series(1, 5)i;
+
+-- We should see 1 pg_aoseg catalog table tuple in state 1 (AVAILABLE) for
+-- segno = 1
+0U: SELECT * FROM gp_toolkit.__gp_aoseg('ao_test_drop_phase');
+
+-- And with a utility mode session on the primary with content = 0, we simulate
+-- an access shared lock that would exist on the QE but not on the QD.
+0U: BEGIN;
+0U: SELECT COUNT(*) FROM ao_test_drop_phase;
+
+-- And we delete 4/5 rows to trigger vacuum's compaction phase.
+1: DELETE FROM ao_test_drop_phase where b != 5;
+-- We should see that VACUUM blocks while the QE holds the access shared lock
+1&: VACUUM ao_test_drop_phase;
+
+0U: END;
+1<:
+
+-- We should see that the one visible tuple left after the DELETE gets compacted
+-- from segno = 1 to segno = 2.
+-- Also, segno = 1 should be empty and in state 1 (AVAILABLE)
+0U: SELECT * FROM gp_toolkit.__gp_aoseg('ao_test_drop_phase');
+
+-- We should see that the QD's hash table matches content = 0's pg_aoseg catalog
+1: SELECT segno, total_tupcount, state
+FROM gp_toolkit.__gp_get_ao_entry_from_cache('ao_test_drop_phase'::regclass::oid)
+WHERE segno IN (1, 2);
+
+-- We should see that a subsequent insert succeeds and lands on segno = 1
+1: INSERT INTO ao_test_drop_phase SELECT 2,i from generate_series(11, 15)i;
+0U: SELECT * FROM gp_toolkit.__gp_aoseg('ao_test_drop_phase');
+
+1: SELECT * FROM ao_test_drop_phase;


### PR DESCRIPTION
This commit ports two pieces from the 5X_STABLE commit: aee8cac

1. The test to ensure that the drop phase for AO tables doesn't get skipped because of a failure to acquire the AccessExclusiveLock on the QE.
2. Align `AOCSDrop` with `AppendOnlyDrop` to block trying to acquire AccessExclusiveLock while dropping segfiles.

Note: The main fix introduced in aee8cac is not required here and the problem has been solved (through significant refactoring around vacuum)

Needs backport to 6X.