### PR TITLE
Print pg_aocsseg and gp_relation_node entries in case of mismatch

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -1913,6 +1913,7 @@ CheckCOConsistencyWithGpRelationNode( Snapshot snapshot, Relation rel, int total
 
 		if (segmentCount > totalsegs + 1)
 		{
+			PrintPgaocssegAndGprelationNodeEntries(allseginfo, totalsegs, segmentFileNumMap);
 			elog(ERROR, "gp_relation_node (%d) has more entries than pg_aocsseg (%d) for relation %s",
 				segmentCount,
 				totalsegs,


### PR DESCRIPTION
If "gp_relation_node has more entries than pg_aocsseg for relation"
ERROR is encountred, we need entries from pg_aocsseg and
gp_relation_node to really know what mismatched between the two
tables. The information was printed for other instance of ERROR but
seems oversight and was missed for this aocs case.
