### PR TITLE
6X: Avoid index path under correlated subplan if upper-level system table…

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -19,7 +19,6 @@
 
 #include <math.h>
 
-#include "catalog/catalog.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_operator.h"
 #include "foreign/fdwapi.h"
@@ -43,7 +42,6 @@
 #include "rewrite/rewriteManip.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
-#include "utils/syscache.h"
 
 #include "cdb/cdbmutate.h"		/* cdbmutate_warn_ctid_without_segid */
 #include "cdb/cdbpath.h"		/* cdbpath_rows() */
@@ -585,154 +583,6 @@ set_plain_rel_size(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 }
 
 /*
- * is_table_distributed
- *	  Is the table distributed?
- */
-static bool
-is_table_distributed(Oid relid)
-{
-	HeapTuple	gp_policy_tuple;
-
-	gp_policy_tuple = SearchSysCache1(GPPOLICYID, ObjectIdGetDatum(relid));
-	if (HeapTupleIsValid(gp_policy_tuple))
-	{
-		ReleaseSysCache(gp_policy_tuple);
-		return true;
-	}
-
-	return false;
-}
-
-/*
- * maybe_rte_non_distributed
- *	  Is a range table entry non-distributed possibly?
- */
-static bool
-maybe_rte_non_distributed(List *rtable, Index rtindex)
-{
-	RangeTblEntry *rte;
-
-	rte = rt_fetch(rtindex, rtable);
-
-	if (rte->rtekind == RTE_RELATION)
-		return !is_table_distributed(rte->relid);
-
-	/*
-	 * For other rte kind e.g. RTE_SUBQUERY or RTE_FUNCTION, we may
-	 * not be able to know the locus of its path at this moment so
-	 * set it as true.
-	 */
-	return true;
-}
-
-/*
- * maybe_param_non_distributed
- *	  Is a Param related to a non-distributed table possibly?
- */
-static bool
-maybe_param_non_distributed(PlannerInfo *root, Param *param)
-{
-	Index rtindex;
-
-	for (root = root->parent_root; root != NULL; root = root->parent_root)
-	{
-		ListCell *ppl;
-
-		foreach(ppl, root->plan_params)
-		{
-			PlannerParamItem *pitem = (PlannerParamItem *) lfirst(ppl);
-
-			if (pitem->paramId == param->paramid)
-			{
-				if (IsA(pitem->item, Var))
-				{
-					Var *v = (Var *) pitem->item;
-					rtindex = v->varno;
-
-					return maybe_rte_non_distributed(root->parse->rtable, rtindex);
-				}
-				else if (IsA(pitem->item, PlaceHolderVar))
-				{
-					PlaceHolderVar *phv = (PlaceHolderVar *) pitem->item;
-					rtindex = bms_singleton_member(phv->phrels);
-
-					return maybe_rte_non_distributed(root->parse->rtable, rtindex);
-				}
-			}
-		}
-	}
-
-	return false;
-}
-
-/*
- * maybe_contain_non_distributed_param_walker
- *	  Does a Param contain a non-distributed table possibly?
- */
-static bool
-maybe_contain_non_distributed_param_walker(Node *node, void *context)
-{
-	PlannerInfo *root =  (PlannerInfo *) context;
-
-	if (node == NULL)
-		return false;
-
-	if (IsA(node, Param) && maybe_param_non_distributed(root, (Param *) node))
-		return true;
-
-	return expression_tree_walker(node, maybe_contain_non_distributed_param_walker, context);
-}
-
-/*
- * maybe_restrictclauses_include_non_distributed_param
- *	  Does a RestrictInfo list contain param with non distributed table possibly?
- */
-static bool
-maybe_restrictclauses_include_non_distributed_param(PlannerInfo *root, List *clauses)
-{
-	ListCell   *l;
-
-	foreach(l, clauses)
-	{
-		RestrictInfo *c = (RestrictInfo *) lfirst(l);
-		Node *expr;
-
-		expr = (Node *) c->clause;
-
-		if (maybe_contain_non_distributed_param_walker(expr, root))
-			return true;
-	}
-
-	return false;
-}
-
-/*
- * plain_allow_indexpath_under_subplan
- *	  Determine whether create an index path for the RelOptInfo.
- *    TODO: below might have been too ambitious.
- */
-static bool
-plain_allow_indexpath_under_subplan(PlannerInfo *root, RelOptInfo *rel)
-{
-
-	if (!root->is_correlated_subplan)
-		return true;
-
-	if (GpPolicyIsPartitioned(rel->cdbpolicy))
-		return false;
-
-	if (GpPolicyIsReplicated(rel->cdbpolicy))
-	{
-		if (maybe_restrictclauses_include_non_distributed_param(root, rel->baserestrictinfo))
-			return false;
-		if (maybe_restrictclauses_include_non_distributed_param(root, rel->joininfo))
-			return false;
-	}
-
-	return true;
-}
-
-/*
  * set_plain_rel_pathlist
  *	  Build access paths for a plain relation (no subquery, no inheritance)
  */
