### PR TITLE
pg_upgrade ci: Add gpdb5 as a resource instead of downloading in script.

### DIFF
--- a/contrib/pg_upgrade/ci/ci.yml
+++ b/contrib/pg_upgrade/ci/ci.yml
@@ -1,14 +1,23 @@
 resources:
-  - name: gpdb
+  - name: gpdb6
     type: git
     source:
       uri: https://github.com/greenplum-db/gpdb.git
       branch: 6X_STABLE
 
+  - name: gpdb5
+    type: git
+    source:
+      uri: https://github.com/greenplum-db/gpdb.git
+      branch: 5X_STABLE
+
 jobs:
   - name: end-to-end-test
     plan:
-      - get: gpdb
-        trigger: true
+      - aggregate:
+        - get: gpdb6
+          trigger: true
+        - get: gpdb5
+          trigger: true
       - task: run-test
-        file: gpdb/contrib/pg_upgrade/ci/run-test.yml
+        file: gpdb6/contrib/pg_upgrade/ci/run-test.yml

--- a/contrib/pg_upgrade/ci/run-test-as-gpadmin.sh
+++ b/contrib/pg_upgrade/ci/run-test-as-gpadmin.sh
@@ -1,23 +1,56 @@
 #!/usr/bin/env bash
 
+
+install_gpdb5() {
+	local gpdb5_installation_path=$1
+	local gpdb5_source_path=$2
+
+	pushd "$gpdb5_source_path"
+
+	./configure --disable-orca --prefix="$gpdb5_installation_path" &&
+		make -j 4 -l 4 &&
+		make install
+
+	source "$gpdb5_source_path/gpAux/greenplum-installation/greenplum_path.sh"
+
+	popd
+}
+
+install_gpdb6() {
+	local gpdb6_installation_path=$1
+	local gpdb6_source_path=$2
+
+	pushd "$gpdb6_source_path"
+
+	./configure --disable-orca --prefix="$gpdb6_installation_path" --without-zstd &&
+		make -j 4 -l 4 &&
+		make install
+
+	source "$gpdb6_source_path/gpAux/greenplum-installation/greenplum_path.sh"
+
+	popd
+}
+
 main() {
+	local gpdb5_installation_path=$PWD/gpdb5/gpAux/greenplum-installation
+	local gpdb5_source_path=$PWD/gpdb5/
+
+	local gpdb6_installation_path=$PWD/gpdb6/gpAux/greenplum-installation
+	local gpdb6_source_path=$PWD/gpdb6/
+
 	ssh-keygen -f ~/.ssh/id_rsa -N ''
 	cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys
 	ssh-keyscan -H localhost >>~/.ssh/known_hosts
 
-	pushd gpdb
+	install_gpdb5 "$gpdb5_installation_path" "$gpdb5_source_path"
+	install_gpdb6 "$gpdb6_installation_path" "$gpdb6_source_path"
 
-	./configure --disable-orca --prefix=$PWD/gpAux/greenplum-installation --without-zstd &&
-		make -j 4 -l 4 &&
-		make install
+	pushd "$gpdb6_source_path/contrib/pg_upgrade/test/integration"
 
-	source gpAux/greenplum-installation/greenplum_path.sh
-
-	popd
-
-	pushd gpdb/contrib/pg_upgrade/test/integration
-
-	./scripts/test.bash
+	./scripts/test.bash "$gpdb5_installation_path" \
+		"$gpdb5_source_path" \
+		"$gpdb6_installation_path" \
+		"$gpdb6_source_path"
 }
 
 main "$@"

--- a/contrib/pg_upgrade/ci/run-test.sh
+++ b/contrib/pg_upgrade/ci/run-test.sh
@@ -1,14 +1,32 @@
 #!/usr/bin/env bash
 
-main() {
+create_gpadmin_user() {
 	adduser --disabled-password --gecos "" gpadmin
-	locale-gen en_US.UTF-8
-	service ssh start
+}
 
+ensure_ssh_daemon_is_running() {
+	service ssh start
+}
+
+setup_utf8_locale() {
+	locale-gen en_US.UTF-8
+}
+
+change_ownership_of_resources_to_gpadmin() {
 	chown -R gpadmin:gpadmin ./gpdb6
 	chown -R gpadmin:gpadmin ./gpdb5
+}
 
+run_test() {
 	su -c ./gpdb6/contrib/pg_upgrade/ci/run-test-as-gpadmin.sh gpadmin
+}
+
+main() {
+	create_gpadmin_user
+	ensure_ssh_daemon_is_running
+	setup_utf8_locale
+	change_ownership_of_resources_to_gpadmin
+	run_test
 }
 
 main "$@"

--- a/contrib/pg_upgrade/ci/run-test.sh
+++ b/contrib/pg_upgrade/ci/run-test.sh
@@ -5,9 +5,10 @@ main() {
 	locale-gen en_US.UTF-8
 	service ssh start
 
-	chown -R gpadmin:gpadmin ./gpdb
+	chown -R gpadmin:gpadmin ./gpdb6
+	chown -R gpadmin:gpadmin ./gpdb5
 
-	su -c ./gpdb/contrib/pg_upgrade/ci/run-test-as-gpadmin.sh gpadmin
+	su -c ./gpdb6/contrib/pg_upgrade/ci/run-test-as-gpadmin.sh gpadmin
 }
 
 main "$@"

--- a/contrib/pg_upgrade/ci/run-test.yml
+++ b/contrib/pg_upgrade/ci/run-test.yml
@@ -8,7 +8,8 @@ image_resource:
     tag: 16.04
 
 inputs:
-  - name: gpdb
+  - name: gpdb6
+  - name: gpdb5
 
 run:
-  path: gpdb/contrib/pg_upgrade/ci/run-test.sh
+  path: gpdb6/contrib/pg_upgrade/ci/run-test.sh

--- a/contrib/pg_upgrade/test/integration/scripts/test.bash
+++ b/contrib/pg_upgrade/test/integration/scripts/test.bash
@@ -2,33 +2,20 @@
 
 set -o nounset
 
-download_gpdb5() {
-	./scripts/download-gpdb5-source.bash
-}
-
-initialize_gpdb5_cluster() {
-	./scripts/init-gpdb5-cluster.bash \
-		./gpdb5-source/gpdb5-installation \
-		./gpdb5-source
-}
-
-initialize_gpdb6_cluster() {
-	local root_directory=$(git rev-parse --show-toplevel)
-
-	./scripts/init-gpdb6-cluster.bash \
-		"$GPHOME" \
-		"$root_directory"
-}
-
 #
 # Test assumes that the 6X installation has already been created
 #
 # ./scripts/test.bash
 #
 main() {
-	download_gpdb5
-	initialize_gpdb5_cluster
-	initialize_gpdb6_cluster
+	local gpdb5_installation_path=$1
+	local gpdb5_source_path=$2
+
+	local gpdb6_installation_path=$3
+	local gpdb6_source_path=$4
+
+	./scripts/init-gpdb5-cluster.bash "$gpdb5_installation_path" "$gpdb5_source_path"
+	./scripts/init-gpdb6-cluster.bash "$gpdb6_installation_path" "$gpdb6_source_path"
 
 	make check
 }


### PR DESCRIPTION
Rather than attempt to git clone gpdb5 inside of the testing script, use concourse to pull it down in parallel at the same time it pulls the gpdb6 repository. This should speed things up - but not significantly.

This change has a dev pipeline here:

https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/pg-upgrade-5-to-6/jobs/end-to-end-test/builds/30