### PR TITLE
Fix warning message for file permission check

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1125,8 +1125,8 @@ CHK_GPDB_ID () {
 		elif [ x$GPDB_GROUPID_CHK == x$MASTER_INITDB_GROUPID ] && [ x"x" == x"$GROUP_EXECUTE" ] ; then
 		    LOG_MSG "[INFO]:-Current group id of $GPDB_GROUPID, matches initdb group id of $MASTER_INITDB_GROUPID"
 		else
-			LOG_MSG "[WARN]:-File permission mismatch.  The $GPDB_ID_CHK owns the Greenplum Database installation directory."
-			LOG_MSG "[WARN]:-You are currently logged in as $MASTER_INITDB_ID and may not have sufficient"
+			LOG_MSG "[WARN]:-File permission mismatch.  The $MASTER_INITDB_ID owns the Greenplum Database installation directory."
+			LOG_MSG "[WARN]:-You are currently logged in as $GPDB_ID and may not have sufficient"
 			LOG_MSG "[WARN]:-permissions to run the Greenplum binaries and management utilities."
 		fi
 


### PR DESCRIPTION
As was originally surfaced in this issue #665[1], the error message is
wrong when the user that owns Greenplum installation is not the user
that is running a command, e.g., gpinitsystem.

With this commit, we switch the order of GPDB user and the owner
of Greenplum installation, and stop abbreviating owner username in
warning message.

[1] https://github.com/greenplum-db/gpdb/issues/665

Co-authored-by: Oliver Albertini <oalbertini@pivotal.io>
Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>

