### PR TITLE
Enable materialized view in greenplum

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1133,7 +1133,7 @@ validateAppendOnlyRelOptions(bool ao,
 							 char relkind,
 							 bool co)
 {
-	if (relkind != RELKIND_RELATION)
+	if (relkind != RELKIND_RELATION  && relkind != RELKIND_MATVIEW)
 	{
 		if (ao)
 			ereport(ERROR,

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2482,13 +2482,13 @@ heap_drop_with_catalog(Oid relid)
 	/*
 	 * Remove distribution policy, if any.
  	 */
-	if (relkind == RELKIND_RELATION)
+	if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW)
 		GpPolicyRemove(relid);
 
 	/*
 	 * Attribute encoding
 	 */
-	if (relkind == RELKIND_RELATION)
+	if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW)
 		RemoveAttributeEncodingsByRelid(relid);
 
 	/* MPP-6929: metadata tracking */

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1418,7 +1418,7 @@ heap_create_with_catalog(const char *relname,
 	 * Was "appendonly" specified in the relopts? If yes, fix our relstorage.
 	 * Also, check for override (debug) GUCs.
 	 */
-	if (relkind == RELKIND_RELATION)
+	if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW)
 	{
 		stdRdOptions = (StdRdOptions*) heap_reloptions(
 			relkind, reloptions, !valid_opts);

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -640,7 +640,8 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 	OIDNewHeap = make_new_heap(tableOid, tableSpace,
 							   relpersistence,
 							   AccessExclusiveLock,
-							   true /* createAoBlockDirectory */);
+							   true /* createAoBlockDirectory */,
+							   false);
 
 	/* Copy the heap data into the new table in the desired order */
 	copy_heap_data(OIDNewHeap, tableOid, indexOid, verbose,
@@ -672,7 +673,8 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 Oid
 make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, char relpersistence,
 			  LOCKMODE lockmode,
-			  bool createAoBlockDirectory)
+			  bool createAoBlockDirectory,
+			  bool makeCdbPolicy)
 {
 	TupleDesc	OldHeapDesc;
 	char		NewHeapName[NAMEDATALEN];
@@ -757,7 +759,7 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, char relpersistence,
 										  true,
 										  0,
 										  ONCOMMIT_NOOP,
-                                          NULL,                         /*CDB*/
+										  makeCdbPolicy? OldHeap->rd_cdbpolicy: NULL,/*CDB*/
 										  reloptions,
 										  false,
 										  true,

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -437,7 +437,7 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 								dest, params, 0);
 
 
-	if (into->skipData)
+	if (into->skipData && !is_matview)
 	{
 		/*
 		 * If WITH NO DATA was specified, do not go through the rewriter,

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -176,7 +176,7 @@ create_ctas_internal(List *attrList, IntoClause *into, QueryDesc *queryDesc, boo
 	create->attr_encodings = NULL; /* Handle by AddDefaultRelationAttributeOptions() */
 
 	/* Save them in CreateStmt for dispatching. */
-	create->relKind = RELKIND_RELATION;
+	create->relKind = relkind;
 	create->relStorage = relstorage;
 	create->ownerid = GetUserId();
 

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -14,6 +14,7 @@
  */
 #include "postgres.h"
 
+#include "access/appendonlywriter.h"
 #include "access/htup_details.h"
 #include "access/multixact.h"
 #include "access/xact.h"
@@ -24,6 +25,9 @@
 #include "catalog/pg_am.h"
 #include "catalog/pg_opclass.h"
 #include "catalog/pg_operator.h"
+#include "cdb/cdbaocsam.h"
+#include "cdb/cdbappendonlyam.h"
+#include "cdb/cdbvars.h"
 #include "commands/cluster.h"
 #include "commands/matview.h"
 #include "commands/tablecmds.h"
@@ -47,21 +51,28 @@ typedef struct
 {
 	DestReceiver pub;			/* publicly-known function pointers */
 	Oid			transientoid;	/* OID of new heap into which to store */
+	Oid			oldreloid;
+	bool		concurrent;
+	char 		relpersistence;
 	/* These fields are filled by transientrel_startup: */
 	Relation	transientrel;	/* relation to write to */
 	CommandId	output_cid;		/* cmin to insert in output tuples */
 	int			hi_options;		/* heap_insert performance options */
 	BulkInsertState bistate;	/* bulk insert state */
+
+	struct AppendOnlyInsertDescData *ao_insertDesc; /* descriptor to AO tables */
+	struct AOCSInsertDescData *aocs_insertDes;      /* descriptor for aocs */
 } DR_transientrel;
 
 static int	matview_maintenance_depth = 0;
 
+static RefreshClause* MakeRefreshClause(bool concurrent, bool skipData, RangeVar *relation);
 static void transientrel_startup(DestReceiver *self, int operation, TupleDesc typeinfo);
 static void transientrel_receive(TupleTableSlot *slot, DestReceiver *self);
 static void transientrel_shutdown(DestReceiver *self);
 static void transientrel_destroy(DestReceiver *self);
 static void refresh_matview_datafill(DestReceiver *dest, Query *query,
-						 const char *queryString);
+						 const char *queryString,RefreshClause *refreshClause);
 static char *make_temptable_name_n(char *tempname, int n);
 static void refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 						 int save_sec_context);
@@ -112,6 +123,19 @@ SetMatViewPopulatedState(Relation relation, bool newstate)
 	CommandCounterIncrement();
 }
 
+static RefreshClause*
+MakeRefreshClause(bool concurrent, bool skipData, RangeVar *relation)
+{
+	RefreshClause *refreshClause;
+	refreshClause = makeNode(RefreshClause);
+
+	refreshClause->concurrent = concurrent;
+	refreshClause->skipData = skipData;
+	refreshClause->relation = relation;
+
+	return refreshClause;
+}
+
 /*
  * ExecRefreshMatView -- execute a REFRESH MATERIALIZED VIEW command
  *
@@ -152,6 +176,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	int			save_sec_context;
 	int			save_nestlevel;
 	ObjectAddress address;
+	RefreshClause *refreshClause;
 
 	/* MATERIALIZED_VIEW_FIXME: Refresh MatView is not MPP-fied. */
 
@@ -216,12 +241,6 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 			 "the rule for materialized view \"%s\" is not a single action",
 			 RelationGetRelationName(matviewRel));
 
