### PR TITLE
Omit slice information for SubPlans that are not dispatched separately.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1586,13 +1586,16 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			appendStringInfo(es->str, "%s", plan_name);
 
 			/*
-			 * Show slice information after the plan name.
+			 * If this SubPlan is being dispatched separately, show slice
+			 * information after the plan name. Currently, we do this for
+			 * Init Plans.
 			 *
 			 * Note: If the top node was a Motion node, we print the slice
 			 * *above* the Motion here. We will print the slice below the
 			 * Motion, below.
 			 */
-			show_dispatch_info(save_currentSlice, es, plan);
+			if (es->subplanDispatchedSeparately)
+				show_dispatch_info(save_currentSlice, es, plan);
 			appendStringInfoChar(es->str, '\n');
 			es->indent++;
 		}
@@ -3472,7 +3475,10 @@ ExplainSubPlans(List *plans, List *ancestors,
 		{
 			es->currentSlice = (Slice *)list_nth(sliceTable->slices,
 												 sp->qDispSliceId);
+			es->subplanDispatchedSeparately = true;
 		}
+		else
+			es->subplanDispatchedSeparately = false;
 
 		ExplainNode(sps->planstate, ancestors,
 					relationship, sp->plan_name, es);

--- a/src/include/commands/explain.h
+++ b/src/include/commands/explain.h
@@ -52,7 +52,8 @@ typedef struct ExplainState
 
     /* CDB */
     struct CdbExplain_ShowStatCtx  *showstatctx;    /* EXPLAIN ANALYZE info */
-    Slice          *currentSlice;   /* slice whose nodes we are visiting */
+	Slice	   *currentSlice;	/* slice whose nodes we are visiting */
+	bool		subplanDispatchedSeparately;
 
 	PlanState  *parentPlanState;
 } ExplainState;

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -739,7 +739,7 @@ explain (costs off)
 -----------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Seq Scan on int4_tbl
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Aggregate
                  ->  Result
                        Filter: (tenk1.unique1 > int4_tbl.f1)

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -751,7 +751,7 @@ explain (costs off)
  Result
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on int4_tbl
-   SubPlan 1  (slice0)
+   SubPlan 1
      ->  Aggregate
            ->  Result
                  Filter: (tenk1.unique1 > int4_tbl.f1)

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -436,7 +436,7 @@ EXPLAIN SELECT a.* FROM MPP_22019_a a INNER JOIN MPP_22019_b b ON a.i = b.i WHER
                      ->  Hash  (cost=431.00..431.00 rows=1 width=8)
                            ->  Seq Scan on mpp_22019_b  (cost=0.00..431.00 rows=1 width=8)
                                  Filter: i = 1
-               SubPlan 1  (slice2; segments: 3)
+               SubPlan 1
                  ->  Result  (cost=0.00..431.00 rows=1 width=4)
                        Filter: mpp_22019_a_1.j = mpp_22019_b.j
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11117,7 +11117,7 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..3.30 rows=4 width=4)
                      Hash Key: f2.b
                      ->  Seq Scan on onetimefilter2 f2  (cost=0.00..3.10 rows=4 width=4)
-         SubPlan 1  (slice6; segments: 3)
+         SubPlan 1
            ->  Limit  (cost=0.00..0.04 rows=1 width=0)
                  ->  Limit  (cost=0.00..0.02 rows=1 width=0)
                        ->  Result  (cost=0.00..0.20 rows=4 width=0)
@@ -11132,7 +11132,7 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                                                                  ->  Seq Scan on onetimefilter1  (cost=0.00..3.10 rows=4 width=8)
                                                                  ->  Hash  (cost=3.10..3.10 rows=4 width=4)
                                                                        ->  Seq Scan on onetimefilter2  (cost=0.00..3.10 rows=4 width=4)
-         SubPlan 2  (slice6; segments: 3)
+         SubPlan 2
            ->  Result  (cost=0.00..0.28 rows=1 width=0)
                  One-Time Filter: (f1.a = 2)
                  ->  Subquery Scan on abc  (cost=0.00..0.28 rows=1 width=0)
@@ -11141,7 +11141,7 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                              ->  Materialize  (cost=6.51..6.77 rows=4 width=8)
                                    ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=6.51..6.72 rows=4 width=8)
                                          ->  Shared Scan (share slice:id 2:0)  (cost=6.51..6.72 rows=4 width=8)
-         SubPlan 3  (slice6; segments: 3)
+         SubPlan 3
            ->  Subquery Scan on abc_1  (cost=0.00..0.22 rows=1 width=4)
                  Filter: (abc_1.b = f1.b)
                  ->  Result  (cost=6.51..6.77 rows=4 width=8)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11181,7 +11181,7 @@ EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 TH
    ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
          ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
                Filter: (SubPlan 1)
-               SubPlan 1  (slice2; segments: 3)
+               SubPlan 1
                  ->  Result  (cost=0.00..431.00 rows=2 width=4)
                        ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
@@ -11207,7 +11207,7 @@ EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 TH
    ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
          ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
                Filter: (SubPlan 1)
-               SubPlan 1  (slice2; segments: 3)
+               SubPlan 1
                  ->  Result  (cost=0.00..431.00 rows=2 width=4)
                        ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
@@ -11283,7 +11283,7 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
                                  Hash Key: onetimefilter2.b
                                  ->  Seq Scan on onetimefilter2  (cost=0.00..431.00 rows=4 width=4)
-               SubPlan 1  (slice6; segments: 3)
+               SubPlan 1
                  ->  Result  (cost=0.00..431.01 rows=1 width=4)
                        ->  Limit  (cost=0.00..431.01 rows=1 width=1)
                              ->  Result  (cost=0.00..431.01 rows=5 width=1)
