### PR TITLE
Don't Assert() in MemoryAccounting_ConvertIdToAccount()

### DIFF
--- a/src/include/utils/memaccounting_private.h
+++ b/src/include/utils/memaccounting_private.h
@@ -94,21 +94,34 @@ MemoryAccounting_ConvertIdToAccount(MemoryAccountIdType id)
 {
 	MemoryAccount *memoryAccount = NULL;
 
+	/*
+	 * Don't Assert() in this function, which eventually invokes
+	 * MemoryAccounting_Allocate() then go back here again and falls into an
+	 * infinite loop.
+	 *
+	 * Just assert() to abort.
+	 */
 	if (id >= liveAccountStartId)
 	{
+#ifdef USE_ASSERT_CHECKING
 		assert(NULL != shortLivingMemoryAccountArray);
 		assert(id < liveAccountStartId + shortLivingMemoryAccountArray->accountCount);
+#endif
 		memoryAccount = shortLivingMemoryAccountArray->allAccounts[id - liveAccountStartId];
 	}
 	else if (id <= MEMORY_OWNER_TYPE_END_LONG_LIVING)
 	{
+#ifdef USE_ASSERT_CHECKING
 		assert(NULL != longLivingMemoryAccountArray);
+#endif
 		/* 0 is reserved as undefined. So, the array index is 1 behind */
 		memoryAccount = longLivingMemoryAccountArray[id];
 	}
 	else if (id < liveAccountStartId) /* Dead account; so use rollover */
 	{
+#ifdef USE_ASSERT_CHECKING
 		assert(NULL != longLivingMemoryAccountArray);
+#endif
 		/*
 		 * For dead accounts we use a single rollover account to account for all
 		 * the long living allocations. Rollover is a long-living account, so it
@@ -118,7 +131,9 @@ MemoryAccounting_ConvertIdToAccount(MemoryAccountIdType id)
 		memoryAccount = longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Rollover];
 	}
 
+#ifdef USE_ASSERT_CHECKING
 	assert(IsA(memoryAccount, MemoryAccount));
+#endif
 
 	return memoryAccount;
 }

--- a/src/include/utils/memaccounting_private.h
+++ b/src/include/utils/memaccounting_private.h
@@ -16,6 +16,8 @@
 #ifndef MEMACCOUNTING_PRIVATE_H
 #define MEMACCOUNTING_PRIVATE_H
 
+#include <assert.h>
+
 #include "utils/memaccounting.h"
 
 extern MemoryAccountIdType liveAccountStartId;
@@ -94,19 +96,19 @@ MemoryAccounting_ConvertIdToAccount(MemoryAccountIdType id)
 
 	if (id >= liveAccountStartId)
 	{
-		Assert(NULL != shortLivingMemoryAccountArray);
-		Assert(id < liveAccountStartId + shortLivingMemoryAccountArray->accountCount);
+		assert(NULL != shortLivingMemoryAccountArray);
+		assert(id < liveAccountStartId + shortLivingMemoryAccountArray->accountCount);
 		memoryAccount = shortLivingMemoryAccountArray->allAccounts[id - liveAccountStartId];
 	}
 	else if (id <= MEMORY_OWNER_TYPE_END_LONG_LIVING)
 	{
-		Assert(NULL != longLivingMemoryAccountArray);
+		assert(NULL != longLivingMemoryAccountArray);
 		/* 0 is reserved as undefined. So, the array index is 1 behind */
 		memoryAccount = longLivingMemoryAccountArray[id];
 	}
 	else if (id < liveAccountStartId) /* Dead account; so use rollover */
 	{
-		Assert(NULL != longLivingMemoryAccountArray);
+		assert(NULL != longLivingMemoryAccountArray);
 		/*
 		 * For dead accounts we use a single rollover account to account for all
 		 * the long living allocations. Rollover is a long-living account, so it
@@ -116,7 +118,7 @@ MemoryAccounting_ConvertIdToAccount(MemoryAccountIdType id)
 		memoryAccount = longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Rollover];
 	}
 
-	Assert(IsA(memoryAccount, MemoryAccount));
+	assert(IsA(memoryAccount, MemoryAccount));
 
 	return memoryAccount;
 }


### PR DESCRIPTION
Greenplum's Assert() invokes Trap(), then ExceptionalCondition(), then
errdetail(), MemoryAccounting_Allocate(),
MemoryAccounting_ConvertIdToAccount() and Assert() again.

It will fall into an infinite error handling loop until the process got
signaled.

Just abort here.