### PR TITLE
docs - promote pxf protocol over s3 protocol

### DIFF
--- a/gpdb-doc/dita/admin_guide/external/external-tables.ditamap
+++ b/gpdb-doc/dita/admin_guide/external/external-tables.ditamap
@@ -3,6 +3,7 @@
 <map>
   <title>Working with External Data</title>
   <topicref href="g-working-with-file-based-ext-tables.xml" navtitle="Working with External Data">
+    <topicref href="pxf-overview.xml" navtitle="Accessing External Data with PXF"/>
     <topicref href="g-external-tables.xml" navtitle="Working with External Tables">
       <topicref href="g-file-protocol.xml"/>
       <topicref href="g-gpfdist-protocol.xml"/>
@@ -17,7 +18,8 @@
         <topicref href="g-example-2-multiple-gpfdist-instances.xml" type="topic"/>
         <topicref href="g-example-3-multiple-gpfdists-instances.xml" type="topic"/>
         <topicref href="g-example-4-single-gpfdist-instance-with-error-logging.xml" type="topic"/>
-        <topicref href="g-example-5-text-format-on-a-hadoop-distributed-file-server.xml" type="topic"/>
+        <topicref href="g-example-5-text-format-on-a-hadoop-distributed-file-server.xml"
+          type="topic"/>
         <topicref href="g-example-6-multiple-files-in-csv-format-with-header-rows.xml" type="topic"/>
         <topicref href="g-example-7-readable-web-external-table-with-script.xml" type="topic"/>
         <topicref href="g-example-8-writable-external-table-with-gpfdist.xml"/>
@@ -27,7 +29,6 @@
           type="topic"/>
       </topicref>
     </topicref>
-    <topicref href="pxf-overview.xml" navtitle="Accessing External Data with PXF"/>
     <topicref href="g-foreign.xml" navtitle="Accessing External Data with Foreign Tables">
       <topicref href="g-devel-fdw.xml"/>
     </topicref>

--- a/gpdb-doc/dita/admin_guide/external/g-external-tables.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-external-tables.xml
@@ -3,8 +3,8 @@
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic3">
    <title>Defining External Tables</title>
-   <shortdesc>External tables enable accessing external data as if it were a regular database
-      table. They are often used to move data into and out of a Greenplum database.</shortdesc>
+   <shortdesc>External tables enable accessing external data as if it were a regular database table.
+      They are often used to move data into and out of a Greenplum database.</shortdesc>
    <body>
       <p>To create an external table definition, you specify the format of your input files and the
          location of your external data sources. For information about input file formats, see <xref
@@ -19,57 +19,59 @@
                   href="g-gpfdist-protocol.xml#topic_sny_yph_kr"/>.</li>
             <li><codeph>gpfdists://</codeph> is the secure version of <codeph>gpfdist</codeph>. See
                   <xref href="g-gpfdists-protocol.xml#topic_sny_yph_kr"/>.</li>
+            <li>The <codeph>pxf://</codeph> protocol accesses object store systems (Azure, Google
+               Cloud Storage, Minio, S3), external Hadoop systems (HDFS, Hive, HBase), and SQL
+               databases using the Greenplum Platform Extension Framework (PXF). See <xref
+                  href="g-pxf-protocol.xml"/>.</li>
             <li><codeph>s3://</codeph> accesses files in an Amazon S3 bucket. See <xref
                   href="g-s3-protocol.xml#amazon-emr"/>.</li>
-
-            <li>The <codeph>pxf://</codeph> protocol accesses external HDFS files and HBase and Hive tables using the Greenplum Platform Extension Framework (PXF). See <xref href="g-pxf-protocol.xml"></xref>.</li>
          </ul></p>
