### PR TITLE
Remove plan->nMotionNodes

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -225,7 +225,7 @@ CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL
 
 	planned_stmt->commandType = m_cmd_type;
 	
-	GPOS_ASSERT(plan->nMotionNodes >= 0);
+	GPOS_ASSERT(planned_stmt->nMotionNodes >= 0);
 	if (0 == planned_stmt->nMotionNodes && !m_is_tgt_tbl_distributed)
 	{
 		// no motion nodes and not a DML on a distributed table


### PR DESCRIPTION
After commit 1c2489d07 nMotionNodes are no longer part of the plan
struct.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
