### PR TITLE
Allow COPY FROM to catalog tables only with allow_system_table_mods=on

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <catalog/catalog.h>
 
 #include "access/heapam.h"
 #include "access/htup_details.h"
@@ -988,6 +989,17 @@ DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed)
 		/* Open and lock the relation, using the appropriate lock type. */
 		rel = heap_openrv(stmt->relation,
 						  (is_from ? RowExclusiveLock : AccessShareLock));
+
+		if (is_from)
+		{
+			if (!allowSystemTableMods && IsUnderPostmaster && IsSystemRelation(rel))
+			{
+				ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+						errmsg("permission denied: \"%s\" is a system catalog",
+							RelationGetRelationName(rel))));
+			}
+		}
 
 		relid = RelationGetRelid(rel);
 

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1334,11 +1334,16 @@ drop type broken_int4 cascade; -- drops the I/O functions, too.
 -- Test COPY FROM and TO work for catalog tables in dispatch
 -- connection
 BEGIN;
+SET allow_system_table_mods=on;
 COPY gp_configuration_history from stdin with delimiter '|';
 1900-01-01 00:00:00.000000-07|12345|Just testing COPY
 \.
 
 COPY (select dbid from gp_configuration_history where dbid=12345) to stdin;
+RESET allow_system_table_mods;
+
+-- cannot copy to a catalog table with allow_system_table_mods=off;
+COPY gp_configuration_history from stdin with delimiter '|';
 ABORT;
 
 -- GPDB makes the database name, and many other things, available

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1615,6 +1615,7 @@ RESET allow_system_table_mods;
 -- cannot copy to a catalog table with allow_system_table_mods=off;
 COPY gp_configuration_history from stdin with delimiter '|';
 ERROR:  permission denied: "gp_configuration_history" is a system catalog
+HINT:  Make sure the configuration parameter allow_system_table_mods is set.
 ABORT;
 -- GPDB makes the database name, and many other things, available
 -- as environment variables to the program. Test those.

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1607,9 +1607,14 @@ drop cascades to function broken_int4out(broken_int4)
 -- Test COPY FROM and TO work for catalog tables in dispatch
 -- connection
 BEGIN;
+SET allow_system_table_mods=on;
 COPY gp_configuration_history from stdin with delimiter '|';
 COPY (select dbid from gp_configuration_history where dbid=12345) to stdin;
 12345
+RESET allow_system_table_mods;
+-- cannot copy to a catalog table with allow_system_table_mods=off;
+COPY gp_configuration_history from stdin with delimiter '|';
+ERROR:  permission denied: "gp_configuration_history" is a system catalog
 ABORT;
 -- GPDB makes the database name, and many other things, available
 -- as environment variables to the program. Test those.


### PR DESCRIPTION
Earlier, COPY <Catalogtable> from <file> was allowed irrespective of the
value of allow_system_table_mods. This commit restricts such statements
only when allow_system_table_mods is set to ON.

Co-Authored-By: Ashwin Agrawal<aagrawal@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
