### PR TITLE
Remove nMotionNodes and nInitPlans from Plan struct.

### DIFF
--- a/contrib/file_fdw/output/file_fdw.source
+++ b/contrib/file_fdw/output/file_fdw.source
@@ -276,9 +276,9 @@ SELECT tableoid::regclass, * FROM ONLY agg;
 
 -- updates aren't supported
 UPDATE agg SET a = 1;
-ERROR:  incompatible loci in target inheritance set (planner.c:1513)
+ERROR:  incompatible loci in target inheritance set
 DELETE FROM agg WHERE a = 100;
-ERROR:  incompatible loci in target inheritance set (planner.c:1513)
+ERROR:  incompatible loci in target inheritance set
 -- but this should be allowed
 SELECT tableoid::regclass, * FROM agg FOR UPDATE;
  tableoid |  a  |    b    

--- a/contrib/file_fdw/output/file_fdw_optimizer.source
+++ b/contrib/file_fdw/output/file_fdw_optimizer.source
@@ -276,9 +276,9 @@ SELECT tableoid::regclass, * FROM ONLY agg;
 
 -- updates aren't supported
 UPDATE agg SET a = 1;
-ERROR:  incompatible loci in target inheritance set (planner.c:1513)
+ERROR:  incompatible loci in target inheritance set
 DELETE FROM agg WHERE a = 100;
-ERROR:  incompatible loci in target inheritance set (planner.c:1513)
+ERROR:  incompatible loci in target inheritance set
 -- but this should be allowed
 SELECT tableoid::regclass, * FROM agg FOR UPDATE;
  tableoid |  a  |    b    

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -649,8 +649,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 		AssignContentIdsToPlanData(query, result, root);
 	}
 
-	Assert(result->nMotionNodes == state.nextMotionID - 1);
-	Assert(result->nInitPlans == list_length(state.initPlans));
+	root->glob->nMotionNodes = state.nextMotionID - 1;
 
 	/* Assign slice numbers to the initplans. */
 	foreach(cell, state.initPlans)
@@ -660,6 +659,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 		Assert(IsA(subplan, SubPlan) &&subplan->qDispSliceId == 0);
 		subplan->qDispSliceId = state.nextMotionID++;
 	}
+	root->glob->nInitPlans = list_length(state.initPlans);
 
 	/*
 	 * Discard subtrees of Query node that aren't needed for execution. Note
@@ -913,16 +913,6 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 		Assert(flow->req_move == MOVEMENT_NONE);
 
 done:
-
-	/*
-	 * Label the Plan node with the number of Motion nodes and Init Plans in
-	 * this subtree, inclusive of the node itself.  This info is used only in
-	 * the top node of a query or subquery.  Someday, find a better place to
-	 * keep it.
-	 */
-	plan = (Plan *) newnode;
-	plan->nMotionNodes = context->nextMotionID - saveNextMotionID;
-	plan->nInitPlans = list_length(context->initPlans) - saveNumInitPlans;
 
 	/*
 	 * Remember if this was a Motion node. This is used at the top of the

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1474,7 +1474,7 @@ cdbexplain_showExecStatsBegin(struct QueryDesc *queryDesc,
 	ctx->querystarttime = querystarttime;
 
 	/* Determine number of slices.  (SliceTable hasn't been built yet.) */
-	nslice = 1 + queryDesc->plannedstmt->planTree->nMotionNodes + queryDesc->plannedstmt->planTree->nInitPlans;
+	nslice = 1 + queryDesc->plannedstmt->nMotionNodes + queryDesc->plannedstmt->nInitPlans;
 
 	/* Allocate and zero the SliceSummary array. */
 	ctx->nslice = nslice;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -153,7 +153,6 @@ static void FillSliceTable(EState *estate, PlannedStmt *stmt);
 static PartitionNode *BuildPartitionNodeFromRoot(Oid relid);
 static void InitializeQueryPartsMetadata(PlannedStmt *plannedstmt, EState *estate);
 static void AdjustReplicatedTableCounts(EState *estate);
