### PR TITLE
docs - add pxf 5to6 migration topic

### DIFF
--- a/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -74,6 +74,7 @@
       </li>
       <li><a href="/6-0/pxf/jdbc_pxf.html" format="markdown">Accessing an SQL Database with PXF (JDBC)</a></li>
       <li><a href="/6-0/pxf/troubleshooting_pxf.html" format="markdown">Troubleshooting PXF</a></li>
+      <li><a href="/6-0/pxf/migrate_5to6.html" format="markdown">Migrating PXF from Greenplum 5</a></li>
       <li class="has_submenu">
         <a href="/6-0/pxf/ref/pxf-ref.html" format="markdown">PXF Utility Reference</a>
         <ul>

--- a/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
+++ b/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
@@ -2,7 +2,7 @@
 title: Migrating PXF from Greenplum 5
 ---
 
-If you are using PXF in your Greenplum Database 5 installation, Pivotal recommends that you upgrade Greenplum Database to version 5.21.2 or later before you migrate PXF to Greenplum Database 6. If you migrate from an earlier version of Greenplum 5, you will be required to perform additional migration steps in your Greenplum 6 installation.
+If you are using PXF in your Greenplum Database 5 installation, Pivotal recommends that you upgrade Greenplum Database to version **5.21.2** or later before you migrate PXF to Greenplum Database 6. If you migrate from an earlier version of Greenplum 5, you will be required to perform additional migration steps in your Greenplum 6 installation.
 
 The PXF Greenplum Database 5 to 6 migration procedure has two parts. You perform one PXF procedure in your Greenplum Database 5 installation, then install, configure, and migrate data to Greenplum 6, and then perform another PXF procedure in your Greenplum Database 6.0 installation:
 
@@ -18,7 +18,7 @@ Before migrating PXF from Greenplum 5 to Greenplum 6, ensure that you can:
 
 - Identify the version number of your Greenplum 5 installation.
 - Determine if you have `gphdfs` external tables defined in your Greenplum 5 installation.
-- Identify the file system location of the PXF `$PXF_CONF` directory in your Greenplum 5 installation.
+- Identify the file system location of the PXF `$PXF_CONF` directory in your Greenplum 5 installation. In Greenplum 5.15 and later, `$PXF_CONF` identifies the user configuration directory that was provided to the `pxf cluster init` command. This directory contains PXF server configurations, security keytab files, and log files.
 
 
 ## <a id="pxf5pre"></a>Step 1: PXF Greenplum Database 5 Pre-Migration Actions

--- a/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
+++ b/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
@@ -17,6 +17,7 @@ The PXF Greenplum Database 5 to 6 migration procedure has two parts. You perform
 Before migrating PXF from Greenplum 5 to Greenplum 6, ensure that you can:
 
 - Identify the version number of your Greenplum 5 installation.
+- Determine if you have `gphdfs` external tables defined in your Greenplum 5 installation.
 - Identify the file system location of the PXF `$PXF_CONF` directory in your Greenplum 5 installation.
 
 