-      <note>
-         <p>The <codeph>s3://</codeph> and <codeph>pxf://</codeph>
-            protocols are custom data access protocols, where the <codeph>file://</codeph>,
-               <codeph>gpfdist://</codeph>, and <codeph>gpfdists://</codeph> protocols are
-            implemented internally in Greenplum Database. The custom and internal protocols differ
-            in these ways:</p>
-         <ul id="ul_ifb_crh_qfb">
-            <li>Custom protocols must be registered using the <codeph>CREATE PROTOCOL</codeph>
-               command. Registering the PXF extension in a database creates the
-                  <codeph>pxf://</codeph> protocol. (See <xref
-                  href="pxf-overview.xml#topic_u14_wtd_dbb"/>.) You can optionally register the
-                  <codeph>s3://</codeph> protocol. (See <xref
-                  href="g-s3-protocol.xml#amazon-emr/s3_prereq"/>.) Internal protocols are always
-               present and cannot be unregistered.</li>
-            <li>When a custom protocol is registered, a row is added to the
-                  <codeph>pg_extprotocol</codeph> catalog table to specify the handler functions
-               that implement the protocol. The protocol's shared libraries must have been installed
-               on all Greenplum Database hosts. The internal protocols are not represented in the
-                  <codeph>pg_extprotocol</codeph> table and have no additional libraries to
-               install.</li>
-            <li>To grant users permissions on custom protocols, you use <codeph>GRANT [SELECT |
-                  INSERT | ALL] ON PROTOCOL</codeph>. To allow (or deny) users permissions on the
-               internal protocols, you use <codeph>CREATE ROLE</codeph> or <codeph>ALTER
-                  ROLE</codeph> to add the <codeph>CREATEEXTTABLE</codeph> (or
-                  <codeph>NOCREATEEXTTABLE</codeph>) attribute to each user's role.</li>
-         </ul>
-      </note>
+      <p>The <codeph>pxf://</codeph> and <codeph>s3://</codeph> protocols are custom data access
+         protocols, where the <codeph>file://</codeph>, <codeph>gpfdist://</codeph>, and
+            <codeph>gpfdists://</codeph> protocols are implemented internally in Greenplum Database.
+         The custom and internal protocols differ in these ways:</p>
+      <ul id="ul_ifb_crh_qfb">
+         <li><codeph>pxf://</codeph> and <codeph>s3://</codeph> are custom protocols that must be
+            registered using the <codeph>CREATE EXTENSION</codeph> command (<codeph>pxf</codeph>) or
+            the <codeph>CREATE PROTOCOL</codeph> command (<codeph>s3</codeph>). Registering the PXF
+            extension in a database creates the <codeph>pxf</codeph> protocol. (See <xref
+               href="pxf-overview.xml#topic_u14_wtd_dbb"/>.) To use the <codeph>s3</codeph>
+            protocol, you must configure the database and register the <codeph>s3</codeph> protocol.
+            (See <xref href="g-s3-protocol.xml#amazon-emr/s3_prereq"/>.) Internal protocols are
+            always present and cannot be unregistered.</li>
+         <li>When a custom protocol is registered, a row is added to the
+               <codeph>pg_extprotocol</codeph> catalog table to specify the handler functions that
+            implement the protocol. The protocol's shared libraries must have been installed on all
+            Greenplum Database hosts. The internal protocols are not represented in the
+               <codeph>pg_extprotocol</codeph> table and have no additional libraries to
+            install.</li>
+         <li>To grant users permissions on custom protocols, you use <codeph>GRANT [SELECT | INSERT
+               | ALL] ON PROTOCOL</codeph>. To allow (or deny) users permissions on the internal
+            protocols, you use <codeph>CREATE ROLE</codeph> or <codeph>ALTER ROLE</codeph> to add
+            the <codeph>CREATEEXTTABLE</codeph> (or <codeph>NOCREATEEXTTABLE</codeph>) attribute to
+            each user's role.</li>
+      </ul>
       <p>External tables access external files from within the database as if they are regular
          database tables. External tables defined with the
             <codeph>gpfdist</codeph>/<codeph>gpfdists</codeph>, <codeph>pxf</codeph>, and
             <codeph>s3</codeph> protocols utilize Greenplum parallelism by using the resources of
