### PR TITLE
Fix potential shared memory corruption in resource group slot managem…

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_unassign_entrydb.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_unassign_entrydb.out
@@ -1,0 +1,102 @@
+-- Testing when we terminate a query involves entrydb, UnassignResGroup() would
+-- be called on both QD and entrydb process. If that function finishes calling
+-- on QD before entrydb calling, a bug could previously be triggered that leads
+-- to data corruption. This test verifies this.
+
+-- start_ignore
+DROP ROLE IF EXISTS role_test;
+DROP
+DROP RESOURCE GROUP rg_test;
+ERROR:  resource group "rg_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=10);
+CREATE
+CREATE ROLE role_test RESOURCE GROUP rg_test;
+CREATE
+
+-- By pass this session, else this affects the testing session, i.e. 1:
+SET gp_resource_group_bypass = true;
+SET
+
+1: SET ROLE role_test;
+SET
+
+SELECT gp_inject_fault('unassign_resgroup_end_qd', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('unassign_resgroup_start_entrydb', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('unassign_resgroup_end_qd', 'suspend', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('unassign_resgroup_start_entrydb', 'suspend', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- A query invovles entrydb.
+1&: SELECT * from gp_dist_random('gp_id'), pg_sleep(15);  <waiting ...>
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query LIKE 'SELECT * from gp_dist_random%' ORDER BY xact_start LIMIT 1;
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+
+-- Make sure entry db starts calling UnassignResGroup() after QD
+-- finishes calling UnassignResGroup().
+SELECT gp_wait_until_triggered_fault('unassign_resgroup_end_qd', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_inject_fault('unassign_resgroup_start_entrydb', 'resume', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('unassign_resgroup_end_qd', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('unassign_resgroup_start_entrydb', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- Verify the system is ok with entrydb.
+2: SET ROLE role_test;
+SET
+2: SELECT * from gp_dist_random('gp_id'), pg_sleep(0.1);
+ gpname    | numsegments | dbid | content | pg_sleep 
+-----------+-------------+------+---------+----------
+ Greenplum | -1          | -1   | -1      |          
+ Greenplum | -1          | -1   | -1      |          
+ Greenplum | -1          | -1   | -1      |          
+(3 rows)
+2q: ... <quitting>
+
+-- Clean up
+DROP ROLE role_test;
+DROP
+DROP RESOURCE GROUP rg_test;
+DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_views.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views.out
@@ -10,7 +10,7 @@ select rsgname , groupid , num_running , num_queueing , num_queued , num_execute
  default_group | 6437    | 0           | 0            | 0          | 0            | 0.00         | 0              | 0                     
 (1 row)
 
-select rsgname , groupid , cpu , memory_used , memory_shared_used from gp_toolkit.gp_resgroup_status_per_host s join gp_segment_configuration c on s.hostname=c.hostname and c.content=-1 where rsgname='default_group';
+select rsgname , groupid , cpu , memory_used , memory_shared_used from gp_toolkit.gp_resgroup_status_per_host s join gp_segment_configuration c on s.hostname=c.hostname and c.content=-1 and role='p' where rsgname='default_group';
  rsgname       | groupid | cpu  | memory_used | memory_shared_used 
 ---------------+---------+------+-------------+--------------------
  default_group | 6437    | 0.00 | 0           | 0                  

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -7,6 +7,10 @@ test: resgroup/resgroup_syntax
 test: resgroup/resgroup_transaction
 test: resgroup/resgroup_name_convention
 
+# fault injection tests
+test: resgroup/resgroup_assign_slot_fail
+test: resgroup/resgroup_unassign_entrydb
+
 # functions
 test: resgroup/resgroup_concurrency
 test: resgroup/resgroup_bypass
@@ -41,8 +45,5 @@ test: resgroup/resgroup_operator_memory
 
 # dump info
 test: resgroup/resgroup_dumpinfo
-
-# fault injection tests
-test: resgroup/resgroup_assign_slot_fail
 
 test: resgroup/disable_resgroup

--- a/src/test/isolation2/sql/resgroup/resgroup_unassign_entrydb.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_unassign_entrydb.sql
@@ -1,0 +1,50 @@
+-- Testing when we terminate a query involves entrydb, UnassignResGroup() would
+-- be called on both QD and entrydb process. If that function finishes calling
+-- on QD before entrydb calling, a bug could previously be triggered that leads
+-- to data corruption. This test verifies this.
+
+-- start_ignore
+DROP ROLE IF EXISTS role_test;
+DROP RESOURCE GROUP rg_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=10);
+CREATE ROLE role_test RESOURCE GROUP rg_test;
+
+-- By pass this session, else this affects the testing session, i.e. 1:
+SET gp_resource_group_bypass = true;
+
+1: SET ROLE role_test;
+
+SELECT gp_inject_fault('unassign_resgroup_end_qd', 'reset', 1);
+SELECT gp_inject_fault('unassign_resgroup_start_entrydb', 'reset', 1);
+
+SELECT gp_inject_fault('unassign_resgroup_end_qd', 'suspend', 1);
+SELECT gp_inject_fault('unassign_resgroup_start_entrydb', 'suspend', 1);
+
+-- A query invovles entrydb.
+1&: SELECT * from gp_dist_random('gp_id'), pg_sleep(15);
+
+SELECT pg_terminate_backend(pid)
+  FROM pg_stat_activity WHERE query LIKE
+  'SELECT * from gp_dist_random%'
+  ORDER BY xact_start LIMIT 1;
+
+-- Make sure entry db starts calling UnassignResGroup() after QD
+-- finishes calling UnassignResGroup().
+SELECT gp_wait_until_triggered_fault('unassign_resgroup_end_qd', 1, 1);
+SELECT gp_inject_fault('unassign_resgroup_start_entrydb', 'resume', 1);
+
+SELECT gp_inject_fault('unassign_resgroup_end_qd', 'reset', 1);
+SELECT gp_inject_fault('unassign_resgroup_start_entrydb', 'reset', 1);
+
+1<:
+
+-- Verify the system is ok with entrydb.
+2: SET ROLE role_test;
+2: SELECT * from gp_dist_random('gp_id'), pg_sleep(0.1);
+2q:
+
+-- Clean up
+DROP ROLE role_test;
+DROP RESOURCE GROUP rg_test;

--- a/src/test/isolation2/sql/resgroup/resgroup_views.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_views.sql
@@ -21,7 +21,7 @@ select rsgname
      , memory_shared_used
   from gp_toolkit.gp_resgroup_status_per_host s
   join gp_segment_configuration c
-    on s.hostname=c.hostname and c.content=-1
+    on s.hostname=c.hostname and c.content=-1 and role='p'
  where rsgname='default_group';
 
 select rsgname


### PR DESCRIPTION
…ent when query involves entrydb.

We've observed that when we terminate a query that involves entrydb, if QD
detaches from a resource group before the entrydb backend does that in
UnassignResGroup(), data corruption on shared slot pool could happen.  In a
cassert enabled gpdb version, you could see below FATAL message as below when
terminating the query using pg_terminate_backend().

FATAL:  Unexpected internal error (resgroup.c:1545)
DETAIL:  FailedAssertion("!(slot->nProcs == 0)", File: "resgroup.c", Line: 1545)
HINT:  Process 9903 will wait for gp_debug_linger=120 seconds before termination.
Note that its locks and other resources will not be released until then.

While on producd release that without cassert enabled some subsequent queries
could lead to panic.

We fix this by let the final process (either QD or entrydb process) do clean up
when the nProcs reference number is zero. This is more robust and is less bug
prone cross future code change and upstream merge.

This patch refactors the related resource code a bit and also moves the fault
inject related negative tests ahead so that we could capture some potential
errors which happen later (typically the case in this patch).

Besides, it fixes another panic caused by potential MySessionState NULL
resetting (see code comment for details). That was revealed when running tests
in a dev machine so it's a potential flaky testing part.

Co-authored-by: Paul Guo <pguo@pivotal.io>
Co-authored-by: Ning Yu <nyu@pivotal.io>
Co-authored-by: Gang Xiong <gxiong@pivotal.io>