@@ -44,6 +45,8 @@ Perform this procedure in your Greenplum Database 5 installation:
  PostgreSQL 8.3.23 (Greenplum Database 5.21.2 build commit:610b6d777436fe4a281a371cae85ac40f01f4f5e) on x86_64-pc-linux-gnu, compiled by GCC gcc (GCC) 6.2.0, 64-bit compiled on Aug  7 2019 20:38:47
 (1 row)
     ```
+
+3. Greenplum 6 removes the `gphdfs` external table protocol. If you have `gphdfs` external tables defined in your Greenplum 5 installation, you must delete or migrate them to `pxf` as described in the PXF documentation.
 
 3. Stop PXF on each segment host as described in [Stopping PXF](cfginitstart_pxf.html#stop_pxf).
 

--- a/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
+++ b/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
@@ -1,0 +1,82 @@
+---
+title: Migrating PXF from Greenplum 5
+---
+
+If you are using PXF in your Greenplum Database 5 installation, Pivotal recommends that you upgrade Greenplum Database to version 5.21.2 or later before you migrate PXF to Greenplum Database 6. If you migrate from an earlier version of Greenplum 5, you will be required to perform additional migration steps in your Greenplum 6 installation.
+
+The PXF Greenplum Database 5 to 6 migration procedure has two parts. You perform one PXF procedure in your Greenplum Database 5 installation, then install, configure, and migrate data to Greenplum 6, and then perform another PXF procedure in your Greenplum Database 6.0 installation:
+
+-   [Step 1: PXF Greenplum Database 5 Pre-Migration Actions](#pxf5pre)
+-   Install Greenplum Database 6
+-   Migrate Data from Greenplum Database 5 to Greenplum Database 6
+-   [Step 2: Migrate PXF to Greenplum Database 6](#pxfmig)
+
+
+## <a id="prerequisites"></a>Prerequisites
+
+Before migrating PXF from Greenplum 5 to Greenplum 6, ensure that you can:
+
+- Identify the version number of your Greenplum 5 installation.
+- Identify the file system location of the PXF `$PXF_CONF` directory in your Greenplum 5 installation.
+
+
+## <a id="pxf5pre"></a>Step 1: PXF Greenplum Database 5 Pre-Migration Actions
+
+Perform this procedure in your Greenplum Database 5 installation:
+
+1. Log in to the Greenplum Database master node. For example:
+
+    ``` shell
+    $ ssh gpadmin@<gp5master>
+    ```
+
+2. Identify and save the Greenplum Database version number of your 5 installation. For example:
+
+    ``` shell
+    gpadmin@gp5master$ psql -d postgres
+    ```
+
+    ``` sql
+    SELECT version();
+
+               version 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ PostgreSQL 8.3.23 (Greenplum Database 5.21.2 build commit:610b6d777436fe4a281a371cae85ac40f01f4f5e) on x86_64-pc-linux-gnu, compiled by GCC gcc (GCC) 6.2.0, 64-bit compiled on Aug  7 2019 20:38:47
+(1 row)
+    ```
+
+3. Stop PXF on each segment host as described in [Stopping PXF](cfginitstart_pxf.html#stop_pxf).
+
+4. If you plan to install Greenplum Database 6 on a new set of hosts, be sure to retain or save a copy of the `$PXF_CONF` directory in your Greenplum 5 installation.
+
+5. Install and configure Greenplum Database 6, migrate Greenplum 5 table definitions and data to your Greenplum 6 installation, and then continue your PXF migration with [Step 2: Migrating PXF to Greenplum 6](#pxfmig).
+
+
+## <a id="pxfmig"></a>Step 2: Migrating PXF to Greenplum 6
+
+After you install and configure Greenplum Database 6 and migrate table definitions and data from the Greenplum 5 installation, perform the following procedure to configure and start the new PXF software:
+
+1. Log in to the Greenplum Database 6 master node. For example:
+
+    ``` shell
+    $ ssh gpadmin@<gp6master>
+    ```
+
+2. If you installed Greenplum Database 6 on a new set of hosts, copy the `$PXF_CONF` directory from your Greenplum 5 installation to the master node. Consider copying the directory to the same file system location at which it resided in the 5 cluster. For example, if `PXF_CONF=/usr/local/greenplum-pxf`:
+
+    ``` shell
+    gpadmin@gp6master$ scp -r gpadmin@<gp5master>:/usr/local/greenplum-pxf /usr/local/
+    ```
+
+3. Initialize PXF on each segment host as described in [Initializing PXF](init_pxf.html), specifying the `PXF_CONF` directory that you copied in the step above.
+
+4. **If you are migrating from Greenplum Database version 5.21.1 or earlier**, perform the version-applicable steps identified in the Greenplum Database 5.21 [Upgrading PXF](https://gpdb.docs.pivotal.io/5210/pxf/upgrade_pxf.html#pxfup) documentation in your Greenplum Database 6 installation. **Start with step 4 in the procedure**. (Note that this procedure identifies the actions required to upgrade PXF between Greenplum Database 5.x releases. Some of these steps may be required to configure a Greenplum version-6-compatible PXF.)
+
+5. Synchronize the PXF configuration from the Greenplum Database 6 master host to the standby master and each segment host in the cluster. For example:
+
+    ``` shell
+    gpadmin@gp6master$ $GPHOME/pxf/bin/pxf cluster sync
+    ```
+ 
+6. Start PXF on each Greenplum Database 6 segment host as described in [Starting PXF](cfginitstart_pxf.html#start_pxf).
+

--- a/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
+++ b/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
@@ -46,7 +46,7 @@ Perform this procedure in your Greenplum Database 5 installation:
 (1 row)
     ```
 
