### PR TITLE
Ensure link mode upgrades an entire cluster successfully with hard links.

### DIFF
--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test.c
@@ -6,6 +6,7 @@
 #include "libpq-fe.h"
 #include "stdbool.h"
 #include "stdlib.h"
+#include "sys/stat.h"
 
 #include "utilities/gpdb5-cluster.h"
 #include "utilities/gpdb6-cluster.h"
@@ -106,47 +107,31 @@ extract_user_rows(PGresult *result, User *rows[])
 	}
 }
 
-static void
-test_a_heap_table_with_data_can_be_upgraded(void **state)
+static void 
+createHeapTableWithDataInFiveCluster(void)
 {
-	/*
-	 * Given a heap table in a greenplum 5 database
-	 * with rows of data
-	 */
-	startGpdbFiveCluster();
 	PGconn *connection = connectToFive();
 	executeQuery(connection, "alter role adamberlin NOCREATEEXTTABLE(protocol='gphdfs',type='readable');");
 	executeQuery(connection, "alter role adamberlin NOCREATEEXTTABLE(protocol='gphdfs',type='writable');");
 	executeQuery(connection, "create schema five_to_six_upgrade;");
 	executeQuery(connection, "set search_path to five_to_six_upgrade");
-	executeQuery(connection,
-	             "create table users (id integer, name text) distributed by (id);");
+	executeQuery(connection, "create table users (id integer, name text) distributed by (id);");
 	executeQuery(connection, "insert into users values (1, 'Jane')");
 	executeQuery(connection, "insert into users values (2, 'John')");
 	executeQuery(connection, "insert into users values (3, 'Joe')");
 	PQfinish(connection);
-	stopGpdbFiveCluster();
+}
 
-	/*
-	 * When I upgrade the database
-	 */
-	upgradeMaster();
-	upgradeContentId0();
-	upgradeContentId1();
-	upgradeContentId2();
-
-	/* 
-	 * Then that heap table should exist in the greenplum 6 cluster
-	 * with all of its data
-	 */
-	startGpdbSixCluster();
-	connection = connectToSix();
+static void 
+heapTableShouldHaveDataUpgradedToSixCluster()
+{
+	PGconn *connection = connectToSix();
 	executeQuery(connection, "set search_path to five_to_six_upgrade;");
 	PGresult *result = executeQuery(connection, "select * from users;");
 
 	const int size = 10;
 	User     *rows[size];
-	
+
 	initialize_user_rows(&rows, size);
 	extract_user_rows(result, &rows);
 
@@ -156,9 +141,154 @@ test_a_heap_table_with_data_can_be_upgraded(void **state)
 	assert_rows_contain_user((User) {.id=3, .name="Joe"}, &rows, size);
 
 	PQfinish(connection);
+}
+
+static void
+assertNumberOfHardLinks(struct stat *fileInformation, int expectedNumberOfHardLinks)
+{
+	assert_int_equal(
+		fileInformation->st_nlink, 
+		expectedNumberOfHardLinks);
+}
+
+static void
+assertRelfilenodeHardLinked(
+	char *segment_path, 
+	int databaseOid,
+	int relfilenodeNumber
+	)
+{
+	char path[2000];
+
+	sprintf(
+		path,
+		"./gpdb6-data/%s/base/%d/%d",
+		segment_path,
+		databaseOid,
+		relfilenodeNumber);
+
+	struct stat fileInformation;
+
+	stat(path, &fileInformation);
+
+	/*
+	 * The file should have two hard links to 
+	 */
+	assertNumberOfHardLinks(
+		&fileInformation,
+		2);
+}
+
+static void 
+assertMasterHasTableLinked(int databaseOid, int relfilenodeNumber)
+{
+	char *segment_path = "qddir/demoDataDir-1";
+
+	assertRelfilenodeHardLinked(
+		segment_path, 
+		databaseOid, 
+		relfilenodeNumber);
+}
+
+static void
+assertContentId0HasTableLinked(int databaseOid, int relfilenodeNumber)
+{
+	char *segment_path = "dbfast1/demoDataDir0";
+
+	assertRelfilenodeHardLinked(
+		segment_path, 
+		databaseOid, 
+		relfilenodeNumber);
+}
+
+static void
+assertContentId1HasTableLinked(int databaseOid, int relfilenodeNumber)
+{
+	char *segment_path = "dbfast2/demoDataDir1";
+
+	assertRelfilenodeHardLinked(
+		segment_path,
+		databaseOid,
+		relfilenodeNumber);
+}
+
+static void
+assertContentId2HasTableLinked(int databaseOid, int relfilenodeNumber)
+{
+	char *segment_path = "dbfast3/demoDataDir2";
+
+	assertRelfilenodeHardLinked(
+		segment_path,
+		databaseOid,
+		relfilenodeNumber);
+}
+
+
+
+static void 
+heapTableShouldBeHardLinked(void)
+{
+	int rowNumber;
+	int databaseOid;
+	int relfilenodeNumber;
+
+	PGconn *connection = connectToSix();
+	executeQuery(connection, "set search_path to five_to_six_upgrade;");
+	PGresult *result = executeQuery(connection, "select pg_database.oid, relfilenode from pg_class, pg_database where relname = 'users' and datname = current_database();");
+	rowNumber = 0;
+	databaseOid = atoi(PQgetvalue(result, rowNumber, 0));
+	relfilenodeNumber = atoi(PQgetvalue(result, rowNumber, 1));
+	PQfinish(connection);
+
+	assertMasterHasTableLinked(databaseOid, relfilenodeNumber);
+	assertContentId0HasTableLinked(databaseOid, relfilenodeNumber);
+	assertContentId1HasTableLinked(databaseOid, relfilenodeNumber);
+	assertContentId2HasTableLinked(databaseOid, relfilenodeNumber);
+}
+
+static void
+anAdministratorPerformsAnUpgrade()
+{
+	performUpgrade();
+}
+
+static void 
+given((* arrangeFunction)(void))
+{
+	startGpdbFiveCluster();
+	arrangeFunction();
+	stopGpdbFiveCluster();
+}
+
+static void
+then((* assertionFunction)(void))
+{
+	startGpdbSixCluster();
+	assertionFunction();
 	stopGpdbSixCluster();
 }
 
