### PR TITLE
docs - replace incorrect refs to PXF_HOME with PXF_CONF

### DIFF
--- a/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/client_instcfg.html.md.erb
@@ -25,7 +25,7 @@ In this procedure, you use the `default`, or create a new, PXF server configurat
 
 2. Identify the name of your PXF Hadoop server configuration. If your Hadoop cluster is Kerberized, you must use the `default` PXF server.
 
-3. If you are not using the `default` PXF server, create the `$PXF_HOME/servers/<server_name>` directory. For example, use the following command to create a Hadoop server configuration named `hdp3`:
+3. If you are not using the `default` PXF server, create the `$PXF_CONF/servers/<server_name>` directory. For example, use the following command to create a Hadoop server configuration named `hdp3`:
 
     ``` shell
     gpadmin@gpmaster$ mkdir $PXF_CONF/servers/hdp3

--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -267,7 +267,7 @@ In this procedure, you name and add a PXF JDBC server configuration for a Postgr
 
     **Note**: The server name `default` is reserved.
 
-3. Create the `$PXF_HOME/servers/<server_name>` directory. For example, use the following command to create a JDBC server configuration named `pg_user1_testdb`:
+3. Create the `$PXF_CONF/servers/<server_name>` directory. For example, use the following command to create a JDBC server configuration named `pg_user1_testdb`:
 
     ``` shell
     gpadmin@gpmaster$ mkdir $PXF_CONF/servers/pg_user1_testdb
@@ -366,7 +366,7 @@ Perform the following procedure to configure a PXF JDBC server for Hive:
 
 2. Choose a name for the JDBC server.
 
-3. Create the `$PXF_HOME/servers/<server_name>` directory. For example, use the following command to create a JDBC server configuration named `hivejdbc1`:
+3. Create the `$PXF_CONF/servers/<server_name>` directory. For example, use the following command to create a JDBC server configuration named `hivejdbc1`:
 
     ``` shell
     gpadmin@gpmaster$ mkdir $PXF_CONF/servers/hivejdbc1

--- a/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_cfg.html.md.erb
@@ -61,7 +61,7 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_CONF
 
 2. Choose a name for the server. You will provide the name to end users that need to reference files in the object store.
 
-3. Create the `$PXF_HOME/servers/<server_name>` directory. For example, use the following command to create a server configuration for a Google Cloud Storage server named `gs_public`:
+3. Create the `$PXF_CONF/servers/<server_name>` directory. For example, use the following command to create a server configuration for a Google Cloud Storage server named `gs_public`:
 
     ``` shell
     gpadmin@gpmaster$ mkdir $PXF_CONF/servers/gs_public

--- a/gpdb-doc/markdown/pxf/s3_objstore_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/s3_objstore_cfg.html.md.erb
@@ -155,7 +155,7 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_CONF
 
 2. Choose a name for the server. You will provide the name to end users that need to reference files in the object store.
 
-3. Create the `$PXF_HOME/servers/<server_name>` directory. For example, use the following command to create a server configuration for an S3 server named `s3_user1cfg`:
+3. Create the `$PXF_CONF/servers/<server_name>` directory. For example, use the following command to create a server configuration for an S3 server named `s3_user1cfg`:
 
     ``` shell
     gpadmin@gpmaster$ mkdir $PXF_CONF/servers/s3_user1cfg


### PR DESCRIPTION
fix a few incorrect refs to PXF_HOME in some config steps; the actual command example is correct.

(this will be backported to 5x.)