@@ -790,7 +640,10 @@ set_plain_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			return;
 	}
 
-	if (plain_allow_indexpath_under_subplan(root, rel))
+	/* TODO: this might have been too ambitious of a re-ordering */
+	/* If an indexscan is not allowed, don't bother making paths */
+	if(!(root->is_correlated_subplan &&
+		 (GpPolicyIsPartitioned(rel->cdbpolicy) || GpPolicyIsReplicated(rel->cdbpolicy))))
 	{
 		/* Consider index and bitmap scans */
 		create_index_paths(root, rel);

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -58,6 +58,7 @@ select count(*) from hjtest a1, hjtest a2 where a2.i = least (a1.i,4) and a2.j =
      1
 (1 row)
 
+drop table hjtest;
 --
 -- Test for correct behavior when there is a Merge Join on top of Materialize
 -- on top of a Motion :
@@ -1291,3 +1292,87 @@ on (coalesce(t.id1) = tq_all.id1  and t.id2 = tq_all.id2) ;
 (14 rows)
 
 drop table t_issue_10315;
+--
+-- test in subplan, if one side of a qual is a Param refers to system table
+-- and another side refers to a replicate table, we do not create index plan
+-- in the subplan though this is kind of aggressive (Defintely there exists room
+-- for optimization) but let's make sure the correctness of these cases at first.
+-- https://github.com/greenplum-db/gpdb/issues/8648
+--
+set enable_seqscan = 0;
+create table rep_tbl (tablename text, explanation text) distributed replicated;
+insert into rep_tbl values ('pg_class', 'contains all relations');
+create index on rep_tbl (tablename);
+analyze rep_tbl;
+--- The Var case
+explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using pg_class_relname_nsp_index on pg_catalog.pg_class c  (cost=0.28..10000000201.31 rows=1 width=64)
+   Output: c.relname, (SubPlan 1)
+   Index Cond: (c.relname = 'pg_class'::name)
+   SubPlan 1  (slice0)
+     ->  Result  (cost=10000000000.00..10000000001.02 rows=1 width=23)
+           Output: rep_tbl.explanation
+           Filter: (rep_tbl.tablename = (c.relname)::text)
+           ->  Materialize  (cost=10000000000.00..10000000001.02 rows=1 width=23)
+                 Output: rep_tbl.explanation, rep_tbl.tablename
+                 ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000000001.01 rows=1 width=23)
+                       Output: rep_tbl.explanation, rep_tbl.tablename
+                       ->  Seq Scan on public.rep_tbl  (cost=10000000000.00..10000000001.01 rows=1 width=23)
+                             Output: rep_tbl.explanation, rep_tbl.tablename
+ Optimizer: Postgres query optimizer
+ Settings: enable_mergejoin=on, enable_seqscan=off
+(15 rows)
+
+select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
+ relname  |      explanation       
+----------+------------------------
+ pg_class | contains all relations
+(1 row)
+
+--- The PlaceholderVar case
+explain verbose select t1.relname, ss.x from
+  pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
+  on t1.relname = ss.y
+  where 1 = (select 1 from rep_tbl t3 where ss.y = t3.tablename limit 1);
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=10000000923.23..28100000004904.11 rows=12 width=65)
+   Output: t1.relname, t2.relisshared
+   Hash Cond: (t1.relname = COALESCE(t2.relname, 'dummy'::name))
+   Filter: (1 = (SubPlan 1))
+   ->  Bitmap Heap Scan on pg_catalog.pg_class t1  (cost=815.03..888.12 rows=2809 width=64)
+         Output: t1.relname
+         ->  Bitmap Index Scan on pg_class_relname_nsp_index  (cost=0.00..814.32 rows=937 width=0)
+   ->  Hash  (cost=10000000073.09..10000000073.09 rows=937 width=129)
+         Output: t2.relisshared, t2.relname, (COALESCE(t2.relname, 'dummy'::name))
+         ->  Seq Scan on pg_catalog.pg_class t2  (cost=10000000000.00..10000000073.09 rows=2809 width=129)
+               Output: t2.relisshared, t2.relname, COALESCE(t2.relname, 'dummy'::name)
+   SubPlan 1  (slice0)
+     ->  Limit  (cost=10000000000.00..10000000001.03 rows=1 width=0)
+           Output: "outer".?column?
+           ->  Result  (cost=10000000000.00..10000000001.02 rows=1 width=0)
+                 Output: 1
+                 Filter: (((COALESCE(t2.relname, 'dummy'::name)))::text = t3.tablename)
+                 ->  Materialize  (cost=10000000000.00..10000000001.02 rows=1 width=0)
+                       Output: t3.tablename
+                       ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000000001.01 rows=1 width=0)
+                             Output: t3.tablename
+                             ->  Seq Scan on public.rep_tbl t3  (cost=10000000000.00..10000000001.01 rows=1 width=0)
+                                   Output: t3.tablename
+ Optimizer: Postgres query optimizer
+ Settings: enable_mergejoin=on, enable_seqscan=off
+(25 rows)
+
+select t1.relname, ss.x from
+  pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
+  on t1.relname = ss.y
+  where 1 = (select 1 from rep_tbl t3 where ss.y = t3.tablename limit 1);
+ relname  | x 
+----------+---
+ pg_class | f
+(1 row)
+
+drop table rep_tbl;
+reset enable_seqscan;

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1331,6 +1331,34 @@ select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.rel
  pg_class | contains all relations
 (1 row)
 
+explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from (select oid, relname from pg_class offset 0) c where relname = 'pg_class';
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on c  (cost=10000000000.00..20000000097.20 rows=1 width=64)
+   Output: c.relname, (SubPlan 1)
+   Filter: (c.relname = 'pg_class'::name)
+   ->  Seq Scan on pg_catalog.pg_class  (cost=10000000000.00..10000000064.97 rows=2497 width=68)
+         Output: pg_class.oid, pg_class.relname
+   SubPlan 1  (slice0)
+     ->  Result  (cost=10000000000.00..10000000001.02 rows=1 width=23)
+           Output: rep_tbl.explanation
+           Filter: (rep_tbl.tablename = (c.relname)::text)
+           ->  Materialize  (cost=10000000000.00..10000000001.02 rows=1 width=23)
+                 Output: rep_tbl.explanation, rep_tbl.tablename
+                 ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000000001.01 rows=1 width=23)
+                       Output: rep_tbl.explanation, rep_tbl.tablename
+                       ->  Seq Scan on public.rep_tbl  (cost=10000000000.00..10000000001.01 rows=1 width=23)
+                             Output: rep_tbl.explanation, rep_tbl.tablename
+ Optimizer: Postgres query optimizer
+ Settings: enable_mergejoin=on, enable_seqscan=off
+(17 rows)
+
+select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from (select oid, relname from pg_class offset 0) c where relname = 'pg_class';
+ relname  |      explanation       
+----------+------------------------
+ pg_class | contains all relations
+(1 row)
+
 --- The PlaceholderVar case
 explain verbose select t1.relname, ss.x from
   pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1301,9 +1301,6 @@ drop table t_issue_10315;
 --
 set enable_seqscan = 0;
 create table rep_tbl (tablename text, explanation text) distributed replicated;
