### PR TITLE
Fix gpexpand entries in hba.conf

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -15,6 +15,7 @@ import json
 import shutil
 import signal
 import traceback
+from collections import defaultdict
 from time import strftime, sleep
 
 try:
@@ -144,6 +145,8 @@ def parseargs():
                       help='show this help message and exit.')
     parser.add_option('-s', '--silent', action='store_true',
                       help='Do not prompt for confirmation to proceed on warnings')
+    parser.add_option('', '--hba-hostnames', action='store_true', default=False,
+                      help='use hostnames instead of CIDR in pg_hba.conf')
     parser.add_option('--usage', action="briefhelp")
 
     parser.set_defaults(verbose=False, filters=[], slice=(None, None))
@@ -571,7 +574,7 @@ class SegmentTemplate:
 
     def __init__(self, logger, statusLogger, pool,
                  gparray, masterDataDirectory,
-                 dburl, conn, tempDir, batch_size,
+                 dburl, conn, tempDir, batch_size, is_hba_hostnames,
                  segTarDir='.', schemaTarFile='gpexpand_schema.tar'):
         self.logger = logger
         self.statusLogger = statusLogger
@@ -586,6 +589,7 @@ class SegmentTemplate:
         self.maxDbId = self.gparray.get_max_dbid()
         self.segTarDir = segTarDir
         self.segTarFile = os.path.join(segTarDir, self.schema_tar_file)
+        self.isHbaHostnames = is_hba_hostnames
 
         hosts = []
         for seg in self.gparray.getExpansionSegDbList():
@@ -816,6 +820,26 @@ class SegmentTemplate:
                                             verbose=gplog.logging_is_verbose(), batchSize=self.batch_size,
                                             ctxt=REMOTE, remoteHost=host)
             self.pool.addCommand(segCfgCmd)
+
+        self.pool.join()
+        self.pool.check_results()
+
+        # Map primary and mirror hostnames to expanded segment's contentid
+        m = defaultdict(lambda: [])
+        for seg in self.gparray.getExpansionSegDbList():
+            m[seg.getSegmentContentId()].append(seg.getSegmentHostName())
+
+        # Now update the primary's hba config with the corresponding primary
+        # and mirror information
+        for seg in self.gparray.getExpansionSegDbList():
+            if seg.isSegmentPrimary():
+                modifyConfCmd = ModifyPgHbaConfSetting(
+                        'Updating %s/pg_hba.conf' % seg.getSegmentHostName(),
+                        os.path.join(seg.getSegmentDataDirectory(), 'pg_hba.conf'),
+                        ctxt=REMOTE, remoteHost=seg.getSegmentHostName(),
+                        addresses=m[seg.getSegmentContentId()],
+                        is_hba_hostnames=self.isHbaHostnames)
+                self.pool.addCommand(modifyConfCmd)
 
         self.pool.join()
         self.pool.check_results()
@@ -1254,7 +1278,8 @@ class gpexpand:
                                            conn=self.conn,
                                            tempDir=self.tempDir,
                                            segTarDir=self.options.tardir,
-                                           batch_size=self.options.batch_size)
+                                           batch_size=self.options.batch_size,
+                                           is_hba_hostnames=self.options.hba_hostnames)
         try:
             self.segTemplate.build_segment_template(newTableSpaceInfo)
             self.segTemplate.build_new_segments()

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -815,6 +815,28 @@ class ModifyConfSetting(Command):
         self.cmdStr = cmdStr
         Command.__init__(self, name, self.cmdStr, ctxt, remoteHost)
 
+class ModifyPgHbaConfSetting(Command):
+    def __init__(self, name, file, ctxt, remoteHost, addresses, is_hba_hostnames):
+        hba_content = ""
+
+        for address in addresses:
+            if is_hba_hostnames:
+                hba_content += "\nhost all {0} {1} trust".format(getUserName(), address)
+            else:
+                ips = InterfaceAddrs.remote('get mirror ips', address)
+                for ip in ips:
+                    cidr_suffix = '/128' if ':' in ip else '/32'
+                    cidr = ip + cidr_suffix
+                    hba_content += "\nhost all {0} {1} trust".format(getUserName(), cidr)
+
+        # You might think you can substitute the primary and mirror addresses
+        # with the new primary and mirror addresses, but what if they were the
+        # same? Then you could end up with only the new primary or new mirror
+        # address.
+        cmdStr = "echo '{0}' >> {1}".format(hba_content, file)
+        self.cmdStr = cmdStr
+        Command.__init__(self, name, self.cmdStr, ctxt, remoteHost)
+
 #-----------------------------------------------
 class GpCleanSegmentDirectories(Command):
     """

--- a/gpMgmt/doc/gpexpand_help
+++ b/gpMgmt/doc/gpexpand_help
@@ -11,6 +11,7 @@ gpexpand
       | -i <input_file> [-B <batch_size>] [-V] [-t segment_tar_dir] [-S]
       | {-d <hh:mm:ss> | -e '<YYYY-MM-DD hh:mm:ss>'} 
         [-analyze] [-n <parallel_processes>]
+      | --hba-hostnames
       | --rollback
       | --clean
 [--verbose] [--silent]
@@ -121,6 +122,10 @@ OPTIONS
  interfaces specified. The gpexpand utility handles either case, 
  adding interface numbers to end of the hostname if the original nodes 
  are configured with multiple network interfaces.
+
+
+--hba-hostnames
+ Optional. use hostnames instead of CIDR in pg_hba.conf
 
 
 -i | --input <input_file>

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -132,6 +132,26 @@ Feature: expand the cluster by adding more segments
         Then verify that the cluster has 4 new segments
 
     @gpexpand_mirrors
+    @gpexpand_segment
+    Scenario: expand a cluster that has mirrors and recover a failed segment
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with mirrors on "mdw" and "sdw1"
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "mdw,sdw1"
+        And the user runs gpexpand with a static inputfile for a two-node cluster with mirrors
+        And expanded preferred primary on segment "3" has failed
+        When the user runs "gprecoverseg -a"
+        Then gprecoverseg should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized
+        When the user runs "gprecoverseg -ra"
+        Then gprecoverseg should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized
+
+    @gpexpand_mirrors
     @gpexpand_host
     Scenario: expand a cluster that has mirrors with one new hosts
         Given the database is not running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2232,10 +2232,10 @@ def step_impl(context, segment_id):
 @given('the user runs gpexpand with a static inputfile for a two-node cluster with mirrors')
 def impl(context):
     inputfile_contents = """
