### PR TITLE
Revert default libedit-preferred configure flag to its original value

### DIFF
--- a/configure
+++ b/configure
@@ -1587,8 +1587,8 @@ Optional Packages:
   --with-openssl          build with OpenSSL support
   --with-selinux          build with SELinux support
   --without-readline      do not use GNU Readline nor BSD Libedit for editing
-  --without-libedit-preferred
-                          do not prefer BSD Libedit over GNU Readline
+  --with-libedit-preferred
+                          prefer BSD Libedit over GNU Readline
   --with-uuid=LIB         build contrib/uuid-ossp using LIB (bsd,e2fs,ossp)
   --with-ossp-uuid        obsolete spelling of --with-uuid=ossp
   --with-libxml           build with XML support
@@ -7801,8 +7801,6 @@ fi
 #
 # Prefer libedit
 #
-# In GPDB we want the default to be yes, because we don't want to link with GPL code.
-#
 
 
 
@@ -7822,7 +7820,7 @@ if test "${with_libedit_preferred+set}" = set; then :
   esac
 
 else
-  with_libedit_preferred=yes
+  with_libedit_preferred=no
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -999,10 +999,8 @@ fi
 #
 # Prefer libedit
 #
-# In GPDB we want the default to be yes, because we don't want to link with GPL code.
-#
-PGAC_ARG_BOOL(with, libedit-preferred, yes,
-              [do not prefer BSD Libedit over GNU Readline])
+PGAC_ARG_BOOL(with, libedit-preferred, no,
+              [prefer BSD Libedit over GNU Readline])
 
 
 #


### PR DESCRIPTION
Otherwise it is necessary to always pass the flag set to 'no' for the package
builds. This commit completes <3827c3a6ff2> regarding tab completion.

Reported-by: Bradford D. Boyle <bboyle@pivotal.io>