-	/*
-	 * The stored query was rewritten at the time of the MV definition, but
-	 * has not been scribbled on by the planner.
-	 */
-	dataQuery = (Query *) linitial(actions);
-	Assert(IsA(dataQuery, Query));
 
 	/*
 	 * Check for active uses of the relation in the current transaction, such
@@ -237,6 +256,15 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	 * if we fail later).
 	 */
 	SetMatViewPopulatedState(matviewRel, !stmt->skipData);
+
+	/*
+	 * The stored query was rewritten at the time of the MV definition, but
+	 * has not been scribbled on by the planner.
+	 */
+	dataQuery = (Query *) linitial(actions);
+	Assert(IsA(dataQuery, Query));
+
+	dataQuery->parentStmtType = PARENTSTMTTYPE_REFRESH_MATVIEW;
 
 	relowner = matviewRel->rd_rel->relowner;
 
@@ -269,9 +297,9 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	 * will be gone).
 	 */
 	OIDNewHeap = make_new_heap(matviewOid, tableSpace, relpersistence,
-							   ExclusiveLock, false);
+							   ExclusiveLock, false, true);
 	LockRelationOid(OIDNewHeap, AccessExclusiveLock);
-	dest = CreateTransientRelDestReceiver(OIDNewHeap);
+	dest = CreateTransientRelDestReceiver(OIDNewHeap, matviewOid, concurrent, relpersistence);
 
 	/*
 	 * Now lock down security-restricted operations.
@@ -279,9 +307,12 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	SetUserIdAndSecContext(relowner,
 						   save_sec_context | SECURITY_RESTRICTED_OPERATION);
 
+	refreshClause = MakeRefreshClause(concurrent, stmt->skipData, stmt->relation);
+
+	dataQuery->intoPolicy = matviewRel->rd_cdbpolicy;
 	/* Generate the data, if wanted. */
 	if (!stmt->skipData)
-		refresh_matview_datafill(dest, dataQuery, queryString);
+		refresh_matview_datafill(dest, dataQuery, queryString, refreshClause);
 
 	heap_close(matviewRel, NoLock);
 
@@ -322,7 +353,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
  */
 static void
 refresh_matview_datafill(DestReceiver *dest, Query *query,
-						 const char *queryString)
+						 const char *queryString, RefreshClause *refreshClause)
 {
 	List	   *rewritten;
 	PlannedStmt *plan;
@@ -344,6 +375,8 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 
 	/* Plan the query which will generate data for the refresh. */
 	plan = pg_plan_query(query, 0, NULL);
+
+	plan->refreshClause = refreshClause;
 
 	/*
 	 * Use a snapshot with an updated command ID to ensure this query sees
@@ -375,7 +408,7 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 }
 
 DestReceiver *
-CreateTransientRelDestReceiver(Oid transientoid)
+CreateTransientRelDestReceiver(Oid transientoid, Oid oldreloid, bool concurrent, char relpersistence)
 {
 	DR_transientrel *self = (DR_transientrel *) palloc0(sizeof(DR_transientrel));
 
@@ -385,8 +418,68 @@ CreateTransientRelDestReceiver(Oid transientoid)
 	self->pub.rDestroy = transientrel_destroy;
 	self->pub.mydest = DestTransientRel;
 	self->transientoid = transientoid;
+	self->oldreloid = oldreloid;
+	self->concurrent = concurrent;
+	self->relpersistence = relpersistence;
 
 	return (DestReceiver *) self;
+}
+
+void
+transientrel_init(QueryDesc *queryDesc)
+{
+	Oid			matviewOid;
+	Relation	matviewRel;
+	Oid			tableSpace;
+	Oid			OIDNewHeap;
+	bool		concurrent;
+	char		relpersistence;
+	LOCKMODE	lockmode;
+	RefreshClause *refreshClause;
+
+	refreshClause = queryDesc->plannedstmt->refreshClause;
+	/* Determine strength of lock needed. */
+	concurrent = refreshClause->concurrent;
+	lockmode = concurrent ? ExclusiveLock : AccessExclusiveLock;
+
+	/*
+	 * Get a lock until end of transaction.
+	 */
+	matviewOid = RangeVarGetRelidExtended(refreshClause->relation,
+										  lockmode, false, false,
+										  RangeVarCallbackOwnsTable, NULL);
+	matviewRel = heap_open(matviewOid, NoLock);
+
+	/*
+	 * Tentatively mark the matview as populated or not (this will roll back
+	 * if we fail later).
+	 */
+	SetMatViewPopulatedState(matviewRel, !refreshClause->skipData);
+
+	/* Concurrent refresh builds new data in temp tablespace, and does diff. */
+	if (concurrent)
+	{
+		tableSpace = GetDefaultTablespace(RELPERSISTENCE_TEMP);
+		relpersistence = RELPERSISTENCE_TEMP;
+	}
+	else
+	{
+		tableSpace = matviewRel->rd_rel->reltablespace;
+		relpersistence = matviewRel->rd_rel->relpersistence;
+	}
+	/*
+	 * Create the transient table that will receive the regenerated data. Lock
+	 * it against access by any other process until commit (by which time it
+	 * will be gone).
+	 */
+	OIDNewHeap = make_new_heap(matviewOid, tableSpace, relpersistence,
+							   ExclusiveLock, false, false);
+	LockRelationOid(OIDNewHeap, AccessExclusiveLock);
+
+	queryDesc->dest = CreateTransientRelDestReceiver(OIDNewHeap, matviewOid, concurrent,
+													 relpersistence);
+
+	heap_close(matviewRel, NoLock);
 }
 
 /*
@@ -426,20 +519,57 @@ static void
 transientrel_receive(TupleTableSlot *slot, DestReceiver *self)
 {
 	DR_transientrel *myState = (DR_transientrel *) self;
-	HeapTuple	tuple;
 
 	/*
 	 * get the heap tuple out of the tuple table slot, making sure we have a
 	 * writable copy
 	 */
-	tuple = ExecMaterializeSlot(slot);
 
