### PR TITLE
Suppress the temp file unlink failure log message

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1573,7 +1573,7 @@ FileClose(File file)
 
 		/* in any case do the unlink */
 		if (unlink(vfdP->fileName))
-			elog(LOG, "could not unlink file \"%s\": %m", vfdP->fileName);
+			elog(DEBUG1, "could not unlink file \"%s\": %m", vfdP->fileName);
 
 		/* and last report the stat results */
 		if (stat_errno == 0)
@@ -1592,7 +1592,7 @@ FileClose(File file)
 		else
 		{
 			errno = stat_errno;
-			elog(LOG, "could not stat file \"%s\": %m", vfdP->fileName);
+			elog(DEBUG1, "could not stat file \"%s\": %m", vfdP->fileName);
 		}
 	}
 


### PR DESCRIPTION
In GPDB, writing out shared snapshot to file uses named temp
files. Currently for cursor case this file gets registered twice in
`shared_snapshot_files` list via
dumpSharedLocalSnapshot_forCursor(). These registered files get
deleted from `AtEOXact_SharedSnapshot()` on Prepare/Abort/Commit
transaction. The reason for calling
dumpSharedLocalSnapshot_forCursor() twice on QE is because QD calls
verify_shared_snapshot_ready() twice in ExecutorStart() and
CdbDispatchPlan(). As a result FileClose() is called twice for the
same path, resulting in reporting unlink failure second time.

Hence, to reduce the noise in logs, suppress the temp file unlink
failures.

In long term, we wish to revisit shared snapshot writing to file and
possibly can completely avoid this change. With that we would be able
to revert this change.

Batchpath all the way till 5X_STABLE (where this is helpful for
workfile unlinking as well).

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
