### PR TITLE
Add MASTER ONLY option for LOCK TABLE

### DIFF
--- a/src/backend/commands/lockcmds.c
+++ b/src/backend/commands/lockcmds.c
@@ -87,7 +87,7 @@ LockTableCommand(LockStmt *lockstmt)
 			LockTableRecurse(reloid, lockstmt->mode, lockstmt->nowait, GetUserId());
 	}
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role == GP_ROLE_DISPATCH && !lockstmt->coordinatoronly)
 	{
 		CdbDispatchUtilityStatement((Node *) lockstmt,
 									DF_CANCEL_ON_ERROR|

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4970,6 +4970,7 @@ _copyLockStmt(const LockStmt *from)
 	COPY_NODE_FIELD(relations);
 	COPY_SCALAR_FIELD(mode);
 	COPY_SCALAR_FIELD(nowait);
+	COPY_SCALAR_FIELD(coordinatoronly);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2265,6 +2265,7 @@ _equalLockStmt(const LockStmt *a, const LockStmt *b)
 	COMPARE_NODE_FIELD(relations);
 	COMPARE_SCALAR_FIELD(mode);
 	COMPARE_SCALAR_FIELD(nowait);
+	COMPARE_SCALAR_FIELD(coordinatoronly);
 
 	return true;
 }

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3789,6 +3789,7 @@ typedef struct LockStmt
 	List	   *relations;		/* relations to lock */
 	int			mode;			/* lock mode */
 	bool		nowait;			/* no wait mode */
+	bool		coordinatoronly;		/* GPDB: lock only on master */
 } LockStmt;
 
 /* ----------------------

--- a/src/test/regress/expected/gp_lock.out
+++ b/src/test/regress/expected/gp_lock.out
@@ -1,0 +1,33 @@
+CREATE TABLE gp_lock_test (a int);
+BEGIN;
+LOCK TABLE gp_lock_test IN ACCESS SHARE MODE;
+SELECT l.gp_segment_id, c.relname, l.mode, l.granted
+FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
+ gp_segment_id |   relname    |      mode       | granted 
+---------------+--------------+-----------------+---------
+             0 | gp_lock_test | AccessShareLock | t
+             1 | gp_lock_test | AccessShareLock | t
+             2 | gp_lock_test | AccessShareLock | t
+            -1 | gp_lock_test | AccessShareLock | t
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+LOCK TABLE gp_lock_test IN ACCESS SHARE MODE COORDINATOR ONLY;
+SELECT l.gp_segment_id, c.relname, l.mode, l.granted
+FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
+ gp_segment_id |   relname    |      mode       | granted 
+---------------+--------------+-----------------+---------
+            -1 | gp_lock_test | AccessShareLock | t
+(1 row)
+
+ROLLBACK;
+-- other modes are not supported
+BEGIN;
+LOCK TABLE gp_lock_test IN EXCLUSIVE MODE COORDINATOR ONLY;
+ERROR:  provided lock mode is not supported for COORDINATOR ONLY
+LINE 1: LOCK TABLE gp_lock_test IN EXCLUSIVE MODE COORDINATOR ONLY;
+                                ^
+HINT:  Only ACCESS SHARE mode is supported for COORDINATOR ONLY.
+ROLLBACK;
+DROP TABLE gp_lock_test;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -39,6 +39,7 @@ test: instr_in_shmem
 test: createdb
 test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp resource_queue_with_rule gp_types gp_index cluster_gp combocid_gp gp_sort gp_prepared_xacts gp_backend_info
 test: spi_processed64bit
+test: gp_lock
 test: gp_tablespace_with_faults
 # below test(s) inject faults so each of them need to be in a separate group
 test: gp_tablespace

--- a/src/test/regress/sql/gp_lock.sql
+++ b/src/test/regress/sql/gp_lock.sql
@@ -1,0 +1,22 @@
+CREATE TABLE gp_lock_test (a int);
+
+BEGIN;
+LOCK TABLE gp_lock_test IN ACCESS SHARE MODE;
+
+SELECT l.gp_segment_id, c.relname, l.mode, l.granted
+FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
+ROLLBACK;
+
+BEGIN;
+LOCK TABLE gp_lock_test IN ACCESS SHARE MODE COORDINATOR ONLY;
+
+SELECT l.gp_segment_id, c.relname, l.mode, l.granted
+FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
+ROLLBACK;
+
+-- other modes are not supported
+BEGIN;
+LOCK TABLE gp_lock_test IN EXCLUSIVE MODE COORDINATOR ONLY;
+ROLLBACK;
+
+DROP TABLE gp_lock_test;


### PR DESCRIPTION
Currently, LOCK TABLE will always dispatch the lock statement to the
segments. However, the dispatch is unnecessary in many common cases
(e.g. when you just want to prevent DDL changes from ALTER TABLE or
DROP TABLE). Having the ability to not dispatch would give a small
performance boost in large Greenplum clusters when explicitly locking
a large amount of tables in a transaction.

To skip the dispatch, we introduce a new option to LOCK TABLE called
MASTER ONLY.  When added to the LOCK TABLE query, the lock will only
be taken on the master.

----------------------------

This idea came from observing a large Greenplum cluster taking a couple hours to lock 10000+ tables on a presumably saturated network.  The locks were being taken just to prevent DDL changes.

Need to add doc changes but this PR is mostly just a feature proposal right now (I would have created a gpdb-dev thread but creating this patch was faster).