### PR TITLE
Bump ORCA version to 3.73.0

### DIFF
--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -19,4 +19,4 @@ params:
   BLD_TARGETS:
   OUTPUT_ARTIFACT_DIR: gpdb_artifacts
   CONFIGURE_FLAGS:
-  ORCA_TAG: v3.72.0
+  ORCA_TAG: v3.73.0

--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.72.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.73.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.72.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.73.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -14131,7 +14131,7 @@ int
 main ()
 {
 
-return strncmp("3.72.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.73.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -14141,7 +14141,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.72.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.73.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.72.0@gpdb/stable
+orca/v3.73.0@gpdb/stable
 
 [imports]
 include, * -> build/include


### PR DESCRIPTION
Corresponding ORCA commits:
* Refactor: Simplify property derivation in CExpression
* Support on-demand property derivation in CDrvdPropRelational
* Rename DrvdPropArray to DrvdProp and DrvdProp2dArray to DrvdPropArray
* Bump ORCA version to 3.73.0

Authored-by: Chris Hajas <chajas@pivotal.io>