### PR TITLE
Refactor EXISTS sublink pull-up.

### DIFF
--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10918,7 +10918,11 @@ insert into wst1 select i, i from generate_series(1,10) i;
 insert into wst2 select i, i from generate_series(1,10) i;
 -- NB: the rank() is need to force materialization (via Sort) in the subplan
 select count(*) from wst0 where exists (select 1, rank() over (order by wst1.a1) from wst1 where a1 = (select b2 from wst2 where a0=a2+5));
-ERROR:  correlated subquery with skip-level correlations is not supported
+ count 
+-------
+     5
+(1 row)
+
 --
 -- Test to ensure sane behavior when DML queries are optimized by ORCA by
 -- enforcing a non-master gather motion, controlled by

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -643,17 +643,17 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
                                                                   QUERY PLAN                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=30000000026.26..30000000026.48 rows=10 width=12)
+ Limit  (cost=30000000026.45..30000000026.68 rows=10 width=12)
    InitPlan 1 (returns $0)  (slice7)
-     ->  Limit  (cost=10000000000.00..10000000001.58 rows=1 width=0)
-           ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=10000000000.00..10000000001.58 rows=1 width=0)
-                 ->  Limit  (cost=10000000000.00..10000000001.56 rows=1 width=0)
-                       ->  Nested Loop  (cost=10000000000.00..10000000005.18 rows=2 width=0)
+     ->  Limit  (cost=10000000000.00..10000000001.58 rows=1 width=4)
+           ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=10000000000.00..10000000001.58 rows=1 width=4)
+                 ->  Limit  (cost=10000000000.00..10000000001.56 rows=1 width=4)
+                       ->  Nested Loop  (cost=10000000000.00..10000000005.18 rows=2 width=4)
                              ->  Seq Scan on c c_2  (cost=0.00..3.11 rows=1 width=4)
-                                   Filter: i = 10
+                                   Filter: (i = 10)
                              ->  Seq Scan on a a_1  (cost=0.00..2.06 rows=1 width=4)
-                                   Filter: i = 10
-   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=20000000024.67..20000000024.90 rows=10 width=12)
+                                   Filter: (i = 10)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=20000000024.87..20000000025.09 rows=10 width=12)
          Merge Key: a.i, b.i, c.j
          ->  Limit  (cost=20000000024.67..20000000024.70 rows=4 width=12)
                ->  Sort  (cost=20000000024.67..20000000025.35 rows=90 width=12)
@@ -776,9 +776,15 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
  99 | 62 | 1 | 43
 (8 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ i  | j  | i | j 
+----+----+---+---
+  1 |  1 | 1 | 1
+  1 |  1 | 1 | 1
+ 78 | -1 | 1 | 1
+ 99 | 62 | 1 | 1
+(4 rows)
+
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -842,10 +848,10 @@ explain select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C wh
 ------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=40000000026.22..40000000026.44 rows=10 width=12)
    InitPlan 1 (returns $0)  (slice6)
-     ->  Limit  (cost=10000000000.00..10000000001.58 rows=1 width=0)
-           ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000000.00..10000000001.58 rows=1 width=0)
-                 ->  Limit  (cost=10000000000.00..10000000001.56 rows=1 width=0)
-                       ->  Nested Loop  (cost=10000000000.00..10000000005.18 rows=2 width=0)
+     ->  Limit  (cost=10000000000.00..10000000001.58 rows=1 width=4)
+           ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000000.00..10000000001.58 rows=1 width=4)
+                 ->  Limit  (cost=10000000000.00..10000000001.56 rows=1 width=4)
+                       ->  Nested Loop  (cost=10000000000.00..10000000005.18 rows=2 width=4)
                              ->  Seq Scan on c c_2  (cost=0.00..3.11 rows=1 width=4)
                                    Filter: (i = 10)
                              ->  Seq Scan on a a_1  (cost=0.00..2.06 rows=1 width=4)
