### PR TITLE
6X: Correct memory unit (cherry pick from master)

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2787,7 +2787,7 @@ initial_cost_hashjoin(PlannerInfo *root, JoinCostWorkspace *workspace,
 	ExecChooseHashTableSize(inner_path_rows,
 							inner_path->parent->width,
 							true,		/* useskew */
-							global_work_mem(root),
+							global_work_mem(root) / 1024L,
 							&numbuckets,
 							&numbatches,
 							&num_skew_mcvs);
@@ -4692,7 +4692,7 @@ Cost incremental_hashjoin_cost(double rows, int inner_width, int outer_width, Li
 	ExecChooseHashTableSize(rows,
 							inner_width,
 							true /* useSkew */,
-							global_work_mem(root),
+							global_work_mem(root) / 1024L,
 							&numbuckets,
 							&numbatches,
 							&num_skew_mcvs);


### PR DESCRIPTION
ExecChooseHashTableSize takes KB as parameter while global_work_mem returns bytes

---------------

This is cherry pick from master (c8ac464331e26204a536fcb20ce44bfdd55d0c6a) to 6X.

This commit is already in master and should be backport to 6x. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
