### PR TITLE
Automate creation of clusters for pg_upgrade tests

### DIFF
--- a/contrib/pg_upgrade/test/integration/README.md
+++ b/contrib/pg_upgrade/test/integration/README.md
@@ -4,24 +4,14 @@
 
 Step 1: setup environment
 
-    # setup installations for 5 and 6
-    ln -s /some/path/to/gpdb6/installation gpdb6
-    ln -s /some/path/to/gpdb5/installation gpdb5
+    ./scripts/init-gpdb5-cluster.bash [INSTALLATION DIRECTORY] [SOURCE DIRECTORY]
+    ./scripts/init-gpdb6-cluster.bash [INSTALLATION DIRECTORY] [SOURCE DIRECTORY]
 
-    # setup demo clusters for 5 and 6
-    source configuration/gpdb5-env.sh && \ 
-        source ./gpdb5/greenplum_path.sh && \
-        make -C /some/path/to/gpdb5/source/gpAux/gpdemo && \
-        gpstop -a; # ensure cluster is stopped
+    example:
 
-    source configuration/gpdb6-env.sh && \ 
-        source ./gpdb6/greenplum_path.sh && \
-        make -C /some/path/to/gpdb6/source/gpAux/gpdemo && \
-        gpstop -a; # ensure cluster is stopped
-        
-    # make a backup of the original data directories
-    cp -r gpdb5-data gpdb5-data-copy
-    cp -r gpdb6-data gpdb6-data-copy
+    ./scripts/init-gpdb5-cluster.bash \
+        /Users/adamberlin/workspace/gpdb5/gpAux/greenplum-db-installation \
+        /Users/adamberlin/workspace/gpdb5
 
 Step 2: run tests
 

--- a/contrib/pg_upgrade/test/integration/scripts/init-gpdb5-cluster.bash
+++ b/contrib/pg_upgrade/test/integration/scripts/init-gpdb5-cluster.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+main() {
+  source "scripts/shared/ui.bash"
+  source "scripts/shared/init_cluster.bash"
+  
+  # extract arguments
+  local gpdb_installation_path=$1
+  local gpdb_source_path=$2
+  local gpdb_version="gpdb5"
+
+  # validate arguments
+  validate_gpdb_installation_path "$gpdb_installation_path" "$gpdb_version"
+  validate_gpdb_source_path "$gpdb_source_path" "$gpdb_version"
+  
+  # initialize
+  init_cluster "$gpdb_installation_path" "$gpdb_source_path" "$gpdb_version"
+}
+
+main "$@"

--- a/contrib/pg_upgrade/test/integration/scripts/init-gpdb6-cluster.bash
+++ b/contrib/pg_upgrade/test/integration/scripts/init-gpdb6-cluster.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+main() {
+  source "scripts/shared/ui.bash"
+  source "scripts/shared/init_cluster.bash"
+
+  # extract arguments
+  local gpdb_installation_path=$1
+  local gpdb_source_path=$2
+  local gpdb_version="gpdb6"
+
+  # validate arguments
+  validate_gpdb_installation_path "$gpdb_installation_path" "$gpdb_version"
+  validate_gpdb_source_path "$gpdb_source_path" "$gpdb_version"
+
+  # initialize
+  init_cluster "$gpdb_installation_path" "$gpdb_source_path" "$gpdb_version"
+}
+
+main "$@"

--- a/contrib/pg_upgrade/test/integration/scripts/shared/init_cluster.bash
+++ b/contrib/pg_upgrade/test/integration/scripts/shared/init_cluster.bash
@@ -1,0 +1,63 @@
+
+
+remove_existing_symlink_to_installation() {
+  local installation_link_name=$1
+  rm $1
+}
+
+#
+# Helpers
+#
+create_symlink_to_installation() {
+  local gpdb_installation_path=$1
+  local link_name=$2
+
+  ln -s $gpdb_installation_path $link_name
+}
+
+create_demo_cluster() {
+  local gpdb_source_path=$1;
+  local installation_path=$2;
+  local gpdb_version=$3;
+
+  source "./configuration/$gpdb_version-env.sh";
+  source "./$installation_path/greenplum_path.sh";
+
+  make -C "$gpdb_source_path/gpAux/gpdemo";
+
+  # ensure cluster is stopped
+  "./$installation_path/bin/gpstop" -a;
+}
+
+create_backup_of_data_dirs() {
+  local source_directory=$1
+  local backup_directory=$2
+
+  rm -rf "$backup_directory"
+  cp -r "$source_directory" "$backup_directory"
+}
+
+#
+# Main body: takes two arguments
+#
+# - gpdb installation path: the path to an installed GPDB
+# - gpdb source path: the path to a gpdb source tree containing gpdemo
+#
+init_cluster() {
+  local gpdb_installation_path=$1
+  local gpdb_source_path=$2
+  local gpdb_version=$3
+
+  local gpdb_installation_link_name="$gpdb_version"
+  local data_directory="$gpdb_version-data"
+  local backup_data_directory="$gpdb_version-data-copy"
+
+  remove_existing_symlink_to_installation "$gpdb_installation_link_name"
+  create_symlink_to_installation "$gpdb_installation_path" "$gpdb_installation_link_name"
+  create_demo_cluster "$gpdb_source_path" "$gpdb_installation_link_name" "$gpdb_version"
+  
+  echo ""
+  echo "Creating back up of data directory from $data_directory to $backup_data_directory."
+  create_backup_of_data_dirs "$data_directory" "$backup_data_directory"
+  echo "Done."
+}

--- a/contrib/pg_upgrade/test/integration/scripts/shared/ui.bash
+++ b/contrib/pg_upgrade/test/integration/scripts/shared/ui.bash
@@ -1,0 +1,34 @@
+validate_gpdb_installation_path() {
+  if [ ! -d "$1" ]; then
+    echo "missing argument: installation path"
+    usage "$2"
+    exit 1
+  fi
+}
+
+validate_gpdb_source_path() {
+  if [ ! -d "$1" ]; then
+    echo "missing argument: source path"
+    usage "$2"
+    exit 1
+  fi
+}
+
+usage() {
+  local gpdb_version=$1
+  
+  cat <<USAGE
+
+usage:
+
+./scripts/init-$gpdb_version-cluster.bash [INSTALLATION_PATH] [SOURCE_PATH]
+
+example:
+
+./scripts/init-$gpdb_version-cluster.bash \
+  $HOME/workspace/$gpdb_version/gpAux/greenplum-db-installation \
+  $HOME/workspace/$gpdb_version;
+USAGE
+}
+
+


### PR DESCRIPTION
These scripts require that you have a source tree and an installed version of gpdb5 and gpdb6. The scripts will create your testing demo cluster and set up the appropriate links to the installation directory for the integration test suite to work correctly.