### PR TITLE
Do not optimize select with locking clause in extend queries.

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3440,6 +3440,7 @@ _copySelectStmt(const SelectStmt *from)
 	COPY_SCALAR_FIELD(all);
 	COPY_NODE_FIELD(larg);
 	COPY_NODE_FIELD(rarg);
+	COPY_SCALAR_FIELD(disableLockingOptimization);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1055,6 +1055,7 @@ _equalSelectStmt(const SelectStmt *a, const SelectStmt *b)
 	COMPARE_SCALAR_FIELD(all);
 	COMPARE_NODE_FIELD(larg);
 	COMPARE_NODE_FIELD(rarg);
+	COMPARE_SCALAR_FIELD(disableLockingOptimization);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3581,6 +3581,7 @@ _outSelectStmt(StringInfo str, const SelectStmt *node)
 	WRITE_BOOL_FIELD(all);
 	WRITE_NODE_FIELD(larg);
 	WRITE_NODE_FIELD(rarg);
+	WRITE_BOOL_FIELD(disableLockingOptimization);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -679,6 +679,7 @@ _readSelectStmt(void)
 	READ_BOOL_FIELD(all);
 	READ_NODE_FIELD(larg);
 	READ_NODE_FIELD(rarg);
+	READ_BOOL_FIELD(disableLockingOptimization);
 	READ_DONE();
 }
 

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -272,6 +272,10 @@ transformTopLevelStmt(ParseState *pstate, Node *parseTree)
 		 * statement with locking clause contains only one table, we are
 		 * sure that there are no motions. For such simple cases, we could
 		 * make the behavior just the same as Postgres.
+		 *
+		 * For extended protocal (like jdbc), we do not try to do such
+		 * optimization since these queries will be considered as cursor
+		 * and dispatched to reader gangs.
 		 */
 		pstate->p_canOptSelectLockingClause = checkCanOptSelectLockingClause(stmt);
 
@@ -3980,6 +3984,14 @@ checkCanOptSelectLockingClause(SelectStmt *stmt)
 		return false;
 
 	if (!gp_enable_global_deadlock_detector)
+		return false;
+
+	/*
+	 * The disableLockingOptimization field is set true
+	 * in exec_parse_message to mark queries that using extended
+	 * protocal.
+	 */
+	if (stmt->disableLockingOptimization)
 		return false;
 
 	/*

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1416,6 +1416,15 @@ typedef struct SelectStmt
 	struct SelectStmt *larg;	/* left child */
 	struct SelectStmt *rarg;	/* right child */
 	/* Eventually add fields for CORRESPONDING spec here */
+
+	/*
+	 * Greenplum specific field.
+	 * If disableLockingOptimization is true, we do not try to
+	 * optimize the behavior of locking clause, this means
+	 * we will lock the table in Exclusive Mode and do not
+	 * emit lockrows plannode.
+	 */
+	bool disableLockingOptimization;
 } SelectStmt;
 
 

--- a/src/test/isolation2/.gitignore
+++ b/src/test/isolation2/.gitignore
@@ -4,6 +4,7 @@ regression.out
 */dummy.out
 
 # Local binaries and symbolic links
+/extended_protocol_test
 /pg_isolation2_regress
 /atmsort.pm
 /explain.pm

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -17,7 +17,10 @@ endif
 override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPFLAGS)
 override LDLIBS := $(libpq_pgport) $(LDLIBS)
 
-all: test_python pg_isolation2_regress$(X) all-lib
+all: test_python pg_isolation2_regress$(X) all-lib extended_protocol_test
+
+extended_protocol_test: extended_protocol_test.c
+	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq  -o $@ $< -lpq
 
 test_python:
 	python helpers_test.py

--- a/src/test/isolation2/expected/gdd/extended_protocol_test.out
+++ b/src/test/isolation2/expected/gdd/extended_protocol_test.out
@@ -1,0 +1,3 @@
+! ./extended_protocol_test dbname=isolation2test;
+extended_protocol_test test ok!
+

--- a/src/test/isolation2/extended_protocol_test.c
+++ b/src/test/isolation2/extended_protocol_test.c
@@ -1,0 +1,82 @@
+/*
+ * extended_protocol_test.c
+ *
+ * This program is to test whether exetend-queries run on reader gang
+ * or writer gang.
+ *
+ * More details please refer:
+ * https://groups.google.com/a/greenplum.org/forum/#!msg/gpdb-dev/ugsZca1qLXU/CtUmzEa7CAAJ
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include "libpq-fe.h"
+
+/* for ntohl/htonl */
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+
+static void
+exit_nicely(PGconn *conn)
+{
+	PQfinish(conn);
+	exit(1);
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *conninfo;
+	PGconn     *conn;
+	PGresult   *res;
+	const char *paramValues[1];
+
+	/*
+	 * If the user supplies a parameter on the command line, use it as the
+	 * conninfo string; otherwise default to setting dbname=postgres and using
+	 * environment variables or defaults for all other connection parameters.
+	 */
+	if (argc > 1)
+		conninfo = argv[1];
+	else
+		conninfo = "dbname = postgres";
+
+	/* Make a connection to the database */
+	conn = PQconnectdb(conninfo);
+
+	/* Check to see that the backend connection was successfully made */
+	if (PQstatus(conn) != CONNECTION_OK)
+	{
+		fprintf(stderr, "Connection to database failed: %s",
+				PQerrorMessage(conn));
+		exit_nicely(conn);
+	}
+
+	PQexec(conn, "create table t_extended_protocol_test(c int) distributed randomly;");
+	PQexec(conn, "insert into t_extended_protocol_test select * from generate_series(1, 10);");
+
+	PQprepare(conn, "extend_query_cursor",
+			  "select * from t_extended_protocol_test where c > $1 for update",
+			  1, NULL);
+
+	paramValues[0] = "0";
+	res = PQexecPrepared(conn, "extend_query_cursor", 1,
+						 paramValues, NULL, NULL, 0);
+
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		printf("%s", PQresultErrorMessage(res));
+	else if (PQntuples(res) != 10)
+		printf("expected 10 tuples but getting %d tuples.", PQntuples(res));
+	else
+		printf("%s", "extended_protocol_test test ok!\n");
+
+	PQclear(res);
+
+	PQfinish(conn);
+
+	return 0;
+}

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -26,6 +26,7 @@ test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-de
 # until we can improve below flaky case please keep it disabled
 ignore: gdd/non-lock-107
 # keep this in a separate group
+test: gdd/extended_protocol_test
 test: gdd/avoid-qd-deadlock
 test: gdd/delete-deadlock-root-leaf-concurrent-op
 test: gdd/planner_insert_while_vacuum_drop

--- a/src/test/isolation2/sql/gdd/extended_protocol_test.sql
+++ b/src/test/isolation2/sql/gdd/extended_protocol_test.sql
@@ -1,0 +1,1 @@
+! ./extended_protocol_test dbname=isolation2test;


### PR DESCRIPTION
Exextend queries are taken as cursors in Greenplum and dispatched
to reader gangs. Under such condition, we do not try to optimize the
select statement with locking clause, which means we will lock the
whole table in Exclusive mode and do not emit lockrows plannode.

For more details, please refer the mailing list:
https://groups.google.com/a/greenplum.org/forum/#!msg/gpdb-dev/ugsZca1qLXU/CtUmzEa7CAAJ

Co-authored-by: Jinbao Chen <jinchen@pivotal.io>

-------------------------

This fix https://github.com/greenplum-db/gpdb/issues/8365

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