-	heap_insert(myState->transientrel,
-				tuple,
-				myState->output_cid,
-				myState->hi_options,
-				myState->bistate,
-				GetCurrentTransactionId());
+	if (RelationIsAoRows(myState->transientrel))
+	{
+		AOTupleId	aoTupleId;
+		MemTuple	tuple;
+
+		tuple = ExecCopySlotMemTuple(slot);
+		if (myState->ao_insertDesc == NULL)
+			myState->ao_insertDesc = appendonly_insert_init(myState->transientrel, RESERVED_SEGNO, false);
+
+		appendonly_insert(myState->ao_insertDesc, tuple, InvalidOid, &aoTupleId);
+		pfree(tuple);
+	}
+	else if (RelationIsAoCols(myState->transientrel))
+	{
+		if(myState->aocs_insertDes == NULL)
+			myState->aocs_insertDes = aocs_insert_init(myState->transientrel, RESERVED_SEGNO, false);
+
+		aocs_insert(myState->aocs_insertDes, slot);
+	}
+	else
+	{
+		HeapTuple	tuple;
+
+		/*
+		 * get the heap tuple out of the tuple table slot, making sure we have a
+		 * writable copy
+		 */
+		tuple = ExecMaterializeSlot(slot);
+
+		/*
+		 * force assignment of new OID (see comments in ExecInsert)
+		 */
+		if (myState->transientrel->rd_rel->relhasoids)
+			HeapTupleSetOid(tuple, InvalidOid);
+
+		heap_insert(myState->transientrel,
+					tuple,
+					myState->output_cid,
+					myState->hi_options,
+					myState->bistate,
+					GetCurrentTransactionId());
+
+		/* We know this is a newly created relation, so there are no indexes */
+	}
+
 
 	/* We know this is a newly created relation, so there are no indexes */
 }
@@ -458,9 +588,17 @@ transientrel_shutdown(DestReceiver *self)
 	if (myState->hi_options & HEAP_INSERT_SKIP_WAL)
 		heap_sync(myState->transientrel);
 
+	if (RelationIsAoRows(myState->transientrel) && myState->ao_insertDesc)
+		appendonly_insert_finish(myState->ao_insertDesc);
+	else if (RelationIsAoCols(myState->transientrel) && myState->aocs_insertDes)
+		aocs_insert_finish(myState->aocs_insertDes);
+
 	/* close transientrel, but keep lock until commit */
 	heap_close(myState->transientrel, NoLock);
+
 	myState->transientrel = NULL;
+	if (Gp_role == GP_ROLE_EXECUTE && !myState->concurrent)
+		refresh_by_heap_swap(myState->oldreloid, myState->transientoid, myState->relpersistence);
 }
 
 /*
@@ -539,6 +677,7 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 	ListCell   *indexoidscan;
 	int16		relnatts;
 	Oid		   *opUsedForQual;
+	char 	   *distributed;
 
 	initStringInfo(&querybuf);
 	matviewRel = heap_open(matviewOid, NoLock);
@@ -574,7 +713,8 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 					 "(SELECT 1 FROM %s newdata2 WHERE newdata2 IS NOT NULL "
 					 "AND newdata2 OPERATOR(pg_catalog.*=) newdata "
 					 "AND newdata2.ctid OPERATOR(pg_catalog.<>) "
-					 "newdata.ctid)",
+					 "newdata.ctid and newdata2.gp_segment_id = "
+					 "newdata.gp_segment_id)",
 					 tempname, tempname);
 	if (SPI_execute(querybuf.data, false, 1) != SPI_OK_SELECT)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
@@ -598,11 +738,29 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 	SetUserIdAndSecContext(relowner,
 						   save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
 
-	/* Start building the query for creating the diff table. */
 	resetStringInfo(&querybuf);
 	appendStringInfo(&querybuf,
-					 "CREATE TEMP TABLE %s AS "
-					 "SELECT mv.ctid AS tid, newdata "
+					"select pg_catalog.pg_get_table_distributedby('%d')",
+					matviewOid);
+	if (SPI_execute(querybuf.data, false, 1) != SPI_OK_SELECT)
+		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
+
+
+	if (SPI_processed > 0)
+	{
+		TupleDesc	spi_tupdesc = SPI_tuptable->tupdesc;
+		HeapTuple	spi_tuple = SPI_tuptable->vals[0];
+		distributed = SPI_getvalue(spi_tuple, spi_tupdesc, 1);
+	}
+	else
+		distributed = "";
+
+	/* Start building the query for creating the diff table. */
+	resetStringInfo(&querybuf);
+
+	appendStringInfo(&querybuf,
+					 "CREATE TABLE %s AS "
+					 "SELECT mv.ctid AS tid, mv.gp_segment_id as sid, newdata.* "
 					 "FROM %s mv FULL JOIN %s newdata ON (",
 					 diffname, matviewname, tempname);
 
@@ -723,10 +881,13 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 					  matviewname),
 				 errhint("Create a unique index with no WHERE clause on one or more columns of the materialized view.")));
 
+
+
 	appendStringInfoString(&querybuf,
 						   " AND newdata OPERATOR(pg_catalog.*=) mv) "
 						   "WHERE newdata IS NULL OR mv IS NULL "
-						   "ORDER BY tid");
+						   "ORDER BY tid ");
+	appendStringInfoString(&querybuf, distributed);
 
 	/* Create the temporary "diff" table. */
 	if (SPI_exec(querybuf.data, 0) != SPI_OK_UTILITY)
@@ -751,20 +912,28 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 	/* Deletes must come before inserts; do them first. */
 	resetStringInfo(&querybuf);
 	appendStringInfo(&querybuf,
-				   "DELETE FROM %s mv WHERE ctid OPERATOR(pg_catalog.=) ANY "
+					 "DELETE FROM %s mv WHERE exists "
 					 "(SELECT diff.tid FROM %s diff "
-					 "WHERE diff.tid IS NOT NULL "
-					 "AND diff.newdata IS NULL)",
+					 "WHERE diff.tid = mv.ctid and diff.sid = mv.gp_segment_id and"
+	 				 " diff.tid IS NOT NULL)",
 					 matviewname, diffname);
 	if (SPI_exec(querybuf.data, 0) != SPI_OK_DELETE)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
 
 	/* Inserts go last. */
 	resetStringInfo(&querybuf);
