### PR TITLE
docs - doc updates for recent 9.4 merges

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-index.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-index.xml
@@ -90,7 +90,7 @@ VACUUM ANALYZE old_table;
   <topic id="topic92" xml:lang="en">
     <title>Index Types</title>
     <body>
-      <p>Greenplum Database supports the Postgres index types B-tree, GiST, and GIN. Hash indexes
+      <p>Greenplum Database supports the Postgres index types B-tree, GiST, SP-GiST, and GIN. Hash indexes
         are not supported. Each index type uses a different algorithm that is best suited to
         different types of queries. B-tree indexes fit the most common situations and are the
         default index type. See <xref

--- a/gpdb-doc/dita/admin_guide/query/topics/json-data.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/json-data.xml
@@ -51,7 +51,7 @@
         are specialized needs, such as legacy assumptions about ordering of object keys.</p>
       <section>
         <title>About Unicode Characters in JSON Data</title>
-        <p>The <xref href="http://rfc7159.net/rfc7159" format="html" scope="external">RFC
+        <p>The <xref href="https://tools.ietf.org/html/rfc7159" format="html" scope="external">RFC
             7159</xref> document permits JSON strings to contain Unicode escape sequences denoted by
               <codeph>\u<varname>XXXX</varname></codeph>. However, Greenplum Database allows only
           one character set encoding per database. It is not possible for the <codeph>json</codeph>

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -22,8 +22,8 @@
       <p>These features are unsupported when GPORCA is enabled (the default): <ul id="ul_ndm_gyl_vp">
           <li>Indexed expressions (an index defined as expression based on one or more columns of
             the table)</li>
-          <li>GIN indexing method. GPORCA supports only B-tree, bitmap, and GiST indexes. GPORCA
-            ignores indexes created with unsupported methods.</li>
+          <li>SP-GiST indexing method. GPORCA supports only B-tree, bitmap, GIN, and GiST indexes.
+            GPORCA ignores indexes created with unsupported methods.</li>
           <li>External parameters</li>
           <li>These types of partitioned tables:<ul id="ul_v2m_mmc_bt">
               <li>Non-uniform partitioned tables.</li>

--- a/gpdb-doc/dita/admin_guide/query/topics/xml-data.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/xml-data.xml
@@ -11,8 +11,10 @@
     <p otherprops="oss-only">Use of this data type requires the installation to have been built with
         <codeph>configure --with-libxml</codeph>. </p>
     <p>The <codeph>xml</codeph> type can store well-formed "documents", as defined by the XML
-      standard, as well as "content" fragments, which are defined by the production
-        <codeph>XMLDecl?</codeph> content in the XML standard. Roughly, this means that content
+      standard, as well as "content" fragments, which are defined by reference to the more
+      permissive <xref href="https://www.w3.org/TR/2010/REC-xpath-datamodel-20101214/#DocumentNode"
+        format="html" scope="external">document node</xref> of the XQuery and XPath model.
+      Roughly, this means that content
       fragments can have more than one top-level element or character node. The expression
           <codeph><varname>xmlvalue</varname> IS DOCUMENT</codeph> can be used to evaluate whether a
       particular <codeph>xml</codeph> value is a full document or only a content fragment.</p>
@@ -57,12 +59,6 @@ XMLPARSE (CONTENT 'abc&lt;foo>bar&lt;/foo>&lt;bar>foo&lt;/bar>')</codeblock></p>
       <p>or simply like Greenplum
         Database:<codeblock>SET XML OPTION TO { DOCUMENT | CONTENT };</codeblock></p>
       <p>The default is CONTENT, so all forms of XML data are allowed.</p>
-      <note>
-        <p>With the default XML option setting, you cannot directly cast character strings to type
-            <codeph>xml</codeph> if they contain a document type declaration, because the definition
-          of XML content fragment does not accept them. If you need to do that, either use
-            <codeph>XMLPARSE</codeph> or change the <codeph>XML</codeph> option.</p>
-      </note>
     </body>
   </topic>
   <topic id="topic_eyt_3tw_mq">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -900,6 +900,7 @@
           </tbody>
         </tgroup>
       </table>