@@ -11292,7 +11292,7 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                                          ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=11 width=1)
                                                ->  Result  (cost=0.00..431.00 rows=4 width=1)
                                                      ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=4 width=1)
-               SubPlan 2  (slice6; segments: 3)
+               SubPlan 2
                  ->  Result  (cost=0.00..431.33 rows=3 width=4)
                        ->  Result  (cost=0.00..431.33 rows=3 width=1)
                              One-Time Filter: (onetimefilter1.a = 2)
@@ -11301,7 +11301,7 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                                    ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=11 width=1)
                                          ->  Result  (cost=0.00..431.00 rows=4 width=1)
                                                ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=4 width=1)
-               SubPlan 3  (slice6; segments: 3)
+               SubPlan 3
                  ->  Result  (cost=0.00..431.66 rows=1 width=4)
                        Filter: (share0_ref3.b = onetimefilter1.b)
                        ->  Materialize  (cost=0.00..431.00 rows=11 width=4)
@@ -11453,7 +11453,7 @@ explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_p
          Hash Cond: (ds_part.c = non_part2.e)
          ->  Dynamic Seq Scan on ds_part (dynamic scan id: 1)  (cost=0.00..1324050.11 rows=334 width=12)
                Filter: ((a = (b + 1)) AND (SubPlan 1))
-               SubPlan 1  (slice4; segments: 3)
+               SubPlan 1
                  ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                        ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=4)
                              ->  Limit  (cost=0.00..431.00 rows=1 width=4)

--- a/src/test/regress/expected/insert_conflict.out
+++ b/src/test/regress/expected/insert_conflict.out
@@ -52,13 +52,13 @@ explain (costs off) insert into insertconflicttest values(0, 'Crowberry') on con
    Conflict Arbiter Indexes: op_index_key, collation_index_key, both_index_key
    Conflict Filter: (alternatives: SubPlan 1 or hashed SubPlan 2)
    ->  Result
-   SubPlan 1  (slice0; segments: 1)
+   SubPlan 1
      ->  Result
            Filter: (ii.key = excluded.key)
            ->  Materialize
                  ->  Broadcast Motion 3:3  (slice1; segments: 3)
                        ->  Seq Scan on insertconflicttest ii
-   SubPlan 2  (slice0; segments: 1)
+   SubPlan 2
      ->  Materialize
            ->  Broadcast Motion 3:3  (slice2; segments: 3)
                  ->  Seq Scan on insertconflicttest ii_1

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -2953,7 +2953,7 @@ order by 1,2;
                      ->  Seq Scan on int8_tbl t1
                ->  Hash
                      ->  Seq Scan on int8_tbl t2
-               SubPlan 1  (slice3; segments: 3)
+               SubPlan 1
                  ->  Limit
                        ->  Limit
                              ->  Result

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2977,7 +2977,7 @@ order by 1,2;
                      ->  Result
                            ->  Gather Motion 3:1  (slice2; segments: 3)
                                  ->  Seq Scan on int8_tbl int8_tbl_1
-         SubPlan 1  (slice0)
+         SubPlan 1
            ->  Result
                  ->  Result
                        Filter: (1 = "outer".?column?)
@@ -5782,7 +5782,7 @@ select * from
                Output: int4_tbl.f1
                ->  Seq Scan on public.int4_tbl
                      Output: int4_tbl.f1
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Result
                  Output: tenk1.unique1
                  Filter: (tenk1.unique2 = "*VALUES*".column2)

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -744,7 +744,7 @@ explain select c2 from t2 where not c2 < all (select c2 from t2);
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324033.39 rows=5 width=4)
    ->  Seq Scan on t2  (cost=0.00..1324033.39 rows=2 width=4)
          Filter: (SubPlan 1)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan
            ->  Materialize  (cost=0.00..431.00 rows=5 width=4)
                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                        ->  Seq Scan on t2 t2_1  (cost=0.00..431.00 rows=2 width=4)

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -389,7 +389,7 @@ select gp_debug_reset_create_table_default_numsegments();
    ->  Nested Loop  (cost=10000000000.00..10182108256.73 rows=421267500 width=32) (actual time=0.000..0.053 rows=0 loops=1)
          ->  Seq Scan on t1  (cost=0.00..70516404.55 rows=11850 width=16) (actual time=0.000..0.041 rows=0 loops=1)
                Filter: (SubPlan 1)
-               SubPlan 1  (slice4; segments: 1)
+               SubPlan 1
                  ->  Aggregate  (cost=991.77..991.78 rows=1 width=4) (never executed)
                        ->  Result  (cost=0.00..989.11 rows=24 width=4) (never executed)
                              Filter: (t2_1.c2 = t1.c2)
@@ -400,7 +400,7 @@ select gp_debug_reset_create_table_default_numsegments();
                ->  Broadcast Motion 2:1  (slice3; segments: 2)  (cost=0.00..70517826.55 rows=35550 width=16) (never executed)
                      ->  Seq Scan on t2  (cost=0.00..70516404.55 rows=11850 width=16) (actual time=0.000..0.087 rows=0 loops=1)
                            Filter: (SubPlan 2)
-                           SubPlan 2  (slice3; segments: 2)
+                           SubPlan 2
                              ->  Aggregate  (cost=991.77..991.78 rows=1 width=4) (never executed)
                                    ->  Result  (cost=0.00..989.11 rows=24 width=4) (never executed)
                                          Filter: (t1_1.c2 = t2.c2)

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -387,13 +387,13 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..87.36 rows=1 width=8)
                                        ->  Seq Scan on a  (cost=0.00..87.32 rows=1 width=8)
                                              Filter: j = ((SubPlan 2))
