### PR TITLE
Split MOTIONTYPE_FIXED into GATHER and BROADCAST.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1479,26 +1479,19 @@ ExplainNode(PlanState *planstate, List *ancestors,
 
 				switch (pMotion->motionType)
 				{
+					case MOTIONTYPE_GATHER:
+						if (plan->lefttree->flow->locustype == CdbLocusType_Replicated)
+							sname = "Explicit Gather Motion";
+						else
+							sname = "Gather Motion";
+						scaleFactor = 1;
+						motion_recv = 1;
+						break;
 					case MOTIONTYPE_HASH:
 						sname = "Redistribute Motion";
 						break;
-					case MOTIONTYPE_FIXED:
-						if (pMotion->isBroadcast)
-						{
-							sname = "Broadcast Motion";
-						}
-						else if (plan->lefttree->flow->locustype == CdbLocusType_Replicated)
-						{
-							sname = "Explicit Gather Motion";
-							scaleFactor = 1;
-							motion_recv = 1;
-						}
-						else
-						{
-							sname = "Gather Motion";
-							scaleFactor = 1;
-							motion_recv = 1;
-						}
+					case MOTIONTYPE_BROADCAST:
+						sname = "Broadcast Motion";
 						break;
 					case MOTIONTYPE_EXPLICIT:
 						sname = "Explicit Redistribute Motion";
@@ -1529,8 +1522,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 						motion_snd = plan->lefttree->flow->numsegments;
 					}
 
-					if (pMotion->motionType == MOTIONTYPE_FIXED &&
-						!pMotion->isBroadcast)
+					if (pMotion->motionType == MOTIONTYPE_GATHER)
 					{
 						/* In Gather Motion always display receiver size as 1 */
 						motion_recv = 1;

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1763,20 +1763,6 @@ gpdb::ListFreeDeep
 }
 
 bool
-gpdb::IsMotionGather
-	(
-	const Motion *motion
-	)
-{
-	GP_WRAP_START;
-	{
-		return isMotionGather(motion);
-	}
-	GP_WRAP_END;
-	return false;
-}
-
-bool
 gpdb::IsAppendOnlyPartitionTable
 	(
 	Oid root_oid

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -260,8 +260,8 @@ CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL
 			{
 				Motion *motion = (Motion *) lfirst(lc);
 				GPOS_ASSERT(IsA(motion, Motion));
-				GPOS_ASSERT(gpdb::IsMotionGather(motion));
-				
+				GPOS_ASSERT(motion->motionType == MOTIONTYPE_GATHER);
+
 				motion->plan.directDispatch.isDirectDispatch = true;
 				motion->plan.directDispatch.contentIds = plan->directDispatch.contentIds;
 			}
@@ -2036,25 +2036,19 @@ CTranslatorDXLToPlStmt::TranslateDXLMotion
 	{
 		case EdxlopPhysicalMotionGather:
 		{
-			motion->motionType = MOTIONTYPE_FIXED;
-			motion->isBroadcast = false;
+			motion->motionType = MOTIONTYPE_GATHER;
 			flow->numsegments = 1;
-
 			break;
 		}
 		case EdxlopPhysicalMotionRedistribute:
 		case EdxlopPhysicalMotionRandom:
 		{
 			motion->motionType = MOTIONTYPE_HASH;
-			motion->isBroadcast = false;
-
 			break;
 		}
 		case EdxlopPhysicalMotionBroadcast:
 		{
-			motion->motionType = MOTIONTYPE_FIXED;
-			motion->isBroadcast = true;
-
+			motion->motionType = MOTIONTYPE_BROADCAST;
 			break;
 		}
 		case EdxlopPhysicalMotionRoutedDistribute:
@@ -2064,8 +2058,6 @@ CTranslatorDXLToPlStmt::TranslateDXLMotion
 
 			motion->motionType = MOTIONTYPE_EXPLICIT;
 			motion->segidColIdx = te_sort_col->resno;
-			motion->isBroadcast = false;
-
 			break;
 			
 		}

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1357,8 +1357,6 @@ _copyMotion(const Motion *from)
 	COPY_NODE_FIELD(hashExprs);
 	COPY_POINTER_FIELD(hashFuncs, list_length(from->hashExprs) * sizeof(Oid));
 
-	COPY_SCALAR_FIELD(isBroadcast);
-
 	COPY_SCALAR_FIELD(numSortCols);
 	COPY_POINTER_FIELD(sortColIdx, from->numSortCols * sizeof(AttrNumber));
 	COPY_POINTER_FIELD(sortOperators, from->numSortCols * sizeof(Oid));

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -587,8 +587,6 @@ _outMotion(StringInfo str, Motion *node)
 	WRITE_NODE_FIELD(hashExprs);
 	WRITE_OID_ARRAY(hashFuncs, list_length(node->hashExprs));
 
-	WRITE_INT_FIELD(isBroadcast);
-
 	WRITE_INT_FIELD(numSortCols);
 	WRITE_INT_ARRAY(sortColIdx, node->numSortCols, AttrNumber);
 	WRITE_OID_ARRAY(sortOperators, node->numSortCols);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1205,8 +1205,6 @@ _outMotion(StringInfo str, const Motion *node)
 	for (i = 0; i < list_length(node->hashExprs); i++)
 		appendStringInfo(str, " %u", node->hashFuncs[i]);
 
-	WRITE_INT_FIELD(isBroadcast);
-
 	WRITE_INT_FIELD(numSortCols);
 	appendStringInfoLiteral(str, " :sortColIdx");
 	for (i = 0; i < node->numSortCols; i++)

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2320,14 +2320,15 @@ _readMotion(void)
 	READ_INT_FIELD(motionID);
 	READ_ENUM_FIELD(motionType, MotionType);
 
-	Assert(local_node->motionType == MOTIONTYPE_FIXED || local_node->motionType == MOTIONTYPE_HASH || local_node->motionType == MOTIONTYPE_EXPLICIT);
+	Assert(local_node->motionType == MOTIONTYPE_GATHER ||
+		   local_node->motionType == MOTIONTYPE_HASH ||
+		   local_node->motionType == MOTIONTYPE_BROADCAST ||
+		   local_node->motionType == MOTIONTYPE_EXPLICIT);
 
 	READ_BOOL_FIELD(sendSorted);
 
 	READ_NODE_FIELD(hashExprs);
 	READ_OID_ARRAY(hashFuncs, list_length(local_node->hashExprs));
-
-	READ_INT_FIELD(isBroadcast);
 
 	READ_INT_FIELD(numSortCols);
 	READ_INT_ARRAY(sortColIdx, local_node->numSortCols, AttrNumber);

--- a/src/include/executor/nodeMotion.h
+++ b/src/include/executor/nodeMotion.h
@@ -24,6 +24,4 @@ extern void ExecReScanMotion(MotionState *node);
 
 extern void ExecSquelchMotion(MotionState *node);
 
-extern bool isMotionGather(const Motion *m);
-
 #endif   /* NODEMOTION_H */

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -392,9 +392,6 @@ namespace gpdb {
 	// deep free of a list
 	void ListFreeDeep(List *list);
 
-	// is this a Gather motion
-	bool IsMotionGather(const Motion *motion);
-
 	// does a partition table have an appendonly child
 	bool IsAppendOnlyPartitionTable(Oid root_oid);
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1294,8 +1294,9 @@ typedef struct Limit
  */
 typedef enum MotionType
 {
+	MOTIONTYPE_GATHER,		/* Send tuples from N senders to one receiver */
 	MOTIONTYPE_HASH,		/* Use hashing to select a segindex destination */
-	MOTIONTYPE_FIXED,		/* Send tuples to a fixed set of segindexes */
+	MOTIONTYPE_BROADCAST,	/* Send tuples from one sender to a fixed set of segindexes */
 	MOTIONTYPE_EXPLICIT		/* Send tuples to the segment explicitly specified in their segid column */
 } MotionType;
 
@@ -1314,18 +1315,6 @@ typedef struct Motion
 	/* For Hash */
 	List		*hashExprs;			/* list of hash expressions */
 	Oid			*hashFuncs;			/* corresponding hash functions */
-
-	/*
-	 * The isBroadcast field is only used for motionType=MOTIONTYPE_FIXED,
-	 * if it is other kind of motion, please do not access this field.
-	 * The field is set true for Broadcast motion, and set false for
-	 * Gather motion.
-	 *
-	 * TODO: Historically, broadcast motion and gather motion's motiontype
-	 * are both MOTIONTYPE_FIXED. It is not a good idea. They should belong
-	 * to different motiontypes. We should refactor the motion types in future.
-	 */
-	bool 	  	isBroadcast;
 
 	/* For Explicit */
 	AttrNumber segidColIdx;			/* index of the segid column in the target list */


### PR DESCRIPTION
MOTIONTYPE_FIXED was used for both Gather and Broadcast Motions, and
there was an extra flag to indicate which one it was. There was a comment
that suggested we should have a two different MOTIONTYPE codes for them,
instead. I totally agree, Gather and Broadcast motions are quite different,
and practically all the code that checked for MOTIONTYPE_FIXED also had to
check the flag to see which it is, so separating the two makes a lot of
sense.

This doesn't have any user-visible effect, just refactoring to make the
code nicer.