-create table dis_tbl (relname text, tablename text, explanation text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'relname' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into rep_tbl values ('pg_class', 'contains all relations');
 create index on rep_tbl (tablename);
 analyze rep_tbl;
@@ -1362,43 +1359,6 @@ select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.rel
  pg_class | contains all relations
 (1 row)
 
--- Simply test that the change does not affect non-system table and non-rep table.
-explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from dis_tbl c where relname = 'pg_class';
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000010476.95 rows=49 width=32)
-   Output: c.relname, ((SubPlan 1))
-   ->  Seq Scan on public.dis_tbl c  (cost=10000000000.00..10000010476.95 rows=17 width=32)
-         Output: c.relname, (SubPlan 1)
-         Filter: (c.relname = 'pg_class'::text)
-         SubPlan 1  (slice1; segments: 1)
-           ->  Index Scan using rep_tbl_tablename_idx on public.rep_tbl  (cost=0.12..200.14 rows=1 width=23)
-                 Output: rep_tbl.explanation
-                 Index Cond: (rep_tbl.tablename = c.relname)
- Optimizer: Postgres query optimizer
- Settings: enable_seqscan=off, optimizer=off
-(11 rows)
-
-explain verbose select c.relname, (select explanation from dis_tbl where dis_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Index Only Scan using pg_class_relname_nsp_index on pg_catalog.pg_class c  (cost=0.27..10000000588.79 rows=1 width=64)
-   Output: c.relname, (SubPlan 1)
-   Index Cond: (c.relname = 'pg_class'::name)
-   SubPlan 1  (slice0)
-     ->  Result  (cost=10000000000.00..10000000488.63 rows=9 width=32)
-           Output: dis_tbl.explanation
-           Filter: (dis_tbl.tablename = (c.relname)::text)
-           ->  Materialize  (cost=10000000000.00..10000000488.63 rows=9 width=32)
-                 Output: dis_tbl.explanation, dis_tbl.tablename
-                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000488.50 rows=26 width=32)
-                       Output: dis_tbl.explanation, dis_tbl.tablename
-                       ->  Seq Scan on public.dis_tbl  (cost=10000000000.00..10000000488.50 rows=9 width=32)
-                             Output: dis_tbl.explanation, dis_tbl.tablename
- Optimizer: Postgres query optimizer
- Settings: enable_seqscan=off, optimizer=off
-(17 rows)
-
 --- The PlaceholderVar case
 explain verbose select t1.relname, ss.x from
   pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
@@ -1443,5 +1403,4 @@ select t1.relname, ss.x from
 (1 row)
 
 drop table rep_tbl;
-drop table dis_tbl;
 reset enable_seqscan;

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1301,6 +1301,9 @@ drop table t_issue_10315;
 --
 set enable_seqscan = 0;
 create table rep_tbl (tablename text, explanation text) distributed replicated;
+create table dis_tbl (relname text, tablename text, explanation text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'relname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into rep_tbl values ('pg_class', 'contains all relations');
 create index on rep_tbl (tablename);
 analyze rep_tbl;
@@ -1359,6 +1362,43 @@ select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.rel
  pg_class | contains all relations
 (1 row)
 
+-- Simply test that the change does not affect non-system table and non-rep table.
+explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from dis_tbl c where relname = 'pg_class';
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000010476.95 rows=49 width=32)
+   Output: c.relname, ((SubPlan 1))
+   ->  Seq Scan on public.dis_tbl c  (cost=10000000000.00..10000010476.95 rows=17 width=32)
+         Output: c.relname, (SubPlan 1)
+         Filter: (c.relname = 'pg_class'::text)
+         SubPlan 1  (slice1; segments: 1)
+           ->  Index Scan using rep_tbl_tablename_idx on public.rep_tbl  (cost=0.12..200.14 rows=1 width=23)
+                 Output: rep_tbl.explanation
+                 Index Cond: (rep_tbl.tablename = c.relname)
+ Optimizer: Postgres query optimizer
+ Settings: enable_seqscan=off, optimizer=off
+(11 rows)
+
+explain verbose select c.relname, (select explanation from dis_tbl where dis_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using pg_class_relname_nsp_index on pg_catalog.pg_class c  (cost=0.27..10000000588.79 rows=1 width=64)
+   Output: c.relname, (SubPlan 1)
+   Index Cond: (c.relname = 'pg_class'::name)
+   SubPlan 1  (slice0)
+     ->  Result  (cost=10000000000.00..10000000488.63 rows=9 width=32)
+           Output: dis_tbl.explanation
+           Filter: (dis_tbl.tablename = (c.relname)::text)
+           ->  Materialize  (cost=10000000000.00..10000000488.63 rows=9 width=32)
+                 Output: dis_tbl.explanation, dis_tbl.tablename
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000488.50 rows=26 width=32)
+                       Output: dis_tbl.explanation, dis_tbl.tablename
+                       ->  Seq Scan on public.dis_tbl  (cost=10000000000.00..10000000488.50 rows=9 width=32)
+                             Output: dis_tbl.explanation, dis_tbl.tablename
+ Optimizer: Postgres query optimizer
+ Settings: enable_seqscan=off, optimizer=off
+(17 rows)
+
 --- The PlaceholderVar case
 explain verbose select t1.relname, ss.x from
   pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
