### PR TITLE
6X: Replace planIsParallel by checking Plan->dispatch flag

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -152,8 +152,6 @@ static PartitionNode *BuildPartitionNodeFromRoot(Oid relid);
 static void InitializeQueryPartsMetadata(PlannedStmt *plannedstmt, EState *estate);
 static void AdjustReplicatedTableCounts(EState *estate);
 
-static bool planIsParallel(PlannedStmt *plannedstmt, Plan *plan);
-
 /* end of local decls */
 
 /*
@@ -262,43 +260,6 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 		(*ExecutorStart_hook) (queryDesc, eflags);
 	else
 		standard_ExecutorStart(queryDesc, eflags);
-}
-
-/*
- * Check whether a plan is parallel by counting motions.
- *
- * A plan itself and its init plans can all contain motions, when itself
- * contains at least one motion then it is a parallel plan.  In this function
- * we count the motions of the plan itself to tell whether it is a parallel
- * plan.
- *
- * NOTE: plan->dispatch is not checked by this function.
- */
-static bool
-planIsParallel(PlannedStmt *plannedstmt, Plan *plan)
-{
-	ListCell   *cell;
-	int			nMotionNodes;
-
-	nMotionNodes = plan->nMotionNodes;
-	Assert(nMotionNodes >= 0);
-	if (nMotionNodes == 0)
-		return false;
-
-	foreach(cell, plan->initPlan)
-	{
-		int			subplan_id = lfirst_node(SubPlan, cell)->plan_id;
-		Plan	   *subplan = (Plan *) list_nth(plannedstmt->subplans,
-												subplan_id - 1);
-
-		nMotionNodes -= subplan->nMotionNodes;
-		Assert(nMotionNodes >= 0);
-		if (nMotionNodes == 0)
-			return false;
-	}
-
-	Assert(nMotionNodes > 0);
-	return true;
 }
 
 void
@@ -741,9 +702,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 *
 			 * Main plan is parallel, send plan to it.
 			 */
-			if (queryDesc->plannedstmt->planTree->dispatch == DISPATCH_PARALLEL ||
-				planIsParallel(queryDesc->plannedstmt,
-							   queryDesc->plannedstmt->planTree))
+			if (queryDesc->plannedstmt->planTree->dispatch == DISPATCH_PARALLEL)
 				CdbDispatchPlan(queryDesc, needDtxTwoPhase, true);
 		}
 
@@ -776,8 +735,8 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		{
 			/* Run a root slice. */
 			if (queryDesc->planstate != NULL &&
-				planIsParallel(queryDesc->plannedstmt,
-							   queryDesc->planstate->plan) &&
+				queryDesc->plannedstmt->planTree->dispatch == DISPATCH_PARALLEL &&
+				queryDesc->plannedstmt->nMotionNodes > 0 &&
 				!estate->es_interconnect_is_setup)
 			{
 				Assert(!estate->interconnect_context);

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -451,5 +451,17 @@ language plpgsql volatile;
 set gp_cached_segworkers_threshold to 1;
 select count(*) from dispatch_foo, dispatch_bar where exists (select dispatch_foo_func());
 reset gp_cached_segworkers_threshold;
+
+-- A regression test, derived from diskquota tests.  It contains two init
+-- plans, both contain motions, the plans should be dispatched correctly.
+create table table_size (tableid oid, size bigint, primary key(tableid));
+create view show_fast_database_size_view as
+  select ((select sum(pg_relation_size(oid))
+             from gp_dist_random('pg_class')
+            where oid <= 16384) +
+          (select sum(size) from table_size)) as dbsize;
+select count((pg_database_size(oid) - dbsize) / dbsize) < 0
+  from pg_database, show_fast_database_size_view;
+
 \c regression
 DROP DATABASE dispatch_test_db;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -751,5 +751,20 @@ select count(*) from dispatch_foo, dispatch_bar where exists (select dispatch_fo
 (1 row)
 
 reset gp_cached_segworkers_threshold;
+-- A regression test, derived from diskquota tests.  It contains two init
+-- plans, both contain motions, the plans should be dispatched correctly.
+create table table_size (tableid oid, size bigint, primary key(tableid));
+create view show_fast_database_size_view as
+  select ((select sum(pg_relation_size(oid))
+             from gp_dist_random('pg_class')
+            where oid <= 16384) +
+          (select sum(size) from table_size)) as dbsize;
+select count((pg_database_size(oid) - dbsize) / dbsize) < 0
+  from pg_database, show_fast_database_size_view;
+ ?column? 
+----------
+ f
+(1 row)
+
 \c regression
 DROP DATABASE dispatch_test_db;


### PR DESCRIPTION
In commit 7d74aa5527bc10b6c402b80660ef701f22ab0d5f we introduced a regression
which was only triggered by the out-tree diskquota tests.

Backported c1851b62ca68fe4100730ec3d929a5d4b29f56b1 to fix the issue.

Also added a simplified version of the diskquota tests to ICW to prevent future regressions.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
