### PR TITLE
docs - pg_stat_activity - add note about resource group values.

### DIFF
--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_activity.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_activity.xml
@@ -4,9 +4,9 @@
 <topic id="topic1" xml:lang="en">
   <title id="hq141670">pg_stat_activity</title>
   <body>
-    <p>The view <codeph>pg_stat_activity</codeph> shows one row per server process and details about
-      it associated user session and query. The columns that report data on the current query are
-      available unless the parameter <codeph>stats_command_string</codeph> has been turned off.
+    <p>The view <codeph>pg_stat_activity</codeph> shows one row per server process with details
+      about the associated user session and query. The columns that report data on the current query
+      are available unless the parameter <codeph>stats_command_string</codeph> has been turned off.
       Furthermore, these columns are only visible if the user examining the view is a superuser or
       the same as the user owning the process being reported on.</p>
     <p>The maximum length of the query text string stored in the column

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_activity.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_activity.xml
@@ -1,14 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1" xml:lang="en"><title id="hq141670">pg_stat_activity</title><body><p>The view <codeph>pg_stat_activity</codeph> shows one row per server
-process and details about it associated user session and query. The columns
-that report data on the current query are available unless the parameter
-<codeph>stats_command_string</codeph> has been turned off. Furthermore,
-these columns are only visible if the user examining the view is a superuser
-or the same as the user owning the process being reported on.</p><p>The maximum length of the query text string stored in the column <codeph>current_query</codeph>
-      can be controlled with the server configuration parameter
-        <codeph>track_activity_query_size</codeph>. </p><table id="hq141982"><title>pg_catalog.pg_stat_activity</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody><row><entry colname="col1"><codeph>datid</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_database.oid</entry><entry colname="col4">Database OID</entry></row><row><entry colname="col1"><codeph>datname</codeph></entry><entry colname="col2">name</entry><entry colname="col3"/><entry colname="col4">Database name</entry></row>
+<topic id="topic1" xml:lang="en">
+  <title id="hq141670">pg_stat_activity</title>
+  <body>
+    <p>The view <codeph>pg_stat_activity</codeph> shows one row per server process and details about
+      it associated user session and query. The columns that report data on the current query are
+      available unless the parameter <codeph>stats_command_string</codeph> has been turned off.
+      Furthermore, these columns are only visible if the user examining the view is a superuser or
+      the same as the user owning the process being reported on.</p>
+    <p>The maximum length of the query text string stored in the column
+        <codeph>current_query</codeph> can be controlled with the server configuration parameter
+        <codeph>track_activity_query_size</codeph>. </p>
+    <table id="hq141982">
+      <title>pg_catalog.pg_stat_activity</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>datid</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_database.oid</entry>
+            <entry colname="col4">Database OID</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>datname</codeph></entry>
+            <entry colname="col2">name</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">Database name</entry>
+          </row>
           <row>
             <entry><codeph>pid</codeph></entry>
             <entry>integer</entry>
@@ -142,13 +173,15 @@ or the same as the user owning the process being reported on.</p><p>The maximum 
             <entry colname="col1"><codeph>rsgid</codeph></entry>
             <entry colname="col2">oid</entry>
             <entry colname="col3">pg_resgroup.oid</entry>
-            <entry colname="col4">Resource group OID</entry>
+            <entry colname="col4">Resource group OID or <codeph>0</codeph>.<p>See <xref
+                  href="#topic1/rsg_note" format="dita">Note</xref>.</p></entry>
           </row>
           <row>
             <entry colname="col1"><codeph>rsgname</codeph></entry>
             <entry colname="col2">text</entry>
             <entry colname="col3">pg_resgroup.rsgname</entry>
-            <entry colname="col4">Resource group name</entry>
+            <entry colname="col4">Resource group name or <codeph>unknown</codeph>.<p>See <xref
+                  href="#topic1/rsg_note" format="dita">Note</xref>.</p></entry>
           </row>
           <row>
             <entry colname="col1"><codeph>rsgqueueduration</codeph></entry>
@@ -157,4 +190,13 @@ or the same as the user owning the process being reported on.</p><p>The maximum 
             <entry colname="col4">For a queued query, the total time the query has been
               queued.</entry>
           </row>
-</tbody></tgroup></table></body></topic>
+        </tbody>
+      </tgroup>
+    </table>
+    <note id="rsg_note">When resource groups are enabled. Only query dispatcher (QD) processes will
+      have a <codeph>rsgid</codeph> and <codeph>rsgname</codeph>. Other server processes such as a
+      query executer (QE) process or session connection processes will have a <codeph>rsgid</codeph>
+      value of <codeph>0</codeph> and a <codeph>rsgname</codeph> value of <codeph>unknown</codeph>.
+      QE processes are managed by the same resource group as the dispatching QD process. </note>
+  </body>
+</topic>


### PR DESCRIPTION
Added note after the table stating only QD processes will have
values when resource groups are enabled.

This will be backported to 6X_STABLE and 5X_STABLE