### PR TITLE
Revert "Fix issue for "grant all on all tables in schema xxx to yyy;""

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -493,6 +493,25 @@ ExecuteGrantStmt(GrantStmt *stmt)
 		istmt.objects = objs;
 	}
 
+	/* If we're dispatching, put the objects back in into the parse tree */
+	if (Gp_role == GP_ROLE_DISPATCH && added_objs)
+	{
+		List *n = NIL;
+
+		foreach(cell, istmt.objects)
+		{
+			Oid rid = lfirst_oid(cell);
+			RangeVar *rv;
+			char *nspname = get_namespace_name(get_rel_namespace(rid));
+			char *relname = get_rel_name(rid);
+
+			rv = makeRangeVar(nspname, relname, -1);
+			n = lappend(n, rv);
+		}
+
+		stmt->objects = n;
+	}
+
 	/*
 	 * Convert the PrivGrantee list into an Oid list.  Note that at this point
 	 * we insert an ACL_ID_PUBLIC into the list if an empty role name is

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1660,9 +1660,6 @@ SELECT d.*     -- check that entries went away
 CREATE SCHEMA testns;
 CREATE TABLE testns.t1 (f1 int);
 CREATE TABLE testns.t2 (f1 int);
-CREATE TABLE testns.t3 (f1 int) PARTITION BY RANGE (f1) (START (2018) END (2020) EVERY (1),DEFAULT PARTITION extra );
-CREATE TABLE testns.t4 (f1 int) inherits (testns.t1);
-NOTICE:  merging column "f1" with inherited definition
 SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
  has_table_privilege 
 ---------------------

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -963,8 +963,6 @@ SELECT d.*     -- check that entries went away
 CREATE SCHEMA testns;
 CREATE TABLE testns.t1 (f1 int);
 CREATE TABLE testns.t2 (f1 int);
-CREATE TABLE testns.t3 (f1 int) PARTITION BY RANGE (f1) (START (2018) END (2020) EVERY (1),DEFAULT PARTITION extra );
-CREATE TABLE testns.t4 (f1 int) inherits (testns.t1);
 
 SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
 


### PR DESCRIPTION
This issue was causing the build pipeline to go red. Reverting for now.

This reverts commit 2154dfae77ebc85870061fd940106a6064aa8a4b.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
