### PR TITLE
Fix build system to work with non-empty DESTDIR

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -27,7 +27,7 @@ installprograms: installdirs
 	done
 	# Symlink gpcheckcat from bin to bin/lib to maintain backward compatibility
 	if [ ! -L $(DESTDIR)$(bindir)/lib/gpcheckcat  ]; then \
-		$(LN_S) $(DESTDIR)$(bindir)/gpcheckcat $(DESTDIR)$(bindir)/lib/gpcheckcat; \
+		$(LN_S) $(bindir)/gpcheckcat $(DESTDIR)$(bindir)/lib/gpcheckcat; \
 	fi
 	$(INSTALL_DATA) gpload.bat '$(DESTDIR)$(bindir)/gpload.bat'
 
@@ -55,7 +55,7 @@ LIB_DIR=$(SRC)/lib
 PYLIB_DIR=$(SRC)/ext
 
 core: pygresql subprocess32
-	python gpconfig_modules/parse_guc_metadata.py $(prefix)
+	python gpconfig_modules/parse_guc_metadata.py $(DESTDIR)$(prefix)
 
 ifneq "$(wildcard $(CURDIR)/pythonSrc/ext/*.tar.gz)" ""
 install: installdirs installprograms core lockfile psutil
@@ -79,7 +79,7 @@ pygresql:
 		unset LIBPATH; \
 		./generate-greenplum-path.sh $(prefix) > $(DESTDIR)$(prefix)/greenplum_path.sh ; \
 	fi
-	. $(prefix)/greenplum_path.sh && unset PYTHONHOME && \
+	. $(DESTDIR)$(prefix)/greenplum_path.sh && unset PYTHONHOME && \
 	if [ "$(BLD_ARCH)" = 'aix7_ppc_64' ]; then \
 	    unset PYTHONPATH && cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python_64 setup.py build; \
 	elif [ `uname -s` = 'OpenBSD' ]; then \

--- a/gpcontrib/gpcloud/Makefile
+++ b/gpcontrib/gpcloud/Makefile
@@ -32,7 +32,7 @@ gpcheckcloud:
 install: install-symlink
 
 install-symlink:
-	ln -sf gpcloud.so $(pkglibdir)/gps3ext.so
+	ln -sf gpcloud.so $(DESTDIR)$(pkglibdir)/gps3ext.so
 
 test: format
 	@$(MAKE) -C test test


### PR DESCRIPTION
When building gpdb with a non-empty DESTDIR, the build would fail
because certain Makefiles were not correctly account for it.
Additionally, when we make a symlink for `gpcheckcat` we *should not*
include DESTDIR in the target. A common usage for DESTDIR is to allow
moving the build artifacts after the build is completed. If the target
includes DESTDIR, than the link could point to a non-existing path.

Authored-by: Bradford D. Boyle <bboyle@pivotal.io>