### PR TITLE
Fix pg_regress arg parsing error

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2625,10 +2625,10 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 		{"load-extension", required_argument, NULL, 22},
 		{"config-auth", required_argument, NULL, 24},
 		{"init-file", required_argument, NULL, 25},
-		{"exclude-tests", required_argument, NULL, 27},
-		{"ignore-plans", no_argument, NULL, 28},
-		{"prehook", required_argument, NULL, 29},
-		{"print-failure-diffs", no_argument, NULL, 30},
+		{"exclude-tests", required_argument, NULL, 26},
+		{"ignore-plans", no_argument, NULL, 27},
+		{"prehook", required_argument, NULL, 28},
+		{"print-failure-diffs", no_argument, NULL, 29},
 		{"tablespace-dir", required_argument, NULL, 80},
 		{NULL, 0, NULL, 0}
 	};


### PR DESCRIPTION
Due to an option index error, exclude-tests, ignore-plans, prehook and
print-failure-diffs are not parsed from command line correctly.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community