-3. Greenplum 6 removes the `gphdfs` external table protocol. If you have `gphdfs` external tables defined in your Greenplum 5 installation, you must delete or migrate them to `pxf` as described in the PXF documentation.
+3. Greenplum 6 removes the `gphdfs` external table protocol. If you have `gphdfs` external tables defined in your Greenplum 5 installation, you must delete or migrate them to `pxf` as described in [Migrating gphdfs External Tables to PXF](gphdfs-pxf-migrate.html).
 
 3. Stop PXF on each segment host as described in [Stopping PXF](cfginitstart_pxf.html#stop_pxf).
 

--- a/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
+++ b/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
@@ -4,11 +4,9 @@ title: Migrating PXF from Greenplum 5
 
 If you are using PXF in your Greenplum Database 5 installation, Pivotal recommends that you upgrade Greenplum Database to version **5.21.2** or later before you migrate PXF to Greenplum Database 6. If you migrate from an earlier version of Greenplum 5, you will be required to perform additional migration steps in your Greenplum 6 installation.
 
-The PXF Greenplum Database 5 to 6 migration procedure has two parts. You perform one PXF procedure in your Greenplum Database 5 installation, then install, configure, and migrate data to Greenplum 6, and then perform another PXF procedure in your Greenplum Database 6.0 installation:
+The PXF Greenplum Database 5 to 6 migration procedure has two parts. You perform one PXF procedure in your Greenplum Database 5 installation, then install, configure, and migrate data to Greenplum 6:
 
--   [Step 1: PXF Greenplum Database 5 Pre-Migration Actions](#pxf5pre)
--   Install Greenplum Database 6
--   Migrate Data from Greenplum Database 5 to Greenplum Database 6
+-   [Step 1: Complete PXF Greenplum Database 5 Pre-Migration Actions](#pxf5pre)
 -   [Step 2: Migrate PXF to Greenplum Database 6](#pxfmig)
 
 
@@ -21,7 +19,7 @@ Before migrating PXF from Greenplum 5 to Greenplum 6, ensure that you can:
 - Identify the file system location of the PXF `$PXF_CONF` directory in your Greenplum 5 installation. In Greenplum 5.15 and later, `$PXF_CONF` identifies the user configuration directory that was provided to the `pxf cluster init` command. This directory contains PXF server configurations, security keytab files, and log files.
 
 
-## <a id="pxf5pre"></a>Step 1: PXF Greenplum Database 5 Pre-Migration Actions
+## <a id="pxf5pre"></a>Step 1: Complete PXF Greenplum Database 5 Pre-Migration Actions
 
 Perform this procedure in your Greenplum Database 5 installation:
 
@@ -31,7 +29,7 @@ Perform this procedure in your Greenplum Database 5 installation:
     $ ssh gpadmin@<gp5master>
     ```
 
-2. Identify and save the Greenplum Database version number of your 5 installation. For example:
+2. Identify the Greenplum Database version number of your 5 installation. For example:
 
     ``` shell
     gpadmin@gp5master$ psql -d postgres
@@ -46,11 +44,13 @@ Perform this procedure in your Greenplum Database 5 installation:
 (1 row)
     ```
 
+    If you are running a Greenplum Database version prior to 5.21.2, consider upgrading to version 5.21.2 as described in [Upgrading PXF](https://gpdb.docs.pivotal.io/5210/pxf/upgrade_pxf.html#pxfup) in the Greenplum 5 documentation.
+
 3. Greenplum 6 removes the `gphdfs` external table protocol. If you have `gphdfs` external tables defined in your Greenplum 5 installation, you must delete or migrate them to `pxf` as described in [Migrating gphdfs External Tables to PXF](gphdfs-pxf-migrate.html).
 
 3. Stop PXF on each segment host as described in [Stopping PXF](cfginitstart_pxf.html#stop_pxf).
 
-4. If you plan to install Greenplum Database 6 on a new set of hosts, be sure to retain or save a copy of the `$PXF_CONF` directory in your Greenplum 5 installation.
+4. If you plan to install Greenplum Database 6 on a new set of hosts, be sure to save a copy of the `$PXF_CONF` directory in your Greenplum 5 installation.
 
 5. Install and configure Greenplum Database 6, migrate Greenplum 5 table definitions and data to your Greenplum 6 installation, and then continue your PXF migration with [Step 2: Migrating PXF to Greenplum 6](#pxfmig).
 
@@ -73,7 +73,7 @@ After you install and configure Greenplum Database 6 and migrate table definitio
 
 3. Initialize PXF on each segment host as described in [Initializing PXF](init_pxf.html), specifying the `PXF_CONF` directory that you copied in the step above.
 
-4. **If you are migrating from Greenplum Database version 5.21.1 or earlier**, perform the version-applicable steps identified in the Greenplum Database 5.21 [Upgrading PXF](https://gpdb.docs.pivotal.io/5210/pxf/upgrade_pxf.html#pxfup) documentation in your Greenplum Database 6 installation. **Start with step 4 in the procedure**. (Note that this procedure identifies the actions required to upgrade PXF between Greenplum Database 5.x releases. Some of these steps may be required to configure a Greenplum version-6-compatible PXF.)
+4. **If you are migrating from Greenplum Database version 5.21.1 or earlier**, perform the version-applicable steps identified in the Greenplum Database 5.21 [Upgrading PXF](https://gpdb.docs.pivotal.io/5210/pxf/upgrade_pxf.html#pxfup) documentation in your Greenplum Database 6 installation. **Start with step 4 in the procedure**. (Note that this procedure identifies the actions required to upgrade PXF between Greenplum Database 5.x releases. These steps are required to configure a Greenplum version-6-compatible PXF.)
 
 5. Synchronize the PXF configuration from the Greenplum Database 6 master host to the standby master and each segment host in the cluster. For example:
 
@@ -82,4 +82,6 @@ After you install and configure Greenplum Database 6 and migrate table definitio
     ```
  
 6. Start PXF on each Greenplum Database 6 segment host as described in [Starting PXF](cfginitstart_pxf.html#start_pxf).
+
+7. Verify the migration by testing that each PXF external table can access the referenced data store.
 


### PR DESCRIPTION
(work in progress)  add topic for pxf migration from greenplum 5 to 6.  similar to pxf upgrade, some tasks are performed in the greenplum 5 installation, and other tasks are performed in the greenplum 6 installation after it is configured and data is migrated.

todo:  need to address gphdfs-to-pxf migration in this topic, or vice-versa.

doc review site link:  http://docs-lisa-pxf-5to6-migrate.cfapps.io/6-0/pxf/migrate_5to6.html