-         all Greenplum Database segments to load or unload data. The <codeph>pxf</codeph>
-         protocol leverages the parallel architecture of the Hadoop Distributed File System to
-         access files on that system. The <codeph>s3</codeph> protocol utilizes the Amazon Web
-         Services (AWS) capabilities. </p>
+         all Greenplum Database segments to load or unload data. The <codeph>pxf</codeph> protocol
+         leverages the parallel architecture of the Hadoop Distributed File System to access files
+         on that system. The <codeph>s3</codeph> protocol utilizes the Amazon Web Services (AWS)
+         capabilities. </p>
       <p>You can query external table data directly and in parallel using SQL commands such as
             <codeph>SELECT</codeph>, <codeph>JOIN</codeph>, or <codeph>SORT EXTERNAL TABLE
             DATA</codeph>, and you can create views for external tables. </p>
       <p>The steps for using external tables are:</p>
       <ol>
-         <li id="du215913">Define the external table. <p>To use the <codeph>s3</codeph> protocol,
-               you must also configure Greenplum Database and enable the protocol. See <xref
+         <li id="du215913">Define the external table. <p>To use the <codeph>pxf</codeph> or
+                  <codeph>s3</codeph> protocol, you must also configure Greenplum Database and
+               enable the protocol. See <xref href="g-pxf-protocol.xml"/> or <xref
                   href="g-s3-protocol.xml#amazon-emr"/>.</p></li>
          <li id="du220314">Do one of the following:<ul id="ul_nd1_gd5_h4">
                <li id="du220318">Start the Greenplum Database file server(s) when using the
                      <codeph>gpfdist</codeph> or <codeph>gpdists</codeph> protocols. </li>
+               <li>Verify the configuration for the PXF service and start the service.</li>
                <li>Verify the Greenplum Database configuration for the <codeph>s3</codeph>
                   protocol.</li>
             </ul></li>
@@ -84,12 +86,12 @@
                   data warehousing</li>
                <li id="du210102">Reading external table data in parallel from multiple Greenplum
                   database segment instances, to optimize large load operations</li>
-               <li id="du210103">Filter pushdown. If a query contains a <codeph>WHERE</codeph> clause,
-                  it may be passed to the external data source. Refer to the <xref
+               <li id="du210103">Filter pushdown. If a query contains a <codeph>WHERE</codeph>
+                  clause, it may be passed to the external data source. Refer to the <xref
                      href="../../ref_guide/config_params/guc-list.xml#gp_external_enable_filter_pushdown"
-                  /> server configuration parameter discussion for more information. Note that
-                  this feature is currently supported only with the
-                     <codeph>pxf</codeph> protocol (see <xref href="g-pxf-protocol.xml"/>).</li>
+                  /> server configuration parameter discussion for more information. Note that this
+                  feature is currently supported only with the <codeph>pxf</codeph> protocol (see
+                     <xref href="g-pxf-protocol.xml"/>).</li>
             </ul><p>Readable external tables allow only <codeph>SELECT</codeph> operations.</p>
          </li>
          <li id="du220433">Writable external tables for data unloading. Writable external tables
@@ -114,7 +116,7 @@
             scripts. External web tables are not rescannable: the data can change while the query
             runs. </li>
       </ul>
-      <p>Dump and restore operate only on external and external web table <i>definitions</i>, not on
-         the data sources.</p>
+      <p>Greenplum Database backup and restore operations back up and restore only external and
+         external web table <i>definitions</i>, not the data source data.</p>
    </body>
 </topic>

--- a/gpdb-doc/dita/admin_guide/external/g-pxf-protocol.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-pxf-protocol.xml
@@ -2,7 +2,9 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_z5g_l5h_kr1313">
   <title>pxf:// Protocol</title>
