### PR TITLE
icw: check for flaky fault injectors

### DIFF
--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -17,7 +17,7 @@ endif
 override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPFLAGS)
 override LDLIBS := $(libpq_pgport) $(LDLIBS)
 
-all: test_python pg_isolation2_regress$(X) all-lib extended_protocol_test
+all: test_python pg_isolation2_regress$(X) all-lib extended_protocol_test scan_flaky_fault_injectors
 
 extended_protocol_test: extended_protocol_test.c
 	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq  -o $@ $< -lpq
@@ -43,6 +43,10 @@ atmsort.pm:
 
 explain.pm:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/explain.pm
+
+.PHONY: scan_flaky_fault_injectors
+scan_flaky_fault_injectors:
+	$(top_builddir)/src/test/regress/scan_flaky_fault_injectors.sh
 
 pg_isolation2_regress$(X): isolation2_main.o pg_regress.o submake-libpq submake-libpgport
 	$(CC) $(CFLAGS) $(filter %.o,$^) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -45,7 +45,9 @@ test: gdd/end
 # concurrent test, so run the test by itself.
 test: deadlock_under_entry_db_singleton
 
-test: pg_terminate_backend starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc vacuum_drop_phase_ao
+test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc vacuum_drop_phase_ao
+# below test(s) inject faults so each of them need to be in a separate group
+test: pg_terminate_backend
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation
@@ -79,7 +81,7 @@ test: uao/cursor_withhold2_row
 test: uao/delete_while_vacuum_row
 test: uao/insert_policy_row
 test: uao/insert_while_vacuum_row
-test: uao/max_concurrency_row segwalrep/master_xlog_switch
+test: uao/max_concurrency_row
 test: uao/max_concurrency2_row
 test: uao/modcount_row
 test: uao/modcount_vacuum_row
