### PR TITLE
Fix database PANIC issue for "grant all on all tables in schema xxx to yyy;"

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -394,8 +394,6 @@ ExecuteGrantStmt(GrantStmt *stmt)
 	ListCell   *cell;
 	const char *errormsg;
 	AclMode		all_privileges;
-	List	   *objs = NIL;
-	bool		added_objs = false;
 
 	/*
 	 * Turn the regular GrantStmt into the InternalGrant form.
@@ -425,49 +423,6 @@ ExecuteGrantStmt(GrantStmt *stmt)
 	istmt.grant_option = stmt->grant_option;
 	istmt.behavior = stmt->behavior;
 
-	/* If this is a GRANT/REVOKE on a table, expand partition references */
-	if (istmt.objtype == ACL_OBJECT_RELATION)
-	{
-		foreach(cell, istmt.objects)
-		{
-			Oid relid = lfirst_oid(cell);
-			Relation rel = heap_open(relid, AccessShareLock);
-			bool add_self = true;
-
-			if (Gp_role == GP_ROLE_DISPATCH)
-			{
-				List *a;
-				if (rel_is_partitioned(relid))
-				{
-					PartitionNode *pn = RelationBuildPartitionDesc(rel, false);
-
-					a = all_partition_relids(pn);
-					if (a)
-						added_objs = true;
-
-					objs = list_concat(objs, a);
-				}
-				else if (rel_is_child_partition(relid))
-				{
-					/* get my children */
-					a = find_all_inheritors(relid, NoLock, NULL);
-					if (a)
-						added_objs = true;
-
-					objs = list_concat(objs, a);
-
-					/* find_all_inheritors() adds me, don't do it twice */
-					add_self = false;
-				}
-			}
-
-			heap_close(rel, NoLock);
-
-			if (add_self)
-				objs = lappend_oid(objs, relid);
-		}
-		istmt.objects = objs;
-	}
 
 	/*
 	 * Convert the RoleSpec list into an Oid list.  Note that at this point we
@@ -642,6 +597,30 @@ ExecuteGrantStmt(GrantStmt *stmt)
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		/*
+		 * GPDB: It is possible that objectNamesToOids has expanded references to
+		 * partitioned relations. It is needed to recostruct the GrantStmt objects
+		 * to include those references. We do it uncoditionally of partitioned
+		 * references now for Object Targets.
+		 */
+		if (stmt->targtype == ACL_TARGET_OBJECT &&
+				stmt->objtype == ACL_OBJECT_RELATION)
+		{
+			List *n = NIL;
+			foreach(cell, istmt.objects)
+			{
+				Oid rid = lfirst_oid(cell);
+				RangeVar *rv;
+				char *nspname = get_namespace_name(get_rel_namespace(rid));
+				char *relname = get_rel_name(rid);
+
+				rv = makeRangeVar(nspname, relname, -1);
+				n = lappend(n, rv);
+			}
+
+			stmt->objects = n;
+		}
+
 		CdbDispatchUtilityStatement((Node *) stmt,
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
@@ -854,6 +833,41 @@ objectNamesToOids(GrantObjectType objtype, List *objnames)
 		default:
 			elog(ERROR, "unrecognized GrantStmt.objtype: %d",
 				 (int) objtype);
+	}
+
+	/*
+	 * GPDB: If we are the DISPATCH node and the object is a partitioned
+	 * relation, then we need to populate the partition references because the
+	 * information is not present in the cataloge tables on the segment nodes.
+	 */
+	if (Gp_role == GP_ROLE_DISPATCH && objtype == ACL_OBJECT_RELATION)
+	{
+		List *expanded = NIL;
+
+		foreach(cell, objects)
+		{
+			Oid relOid = lfirst_oid(cell);
+			List *partOids;
+
+			if (rel_is_partitioned(relOid))
+			{
+				PartitionNode *pn = RelationBuildPartitionDescByOid(relOid, false);
+				partOids = all_partition_relids(pn);
+
+				expanded = list_concat(expanded, partOids);
+				expanded = lappend_oid(expanded, relOid);
+			}
+			else if (rel_is_child_partition(relOid))
+			{
+				partOids = find_all_inheritors(relOid, NoLock, NULL);
+
+				/* partOids contains relOid so concat is enough */
+				expanded = list_concat(expanded, partOids);
+			}
+		}
+
+		if (expanded != NIL)
+			objects = expanded;
 	}
 
 	return objects;

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1617,6 +1617,9 @@ SELECT d.*     -- check that entries went away
 CREATE SCHEMA testns;
 CREATE TABLE testns.t1 (f1 int);
 CREATE TABLE testns.t2 (f1 int);
+CREATE TABLE testns.t3 (f1 int) PARTITION BY RANGE (f1) (START (2018) END (2020) EVERY (1),DEFAULT PARTITION extra );
+CREATE TABLE testns.t4 (f1 int) inherits (testns.t1);
+NOTICE:  merging column "f1" with inherited definition
 SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
  has_table_privilege 
 ---------------------

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1614,6 +1614,21 @@ SELECT d.*     -- check that entries went away
 
 -- Grant on all objects of given type in a schema
 \c -