+	appendStringInfo(&querybuf, "INSERT INTO %s SELECT", matviewname);
+	for (int i = 0; i < tupdesc->natts; ++i)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+		if (i == tupdesc->natts - 1)
+			appendStringInfo(&querybuf, " %s", NameStr(attr->attname));
+		else
+			appendStringInfo(&querybuf, " %s,", NameStr(attr->attname));
+	}
 	appendStringInfo(&querybuf,
-					 "INSERT INTO %s SELECT (diff.newdata).* "
-					 "FROM %s diff WHERE tid IS NULL",
-					 matviewname, diffname);
+					 " FROM %s diff WHERE tid IS NULL",
+					 diffname);
 	if (SPI_exec(querybuf.data, 0) != SPI_OK_INSERT)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
 
@@ -862,7 +1031,10 @@ is_usable_unique_index(Relation indexRel)
 bool
 MatViewIncrementalMaintenanceIsEnabled(void)
 {
-	return matview_maintenance_depth > 0;
+	if (Gp_role == GP_ROLE_DISPATCH)
+		return matview_maintenance_depth > 0;
+	else
+		return true;
 }
 
 static void

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5971,7 +5971,7 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 			 * unlogged anyway.
 			 */
 			OIDNewHeap = make_new_heap(tab->relid, NewTableSpace, persistence,
-									   lockmode, hasIndexes);
+									   lockmode, hasIndexes, false);
 
 			/*
 			 * Copy the heap data into the new table with the desired

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -448,7 +448,7 @@ CTranslatorQueryToDXL::CheckSupportedCmdType
 		}
 		if (query->parentStmtType == PARENTSTMTTYPE_REFRESH_MATVIEW)
 		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("COPY. Refresh matview is not supported with GPORCA"));
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Refresh matview is not supported with GPORCA"));
 		}
 
 		// supported: regular select or CTAS when it is enabled

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -446,7 +446,11 @@ CTranslatorQueryToDXL::CheckSupportedCmdType
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("COPY. Copy select statement to file on segment is not supported with GPORCA"));
 		}
-		
+		if (query->parentStmtType == PARENTSTMTTYPE_REFRESH_MATVIEW)
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("COPY. Refresh matview is not supported with GPORCA"));
+		}
+
 		// supported: regular select or CTAS when it is enabled
 		return;
 	}

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -135,6 +135,7 @@ _copyPlannedStmt(const PlannedStmt *from)
 
 	COPY_NODE_FIELD(intoClause);
 	COPY_NODE_FIELD(copyIntoClause);
+	COPY_NODE_FIELD(refreshClause);
 	COPY_SCALAR_FIELD(metricsQueryType);
 
 	return newnode;
@@ -1550,6 +1551,20 @@ _copyCopyIntoClause(const CopyIntoClause *from)
 	COPY_STRING_FIELD(filename);
 	COPY_NODE_FIELD(options);
 	COPY_NODE_FIELD(ao_segnos);
+
+	return newnode;
+}
+
+/*
+ * _copyRefreshClause
+ */
+static RefreshClause *
+_copyRefreshClause(const RefreshClause *from)
+{
+	RefreshClause *newnode = makeNode(RefreshClause);
+
+	COPY_SCALAR_FIELD(concurrent);
+	COPY_NODE_FIELD(relation);
 
 	return newnode;
 }
@@ -5528,6 +5543,9 @@ copyObject(const void *from)
 			break;
 		case T_CopyIntoClause:
 			retval = _copyCopyIntoClause(from);
+			break;
+		case T_RefreshClause:
+			retval = _copyRefreshClause(from);
 			break;
 		case T_Var:
 			retval = _copyVar(from);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -392,6 +392,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
+	WRITE_NODE_FIELD(refreshClause);
 	WRITE_INT8_FIELD(metricsQueryType);
 }
 
@@ -1551,6 +1552,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_CopyIntoClause:
 				_outCopyIntoClause(str, obj);
+				break;
+			case T_RefreshClause:
+				_outRefreshClause(str, obj);
 				break;
 			case T_Var:
 				_outVar(str, obj);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -322,6 +322,7 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
+	WRITE_NODE_FIELD(refreshClause);
 	WRITE_INT_FIELD(metricsQueryType);
 }
 #endif /* COMPILING_BINARY_FUNCS */
@@ -1366,6 +1367,15 @@ _outCopyIntoClause(StringInfo str, const CopyIntoClause *node)
 	WRITE_NODE_FIELD(options);
 	WRITE_NODE_FIELD(ao_segnos);
 
+}
+
+static void
+_outRefreshClause(StringInfo str, const RefreshClause *node)
+{
+	WRITE_NODE_TYPE("REFRESHCLAUSE");
+
+	WRITE_BOOL_FIELD(concurrent);
+	WRITE_NODE_FIELD(relation);
 }
 
 static void
@@ -5050,6 +5060,9 @@ _outNode(StringInfo str, const void *obj)
 				break;
 			case T_CopyIntoClause:
 				_outCopyIntoClause(str, obj);
+				break;
+			case T_RefreshClause:
+				_outRefreshClause(str, obj);
 				break;
 			case T_Var:
 				_outVar(str, obj);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1133,6 +1133,7 @@ _readCreateStmt_common(CreateStmt *local_node)
 		   local_node->relKind == RELKIND_COMPOSITE_TYPE ||
 		   local_node->relKind == RELKIND_FOREIGN_TABLE ||
 		   local_node->relKind == RELKIND_UNCATALOGED ||
+		   local_node->relKind == RELKIND_MATVIEW ||
 		   IsAppendonlyMetadataRelkind(local_node->relKind));
 	Assert(local_node->oncommit <= ONCOMMIT_DROP);
 }
@@ -1481,6 +1482,7 @@ _readPlannedStmt(void)
 	READ_UINT64_FIELD(query_mem);
 	READ_NODE_FIELD(intoClause);
 	READ_NODE_FIELD(copyIntoClause);
+	READ_NODE_FIELD(refreshClause);
 	READ_INT8_FIELD(metricsQueryType);
 	READ_DONE();
 }
@@ -3327,6 +3329,9 @@ readNodeBinary(void)
 				break;
 			case T_CopyIntoClause:
 				return_value = _readCopyIntoClause();
+				break;
+			case T_RefreshClause:
+				return_value = _readRefreshClause();
 				break;
 			case T_Var:
 				return_value = _readVar();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -725,6 +725,17 @@ _readCopyIntoClause(void)
 	READ_DONE();
 }
 