-  <shortdesc>You can use the Greenplum Platform Extension Framework (PXF) <codeph>pxf://</codeph> protocol to access data residing on external Hadoop systems (HDFS, Hive, HBase), object store systems (Azure, Google Cloud Storage, Minio, S3), and SQL databases.</shortdesc>
+  <shortdesc>You can use the Greenplum Platform Extension Framework (PXF) <codeph>pxf://</codeph>
+    protocol to access data residing in object store systems (Azure, Google Cloud Storage, Minio,
+    S3), external Hadoop systems (HDFS, Hive, HBase), and SQL databases.</shortdesc>
   <body>
     <p>The PXF <codeph>pxf</codeph> protocol is packaged as a Greenplum Database extension. The <codeph>pxf</codeph> protocol supports reading from external data stores. You can also write text, binary, and parquet-format data with the <codeph>pxf</codeph> protocol.</p>
     <p>When you use the <codeph>pxf</codeph> protocol to query an external data store, you specify the directory, file, or table that you want to access. PXF requests the data from the data store and delivers the relevant portions in parallel to each Greenplum Database segment instance serving the query.</p>

--- a/gpdb-doc/dita/admin_guide/external/g-s3-protocol.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-s3-protocol.xml
@@ -18,6 +18,10 @@
       <p>The <codeph>s3</codeph> protocol also supports <xref
             href="https://www.emc.com/en-us/storage/ecs/index.htm" format="html" scope="external"
             >Dell EMC Elastic Cloud Storage</xref> (ECS), an Amazon S3 compatible service. </p>
+      <note>The <codeph>pxf</codeph> protocol can access data in S3 and other object store systems
+         such as Azure, Google Cloud Storage, and Minio. The <codeph>pxf</codeph> protocol can also
+         access data in external Hadoop systems (HDFS, Hive, HBase), and SQL databases. See <xref
+            href="g-pxf-protocol.xml#topic_z5g_l5h_kr1313"/>.</note>
       <p>This topic contains the sections:<ul id="ul_o15_22r_kx">
             <li><xref href="#amazon-emr/s3_prereq" format="dita"/></li>
             <li><xref href="#amazon-emr/section_stk_c2r_kx" format="dita"/></li>
@@ -45,13 +49,12 @@
    '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;</codeblock></li>
                      <li> In each database that will access an S3 bucket, declare the
                            <codeph>s3</codeph> protocol and specify the read and write functions you
-                        created in the previous
-                           step:<codeblock>CREATE PROTOCOL s3 (writefunc = write_to_s3, readfunc = read_from_s3);</codeblock><note>The
-                           protocol name <codeph>s3</codeph> must be the same as the protocol of the
-                           URL specified for the external table you create to access an S3 resource.
-                              <p>The corresponding function is called by every Greenplum Database
-                              segment instance. All segment hosts must have access to the S3
-                              bucket.</p></note></li>
+                        created in the previous step:<codeblock>CREATE PROTOCOL s3 (writefunc = write_to_s3, readfunc = read_from_s3);</codeblock>
+                        <note>The protocol name <codeph>s3</codeph> must be the same as the protocol
+                           of the URL specified for the external table you create to access an S3
+                           resource. <p>The corresponding function is called by every Greenplum
+                              Database segment instance. All segment hosts must have access to the
+                              S3 bucket.</p></note></li>
                   </ol></li>
                <li>On each Greenplum Database segment, create and install the <codeph>s3</codeph>
                   protocol configuration file:<ol id="ol_mnq_rnq_kx">
@@ -280,15 +283,14 @@ server_side_encryption = sse-s3
       <section id="s3_proxy">
          <title>s3 Protocol Proxy Support </title>
          <p>You can specify a URL that is the proxy that S3 uses to connect to a data source. S3
-            supports these protocols: HTTP and HTTPS. You can specify a proxy
-            with the <codeph>s3</codeph> protocol configuration parameter <codeph>proxy</codeph> or
-            an environment variable. If the configuration parameter is set, the environment
-            variables are ignored. </p>
+            supports these protocols: HTTP and HTTPS. You can specify a proxy with the
+               <codeph>s3</codeph> protocol configuration parameter <codeph>proxy</codeph> or an
+            environment variable. If the configuration parameter is set, the environment variables
+            are ignored. </p>
          <p>To specify proxy with an environment variable, you set the environment variable based on
