### PR TITLE
Replace toolsmiths/ccp with pivotaldata/ccp

### DIFF
--- a/concourse/tasks/test_upgrade.yml
+++ b/concourse/tasks/test_upgrade.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: toolsmiths/ccp
+    repository: pivotaldata/ccp
     tag: "7"
 
 inputs:


### PR DESCRIPTION
The toolsmiths DockerHub repository is deprecated and replaced by pivotaldata.