### PR TITLE
Support pg_tablespace_size() for non-default tablespaces

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -586,6 +586,7 @@ mdcreatetablespacedir(
 	char *primaryFilespaceLocation;
 	char *mirrorFilespaceLocation;
 	char tablespacePath[MAXPGPATH];
+	char *location;
 
 	*primaryError = 0;
 	*mirrorDataLossOccurred = false;
@@ -617,6 +618,12 @@ mdcreatetablespacedir(
 
 		if (mkdir(tablespacePath, 0700) < 0)
 			*primaryError = errno;
+
+		location = (char *) palloc(10 + 10 + 1);
+		sprintf(location, "pg_tblspc/%u", tablespaceOid);
+		if (symlink(tablespacePath, location))
+			*primaryError = errno;
+		pfree(location);
 	}
 
 	if (StorageManagerMirrorMode_SendToMirror(mirrorMode) &&

--- a/src/test/regress/input/filespace.source
+++ b/src/test/regress/input/filespace.source
@@ -180,6 +180,7 @@ INSERT INTO fsts_test_part5 VALUES (1,'ann',1,'2001-01-01','F');
 INSERT INTO fsts_test_part5 VALUES (2,'ben',2,'2002-01-01','M');
 INSERT INTO fsts_test_part5 VALUES (3,'leni',3,'2003-01-01','F');
 INSERT INTO fsts_test_part5 VALUES (4,'sam',4,'2003-01-01','M');
+SELECT pg_size_pretty(pg_tablespace_size('regression_ts_b3'));
 
 -- Alter the table set distributed by
 ALTER TABLE fsts_test_part5 SET DISTRIBUTED BY (id, gender, year);

--- a/src/test/regress/output/filespace.source
+++ b/src/test/regress/output/filespace.source
@@ -1195,6 +1195,12 @@ INSERT INTO fsts_test_part5 VALUES (1,'ann',1,'2001-01-01','F');
 INSERT INTO fsts_test_part5 VALUES (2,'ben',2,'2002-01-01','M');
 INSERT INTO fsts_test_part5 VALUES (3,'leni',3,'2003-01-01','F');
 INSERT INTO fsts_test_part5 VALUES (4,'sam',4,'2003-01-01','M');
+SELECT pg_size_pretty(pg_tablespace_size('regression_ts_b3'));
+ pg_size_pretty 
+----------------
+ 1040 kB
+(1 row)
+
 -- Alter the table set distributed by
 ALTER TABLE fsts_test_part5 SET DISTRIBUTED BY (id, gender, year);
 -- Select from the table


### PR DESCRIPTION
Issue is that calculate_tablespace_size() has an expectation that the
directory to get the size of can be accessed as a relative path from
inside data directory. Since filespaces are not necessarily in the data
directory, a simple solution is to create a symlink.