@@ -112,6 +114,8 @@ test: uao/vacuum_while_vacuum_row
 test: uao/vacuum_cleanup_row
 test: uao/insert_should_not_use_awaiting_drop_row
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
+# below test(s) inject faults so each of them need to be in a separate group
+test: segwalrep/master_xlog_switch
 
 # Tests on Append-Optimized tables (column-oriented).
 test: uao/alter_while_vacuum_column uao/alter_while_vacuum2_column

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -49,7 +49,7 @@ LIBS := $(filter-out -lreadline -ledit -ltermcap -lncurses -lcurses -lcurl -lssl
 
 # Build regression test driver
 
-all: pg_regress$(X)
+all: pg_regress$(X) scan_flaky_fault_injectors
 
 pg_regress$(X): pg_regress.o pg_regress_main.o $(WIN32RES) | submake-libpgport
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
@@ -59,6 +59,10 @@ pg_regress.o: pg_regress.c $(top_builddir)/src/port/pg_config_paths.h
 pg_regress.o: override CPPFLAGS += -I$(top_builddir)/src/port $(EXTRADEFS)
 regress_gp.o: override CFLAGS += -I$(top_builddir)/src/interfaces/libpq
 regress_gp.o: override LDFLAGS += -L$(top_builddir)/src/interfaces/libpq
+
+.PHONY: scan_flaky_fault_injectors
+scan_flaky_fault_injectors:
+	$(top_builddir)/src/test/regress/scan_flaky_fault_injectors.sh
 
 twophase_pqexecparams: twophase_pqexecparams.c
 	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq  -o $@ $< -lpq

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -27,17 +27,23 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_tablespace gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp returning_gp resource_queue_with_rule gp_types gp_index
+test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp returning_gp resource_queue_with_rule gp_types gp_index
 test: spi_processed64bit
 test: python_processed64bit
 test: gp_tablespace_with_faults
+# below test(s) inject faults so each of them need to be in a separate group
+test: gp_tablespace
 
 test: temp_tablespaces
 test: default_tablespace
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gpcopy_encoding gp_create_table gp_create_view window_views replication_slots create_table_like_gp gp_constraints
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views replication_slots create_table_like_gp gp_constraints
+# below test(s) inject faults so each of them need to be in a separate group
+test: gpcopy
 
-test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
+test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format
+# below test(s) inject faults so each of them need to be in a separate group
+test: guc_gp
 
 # namespace_gp test will show diff if concurrent tests use temporary tables.
 # So run it separately.
@@ -120,8 +126,10 @@ test: db_size_functions
 # ERROR:  parameter "gp_interconnect_type" cannot be set after connection start
 
 ignore: gp_portal_error
-test: external_table external_table_create_privs column_compression eagerfree alter_table_aocs alter_table_aocs2 alter_distribution_policy aoco_privileges aocs
+test: external_table external_table_create_privs column_compression eagerfree alter_table_aocs alter_table_aocs2 alter_distribution_policy aoco_privileges
 test: alter_table_set alter_table_gp alter_table_ao subtransaction_visibility oid_consistency udf_exception_blocks
+# below test(s) inject faults so each of them need to be in a separate group
+test: aocs
 test: ic
 
 test: resource_queue
@@ -237,9 +245,11 @@ test: vacuum_full_freeze_heap
 test: vacuum_full_heap
 test: vacuum_full_heap_bitmapindex
 
-test: ao_checksum_corruption AOCO_Compression AORO_Compression table_statistics fts_error
+test: ao_checksum_corruption AOCO_Compression AORO_Compression table_statistics
 test: workfile_mgr_test
 test: session_reset
+# below test(s) inject faults so each of them need to be in a separate group
+test: fts_error
 
 test: psql_gp_commands pg_resetxlog dropdb_check_shared_buffer_cache gp_upgrade_cornercases
 

--- a/src/test/regress/scan_flaky_fault_injectors.sh
+++ b/src/test/regress/scan_flaky_fault_injectors.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# This scripts scan for the tests that inject faults and are put into parallel
+# testing groups.  These tests are flaky as the injected faults can be
+# triggered by the tests in the same testing groups.  To make the testing
+# results deterministic each of these tests must be put in a separate group.
+
+set -e
+
+fault_injection_tests=$(mktemp fault_injection_tests.XXX)
+parallel_tests=$(mktemp parallel_tests.XXX)
+retcode=0
+
+# list the tests that inject faults
+grep -ERIli '(select|perform)\s+gp_inject_fault' sql input \
+| sed 's,^[^/]*/\(.*\)\.[^.]*$,\1,' \
+| sort -u \
+> $fault_injection_tests
+
+echo "scanning for flaky fault-injection tests..."
+
+for schedule in *_schedule; do
+	# list the tests that are in parallel testing groups
+	grep -E '^test:(\s+\S+){2,}' $schedule \
+	| cut -d' ' -f2- \
+	| tr ' ' '\n' \
+	| sort -u \
+	> $parallel_tests
+
+	# find out the tests that are in both lists
+	tests=$(comm -12 $fault_injection_tests $parallel_tests)
+	if [ -n "$tests" ]; then
+		echo "- $schedule:" $tests
+		retcode=1
+	fi
+done
+
+rm -f $fault_injection_tests $parallel_tests
+
+if [ $retcode = 0 ]; then
+	echo "done"
+else
+	cat <<EOF
+
+ERROR: above tests are flaky as they inject faults and are put in parallel testing groups.
+HINT: move each of them to a separate testing group.
+
+EOF
+fi
+
+exit $retcode


### PR DESCRIPTION
Some tests use fault injection for testing, they could be flaky if they
are put into parallel testing groups as the injected faults can be
triggered by the tests in the same testing groups.  To make the testing
results deterministic each of these tests must be put in a separate
group.

Such kind of flaky tests are very confusing as a test fails randomly due
to fault injected in other tests, so it can be hard to debug.

So we add a checking at beginning of ICW and isolation2 tests, it raises
and error when fault injectors are put in parallel testing groups.

Some tests are detected by the script, moved them into separate groups.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
