### PR TITLE
6X Backport: Fix compilation without libz

### DIFF
--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -48,6 +48,7 @@ char *storage_directive_names[] = {"compresstype", "compresslevel",
 								   "blocksize", NULL};
 
 
+#ifdef HAVE_LIBZ
 /* Internal state for zlib */
 typedef struct zlib_state
 {
@@ -69,6 +70,7 @@ typedef struct zlib_state
 						  uLong sourceLen);
 
 } zlib_state;
+#endif
 
 static NameData
 comptype_to_name(char *comptype)
@@ -224,6 +226,7 @@ callCompressionValidator(PGFunction func, char *comptype, int32 complevel,
 	(void)DirectFunctionCall1(func, PointerGetDatum(&sa));
 }
 
+#ifdef HAVE_LIBZ
 Datum
 zlib_constructor(PG_FUNCTION_ARGS)
 {
@@ -378,6 +381,42 @@ zlib_validator(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_VOID();
 }
+#else
+Datum
+zlib_constructor(PG_FUNCTION_ARGS)
+{
+	elog(ERROR, "libz compression is not supported in this build of Greenplum");
+	PG_RETURN_VOID();
+}
+
+Datum
+zlib_destructor(PG_FUNCTION_ARGS)
+{
+	elog(ERROR, "libz compression is not supported in this build of Greenplum");
+	PG_RETURN_VOID();
+}
+
+Datum
+zlib_compress(PG_FUNCTION_ARGS)
+{
+	elog(ERROR, "libz compression is not supported in this build of Greenplum");
+	PG_RETURN_VOID();
+}
+
+Datum
+zlib_decompress(PG_FUNCTION_ARGS)
+{
+	elog(ERROR, "libz compression is not supported in this build of Greenplum");
+	PG_RETURN_VOID();
+}
+
+Datum
+zlib_validator(PG_FUNCTION_ARGS)
+{
+	elog(ERROR, "libz compression is not supported in this build of Greenplum");
+	PG_RETURN_VOID();
+}
+#endif
 
 Datum
 rle_type_constructor(PG_FUNCTION_ARGS)
@@ -456,9 +495,6 @@ dummy_compression_validator(PG_FUNCTION_ARGS)
 bool
 compresstype_is_valid(char *comptype)
 {
-	bool found = false;
-	int i;
-
 	/*
 	 * Hard-coding compresstypes is bad, agreed.  But there isn't a
 	 * better way in sight at this point.  Lookup into pg_compression
@@ -470,14 +506,25 @@ compresstype_is_valid(char *comptype)
 	 * Whenever the list of supported compresstypes is changed, this
 	 * must change!
 	 */
-	static const char *const valid_comptypes[] =
-			{"quicklz", "zlib", "rle_type", "none", "zstd"};
-	for (i = 0; !found && i < ARRAY_SIZE(valid_comptypes); ++i)
+	static const char *const valid_comptypes[] = {
+#ifdef HAVE_LIBQUICKLZ
+			"quicklz",
+#endif
+#ifdef HAVE_LIBZ
+			"zlib",
+#endif
+#ifdef HAVE_LIBZSTD
+			"zstd",
+#endif
+			"rle_type", "none"};
+
+	for (int i = 0; i < ARRAY_SIZE(valid_comptypes); ++i)
 	{
 		if (pg_strcasecmp(valid_comptypes[i], comptype) == 0)
-			found = true;
+			return true;
 	}
-	return found;
+
+	return false;
 }
 
 /*

--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/file.h>   /* for flock */
+#include <unistd.h>
 
 #ifdef WIN32
 #include <io.h>

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -34,7 +34,11 @@
  * If compression is turned on without specifying compresstype, this
  * is the default.
  */
+#ifdef HAVE_LIBZ
 #define AO_DEFAULT_COMPRESSTYPE   "zlib"
+#else
+#define AO_DEFAULT_COMPRESSTYPE   "none"
+#endif
 #define AO_DEFAULT_CHECKSUM       true
 #define AO_DEFAULT_COLUMNSTORE    false
 


### PR DESCRIPTION
Configuring the tree with --without-zlib generated compiler errors as we didn't properly guard usage of zlib with the autoconf feature-macro HAVE_LIBZ. This fixes the build by wrapping all callsites and provide a dummy implementation to error out in as a fallback (as we do for the other algorithms currently). While at it, compresstype_is_valid gets a little bit of polish and C99 loop initialization.

The inclusion of unistd.h in gfile.c may seem a bit odd as part of this patch but it turns out that zconf.h pulls in unistd.h which is required by gfile.c. When compiling without libz this header is missing and the file fails to compile. The fix is to always include it as gfile.c does depend on it for compilation of non-featuregated code.

While it will be rare that anyone wants to build explicitly without libz support (the default is to include it), it should still work. It is such a cornercase though that I don't see much point in adding a test for it

Backported from master commit dabe4488e8c
Reviewed-by: Adam Lee <ali@pivotal.io>

Fixes #8561 