+      <p><codeph>INFO</codeph> level messages are always sent to the client.</p>
     </body>
   </topic>
   <topic id="cpu_index_tuple_cost">

--- a/gpdb-doc/dita/ref_guide/datatype-datetime.xml
+++ b/gpdb-doc/dita/ref_guide/datatype-datetime.xml
@@ -670,7 +670,7 @@ January 8 04:05:06 1999 PST
       <li>A full time zone name, for example <codeph>America/New_York</codeph>. The recognized time
        zone names are listed in the <codeph>pg_timezone_names</codeph> view. Greenplum uses the
        widely-used IANA time zone data for this purpose, so the same time zone names are also
-       recognized by much other software. </li>
+       recognized by other software. </li>
       <li>A time zone abbreviation, for example <codeph>PST</codeph>. Such a specification merely
        defines a particular offset from UTC, in contrast to full time zone names which can imply a
        set of daylight savings transition-date rules as well. The recognized abbreviations are

--- a/gpdb-doc/dita/ref_guide/datatype-range.xml
+++ b/gpdb-doc/dita/ref_guide/datatype-range.xml
@@ -268,7 +268,7 @@ SELECT '[1.234, 5.678]'::floatrange;
                instance, a range type over <codeph>timestamp</codeph> could be defined to have a
                step size of an hour, in which case the canonicalization function would need to round
                off bounds that weren't a multiple of an hour, or perhaps throw an error instead. </p>
-            <p> In addition, any range type that is meant to be used with GiST indexes
+            <p> In addition, any range type that is meant to be used with GiST or SP-GiST indexes
                should define a subtype difference, or <codeph>subtype_diff</codeph>, function. (The
                index will still work without <codeph>subtype_diff</codeph>, but it is likely to be
                considerably less efficient than if a difference function is provided.) The subtype
@@ -301,12 +301,12 @@ SELECT '[11:10, 23:00]'::timerange;
       <topic xml:lang="en-us" id="rangetypes-indexing">
          <title>Indexing</title>
          <body>
-            <p> GiST indexes can be created for table columns of range types. For
+            <p> GiST and SP-GiST indexes can be created for table columns of range types. For
                instance, to create a GiST index:
                <codeblock>
 CREATE INDEX reservation_idx ON reservation USING GIST (during);
 </codeblock>
-               A GiST index can accelerate queries involving these range operators:
+               A GiST or SP-GiST index can accelerate queries involving these range operators:
                   <codeph>=</codeph>, <codeph>&amp;&amp;</codeph>, <codeph>&lt;@</codeph>,
                   <codeph>@&gt;</codeph>, <codeph>&lt;&lt;</codeph>, <codeph>&gt;&gt;</codeph>,
                   <codeph>-|-</codeph>, <codeph>&amp;&lt;</codeph>, and <codeph>&amp;&gt;</codeph>

--- a/gpdb-doc/dita/ref_guide/datatype-range.xml
+++ b/gpdb-doc/dita/ref_guide/datatype-range.xml
@@ -268,7 +268,7 @@ SELECT '[1.234, 5.678]'::floatrange;
                instance, a range type over <codeph>timestamp</codeph> could be defined to have a
                step size of an hour, in which case the canonicalization function would need to round
                off bounds that weren't a multiple of an hour, or perhaps throw an error instead. </p>
-            <p> In addition, any range type that is meant to be used with GiST or SP-GiST indexes
+            <p> In addition, any range type that is meant to be used with GiST indexes
                should define a subtype difference, or <codeph>subtype_diff</codeph>, function. (The
                index will still work without <codeph>subtype_diff</codeph>, but it is likely to be
                considerably less efficient than if a difference function is provided.) The subtype
@@ -301,12 +301,12 @@ SELECT '[11:10, 23:00]'::timerange;
       <topic xml:lang="en-us" id="rangetypes-indexing">
          <title>Indexing</title>
          <body>
-            <p> GiST and SP-GiST indexes can be created for table columns of range types. For
+            <p> GiST indexes can be created for table columns of range types. For
                instance, to create a GiST index:
                <codeblock>
 CREATE INDEX reservation_idx ON reservation USING GIST (during);
 </codeblock>