+-- GPDB: Create a helper function to inspect the segment information also
+DROP FUNCTION IF EXISTS has_table_privilege_seg(u text, r text, p text);
+NOTICE:  function has_table_privilege_seg(text,text,text) does not exist, skipping
+CREATE FUNCTION has_table_privilege_seg(us text, rel text, priv text)
+RETURNS TABLE (
+	segid int,
+	has_table_privilege bool
+) AS $$
+	SELECT
+		gp_execution_segment() AS gegid,
+		p.*
+	FROM
+		has_table_privilege($1, $2, $3) p
+$$ LANGUAGE SQL VOLATILE
+CONTAINS SQL EXECUTE ON ALL SEGMENTS;
 CREATE SCHEMA testns;
 CREATE TABLE testns.t1 (f1 int);
 CREATE TABLE testns.t2 (f1 int);
@@ -1625,6 +1640,38 @@ SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
 ---------------------
  f
 (1 row)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t1', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     2 | f
+     0 | f
+     1 | f
+(3 rows)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
 
 GRANT ALL ON ALL TABLES IN SCHEMA testns TO regressuser1;
 SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- true
@@ -1639,6 +1686,38 @@ SELECT has_table_privilege('regressuser1', 'testns.t2', 'SELECT'); -- true
  t
 (1 row)
 
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t1', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+     0 | t
+     1 | t
+     2 | t
+(3 rows)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+     0 | t
+     1 | t
+     2 | t
+(3 rows)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+     0 | t
+     1 | t
+     2 | t
+(3 rows)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+     0 | t
+     1 | t
+     2 | t
+(3 rows)
+
 REVOKE ALL ON ALL TABLES IN SCHEMA testns FROM regressuser1;
 SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
  has_table_privilege 
@@ -1651,6 +1730,30 @@ SELECT has_table_privilege('regressuser1', 'testns.t2', 'SELECT'); -- false
 ---------------------
  f
 (1 row)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
+
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
 
 CREATE FUNCTION testns.testfunc(int) RETURNS int AS 'select 3 * $1;' LANGUAGE sql;
 SELECT has_function_privilege('regressuser1', 'testns.testfunc(int)', 'EXECUTE'); -- true by default

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -963,6 +963,8 @@ SELECT d.*     -- check that entries went away
 CREATE SCHEMA testns;
 CREATE TABLE testns.t1 (f1 int);
 CREATE TABLE testns.t2 (f1 int);
+CREATE TABLE testns.t3 (f1 int) PARTITION BY RANGE (f1) (START (2018) END (2020) EVERY (1),DEFAULT PARTITION extra );
+CREATE TABLE testns.t4 (f1 int) inherits (testns.t1);
 
 SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
 

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -960,6 +960,21 @@ SELECT d.*     -- check that entries went away
 -- Grant on all objects of given type in a schema
 \c -
 
+-- GPDB: Create a helper function to inspect the segment information also
+DROP FUNCTION IF EXISTS has_table_privilege_seg(u text, r text, p text);
+CREATE FUNCTION has_table_privilege_seg(us text, rel text, priv text)
+RETURNS TABLE (
+	segid int,
+	has_table_privilege bool
+) AS $$
+	SELECT
+		gp_execution_segment() AS gegid,
+		p.*
+	FROM
+		has_table_privilege($1, $2, $3) p
+$$ LANGUAGE SQL VOLATILE
+CONTAINS SQL EXECUTE ON ALL SEGMENTS;
+
 CREATE SCHEMA testns;
 CREATE TABLE testns.t1 (f1 int);
 CREATE TABLE testns.t2 (f1 int);
@@ -967,16 +982,27 @@ CREATE TABLE testns.t3 (f1 int) PARTITION BY RANGE (f1) (START (2018) END (2020)
 CREATE TABLE testns.t4 (f1 int) inherits (testns.t1);
 
 SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t1', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- false
 
 GRANT ALL ON ALL TABLES IN SCHEMA testns TO regressuser1;
 
 SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- true
 SELECT has_table_privilege('regressuser1', 'testns.t2', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t1', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- true
 
 REVOKE ALL ON ALL TABLES IN SCHEMA testns FROM regressuser1;
 
 SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
 SELECT has_table_privilege('regressuser1', 'testns.t2', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- false
 
 CREATE FUNCTION testns.testfunc(int) RETURNS int AS 'select 3 * $1;' LANGUAGE sql;
 


### PR DESCRIPTION
1) We have found in gpdb 6 versions there is an issue when using  "grant all on all tables in schema xxx to yyy;",  tables with partitions or inherits child tables, will lead to database PANIC.

2) After analyze coredump informations, we have found that the data structure that used to decode objects on segments has been incorrectly used, which leads to NullPointer and PANIC.

![Screen Shot 2019-09-10 at 10 23 53 PM](https://user-images.githubusercontent.com/3192108/64749597-bc002b00-d548-11e9-98e2-e2bf58f7a284.png)

3) After analyzing code logical, we have found that there is flag call "added_objs", which will be used in the master node to encode objects that have partition references into "RangerVar" format. It is the root cause of the issue. 
This PR has used NodeType information to tell different kinds of object and fix the issue.

4) Will add some test cases also in this PR.