-                                             SubPlan 2  (slice3; segments: 3)
+                                             SubPlan 2
                                                ->  Result  (cost=0.00..17.06 rows=1 width=4)
                                                      Filter: c_1.j = a.j AND ((SubPlan 1))
                                                      ->  Materialize  (cost=0.00..17.06 rows=1 width=4)
                                                            ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..17.05 rows=1 width=4)
                                                                  ->  Seq Scan on c c_1  (cost=0.00..17.05 rows=1 width=4)
-                                                     SubPlan 1  (slice3; segments: 3)
+                                                     SubPlan 1
                                                        ->  Result  (cost=0.00..3.10 rows=1 width=4)
                                                              Filter: c_1.i = b_1.i
                                                              ->  Materialize  (cost=0.00..3.10 rows=1 width=4)
@@ -436,13 +436,13 @@ explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j a
                            ->  Nested Loop  (cost=10000000000.00..10000000090.89 rows=2 width=4)
                                  ->  Seq Scan on a  (cost=0.00..87.32 rows=1 width=4)
                                        Filter: j = ((SubPlan 2))
-                                       SubPlan 2  (slice5; segments: 3)
+                                       SubPlan 2
                                          ->  Result  (cost=0.00..17.06 rows=1 width=4)
                                                Filter: c_1.j = a.j AND ((SubPlan 1))
                                                ->  Materialize  (cost=0.00..17.06 rows=1 width=4)
                                                      ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..17.05 rows=1 width=4)
                                                            ->  Seq Scan on c c_1  (cost=0.00..17.05 rows=1 width=4)
-                                               SubPlan 1  (slice5; segments: 3)
+                                               SubPlan 1
                                                  ->  Result  (cost=0.00..3.10 rows=1 width=4)
                                                        Filter: c_1.i = b_1.i
                                                        ->  Materialize  (cost=0.00..3.10 rows=1 width=4)
@@ -479,7 +479,7 @@ explain select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..33.51 rows=1 width=4)
    ->  Seq Scan on a  (cost=0.00..33.51 rows=1 width=4)
          Filter: (j = (SubPlan 1))
-         SubPlan 1  (slice3; segments: 3)
+         SubPlan 1
            ->  Hash Semi Join  (cost=3.14..6.29 rows=2 width=4)
                  Hash Cond: (c.i = b.i)
                  ->  Result  (cost=0.00..3.12 rows=1 width=8)
@@ -602,7 +602,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..33.66 rows=1 width=8)
                                        ->  Seq Scan on a  (cost=0.00..33.62 rows=1 width=8)
                                              Filter: j = ((SubPlan 1))
-                                             SubPlan 1  (slice3; segments: 3)
+                                             SubPlan 1
                                                ->  Hash Semi Join  (cost=3.14..6.31 rows=2 width=4)
                                                      Hash Cond: (c_1.i = b_1.i)
                                                      ->  Result  (cost=0.00..3.14 rows=1 width=8)
@@ -709,7 +709,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C whe
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.01..2.18 rows=3 width=4)
                                        ->  Seq Scan on a  (cost=0.01..2.08 rows=1 width=4)
                                              Filter: (hashed SubPlan 1)
-                                             SubPlan 1  (slice2; segments: 3)
+                                             SubPlan 1
                                                ->  Materialize  (cost=0.00..0.01 rows=1 width=0)
                                                      ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.01 rows=1 width=0)
                                                            ->  Result  (cost=0.00..0.01 rows=1 width=0)
@@ -805,7 +805,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                                                                            Group Key: c_1.j
                                                                            ->  Seq Scan on c c_1  (cost=0.00..17.03 rows=2 width=4)
                                                                                  Filter: (SubPlan 1)
-                                                                                 SubPlan 1  (slice3; segments: 3)
+                                                                                 SubPlan 1
                                                                                    ->  Result  (cost=0.00..3.10 rows=1 width=4)
                                                                                          Filter: c_1.i = b_1.i
                                                                                          ->  Materialize  (cost=0.00..3.10 rows=1 width=4)
@@ -889,7 +889,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C whe
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..2.19 rows=3 width=4)
                                        ->  Seq Scan on a  (cost=0.00..2.09 rows=1 width=4)
                                              Filter: (SubPlan 1)
-                                             SubPlan 1  (slice2; segments: 3)
+                                             SubPlan 1
                                                ->  Materialize  (cost=0.00..0.01 rows=1 width=0)
                                                      ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.01 rows=1 width=0)
                                                            ->  Result  (cost=0.00..0.01 rows=1 width=0)
@@ -1201,7 +1201,7 @@ explain select C.j from C where not exists (select max(B.i) from B  where C.i = 
          Sort Key: c.j
          ->  Seq Scan on c  (cost=0.00..31.34 rows=2 width=4)
                Filter: NOT ((SubPlan 1))
-               SubPlan 1  (slice2; segments: 3)
+               SubPlan 1
                  ->  Aggregate  (cost=3.13..3.14 rows=1 width=4)
                        Filter: max(b.i) IS NOT NULL
                        ->  Result  (cost=0.00..3.08 rows=1 width=4)
@@ -3656,7 +3656,7 @@ explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
 -------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..39.57 rows=3 width=4)
    ->  Seq Scan on t1 x1  (cost=0.00..39.57 rows=1 width=4)
-         SubPlan 1  (slice1; segments: 1)
+         SubPlan 1
            ->  Aggregate  (cost=12.50..12.51 rows=1 width=8)
                  ->  Function Scan on generate_series  (cost=0.00..10.00 rows=334 width=0)
  Optimizer: legacy query optimizer
