### PR TITLE
Enable Init Plans in queries executed locally in QEs.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2191,8 +2191,12 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 	/* No more use for locallyExecutableSubplans */
 	bms_free(locallyExecutableSubplans);
 
-	/* Extract all precomputed parameters from init plans */
-	ExtractParamsFromInitPlans(plannedstmt, plannedstmt->planTree, estate);
+	/*
+	 * If this is a query that was dispatched from the QE, extract precomputed
+	 * parameters from all init plans
+	 */
+	if (Gp_role == GP_ROLE_EXECUTE && queryDesc->ddesc)
+		ExtractParamsFromInitPlans(plannedstmt, plannedstmt->planTree, estate);
 
 	/*
 	 * Initialize the private state information for all the nodes in the query

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1948,7 +1948,7 @@ static void ExtractSubPlanParam(SubPlan *subplan, EState *estate)
 			 * we will simply substitute the actual value from
 			 * the external parameters.
 			 */
-			if (Gp_role == GP_ROLE_EXECUTE && subplan->is_initplan)
+			if (subplan->is_initplan)
 			{
 				ParamListInfo paramInfo = estate->es_param_list_info;
 				ParamExternData *prmExt = NULL;
@@ -2012,11 +2012,15 @@ ParamExtractorWalker(Plan *node,
 /*
  * Find and extract all the InitPlan setParams in a root node's subtree.
  */
-void ExtractParamsFromInitPlans(PlannedStmt *plannedstmt, Plan *root, EState *estate)
+void
+ExtractParamsFromInitPlans(PlannedStmt *plannedstmt, Plan *root, EState *estate)
 {
 	ParamExtractorContext ctx;
-	ctx.base.node = (Node*)plannedstmt;
+
+	ctx.base.node = (Node*) plannedstmt;
 	ctx.estate = estate;
+
+	Assert(Gp_role == GP_ROLE_EXECUTE);
 
 	/* If gather motion shows up at top, we still need to find master only init plan */
 	if (IsA(root, Motion))

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -782,7 +782,8 @@ ExecInitSubPlan(SubPlan *subplan, PlanState *parent)
 			/**
 			 * If we need to evaluate a parameter, save the planstate to do so.
 			 */
-			if ((Gp_role != GP_ROLE_EXECUTE || !subplan->is_initplan))
+			if ((Gp_role != GP_ROLE_EXECUTE || !subplan->is_initplan ||
+				 estate->es_sliceTable == NULL))
 			{
 				prmExec->execPlan = sstate;
 			}

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -873,7 +873,7 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 	 * not need to return anything useful, since the referencing Params are
 	 * elsewhere.
 	 */
-	if (splan->parParam == NIL && subLinkType == EXISTS_SUBLINK && Gp_role == GP_ROLE_DISPATCH)
+	if (splan->parParam == NIL && subLinkType == EXISTS_SUBLINK)
 	{
 		Param	   *prm;
 
@@ -883,7 +883,7 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 		splan->is_initplan = true;
 		result = (Node *) prm;
 	}
-	else if (splan->parParam == NIL && subLinkType == EXPR_SUBLINK && Gp_role == GP_ROLE_DISPATCH)
+	else if (splan->parParam == NIL && subLinkType == EXPR_SUBLINK)
 	{
 		TargetEntry *te = linitial(plan->targetlist);
 		Param	   *prm;
@@ -898,7 +898,7 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 		splan->is_initplan = true;
 		result = (Node *) prm;
 	}
-	else if (splan->parParam == NIL && subLinkType == ARRAY_SUBLINK && Gp_role == GP_ROLE_DISPATCH)
+	else if (splan->parParam == NIL && subLinkType == ARRAY_SUBLINK)
 	{
 		TargetEntry *te = linitial(plan->targetlist);
 		Oid			arraytype;
@@ -918,7 +918,7 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 		splan->is_initplan = true;
 		result = (Node *) prm;
 	}
-	else if (splan->parParam == NIL && subLinkType == ROWCOMPARE_SUBLINK && Gp_role == GP_ROLE_DISPATCH)
+	else if (splan->parParam == NIL && subLinkType == ROWCOMPARE_SUBLINK)
 	{
 		/* Adjust the Params */
 		List	   *params;

--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -78,3 +78,33 @@ select * from subselect_t2 where false and exists (select generate_series(1,2));
 ---+---+---
 (0 rows)
 
+--
+-- Test running Init Plans in a query that runs in a function in a QE.
+-- Init Plans get special treatment in the QD, for queries that are
+-- dispatched. The point of this test is to make sure the Init Plans work
+-- correctly when they *don't* need the special treatment, in local queries
+-- in QEs.
+--
+create temp table datetab (start timestamp, stop timestamp);
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'start' as the Greenplum Database data distribution key for this table.
+insert into datetab values ('2019-01-01', '2019-01-10');
+-- A function, that contains a query with a subquery that can be turned into
+-- an Init Plan.
+create or replace function number_of_days(start timestamp, stop timestamp) returns text
+as $$
+declare
+  result text;
+begin
+  result := 'full days: ' || (select count(g) from generate_series(start, stop, '1 day') g)::text;
+
+  return result;
+end;
+$$ language plpgsql;
+-- Run the function in QEs.
+select number_of_days(start, stop) from datetab;
+ number_of_days 
+----------------
+ full days: 10
+(1 row)
+


### PR DESCRIPTION
I've been wondering for some time why we have disabled constructing Init
Plans in queries that are planned in QEs, like in SPI queries that run in
user-defined functions. So I removed the diff vs upstream in
build_subplan() to see what happens. It turns out it was because we always
ran the ExtractParamsFromInitPlans() function in QEs, to get the InitPlan
values that the QD sent with the plan, even for queries that were not
dispatched from the QD but planned locally. Fix the call in InitPlan to
only call ExtractParamsFromInitPlans() for queries that were actually
dispatched from the QD, and allow QE-local queries to build Init Plans.

Include a new test case, for clarity, even though there were some existing
ones that incidentally covered this case.
