### PR TITLE
Fix crash in COPY FROM for non-distributed/non-replicated table

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4517,7 +4517,8 @@ BeginCopyFrom(Relation rel,
 	/*
 	 * Determine the mode
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH && !cstate->on_segment)
+	if (Gp_role == GP_ROLE_DISPATCH && !cstate->on_segment &&
+		cstate->rel && cstate->rel->rd_cdbpolicy)
 		cstate->dispatch_mode = COPY_DISPATCH;
 	else if (Gp_role == GP_ROLE_EXECUTE && !cstate->on_segment)
 		cstate->dispatch_mode = COPY_EXECUTOR;

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1331,6 +1331,16 @@ copy broken_type_test to '/tmp/g';
 drop table broken_type_test;
 drop type broken_int4 cascade; -- drops the I/O functions, too.
 
+-- Test COPY FROM and TO work for catalog tables in dispatch
+-- connection
+BEGIN;
+COPY gp_configuration_history from stdin with delimiter '|';
+1900-01-01 00:00:00.000000-07|12345|Just testing COPY
+\.
+
+COPY (select dbid from gp_configuration_history where dbid=12345) to stdin;
+ABORT;
+
 -- GPDB makes the database name, and many other things, available
 -- as environment variables to the program. Test those.
 --

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1604,6 +1604,13 @@ drop type broken_int4 cascade; -- drops the I/O functions, too.
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to function broken_int4in(cstring)
 drop cascades to function broken_int4out(broken_int4)
+-- Test COPY FROM and TO work for catalog tables in dispatch
+-- connection
+BEGIN;
+COPY gp_configuration_history from stdin with delimiter '|';
+COPY (select dbid from gp_configuration_history where dbid=12345) to stdin;
+12345
+ABORT;
 -- GPDB makes the database name, and many other things, available
 -- as environment variables to the program. Test those.
 --


### PR DESCRIPTION
Current code for COPY FROM picks mode as COPY_DISPATCH for
non-distributed/non-replicated table as well. This causes crash. It
should be using COPY_DIRECT, which is normal/direct mode to be used
for such tables.

The crash was exposed by following SQL commands:

    CREATE TABLE public.heap01 (a int, b int) distributed by (a);
    INSERT INTO public.heap01 VALUES (generate_series(0,99), generate_series(0,98));
    ANALYZE public.heap01;

    COPY (select * from pg_statistic where starelid = 'public.heap01'::regclass) TO '/tmp/heap01.stat';
    DELETE FROM pg_statistic where starelid = 'public.heap01'::regclass;
    COPY pg_statistic from '/tmp/heap01.stat';

Important note: Yes, it's known and strongly recommended to not touch
the `pg_statistics` or any other catalog table this way. But it's no
good to panic either. The copy to `pg_statictics` is going to ERROR
out "correctly" and not crash after this change with `cannot accept a
value of type anyarray`, as there just isn't any way at the SQL level
to insert data into pg_statistic's anyarray columns. Refer:
https://www.postgresql.org/message-id/12138.1277130186%40sss.pgh.pa.us
