### PR TITLE
Do not prefer libedit over readline for tab completion and history

### DIFF
--- a/README.conda.md
+++ b/README.conda.md
@@ -34,7 +34,7 @@ The python-devel is not required here because it is provided by Anaconda.
 ## Download and build GPDB
 	git clone https://github.com/greenplum-db/gpdb.git
 	cd gpdb
-	./configure --prefix=`pwd`/greenplumdb  --with-gssapi --with-pgport=5432 --with-libedit-preferred --with-perl --with-python --with-openssl  --with-libxml --enable-cassert --enable-debug --enable-depend
+	./configure --prefix=`pwd`/greenplumdb  --with-gssapi --with-pgport=5432 --with-perl --with-python --with-openssl  --with-libxml --enable-cassert --enable-debug --enable-depend
 	make install
 
 Make sure "--with-python" parameter exists. Because the default Python is the Anaconda Python, It's done.

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -134,7 +134,7 @@ ubuntu18.04_x86_64_CONFIGFLAGS=--with-quicklz --enable-tap-tests --enable-gpperf
 
 BLD_CONFIGFLAGS=$($(BLD_ARCH)_CONFIGFLAGS)
 
-CONFIGFLAGS=$(strip $(BLD_CONFIGFLAGS) --with-pgport=$(DEFPORT) --with-libedit-preferred $(BLD_DEPLOYMENT_SETTING))
+CONFIGFLAGS=$(strip $(BLD_CONFIGFLAGS) --with-pgport=$(DEFPORT) $(BLD_DEPLOYMENT_SETTING))
 
 ifdef CONFIGURE_FLAGS
 CONFIGFLAGS+= $(CONFIGURE_FLAGS)


### PR DESCRIPTION
Tab completion does not work for centos 7 as reported in #8575  and installing from the rpms.
The root cause is that the binary is linked against libedit (v 0x402) which is
providing the necessary `rl_line_buffer` yet with different contents from
readline. In libedit, the variable contains the last flushed entry in the
history file whereas in readline it contains the current line in the interactive
terminal.

It is not necessary to link with libedit on the build packages so the flag is
removed.

Should also get backported to 6X_STABLE 