@@ -1403,4 +1443,5 @@ select t1.relname, ss.x from
 (1 row)
 
 drop table rep_tbl;
+drop table dis_tbl;
 reset enable_seqscan;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1347,6 +1347,34 @@ select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.rel
  pg_class | contains all relations
 (1 row)
 
+explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from (select oid, relname from pg_class offset 0) c where relname = 'pg_class';
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on c  (cost=10000000000.00..20000000097.20 rows=1 width=64)
+   Output: c.relname, (SubPlan 1)
+   Filter: (c.relname = 'pg_class'::name)
+   ->  Seq Scan on pg_catalog.pg_class  (cost=10000000000.00..10000000064.97 rows=2497 width=68)
+         Output: pg_class.oid, pg_class.relname
+   SubPlan 1  (slice0)
+     ->  Result  (cost=10000000000.00..10000000001.02 rows=1 width=23)
+           Output: rep_tbl.explanation
+           Filter: (rep_tbl.tablename = (c.relname)::text)
+           ->  Materialize  (cost=10000000000.00..10000000001.02 rows=1 width=23)
+                 Output: rep_tbl.explanation, rep_tbl.tablename
+                 ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000000001.01 rows=1 width=23)
+                       Output: rep_tbl.explanation, rep_tbl.tablename
+                       ->  Seq Scan on public.rep_tbl  (cost=10000000000.00..10000000001.01 rows=1 width=23)
+                             Output: rep_tbl.explanation, rep_tbl.tablename
+ Optimizer: Postgres query optimizer
+ Settings: enable_mergejoin=on, enable_seqscan=off
+(17 rows)
+
+select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from (select oid, relname from pg_class offset 0) c where relname = 'pg_class';
+ relname  |      explanation       
+----------+------------------------
+ pg_class | contains all relations
+(1 row)
+
 --- The PlaceholderVar case
 explain verbose select t1.relname, ss.x from
   pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1317,6 +1317,9 @@ drop table t_issue_10315;
 --
 set enable_seqscan = 0;
 create table rep_tbl (tablename text, explanation text) distributed replicated;
+create table dis_tbl (relname text, relisshared bool, oid oid);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'relname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into rep_tbl values ('pg_class', 'contains all relations');
 create index on rep_tbl (tablename);
 analyze rep_tbl;
@@ -1375,6 +1378,48 @@ select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.rel
  pg_class | contains all relations
 (1 row)
 
+-- Simply test that the change does not affect non-system table and non-rep table.
+explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from dis_tbl c where relname = 'pg_class';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..888866.34 rows=1 width=16)
+   Output: dis_tbl.relname, ((SubPlan 1))
+   ->  Result  (cost=0.00..888866.34 rows=1 width=16)
+         Output: dis_tbl.relname, (SubPlan 1)
+         ->  Seq Scan on public.dis_tbl  (cost=0.00..888866.34 rows=334 width=16)
+               Output: dis_tbl.relname
+               Filter: (dis_tbl.relname = 'pg_class'::text)
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result  (cost=0.00..6.00 rows=1 width=23)
+                 Output: rep_tbl.explanation
+                 ->  Index Scan using rep_tbl_tablename_idx on public.rep_tbl  (cost=0.00..6.00 rows=1 width=23)
+                       Output: rep_tbl.tablename, rep_tbl.explanation
+                       Index Cond: (rep_tbl.tablename = 'pg_class'::text)
+                       Filter: (rep_tbl.tablename = dis_tbl.relname)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_seqscan=off
+(16 rows)
+
+explain verbose select c.relname, (select explanation from dis_tbl where dis_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using pg_class_relname_nsp_index on pg_catalog.pg_class c  (cost=0.27..10000000588.79 rows=1 width=64)
+   Output: c.relname, (SubPlan 1)
+   Index Cond: (c.relname = 'pg_class'::name)
+   SubPlan 1  (slice0)
+     ->  Result  (cost=10000000000.00..10000000488.63 rows=9 width=32)
+           Output: dis_tbl.explanation
+           Filter: (dis_tbl.tablename = (c.relname)::text)
+           ->  Materialize  (cost=10000000000.00..10000000488.63 rows=9 width=32)
+                 Output: dis_tbl.explanation, dis_tbl.tablename
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000488.50 rows=26 width=32)
+                       Output: dis_tbl.explanation, dis_tbl.tablename
+                       ->  Seq Scan on public.dis_tbl  (cost=10000000000.00..10000000488.50 rows=9 width=32)
+                             Output: dis_tbl.explanation, dis_tbl.tablename
+ Optimizer: Postgres query optimizer
+ Settings: enable_seqscan=off
+(16 rows)
+
 --- The PlaceholderVar case
 explain verbose select t1.relname, ss.x from
   pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
