### PR TITLE
Test an administrator can upgrade partitioned heap table.

### DIFF
--- a/contrib/pg_upgrade/test/integration/Makefile
+++ b/contrib/pg_upgrade/test/integration/Makefile
@@ -51,8 +51,10 @@ test_dependencies = bdd-library/upgrade-bdd.o \
 	$(scenario_objs) \
 	$(CMOCKERY_OBJS)
 
+debugging_flags = -Og -g
+
 greenplum_five_to_greenplum_six_upgrade_test_suite.t: greenplum_five_to_greenplum_six_upgrade_test_suite.o $(test_dependencies)
-	$(CC) $(CFLAGS) $^ $(libpq_pgport) $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(debugging_flags) $^ $(libpq_pgport) $(LDFLAGS) -o $@
 
 clean:
 	rm -f $(OBJS) $(EXS)

--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -5,6 +5,7 @@
 #include "cmockery.h"
 
 #include "scenarios/heap_table.h"
+#include "scenarios/subpartitioned_heap_table.h"
 #include "scenarios/ao_table.h"
 #include "scenarios/aocs_table.h"
 
@@ -36,6 +37,7 @@ main(int argc, char *argv[])
 		unit_test_setup_teardown(test_an_ao_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_an_aocs_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_heap_table_with_data_can_be_upgraded, setup, teardown),
+		unit_test_setup_teardown(test_a_subpartitioned_heap_table_with_data_can_be_upgraded, setup, teardown),
 	};
 
 	return run_tests(tests);

--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -13,12 +13,16 @@
 #include "utilities/gpdb6-cluster.h"
 
 #include "utilities/test-helpers.h"
+#include "utilities/row-assertions.h"
 
 static void
 setup(void **state)
 {
 	resetGpdbFiveDataDirectories();
 	resetGpdbSixDataDirectories();
+
+	matcher = NULL;
+	match_failed = NULL;
 }
 
 static void

--- a/contrib/pg_upgrade/test/integration/scenarios/heap_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/heap_table.c
@@ -80,7 +80,9 @@ extract_user_rows(PGresult *result, Rows *rows)
 		user->id = atoi(PQgetvalue(result, i, i_id));
 		user->name = PQgetvalue(result, i, i_name);
 	}
+
 	rows->size = number_of_rows;
+
 }
 
 static void

