### PR TITLE
Fix how TargetEntry is replaced with NULL for grouping sets.

### DIFF
--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6118,3 +6118,41 @@ select x, y, count(*), grouping(x,y) from generate_series(1,1) x, generate_serie
  1 |   |     1 |        1
 (1 row)
 
+-- test for replacing grouping columns with NULL constants in the given targetlist
+create table replace_col_agg(a int, b int, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into replace_col_agg values (1,2,'c1');
+insert into replace_col_agg values (1,3,'c2');
+insert into replace_col_agg values (2,4);
+select coalesce(c, 'total'), count(distinct b) from replace_col_agg group by grouping sets(c,());
+ coalesce | count 
+----------+-------
+ c1       |     1
+ c2       |     1
+ total    |     1
+ total    |     3
+(4 rows)
+
+select a, b, count(distinct b)+a from replace_col_agg group by grouping sets((a), (b));
+ a | b | ?column? 
+---+---+----------
+   | 3 |         
+   | 4 |         
+   | 2 |         
+ 1 |   |        3
+ 2 |   |        3
+(5 rows)
+
+select count(distinct a), b + 1 as f, 1 as g from replace_col_agg GROUP BY grouping sets((f,g), (f));
+ count | f | g 
+-------+---+---
+     1 | 3 | 1
+     1 | 4 | 1
+     1 | 5 | 1
+     1 | 3 |  
+     1 | 4 |  
+     1 | 5 |  
+(6 rows)
+
+drop table replace_col_agg;

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -637,3 +637,18 @@ insert into test_gsets values (0, 0), (0, 1), (0,2);
 select i,n,count(*), grouping(i), grouping(n), grouping(i,n) from test_gsets group by grouping sets((), (i,n)) having n is null;
 
 select x, y, count(*), grouping(x,y) from generate_series(1,1) x, generate_series(1,1) y group by grouping sets(x,y) having x is not null;
+
+
+-- test for replacing grouping columns with NULL constants in the given targetlist
+create table replace_col_agg(a int, b int, c text);
+
+insert into replace_col_agg values (1,2,'c1');
+insert into replace_col_agg values (1,3,'c2');
+insert into replace_col_agg values (2,4);
+
+
+select coalesce(c, 'total'), count(distinct b) from replace_col_agg group by grouping sets(c,());
+select a, b, count(distinct b)+a from replace_col_agg group by grouping sets((a), (b));
+select count(distinct a), b + 1 as f, 1 as g from replace_col_agg GROUP BY grouping sets((f,g), (f));
+
+drop table replace_col_agg;


### PR DESCRIPTION
For grouping sets, one thing that needs to be done is to rewrite the
targetlist by replacing the removed grouping columns to NULLs. While
doing this, currently GPDB does not recur into the TargetEntry. As a
result, the removed grouping columns that wrapped in OpExpr or FuncExpr
cannot get replaced.

This patch fixes that by walking into the targetlist with
expression_tree_mutator and replacing the removed grouping columns to
NULLs.

This patch also fixes issue #8710 .

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
