### PR TITLE
Reset GPDB_EXTRA_COL() markings between DATA lines.

### DIFF
--- a/src/backend/catalog/Catalog.pm
+++ b/src/backend/catalog/Catalog.pm
@@ -92,6 +92,8 @@ sub Catalogs
 				my $bki_values = $3;
 				$bki_values = ProcessDataLine(\%catalog, $bki_values, \%coldefaults, \%extra_values);
 
+				undef %extra_values;
+
 				push @{ $catalog{data} }, { oid => $2, bki_values => $bki_values };
 			}
 			elsif (/^DESCR\(\"(.*)\"\)$/)

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301908261
+#define CATALOG_VERSION_NO	301909301
 
 #endif


### PR DESCRIPTION
GPDB_EXTRA_COL() is only supposed to affect the next DATA line. But we
failed reset it between DATA lines, so the setting stayed in effect for
all the subsequent lines, too.

This is relatively harmless, because it's mostly only used for the
prodataaccess column, which is ignored by the system anyway. The only
other place where it was used was to set proexeclocation for
pg_event_trigger_dropped_objects(), which also happened to do little damage
to the subsequent lines because all the subsequent lines include the
GPDB-specific columns, which overrode the bogus GPDB_EXTRA_COL() setting.

This was broken in 6X_STABLE, but it's too late to change the catalogs
there.