--- a/contrib/pg_upgrade/test/integration/scenarios/subpartitioned_heap_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/subpartitioned_heap_table.c
@@ -1,0 +1,162 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "cmockery.h"
+#include "libpq-fe.h"
+
+#include "bdd-library/bdd.h"
+
+#include "utilities/upgrade-helpers.h"
+#include "utilities/test-helpers.h"
+#include "utilities/query-helpers.h"
+
+#include "subpartitioned_heap_table.h"
+
+typedef struct UserData
+{
+	int id;
+	int age;
+} User;
+
+typedef struct RowsData
+{
+	int  size;
+	User *users[10];
+} Rows;
+
+static Rows *
+extract_rows(PGresult *result)
+{
+	int number_of_rows = PQntuples(result);
+
+	Rows *rows = calloc(1, sizeof(Rows));
+
+	int id_column_index  = PQfnumber(result, "id");
+	int age_column_index = PQfnumber(result, "age");
+
+	for (int i = 0; i < number_of_rows; i++)
+	{
+		User *user = calloc(1, sizeof(User));
+		user->id  = atoi(PQgetvalue(result, i, id_column_index));
+		user->age = atoi(PQgetvalue(result, i, age_column_index));
+
+		rows->users[i] = user;
+	}
+
+	rows->size = number_of_rows;
+
+	return rows;
+}
+
+static Rows *
+queryForRows(char *queryString)
+{
+	PGconn *connection = connectToSix();
+	executeQuery(connection, "set search_path to 'five_to_six_upgrade';");
+	PGresult *result = executeQuery(connection, queryString);
+
+	Rows *rows = extract_rows(result);
+	PQfinish(connection);
+
+	return rows;
+}
+
+static bool
+users_match(User *first_user, User *second_user)
+{
+	return first_user->age == second_user->age &&
+		first_user->id == second_user->id;
+}
+
+static bool
+row_in(User *expected_user, Rows *actual_rows)
+{
+	for (int i = 0; i < actual_rows->size; i++)
+	{
+		User *current_user = actual_rows->users[i];
+
+		if (users_match(current_user, expected_user))
+			return true;
+	}
+
+	return false;
+}
+
+static void
+assert_row_in(User *expected_user, Rows *actual_rows)
+{
+	bool found = row_in(expected_user, actual_rows);
+
+	if (!found)
+		printf("==============> expected {.id=%d, .age=%d} to be in actual rows\n",
+			expected_user->id,
+			expected_user->age);
+
+	assert_true(found);
+}
+
+static void
+assert_rows(Rows *actual_rows, Rows expected_rows)
+{
+	for (int i = 0; i < expected_rows.size; i++)
+		assert_row_in(expected_rows.users[i], actual_rows);
+}
+
+static void
+aSubpartitionedHeapTableHasDataInAGpdbFiveCluster(void)
+{
+	PGconn *connection = connectToFive();
+
+	executeQuery(connection, "create schema five_to_six_upgrade;");
+	executeQuery(connection, "set search_path to 'five_to_six_upgrade';");
+	executeQuery(connection, "create table users (id int, age int) distributed by (id) partition by range (id) subpartition by range (age) (partition partition_id start(1) end(3) ( subpartition subpartition_age_first start(1) end(20), subpartition subpartition_age_second start(20) end(30) ))");
+	executeQuery(connection, "insert into users (id, age) values (1, 10), (2, 20)");
+	executeQuery(connection, "vacuum freeze;");
+
+	PQfinish(connection);
+}
+
+static void
+anAdministratorPerformsAnUpgrade(void)
+{
+	performUpgrade();
+}
+
+static void
+theSubpartitionShouldExistWithDataInTheGpdbSixCluster(void)
+{
+	Rows *rows_in_partition_a = queryForRows("select id, age from users_1_prt_partition_id_2_prt_subpartition_age_first");
+	Rows *rows_in_partition_b = queryForRows("select id, age from users_1_prt_partition_id_2_prt_subpartition_age_second");
+
+	User expected_user = {.id = 1, .age = 10};
+	User other_expected_user = {.id = 2, .age = 20};
+
+	assert_rows(rows_in_partition_a, (Rows) {
+		.size = 1,
+		.users = {&expected_user}
+	});
+
+	assert_rows(rows_in_partition_b, (Rows) {
+		.size = 1,
+		.users = {&other_expected_user}
+	});
+
+	Rows *all_rows = queryForRows("select id, age from users;");
+
+	assert_rows(all_rows, (Rows) {
+		.size = 2,
+		.users = {&expected_user, &other_expected_user}
+	});
+}
+
+void
+test_a_subpartitioned_heap_table_with_data_can_be_upgraded(void **state)
+{
+	given(aSubpartitionedHeapTableHasDataInAGpdbFiveCluster);
+	when(anAdministratorPerformsAnUpgrade);
+	then(theSubpartitionShouldExistWithDataInTheGpdbSixCluster);
+}

--- a/contrib/pg_upgrade/test/integration/scenarios/subpartitioned_heap_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/subpartitioned_heap_table.c
@@ -13,8 +13,10 @@
 #include "utilities/upgrade-helpers.h"
 #include "utilities/test-helpers.h"
 #include "utilities/query-helpers.h"
+#include "utilities/row-assertions.h"
 
 #include "subpartitioned_heap_table.h"
+
 
 typedef struct UserData
 {
@@ -22,11 +24,6 @@ typedef struct UserData
 	int age;
 } User;
 
