### PR TITLE
Require --with-libxml for enabling gpcloud

### DIFF
--- a/configure
+++ b/configure
@@ -8243,6 +8243,10 @@ if test "$with_libcurl" = "no" && test "$enable_gpcloud" = "yes"; then
   as_fn_error $? "libcurl is required by gpcloud" "$LINENO" 5
 fi
 
+if test "$with_libxml" = "no" && test "$enable_gpcloud" = "yes"; then
+  as_fn_error $? "libxml is required by gpcloud" "$LINENO" 5
+fi
+
 #
 # libapr. Used for gpfdist and gpperfmon
 #

--- a/configure.in
+++ b/configure.in
@@ -1130,6 +1130,10 @@ if test "$with_libcurl" = "no" && test "$enable_gpcloud" = "yes"; then
   AC_MSG_ERROR([libcurl is required by gpcloud])
 fi
 
+if test "$with_libxml" = "no" && test "$enable_gpcloud" = "yes"; then
+  AC_MSG_ERROR([libxml is required by gpcloud])
+fi
+
 #
 # libapr. Used for gpfdist and gpperfmon
 #


### PR DESCRIPTION
GPCloud requires libxml, but the dependency wasn't coded in autoconf
which would lead to a tree that didn't compile on systems without
libxml installed.

Fixes #8560 
Reported-by: Bradford D. Boyle <bboyle@pivotal.io>