-               A GiST or SP-GiST index can accelerate queries involving these range operators:
+               A GiST index can accelerate queries involving these range operators:
                   <codeph>=</codeph>, <codeph>&amp;&amp;</codeph>, <codeph>&lt;@</codeph>,
                   <codeph>@&gt;</codeph>, <codeph>&lt;&lt;</codeph>, <codeph>&gt;&gt;</codeph>,
                   <codeph>-|-</codeph>, <codeph>&amp;&lt;</codeph>, and <codeph>&amp;&gt;</codeph>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_OPERATOR_FAMILY.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_OPERATOR_FAMILY.xml
@@ -57,7 +57,7 @@ ALTER OPERATOR FAMILY <varname>name</varname> USING <varname>index_method</varna
             the function is intended to support, if different from the input data type(s) of the
             function. For B-tree comparison functions it is not necessary to specify <varname>op_type</varname> since the
             function's input data type(s) are always the correct ones to use.  For B-tree sort
-            support functions and all functions in GiST, SP-GiST and GIN operator
+            support functions and all functions in GiST, SP-GiST, and GIN operator
             classes, it is necessary to specify the operand data type(s) the function
             is to be used with.</pd> 
         </plentry>
@@ -93,7 +93,7 @@ ALTER OPERATOR FAMILY <varname>name</varname> USING <varname>index_method</varna
         family, by strategy or support number and input data type(s). The name of the operator or
         function occupying the slot is not mentioned. Also, for <codeph>DROP FUNCTION</codeph> the
         type(s) to specify are the input data type(s) the function is intended to support; for
-          <codeph>GiST</codeph>, <codeph>SP_GiST</codeph> and <codeph>GIN</codeph> indexes this
+          <codeph>GiST</codeph>, <codeph>SP_GiST</codeph>, and <codeph>GIN</codeph> indexes this
         might have nothing to do with the actual input argument types of the function. </p>
       <p>Because the index machinery does not check access permissions on functions before using
         them, including a function or operator in an operator family is tantamount to granting

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_OPERATOR_FAMILY.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_OPERATOR_FAMILY.xml
@@ -57,7 +57,7 @@ ALTER OPERATOR FAMILY <varname>name</varname> USING <varname>index_method</varna
             the function is intended to support, if different from the input data type(s) of the
             function. For B-tree comparison functions it is not necessary to specify <varname>op_type</varname> since the
             function's input data type(s) are always the correct ones to use.  For B-tree sort
-            support functions and all functions in GiST, SP-GiST and GIN operator
+            support functions and all functions in GiST and GIN operator
             classes, it is necessary to specify the operand data type(s) the function
             is to be used with.</pd> 
         </plentry>
@@ -93,7 +93,7 @@ ALTER OPERATOR FAMILY <varname>name</varname> USING <varname>index_method</varna
         family, by strategy or support number and input data type(s). The name of the operator or
         function occupying the slot is not mentioned. Also, for <codeph>DROP FUNCTION</codeph> the
         type(s) to specify are the input data type(s) the function is intended to support; for
-          <codeph>GiST</codeph>, <codeph>SP_GiST</codeph> and <codeph>GIN</codeph> indexes this
+          <codeph>GiST</codeph> and <codeph>GIN</codeph> indexes this
         might have nothing to do with the actual input argument types of the function. </p>
       <p>Because the index machinery does not check access permissions on functions before using
         them, including a function or operator in an operator family is tantamount to granting

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_OPERATOR_FAMILY.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_OPERATOR_FAMILY.xml
@@ -57,7 +57,7 @@ ALTER OPERATOR FAMILY <varname>name</varname> USING <varname>index_method</varna
             the function is intended to support, if different from the input data type(s) of the
             function. For B-tree comparison functions it is not necessary to specify <varname>op_type</varname> since the
             function's input data type(s) are always the correct ones to use.  For B-tree sort
-            support functions and all functions in GiST and GIN operator
+            support functions and all functions in GiST, SP-GiST and GIN operator
             classes, it is necessary to specify the operand data type(s) the function
             is to be used with.</pd> 
         </plentry>
