### PR TITLE
Speedup test string substitutions from .source to .sql/.out files

### DIFF
--- a/src/test/isolation2/input/gp_collation.source
+++ b/src/test/isolation2/input/gp_collation.source
@@ -28,7 +28,7 @@ select pg_import_system_collations( (select oid from pg_namespace where nspname 
 -- Create a collation from an on-disk locale
 --
 select gp_segment_id, collname from pg_collation where collname='collation_from_disk';
-create collation "collation_from_disk" (locale="@syslocale@");
+create collation "collation_from_disk" (locale="@gp_syslocale@");
 select gp_segment_id, collname from pg_collation where collname='collation_from_disk';
 select gp_segment_id, collname from gp_dist_random('pg_collation') where oid=(select oid from pg_collation where collname='collation_from_disk');
 select count(distinct oid) from gp_dist_random('pg_collation') where oid=(select oid from pg_collation where collname='collation_from_disk');
@@ -80,7 +80,7 @@ SELECT gp_inject_fault('collate_locale_os_lookup', 'error', dbid)
 
 select gp_segment_id, collname from gp_dist_random('pg_collation') where oid=(select oid from pg_collation where collname='locale_missing_on_one_segment');
 --  The fault injector should simulate a collation being missing on this segment
-create collation "locale_missing_on_one_segment" (locale="@syslocale@");
+create collation "locale_missing_on_one_segment" (locale="@gp_syslocale@");
 -- Confirm 'collation_create_fails' is missing from all segments.
 select gp_segment_id, collname from pg_collation where collname='locale_missing_on_one_segment';
 select gp_segment_id, collname from gp_dist_random('pg_collation') where collname='locale_missing_on_one_segment';
@@ -95,7 +95,7 @@ SELECT gp_inject_fault('collate_locale_os_lookup', 'reset', dbid)
 -- will throw an error.
 --
 select gp_segment_id, collname from pg_collation where collname='locale_missing_on_one_segment';
-create collation "locale_missing_on_one_segment" (locale="@syslocale@");
+create collation "locale_missing_on_one_segment" (locale="@gp_syslocale@");
 -- Confirm is on all segments.
 select gp_segment_id, collname from pg_collation where collname='locale_missing_on_one_segment';
 select gp_segment_id, collname from gp_dist_random('pg_collation') where collname='locale_missing_on_one_segment';

--- a/src/test/isolation2/output/gp_collation.source
+++ b/src/test/isolation2/output/gp_collation.source
@@ -47,7 +47,7 @@ select gp_segment_id, collname from pg_collation where collname='collation_from_
  gp_segment_id | collname 
 ---------------+----------
 (0 rows)
-create collation "collation_from_disk" (locale="@syslocale@");
+create collation "collation_from_disk" (locale="@gp_syslocale@");
 CREATE
 select gp_segment_id, collname from pg_collation where collname='collation_from_disk';
  gp_segment_id | collname            
@@ -162,7 +162,7 @@ select gp_segment_id, collname from gp_dist_random('pg_collation') where oid=(se
 ---------------+----------
 (0 rows)
 --  The fault injector should simulate a collation being missing on this segment
-create collation "locale_missing_on_one_segment" (locale="@syslocale@");
+create collation "locale_missing_on_one_segment" (locale="@gp_syslocale@");
 ERROR:  fault triggered, fault name:'collate_locale_os_lookup' fault type:'error'  (seg0 127.0.1.1:25432 pid=23851)
 -- Confirm 'collation_create_fails' is missing from all segments.
 select gp_segment_id, collname from pg_collation where collname='locale_missing_on_one_segment';
@@ -190,7 +190,7 @@ select gp_segment_id, collname from pg_collation where collname='locale_missing_
  gp_segment_id | collname 
 ---------------+----------
 (0 rows)
-create collation "locale_missing_on_one_segment" (locale="@syslocale@");
+create collation "locale_missing_on_one_segment" (locale="@gp_syslocale@");
 CREATE
 -- Confirm is on all segments.
 select gp_segment_id, collname from pg_collation where collname='locale_missing_on_one_segment';

--- a/src/test/regress/input/gptokencheck.source
+++ b/src/test/regress/input/gptokencheck.source
@@ -5,7 +5,7 @@
 -- testtablespace #is_transformed_to# @testtablespace@
 -- DLSUFFIX       #is_transformed_to# @DLSUFFIX@
 -- hostname       #is_transformed_to# @hostname@
--- syslocale      #is_transformed_to# @syslocale@
+-- gp_syslocale      #is_transformed_to# @gp_syslocale@
 -- gpwhich_gpmapreduce  #is_transformed_to# @gpwhich_gpmapreduce@
 -- gpcurusername #is_transformed_to# @gpcurusername@
 --

--- a/src/test/regress/output/gptokencheck.source
+++ b/src/test/regress/output/gptokencheck.source
@@ -5,7 +5,7 @@
 -- testtablespace #is_transformed_to# @testtablespace@
 -- DLSUFFIX       #is_transformed_to# @DLSUFFIX@
 -- hostname       #is_transformed_to# @hostname@
--- syslocale      #is_transformed_to# @syslocale@
+-- gp_syslocale      #is_transformed_to# @gp_syslocale@
 -- gpwhich_gpmapreduce  #is_transformed_to# @gpwhich_gpmapreduce@
 -- gpcurusername #is_transformed_to# @gpcurusername@
 --


### PR DESCRIPTION
In GPDB, gpstringsubs.pl is used to replace tokens in .source test
files when creating .sql/.out files for pg_regress. pg_regress itself
also performs the substitutions. The order is pg_regress performs
substitutions and after that remaining ones are performed by
gpstringsubs.pl if required.

The logic to check if there are still tokens remaining to be replaced
after pg_regress has performed replacement was based on checking if
'@' character is present in file or not. If '@' is present in file
then gpstringsubs.pl is invoked for that file. gpstringsubs.pl is
super slow and takes long time. In many .source files keywords exist
like `@Description` or `@db_name` (specially for UAO related tests),
which don't need any substitution. But due to presence of these '@'
charater keywords, gpstringsubs.pl was invoked for such files
unnecessarily, causing the slow down.

So, modifying the check to invoke gpstringsubs.pl only on presence of
"@gp" keyword instead. So, now any token replacements handled by
gpstringsubs.pl should start with "@gp" in the name. Hence, renamed
`@syslocale@` to "@gp_syslocale@".

Also, moved the logic to perform replacement for `@hostname@` and
`@gpcurusername@` to pg_regress itself, as it's much faster and easier
to do the same in C.

Given the whole testsuite takes very long time in GPD. Need to iterate
on single test routinely. These substitutions are invoked on every run
of pg_regress (mainly isolation2 also), hence helps to reduce the
iteration time for running single test in test suite during
development, along with helping cut down pg_regress file conversion
time in CI. For regress directory cuts down time from 8 secs and
isolation2 from 25 secs to few msecs.

In long run we should complete move all the logic in gpstringsubs.pl
to pg_regress and kill gpstringsubs.pl.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
