### PR TITLE
Avoid gp_tablespace_with_faults test failure by pg_switch_xlog()

### DIFF
--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -150,6 +150,25 @@ $$LANGUAGE plpgsql;
 
 create or replace function force_mirrors_to_catch_up() returns void as $$
 begin
+
+    -- Switch xlog to have no-op record at far distance from
+    -- previously emitted xlog record. This is required due to
+    -- existing code behavior in startup and walreceiver process. If
+    -- primary writes big (means spanning across multiple pages) xlog
+    -- record, flushes only partial xlog record due to
+    -- XLogBackgroundFlush() but restarts before commiting the
+    -- transaction, mirror only receives partial record and waits to
+    -- get complete record. Meanwhile after recover, no-op record gets
+    -- written in place of that big record, startup process on mirror
+    -- continues to wait to receive xlog beyond previously received
+    -- point to proceed further. Hence, switch xlog as temperory
+    -- workaround before writing no-op record to avoid this test from
+    -- hanging sometimes in CI. Refer
+    -- https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/vR7-LwpPsVs/zKmhIpJ3CAAJ
+
+    PERFORM pg_switch_xlog();
+    PERFORM pg_switch_xlog() from gp_dist_random('gp_id');
+
     PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
     PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -135,6 +135,25 @@ END;
 $$LANGUAGE plpgsql;
 create or replace function force_mirrors_to_catch_up() returns void as $$
 begin
+
+    -- Switch xlog to have no-op record at far distance from
+    -- previously emitted xlog record. This is required due to
+    -- existing code behavior in startup and walreceiver process. If
+    -- primary writes big (means spanning across multiple pages) xlog
+    -- record, flushes only partial xlog record due to
+    -- XLogBackgroundFlush() but restarts before commiting the
+    -- transaction, mirror only receives partial record and waits to
+    -- get complete record. Meanwhile after recover, no-op record gets
+    -- written in place of that big record, startup process on mirror
+    -- continues to wait to receive xlog beyond previously received
+    -- point to proceed further. Hence, switch xlog as temperory
+    -- workaround before writing no-op record to avoid this test from
+    -- hanging sometimes in CI. Refer
+    -- https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/vR7-LwpPsVs/zKmhIpJ3CAAJ
+
+    PERFORM pg_switch_xlog();
+    PERFORM pg_switch_xlog() from gp_dist_random('gp_id');
+
     PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
     PERFORM insert_noop_xlog_record();
     PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';


### PR DESCRIPTION
gp_tablespace_with_faults test writes no-op record and waits for
mirror to replay the same before deleting the tablespace
directories. This step fails sometime in CI and causes flaky
behavior. The is due to existing code behavior in startup and
walreceiver process. If primary writes big (means spanning across
multiple pages) xlog record, flushes only partial xlog record due to
XLogBackgroundFlush() but restarts before commiting the transaction,
mirror only receives partial record and waits to get complete
record. Meanwhile after recover, no-op record gets written in place of
that big record, startup process on mirror continues to wait to
receive xlog beyond previously received point to proceed further.

Hence, as temperory workaround till the actual code problem is not
resolved and to avoid failures for this test, switch xlog before
emitting no-op xlog record, to have no-op record at far distance from
previously emitted xlog record.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
