### PR TITLE
Make estimate_hash_bucketsize MPP-correct.

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -3076,8 +3076,9 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 					/* not cached yet */
 					thisbucketsize =
 						estimate_hash_bucketsize(root,
-										   get_rightop(clause),
-												 virtualbuckets);
+												 get_rightop(clause),
+												 virtualbuckets,
+												 inner_path);
 					restrictinfo->right_bucketsize = thisbucketsize;
 				}
 			}
@@ -3092,8 +3093,9 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 					/* not cached yet */
 					thisbucketsize =
 						estimate_hash_bucketsize(root,
-											get_leftop(clause),
-												 virtualbuckets);
+												 get_leftop(clause),
+												 virtualbuckets,
+												 inner_path);
 					restrictinfo->left_bucketsize = thisbucketsize;
 				}
 			}

--- a/src/include/utils/selfuncs.h
+++ b/src/include/utils/selfuncs.h
@@ -195,7 +195,7 @@ extern double estimate_num_groups(PlannerInfo *root, List *groupExprs,
 					double input_rows, List **pgset);
 
 extern Selectivity estimate_hash_bucketsize(PlannerInfo *root, Node *hashkey,
-						 double nbuckets);
+											double nbuckets, Path *path);
 
 extern Datum brincostestimate(PG_FUNCTION_ARGS);
 extern Datum btcostestimate(PG_FUNCTION_ARGS);
@@ -213,5 +213,6 @@ extern Selectivity scalararraysel_containment(PlannerInfo *root,
 						   int varRelid);
 extern Datum arraycontsel(PG_FUNCTION_ARGS);
 extern Datum arraycontjoinsel(PG_FUNCTION_ARGS);
+extern double estimate_num_groups_per_segment(double groupNum, double numPerGroup, double numsegments);
 
 #endif   /* SELFUNCS_H */

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3067,30 +3067,30 @@ INNER JOIN member_subgroup
 ON member_group.group_id = member_subgroup.group_id
 LEFT OUTER JOIN region
 ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
-   ->  Hash Left Join
-         Hash Cond: (member_subgroup.subgroup_name = (region.county_name)::text)
-         Join Filter: (member_group."group_id" = ANY ('{12,13,14,15}'::integer[]))
-         ->  Redistribute Motion 3:3  (slice3; segments: 3)
-               Hash Key: member_subgroup.subgroup_name
-               ->  Hash Join
-                     Hash Cond: (member."group_id" = member_group."group_id")
-                     ->  Seq Scan on member
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                 ->  Hash Join
-                                       Hash Cond: (member_group."group_id" = member_subgroup."group_id")
-                                       ->  Seq Scan on member_group
-                                       ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                                   Hash Key: member_subgroup."group_id"
-                                                   ->  Seq Scan on member_subgroup
+   ->  Hash Join
+         Hash Cond: (member."group_id" = member_group."group_id")
+         ->  Seq Scan on member
          ->  Hash
-               ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                     Hash Key: region.county_name
-                     ->  Seq Scan on region
+               ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                     ->  Hash Right Join
+                           Hash Cond: ((region.county_name)::text = member_subgroup.subgroup_name)
+                           Join Filter: (member_group."group_id" = ANY ('{12,13,14,15}'::integer[]))
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: region.county_name
+                                 ->  Seq Scan on region
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Hash Key: member_subgroup.subgroup_name
+                                       ->  Hash Join
+                                             Hash Cond: (member_group."group_id" = member_subgroup."group_id")
+                                             ->  Seq Scan on member_group
+                                             ->  Hash
+                                                   ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                                         Hash Key: member_subgroup."group_id"
+                                                         ->  Seq Scan on member_subgroup
  Optimizer: Postgres query optimizer
 (23 rows)
 

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -2265,24 +2265,24 @@ analyze b;
 analyze c;
 set gp_dynamic_partition_pruning = off;
 explain select * from apart as a, b, c where a.t = b.t and a.id = c.id;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=6.78..35.85 rows=5 width=20)
-   ->  Hash Join  (cost=6.78..35.85 rows=2 width=20)
-         Hash Cond: a.t = b.t
-         ->  Hash Join  (cost=3.45..32.39 rows=7 width=14)
-               Hash Cond: a.id = c.id
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=6.89..35.80 rows=5 width=20)
+   ->  Hash Join  (cost=6.89..35.80 rows=2 width=20)
+         Hash Cond: (a.id = c.id)
+         ->  Hash Join  (cost=3.44..32.27 rows=4 width=14)
+               Hash Cond: (a.t = b.t)
                ->  Append  (cost=0.00..24.99 rows=333 width=8)
                      ->  Seq Scan on apart_1_prt_1 a  (cost=0.00..5.00 rows=67 width=7)
                      ->  Seq Scan on apart_1_prt_2 a_1  (cost=0.00..5.00 rows=67 width=8)
                      ->  Seq Scan on apart_1_prt_3 a_2  (cost=0.00..5.00 rows=67 width=8)
                      ->  Seq Scan on apart_1_prt_4 a_3  (cost=0.00..5.00 rows=67 width=8)
                      ->  Seq Scan on apart_1_prt_5 a_4  (cost=0.00..4.99 rows=67 width=8)
