### PR TITLE
5X: Avoid duplicated repeat node. 

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -1592,6 +1592,32 @@ make_two_stage_agg_plan(PlannerInfo *root,
 	/* Marshal implicit results. Return explicit result. */
 	ctx->current_pathkeys = current_pathkeys;
 	ctx->querynode_changed = true;
+
+	/* Add the Repeat node if needed. */
+	if (result_plan != NULL &&
+		ctx->canonical_grpsets != NULL &&
+		ctx->canonical_grpsets->grpset_counts != NULL)
+	{
+		bool		need_repeat_node = false;
+		int			grpset_no;
+		int			repeat_count = 0;
+
+		for (grpset_no = 0; grpset_no < ctx->canonical_grpsets->ngrpsets; grpset_no++)
+		{
+			if (ctx->canonical_grpsets->grpset_counts[grpset_no] > 1)
+			{
+				need_repeat_node = true;
+				break;
+			}
+		}
+		if (ctx->canonical_grpsets->ngrpsets == 1)
+			repeat_count = ctx->canonical_grpsets->grpset_counts[0];
+
+		if (need_repeat_node)
+		{
+			result_plan = add_repeat_node(result_plan, repeat_count, 0);
+		}
+	}
 	return result_plan;
 }
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1594,33 +1594,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 												   &agg_counts,
 												   &group_context);
 
-			/* Add the Repeat node if needed. */
-			if (result_plan != NULL &&
-				canonical_grpsets != NULL &&
-				canonical_grpsets->grpset_counts != NULL)
-			{
-				bool		need_repeat_node = false;
-				int			grpset_no;
-				int			repeat_count = 0;
-
-				for (grpset_no = 0; grpset_no < canonical_grpsets->ngrpsets; grpset_no++)
-				{
-					if (canonical_grpsets->grpset_counts[grpset_no] > 1)
-					{
-						need_repeat_node = true;
-						break;
-					}
-				}
-
-				if (canonical_grpsets->ngrpsets == 1)
-					repeat_count = canonical_grpsets->grpset_counts[0];
-
-				if (need_repeat_node)
-				{
-					result_plan = add_repeat_node(result_plan, repeat_count, 0);
-				}
-			}
-
 			if (result_plan != NULL && result_plan->flow->numSortCols == 0)
 			{
 				/*

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6118,3 +6118,55 @@ select x, y, count(*), grouping(x,y) from generate_series(1,1) x, generate_serie
  1 |   |     1 |        1
 (1 row)
 
+-- test repeat node
+-- Greenplum uses repeat node in plan to handle the case
+-- that duplicated groups in grouping sets. we have some
+-- bugs causing duplicated repeat node and wrong result.
+-- Fix it and add some tests.
+create table repeat_node_sale
+(
+    cn int not null,
+    vn int not null,
+    pn int not null,
+    dt date not null,
+    qty int not null,
+    prc float not null
+) distributed by (cn,vn,pn);
+insert into repeat_node_sale values
+  ( 2, 40, 100, '1401-1-1', 1100, 2400),
+  ( 1, 10, 200, '1401-3-1', 1, 0),
+  ( 3, 40, 200, '1401-4-1', 1, 0),
+  ( 1, 20, 100, '1401-5-1', 1, 0),
+  ( 1, 30, 300, '1401-5-2', 1, 0),
+  ( 1, 50, 400, '1401-6-1', 1, 0),
+  ( 2, 50, 400, '1401-6-1', 1, 0),
+  ( 1, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 600, '1401-6-1', 12, 5),
+  ( 4, 40, 700, '1401-6-1', 1, 1),
+  ( 4, 40, 800, '1401-6-1', 1, 1);
+set gp_eager_one_phase_agg to on;
+select cn,vn,sum(qty) from repeat_node_sale group by grouping sets ((cn,vn), cn, cn);
+ cn | vn | sum  
+----+----+------
+  1 | 30 |   13
+  1 | 50 |    1
+  1 | 10 |    1
+  3 | 30 |   24
+  2 | 50 |    1
+  2 | 40 | 1100
+  4 |    |    2
+  4 |    |    2
+  3 |    |   25
+  3 |    |   25
+  3 | 40 |    1
+  1 | 20 |    1
+  4 | 40 |    2
+  1 |    |   16
+  1 |    |   16
+  2 |    | 1101
+  2 |    | 1101
+(17 rows)
+
+reset gp_eager_one_phase_agg;
+drop table repeat_node_sale;

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -637,3 +637,40 @@ insert into test_gsets values (0, 0), (0, 1), (0,2);
 select i,n,count(*), grouping(i), grouping(n), grouping(i,n) from test_gsets group by grouping sets((), (i,n)) having n is null;
 
 select x, y, count(*), grouping(x,y) from generate_series(1,1) x, generate_series(1,1) y group by grouping sets(x,y) having x is not null;
+
+-- test repeat node
+-- Greenplum uses repeat node in plan to handle the case
+-- that duplicated groups in grouping sets. we have some
+-- bugs causing duplicated repeat node and wrong result.
+-- Fix it and add some tests.
+create table repeat_node_sale
+(
+    cn int not null,
+    vn int not null,
+    pn int not null,
+    dt date not null,
+    qty int not null,
+    prc float not null
+) distributed by (cn,vn,pn);
+
+insert into repeat_node_sale values
+  ( 2, 40, 100, '1401-1-1', 1100, 2400),
+  ( 1, 10, 200, '1401-3-1', 1, 0),
+  ( 3, 40, 200, '1401-4-1', 1, 0),
+  ( 1, 20, 100, '1401-5-1', 1, 0),
+  ( 1, 30, 300, '1401-5-2', 1, 0),
+  ( 1, 50, 400, '1401-6-1', 1, 0),
+  ( 2, 50, 400, '1401-6-1', 1, 0),
+  ( 1, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 600, '1401-6-1', 12, 5),
+  ( 4, 40, 700, '1401-6-1', 1, 1),
+  ( 4, 40, 800, '1401-6-1', 1, 1);
+
+set gp_eager_one_phase_agg to on;
+
+select cn,vn,sum(qty) from repeat_node_sale group by grouping sets ((cn,vn), cn, cn);
+
+reset gp_eager_one_phase_agg;
+
+drop table repeat_node_sale;


### PR DESCRIPTION
Greenplum uses repeat node in plan to handle the case
that duplicated groups in grouping sets. Previously,
we add this node at two places:
  1. make_list_aggs_for_rollup, when is not twostage agg
  2. grouping_planner, when group-by keys are not collocated with dist-keys

But under some contitions, there are code paths that will add duplicated
repeat nodes. For example, when the GUC gp_eager_one_phase_agg is set to on,
, the grouping sets contains duplicated groups and group-by keys are not
collcated with dist-keys. In such case, repeate node is added both in 1 and
2.

This commit fixes the bug by:
  1. removing the code adding repeat node in grouping_planner
  2. let make_one_stage_agg_plan and make_two_stage_agg_plan handle adding
     repeat node

This commit is cherry-pick from ce4e18fca182ed781c4d06c92b0c541de299c23c

Co-authored-by: Zhenghua Lyu <zlv@pivotal.io>

----

This commit is cherry-picked from 6x, and it has been reviewed and merged into 6x.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] PM's green light
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
