### PR TITLE
Fix miscellaneous warnings when building ORCA translator code

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -726,7 +726,9 @@ inline CTranslatorDXLToScalar::STypeOidAndTypeModifier OidParamOidFromDXLIdentOr
 	}
 	Oid inner_type_oid = CMDIdGPDB::CastMdid(inner_ident->MdidType())->Oid();
 	INT type_modifier = inner_ident->TypeModifier();
-	return {inner_type_oid, type_modifier};
+
+	CTranslatorDXLToScalar::STypeOidAndTypeModifier modifier = { inner_type_oid, type_modifier};
+	return modifier;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/utils/funcs.cpp
+++ b/src/backend/gpopt/utils/funcs.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #include "utils/builtins.h"
 }
 
+#include "gpopt/utils/funcs.h"
 #include "gpopt/utils/COptTasks.h"
 
 #include "gpos/_api.h"

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -44,4 +44,14 @@ class CGPOptimizer
     void TerminateGPOPT();
 };
 
+extern "C"
+{
+
+extern PlannedStmt *GPOPTOptimizedPlan(Query *query, bool *had_unexpected_failure);
+extern char *SerializeDXLPlan(Query *query);
+extern void InitGPOPT ();
+extern void TerminateGPOPT ();
+
+}
+
 #endif // CGPOptimizer_H

--- a/src/include/gpopt/translate/CContextQueryToDXL.h
+++ b/src/include/gpopt/translate/CContextQueryToDXL.h
@@ -41,8 +41,8 @@ namespace gpdxl
 	//---------------------------------------------------------------------------
 	class CContextQueryToDXL
 	{
-		friend CTranslatorQueryToDXL;
-		friend CTranslatorScalarToDXL;
+		friend class CTranslatorQueryToDXL;
+		friend class CTranslatorScalarToDXL;
 
 		private:
 			// memory pool

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -60,7 +60,7 @@ namespace gpdxl
 	//---------------------------------------------------------------------------
 	class CTranslatorQueryToDXL
 	{
-		friend CTranslatorScalarToDXL;
+		friend class CTranslatorScalarToDXL;
 
 		// shorthand for functions for translating DXL nodes to GPDB expressions
 		typedef CDXLNode * (CTranslatorQueryToDXL::*DXLNodeToLogicalFunc)(const RangeTblEntry *rte, ULONG rti, ULONG current_query_level);

--- a/src/include/gpopt/utils/funcs.h
+++ b/src/include/gpopt/utils/funcs.h
@@ -1,0 +1,28 @@
+//---------------------------------------------------------------------------
+//
+// funcs.h
+//    API for invoking optimizer using GPDB udfs
+//
+// Copyright (c) 2019-Present Pivotal Software, Inc.
+//
+//---------------------------------------------------------------------------
+
+#ifndef GPOPT_funcs_H
+#define GPOPT_funcs_H
+
+
+extern "C"
+{
+
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+
+extern Datum DisableXform(PG_FUNCTION_ARGS);
+extern Datum EnableXform(PG_FUNCTION_ARGS);
+extern Datum LibraryVersion();
+extern const char * OptVersion(void);
+
+}
+
+#endif // GPOPT_funcs_H


### PR DESCRIPTION
These pop up while building GPDB on OSX with clang version `Apple LLVM version 10.0.1 (clang-1001.0.46.4)`.

See individual commit for the warnings it fixes.