-            the protocol: <codeph>http_proxy</codeph> or <codeph>https_proxy</codeph>.
-               You can specify a different URL for each protocol by
-            setting the appropriate environment variable. S3 supports these environment
-               variables.<ul id="ul_cy3_km2_r1b">
+            the protocol: <codeph>http_proxy</codeph> or <codeph>https_proxy</codeph>. You can
+            specify a different URL for each protocol by setting the appropriate environment
+            variable. S3 supports these environment variables.<ul id="ul_cy3_km2_r1b">
                <li><codeph>all_proxy</codeph> specifies the proxy URL that is used if an environment
                   variable for a specific protocol is not set. </li>
                <li><codeph>no_proxy</codeph> specifies a comma-separated list of hosts names that do
@@ -432,19 +434,17 @@ chunksize = 67108864</codeblock></p>
                <plentry>
                   <pt>proxy</pt>
                   <pd>Specify a URL that is the proxy that S3 uses to connect to a data source. S3
-                     supports these protocols: HTTP and HTTPS. This is the
-                     format for the
+                     supports these protocols: HTTP and HTTPS. This is the format for the
                      parameter.<codeblock>proxy = <varname>protocol</varname>://[<varname>user</varname>:<varname>password</varname>@]<varname>proxyhost</varname>[:<varname>port</varname>]</codeblock></pd>
                   <pd>If this parameter is not set or is an empty string (<codeph>proxy =
                         ""</codeph>), S3 uses the proxy specified by the environment variable
-                        <codeph>http_proxy</codeph> or <codeph>https_proxy</codeph>
-                        (and the environment variables
-                        <codeph>all_proxy</codeph> and <codeph>no_proxy</codeph>). The environment
-                     variable that S3 uses depends on the protocol. For information about the
-                     environment variables, see <xref href="g-s3-protocol.xml#amazon-emr/s3_proxy"
-                        format="dita" scope="peer">s3 Protocol Proxy Support</xref><ph
-                        otherprops="op-print"> in the <cite>Greenplum Database Administrator
-                           Guide</cite></ph>.</pd>
+                        <codeph>http_proxy</codeph> or <codeph>https_proxy</codeph> (and the
+                     environment variables <codeph>all_proxy</codeph> and
+                     <codeph>no_proxy</codeph>). The environment variable that S3 uses depends on
+                     the protocol. For information about the environment variables, see <xref
+                        href="g-s3-protocol.xml#amazon-emr/s3_proxy" format="dita" scope="peer">s3
+                        Protocol Proxy Support</xref><ph otherprops="op-print"> in the
+                           <cite>Greenplum Database Administrator Guide</cite></ph>.</pd>
                   <pd>There can be at most one <codeph>proxy</codeph> parameter in the configuration
                      file. The URL specified by the parameter is the proxy for all supported
                      protocols. </pd>
@@ -475,11 +475,10 @@ chunksize = 67108864</codeblock></p>
                            proper certificate) for encrypted communication over HTTPS.</li>
                      </ul></pd>
                   <pd>Setting the value to <codeph>false</codeph> can be useful in testing and
-                     development environments to allow communication without changing
-                        certificates.<note type="warning">Setting the value to
-                           <codeph>false</codeph> exposes a security risk by ignoring invalid
-                        credentials when establishing communication between a client and a S3 data
-                        store. </note></pd>
+                     development environments to allow communication without changing certificates.
+                     <note type="warning">Setting the value to <codeph>false</codeph> exposes a
+                        security risk by ignoring invalid credentials when establishing
+                        communication between a client and a S3 data store. </note></pd>
                </plentry>
                <plentry>
                   <pt>version</pt>


### PR DESCRIPTION
--Reordered listing of pxf and s3.
--Added link to pxf protocol from s3 protocol
--Updated some pxf/s3 information in g-external-tables.xml
 pxf uses CREATE EXTENSION, s3 uses CREATE PROTOCOL
