### PR TITLE
Ship subprocess32 and replace subprocess with it in python code

### DIFF
--- a/gpAux/gpdemo/gpsegwalrep.py
+++ b/gpAux/gpdemo/gpsegwalrep.py
@@ -28,7 +28,10 @@ Assuming all of the above, you can just run the tool as so:
 import argparse
 import os
 import sys
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 import threading
 import datetime
 import time

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -30,6 +30,10 @@ install: generate_greenplum_path_file
 	if [ -e bin/ext/yaml ]; then \
 	    cp -rp bin/ext/yaml $(DESTDIR)$(prefix)/lib/python ; \
 	fi
+	if [ -e bin/ext/subprocess32.py ]; then \
+	    cp -p bin/ext/subprocess32.py $(DESTDIR)$(prefix)/lib/python ; \
+	    cp -p bin/ext/_posixsubprocess.so $(DESTDIR)$(prefix)/lib/python ; \
+	fi
 
 clean distclean:
 	$(MAKE) -C bin $@

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -49,7 +49,11 @@ except Exception, e:
     sys.exit(2)
 
 import hashlib
-import datetime,getpass,os,signal,socket,subprocess,threading,time,traceback,re
+import datetime,getpass,os,signal,socket,threading,time,traceback,re
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 import uuid
 
 from gppylib.gpversion import GpVersion

--- a/gpMgmt/bin/gpload_test/gpload/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload/TEST.py
@@ -10,7 +10,10 @@ import socket
 import fileinput
 import platform
 import re
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 from pygresql import pg
 
 """

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -9,7 +9,10 @@ import socket
 import fileinput
 import platform
 import re
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 from pygresql import pg
 
 def get_port_from_conf():

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
@@ -9,7 +9,10 @@ import socket
 import fileinput
 import platform
 import re
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 from shutil import copyfile
 from pygresql import pg
 

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -21,7 +21,10 @@ from threading import Thread
 
 import os
 import signal
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 import sys
 import time
 

--- a/gpMgmt/bin/gppylib/test/regress/test_regress_gpssh.py
+++ b/gpMgmt/bin/gppylib/test/regress/test_regress_gpssh.py
@@ -3,7 +3,10 @@
 import os, signal, time, re
 import unittest
 import psutil
-from subprocess import PIPE
+try:
+    from subprocess32 import PIPE
+except:
+    from subprocess import PIPE
 
 class GpsshTestCase(unittest.TestCase):
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpinitsystem.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpinitsystem.py
@@ -2,7 +2,10 @@ import os
 from mock import *
 from gp_unittest import *
 from StringIO import StringIO
-from subprocess import Popen, PIPE
+try:
+    from subprocess32 import Popen, PIPE
+except:
+    from subprocess import Popen, PIPE
 
 class GpInitSystemTest(GpTestCase):
     def setUp(self):

--- a/gpMgmt/bin/gppylib/utils.py
+++ b/gpMgmt/bin/gppylib/utils.py
@@ -1,7 +1,10 @@
 import shutil, filecmp,re
 import os, fcntl, select, getpass, socket
 import stat
-from subprocess import *
+try:
+    from subprocess32 import *
+except:
+    from subprocess import *
 from sys import *
 from xml.dom import minidom
 from xml.dom import Node

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpconfig_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpconfig_mgmt_utils.py
@@ -1,5 +1,8 @@
 from os import path
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 from gppylib.db import dbconn
 from gppylib.gparray import GpArray
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpssh_exkeys_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpssh_exkeys_mgmt_utils.py
@@ -2,7 +2,10 @@ from os import path
 import os
 import shutil
 import socket
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 import sys
 import tempfile
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -15,7 +15,10 @@ import tarfile
 import tempfile
 import thread
 import json
-from subprocess import Popen, PIPE
+try:
+    from subprocess32 import Popen, PIPE
+except:
+    from subprocess import Popen, PIPE
 import commands
 import signal
 from collections import defaultdict

--- a/gpMgmt/test/behave_utils/cluster_expand.py
+++ b/gpMgmt/test/behave_utils/cluster_expand.py
@@ -1,6 +1,9 @@
 import glob
 from datetime import datetime, timedelta
-from subprocess import Popen, PIPE
+try:
+    from subprocess32 import Popen, PIPE
+except:
+    from subprocess import Popen, PIPE
 from utils import run_gpcommand
 
 from gppylib.commands.base import Command

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -8,7 +8,10 @@ import stat
 import time
 import glob
 import shutil
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 import difflib
 
 import yaml

--- a/gpcontrib/gp_replica_check/gp_replica_check.py
+++ b/gpcontrib/gp_replica_check/gp_replica_check.py
@@ -30,7 +30,10 @@ gp_replica_check.py -d "mydb1,mydb2,..." -r "hash,bitmap,gist,..."
 
 import argparse
 import sys
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 import threading
 import Queue
 import pipes  # for shell-quoting, pipes.quote()

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -17,7 +17,10 @@ limitations under the License.
 
 import pygresql.pg
 import os
-import subprocess
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 import re
 import multiprocessing
 import tempfile

--- a/src/test/regress/mem_quota_util.py
+++ b/src/test/regress/mem_quota_util.py
@@ -9,7 +9,11 @@ mkpath = lambda *x: os.path.join(MYD, *x)
 #globals
 SAMPLE_QUERY="(select count(*) from (select o0.o_orderkey from (heap_orders o0 left outer join heap_orders o1 on o0.o_orderkey = o1.o_orderkey left outer join heap_orders o2 on o2.o_orderkey = o1.o_orderkey left outer join heap_orders o3 on o3.o_orderkey = o2.o_orderkey left outer join heap_orders o4 on o4.o_orderkey = o3.o_orderkey) order by o0.o_orderkey) as foo);"
 
-import subprocess, shutil, time, re
+import shutil, time, re
+try:
+    import subprocess32 as subprocess
+except:
+    import subprocess
 from optparse import OptionParser, OptionGroup
 
 try:


### PR DESCRIPTION
    subprocess32 is preferred over subprocess according to python documentation. We
    compiled and shipped it long ago but later it was just compiled but not shipped
    somehow due to makefile change (maybe a regression).

    Let's ship it again. We could of course not ship it and let packaging system
    handle it but since we are now compiling it, let's not bother the packaging
    system.

    subprocess32 is said to be able to avoid "Cannot allocate memory" kind of error
    (false alarm though - memory is actually sufficient) compared with subprocess
    sometimes when kernel memory overcommit is disabled (which is recommended in
    the greenplum product environment) - this is also one thing that we like.

    Also modify all related python code to use that.