@@ -1419,4 +1464,5 @@ select t1.relname, ss.x from
 (1 row)
 
 drop table rep_tbl;
+drop table dis_tbl;
 reset enable_seqscan;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1317,9 +1317,6 @@ drop table t_issue_10315;
 --
 set enable_seqscan = 0;
 create table rep_tbl (tablename text, explanation text) distributed replicated;
-create table dis_tbl (relname text, relisshared bool, oid oid);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'relname' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into rep_tbl values ('pg_class', 'contains all relations');
 create index on rep_tbl (tablename);
 analyze rep_tbl;
@@ -1378,48 +1375,6 @@ select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.rel
  pg_class | contains all relations
 (1 row)
 
--- Simply test that the change does not affect non-system table and non-rep table.
-explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from dis_tbl c where relname = 'pg_class';
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..888866.34 rows=1 width=16)
-   Output: dis_tbl.relname, ((SubPlan 1))
-   ->  Result  (cost=0.00..888866.34 rows=1 width=16)
-         Output: dis_tbl.relname, (SubPlan 1)
-         ->  Seq Scan on public.dis_tbl  (cost=0.00..888866.34 rows=334 width=16)
-               Output: dis_tbl.relname
-               Filter: (dis_tbl.relname = 'pg_class'::text)
-         SubPlan 1  (slice1; segments: 3)
-           ->  Result  (cost=0.00..6.00 rows=1 width=23)
-                 Output: rep_tbl.explanation
-                 ->  Index Scan using rep_tbl_tablename_idx on public.rep_tbl  (cost=0.00..6.00 rows=1 width=23)
-                       Output: rep_tbl.tablename, rep_tbl.explanation
-                       Index Cond: (rep_tbl.tablename = 'pg_class'::text)
-                       Filter: (rep_tbl.tablename = dis_tbl.relname)
- Optimizer: Pivotal Optimizer (GPORCA)
- Settings: enable_seqscan=off
-(16 rows)
-
-explain verbose select c.relname, (select explanation from dis_tbl where dis_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Index Only Scan using pg_class_relname_nsp_index on pg_catalog.pg_class c  (cost=0.27..10000000588.79 rows=1 width=64)
-   Output: c.relname, (SubPlan 1)
-   Index Cond: (c.relname = 'pg_class'::name)
-   SubPlan 1  (slice0)
-     ->  Result  (cost=10000000000.00..10000000488.63 rows=9 width=32)
-           Output: dis_tbl.explanation
-           Filter: (dis_tbl.tablename = (c.relname)::text)
-           ->  Materialize  (cost=10000000000.00..10000000488.63 rows=9 width=32)
-                 Output: dis_tbl.explanation, dis_tbl.tablename
-                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000488.50 rows=26 width=32)
-                       Output: dis_tbl.explanation, dis_tbl.tablename
-                       ->  Seq Scan on public.dis_tbl  (cost=10000000000.00..10000000488.50 rows=9 width=32)
-                             Output: dis_tbl.explanation, dis_tbl.tablename
- Optimizer: Postgres query optimizer
- Settings: enable_seqscan=off
-(16 rows)
-
 --- The PlaceholderVar case
 explain verbose select t1.relname, ss.x from
   pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
@@ -1464,5 +1419,4 @@ select t1.relname, ss.x from
 (1 row)
 
 drop table rep_tbl;
-drop table dis_tbl;
 reset enable_seqscan;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -58,6 +58,7 @@ select count(*) from hjtest a1, hjtest a2 where a2.i = least (a1.i,4) and a2.j =
      1
 (1 row)
 