-typedef struct RowsData
-{
-	int  size;
-	User *users[10];
-} Rows;
 
 static Rows *
 extract_rows(PGresult *result)
@@ -44,7 +41,7 @@ extract_rows(PGresult *result)
 		user->id  = atoi(PQgetvalue(result, i, id_column_index));
 		user->age = atoi(PQgetvalue(result, i, age_column_index));
 
-		rows->users[i] = user;
+		rows->rows[i] = user;
 	}
 
 	rows->size = number_of_rows;
@@ -66,45 +63,25 @@ queryForRows(char *queryString)
 }
 
 static bool
-users_match(User *first_user, User *second_user)
+users_match(void *expected, void *actual)
 {
+	User *first_user = (User *) expected;
+	User *second_user = (User *) actual;
+	
 	return first_user->age == second_user->age &&
 		first_user->id == second_user->id;
 }
 
-static bool
-row_in(User *expected_user, Rows *actual_rows)
+static void match_failed_for_user(void *expected_row)
 {
-	for (int i = 0; i < actual_rows->size; i++)
-	{
-		User *current_user = actual_rows->users[i];
+	User *expected_user = (User*) expected_row;
 
-		if (users_match(current_user, expected_user))
-			return true;
-	}
-
-	return false;
+	printf("==============> expected {.id=%d, .age=%d} to be in actual rows\n",
+	       expected_user->id,
+	       expected_user->age);
 }
 
-static void
-assert_row_in(User *expected_user, Rows *actual_rows)
-{
-	bool found = row_in(expected_user, actual_rows);
 
-	if (!found)
-		printf("==============> expected {.id=%d, .age=%d} to be in actual rows\n",
-			expected_user->id,
-			expected_user->age);
-
-	assert_true(found);
-}
-
-static void
-assert_rows(Rows *actual_rows, Rows expected_rows)
-{
-	for (int i = 0; i < expected_rows.size; i++)
-		assert_row_in(expected_rows.users[i], actual_rows);
-}
 
 static void
 aSubpartitionedHeapTableHasDataInAGpdbFiveCluster(void)
@@ -129,6 +106,9 @@ anAdministratorPerformsAnUpgrade(void)
 static void
 theSubpartitionShouldExistWithDataInTheGpdbSixCluster(void)
 {
+	matcher = users_match;
+	match_failed = match_failed_for_user;
+
 	Rows *rows_in_partition_a = queryForRows("select id, age from users_1_prt_partition_id_2_prt_subpartition_age_first");
 	Rows *rows_in_partition_b = queryForRows("select id, age from users_1_prt_partition_id_2_prt_subpartition_age_second");
 
@@ -137,19 +117,19 @@ theSubpartitionShouldExistWithDataInTheGpdbSixCluster(void)
 
 	assert_rows(rows_in_partition_a, (Rows) {
 		.size = 1,
-		.users = {&expected_user}
+		.rows = {&expected_user}
 	});
 
 	assert_rows(rows_in_partition_b, (Rows) {
 		.size = 1,
-		.users = {&other_expected_user}
+		.rows = {&other_expected_user}
 	});
 
 	Rows *all_rows = queryForRows("select id, age from users;");
 
 	assert_rows(all_rows, (Rows) {
 		.size = 2,
-		.users = {&expected_user, &other_expected_user}
+		.rows = {&expected_user, &other_expected_user}
 	});
 }
 

--- a/contrib/pg_upgrade/test/integration/scenarios/subpartitioned_heap_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/subpartitioned_heap_table.h
@@ -1,0 +1,1 @@
+void test_a_subpartitioned_heap_table_with_data_can_be_upgraded(void **state);

--- a/contrib/pg_upgrade/test/integration/scripts/reset-gpdb5-cluster.bash
+++ b/contrib/pg_upgrade/test/integration/scripts/reset-gpdb5-cluster.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+rsync -a --delete ./gpdb5-data-copy/ ./gpdb5-data