+static RefreshClause *
+_readRefreshClause(void)
+{
+	READ_LOCALS(RefreshClause);
+
+	READ_BOOL_FIELD(concurrent);
+	READ_NODE_FIELD(relation);
+
+	READ_DONE();
+}
+
 /*
  * _readVar
  */
@@ -3125,8 +3136,10 @@ parseNodeString(void)
 		return_value = _readRangeVar();
 	else if (MATCH("INTOCLAUSE", 10))
 		return_value = _readIntoClause();
-	else if (MATCH("COPYINTOCLAUSE", 10))
+	else if (MATCH("COPYINTOCLAUSE", 14))
 		return_value = _readCopyIntoClause();
+	else if (MATCH("REFRESHCLAUSE", 13))
+		return_value = _readRefreshClause();
 	else if (MATCH("VAR", 3))
 		return_value = _readVar();
 	else if (MATCH("CONST", 5))

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3466,10 +3466,6 @@ transformCreateTableAsStmt(ParseState *pstate, CreateTableAsStmt *stmt)
 	/* additional work needed for CREATE MATERIALIZED VIEW */
 	if (stmt->relkind == OBJECT_MATVIEW)
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("materialized view is not supported on greenplum")));
-
 		/*
 		 * Prohibit a data-modifying CTE in the query used to create a
 		 * materialized view. It's not sufficiently clear what the user would

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3525,6 +3525,10 @@ transformCreateTableAsStmt(ParseState *pstate, CreateTableAsStmt *stmt)
 	/* GPDB: Set parentStmtType to PARENTSTMTTYPE_CTAS as we know this query is for CTAS */
 	((Query*)stmt->query)->parentStmtType = PARENTSTMTTYPE_CTAS;
 
+	/*
+	 * In binary upgrade mode, we need to create materialize view in utility mode. So we
+	 * should enable the setQryDistributionPolicy function in binary upgrade mode.
+	 */
 	if (stmt->into->distributedBy && (Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade))
 		setQryDistributionPolicy(stmt->into, (Query *)stmt->query);
 
@@ -3907,6 +3911,10 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 	ListCell   *lc;
 	DistributedBy *dist;
 
+	/*
+	 * In binary upgrade mode, we need to create materialize view in utility mode. So we
+	 * should enable the setQryDistributionPolicy function in binary upgrade mode.
+	 */
 	Assert(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY);
 	Assert(into != NULL);
 	Assert(into->distributedBy != NULL);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3525,7 +3525,7 @@ transformCreateTableAsStmt(ParseState *pstate, CreateTableAsStmt *stmt)
 	/* GPDB: Set parentStmtType to PARENTSTMTTYPE_CTAS as we know this query is for CTAS */
 	((Query*)stmt->query)->parentStmtType = PARENTSTMTTYPE_CTAS;
 
-	if (stmt->into->distributedBy && Gp_role == GP_ROLE_DISPATCH)
+	if (stmt->into->distributedBy && (Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade))
 		setQryDistributionPolicy(stmt->into, (Query *)stmt->query);
 
 	return result;
@@ -3907,7 +3907,7 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 	ListCell   *lc;
 	DistributedBy *dist;
 
-	Assert(Gp_role == GP_ROLE_DISPATCH);
+	Assert(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY);
 	Assert(into != NULL);
 	Assert(into->distributedBy != NULL);
 

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -5808,7 +5808,7 @@ ext_opt_encoding_item:
  *****************************************************************************/
 
 CreateMatViewStmt:
-		CREATE OptNoLog MATERIALIZED VIEW create_mv_target AS SelectStmt opt_with_data
+		CREATE OptNoLog MATERIALIZED VIEW create_mv_target AS SelectStmt opt_with_data OptDistributedBy
 				{
 					CreateTableAsStmt *ctas = makeNode(CreateTableAsStmt);
 					ctas->query = $7;
@@ -5819,6 +5819,8 @@ CreateMatViewStmt:
 					/* cram additional flags into the IntoClause */
 					$5->rel->relpersistence = $2;
 					$5->skipData = !($8);
+					ctas->into->distributedBy = $9;
+
 					$$ = (Node *) ctas;
 				}
 		| CREATE OptNoLog MATERIALIZED VIEW IF_P NOT EXISTS create_mv_target AS SelectStmt opt_with_data

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1256,6 +1256,12 @@ addRangeTableEntry(ParseState *pstate,
 			RelationIsAppendOptimized(rel))
 			pstate->p_canOptSelectLockingClause = false;
 
+		if (rel->rd_rel->relkind == RELKIND_MATVIEW)
+			ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					 errmsg("cannot lock rows in materialized view \"%s\"",
+							RelationGetRelationName(rel))));
+
 		lockmode = pstate->p_canOptSelectLockingClause ? RowShareLock : ExclusiveLock;
 
 		heap_close(rel, NoLock);

--- a/src/backend/tcop/dest.c
+++ b/src/backend/tcop/dest.c
@@ -130,7 +130,7 @@ CreateDestReceiver(CommandDest dest)
 			return CreateSQLFunctionDestReceiver();
 
 		case DestTransientRel:
-			return CreateTransientRelDestReceiver(InvalidOid);
+			return CreateTransientRelDestReceiver(InvalidOid, InvalidOid, false, 't');
 	}
 
 	/* should never get here */

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -412,7 +412,8 @@ ChoosePortalStrategy(List *stmts)
 				if (pstmt->commandType == CMD_SELECT &&
 					pstmt->utilityStmt == NULL &&
 					pstmt->intoClause == NULL &&
-					pstmt->copyIntoClause == NULL)
+					pstmt->copyIntoClause == NULL &&
+					pstmt->refreshClause == NULL)
 				{
 					if (pstmt->hasModifyingCTE)
 						return PORTAL_ONE_MOD_WITH;
@@ -538,7 +539,8 @@ FetchStatementTargetList(Node *stmt)
 		if (pstmt->commandType == CMD_SELECT &&
 			pstmt->utilityStmt == NULL &&
 			pstmt->intoClause == NULL &&
-			pstmt->copyIntoClause == NULL)
+			pstmt->copyIntoClause == NULL &&
+			pstmt->refreshClause == NULL)
 			return pstmt->planTree->targetlist;
 		if (pstmt->hasReturning)
 			return pstmt->planTree->targetlist;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -15047,6 +15047,23 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 			appendPQExpBufferChar(q, ')');
 		}
 
