### PR TITLE
**5X Backport* set_config_by_name(): dispatch all values correctly

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5673,18 +5673,19 @@ set_config_by_name(PG_FUNCTION_ARGS)
 					  is_local ? GUC_ACTION_LOCAL : GUC_ACTION_SET,
 					  true);
 
-    if (Gp_role == GP_ROLE_DISPATCH && !IsBootstrapProcessingMode())
-    {
-			StringInfoData buffer;
-			initStringInfo(&buffer);
-			appendStringInfo(&buffer, "SET ");
-			if (is_local)
-					appendStringInfo(&buffer, "LOCAL ");
-			appendStringInfo(&buffer, "%s TO '%s'", name, value);
-			CdbDispatchSetCommand(buffer.data,
-								   false /* cancelOnError */,
-								   false /* no two phase commit */);
-    }
+	if (Gp_role == GP_ROLE_DISPATCH && !IsBootstrapProcessingMode())
+	{
+		StringInfoData buffer;
+
+		initStringInfo(&buffer);
+		appendStringInfo(&buffer, "SET ");
+		if (is_local)
+			appendStringInfo(&buffer, "LOCAL ");
+		appendStringInfo(&buffer, "%s TO '%s'", name, value);
+		CdbDispatchSetCommand(buffer.data,
+		                      false /* cancelOnError */,
+		                      false /* need two phase */);
+	}
 
 	/* get the new current value */
 	new_value = GetConfigOptionByName(name, NULL);

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -14,6 +14,27 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 
 -- Test quoting of GUC values and database names when they're sent to segments
 
+-- set_config() used to have quoting problems as well when dispatching to
+-- segments.
+DROP TABLE IF EXISTS should_be_visible;
+CREATE TABLE should_be_visible();
+
+CREATE TABLE distribute_table_oid_to_all_segs (distribution_key INT, tbl OID) DISTRIBUTED RANDOMLY;
+INSERT INTO distribute_table_oid_to_all_segs SELECT *, 'public.should_be_visible'::regclass FROM generate_series(1, 10);
+
+-- Spin up any gangs necessary to handle the SELECT DISTINCT so that they
+-- receive the new search_path setting from the set_config() dispatch.
+SELECT DISTINCT pg_catalog.pg_table_is_visible(tbl) FROM distribute_table_oid_to_all_segs;
+
+-- Now change search_path. This setting should not affect the visibility of the
+-- public schema if it's dispatched correctly.
+SELECT set_config('search_path', 'pg_catalog,public', false);
+
+-- Check that our test table is still visible.
+SELECT DISTINCT pg_catalog.pg_table_is_visible(tbl) FROM distribute_table_oid_to_all_segs;
+
+RESET search_path;
+
 -- There used to be a bug in the quoting when the search_path setting was sent
 -- to the segment. It was not easily visible when search_path was set with a
 -- SET command, only when the setting was sent as part of the startup packet.

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -10,6 +10,38 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
 -- end_matchsubs
 -- Test quoting of GUC values and database names when they're sent to segments
+-- set_config() used to have quoting problems as well when dispatching to
+-- segments.
+DROP TABLE IF EXISTS should_be_visible;
+NOTICE:  table "should_be_visible" does not exist, skipping
+CREATE TABLE should_be_visible();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+CREATE TABLE distribute_table_oid_to_all_segs (distribution_key INT, tbl OID) DISTRIBUTED RANDOMLY;
+INSERT INTO distribute_table_oid_to_all_segs SELECT *, 'public.should_be_visible'::regclass FROM generate_series(1, 10);
+-- Spin up any gangs necessary to handle the SELECT DISTINCT so that they
+-- receive the new search_path setting from the set_config() dispatch.
+SELECT DISTINCT pg_catalog.pg_table_is_visible(tbl) FROM distribute_table_oid_to_all_segs;
+ pg_table_is_visible 
+---------------------
+ t
+(1 row)
+
+-- Now change search_path. This setting should not affect the visibility of the
+-- public schema if it's dispatched correctly.
+SELECT set_config('search_path', 'pg_catalog,public', false);
+    set_config     
+-------------------
+ pg_catalog,public
+(1 row)
+
+-- Check that our test table is still visible.
+SELECT DISTINCT pg_catalog.pg_table_is_visible(tbl) FROM distribute_table_oid_to_all_segs;
+ pg_table_is_visible 
+---------------------
+ t
+(1 row)
+
+RESET search_path;
 -- There used to be a bug in the quoting when the search_path setting was sent
 -- to the segment. It was not easily visible when search_path was set with a
 -- SET command, only when the setting was sent as part of the startup packet.


### PR DESCRIPTION
This is a 5X backport for PR https://github.com/greenplum-db/gpdb/pull/8371

The two commits were a clean cherry-pick except for the following modifications:
- using quote_literal_internal instead of quote_literal_cstr
- modify regression test to dispatch table oid to all segments in order
  to verify table visibility
