### PR TITLE
gpload.py supports both gpdb5 and gpdb6.

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
@@ -47,6 +47,7 @@ class GpLoadTestCase(unittest.TestCase):
         gploader.read_config()
         gploader.locations = [ 'gpfdist://localhost:8080/test' ]
         rejectLimit = '9999'
+        gploader.gpdb_version = "6.0.0"
 
         sql = gploader.get_reuse_exttable_query('csv', 'header', None, {}, None, False, None)
         self.assertTrue('pgext.fmterrtbl IS NULL' in sql)


### PR DESCRIPTION
Merge gpload.py from GPDB master. gpload.py supports both gpdb5 and gpdb6
Fix gpload unit test case (#8498)
Catch ImportError for gpversion for Windows compatible.

Test can be covered by existing cases.