+
+		/*
+		 * For materialized views, create the AS clause just like a view. At
+		 * this point, we always mark the view as not populated.
+		 */
+		if (tbinfo->relkind == RELKIND_MATVIEW)
+		{
+			PQExpBuffer result;
+
+			result = createViewAsClause(fout, tbinfo);
+			appendPQExpBuffer(q, " AS\n%s\n  WITH NO DATA\n",
+							  result->data);
+			destroyPQExpBuffer(result);
+		}
+		else
+			appendPQExpBufferStr(q, "\n");
+
 		/* START MPP ADDITION */
 
 		/*
@@ -15165,21 +15182,7 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 		if (ftoptions && ftoptions[0])
 			appendPQExpBuffer(q, "\nOPTIONS (\n    %s\n)", ftoptions);
 
-		/*
-		 * For materialized views, create the AS clause just like a view. At
-		 * this point, we always mark the view as not populated.
-		 */
-		if (tbinfo->relkind == RELKIND_MATVIEW)
-		{
-			PQExpBuffer result;
-
-			result = createViewAsClause(fout, tbinfo);
-			appendPQExpBuffer(q, " AS\n%s\n  WITH NO DATA;\n",
-							  result->data);
-			destroyPQExpBuffer(result);
-		}
-		else
-			appendPQExpBufferStr(q, ";\n");
+		appendPQExpBufferStr(q, ";\n");
 
 		/*
 		 * Exchange external partitions. This is an expensive process, so only
@@ -15411,6 +15414,7 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 								  qualrelname,
 								  tbinfo->reloftype);
 			}
+			appendPQExpBuffer(q, "RESET allow_system_table_mods;\n");
 		}
 
 		/*
@@ -15424,6 +15428,8 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 			(tbinfo->relkind == RELKIND_RELATION ||
 			 tbinfo->relkind == RELKIND_MATVIEW))
 		{
+			appendPQExpBuffer(q, "SET allow_system_table_mods = true;\n");
+
 			appendPQExpBufferStr(q, "\n-- For binary upgrade, set heap's relfrozenxid and relminmxid\n");
 			appendPQExpBuffer(q, "UPDATE pg_catalog.pg_class\n"
 							  "SET relfrozenxid = '%u', relminmxid = '%u'\n"
@@ -15464,12 +15470,16 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 		if (dopt->binary_upgrade && tbinfo->relkind == RELKIND_MATVIEW &&
 			tbinfo->relispopulated)
 		{
+			appendPQExpBuffer(q, "SET allow_system_table_mods = true;\n");
+
 			appendPQExpBufferStr(q, "\n-- For binary upgrade, mark materialized view as populated\n");
 			appendPQExpBufferStr(q, "UPDATE pg_catalog.pg_class\n"
 								 "SET relispopulated = 't'\n"
 								 "WHERE oid = ");
 			appendStringLiteralAH(q, qualrelname, fout);
 			appendPQExpBufferStr(q, "::pg_catalog.regclass;\n");
+
+			appendPQExpBuffer(q, "RESET allow_system_table_mods;\n");
 		}
 
 		/*

--- a/src/include/commands/cluster.h
+++ b/src/include/commands/cluster.h
@@ -27,7 +27,8 @@ extern void mark_index_clustered(Relation rel, Oid indexOid, bool is_internal);
 
 extern Oid make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, char relpersistence,
 			  LOCKMODE lockmode,
-			  bool createAoBlockDirectory);
+			  bool createAoBlockDirectory,
+			  bool makeCdbPolicy);
 extern void finish_heap_swap(Oid OIDOldHeap, Oid OIDNewHeap,
 				 bool is_system_catalog,
 				 bool swap_toast_by_content,

--- a/src/include/commands/matview.h
+++ b/src/include/commands/matview.h
@@ -15,6 +15,7 @@
 #define MATVIEW_H
 
 #include "catalog/objectaddress.h"
+#include "executor/execdesc.h"
 #include "nodes/params.h"
 #include "nodes/parsenodes.h"
 #include "tcop/dest.h"
@@ -26,8 +27,11 @@ extern void SetMatViewPopulatedState(Relation relation, bool newstate);
 extern ObjectAddress ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 				   ParamListInfo params, char *completionTag);
 
-extern DestReceiver *CreateTransientRelDestReceiver(Oid oid);
+extern DestReceiver *CreateTransientRelDestReceiver(Oid oid, Oid oldreloid, bool concurrent,
+													char relpersistence);
 
 extern bool MatViewIncrementalMaintenanceIsEnabled(void);
+
+extern void transientrel_init(QueryDesc *queryDesc);
 
 #endif   /* MATVIEW_H */

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -235,6 +235,7 @@ typedef enum NodeTag
 	T_OnConflictExpr,
 	T_IntoClause,
 	T_CopyIntoClause,
+	T_RefreshClause,
 	T_Flow,
 	T_GroupId,
 	T_DistributedBy,

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -94,6 +94,7 @@ typedef uint32 AclMode;			/* a bitmask of privilege bits */
  * PARENTSTMTTYPE_NONE		query is not included in a utility stmt.
  * PARENTSTMTTYPE_CTAS		query is included in a CreateTableAsStmt.
  * PARENTSTMTTYPE_COPY		query is included in a CopyStmt.
+ * PARENTSTMTTYPE_REFRESH_MATVIEW		query is included in a RefreshMatviewStmt.
  *
  * Previously we added the isCtas field to Query to indicate that
  * the query is included in CreateTableAsStmt. For this type of
@@ -111,6 +112,7 @@ typedef uint8 ParentStmtType;
 #define PARENTSTMTTYPE_NONE	0
 #define PARENTSTMTTYPE_CTAS	1
 #define PARENTSTMTTYPE_COPY	2
+#define PARENTSTMTTYPE_REFRESH_MATVIEW	3
 
 /*
  * Query -

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -149,6 +149,7 @@ typedef struct PlannedStmt
 	 */
 	IntoClause *intoClause;
 	CopyIntoClause *copyIntoClause;
+	RefreshClause   *refreshClause;		/* relation to insert into */
 
 	/* 
  	 * GPDB: whether a query is a SPI inner query for extension usage 

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -117,6 +117,15 @@ typedef struct CopyIntoClause
 	List	   *ao_segnos;		/* AO segno map */
 } CopyIntoClause;
 