+static void
+when((* actFunction)(void))
+{
+	actFunction();
+}
+
+static void 
+and((* assertionFunction)(void))
+{
+	/* and has the same behavior as then */
+	then(assertionFunction);
+}
+
+static void
+test_a_heap_table_with_data_can_be_upgraded(void **state)
+{
+	given(createHeapTableWithDataInFiveCluster);
+	when(anAdministratorPerformsAnUpgrade);
+	then(heapTableShouldHaveDataUpgradedToSixCluster);
+	and(heapTableShouldBeHardLinked);
+}
 
 int
 main(int argc, char *argv[])

--- a/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.c
+++ b/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.c
@@ -37,7 +37,7 @@ copy_configuration_files_from_backup_to_datadirs(char *segment_path)
 static void 
 execute_pg_upgrade_for(char *segment_path)
 {
-	static char buffer[2000];
+	char buffer[2000];
 
 	sprintf(buffer, ""
 	        "./gpdb6/bin/pg_upgrade "
@@ -48,7 +48,7 @@ execute_pg_upgrade_for(char *segment_path)
 	        "--old-datadir=./gpdb5-data/%s "
 	        "--new-datadir=./gpdb6-data/%s "
 	, segment_path, segment_path);
-	
+
 	system(buffer);
 }
 

--- a/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.c
+++ b/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.c
@@ -42,6 +42,7 @@ execute_pg_upgrade_for(char *segment_path)
 	sprintf(buffer, ""
 	        "./gpdb6/bin/pg_upgrade "
 	        "--mode=dispatcher "
+	        "--link "
 	        "--old-bindir=./gpdb5/bin "
 	        "--new-bindir=./gpdb6/bin "
 	        "--old-datadir=./gpdb5-data/%s "
@@ -51,18 +52,7 @@ execute_pg_upgrade_for(char *segment_path)
 	system(buffer);
 }
 
-void
-upgradeMaster()
-{
-	char *master_data_directory_path = "qddir/demoDataDir-1";
-
-	execute_pg_upgrade_for(master_data_directory_path);
-
-	copy_configuration_files_from_backup_to_datadirs(
-		master_data_directory_path);
-}
-
-void
+static void
 copy_master_data_directory_into_segment_data_directory(char *segment_path)
 {
 	char buffer[2000];
@@ -78,7 +68,7 @@ copy_master_data_directory_into_segment_data_directory(char *segment_path)
 	system(buffer);
 }
 
-void
+static void
 upgradeSegment(char *segment_path)
 {
 	copy_master_data_directory_into_segment_data_directory(segment_path);
@@ -87,24 +77,43 @@ upgradeSegment(char *segment_path)
 		segment_path);
 }
 
+static void
+upgradeMaster(void)
+{
+	char *master_data_directory_path = "qddir/demoDataDir-1";
 
-void
-upgradeContentId0()
+	execute_pg_upgrade_for(master_data_directory_path);
+
+	copy_configuration_files_from_backup_to_datadirs(
+		master_data_directory_path);
+}
+
+static void
+upgradeContentId0(void)
 {
 	char *segment_path = "dbfast1/demoDataDir0";
 	upgradeSegment(segment_path);
 }
 
-void
-upgradeContentId1()
+static void
+upgradeContentId1(void)
 {
 	char *segment_path = "dbfast2/demoDataDir1";
 	upgradeSegment(segment_path);
 }
 
-void
-upgradeContentId2()
+static void
+upgradeContentId2(void)
 {
 	char *segment_path = "dbfast3/demoDataDir2";
 	upgradeSegment(segment_path);
+}
+
+void
+performUpgrade(void)
+{
+	upgradeMaster();
+	upgradeContentId0();
+	upgradeContentId1();
+	upgradeContentId2();
 }

--- a/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.h
+++ b/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.h
@@ -1,5 +1,7 @@
-void upgradeMaster();
-void upgradeContentId0();
-void upgradeContentId1();
-void upgradeContentId2();
 
+#ifndef PG_UPGRADE_INTEGRATION_TEST_UPGRADE_HELPERS
+#define PG_UPGRADE_INTEGRATION_TEST_UPGRADE_HELPERS
+
+void performUpgrade(void);
+
+#endif /* PG_UPGRADE_INTEGRATION_TEST_UPGRADE_HELPERS */


### PR DESCRIPTION
Adds the `--link` flag to the upgrade invocations.

Test that the relfilenode of the user defined table created in the test is in fact a hard linked file.

Switched to using a scenario format to be able to add several assertions to the scenario without the need for an entirely new test - a good strategy for long-form journey tests.