### PR TITLE
Two simple cleanups.

### DIFF
--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -52,7 +52,6 @@ EXIT_STATUS=0
 PORT_TXT="#port"
 LOG_STATEMENT_TXT="#log_statement ="
 LISTEN_ADR_TXT="listen_addresses"
-CHKPOINT_SEG_TXT="checkpoint_segments"
 CONTENT_ID_TXT="gp_contentid"
 DBID_TXT="gp_dbid"
 TMP_PG_HBA=/tmp/pg_hba_conf_master.$$

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -30,7 +30,6 @@
 		"bytea_output",
 		"check_function_bodies",
 		"checkpoint_completion_target",
-		"checkpoint_segments",
 		"checkpoint_timeout",
 		"checkpoint_warning",
 		"client_encoding",

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -236,7 +236,7 @@ bigcheck: all tablespace-setup
 ## Clean up
 ##
 
-clean distclean maintainer-clean: clean-lib
+clean maintainer-clean: clean-lib
 # things built by `all' target
 	rm -f $(OBJS) refint$(DLSUFFIX) autoinc$(DLSUFFIX)
 	rm -f pg_regress_main.o pg_regress.o pg_regress$(X)
@@ -248,3 +248,6 @@ clean distclean maintainer-clean: clean-lib
 	rm -f $(output_files) $(input_files)
 	rm -rf ./testtablespace ./testtablespace_*
 	rm -rf $(pg_regress_clean_files)
+
+distclean: clean
+	rm -f GPTest.pm


### PR DESCRIPTION
1. checkpoint_segments does not exist since pg9.5. Cleaning up the code that
includes it.

2. GPTest.pm should be cleaned up in src/test/regress/GNUmakefile:distclean
