### PR TITLE
Default wire_format to CSV

### DIFF
--- a/contrib/pxf_fdw/expected/pxf_fdw_foreign_table.out
+++ b/contrib/pxf_fdw/expected/pxf_fdw_foreign_table.out
@@ -156,6 +156,13 @@ CREATE FOREIGN TABLE pxf_fdw_test_table_log_errors (id int, name text)
     OPTIONS ( resource '/path/to/resource', reject_limit '4', log_errors 'yes' );
 ERROR:  log_errors requires a Boolean value
 --
+-- Table creation fails if quote is provided (CSV-only option)
+--
+CREATE FOREIGN TABLE pxf_fdw_test_table_csv_only ()
+    SERVER pxf_fdw_test_server
+    OPTIONS ( resource '/foo', quote '9' );
+ERROR:  quote available only in CSV mode
+--
 -- Table creation succeeds if resource is provided and reject_limit is provided correctly
 --
 CREATE FOREIGN TABLE pxf_fdw_test_table_reject_limit (id int, name text)

--- a/contrib/pxf_fdw/sql/pxf_fdw_foreign_table.sql
+++ b/contrib/pxf_fdw/sql/pxf_fdw_foreign_table.sql
@@ -168,6 +168,13 @@ CREATE FOREIGN TABLE pxf_fdw_test_table_log_errors (id int, name text)
     OPTIONS ( resource '/path/to/resource', reject_limit '4', log_errors 'yes' );
 
 --
+-- Table creation fails if quote is provided (CSV-only option)
+--
+CREATE FOREIGN TABLE pxf_fdw_test_table_csv_only ()
+    SERVER pxf_fdw_test_server
+    OPTIONS ( resource '/foo', quote '9' );
+
+--
 -- Table creation succeeds if resource is provided and reject_limit is provided correctly
 --
 CREATE FOREIGN TABLE pxf_fdw_test_table_reject_limit (id int, name text)


### PR DESCRIPTION
The wire_format in PXF defaults to CSV. Only when the file format is
tab-delimited text, we will use TEXT as the wire_format. This commit
makes CSV the default wire_format for PXF
