### PR TITLE
Fix CTAS with gp_use_legacy_hashops GUC

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -460,9 +460,21 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 							if (target)
 							{
 								Oid			typeOid = exprType((Node *) target->expr);
-								Oid			opclass;
+								Oid			opclass = InvalidOid;
 
-								opclass = cdb_default_distribution_opclass_for_type(typeOid);
+								/*
+								 * Check for a legacy hash operator class if
+								 * gp_use_legacy_hashops GUC is set. If
+								 * InvalidOid is returned or the GUC is not
+								 * set, we'll get the default operator class.
+								 */
+								if (gp_use_legacy_hashops)
+									opclass = get_legacy_cdbhash_opclass_for_base_type(typeOid);
+
+								if (!OidIsValid(opclass))
+									opclass = cdb_default_distribution_opclass_for_type(typeOid);
+
+
 								if (OidIsValid(opclass))
 								{
 									policykeys = lappend_int(policykeys, i + 1);

--- a/src/test/regress/expected/gpdist_legacy_opclasses.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses.out
@@ -112,6 +112,17 @@ insert into all_legacy_types values (
   --uuid_col         -- uuid,
   '5 + 3i'         -- complex
 );
+-- Test that CTAS honors the gp_use_legacy_hashops GUC
+-- Note: When ORCA is on, the distribution is RANDOM.
+create table legacy_hashops_ctas as select 1;
+select gpdp.distkey, gpdp.distclass, pgopc.opcname
+  from gp_distribution_policy gpdp, pg_opclass pgopc
+  where gpdp.localoid='legacy_hashops_ctas'::regclass and pgopc.oid::text = gpdp.distclass::text;
+ distkey | distclass |     opcname      
+---------+-----------+------------------
+ 1       | 10196     | cdbhash_int4_ops
+(1 row)
+
 set gp_use_legacy_hashops=off;
 --
 -- Test joins between tables using a mix of default and legacy opclasses.

--- a/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
@@ -112,6 +112,16 @@ insert into all_legacy_types values (
   --uuid_col         -- uuid,
   '5 + 3i'         -- complex
 );
+-- Test that CTAS honors the gp_use_legacy_hashops GUC
+-- Note: When ORCA is on, the distribution is RANDOM.
+create table legacy_hashops_ctas as select 1;
+select gpdp.distkey, gpdp.distclass, pgopc.opcname
+  from gp_distribution_policy gpdp, pg_opclass pgopc
+  where gpdp.localoid='legacy_hashops_ctas'::regclass and pgopc.oid::text = gpdp.distclass::text;
+ distkey | distclass | opcname 
+---------+-----------+---------
+(0 rows)
+
 set gp_use_legacy_hashops=off;
 --
 -- Test joins between tables using a mix of default and legacy opclasses.

--- a/src/test/regress/sql/gpdist_legacy_opclasses.sql
+++ b/src/test/regress/sql/gpdist_legacy_opclasses.sql
@@ -111,6 +111,13 @@ insert into all_legacy_types values (
   '5 + 3i'         -- complex
 );
 
+-- Test that CTAS honors the gp_use_legacy_hashops GUC
+-- Note: When ORCA is on, the distribution is RANDOM.
+create table legacy_hashops_ctas as select 1;
+select gpdp.distkey, gpdp.distclass, pgopc.opcname
+  from gp_distribution_policy gpdp, pg_opclass pgopc
+  where gpdp.localoid='legacy_hashops_ctas'::regclass and pgopc.oid::text = gpdp.distclass::text;
+
 set gp_use_legacy_hashops=off;
 
 


### PR DESCRIPTION
When gp_use_legacy_hashops GUC was set, CTAS would not assign the
legacy hash class operator to the new table. This is because CTAS goes
through a different code path and uses the first operator class of the
SELECT's result when no distribution key is provided.
