### PR TITLE
Solution for S3 URLs which contain a newline between the 's3://...' p…

### DIFF
--- a/src/backend/access/external/url_custom.c
+++ b/src/backend/access/external/url_custom.c
@@ -57,6 +57,14 @@ url_custom_fopen(char *url,
 	int			url_len;
 	int			i;
 
+	/* Remove any CR or LF chars from the URL.  Leaves the overall length intact. */
+  for (i = 0; url[i] != '\0'; i++)
+  {
+    if ('\r' == url[i] || '\n' == url[i]) {
+      url[i] = ' ';
+    }
+  }
+
 	file = palloc0(sizeof(URL_CUSTOM_FILE));
 	file->common.type = CFTYPE_CUSTOM;
 	file->common.url = pstrdup(url);


### PR DESCRIPTION
This is a proposed solution for query time failures due to the presence of a newline or linefeed in the URL of an `s3://` external table.  We hit this issue a couple of days ago as we prepared for a demo, and the cause wasn't obvious.

* Here is the external table definition:
```
$ cat s3_ext_table.sql
DROP EXTERNAL TABLE IF EXISTS voter_turnout;
CREATE READABLE EXTERNAL TABLE voter_turnout
(
  country text
  , fraction float8
)
LOCATION ('s3://s3-us-east-1.amazonaws.com/hooli-roof/voter_turnout.csv
  config=/home/gpadmin/s3.conf')
FORMAT 'CSV';
```

* We run this:
`$ psql -f s3_ext_table.sql`

* Then run a query against it:
```
$ psql -c "select * from voter_turnout order by 2 desc limit 10;"
ERROR:  Failed to init gpcloud extension (segid = 0, segnum = 2), please check your configurations and network connection: reader_init caught a S3RuntimeError exception: Unexpected error: Failed to parse URL s3://s3-us-east-1.amazonaws.com/hooli-roof/voter_turnout.csv (gpcloud.cpp:304)  (seg0 slice1 172.31.1.246:6000 pid=7973) (gpcloud.cpp:304)
DETAIL:  at field 1, Function: S3Url, File: src/s3url.cpp(25).
CONTEXT:  External table voter_turnout, line 1 of file s3://s3-us-east-1.amazonaws.com/hooli-roof/voter_turnout.csv
  config=/home/gpadmin/s3.conf

```
and observe that the URL could not be parsed.

* If we apply the change which is the subject of this PR, rebuild, install, and restart, then run the same query (the external table definition is left as it was):
```
$ psql -c "select * from voter_turnout order by 2 desc limit 10;"
     country     | fraction
-----------------+----------
 Suriname        |     93.8
 Comoros Islands |     93.6
 Seychelles      |     93.1
 Albania         |     92.4
 Italy           |       92
 Cambodia        |     90.5
 Iceland         |     89.3
 Angola          |     88.3
 Portugal        |     88.2
 Indonesia       |     87.9
(10 rows)

```
Given the examples shown in the docs (https://gpdb.docs.pivotal.io/510/admin_guide/external/g-s3-protocol.html) suggest this line break in the table definition, it makes sense to ensure that doesn't cause these query time errors.


