### PR TITLE
Remove unused var acquireResult in function AOCSDrop.

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -435,7 +435,6 @@ AOCSDrop(Relation aorel,
 	AOCSFileSegInfo **segfile_array;
 	int			i,
 				segno;
-	LockAcquireResult acquireResult;
 	AOCSFileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 


### PR DESCRIPTION
Remove unused var acquireResult in function AOCSDrop to
get rid of compiling warning.

-----------------------------

No need to add test cases since it removes a unused local var.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