-static bool planIsParallel(PlannedStmt *plannedstmt, Plan *plan);
 
 /*
  * Note that GetUpdatedColumns() also exists in commands/trigger.c.  There does
@@ -274,43 +273,6 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 		(*ExecutorStart_hook) (queryDesc, eflags);
 	else
 		standard_ExecutorStart(queryDesc, eflags);
-}
-
-/*
- * Check whether a plan is parallel by counting motions.
- *
- * A plan itself and its init plans can all contain motions, when itself
- * contains at least one motion then it is a parallel plan.  In this function
- * we count the motions of the plan itself to tell whether it is a parallel
- * plan.
- *
- * NOTE: plan->dispatch is not checked by this function.
- */
-static bool
-planIsParallel(PlannedStmt *plannedstmt, Plan *plan)
-{
-	ListCell   *cell;
-	int			nMotionNodes;
-
-	nMotionNodes = plan->nMotionNodes;
-	Assert(nMotionNodes >= 0);
-	if (nMotionNodes == 0)
-		return false;
-
-	foreach(cell, plan->initPlan)
-	{
-		int			subplan_id = lfirst_node(SubPlan, cell)->plan_id;
-		Plan	   *subplan = (Plan *) list_nth(plannedstmt->subplans,
-												subplan_id - 1);
-
-		nMotionNodes -= subplan->nMotionNodes;
-		Assert(nMotionNodes >= 0);
-		if (nMotionNodes == 0)
-			return false;
-	}
-
-	Assert(nMotionNodes > 0);
-	return true;
 }
 
 void
@@ -765,9 +727,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 *
 			 * Main plan is parallel, send plan to it.
 			 */
-			if (queryDesc->plannedstmt->planTree->dispatch == DISPATCH_PARALLEL ||
-				planIsParallel(queryDesc->plannedstmt,
-							   queryDesc->plannedstmt->planTree))
+			if (queryDesc->plannedstmt->planTree->dispatch == DISPATCH_PARALLEL)
 				CdbDispatchPlan(queryDesc, needDtxTwoPhase, true);
 		}
 
@@ -800,8 +760,8 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		{
 			/* Run a root slice. */
 			if (queryDesc->planstate != NULL &&
-				planIsParallel(queryDesc->plannedstmt,
-							   queryDesc->planstate->plan) &&
+				queryDesc->plannedstmt->planTree->dispatch == DISPATCH_PARALLEL &&
+				queryDesc->plannedstmt->nMotionNodes > 0 &&
 				!estate->es_interconnect_is_setup)
 			{
 				Assert(!estate->interconnect_context);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -190,8 +190,6 @@ CopyPlanFields(const Plan *from, Plan *newnode)
 	COPY_BITMAPSET_FIELD(allParam);
 	COPY_NODE_FIELD(flow);
 	COPY_SCALAR_FIELD(dispatch);
-	COPY_SCALAR_FIELD(nMotionNodes);
-	COPY_SCALAR_FIELD(nInitPlans);
 
 	COPY_SCALAR_FIELD(directDispatch.isDirectDispatch);
 	COPY_NODE_FIELD(directDispatch.contentIds);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -192,7 +192,6 @@ CopyPlanFields(const Plan *from, Plan *newnode)
 	COPY_SCALAR_FIELD(dispatch);
 	COPY_SCALAR_FIELD(nMotionNodes);
 	COPY_SCALAR_FIELD(nInitPlans);
-	COPY_NODE_FIELD(sliceTable);
 
 	COPY_SCALAR_FIELD(directDispatch.isDirectDispatch);
 	COPY_NODE_FIELD(directDispatch.contentIds);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -317,8 +317,6 @@ _outPlanInfo(StringInfo str, const Plan *node)
 	WRITE_INT_FIELD(nMotionNodes);
 	WRITE_INT_FIELD(nInitPlans);
 
-	WRITE_NODE_FIELD(sliceTable);
-
     WRITE_NODE_FIELD(lefttree);
     WRITE_NODE_FIELD(righttree);
     WRITE_NODE_FIELD(initPlan);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -314,9 +314,6 @@ _outPlanInfo(StringInfo str, const Plan *node)
 	WRITE_BOOL_FIELD(directDispatch.isDirectDispatch);
 	WRITE_NODE_FIELD(directDispatch.contentIds);
 
-	WRITE_INT_FIELD(nMotionNodes);
-	WRITE_INT_FIELD(nInitPlans);
-
     WRITE_NODE_FIELD(lefttree);
     WRITE_NODE_FIELD(righttree);
     WRITE_NODE_FIELD(initPlan);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -373,8 +373,6 @@ _outPlanInfo(StringInfo str, const Plan *node)
 
 	WRITE_NODE_FIELD(flow);
 	WRITE_ENUM_FIELD(dispatch, DispatchMethod);
-	WRITE_INT_FIELD(nMotionNodes);
-	WRITE_INT_FIELD(nInitPlans);
 
 	WRITE_NODE_FIELD(lefttree);
 	WRITE_NODE_FIELD(righttree);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -375,7 +375,6 @@ _outPlanInfo(StringInfo str, const Plan *node)
 	WRITE_ENUM_FIELD(dispatch, DispatchMethod);
 	WRITE_INT_FIELD(nMotionNodes);
 	WRITE_INT_FIELD(nInitPlans);
-	WRITE_NODE_FIELD(sliceTable);
 
 	WRITE_NODE_FIELD(lefttree);
 	WRITE_NODE_FIELD(righttree);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2489,9 +2489,6 @@ void readPlanInfo(Plan *local_node)
 	READ_BOOL_FIELD(directDispatch.isDirectDispatch);
 	READ_NODE_FIELD(directDispatch.contentIds);
 
-	READ_INT_FIELD(nMotionNodes);
-	READ_INT_FIELD(nInitPlans);
-
     READ_NODE_FIELD(lefttree);
     READ_NODE_FIELD(righttree);
     READ_NODE_FIELD(initPlan);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2492,8 +2492,6 @@ void readPlanInfo(Plan *local_node)
 	READ_INT_FIELD(nMotionNodes);
 	READ_INT_FIELD(nInitPlans);
 
-	READ_NODE_FIELD(sliceTable);
-
     READ_NODE_FIELD(lefttree);
     READ_NODE_FIELD(righttree);
     READ_NODE_FIELD(initPlan);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -312,6 +312,8 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	glob->lastRowMarkId = 0;
 	glob->transientPlan = false;
 	glob->oneoffPlan = false;
+	glob->nMotionNodes = 0;
+	glob->nInitPlans = 0;
 	/* ApplyShareInputContext initialization. */
 	glob->share.producers = NULL;
 	glob->share.producer_count = 0;
@@ -478,8 +480,8 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	result->nParamExec = glob->nParamExec;
 	result->hasRowSecurity = glob->hasRowSecurity;
 
-	result->nMotionNodes = top_plan->nMotionNodes;
-	result->nInitPlans = top_plan->nInitPlans;
+	result->nMotionNodes = glob->nMotionNodes;
+	result->nInitPlans = glob->nInitPlans;
 	result->intoPolicy = GpPolicyCopy(parse->intoPolicy);
 	result->queryPartOids = NIL;
 	result->queryPartsMetadata = NIL;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1508,9 +1508,14 @@ inheritance_planner(PlannerInfo *root)
 			}
 			if (!locus_ok)
 			{
-				ereport(ERROR, (
-								errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("incompatible loci in target inheritance set")));
+				/*
+				 * This is reachable, if you have normal distributed/replicated tables,
+				 * and foreign tables that can only be executed in the QD, in the same
+				 * inheritance tree.
+				 */
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("incompatible loci in target inheritance set")));
 			}
 		}
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -255,13 +255,6 @@ typedef struct Plan
 	 */
 	DirectDispatchInfo directDispatch;
 
