### PR TITLE
gdd: ensure the session orders on segments

### DIFF
--- a/src/test/isolation2/expected/gdd/dist-deadlock-01.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-01.out
@@ -5,6 +5,12 @@ CREATE
 INSERT INTO t01 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 INSERT 100
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/expected/gdd/dist-deadlock-04.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-04.out
@@ -8,6 +8,12 @@ INSERT 100
 DROP TABLE IF EXISTS t04b;
 DROP
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/expected/gdd/dist-deadlock-05.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-05.out
@@ -3,6 +3,12 @@ DROP
 CREATE TABLE t05 (id int primary key);
 CREATE
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/expected/gdd/dist-deadlock-06.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-06.out
@@ -5,6 +5,12 @@ CREATE
 INSERT INTO t06 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 INSERT 100
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/expected/gdd/dist-deadlock-07.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-07.out
@@ -11,6 +11,16 @@ INSERT 100
 INSERT INTO t07b (c1, c2) SELECT i, i FROM generate_series(1, 100) i;
 INSERT 100
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+30: RESET optimizer;
+RESET
+40: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/expected/gdd/dist-deadlock-102.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-102.out
@@ -5,6 +5,14 @@ CREATE
 INSERT INTO t102 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 INSERT 100
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+30: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/expected/gdd/dist-deadlock-103.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-103.out
@@ -5,6 +5,14 @@ CREATE
 INSERT INTO t103 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 INSERT 100
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+30: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/expected/gdd/dist-deadlock-104.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-104.out
@@ -5,6 +5,18 @@ CREATE
 INSERT INTO t104 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 INSERT 100
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+30: RESET optimizer;
+RESET
+40: RESET optimizer;
+RESET
+50: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/expected/gdd/dist-deadlock-106.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-106.out
@@ -5,6 +5,14 @@ CREATE
 INSERT INTO t106 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 INSERT 100
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+30: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/expected/gdd/local-deadlock-03.out
+++ b/src/test/isolation2/expected/gdd/local-deadlock-03.out
@@ -24,6 +24,14 @@ CREATE
 INSERT INTO t03 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 INSERT 100
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+30: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;
@@ -47,18 +55,19 @@ UPDATE 1
 -- seg 1: con30 ==> con10, xid lock
 30>: UPDATE t03 SET val=val WHERE id=segid(1,2);  <waiting ...>
 
--- con20 will be cancelled by local deadlock detector or gdd
+-- a local deadlock between con10 & con30 is formed on seg1,
+-- con10 will be cancelled by local deadlock detector.
+-- note, we must join c20 before c10, otherwise the test will run into infinite
+-- waiting if the local deadlock detector cancels c30 instead of c10.
 30<:  <... completed>
 UPDATE 1
 30q: ... <quitting>
-
--- no more deadlock
+20<:  <... completed>
+FAILED:  Execution failed
+20q: ... <quitting>
 10<:  <... completed>
 ERROR:  deadlock detected  (seg1 127.0.1.1:25433 pid=29851)
 DETAIL:  Process 29851 waits for ShareLock on transaction 1009; blocked by process 29968.
 Process 29968 waits for ShareLock on transaction 1008; blocked by process 29851.
 HINT:  See server log for query details.
 10q: ... <quitting>
-20<:  <... completed>
-FAILED:  Execution failed
-20q: ... <quitting>

--- a/src/test/isolation2/expected/gdd/non-lock-105.out
+++ b/src/test/isolation2/expected/gdd/non-lock-105.out
@@ -5,6 +5,14 @@ CREATE
 INSERT INTO t105 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 INSERT 100
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+30: RESET optimizer;
+RESET
+
 10: BEGIN;
 BEGIN
 20: BEGIN;

--- a/src/test/isolation2/sql/gdd/dist-deadlock-01.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-01.sql
@@ -2,6 +2,10 @@ DROP TABLE IF EXISTS t01;
 CREATE TABLE t01 (id int, val int);
 INSERT INTO t01 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 

