### PR TITLE
6X: ci: fix ic and external_table

### DIFF
--- a/src/test/isolation2/output/external_table.source
+++ b/src/test/isolation2/output/external_table.source
@@ -58,14 +58,14 @@ RESET
 SELECT gp_inject_fault('interconnect_setup_palloc', 'suspend', dbid) FROM gp_segment_configuration WHERE content=-1 AND role='p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- Inject fault on QE to determine when it aborts.
 SELECT gp_inject_fault('transaction_abort_failure', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- Start a transaction with cursor that triggers error on QE
@@ -77,13 +77,13 @@ BEGIN
 SELECT gp_wait_until_triggered_fault('transaction_abort_failure', 1, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 SELECT gp_wait_until_triggered_fault('interconnect_setup_palloc', 1, dbid) FROM gp_segment_configuration WHERE content=-1 AND role='p';
  gp_wait_until_triggered_fault 
 -------------------------------
- t                             
+ Success:                      
 (1 row)
 
 -- Resume QD.
@@ -91,7 +91,7 @@ SELECT gp_wait_until_triggered_fault('interconnect_setup_palloc', 1, dbid) FROM 
 SELECT gp_inject_fault('interconnect_setup_palloc', 'resume', dbid) FROM gp_segment_configuration WHERE content=-1 AND role='p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- Check the result
@@ -106,12 +106,12 @@ COMMIT
 SELECT gp_inject_fault('transaction_abort_failure', 'reset', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', dbid) FROM gp_segment_configuration WHERE content=-1 AND role='p';
  gp_inject_fault 
 -----------------
- t               
+ Success:        
 (1 row)
 
 -- This should have errors populated already

--- a/src/test/regress/expected/ic.out
+++ b/src/test/regress/expected/ic.out
@@ -506,19 +506,17 @@ CREATE TABLE test_ic_error(a INT, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT gp_inject_fault('interconnect_setup_palloc', 'error', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 SELECT * FROM test_ic_error t1, test_ic_error t2 where t1.a=t2.b;
 ERROR:  fault triggered, fault name:'interconnect_setup_palloc' fault type:'error'  (seg0 slice2 172.17.0.4:25432 pid=68446)
 SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', 2);
-NOTICE:  Success:
  gp_inject_fault 
 -----------------
- t
+ Success:
 (1 row)
 
 DROP TABLE test_ic_error;


### PR DESCRIPTION
In commit 90450095e3e88f6bf86dafa966b65f761590d813 we added some tests
with fault injector, however looks like the output format of
gp_inject_fault() has changed on 6X_STABLE, so although the PR was
verified before merging, the tests ic and external_table are red on
6X_STABLE pipelines.

Fixed by updating the output format of gp_inject_fault().

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