@@ -93,7 +93,7 @@ ALTER OPERATOR FAMILY <varname>name</varname> USING <varname>index_method</varna
         family, by strategy or support number and input data type(s). The name of the operator or
         function occupying the slot is not mentioned. Also, for <codeph>DROP FUNCTION</codeph> the
         type(s) to specify are the input data type(s) the function is intended to support; for
-          <codeph>GiST</codeph> and <codeph>GIN</codeph> indexes this
+          <codeph>GiST</codeph>, <codeph>SP_GiST</codeph> and <codeph>GIN</codeph> indexes this
         might have nothing to do with the actual input argument types of the function. </p>
       <p>Because the index machinery does not check access permissions on functions before using
         them, including a function or operator in an operator family is tantamount to granting

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
@@ -99,7 +99,7 @@
                                                 support multicolumn indexes. Up to 32 fields can be
                                                 specified by default. Only B-tree currently supports
                                                 unique indexes.</pd>
-                                        <pd>GPORCA supports only B-tree, bitmap, and GiST indexes.
+                                        <pd>GPORCA supports only B-tree, bitmap, GiST, and GIN indexes.
                                                 GPORCA ignores indexes created with unsupported
                                                 indexing methods.</pd>
                                 </plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
@@ -30,7 +30,7 @@
                                 allow the clause <codeph>WHERE upper(col) = 'JIM'</codeph> to use an
                                 index. </p>
                         <p>Greenplum Database provides the index methods B-tree, bitmap, GiST,
-                                and GIN. Users can also define their own index methods, but
+                                SP-GiST, and GIN. Users can also define their own index methods, but
                                 that is fairly complicated. </p>
                         <p>When the <codeph>WHERE</codeph> clause is present, a partial index is
                                 created. A partial index is an index that contains entries for only
@@ -178,8 +178,8 @@
                                         <pd>The name of an index-method-specific storage parameter.
                                                 Each index method has its own set of allowed storage
                                                 parameters.</pd>
-                                        <pd><codeph>FILLFACTOR</codeph> - B-tree, bitmap, and GiST
-                                                index methods all accept this parameter. The
+                                        <pd><codeph>FILLFACTOR</codeph> - B-tree, bitmap, GiST, and
+                                                SP-GiST index methods all accept this parameter. The
                                                   <codeph>FILLFACTOR</codeph> for an index is a
                                                 percentage that determines how full the index method
                                                 will try to pack index pages. For B-trees, leaf

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_INDEX.xml
@@ -30,7 +30,7 @@
                                 allow the clause <codeph>WHERE upper(col) = 'JIM'</codeph> to use an
                                 index. </p>
                         <p>Greenplum Database provides the index methods B-tree, bitmap, GiST,
-                                SP-GiST, and GIN. Users can also define their own index methods, but
+                                and GIN. Users can also define their own index methods, but
                                 that is fairly complicated. </p>
                         <p>When the <codeph>WHERE</codeph> clause is present, a partial index is
                                 created. A partial index is an index that contains entries for only
@@ -178,8 +178,8 @@
                                         <pd>The name of an index-method-specific storage parameter.
                                                 Each index method has its own set of allowed storage
                                                 parameters.</pd>
-                                        <pd><codeph>FILLFACTOR</codeph> - B-tree, bitmap, GiST, and
-                                                SP-GiST index methods all accept this parameter. The
+                                        <pd><codeph>FILLFACTOR</codeph> - B-tree, bitmap, and GiST
+                                                index methods all accept this parameter. The
                                                   <codeph>FILLFACTOR</codeph> for an index is a
                                                 percentage that determines how full the index method
                                                 will try to pack index pages. For B-trees, leaf

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml
@@ -180,7 +180,7 @@ a valid operator class. </p><p>You must be a superuser to create an operator cla
                         is intended to support, if different from the input data type(s) of the
                         function (for B-tree comparison functions and hash functions) or the class's
                         data type (for B-tree sort support functions and all functions in GiST,
-                        SP-GiST and GIN operator classes). These defaults are correct, and so
+                        SP-GiST, and GIN operator classes). These defaults are correct, and so
                             <varname>op_type</varname> need not be specified in
                             <codeph>FUNCTION</codeph> clauses, except for the case of a B-tree sort
                         support function that is meant to support cross-data-type comparisons.</pd>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml
