### PR TITLE
Only build pxf_fdw when --enable_pxf is present

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -36,7 +36,6 @@ SUBDIRS = \
 		pgstattuple	\
 		pg_xlogdump	\
 		postgres_fdw	\
-		pxf_fdw		\
 		seg		\
 		spi		\
 		tcn		\
@@ -81,6 +80,10 @@ ifeq ($(with_selinux),yes)
 SUBDIRS += sepgsql
 else
 ALWAYS_SUBDIRS += sepgsql
+endif
+
+ifeq ($(enable_pxf),yes)
+SUBDIRS += pxf_fdw
 endif
 
 # Missing:


### PR DESCRIPTION
PXF is enabled by default, but this gives the user the option of turning
off the building of the PXF contrib module with --disable-pxf.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>