--- a/contrib/pg_upgrade/test/integration/utilities/gpdb5-cluster.c
+++ b/contrib/pg_upgrade/test/integration/utilities/gpdb5-cluster.c
@@ -9,7 +9,7 @@ startGpdbFiveCluster(void)
 		   ". $PWD/gpdb5/greenplum_path.sh; "
 		   "export PGPORT=50000; "
 		   "export MASTER_DATA_DIRECTORY=$PWD/gpdb5-data/qddir/demoDataDir-1; "
-		   "$PWD/gpdb5/bin/gpstart -a"
+		   "$PWD/gpdb5/bin/gpstart -a --skip_standby_check --no_standby"
 		);
 }
 

--- a/contrib/pg_upgrade/test/integration/utilities/gpdb6-cluster.c
+++ b/contrib/pg_upgrade/test/integration/utilities/gpdb6-cluster.c
@@ -9,7 +9,7 @@ startGpdbSixCluster(void)
 		   ". ./gpdb6/greenplum_path.sh; "
 		   "export PGPORT=60000; "
 		   "export MASTER_DATA_DIRECTORY=./gpdb6-data/qddir/demoDataDir-1; "
-		   "./gpdb6/bin/gpstart -a"
+		   "./gpdb6/bin/gpstart -a --skip_standby_check --no_standby"
 		);
 }
 

--- a/contrib/pg_upgrade/test/integration/utilities/row-assertions.c
+++ b/contrib/pg_upgrade/test/integration/utilities/row-assertions.c
@@ -1,0 +1,50 @@
+#include "stdbool.h"
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdio.h>
+
+#include "cmockery.h"
+#include "row-assertions.h"
+
+bool (*matcher)(void *expected, void*actual);
+void (*match_failed)(void *expected);
+
+static bool
+row_in(void *expected_user, Rows *actual_rows)
+{
+	for (int i = 0; i < actual_rows->size; i++)
+	{
+		void *current_user = actual_rows->rows[i];
+
+		if (matcher(current_user, expected_user))
+			return true;
+	}
+
+	return false;
+}
+
+static void
+assert_row_in(void *expected_row, Rows *actual_rows)
+{
+	bool found = row_in(expected_row, actual_rows);
+
+	if (!found)
+		match_failed(expected_row);
+
+	assert_true(found);
+}
+
+void
+assert_rows(Rows *actual_rows, Rows expected_rows)
+{
+	if (matcher == NULL)
+		printf("expected matcher() function to be configured, was NULL");
+
+	if (match_failed == NULL)
+		printf("expected match_failed() function to be configured, was NULL");
+
+	for (int i = 0; i < expected_rows.size; i++)
+		assert_row_in(expected_rows.rows[i], actual_rows);
+}
+

--- a/contrib/pg_upgrade/test/integration/utilities/row-assertions.h
+++ b/contrib/pg_upgrade/test/integration/utilities/row-assertions.h
@@ -1,0 +1,24 @@
+#ifndef PG_UPGRADE_TEST_UTILITIES_ROW_ASSERTIONS_H
+#define PG_UPGRADE_TEST_UTILITIES_ROW_ASSERTIONS_H
+
+#include "stdbool.h"
+
+
+typedef struct RowsData
+{
+	int  size;
+	void *rows[10];
+} Rows;
+
+/*
+ * Extension points
+ */
+extern bool (*matcher)(void *expected, void*actual);
+extern void (*match_failed)(void *expected);
+
+/* 
+ * Library function
+ */
+extern void assert_rows(Rows *actual_rows, Rows expected_rows);
+
+#endif /* PG_UPGRADE_TEST_UTILITIES_ROW_ASSERTIONS_H */


### PR DESCRIPTION
Adds test for subpartitioned heap table.

- extracts library for making assertions about rows defined as structs. Tests using the library need to define a `matcher()` function and a `match_failed()` function.