@@ -179,8 +179,8 @@ a valid operator class. </p><p>You must be a superuser to create an operator cla
                     <pd>In a <codeph>FUNCTION</codeph> clause, the operand data type(s) the function
                         is intended to support, if different from the input data type(s) of the
                         function (for B-tree comparison functions and hash functions) or the class's
-                        data type (for B-tree sort support functions and all functions in GiST,
-                        SP-GiST and GIN operator classes). These defaults are correct, and so
+                        data type (for B-tree sort support functions and all functions in GiST
+                        and GIN operator classes). These defaults are correct, and so
                             <varname>op_type</varname> need not be specified in
                             <codeph>FUNCTION</codeph> clauses, except for the case of a B-tree sort
                         support function that is meant to support cross-data-type comparisons.</pd>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_OPERATOR_CLASS.xml
@@ -179,8 +179,8 @@ a valid operator class. </p><p>You must be a superuser to create an operator cla
                     <pd>In a <codeph>FUNCTION</codeph> clause, the operand data type(s) the function
                         is intended to support, if different from the input data type(s) of the
                         function (for B-tree comparison functions and hash functions) or the class's
-                        data type (for B-tree sort support functions and all functions in GiST
-                        and GIN operator classes). These defaults are correct, and so
+                        data type (for B-tree sort support functions and all functions in GiST,
+                        SP-GiST and GIN operator classes). These defaults are correct, and so
                             <varname>op_type</varname> need not be specified in
                             <codeph>FUNCTION</codeph> clauses, except for the case of a B-tree sort
                         support function that is meant to support cross-data-type comparisons.</pd>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_OWNED.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_OWNED.xml
@@ -3,7 +3,7 @@
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic1"><title id="db20941">DROP OWNED</title><body><p id="sql_command_desc">Removes database objects owned by a database role.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DROP OWNED BY <varname>name</varname> [, ...] [CASCADE | RESTRICT]</codeblock></section><section id="section3"><title>Description</title><p><codeph>DROP OWNED</codeph> drops all the objects in the current database
 that are owned by one of the specified roles. Any privileges granted
-to the given roles on objects in the current database will also be revoked.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name of a role whose objects will be dropped, and whose privileges
+to the given roles on objects in the current database or on shared objects (databases, tablespaces) will also be revoked.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name of a role whose objects will be dropped, and whose privileges
 will be revoked.</pd></plentry><plentry><pt>CASCADE</pt><pd>Automatically drop objects that depend on the affected objects.</pd></plentry><plentry><pt>RESTRICT</pt><pd>Refuse to drop the objects owned by a role if any other database
 objects depend on one of the affected objects. This is the default.</pd></plentry></parml></section><section id="section5"><title>Notes</title><p><codeph>DROP OWNED</codeph> is often used to prepare for the removal
 of one or more roles. Because <codeph>DROP OWNED</codeph> only affects

--- a/gpdb-doc/dita/ref_guide/sql_commands/REASSIGN_OWNED.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/REASSIGN_OWNED.xml
@@ -42,8 +42,9 @@
         alternative that simply drops all of the database objects owned by one or more roles.
           <codeph>DROP OWNED</codeph> requires privileges only on the source role(s).</p>
       <p>The <codeph>REASSIGN OWNED</codeph> command does not affect any privileges granted to the
-        old roles for objects that are not owned by them. Use <codeph>DROP OWNED</codeph> to revoke
-        those privileges.</p>
+        <varname>old_role</varname>s on objects that are not owned by them. Likewise, it does
+        not affect default privileges created with <codeph>ALTER DEFAULT PRIVILEGES</codeph>.
+        Use <codeph>DROP OWNED</codeph> to revoke such privileges.</p>
     </section>
     <section id="section6">
       <title>Examples</title>


### PR DESCRIPTION
misc doc updates related to recent 9.4 merges; nothing major.

did notice a few things:
- client-min-messages - the postgresql docs don't include the FATAL and PANIC log levels in their description of this guc.  are these greenplum additions, or should i remove them from the list?
- docs for SP-GiST - does greenplum support SP-GiST indexes?