@@ -977,9 +983,31 @@ select * from A where exists (select * from C,B where C.j = A.j and exists (sele
  99 | 62
 (4 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and exists (select * from C where C.i = B.i));
-ERROR:  correlated subquery with skip-level correlations is not supported
+ i  | j  | i  | j  
+----+----+----+----
+  1 |  1 |  2 |  7
+  1 |  1 |  2 |  7
+ 99 | 62 |  2 |  7
+ 78 | -1 |  2 |  7
+ 99 | 62 | -1 | 62
+ 99 | 62 | 32 |  5
+ 78 | -1 | -1 | 62
+ 78 | -1 | 32 |  5
+  1 |  1 | -1 | 62
+  1 |  1 | 32 |  5
+  1 |  1 | -1 | 62
+  1 |  1 | 32 |  5
+ 99 | 62 |  1 | 43
+ 99 | 62 |  1 |  1
+ 78 | -1 |  1 | 43
+ 78 | -1 |  1 |  1
+  1 |  1 |  1 | 43
+  1 |  1 |  1 |  1
+  1 |  1 |  1 | 43
+  1 |  1 |  1 |  1
+(20 rows)
+
 select * from A where exists (select * from B, C where C.j = A.j and exists (select sum(C.i) from C where C.i != 10 and C.i = B.i)) order by 1, 2;
  i  | j  
 ----+----
@@ -989,9 +1017,15 @@ select * from A where exists (select * from B, C where C.j = A.j and exists (sel
  99 | 62
 (4 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ i  | j  
+----+----
+  1 |  1
+  1 |  1
+ 78 | -1
+ 99 | 62
+(4 rows)
+
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 20;
  i  | i  |  j  
 ----+----+-----
@@ -1053,9 +1087,12 @@ select * from A where exists (select * from C where C.i = A.i and exists (select
  99 | 62
 (1 row)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and A.j < 10));
-ERROR:  correlated subquery with skip-level correlations is not supported
+ i  | j  
+----+----
+ 78 | -1
+(1 row)
+
 select * from A where exists (select * from C where C.i = A.i and not exists (select * from B where C.j = B.j and B.j < 10)) order by 1,2;
  i  | j  
 ----+----

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -813,7 +813,6 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
  99 | 62 | 1 | 43
 (8 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
  i  | j  | i | j 
 ----+----+---+---
@@ -1035,7 +1034,6 @@ select * from A where exists (select * from C,B where C.j = A.j and exists (sele
  99 | 62
 (4 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and exists (select * from C where C.i = B.i));
  i  | j  | i  | j  
 ----+----+----+----
@@ -1070,7 +1068,6 @@ select * from A where exists (select * from B, C where C.j = A.j and exists (sel
  99 | 62
 (4 rows)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2;
  i  | j  
 ----+----
@@ -1141,7 +1138,6 @@ select * from A where exists (select * from C where C.i = A.i and exists (select
  99 | 62
 (1 row)
 
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and A.j < 10));
  i  | j  
 ----+----

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -635,7 +635,10 @@ where a.thousand = b.thousand
   and exists ( select 1 from tenk1 c where b.hundred = c.hundred
                    and not exists ( select 1 from tenk1 d
                                     where a.thousand = d.thousand ) );
-ERROR:  correlated subquery with skip-level correlations is not supported
+ thousand 
+----------
+(0 rows)
+
 --
 -- Check that nested sub-selects are not pulled up if they contain volatiles
 --

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -210,17 +210,17 @@ NOTICE:  table "mrs_t1" does not exist, skipping
 create table mrs_t1(x int) distributed by (x);
 insert into mrs_t1 select generate_series(1,20);
 explain select * from mrs_t1 where exists (select x from mrs_t1 where x < -1);
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=3.27..6.47 rows=20 width=4)
-   ->  Result  (cost=3.27..6.47 rows=7 width=4)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=3.25..6.45 rows=20 width=4)
+   ->  Result  (cost=3.25..6.45 rows=7 width=4)
          One-Time Filter: $0
          InitPlan 1 (returns $0)  (slice3)
-           ->  Limit  (cost=0.00..3.27 rows=1 width=0)
-                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.27 rows=1 width=0)
-                       ->  Limit  (cost=0.00..3.25 rows=1 width=0)
-                             ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..3.25 rows=1 width=0)
-                                   Filter: x < (-1)
+           ->  Limit  (cost=0.00..3.27 rows=1 width=4)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.27 rows=1 width=4)
+                       ->  Limit  (cost=0.00..3.25 rows=1 width=4)
+                             ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..3.25 rows=1 width=4)
+                                   Filter: (x < (-1))
          ->  Seq Scan on mrs_t1  (cost=0.00..3.20 rows=7 width=4)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -231,17 +231,17 @@ select * from mrs_t1 where exists (select x from mrs_t1 where x < -1) order by 1
 (0 rows)
 
 explain select * from mrs_t1 where exists (select x from mrs_t1 where x = 1);
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=3.27..6.47 rows=20 width=4)
-   ->  Result  (cost=3.27..6.47 rows=7 width=4)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=3.25..6.45 rows=20 width=4)
+   ->  Result  (cost=3.25..6.45 rows=7 width=4)
          One-Time Filter: $0
          InitPlan 1 (returns $0)  (slice3)
-           ->  Limit  (cost=0.00..3.27 rows=1 width=0)
-                 ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..3.27 rows=1 width=0)
-                       ->  Limit  (cost=0.00..3.25 rows=1 width=0)
-                             ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..3.25 rows=1 width=0)
-                                   Filter: x = 1
+           ->  Limit  (cost=0.00..3.27 rows=1 width=4)
+                 ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..3.27 rows=1 width=4)
+                       ->  Limit  (cost=0.00..3.25 rows=1 width=4)
+                             ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..3.25 rows=1 width=4)
+                                   Filter: (x = 1)
          ->  Seq Scan on mrs_t1  (cost=0.00..3.20 rows=7 width=4)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1843,3 +1843,276 @@ WHERE A.C01 IN(SELECT C02 FROM TEST_IN);
  10000
 (1 row)
 