+typedef struct RefreshClause
+{
+	NodeTag		type;
+
+	bool		concurrent;		/* allow concurrent access? */
+	bool		skipData;
+	RangeVar   *relation;		/* relation to insert into */
+} RefreshClause;
+
 
 /* ----------------------------------------------------------------
  *					node types for executable expressions

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -3263,9 +3263,7 @@ CREATE TABLE table2(col1 SERIAL PRIMARY KEY, col2 TEXT NOT NULL);
 INSERT INTO table2 SELECT generate_series(1,400), 'abc';
 CREATE INDEX ON table2(col2);
 CREATE MATERIALIZED VIEW matview AS SELECT col1 FROM table2;
-ERROR:  materialized view is not supported on greenplum
 CREATE INDEX ON matview(col1);
-ERROR:  relation "matview" does not exist
 CREATE VIEW view AS SELECT col2 FROM table2;
 CREATE TABLE reindex_before AS
 SELECT oid, relname, relfilenode, relkind, reltoastrelid
@@ -3292,6 +3290,8 @@ SELECT  b.relname,
   ORDER BY 1;
        relname        | relkind |           case           
 ----------------------+---------+--------------------------
+ matview              | m       | relfilenode is unchanged
+ matview_col1_idx     | i       | relfilenode has changed
  pg_toast_TABLE       | t       | relfilenode is unchanged
  pg_toast_TABLE_index | i       | relfilenode has changed
  table1               | r       | relfilenode is unchanged
@@ -3302,7 +3302,7 @@ SELECT  b.relname,
  table2_col2_idx      | i       | relfilenode has changed
  table2_pkey          | i       | relfilenode has changed
  view                 | v       | relfilenode is unchanged
-(10 rows)
+(12 rows)
 
 REINDEX SCHEMA schema_to_reindex;
 BEGIN;

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -3283,9 +3283,7 @@ CREATE TABLE table2(col1 SERIAL PRIMARY KEY, col2 TEXT NOT NULL);
 INSERT INTO table2 SELECT generate_series(1,400), 'abc';
 CREATE INDEX ON table2(col2);
 CREATE MATERIALIZED VIEW matview AS SELECT col1 FROM table2;
-ERROR:  materialized view is not supported on greenplum
 CREATE INDEX ON matview(col1);
-ERROR:  relation "matview" does not exist
 CREATE VIEW view AS SELECT col2 FROM table2;
 CREATE TABLE reindex_before AS
 SELECT oid, relname, relfilenode, relkind, reltoastrelid
@@ -3312,6 +3310,8 @@ SELECT  b.relname,
   ORDER BY 1;
        relname        | relkind |           case           
 ----------------------+---------+--------------------------
+ matview              | m       | relfilenode is unchanged
+ matview_col1_idx     | i       | relfilenode has changed
  pg_toast_TABLE       | t       | relfilenode is unchanged
  pg_toast_TABLE_index | i       | relfilenode has changed
  table1               | r       | relfilenode is unchanged
@@ -3322,7 +3322,7 @@ SELECT  b.relname,
  table2_col2_idx      | i       | relfilenode has changed
  table2_pkey          | i       | relfilenode has changed
  view                 | v       | relfilenode is unchanged
-(10 rows)
+(12 rows)
 
 REINDEX SCHEMA schema_to_reindex;
 BEGIN;

--- a/src/test/regress/expected/matview_ao.out
+++ b/src/test/regress/expected/matview_ao.out
@@ -1,0 +1,58 @@
+CREATE TABLE t_matview_ao (id int NOT NULL PRIMARY KEY, type text NOT NULL, amt numeric NOT NULL);
+INSERT INTO t_matview_ao VALUES
+  (1, 'x', 2),
+  (2, 'x', 3),
+  (3, 'y', 5),
+  (4, 'y', 7),
+  (5, 'z', 11);
+CREATE MATERIALIZED VIEW m_heap AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA distributed by(type);
+CREATE UNIQUE INDEX m_heap_index ON m_heap(type);
+SELECT * from m_heap;
+ERROR:  materialized view "m_heap" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
+ERROR:  CONCURRENTLY cannot be used when the materialized view is not populated
+REFRESH MATERIALIZED VIEW m_heap;
+SELECT * FROM m_heap;
+ type | totamt 
+------+--------
+ z    |     11
+ y    |     12
+ x    |      5
+(3 rows)
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
+SELECT * FROM m_heap;
+ type | totamt 
+------+--------
+ z    |     11
+ y    |     12
+ x    |      5
+(3 rows)
+
+CREATE MATERIALIZED VIEW m_ao with (appendonly=true) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+SELECT * from m_ao;
+ERROR:  materialized view "m_ao" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW m_ao;
+SELECT * FROM m_ao;
+ type | totamt 
+------+--------
+ y    |     12
+ x    |      5
+ z    |     11
+(3 rows)
+
+CREATE MATERIALIZED VIEW m_aocs with (appendonly=true, orientation=column) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+SELECT * from m_aocs;
+ERROR:  materialized view "m_aocs" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW m_aocs;
+SELECT * FROM m_aocs;
+ type | totamt 
+------+--------
+ y    |     12
+ x    |      5
+ z    |     11
+(3 rows)
+

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -19,17 +19,19 @@ SELECT * FROM tv ORDER BY type;
 -- create a materialized view with no data, and confirm correct behavior
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW tm AS SELECT type, sum(amt) AS totamt FROM t GROUP BY type WITH NO DATA distributed by(type);
-                      QUERY PLAN                      
-------------------------------------------------------
- HashAggregate
-   Group Key: t.type
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Hash Key: t.type
-         ->  HashAggregate
-               Group Key: t.type
-               ->  Seq Scan on t
- Optimizer: Postgres query optimizer
-(8 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Result
+   ->  Result
+         ->  GroupAggregate
+               Group Key: type
+               ->  Sort
+                     Sort Key: type
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: type
+                           ->  Seq Scan on t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.71.0
+(10 rows)
 
 CREATE MATERIALIZED VIEW tm AS SELECT type, sum(amt) AS totamt FROM t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'tm'::regclass;
@@ -60,21 +62,23 @@ SELECT * FROM tm;
 -- create various views
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW tvm AS SELECT * FROM tv ORDER BY type;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'type' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-                         QUERY PLAN                         
-------------------------------------------------------------
- Sort
-   Sort Key: t.type
-   ->  HashAggregate
-         Group Key: t.type
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: t.type
-               ->  HashAggregate
-                     Group Key: t.type
-                     ->  Seq Scan on t
- Optimizer: Postgres query optimizer
-(10 rows)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Result
+   ->  Result
+         ->  Sort
+               Sort Key: type
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     ->  Result
+                           ->  GroupAggregate
+                                 Group Key: type
+                                 ->  Sort
+                                       Sort Key: type
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                             Hash Key: type
+                                             ->  Seq Scan on t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.71.0
+(14 rows)
 
 CREATE MATERIALIZED VIEW tvm AS SELECT * FROM tv ORDER BY type;
 SELECT * FROM tvm;
@@ -91,24 +95,22 @@ CREATE UNIQUE INDEX tvmm_expr ON tvmm (grandtot);
 CREATE VIEW tvv AS SELECT sum(totamt) AS grandtot FROM tv;
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW tvvm AS SELECT * FROM tvv;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'grandtot' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Redistribute Motion 1:3  (slice3; segments: 1)
-   Hash Key: (pg_catalog.sum((sum(tv.totamt))))
-   ->  Aggregate
-         ->  Gather Motion 3:1  (slice2; segments: 3)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Result
+   ->  Result
+         ->  Redistribute Motion 1:3  (slice3; segments: 1)
                ->  Aggregate
-                     ->  Subquery Scan on tv
-                           ->  HashAggregate
-                                 Group Key: t.type
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                       Hash Key: t.type
-                                       ->  HashAggregate
-                                             Group Key: t.type
-                                             ->  Seq Scan on t
- Optimizer: Postgres query optimizer
+                     ->  Gather Motion 3:1  (slice2; segments: 3)
+                           ->  Aggregate
+                                 ->  GroupAggregate
+                                       Group Key: type
+                                       ->  Sort
+                                             Sort Key: type
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                                   Hash Key: type
+                                                   ->  Seq Scan on t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.71.0
 (14 rows)
 
 CREATE MATERIALIZED VIEW tvvm AS SELECT * FROM tvv;
@@ -127,7 +129,7 @@ View definition:
     tv.totamt
    FROM tv
   ORDER BY tv.type;
-Distributed by: (type)
+Distributed randomly
 
 \d+ tvm
                     Materialized view "public.tvm"
@@ -140,7 +142,7 @@ View definition:
     tv.totamt
    FROM tv
   ORDER BY tv.type;
-Distributed by: (type)
+Distributed randomly
 
 \d+ tvvm
                     Materialized view "public.tvvm"
@@ -150,7 +152,7 @@ Distributed by: (type)
 View definition:
  SELECT tvv.grandtot
    FROM tvv;
-Distributed by: (grandtot)
+Distributed randomly
 
 \d+ bb
                      Materialized view "public.bb"
@@ -162,7 +164,7 @@ Indexes:
 View definition:
  SELECT tvvmv.grandtot
    FROM tvvmv;
-Distributed by: (grandtot)
+Distributed randomly
 
 -- test schema behavior
 CREATE SCHEMA mvschema;
@@ -192,7 +194,7 @@ View definition:
     tv.totamt
    FROM tv
   ORDER BY tv.type;
-Distributed by: (type)
+Distributed randomly
 
 -- modify the underlying table data
 INSERT INTO t VALUES (6, 'z', 13);
@@ -409,7 +411,7 @@ UNION ALL
  SELECT v_test2.moo,
     3 * v_test2.moo
    FROM v_test2;
-Distributed by: (moo)
+Distributed randomly
 
 CREATE MATERIALIZED VIEW mv_test3 AS SELECT * FROM mv_test2 WHERE moo = 12345;
 SELECT relispopulated FROM pg_class WHERE oid = 'mv_test3'::regclass;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -37,7 +37,7 @@ test: gp_tablespace
 test: temp_tablespaces
 test: default_tablespace
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views replication_slots create_table_like_gp gp_constraints
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views replication_slots create_table_like_gp gp_constraints matview_ao
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -110,7 +110,7 @@ test: namespace
 test: brin gin gist spgist privileges security_label collate lock replica_identity rowsecurity object_address tablesample groupingsets
 
 # MATERIALIZED_VIEW_FIXME : matview is not supported on greenplum. Enable the test when the feature is ready.
-#test: matview
+test: matview
 
 # ----------
 # Another group of parallel tests

--- a/src/test/regress/sql/matview_ao.sql
+++ b/src/test/regress/sql/matview_ao.sql
@@ -1,0 +1,27 @@
+CREATE TABLE t_matview_ao (id int NOT NULL PRIMARY KEY, type text NOT NULL, amt numeric NOT NULL);
+INSERT INTO t_matview_ao VALUES
+  (1, 'x', 2),
+  (2, 'x', 3),
+  (3, 'y', 5),
+  (4, 'y', 7),
+  (5, 'z', 11);
+
+CREATE MATERIALIZED VIEW m_heap AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA distributed by(type);
+CREATE UNIQUE INDEX m_heap_index ON m_heap(type);
+SELECT * from m_heap;
+REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
+REFRESH MATERIALIZED VIEW m_heap;
+SELECT * FROM m_heap;
+REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
+SELECT * FROM m_heap;
+
+CREATE MATERIALIZED VIEW m_ao with (appendonly=true) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+SELECT * from m_ao;
+REFRESH MATERIALIZED VIEW m_ao;
+SELECT * FROM m_ao;
+
+CREATE MATERIALIZED VIEW m_aocs with (appendonly=true, orientation=column) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+SELECT * from m_aocs;
+REFRESH MATERIALIZED VIEW m_aocs;
+SELECT * FROM m_aocs;
+


### PR DESCRIPTION
The commit enabled materialized view on both swap file and
concurrently mode. There are four main change on the code.
1. Add a new type 'PARENTSTMTTYPE_REFRESH_MATVIEW' on ParentStmtType in
Query struct. So that we can make the right query plan without gather
motion.
2. add a new 'transientrel_init' function which was called on
'initplan' to create temp table on segment.
3. Call the swap function on both master and segment.
4. Change the spi query to make the right diff on parallel system.

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
