### PR TITLE
Replace toolsmiths/ccp with pivotaldata/ccp

### DIFF
--- a/concourse/tasks/setup_new_gpdb_for_backup_restore.yml
+++ b/concourse/tasks/setup_new_gpdb_for_backup_restore.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: toolsmiths/ccp
+    repository: pivotaldata/ccp
     tag: "7"
 inputs:
 - name: terraform


### PR DESCRIPTION
The toolsmiths DockerHub repository is deprecated and replaced by pivotaldata.
gpdb_master PR: https://github.com/greenplum-db/gpdb/pull/8667

Co-authored-by: Amil Khanzada <akhanzada@pivotal.io>
Co-authored-by: Jose Munoz <jmunoz@pivotal.io>