@@ -3676,7 +3676,7 @@ explain select t1.a, (select count(*) c from (select city from supplier limit t1
 ---------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.99 rows=3 width=4)
    ->  Seq Scan on t1  (cost=0.00..3.99 rows=1 width=4)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Aggregate  (cost=0.64..0.65 rows=1 width=8)
                  ->  Limit  (cost=0.00..0.63 rows=1 width=2)
                        ->  Limit  (cost=0.00..0.61 rows=1 width=2)
@@ -3701,7 +3701,7 @@ explain select t1.*, (select count(*) as ct from generate_series(1, a), t1) from
 ---------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..30000000533.18 rows=3 width=8)
    ->  Seq Scan on t1  (cost=0.00..30000000533.18 rows=1 width=8)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Aggregate  (cost=10000000177.04..10000000177.05 rows=1 width=8)
                  ->  Nested Loop  (cost=10000000000.00..10000000049.54 rows=1000 width=0)
                        ->  Function Scan on generate_series  (cost=0.00..10.00 rows=334 width=0)
@@ -3727,7 +3727,7 @@ explain select * from t1 where 0 < (select count(*) from generate_series(1, a), 
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..30000000533.19 rows=1 width=8)
    ->  Seq Scan on t1  (cost=0.00..30000000533.19 rows=1 width=8)
          Filter: (0 < (SubPlan 1))
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Aggregate  (cost=10000000177.04..10000000177.05 rows=1 width=8)
                  ->  Nested Loop  (cost=10000000000.00..10000000049.54 rows=1000 width=0)
                        ->  Function Scan on generate_series  (cost=0.00..10.00 rows=334 width=0)

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -207,7 +207,7 @@ select * from A,B where exists (select * from C where B.i not in (select C.i fro
          ->  Result
                Filter: ((SubPlan 1) > '0'::bigint)
                ->  Seq Scan on b
-               SubPlan 1  (slice4; segments: 3)
+               SubPlan 1
                  ->  Aggregate
                        ->  Nested Loop
                              Join Filter: true
@@ -402,7 +402,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                                  ->  Result  (cost=0.00..1356696141.29 rows=2 width=4)
                                        ->  Seq Scan on a  (cost=0.00..1356696141.29 rows=2 width=4)
                                              Filter: j = ((SubPlan 2))
-                                             SubPlan 2  (slice4; segments: 3)
+                                             SubPlan 2
                                                ->  Result  (cost=0.00..1324036.57 rows=1 width=4)
                                                      Filter: c_1.j = a.j
                                                      ->  Materialize  (cost=0.00..1324036.57 rows=9 width=4)
@@ -410,7 +410,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                                                                  ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
                                                                        ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
                                                                              Filter: (SubPlan 1)
-                                                                             SubPlan 1  (slice3; segments: 3)
+                                                                             SubPlan 1
                                                                                ->  Result  (cost=0.00..431.00 rows=1 width=1)
                                                                                      ->  Result  (cost=0.00..431.00 rows=1 width=1)
                                                                                            Filter: (CASE WHEN (sum((CASE WHEN c_1.i = b_1.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN b_1.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN c_1.i IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN c_1.i = b_1.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
@@ -459,7 +459,7 @@ explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j a
                            Join Filter: true
                            ->  Seq Scan on a  (cost=0.00..1356696141.27 rows=2 width=4)
                                  Filter: j = ((SubPlan 2))
-                                 SubPlan 2  (slice5; segments: 3)
+                                 SubPlan 2
                                    ->  Result  (cost=0.00..1324036.57 rows=1 width=4)
                                          Filter: c_1.j = a.j
                                          ->  Materialize  (cost=0.00..1324036.57 rows=9 width=4)
@@ -467,7 +467,7 @@ explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j a
                                                      ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
                                                            ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
                                                                  Filter: (SubPlan 1)
-                                                                 SubPlan 1  (slice4; segments: 3)
+                                                                 SubPlan 1
                                                                    ->  Result  (cost=0.00..431.00 rows=1 width=1)
                                                                          ->  Result  (cost=0.00..431.00 rows=1 width=1)
                                                                                Filter: (CASE WHEN (sum((CASE WHEN c_1.i = b_1.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN b_1.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN c_1.i IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN c_1.i = b_1.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
@@ -511,7 +511,7 @@ explain select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i
    ->  Result  (cost=0.00..1765379.74 rows=2 width=4)
          ->  Seq Scan on a  (cost=0.00..1765379.74 rows=2 width=4)
                Filter: (j = (SubPlan 1))
-               SubPlan 1  (slice2; segments: 3)
+               SubPlan 1
                  ->  Result  (cost=0.00..862.00 rows=1 width=4)
                        Filter: (c.j = a.j)
                        ->  Materialize  (cost=0.00..862.00 rows=6 width=4)
@@ -641,7 +641,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                                        ->  Result  (cost=0.00..1765379.74 rows=2 width=4)
                                              ->  Seq Scan on a  (cost=0.00..1765379.74 rows=2 width=4)
                                                    Filter: j = ((SubPlan 1))
-                                                   SubPlan 1  (slice3; segments: 3)
+                                                   SubPlan 1
                                                      ->  Result  (cost=0.00..862.00 rows=1 width=4)
                                                            Filter: c_1.j = a.j
                                                            ->  Materialize  (cost=0.00..862.00 rows=6 width=4)
@@ -848,7 +848,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                                                                ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
                                                                      ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
                                                                            Filter: (SubPlan 1)
-                                                                           SubPlan 1  (slice3; segments: 3)
+                                                                           SubPlan 1
                                                                              ->  Result  (cost=0.00..431.00 rows=1 width=1)
                                                                                    ->  Result  (cost=0.00..431.00 rows=1 width=1)
                                                                                          Filter: ((CASE WHEN ((sum((CASE WHEN (c_1.i <> b_1.i) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (b_1.i IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (c_1.i IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (c_1.i <> b_1.i) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
@@ -948,7 +948,7 @@ explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C whe
                                        ->  Result  (cost=0.00..882688.08 rows=1 width=4)
                                              ->  Seq Scan on a  (cost=0.00..882688.08 rows=1 width=4)
                                                    Filter: (SubPlan 1)
-                                                   SubPlan 1  (slice2; segments: 3)
+                                                   SubPlan 1
                                                      ->  Result  (cost=0.00..0.00 rows=1 width=1)
                                                            ->  Result  (cost=0.00..0.00 rows=1 width=1)
                                                                  Filter: (CASE WHEN (sum((CASE WHEN $0 <> "outer".j THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN "outer".j IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> "outer".j THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
@@ -3833,7 +3833,7 @@ explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882708.48 rows=3 width=12)
    ->  Result  (cost=0.00..882708.48 rows=1 width=12)
          ->  Seq Scan on t1  (cost=0.00..882708.48 rows=334 width=12)
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Aggregate  (cost=0.00..0.00 rows=1 width=8)
                  ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=1)
  Optimizer: PQO version 3.27.0
@@ -3854,7 +3854,7 @@ explain select t1.a, (select count(*) c from (select city from supplier limit t1
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324051.59 rows=3 width=12)
    ->  Result  (cost=0.00..1324051.59 rows=1 width=12)
          ->  Seq Scan on t1  (cost=0.00..1324051.59 rows=334 width=12)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Limit  (cost=0.00..431.00 rows=5 width=1)
                        ->  Materialize  (cost=0.00..431.00 rows=5 width=1)
@@ -3878,7 +3878,7 @@ explain select t1.*, (select count(*) as ct from generate_series(1, a), t1) from
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1808684647.64 rows=3 width=16)
    ->  Result  (cost=0.00..1808684647.64 rows=1 width=16)
          ->  Seq Scan on t1  (cost=0.00..1808684647.64 rows=334 width=16)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Aggregate  (cost=0.00..1765431.58 rows=1 width=8)
                  ->  Nested Loop  (cost=0.00..1765431.58 rows=1000 width=1)
                        Join Filter: true
@@ -3904,7 +3904,7 @@ explain select * from t1 where 0 < (select count(*) from generate_series(1, a), 
    ->  Result  (cost=0.00..1808684647.65 rows=1 width=8)
          Filter: (0 < (SubPlan 1))
          ->  Seq Scan on t1  (cost=0.00..1808684647.64 rows=334 width=16)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Aggregate  (cost=0.00..1765431.58 rows=1 width=8)
                  ->  Nested Loop  (cost=0.00..1765431.58 rows=1000 width=1)
                        Join Filter: true

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -5883,7 +5883,7 @@ explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
 ------------------------------------------------------------------------------------------------------------------
  Result  (cost=10000000651.88..10000000651.89 rows=1 width=0)
    One-Time Filter: (SubPlan 1)
-   SubPlan 1  (slice0)
+   SubPlan 1
      ->  Materialize  (cost=10000000000.00..10000001544.50 rows=32100 width=4)
            ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000001063.00 rows=96300 width=4)
                  ->  Seq Scan on tbl_z  (cost=10000000000.00..10000001063.00 rows=32100 width=4)
@@ -5897,7 +5897,7 @@ explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
 ----------------------------------------------------------------------------------------------------------------
  Result  (cost=10000000006.52..10000000006.53 rows=1 width=0)
    One-Time Filter: (SubPlan 1)
-   SubPlan 1  (slice0)
+   SubPlan 1
      ->  Materialize  (cost=10000000000.00..10000000015.44 rows=321 width=4)
            ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000010.63 rows=963 width=4)
                  ->  Seq Scan on tbl_z  (cost=10000000000.00..10000000010.63 rows=321 width=4)

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -1233,7 +1233,7 @@ explain with test as (select * from (select * from append_rel) p where att1 in (
    ->  Append  (cost=584.27..3902.34 rows=25968 width=4)
          ->  Seq Scan on append_rel  (cost=584.27..586.31 rows=1 width=4)
                Filter: (hashed SubPlan 1)
-               SubPlan 1  (slice4; segments: 3)
+               SubPlan 1
                  ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
                              ->  Subquery Scan on test  (cost=0.00..519.35 rows=8656 width=4)
@@ -1258,7 +1258,7 @@ explain with test as (select * from (select * from append_rel) p where att1 in (
                                                                  Filter: (att2 >= 19)
          ->  Seq Scan on append_rel1  (cost=584.27..1658.02 rows=12984 width=4)
                Filter: (hashed SubPlan 1)
-               SubPlan 1  (slice4; segments: 3)
+               SubPlan 1
                  ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
                        ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
                              ->  Subquery Scan on test_1  (cost=0.00..519.35 rows=8656 width=4)
@@ -1283,7 +1283,7 @@ explain with test as (select * from (select * from append_rel) p where att1 in (
                                                                  Filter: (att2 >= 19)
          ->  Seq Scan on append_rel2  (cost=584.27..1658.02 rows=12984 width=4)
                Filter: (hashed SubPlan 1)
-               SubPlan 1  (slice4; segments: 3)
+               SubPlan 1
                  ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
                        ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
                              ->  Subquery Scan on test_2  (cost=0.00..519.35 rows=8656 width=4)

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1236,7 +1236,7 @@ explain with test as (select * from (select * from append_rel) p where att1 in (
    ->  Append  (cost=584.27..3902.34 rows=25968 width=4)
          ->  Seq Scan on append_rel  (cost=584.27..586.31 rows=1 width=4)
                Filter: (hashed SubPlan 1)
-               SubPlan 1  (slice4; segments: 3)
+               SubPlan 1
                  ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
                              ->  Subquery Scan on test  (cost=0.00..519.35 rows=8656 width=4)
@@ -1261,7 +1261,7 @@ explain with test as (select * from (select * from append_rel) p where att1 in (
                                                                  Filter: (att2 >= 19)
          ->  Seq Scan on append_rel1  (cost=584.27..1658.02 rows=12984 width=4)
                Filter: (hashed SubPlan 1)
-               SubPlan 1  (slice4; segments: 3)
+               SubPlan 1
                  ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
                        ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
                              ->  Subquery Scan on test_1  (cost=0.00..519.35 rows=8656 width=4)
@@ -1286,7 +1286,7 @@ explain with test as (select * from (select * from append_rel) p where att1 in (
                                                                  Filter: (att2 >= 19)
          ->  Seq Scan on append_rel2  (cost=584.27..1658.02 rows=12984 width=4)
                Filter: (hashed SubPlan 1)
-               SubPlan 1  (slice4; segments: 3)
+               SubPlan 1
                  ->  Materialize  (cost=0.00..649.19 rows=8656 width=4)
                        ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..519.35 rows=8656 width=4)
                              ->  Subquery Scan on test_2  (cost=0.00..519.35 rows=8656 width=4)

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -2097,7 +2097,7 @@ explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) 
    Output: ((SubPlan 1))
    ->  Seq Scan on public.int8_tbl
          Output: (SubPlan 1)
-         SubPlan 1  (slice1; segments: 1)
+         SubPlan 1
            ->  Result
                  Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -2099,7 +2099,7 @@ explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) 
    Output: ((SubPlan 1))
    ->  Seq Scan on public.int8_tbl
          Output: (SubPlan 1)
-         SubPlan 1  (slice1; segments: 1)
+         SubPlan 1
            ->  Result
                  Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/rowsecurity.out
+++ b/src/test/regress/expected/rowsecurity.out
@@ -957,7 +957,7 @@ EXPLAIN (COSTS OFF) SELECT (SELECT x FROM s1 LIMIT 1) xx, * FROM s2 WHERE y like
          Filter: (s2.y ~~ '%28%'::text)
          ->  Seq Scan on s2 s2_1
                Filter: ((x % 2) = 0)
-         SubPlan 1  (slice3; segments: 3)
+         SubPlan 1
            ->  Limit
                  ->  Limit
                        ->  Subquery Scan on s1

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -260,7 +260,7 @@ select * from int4_tbl o where exists
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Seq Scan on int4_tbl o
          Filter: (SubPlan 1)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Limit
                  ->  Limit
                        ->  Result
@@ -846,7 +846,7 @@ select * from int4_tbl where
                                  Output: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id
                                  ->  Seq Scan on public.int4_tbl
                                        Output: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id
-                     SubPlan 1  (slice3; segments: 3)
+                     SubPlan 1
                        ->  Materialize
                              Output: a.unique1
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -95,7 +95,7 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
          ->  Append  (cost=0.00..810353969.20 rows=57400 width=8)
                ->  Seq Scan on csq_t1_1_prt_1  (cost=0.00..202588492.30 rows=14350 width=8)
                      Filter: (SubPlan 1)
-                     SubPlan 1  (slice17; segments: 3)
+                     SubPlan 1
                        ->  Append  (cost=0.00..4705.00 rows=115 width=4)
                              ->  Result  (cost=0.00..1176.68 rows=29 width=4)
                                    Filter: csq_t2_1_prt_1.y = csq_t1_1_prt_1.y
@@ -119,7 +119,7 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
                                                ->  Seq Scan on csq_t2_1_prt_4  (cost=0.00..1176.25 rows=29 width=4)
                ->  Seq Scan on csq_t1_1_prt_2  (cost=0.00..202588492.30 rows=14350 width=8)
                      Filter: (SubPlan 1)
-                     SubPlan 1  (slice17; segments: 3)
+                     SubPlan 1
                        ->  Append  (cost=0.00..4705.00 rows=115 width=4)
                              ->  Result  (cost=0.00..1176.68 rows=29 width=4)
                                    Filter: csq_t2_1_prt_1_1.y = csq_t1_1_prt_2.y
@@ -143,7 +143,7 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
                                                ->  Seq Scan on csq_t2_1_prt_4 csq_t2_1_prt_4_1  (cost=0.00..1176.25 rows=29 width=4)
                ->  Seq Scan on csq_t1_1_prt_3  (cost=0.00..202588492.30 rows=14350 width=8)
                      Filter: (SubPlan 1)
-                     SubPlan 1  (slice17; segments: 3)
+                     SubPlan 1
                        ->  Append  (cost=0.00..4705.00 rows=115 width=4)
                              ->  Result  (cost=0.00..1176.68 rows=29 width=4)
                                    Filter: csq_t2_1_prt_1_2.y = csq_t1_1_prt_3.y
@@ -167,7 +167,7 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
                                                ->  Seq Scan on csq_t2_1_prt_4 csq_t2_1_prt_4_2  (cost=0.00..1176.25 rows=29 width=4)
                ->  Seq Scan on csq_t1_1_prt_4  (cost=0.00..202588492.30 rows=14350 width=8)
                      Filter: (SubPlan 1)
-                     SubPlan 1  (slice17; segments: 3)
+                     SubPlan 1
                        ->  Append  (cost=0.00..4705.00 rows=115 width=4)
                              ->  Result  (cost=0.00..1176.68 rows=29 width=4)
                                    Filter: csq_t2_1_prt_1_3.y = csq_t1_1_prt_4.y
@@ -273,7 +273,7 @@ explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
  Gather Motion 3:1  (slice2; segments: 3)  (cost=3.30..6.60 rows=13 width=4)
    ->  Seq Scan on mrs_t1  (cost=3.30..6.60 rows=5 width=4)
          Filter: ((hashed SubPlan 1)) OR x < 5
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Materialize  (cost=0.00..3.35 rows=7 width=4)
                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=7 width=4)
                        ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..3.25 rows=7 width=4)
@@ -642,7 +642,7 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..10000000001.53 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..10000000001.53 rows=1 width=4)
          Filter: (SubPlan 1)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Nested Loop  (cost=10000000000.00..10000000001.03 rows=2 width=4)
                  ->  Function Scan on csq_f  (cost=0.00..0.01 rows=1 width=4)
                  ->  Result  (cost=0.00..1.01 rows=1 width=0)
@@ -1264,7 +1264,7 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                ->  Append  (cost=0.00..1134.00 rows=31134 width=28)
                      ->  Seq Scan on t_mpp_20470_ptr1 b  (cost=0.00..567.00 rows=15567 width=28)
                      ->  Seq Scan on t_mpp_20470_ptr2 b_1  (cost=0.00..567.00 rows=15567 width=28)
-   SubPlan 1  (slice0)
+   SubPlan 1
      ->  Aggregate  (cost=1371.47..1371.48 rows=1 width=8)
            ->  Append  (cost=0.00..1367.50 rows=32 width=4)
                  ->  Result  (cost=0.00..683.98 rows=16 width=4)
@@ -1697,13 +1697,13 @@ EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) F
    ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..212.10 rows=1 width=4)
          ->  Limit  (cost=0.00..212.08 rows=1 width=4)
                ->  Seq Scan on tenk2  (cost=0.00..2133536.35 rows=3354 width=4)
-                     SubPlan 1  (slice3; segments: 3)
+                     SubPlan 1
                        ->  Result  (cost=0.00..212.07 rows=1 width=0)
                              Filter: tenk1.unique1 = tenk2.unique1
                              ->  Materialize  (cost=0.00..212.07 rows=1 width=0)
                                    ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..212.06 rows=1 width=0)
                                          ->  Seq Scan on tenk1  (cost=0.00..212.06 rows=1 width=0)
-                     SubPlan 2  (slice3; segments: 3)
+                     SubPlan 2
                        ->  Materialize  (cost=0.00..237.08 rows=3335 width=4)
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..187.05 rows=3335 width=4)
                                    ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..187.05 rows=3335 width=4)

--- a/src/test/regress/expected/subselect_gp_indexes.out
+++ b/src/test/regress/expected/subselect_gp_indexes.out
@@ -79,7 +79,7 @@ explain select (select id1 from (select * from choose_seqscan_t2) foo where id2=
 ---------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..184.75 rows=50 width=4)
    ->  Seq Scan on choose_seqscan_t1  (cost=0.00..184.75 rows=17 width=4)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Result  (cost=0.00..3.63 rows=1 width=4)
                  Filter: (choose_seqscan_t2.id2 = choose_seqscan_t1.id2)
                  ->  Materialize  (cost=0.00..3.63 rows=1 width=4)
@@ -139,7 +139,7 @@ explain select (select id1 from (select * from choose_indexscan_t2) foo where id
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..46.40 rows=20 width=4)
    ->  Seq Scan on choose_indexscan_t1  (cost=0.00..46.40 rows=7 width=4)
-         SubPlan 1  (slice1; segments: 1)
+         SubPlan 1
            ->  Index Scan using choose_indexscan_t2_idx on choose_indexscan_t2  (cost=0.14..2.16 rows=1 width=4)
                  Index Cond: (id2 = choose_indexscan_t1.id2)
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/subselect_gp_indexes_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_indexes_optimizer.out
@@ -76,7 +76,7 @@ explain select (select id1 from (select * from choose_seqscan_t2) foo where id2=
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324216.68 rows=50 width=4)
    ->  Result  (cost=0.00..1324216.68 rows=17 width=4)
          ->  Seq Scan on choose_seqscan_t1  (cost=0.00..1324216.68 rows=334 width=4)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Result  (cost=0.00..431.17 rows=1 width=4)
                  Filter: (choose_seqscan_t2.id2 = choose_seqscan_t1.id2)
                  ->  Materialize  (cost=0.00..431.01 rows=50 width=8)
@@ -135,7 +135,7 @@ explain select (select id1 from (select * from choose_indexscan_t2) foo where id
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324176.46 rows=20 width=4)
    ->  Result  (cost=0.00..1324176.46 rows=7 width=4)
          ->  Seq Scan on choose_indexscan_t1  (cost=0.00..1324176.46 rows=334 width=4)
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Seq Scan on choose_indexscan_t2  (cost=0.00..431.13 rows=1 width=4)
                  Filter: (id2 = choose_indexscan_t1.id2)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -97,7 +97,7 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
                      ->  Partition Selector for csq_t1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                            Partitions selected: 4 (out of 4)
                      ->  Dynamic Seq Scan on csq_t1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
-   SubPlan 1  (slice0)
+   SubPlan 1
      ->  Result  (cost=0.00..431.00 rows=1 width=1)
            ->  Result  (cost=0.00..431.00 rows=1 width=1)
                  Filter: (CASE WHEN (sum((CASE WHEN csq_t1.x <= csq_t2.x THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN csq_t2.x IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN csq_t1.x IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN csq_t1.x <= csq_t2.x THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
@@ -469,7 +469,7 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
          Filter: a = ((SubPlan 1))
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
@@ -488,7 +488,7 @@ explain SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
          Filter: a <> ((SubPlan 1))
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
@@ -506,7 +506,7 @@ explain SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
          Filter: (SubPlan 1)
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Result  (cost=0.00..0.00 rows=1 width=1)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
@@ -526,7 +526,7 @@ explain SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
          Filter: (SubPlan 1)
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Result  (cost=0.00..0.00 rows=1 width=1)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
@@ -545,7 +545,7 @@ explain SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1)
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
          Filter: a > ((SubPlan 1))
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Limit  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=4)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
@@ -564,7 +564,7 @@ explain SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
          Filter: a < ((SubPlan 1))
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on; optimizer_segments=3
@@ -583,7 +583,7 @@ explain SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
          Filter: a <= ((SubPlan 1))
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Settings:  optimizer=on; optimizer_segments=3
@@ -603,7 +603,7 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1724.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..1724.00 rows=1 width=4)
          Filter: (SubPlan 1)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Nested Loop  (cost=0.00..862.00 rows=1 width=4)
                  Join Filter: true
                  ->  Result  (cost=0.00..0.00 rows=1 width=4)
@@ -741,7 +741,7 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
          Filter: 1 = ((SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
                        Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.n + 1::numeric)
@@ -769,7 +769,7 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
          Filter: 1 = ((SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
                        Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.i + 1)::numeric
@@ -1070,7 +1070,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
          Filter: (SubPlan 1)
          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
-         SubPlan 1  (slice0)
+         SubPlan 1
            ->  Limit  (cost=0.00..431.00 rows=1 width=4)
                  ->  Result  (cost=0.00..431.00 rows=1 width=4)
                        Filter: t1.a = 1
@@ -1089,7 +1089,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
          Filter: (SubPlan 1)
          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
-         SubPlan 1  (slice0)
+         SubPlan 1
            ->  Limit  (cost=0.00..431.00 rows=1 width=4)
                  ->  Result  (cost=0.00..431.00 rows=1 width=4)
                        Filter: t1.a = 1
@@ -1541,7 +1541,7 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
                Sort Key: subselect_tbl.f1, subselect_tbl.f3
                ->  Seq Scan on subselect_tbl  (cost=0.00..1324033.89 rows=3 width=12)
                      Filter: (SubPlan 1)
-                     SubPlan 1  (slice2; segments: 3)
+                     SubPlan 1
                        ->  Result  (cost=0.00..431.00 rows=4 width=4)
                              ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
                                    ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -248,7 +248,7 @@ select * from int4_tbl o where not exists
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on int4_tbl
-   SubPlan 1  (slice0)
+   SubPlan 1
      ->  Result
            ->  Result
                  ->  Limit
@@ -870,7 +870,7 @@ select * from int4_tbl where
          Output: int4_tbl.f1
          ->  Seq Scan on public.int4_tbl
                Output: int4_tbl.f1
-   SubPlan 1  (slice0)
+   SubPlan 1
      ->  Result
            Output: tenk1.unique1
            ->  Result
@@ -881,7 +881,7 @@ select * from int4_tbl where
                              Output: tenk1.unique1
                              ->  Seq Scan on public.tenk1
                                    Output: tenk1.unique1
-   SubPlan 2  (slice0)
+   SubPlan 2
      ->  Materialize
            Output: tenk1_1.ten
            ->  Gather Motion 3:1  (slice3; segments: 3)

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -1667,13 +1667,13 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (5);
 -------------------------------------------------
  Insert on base_tbl b
    ->  Result
-         SubPlan 1  (slice0; segments: 1)
+         SubPlan 1
            ->  Result
                  Filter: (r.a = b.a)
                  ->  Materialize
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)
                              ->  Seq Scan on ref_tbl r
-         SubPlan 2  (slice0; segments: 1)
+         SubPlan 2
            ->  Materialize
                  ->  Broadcast Motion 3:3  (slice2; segments: 3)
                        ->  Seq Scan on ref_tbl r_1
@@ -1692,13 +1692,13 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
                      ->  Seq Scan on ref_tbl r
                      ->  Hash
                            ->  Seq Scan on base_tbl b
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Result
                  Filter: (r_1.a = b.a)
                  ->  Materialize
                        ->  Broadcast Motion 3:3  (slice2; segments: 3)
                              ->  Seq Scan on ref_tbl r_1
-         SubPlan 2  (slice1; segments: 3)
+         SubPlan 2
            ->  Materialize
                  ->  Broadcast Motion 3:3  (slice3; segments: 3)
                        ->  Seq Scan on ref_tbl r_2

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -1684,13 +1684,13 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (5);
 -------------------------------------------------
  Insert on base_tbl b
    ->  Result
-         SubPlan 1  (slice0; segments: 1)
+         SubPlan 1
            ->  Result
                  Filter: (r.a = b.a)
                  ->  Materialize
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)
                              ->  Seq Scan on ref_tbl r
-         SubPlan 2  (slice0; segments: 1)
+         SubPlan 2
            ->  Materialize
                  ->  Broadcast Motion 3:3  (slice2; segments: 3)
                        ->  Seq Scan on ref_tbl r_1
@@ -1709,13 +1709,13 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
                      ->  Seq Scan on ref_tbl r
                      ->  Hash
                            ->  Seq Scan on base_tbl b
-         SubPlan 1  (slice1; segments: 3)
+         SubPlan 1
            ->  Result
                  Filter: (r_1.a = b.a)
                  ->  Materialize
                        ->  Broadcast Motion 3:3  (slice2; segments: 3)
                              ->  Seq Scan on ref_tbl r_1
-         SubPlan 2  (slice1; segments: 3)
+         SubPlan 2
            ->  Materialize
                  ->  Broadcast Motion 3:3  (slice3; segments: 3)
                        ->  Seq Scan on ref_tbl r_2


### PR DESCRIPTION
Printing the slice information makes sense for Init Plans, which are
dispatched separately, before the main query. But not so much for other
Sub Plans, which are just part of the plan tree; there is no dispatching
or motion involved at such SubPlans. The SubPlan might *contain* Motions,
but we print the slice information for those Motions separately. The slice
information was always just the same as the parent node's, which adds no
information, and can be misleading if it makes the reader think that there
is inter-node communication involved in such SubPlans.

