### PR TITLE
Backport e245c9121 to 5X_STABLE

### DIFF
--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -35,7 +35,7 @@
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/utils/cache/plancache.c,v 1.23 2008/10/04 21:56:54 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/utils/cache/plancache.c,v 1.27.2.2 2010/01/13 16:57:03 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -1197,14 +1197,57 @@ PlanCacheSysCallback(Datum arg, int cacheid, ItemPointer tuplePtr)
 void
 ResetPlanCache(void)
 {
-	ListCell   *lc;
+	ListCell   *lc1;
 
-	foreach(lc, cached_plans_list)
+	foreach(lc1, cached_plans_list)
 	{
-		CachedPlanSource *plansource = (CachedPlanSource *) lfirst(lc);
+		CachedPlanSource *plansource = (CachedPlanSource *) lfirst(lc1);
 		CachedPlan *plan = plansource->plan;
+		ListCell   *lc2;
 
-		if (plan)
-			plan->dead = true;
+		/* No work if it's already invalidated */
+		if (!plan || plan->dead)
+			continue;
+
+		/*
+		 * We *must not* mark transaction control statements as dead,
+		 * particularly not ROLLBACK, because they may need to be executed in
+		 * aborted transactions when we can't revalidate them (cf bug #5269).
+		 * In general there is no point in invalidating utility statements
+		 * since they have no plans anyway.  So mark it dead only if it
+		 * contains at least one non-utility statement.
+		 */
+		if (plan->fully_planned)
+		{
+			/* Search statement list for non-utility statements */
+			foreach(lc2, plan->stmt_list)
+			{
+				PlannedStmt *plannedstmt = (PlannedStmt *) lfirst(lc2);
+
+				Assert(!IsA(plannedstmt, Query));
+				if (IsA(plannedstmt, PlannedStmt))
+				{
+					/* non-utility statement, so invalidate */
+					plan->dead = true;
+					break;		/* out of stmt_list scan */
+				}
+			}
+		}
+		else
+		{
+			/* Search Query list for non-utility statements */
+			foreach(lc2, plan->stmt_list)
+			{
+				Query	   *query = (Query *) lfirst(lc2);
+
+				Assert(IsA(query, Query));
+				if (query->commandType != CMD_UTILITY)
+				{
+					/* non-utility statement, so invalidate */
+					plan->dead = true;
+					break;		/* out of stmt_list scan */
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
GPDB5 is based on PG 8.3 and PG 8.3 pre-backported a commit ee33b95d9c2 from PG8.4 which contain the modification of plan cache invalidation. Unfortunately,  the commit backported is buggy because it does not skip the utility statements, so another commit e245c9121 is merged to PG8.4 to fix it, however, this commit is not included in GPDB5 now. This PR backport e245c9121 to 5X_STABLE