### PR TITLE
docs - pxf misc; hadoop versions, clarify hdfs cmd host

### DIFF
--- a/gpdb-doc/markdown/pxf/access_hdfs.html.md.erb
+++ b/gpdb-doc/markdown/pxf/access_hdfs.html.md.erb
@@ -53,7 +53,10 @@ Before working with Hadoop data using PXF, ensure that:
 
 
 ## <a id="hdfs_cmdline"></a>HDFS Shell Command Primer
-Hadoop includes command-line tools that interact directly with your HDFS file system. These tools support typical file system operations including copying and listing files, changing file permissions, and so forth.
+Examples in the PXF Hadoop topics access files on HDFS. You can choose to access files that already exist in your HDFS cluster. Or, you can follow the steps in the examples to create new files.
+
+A Hadoop installation includes command-line tools that interact directly with your HDFS file system. These tools support typical file system operations that include copying and listing files, changing file permissions, and so forth. You run these tools on a system with a Hadoop client installation. By default, Greenplum Database hosts do not
+include a Hadoop client installation.
 
 The HDFS file system command syntax is `hdfs dfs <options> [<file>]`. Invoked with no options, `hdfs dfs` lists the file system options supported by the tool.
 

--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -6,6 +6,13 @@ The Greenplum Platform Extension Framework (PXF) provides *connectors* that enab
 
 You can query the external table via Greenplum Database, leaving the referenced data in place. Or, you can use the external table to load the data into Greenplum Database for higher performance.
 
+## <a id="suppplat"></a> Supported Platforms
+
+PXF bundles all of the JAR files on which it depends, including the following Hadoop libraries:
+
+- Hadoop version 2.9.2
+- Hive version 1.2.2
+- HBase version 1.3.2
 
 ## <a id="arch"></a> Architectural Overview
 


### PR DESCRIPTION
in this PR - a few misc pxf edits:
- identify pxf supported hadoop versions
- clarify that the hdfs command is run on a host with a hadoop client installation, and that greenplum hosts by default do not include a hadoop client. 
