### PR TITLE
Add pg_upgrade integration test of partitioned heap tables

### DIFF
--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -4,6 +4,7 @@
 
 #include "cmockery.h"
 
+#include "scenarios/partitioned_heap_table.h"
 #include "scenarios/heap_table.h"
 #include "scenarios/subpartitioned_heap_table.h"
 #include "scenarios/ao_table.h"
@@ -42,6 +43,7 @@ main(int argc, char *argv[])
 		unit_test_setup_teardown(test_an_aocs_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_heap_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_subpartitioned_heap_table_with_data_can_be_upgraded, setup, teardown),
+		unit_test_setup_teardown(test_a_partitioned_heap_table_with_data_can_be_upgraded, setup, teardown),
 	};
 
 	return run_tests(tests);

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.c
@@ -1,0 +1,59 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include "cmockery.h"
+
+#include "partitioned_heap_table.h"
+#include "utilities/upgrade-helpers.h"
+#include "utilities/query-helpers.h"
+#include "utilities/test-helpers.h"
+#include "bdd-library/bdd.h"
+
+static void
+partitionedHeapTableShouldHaveDataUpgradedToSixCluster()
+{
+	PGconn	   *connection = connectToSix();
+	PGresult   *result;
+
+	executeQuery(connection, "set search_path to five_to_six_upgrade;");
+
+	result = executeQuery(connection, "select * from users_1_prt_1 where id=1 and name='Jane';");
+	assert_int_equal(1, PQntuples(result));
+
+	result = executeQuery(connection, "select * from users_1_prt_2 where id=2 and name='John';");
+	assert_int_equal(1, PQntuples(result));
+
+	result = executeQuery(connection, "select * from users;");
+	assert_int_equal(2, PQntuples(result));
+
+	PQfinish(connection);
+}
+
+static void
+anAdministratorPerformsAnUpgrade()
+{
+	performUpgrade();
+}
+
+static void
+createPartitionedHeapTableWithDataInFiveCluster(void)
+{
+	PGconn	   *connection = connectToFive();
+
+	executeQuery(connection, "create schema five_to_six_upgrade;");
+	executeQuery(connection, "set search_path to five_to_six_upgrade");
+	executeQuery(connection, "create table users (id integer, name text) distributed by (id) partition by range(id) (start(1) end(3) every(1));");
+	executeQuery(connection, "insert into users values (1, 'Jane')");
+	executeQuery(connection, "insert into users values (2, 'John')");
+	PQfinish(connection);
+}
+
+void
+test_a_partitioned_heap_table_with_data_can_be_upgraded(void **state)
+{
+	given(createPartitionedHeapTableWithDataInFiveCluster);
+	when(anAdministratorPerformsAnUpgrade);
+	then(partitionedHeapTableShouldHaveDataUpgradedToSixCluster);
+
+}

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.h
@@ -1,0 +1,2 @@
+void test_a_partitioned_heap_table_with_data_can_be_upgraded(void **state);
+


### PR DESCRIPTION
Tests that a use can upgrade a partitioned heap table from 5X to 6X and
validates that the data exists on the upgraded cluster.

Co-authored-by: Adam Berlin <aberlin@pivotal.io>