+-- EXISTS sublink simplication
+drop table if exists simplify_sub;
+NOTICE:  table "simplify_sub" does not exist, skipping
+create table simplify_sub (i int) distributed by (i);
+insert into simplify_sub values (1);
+insert into simplify_sub values (2);
+-- limit n
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+(0 rows)
+
+-- aggregates without GROUP BY or HAVING
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+(0 rows)
+
+drop table if exists simplify_sub;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1891,3 +1891,346 @@ WHERE A.C01 IN(SELECT C02 FROM TEST_IN);
  10000
 (1 row)
 
+-- EXISTS sublink simplication
+drop table if exists simplify_sub;
+NOTICE:  table "simplify_sub" does not exist, skipping
+create table simplify_sub (i int) distributed by (i);
+insert into simplify_sub values (1);
+insert into simplify_sub values (2);
+-- limit n
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Result
+           ->  Result
+                 ->  Limit
+                       ->  Result
+                             Filter: (simplify_sub.i = simplify_sub_1.i)
+                             ->  Materialize
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(14 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Result
+           ->  Result
+                 ->  Limit
+                       ->  Result
+                             Filter: (simplify_sub.i = simplify_sub_1.i)
+                             ->  Materialize
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(14 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Semi Join
+         Join Filter: true
+         ->  Seq Scan on simplify_sub
+         ->  Limit
+               ->  Result
+                     ->  Result
+                           One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(9 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Anti Join
+         Join Filter: true
+         ->  Seq Scan on simplify_sub
+         ->  Result
+               One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+(0 rows)
+
+-- aggregates without GROUP BY or HAVING
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Result
+   ->  Result
+         One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(4 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Result
+   ->  Result
+         One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(4 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+(0 rows)
+
+drop table if exists simplify_sub;

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -183,7 +183,6 @@ select A.i from A where A.i = all (select B.i from B where A.i = B.i) order by A
 
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C)) order by 1,2,3,4;
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = 1)) order by 1,2,3,4;
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
@@ -211,11 +210,9 @@ with t as (select * from qp_csq_t2) select b from qp_csq_t1 where exists(select 
 
 select * from A where exists (select * from C where C.j = A.j) order by 1,2;
 select * from A where exists (select * from C,B where C.j = A.j and exists (select * from C where C.i = B.i)) order by 1,2;
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where exists (select * from C where C.j = A.j and exists (select * from C where C.i = B.i));
 
 select * from A where exists (select * from B, C where C.j = A.j and exists (select sum(C.i) from C where C.i != 10 and C.i = B.i)) order by 1, 2;
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2;
 
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 20;
@@ -224,7 +221,6 @@ select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.
 select * from A where exists (select * from C where C.j = A.j and not exists (select sum(B.i) from B where B.i = C.i));
 
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and B.j < 10)) order by 1,2;
--- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and A.j < 10));
 select * from A where exists (select * from C where C.i = A.i and not exists (select * from B where C.j = B.j and B.j < 10)) order by 1,2;
 

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -796,3 +796,80 @@ ANALYZE TEST_IN;
 SELECT COUNT(*) FROM
 TEST_IN A
 WHERE A.C01 IN(SELECT C02 FROM TEST_IN);
+
+
+-- EXISTS sublink simplication
+
+drop table if exists simplify_sub;
+
+create table simplify_sub (i int) distributed by (i);
+insert into simplify_sub values (1);
+insert into simplify_sub values (2);
+
+-- limit n
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+
+-- aggregates without GROUP BY or HAVING
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+
+drop table if exists simplify_sub;


### PR DESCRIPTION
GPDB performs several types of optimization when pulling up EXISTS
sublink, trying to eliminate the sublink altogether if possible. This
mainly includes two cases: 1) the subquery has limit 0, 2) the subquery
has aggregates without GROUP BY or HAVING. But previously it failed to
do it correctly and would give wrong results in the case of 'limit
0/all/null' or 'offset null'.

This patch refactors function convert_EXISTS_sublink_to_join() to fix
the known issues as well as to make it more aligned with PostgreSQL.

This patch fixes #7545, #8484, #8482.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