-sdw1|sdw1|20502|/tmp/gpexpand_behave/data/primary/gpseg2|6|2|p
-sdw2|sdw2|21502|/tmp/gpexpand_behave/data/mirror/gpseg2|8|2|m
-sdw2|sdw2|20503|/tmp/gpexpand_behave/data/primary/gpseg3|7|3|p
-sdw1|sdw1|21503|/tmp/gpexpand_behave/data/mirror/gpseg3|9|3|m"""
+sdw1|sdw1|20502|/tmp/gpexpand_behave/two_nodes/data/primary/gpseg2|6|2|p
+sdw2|sdw2|21502|/tmp/gpexpand_behave/two_nodes/data/mirror/gpseg2|8|2|m
+sdw2|sdw2|20503|/tmp/gpexpand_behave/two_nodes/data/primary/gpseg3|7|3|p
+sdw1|sdw1|21503|/tmp/gpexpand_behave/two_nodes/data/mirror/gpseg3|9|3|m"""
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     inputfile_name = "%s/gpexpand_inputfile_%s" % (context.working_directory, timestamp)
     with open(inputfile_name, 'w') as fd:

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2224,6 +2224,28 @@ def _gpexpand_redistribute(context, duration=False, endtime=False):
     if ret_code != 0:
         raise Exception("gpexpand exited with return code: %d.\nstderr=%s\nstdout=%s" % (ret_code, std_err, std_out))
 
+@given('expanded preferred primary on segment "{segment_id}" has failed')
+def step_impl(context, segment_id):
+    stop_primary(context, int(segment_id))
+    wait_for_unblocked_transactions(context)
+
+@given('the user runs gpexpand with a static inputfile for a two-node cluster with mirrors')
+def impl(context):
+    inputfile_contents = """
+sdw1|sdw1|20502|/tmp/gpexpand_behave/data/primary/gpseg2|6|2|p
+sdw2|sdw2|21502|/tmp/gpexpand_behave/data/mirror/gpseg2|8|2|m
+sdw2|sdw2|20503|/tmp/gpexpand_behave/data/primary/gpseg3|7|3|p
+sdw1|sdw1|21503|/tmp/gpexpand_behave/data/mirror/gpseg3|9|3|m"""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    inputfile_name = "%s/gpexpand_inputfile_%s" % (context.working_directory, timestamp)
+    with open(inputfile_name, 'w') as fd:
+        fd.write(inputfile_contents)
+
+    gpexpand = Gpexpand(context, working_directory=context.working_directory)
+    ret_code, std_err, std_out = gpexpand.initialize_segments()
+    if ret_code != 0:
+        raise Exception("gpexpand exited with return code: %d.\nstderr=%s\nstdout=%s" % (ret_code, std_err, std_out))
+
 @when('the user runs gpexpand with a static inputfile for a single-node cluster with mirrors')
 def impl(context):
     inputfile_contents = """sdw1|sdw1|20502|/tmp/gpexpand_behave/data/primary/gpseg2|6|2|p


### PR DESCRIPTION
Append into pg_hba configs of expanded segments the addresses of the
primary and mirror segments. The hba config is copied from segment 0 (see
`SegmentTemplate._select_src_segment` and `SegmentTemplate._fixup_template`).
We must update it with the new primary/mirror pair information otherwise
connections between the systems will fail. This connection is necessary
during pg_rewind.

Manually confirmed that `gpexpand`'s new `--hba-hostnames` options works
as expected.  Additional testing is blocked on PR https://github.com/greenplum-db/gpdb/pull/8597 for `HBA_HOSTNAMES`
testing setup.