-               ->  Hash  (cost=3.20..3.20 rows=7 width=6)
-                     ->  Seq Scan on c  (cost=0.00..3.20 rows=7 width=6)
-         ->  Hash  (cost=3.20..3.20 rows=4 width=6)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.20 rows=4 width=6)
-                     ->  Seq Scan on b  (cost=0.00..3.05 rows=2 width=6)
+               ->  Hash  (cost=3.25..3.25 rows=5 width=6)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=6)
+                           ->  Seq Scan on b  (cost=0.00..3.05 rows=2 width=6)
+         ->  Hash  (cost=3.20..3.20 rows=7 width=6)
+               ->  Seq Scan on c  (cost=0.00..3.20 rows=7 width=6)
  Optimizer: Postgres query optimizer
 (17 rows)
 
@@ -2298,13 +2298,13 @@ select * from apart as a, b, c where a.t = b.t and a.id = c.id;
 
 set gp_dynamic_partition_pruning = on;
 explain select * from apart as a, b, c where a.t = b.t and a.id = c.id;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=6.78..35.85 rows=5 width=20)
-   ->  Hash Join  (cost=6.78..35.85 rows=2 width=20)
-         Hash Cond: a.t = b.t
-         ->  Hash Join  (cost=3.45..32.39 rows=7 width=14)
-               Hash Cond: a.id = c.id
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=6.89..35.80 rows=5 width=20)
+   ->  Hash Join  (cost=6.89..35.80 rows=2 width=20)
+         Hash Cond: (a.id = c.id)
+         ->  Hash Join  (cost=3.44..32.27 rows=4 width=14)
+               Hash Cond: (a.t = b.t)
                ->  Append  (cost=0.00..24.99 rows=333 width=8)
                      ->  Result  (cost=0.00..5.00 rows=67 width=7)
                            One-Time Filter: PartSelected
@@ -2321,13 +2321,13 @@ explain select * from apart as a, b, c where a.t = b.t and a.id = c.id;
                      ->  Result  (cost=0.00..4.99 rows=67 width=8)
                            One-Time Filter: PartSelected
                            ->  Seq Scan on apart_1_prt_5 a_4  (cost=0.00..4.99 rows=67 width=8)
-               ->  Hash  (cost=3.20..3.20 rows=7 width=6)
-                     ->  Partition Selector for apart (dynamic scan id: 1)  (cost=0.00..3.20 rows=7 width=6)
-                           Filter: c.id
-                           ->  Seq Scan on c  (cost=0.00..3.20 rows=7 width=6)
-         ->  Hash  (cost=3.20..3.20 rows=4 width=6)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.20 rows=4 width=6)
-                     ->  Seq Scan on b  (cost=0.00..3.05 rows=2 width=6)
+               ->  Hash  (cost=3.25..3.25 rows=5 width=6)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=6)
+                           ->  Seq Scan on b  (cost=0.00..3.05 rows=2 width=6)
+         ->  Hash  (cost=3.20..3.20 rows=7 width=6)
+               ->  Partition Selector for apart (dynamic scan id: 1)  (cost=0.00..3.20 rows=7 width=6)
+                     Filter: c.id
+                     ->  Seq Scan on c  (cost=0.00..3.20 rows=7 width=6)
  Optimizer: Postgres query optimizer
 (29 rows)
 

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3085,21 +3085,21 @@ select * from
   int4(sin(1)) q1,
   int4(sin(0)) q2
 where thousand = (q1 + q2);
-                          QUERY PLAN                           
----------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
-         Hash Cond: (tenk1.twothousand = int4_tbl.f1)
+         Hash Cond: (tenk1.thousand = (q1.q1 + q2.q2))
          ->  Hash Join
-               Hash Cond: (tenk1.thousand = (q1.q1 + q2.q2))
+               Hash Cond: (tenk1.twothousand = int4_tbl.f1)
                ->  Seq Scan on tenk1
                ->  Hash
-                     ->  Nested Loop
-                           ->  Function Scan on q1
-                           ->  Function Scan on q2
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Seq Scan on int4_tbl
          ->  Hash
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                     ->  Seq Scan on int4_tbl
+               ->  Nested Loop
+                     ->  Function Scan on q1
+                     ->  Function Scan on q2
  Optimizer: Postgres query optimizer
 (14 rows)
 


### PR DESCRIPTION
In Greenplum, when estimating costs, most of the time we are
in a global view, but sometimes we should shift to a local
view. Postgres does not suffer from this issue because everything
is in one single segment.

The function `estimate_hash_bucketsize` is from postgres and
it plays a very important role in the cost model of hash join.
It should output a result based on locally view. However, the
input parameters like, rows in a table, and ndistinct of the
relation, are all taken from a global view (from all segments).
So, we have to do some compensation for it. The logic is:
  1. for broadcast-like locus, the global ndistinct is the same
     as the local one, we do the compensation by `ndistinct*=numsegments`.
  2. for the case that hash key collcated with locus, on each
     segment, there are `ndistinct/numsegments` distinct groups, so
     no need to do the compensation.
  3. otherwise, the locus has to be partitioned and not collocated with
     hash keys, for these cases, we first estimate the local distinct
     group number, and then do do the compensation.

Co-authored-by: Jinbao Chen <jinchen@pivotal.io>

-------------------------------------

We have do some tests for this PR, combining with the PR https://github.com/greenplum-db/gpdb/pull/8605 and the PR https://github.com/greenplum-db/gpdb/pull/8439 on TPCDS data.

For query 179, it generates a much better plan. More tests will be added here later after we have run a full performance pipeline.

------------------------------------

On test cases: we do not add test cases for this commit. But we have testes the code using some TPCDS queries. It is hard to find a good case in demo-cluster(3 segments). We will appreciate any idea on adding a simple case. Thanks!

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
