### PR TITLE
docs - add note to pageinspect module for GPDB

### DIFF
--- a/gpdb-doc/dita/ref_guide/modules/modules.ditamap
+++ b/gpdb-doc/dita/ref_guide/modules/modules.ditamap
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map title="Additional Supplied Modules">
-  <topicref href="intro.xml" navtitle="Additional Supplied Modules">
-    <topicref href="auto-explain.xml" linking="none"/>
-    <topicref href="citext.xml" linking="none"/>
-    <topicref href="dblink.xml" linking="none"/>
-    <topicref href="diskquota.xml" linking="none"/>
-    <topicref href="fuzzystrmatch.xml" linking="none"/>
-    <topicref href="gp_sparse_vector.xml" linking="none"/>
-    <topicref href="hstore.xml" linking="none"/>
-    <topicref href="orafce_ref.xml" linking="none"/>
-    <topicref href="pageinspect.xml" linking="none"/>
-    <topicref href="pgcrypto.xml" linking="none"/>
+  <topicref href="intro.xml" navtitle="Additional Supplied Modules" linking="targetonly">
+    <topicref href="auto-explain.xml"/>
+    <topicref href="citext.xml"/>
+    <topicref href="dblink.xml"/>
+    <topicref href="diskquota.xml"/>
+    <topicref href="fuzzystrmatch.xml"/>
+    <topicref href="gp_sparse_vector.xml"/>
+    <topicref href="hstore.xml"/>
+    <topicref href="orafce_ref.xml"/>
+    <topicref href="pageinspect.xml"/>
+    <topicref href="pgcrypto.xml"/>
     <topicref href="sslinfo.xml"/>
   </topicref>
 </map>

--- a/gpdb-doc/dita/ref_guide/modules/pageinspect.xml
+++ b/gpdb-doc/dita/ref_guide/modules/pageinspect.xml
@@ -34,8 +34,8 @@
           function reads data only from the segment instance where the function is executed. For
           example, the <codeph>get_raw_page()</codeph> function returns a <codeph>block number out
             of range</codeph> error when you try to read data from a user-defined table on the
-          Greenplum Database master because there is no data in the table on the master. The
-          function will read data from a system catalog table on the master.</note>
+          Greenplum Database master because there is no data in the table on the master segment. The
+          function will read data from a system catalog table on the master segment.</note>
       </body>
     </topic>
   </topic>

--- a/gpdb-doc/dita/ref_guide/modules/pageinspect.xml
+++ b/gpdb-doc/dita/ref_guide/modules/pageinspect.xml
@@ -29,8 +29,13 @@
       <body>
         <p>See <codeph><xref href="https://www.postgresql.org/docs/9.4/pageinspect.html"
             scope="external" format="html">pageinspect</xref></codeph> in the PostgreSQL
-          documentation for detailed information about the individual functions in
-          this module.</p>
+          documentation for detailed information about the individual functions in this module.</p>
+        <note>For <codeph>pageinspect</codeph> functions that read data from a database, the
+          function reads data only from the segment instance where the function is executed. For
+          example, the <codeph>get_raw_page()</codeph> function returns a <codeph>block number out
+            of range</codeph> error when you try to read data from a user-defined table on the
+          Greenplum Database master because there is no data in the table on the master. The
+          function will read data from a system catalog table on the master.</note>
       </body>
     </topic>
   </topic>


### PR DESCRIPTION
data-reading functions only read from segment where function is executed.
Also, a minor fix to ditamap to remove duplicate link to sslinfo in intro page.

Will be backported to 6X_STABLE

See issue 
https://github.com/greenplum-db/gpdb/issues/8127

