### PR TITLE
Set up PR pipeline for pg upgrade 6X_STABLE

### DIFF
--- a/contrib/pg_upgrade/ci/ci.yml
+++ b/contrib/pg_upgrade/ci/ci.yml
@@ -1,3 +1,13 @@
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+  - name: gcs
+    type: docker-image
+    source:
+      repository: frodenas/gcs-resource
+
 resources:
   - name: gpdb6
     type: git
@@ -11,6 +21,16 @@ resources:
       uri: https://github.com/greenplum-db/gpdb.git
       branch: 5X_STABLE
 
+  - name: gpdb6-pull-request
+    type: pull-request
+    source:
+      repository: greenplum-db/gpdb
+      access_token: ((gpdb-git-access-token))
+      base_branch: "6X_STABLE"
+      ignore_paths:
+        - gpdb-doc/*
+        - README*
+
 jobs:
   - name: end-to-end-test
     plan:
@@ -19,5 +39,15 @@ jobs:
           trigger: true
         - get: gpdb5
           trigger: true
+      - task: run-test
+        file: gpdb6/contrib/pg_upgrade/ci/run-test.yml
+
+  - name: pull-request-end-to-end-test
+    plan:
+      - aggregate:
+        - get: gpdb6
+          resource: gpdb6-pull-request
+          trigger: true
+        - get: gpdb5
       - task: run-test
         file: gpdb6/contrib/pg_upgrade/ci/run-test.yml


### PR DESCRIPTION
This adds to the existing `pg-upgrade-5-to-6` pipeline, now including a PRs as a resource. It runs the same suite of tests that 6X_STABLE commits run through.

The Dev pipeline for this change can be seen here:

https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/pg-upgrade-5-to-6

Because the PR pipeline requires a Github access token, I've hidden the dev pipeline behind a login.