### PR TITLE
Fix crash in COPY FROM if error happens

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -695,6 +695,9 @@ cdbCopyEndAndFetchRejectNum(CdbCopy *c, int64 *total_rows_completed)
 	struct	SegmentDatabaseDescriptor *db_descriptors;
 	int size;
 
+	if (c == NULL)
+		return 0;
+
 	/* clean err message */
 	c->err_msg.len = 0;
 	c->err_msg.data[0] = '\0';


### PR DESCRIPTION
If error happens in CopyFrom() it has defined cdbCopy=NULL, so when
PG_CATCH() calls COPY_HANDLE_ERROR it triggers PANIC. Hence, check for
null in cdbCopyEndAndFetchRejectNum().

The crash was exposed by following SQL commands:

    CREATE TABLE public.heap01 (a int, b int) distributed by (a);
    INSERT INTO public.heap01 VALUES (generate_series(0,99), generate_series(0,98));
    ANALYZE public.heap01;

    COPY (select * from pg_statistic where starelid = 'public.heap01'::regclass) TO '/tmp/heap01.stat';
    DELETE FROM pg_statistic where starelid = 'public.heap01'::regclass;
    COPY pg_statistic from '/tmp/heap01.stat';

Important note: Yes, it's known and strongly recommended to not touch
the `pg_statistics` or any other catalog table this way. But it's no
good to panic either. The copy to `pg_statictics` is going to ERROR
out "correctly" and not crash after this change with `cannot accept a
value of type anyarray`, as there just isn't any way at the SQL level
to insert data into pg_statistic's anyarray columns. Refer:
https://www.postgresql.org/message-id/12138.1277130186%40sss.pgh.pa.us

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