--- a/src/test/isolation2/sql/gdd/dist-deadlock-04.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-04.sql
@@ -4,6 +4,10 @@ INSERT INTO t04a (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
 DROP TABLE IF EXISTS t04b;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 

--- a/src/test/isolation2/sql/gdd/dist-deadlock-05.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-05.sql
@@ -1,6 +1,10 @@
 DROP TABLE IF EXISTS t05;
 CREATE TABLE t05 (id int primary key);
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 

--- a/src/test/isolation2/sql/gdd/dist-deadlock-06.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-06.sql
@@ -2,6 +2,10 @@ DROP TABLE IF EXISTS t06;
 CREATE TABLE t06 (id int, val int);
 INSERT INTO t06 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 

--- a/src/test/isolation2/sql/gdd/dist-deadlock-07.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-07.sql
@@ -5,6 +5,12 @@ CREATE TABLE t07b (c1 int, c2 int);
 INSERT INTO t07a (c1, c2) SELECT i, i FROM generate_series(1, 100) i;
 INSERT INTO t07b (c1, c2) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+30: RESET optimizer;
+40: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 30: BEGIN;

--- a/src/test/isolation2/sql/gdd/dist-deadlock-102.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-102.sql
@@ -2,6 +2,11 @@ DROP TABLE IF EXISTS t102;
 CREATE TABLE t102 (id int, val int);
 INSERT INTO t102 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+30: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 30: BEGIN;

--- a/src/test/isolation2/sql/gdd/dist-deadlock-103.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-103.sql
@@ -2,6 +2,11 @@ DROP TABLE IF EXISTS t103;
 CREATE TABLE t103 (id int, val int);
 INSERT INTO t103 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+30: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 30: BEGIN;

--- a/src/test/isolation2/sql/gdd/dist-deadlock-104.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-104.sql
@@ -2,6 +2,13 @@ DROP TABLE IF EXISTS t104;
 CREATE TABLE t104 (id int, val int);
 INSERT INTO t104 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+30: RESET optimizer;
+40: RESET optimizer;
+50: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 30: BEGIN;

--- a/src/test/isolation2/sql/gdd/dist-deadlock-106.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-106.sql
@@ -2,6 +2,11 @@ DROP TABLE IF EXISTS t106;
 CREATE TABLE t106 (id int, val int);
 INSERT INTO t106 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+30: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 30: BEGIN;

--- a/src/test/isolation2/sql/gdd/local-deadlock-03.sql
+++ b/src/test/isolation2/sql/gdd/local-deadlock-03.sql
@@ -12,6 +12,11 @@ DROP TABLE IF EXISTS t03;
 CREATE TABLE t03 (id int, val int);
 INSERT INTO t03 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+30: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 30: BEGIN;
@@ -29,12 +34,13 @@ INSERT INTO t03 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 -- seg 1: con30 ==> con10, xid lock
 30>: UPDATE t03 SET val=val WHERE id=segid(1,2);
 
--- con20 will be cancelled by local deadlock detector or gdd
+-- a local deadlock between con10 & con30 is formed on seg1,
+-- con10 will be cancelled by local deadlock detector.
+-- note, we must join c20 before c10, otherwise the test will run into infinite
+-- waiting if the local deadlock detector cancels c30 instead of c10.
 30<:
 30q:
-
--- no more deadlock
-10<:
-10q:
 20<:
 20q:
+10<:
+10q:

--- a/src/test/isolation2/sql/gdd/non-lock-105.sql
+++ b/src/test/isolation2/sql/gdd/non-lock-105.sql
@@ -2,6 +2,11 @@ DROP TABLE IF EXISTS t105;
 CREATE TABLE t105 (id int, val int);
 INSERT INTO t105 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+30: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 30: BEGIN;

--- a/src/test/isolation2/sql/gdd/non-lock-107.sql
+++ b/src/test/isolation2/sql/gdd/non-lock-107.sql
@@ -2,6 +2,12 @@ DROP TABLE IF EXISTS t107;
 CREATE TABLE t107 (id int, val int);
 INSERT INTO t107 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+30: RESET optimizer;
+40: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 30: BEGIN;

--- a/src/test/isolation2/sql/gdd/non-lock-108.sql
+++ b/src/test/isolation2/sql/gdd/non-lock-108.sql
@@ -2,6 +2,11 @@ DROP TABLE IF EXISTS t108;
 CREATE TABLE t108 (id int, val int);
 INSERT INTO t108 (id, val) SELECT i, i FROM generate_series(1, 100) i;
 
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+30: RESET optimizer;
+
 10: BEGIN;
 20: BEGIN;
 30: BEGIN;


### PR DESCRIPTION
Session order on segments is important in gdd tests, it determines the
cancellation order on deadlocks.  We used to create a full gang on the
BEGIN command, this was used in gdd tests to control the session orders
on segments.  However this behavior was changed during the optimization
of readonly queries, BEGIN command no longer creates a full gang.

So now we use the `RESET optimizer` command to trigger the gang
creation, we do not really care about the optimizer status although.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
