### PR TITLE
6X: Fix flaky partition deadlock tests

### DIFF
--- a/src/test/isolation2/expected/gdd/delete-deadlock-root-leaf-concurrent-op.out
+++ b/src/test/isolation2/expected/gdd/delete-deadlock-root-leaf-concurrent-op.out
@@ -2,8 +2,8 @@ DROP TABLE IF EXISTS part_tbl;
 DROP
 CREATE TABLE part_tbl (a int, b int, c int) PARTITION BY RANGE(b) (START(1) END(2) EVERY(1));
 CREATE
-INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,10)i;
-INSERT 10
+INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,100)i;
+INSERT 100
 
 -- check gdd is enabled
 show gp_enable_global_deadlock_detector;
@@ -13,24 +13,24 @@ show gp_enable_global_deadlock_detector;
 (1 row)
 1:BEGIN;
 BEGIN
-1:DELETE FROM part_tbl_1_prt_1 WHERE c = 9;
+1:DELETE FROM part_tbl_1_prt_1 WHERE c = segid(2,1);
 DELETE 1
 
 2:BEGIN;
 BEGIN
-2:DELETE FROM part_tbl where c = 1;
+2:DELETE FROM part_tbl WHERE c = segid(1,1);
 DELETE 1
 
 -- the below delete will wait to acquire the transaction lock to delete the tuple
 -- held by Session 2
-1&:DELETE FROM part_tbl_1_prt_1 WHERE c = 1;  <waiting ...>
+1&:DELETE FROM part_tbl_1_prt_1 WHERE c = segid(1,1);  <waiting ...>
 
 -- the below delete will wait to acquire the transaction lock to delete the tuple
 -- held by Session 1
 --
 -- It is possible that GDD gets triggered immediately, so use '2>:' instead of
 -- '2&:' for stable output.
-2>:DELETE FROM part_tbl WHERE c = 9;  <waiting ...>
+2>:DELETE FROM part_tbl WHERE c = segid(2,1);  <waiting ...>
 
 1<:  <... completed>
 DELETE 1

--- a/src/test/isolation2/expected/gdd/delete-deadlock-root-leaf-concurrent-op.out
+++ b/src/test/isolation2/expected/gdd/delete-deadlock-root-leaf-concurrent-op.out
@@ -27,7 +27,10 @@ DELETE 1
 
 -- the below delete will wait to acquire the transaction lock to delete the tuple
 -- held by Session 1
-2&:DELETE FROM part_tbl where c = 9;  <waiting ...>
+--
+-- It is possible that GDD gets triggered immediately, so use '2>:' instead of
+-- '2&:' for stable output.
+2>:DELETE FROM part_tbl WHERE c = 9;  <waiting ...>
 
 1<:  <... completed>
 DELETE 1

--- a/src/test/isolation2/expected/gdd/update-deadlock-root-leaf-concurrent-op.out
+++ b/src/test/isolation2/expected/gdd/update-deadlock-root-leaf-concurrent-op.out
@@ -27,7 +27,10 @@ UPDATE 1
 
 -- the below update will wait to acquire the transaction lock to update the tuple
 -- held by Session 1
-2&:UPDATE part_tbl SET c = 9 WHERE c = 9;  <waiting ...>
+--
+-- It is possible that GDD gets triggered immediately, so use '2>:' instead of
+-- '2&:' for stable output.
+2>:UPDATE part_tbl SET c = 9 WHERE c = 9;  <waiting ...>
 
 1<:  <... completed>
 UPDATE 1

--- a/src/test/isolation2/expected/gdd/update-deadlock-root-leaf-concurrent-op.out
+++ b/src/test/isolation2/expected/gdd/update-deadlock-root-leaf-concurrent-op.out
@@ -2,8 +2,8 @@ DROP TABLE IF EXISTS part_tbl;
 DROP
 CREATE TABLE part_tbl (a int, b int, c int) PARTITION BY RANGE(b) (START(1) END(2) EVERY(1));
 CREATE
-INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,10)i;
-INSERT 10
+INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,100)i;
+INSERT 100
 
 -- check gdd is enabled
 show gp_enable_global_deadlock_detector;
@@ -13,24 +13,24 @@ show gp_enable_global_deadlock_detector;
 (1 row)
 1:BEGIN;
 BEGIN
-1:UPDATE part_tbl_1_prt_1 SET c = 9 WHERE c = 9;
+1:UPDATE part_tbl_1_prt_1 SET c = segid(2,1) WHERE c = segid(2,1);
 UPDATE 1
 
 2:BEGIN;
 BEGIN
-2:UPDATE part_tbl SET c = 1 WHERE c = 1;
+2:UPDATE part_tbl SET c = segid(1,1) WHERE c = segid(1,1);
 UPDATE 1
 
 -- the below update will wait to acquire the transaction lock to update the tuple
 -- held by Session 2
-1&:UPDATE part_tbl_1_prt_1 SET c = 1 WHERE c = 1;  <waiting ...>
+1&:UPDATE part_tbl_1_prt_1 SET c = segid(1,1) WHERE c = segid(1,1);  <waiting ...>
 
 -- the below update will wait to acquire the transaction lock to update the tuple
 -- held by Session 1
 --
 -- It is possible that GDD gets triggered immediately, so use '2>:' instead of
 -- '2&:' for stable output.
-2>:UPDATE part_tbl SET c = 9 WHERE c = 9;  <waiting ...>
+2>:UPDATE part_tbl SET c = segid(2,1) WHERE c = segid(2,1);  <waiting ...>
 
 1<:  <... completed>
 UPDATE 1