+drop table hjtest;
 --
 -- Test for correct behavior when there is a Merge Join on top of Materialize
 -- on top of a Motion :
@@ -1307,3 +1308,87 @@ on (coalesce(t.id1) = tq_all.id1  and t.id2 = tq_all.id2) ;
 (14 rows)
 
 drop table t_issue_10315;
+--
+-- test in subplan, if one side of a qual is a Param refers to system table
+-- and another side refers to a replicate table, we do not create index plan
+-- in the subplan though this is kind of aggressive (Defintely there exists room
+-- for optimization) but let's make sure the correctness of these cases at first.
+-- https://github.com/greenplum-db/gpdb/issues/8648
+--
+set enable_seqscan = 0;
+create table rep_tbl (tablename text, explanation text) distributed replicated;
+insert into rep_tbl values ('pg_class', 'contains all relations');
+create index on rep_tbl (tablename);
+analyze rep_tbl;
+--- The Var case
+explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using pg_class_relname_nsp_index on pg_catalog.pg_class c  (cost=0.28..10000000201.31 rows=1 width=64)
+   Output: c.relname, (SubPlan 1)
+   Index Cond: (c.relname = 'pg_class'::name)
+   SubPlan 1  (slice0)
+     ->  Result  (cost=10000000000.00..10000000001.02 rows=1 width=23)
+           Output: rep_tbl.explanation
+           Filter: (rep_tbl.tablename = (c.relname)::text)
+           ->  Materialize  (cost=10000000000.00..10000000001.02 rows=1 width=23)
+                 Output: rep_tbl.explanation, rep_tbl.tablename
+                 ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000000001.01 rows=1 width=23)
+                       Output: rep_tbl.explanation, rep_tbl.tablename
+                       ->  Seq Scan on public.rep_tbl  (cost=10000000000.00..10000000001.01 rows=1 width=23)
+                             Output: rep_tbl.explanation, rep_tbl.tablename
+ Optimizer: Postgres query optimizer
+ Settings: enable_mergejoin=on, enable_seqscan=off
+(15 rows)
+
+select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
+ relname  |      explanation       
+----------+------------------------
+ pg_class | contains all relations
+(1 row)
+
+--- The PlaceholderVar case
+explain verbose select t1.relname, ss.x from
+  pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
+  on t1.relname = ss.y
+  where 1 = (select 1 from rep_tbl t3 where ss.y = t3.tablename limit 1);
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=10000000806.85..24360000004143.87 rows=12 width=65)
+   Output: t1.relname, t2.relisshared
+   Hash Cond: (t1.relname = COALESCE(t2.relname, 'dummy'::name))
+   Filter: (1 = (SubPlan 1))
+   ->  Bitmap Heap Scan on pg_catalog.pg_class t1  (cost=713.06..776.41 rows=2435 width=64)
+         Output: t1.relname
+         ->  Bitmap Index Scan on pg_class_relname_nsp_index  (cost=0.00..712.45 rows=812 width=0)
+   ->  Hash  (cost=10000000063.35..10000000063.35 rows=812 width=129)
+         Output: t2.relisshared, t2.relname, (COALESCE(t2.relname, 'dummy'::name))
+         ->  Seq Scan on pg_catalog.pg_class t2  (cost=10000000000.00..10000000063.35 rows=2435 width=129)
+               Output: t2.relisshared, t2.relname, COALESCE(t2.relname, 'dummy'::name)
+   SubPlan 1  (slice0)
+     ->  Limit  (cost=10000000000.00..10000000001.03 rows=1 width=0)
+           Output: "outer".?column?
+           ->  Result  (cost=10000000000.00..10000000001.02 rows=1 width=0)
+                 Output: 1
+                 Filter: (((COALESCE(t2.relname, 'dummy'::name)))::text = t3.tablename)
+                 ->  Materialize  (cost=10000000000.00..10000000001.02 rows=1 width=0)
+                       Output: t3.tablename
+                       ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000000001.01 rows=1 width=0)
+                             Output: t3.tablename
+                             ->  Seq Scan on public.rep_tbl t3  (cost=10000000000.00..10000000001.01 rows=1 width=0)
+                                   Output: t3.tablename
+ Optimizer: Postgres query optimizer
+ Settings: enable_mergejoin=on, enable_seqscan=off
+(25 rows)
+
+select t1.relname, ss.x from
+  pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
+  on t1.relname = ss.y
+  where 1 = (select 1 from rep_tbl t3 where ss.y = t3.tablename limit 1);
+ relname  | x 
+----------+---
+ pg_class | f
+(1 row)
+
+drop table rep_tbl;
+reset enable_seqscan;

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -33,6 +33,8 @@ insert into hjtest values(3, 4);
 
 select count(*) from hjtest a1, hjtest a2 where a2.i = least (a1.i,4) and a2.j = 4;
 
