### PR TITLE
Test pg_upgrade from 5.X in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,7 +192,9 @@ script:
         pushd $HOME/gpdb-5.21.4
         make -s install
         source $HOME/gpdb5/greenplum_path.sh
-        make -C gpAux/gpdemo cluster
+        make -C gpAux/gpdemo cluster || true
+        cat /home/travis/gpdb-5.21.4/gpAux/gpdemo/datadirs/gpAdminLogs/gpinitsystem_20190909.log
+        exit
         source gpAux/gpdemo/gpdemo-env.sh
         gpstop -aq
         unset MASTER_DATA_DIRECTORY

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,7 +185,9 @@ script:
         make -C gpAux/gpdemo cluster
         source gpAux/gpdemo/gpdemo-env.sh
         gpstop -aq
-        export SRCDIR=$PWD
+        unset MASTER_DATA_DIRECTORY
+        unset PGPORT
+        unset GPHOME
         mkdir -p $HOME/gpdb5
         pushd $HOME/gpdb-5.21.4
         make -s install
@@ -193,6 +195,9 @@ script:
         make -C gpAux/gpdemo cluster
         source gpAux/gpdemo/gpdemo-env.sh
         gpstop -aq
+        unset MASTER_DATA_DIRECTORY
+        unset PGPORT
+        unset GPHOME
         popd
         bash ./src/bin/pg_upgrade/test_gpdb.sh -C -s -o $HOME/gpdb-5.21.4/gpAux/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/ -B $HOME/gpdb5/bin -b $TRAVIS_BUILD_DIR/gpsql/bin
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,14 +183,16 @@ script:
         make -s install
         source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
         make -C gpAux/gpdemo cluster
-        gpstop -a
+        source gpAux/gpdemo/gpdemo-env.sh
+        gpstop -aq
         export SRCDIR=$PWD
         mkdir -p $HOME/gpdb5
         pushd $HOME/gpdb-5.21.4
         make -s install
         source $HOME/gpdb5/greenplum_path.sh
         make -C gpAux/gpdemo cluster
-        gpstop -a
+        source gpAux/gpdemo/gpdemo-env.sh
+        gpstop -aq
         popd
         bash ./src/bin/pg_upgrade/test_gpdb.sh -C -s -o $HOME/gpdb-5.21.4/gpAux/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/ -B $HOME/gpdb5/bin -b $TRAVIS_BUILD_DIR/gpsql/bin
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -192,11 +192,10 @@ script:
         pushd $HOME/gpdb-5.21.4
         make -s install
         source $HOME/gpdb5/greenplum_path.sh
-        export DEFAULT_QD_MAX_CONNECT=5
+        export DEFAULT_QD_MAX_CONNECT=10
         export NEW_BUFFERS="5000kB"
         make -C gpAux/gpdemo cluster || true
         cat /home/travis/gpdb-5.21.4/gpAux/gpdemo/datadirs/gpAdminLogs/gpinitsystem_20190909.log
-        exit
         source gpAux/gpdemo/gpdemo-env.sh
         gpstop -aq
         unset MASTER_DATA_DIRECTORY

--- a/.travis.yml
+++ b/.travis.yml
@@ -192,6 +192,8 @@ script:
         pushd $HOME/gpdb-5.21.4
         make -s install
         source $HOME/gpdb5/greenplum_path.sh
+        export DEFAULT_QD_MAX_CONNECT=10
+        export BLDWRAP_POSTGRES_CONF_ADDONS="shared_buffers=500"
         make -C gpAux/gpdemo cluster || true
         cat /home/travis/gpdb-5.21.4/gpAux/gpdemo/datadirs/gpAdminLogs/gpinitsystem_20190909.log
         exit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@
 
 language: c
 sudo: false
+cache:
+  directories:
+    - $HOME/gpdb-5.21.4
 
 git:
   submodules: false
@@ -66,6 +69,23 @@ matrix:
           osx_image: xcode11
           env: T=macos
         #
+        # Upgrade test
+        # ----------------------------------------------------------------
+        # Runs the pg_upgrade test_gpdb.sh script against the cached 5.x
+        # build.
+        - os: linux
+          dist: bionic
+          compiler: gcc
+          env:
+              - T=upgrade C=""
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+        #
         # Configuration variations
         # ----------------------------------------------------------------
         #
@@ -109,6 +129,18 @@ install:
 before_script:
     - ssh-keygen -t "rsa" -f ~/.ssh/id_rsa -N ""
     - cp ~/.ssh/{id_rsa.pub,authorized_keys}
+    - |
+      if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+        if [ ! -e $HOME/gpdb-5.21.4/GNUmakefile ]; then
+          (cd $HOME && \
+           mkdir -p gpdb5 && \
+           curl -LO https://github.com/greenplum-db/gpdb/archive/5.21.4.tar.gz && \
+           tar -zxf 5.21.4.tar.gz && \
+           cd gpdb-5.21.4 && \
+           CC="gcc-8" CXX="g++-8" ./configure --prefix=$HOME/gpdb5/ --with-perl --with-python --disable-orca --disable-gpcloud && \
+           make -s)
+        fi
+      fi
 
 script:
   - |
@@ -135,6 +167,32 @@ script:
         make -C gpAux/gpdemo cluster
         source gpAux/gpdemo/gpdemo-env.sh
         make -C src/test/regress installcheck-small
+      fi
+  - |
+      set -eo pipefail
+      if [ "$T" = "upgrade" ]; then
+        ./configure \
+            --prefix=${TRAVIS_BUILD_DIR}/gpsql \
+            --with-perl \
+            --with-python \
+            --disable-orca \
+            --disable-gpcloud \
+            --disable-pxf \
+            --with-libcurl \
+            $C
+        make -s install
+        source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
+        make -C gpAux/gpdemo cluster
+        gpstop -a
+        export SRCDIR=$PWD
+        mkdir -p $HOME/gpdb5
+        pushd $HOME/gpdb-5.21.4
+        make -s install
+        source $HOME/gpdb5/greenplum_path.sh
+        make -C gpAux/gpdemo cluster
+        gpstop -a
+        popd
+        bash ./src/bin/pg_upgrade/test_gpdb.sh -C -s -o $HOME/gpdb-5.21.4/gpAux/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/ -B $HOME/gpdb5/bin -b $TRAVIS_BUILD_DIR/gpsql/bin
       fi
   - |
       set -eo pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,7 @@ install:
     - pip install --user --pre psutil
     - pip install --user lockfile
     - pip install --user setuptools
+    - pip install --user paramiko
 
 ## ----------------------------------------------------------------------
 ## Perform build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -192,8 +192,8 @@ script:
         pushd $HOME/gpdb-5.21.4
         make -s install
         source $HOME/gpdb5/greenplum_path.sh
-        export DEFAULT_QD_MAX_CONNECT=10
-        export BLDWRAP_POSTGRES_CONF_ADDONS="shared_buffers=500"
+        export DEFAULT_QD_MAX_CONNECT=5
+        export NEW_BUFFERS="5000kB"
         make -C gpAux/gpdemo cluster || true
         cat /home/travis/gpdb-5.21.4/gpAux/gpdemo/datadirs/gpAdminLogs/gpinitsystem_20190909.log
         exit


### PR DESCRIPTION
This adds a job in the Travis matrix which runs test_gpdb.sh against a cached build of 5.21.4 (becuase it happened to be the latest 5.X at the time of writing). Only a QD upgrade is attempted for now, the idea is to do a full upgrade of a known small dataset, but until the time consumption is known we'll settle for the minimum approach.

This is very much a WIP which I don't expect to work for a few iterations (if at all), but it's worth a try.