--- a/src/test/isolation2/sql/gdd/delete-deadlock-root-leaf-concurrent-op.sql
+++ b/src/test/isolation2/sql/gdd/delete-deadlock-root-leaf-concurrent-op.sql
@@ -16,7 +16,10 @@ show gp_enable_global_deadlock_detector;
 
 -- the below delete will wait to acquire the transaction lock to delete the tuple
 -- held by Session 1
-2&:DELETE FROM part_tbl where c = 9;
+--
+-- It is possible that GDD gets triggered immediately, so use '2>:' instead of
+-- '2&:' for stable output.
+2>:DELETE FROM part_tbl WHERE c = 9;
 
 1<:
 2<:

--- a/src/test/isolation2/sql/gdd/delete-deadlock-root-leaf-concurrent-op.sql
+++ b/src/test/isolation2/sql/gdd/delete-deadlock-root-leaf-concurrent-op.sql
@@ -1,25 +1,25 @@
 DROP TABLE IF EXISTS part_tbl;
 CREATE TABLE part_tbl (a int, b int, c int) PARTITION BY RANGE(b) (START(1) END(2) EVERY(1));
-INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,10)i;
+INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,100)i;
 
 -- check gdd is enabled
 show gp_enable_global_deadlock_detector;
 1:BEGIN;
-1:DELETE FROM part_tbl_1_prt_1 WHERE c = 9;
+1:DELETE FROM part_tbl_1_prt_1 WHERE c = segid(2,1);
 
 2:BEGIN;
-2:DELETE FROM part_tbl where c = 1;
+2:DELETE FROM part_tbl WHERE c = segid(1,1);
 
 -- the below delete will wait to acquire the transaction lock to delete the tuple
 -- held by Session 2
-1&:DELETE FROM part_tbl_1_prt_1 WHERE c = 1;
+1&:DELETE FROM part_tbl_1_prt_1 WHERE c = segid(1,1);
 
 -- the below delete will wait to acquire the transaction lock to delete the tuple
 -- held by Session 1
 --
 -- It is possible that GDD gets triggered immediately, so use '2>:' instead of
 -- '2&:' for stable output.
-2>:DELETE FROM part_tbl WHERE c = 9;
+2>:DELETE FROM part_tbl WHERE c = segid(2,1);
 
 1<:
 2<:

--- a/src/test/isolation2/sql/gdd/update-deadlock-root-leaf-concurrent-op.sql
+++ b/src/test/isolation2/sql/gdd/update-deadlock-root-leaf-concurrent-op.sql
@@ -1,25 +1,25 @@
 DROP TABLE IF EXISTS part_tbl;
 CREATE TABLE part_tbl (a int, b int, c int) PARTITION BY RANGE(b) (START(1) END(2) EVERY(1));
-INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,10)i;
+INSERT INTO part_tbl SELECT i, 1, i FROM generate_series(1,100)i;
 
 -- check gdd is enabled
 show gp_enable_global_deadlock_detector;
 1:BEGIN;
-1:UPDATE part_tbl_1_prt_1 SET c = 9 WHERE c = 9;
+1:UPDATE part_tbl_1_prt_1 SET c = segid(2,1) WHERE c = segid(2,1);
 
 2:BEGIN;
-2:UPDATE part_tbl SET c = 1 WHERE c = 1;
+2:UPDATE part_tbl SET c = segid(1,1) WHERE c = segid(1,1);
 
 -- the below update will wait to acquire the transaction lock to update the tuple
 -- held by Session 2
-1&:UPDATE part_tbl_1_prt_1 SET c = 1 WHERE c = 1;
+1&:UPDATE part_tbl_1_prt_1 SET c = segid(1,1) WHERE c = segid(1,1);
 
 -- the below update will wait to acquire the transaction lock to update the tuple
 -- held by Session 1
 --
 -- It is possible that GDD gets triggered immediately, so use '2>:' instead of
 -- '2&:' for stable output.
-2>:UPDATE part_tbl SET c = 9 WHERE c = 9;
+2>:UPDATE part_tbl SET c = segid(2,1) WHERE c = segid(2,1);
 
 1<:
 2<:

--- a/src/test/isolation2/sql/gdd/update-deadlock-root-leaf-concurrent-op.sql
+++ b/src/test/isolation2/sql/gdd/update-deadlock-root-leaf-concurrent-op.sql
@@ -16,7 +16,10 @@ show gp_enable_global_deadlock_detector;
 
 -- the below update will wait to acquire the transaction lock to update the tuple
 -- held by Session 1
-2&:UPDATE part_tbl SET c = 9 WHERE c = 9;
+--
+-- It is possible that GDD gets triggered immediately, so use '2>:' instead of
+-- '2&:' for stable output.
+2>:UPDATE part_tbl SET c = 9 WHERE c = 9;
 
 1<:
 2<:


### PR DESCRIPTION
To trigger a deadlock we need to construct several waiting relations,
once the last waiting relation is formed the deadlock is detectable by
the deadlock detector.  In update-deadlock-root-leaf-concurrent-op and
delete-deadlock-root-leaf-concurrent-op we used to use `2&:` for the
last waiting relation, the isolation2 framework will check that the
query blocks, that is, it does not return a result in 0.5 seconds.
However it's possible that the deadlock detector is triggered just
within that 0.5 seconds, so the isolation2 framework will report a
failure which makes the tests flaky.  To make these tests deterministic
we should use `2>:` for the last waiting query, it puts the query
background without checking.

Also replaced the hard coded distribution values with segid(segid, nth),
it returns the nth value on segment segid.  Hard coded distribution
values shouldn't be used in the deadlock tests, we can't easily tell
whether two rows are on the same segment or not, and they depends on the
hash and reduce methods as well as the number of segments.  It's easier
to design and understand the tests with segid().


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