-	/*
-	 * CDB: Now many motion nodes are there in the Plan.  How many init plans?
-	 * Additional plan tree global significant only in the root node.
-	 */
-	int nMotionNodes;
-	int nInitPlans;
-
 	/**
 	 * How much memory (in KB) should be used to execute this plan node?
 	 */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -262,19 +262,6 @@ typedef struct Plan
 	int nMotionNodes;
 	int nInitPlans;
 
-	/*
-	 * CDB: This allows the slice table to accompany the plan as it
-	 * moves around the executor. This is anoter plan tree global that
-	 * should be non-NULL only in the top node of a dispatchable tree.
-	 * It could (and should) move to a TopPlan node if we ever do that.
-	 *
-	 * Currently, the slice table should not be installed on the QD.
-	 * Rather is it shipped to QEs as a separate parameter to MPPEXEC.
-	 * The implementation of MPPEXEC, which runs on the QEs, installs
-	 * the slice table in the plan as required there.
-	 */
-	Node *sliceTable;
-
 	/**
 	 * How much memory (in KB) should be used to execute this plan node?
 	 */

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -144,6 +144,10 @@ typedef struct PlannerGlobal
 	ApplyShareInputContext share;	/* workspace for GPDB plan sharing */
 
 	bool		hasRowSecurity; /* row security applied? */
+
+	int			nMotionNodes;
+	int			nInitPlans;
+
 } PlannerGlobal;
 
 /*----------


### PR DESCRIPTION
It was quite silly to have them in the Plan struct, which is all the
plan nodes "inherit",  when the fields were actually only used in the
topmost node in a plan tree. The sillyness was noted in the comments,
along with "Someday, find a better place to keep it". Today is that day.

In the executor, the logical place for these is the PlannedStmt struct.
That contains information for the plan tree as a whole, and in fact, we
already had copies of the fields there, we were just always using them!
PlannedStmt is only build in the last steps of planning, though. During
planning, stash them PlannerGlobal, like many other fields that are
finally copied to the PlannedStmt.

There was one little wrinkle to this plan: there was a check in
EvalPlanQual, which checked that EvalPlanQual is not used on a Plan node
that has any Motions in its subtree. Move that check to ExecInitMotion().