+drop table hjtest;
+
 --
 -- Test for correct behavior when there is a Merge Join on top of Materialize
 -- on top of a Motion :
@@ -632,3 +634,34 @@ full join ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) tq_
 on (coalesce(t.id1) = tq_all.id1  and t.id2 = tq_all.id2) ;
 
 drop table t_issue_10315;
+
+--
+-- test in subplan, if one side of a qual is a Param refers to system table
+-- and another side refers to a replicate table, we do not create index plan
+-- in the subplan though this is kind of aggressive (Defintely there exists room
+-- for optimization) but let's make sure the correctness of these cases at first.
+-- https://github.com/greenplum-db/gpdb/issues/8648
+--
+set enable_seqscan = 0;
+
+create table rep_tbl (tablename text, explanation text) distributed replicated;
+insert into rep_tbl values ('pg_class', 'contains all relations');
+create index on rep_tbl (tablename);
+analyze rep_tbl;
+
+--- The Var case
+explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
+select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
+
+--- The PlaceholderVar case
+explain verbose select t1.relname, ss.x from
+  pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
+  on t1.relname = ss.y
+  where 1 = (select 1 from rep_tbl t3 where ss.y = t3.tablename limit 1);
+select t1.relname, ss.x from
+  pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
+  on t1.relname = ss.y
+  where 1 = (select 1 from rep_tbl t3 where ss.y = t3.tablename limit 1);
+
+drop table rep_tbl;
+reset enable_seqscan;

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -645,23 +645,17 @@ drop table t_issue_10315;
 set enable_seqscan = 0;
 
 create table rep_tbl (tablename text, explanation text) distributed replicated;
-create table dis_tbl (relname text, tablename text, explanation text);
 insert into rep_tbl values ('pg_class', 'contains all relations');
 create index on rep_tbl (tablename);
 analyze rep_tbl;
 
 --- The Var case
-
 explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
 select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
 explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from (select oid, relname from pg_class offset 0) c where relname = 'pg_class';
 select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from (select oid, relname from pg_class offset 0) c where relname = 'pg_class';
--- Simply test that the change does not affect non-system table and non-rep table.
-explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from dis_tbl c where relname = 'pg_class';
-explain verbose select c.relname, (select explanation from dis_tbl where dis_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
 
 --- The PlaceholderVar case
-
 explain verbose select t1.relname, ss.x from
   pg_class t1 left join (select relisshared as x, coalesce(t2.relname, 'dummy') y from pg_class t2) ss
   on t1.relname = ss.y
@@ -672,5 +666,4 @@ select t1.relname, ss.x from
   where 1 = (select 1 from rep_tbl t3 where ss.y = t3.tablename limit 1);
 
 drop table rep_tbl;
-drop table dis_tbl;
 reset enable_seqscan;

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -652,6 +652,8 @@ analyze rep_tbl;
 --- The Var case
 explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
 select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from pg_class c where relname = 'pg_class';
+explain verbose select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from (select oid, relname from pg_class offset 0) c where relname = 'pg_class';
+select c.relname, (select explanation from rep_tbl where rep_tbl.tablename=c.relname ) from (select oid, relname from pg_class offset 0) c where relname = 'pg_class';
 
 --- The PlaceholderVar case
 explain verbose select t1.relname, ss.x from


### PR DESCRIPTION
… parameter and replicate table are involved.

For correlated subplan, if upper-level system table parameter and replicate
table are involved, we do not create index plan in the subplan since replicate
table contents are not on QD.

The fix is not perfect and definitely could be improved, but let's make sure the
correctness of those cases at first.  Prevous related code for index path
judgement is not optimal also.  Given there have been a TODO in the code, we do
not add an additional TODO there.

This patch tries to fix https://github.com/greenplum-db/gpdb/issues/8648

Note this is gp6 only since on master it is being addressed in https://github.com/greenplum-db/gpdb/pull/8684