### PR TITLE
5X: Bump ORCA version to 3.76, send btree indexes on AO tables as type btree

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.74.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.76.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.74.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.76.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.74.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.76.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.74.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.76.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.74.0@gpdb/stable
+orca/v3.76.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.74.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.76.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1116,16 +1116,14 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 		}
 	
 		index_type = IMDIndex::EmdindBtree;
-		IMDRelation::Erelstoragetype rel_storage_type = md_rel->RetrieveRelStorageType();
+		mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
 		if (GIST_AM_OID == index_rel->rd_rel->relam)
 		{
 			index_type = IMDIndex::EmdindGist;
-			mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
 		}
-		else if (BITMAP_AM_OID == index_rel->rd_rel->relam || IMDRelation::ErelstorageAppendOnlyRows == rel_storage_type || IMDRelation::ErelstorageAppendOnlyCols == rel_storage_type)
+		else if (BITMAP_AM_OID == index_rel->rd_rel->relam)
 		{
 			index_type = IMDIndex::EmdindBitmap;
-			mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
 		}
 
 		// get the index name
@@ -1385,16 +1383,14 @@ CTranslatorRelcacheToDXL::RetrievePartTableIndex
 	GPOS_ASSERT(INDTYPE_BITMAP == index_info->indType || INDTYPE_BTREE == index_info->indType || INDTYPE_GIST == index_info->indType);
 	
 	IMDIndex::EmdindexType index_type = IMDIndex::EmdindBtree;
-	IMDId *mdid_item_type = NULL;
+	IMDId *mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);;
 	if (INDTYPE_BITMAP == index_info->indType)
 	{
 		index_type = IMDIndex::EmdindBitmap;
-		mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
 	}
 	else if (INDTYPE_GIST == index_info->indType)
 	{
 		index_type = IMDIndex::EmdindGist;
-		mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
 	}
 	
 	IMdIdArray *pdrgpmdidOpFamilies = RetrieveIndexOpFamilies(mp, mdid_index);

--- a/src/test/regress/expected/co_nestloop_idxscan.out
+++ b/src/test/regress/expected/co_nestloop_idxscan.out
@@ -6,20 +6,22 @@ create table co_nestloop_idxscan.foo (id bigint, data text) with (appendonly=tru
 distributed by (id);
 create table co_nestloop_idxscan.bar (id bigint) distributed by (id);
 -- Changing the text to be smaller doesn't repro the issue
-insert into co_nestloop_idxscan.foo select 1, repeat('xxxxxxxxxx', 100000);
+insert into co_nestloop_idxscan.foo select i, repeat('xxxxxxxxxx', 100000) from generate_series(1,50) i;
 insert into co_nestloop_idxscan.bar values (1);
 create index foo_id_idx on co_nestloop_idxscan.foo(id);
 -- test with hash join
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=1.02..32.07 rows=2 width=8)
-   ->  Hash Join  (cost=1.02..32.07 rows=2 width=8)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..1530.71 rows=6 width=8)
+   ->  Hash Join  (cost=1.02..1530.71 rows=2 width=8)
          Hash Cond: f.id = b.id
-         ->  Append-only Columnar Scan on foo f  (cost=0.00..31.01 rows=1 width=8)
+         ->  Append-only Columnar Scan on foo f  (cost=0.00..1529.50 rows=17 width=8)
          ->  Hash  (cost=1.01..1.01 rows=1 width=8)
                ->  Seq Scan on bar b  (cost=0.00..1.01 rows=1 width=8)
-(6 rows)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(8 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 
@@ -31,15 +33,18 @@ select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id
 set optimizer_enable_hashjoin = off;
 set enable_hashjoin=off;
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..32.03 rows=2 width=8)
-   ->  Nested Loop  (cost=0.00..32.03 rows=2 width=8)
-         Join Filter: f.id = b.id
-         ->  Append-only Columnar Scan on foo f  (cost=0.00..31.01 rows=1 width=8)
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.36..301.39 rows=6 width=8)
+   ->  Nested Loop  (cost=200.36..301.39 rows=2 width=8)
          ->  Seq Scan on bar b  (cost=0.00..1.01 rows=1 width=8)
- Settings:  enable_hashjoin=off
-(6 rows)
+         ->  Bitmap Append-Only Column-Oriented Scan on foo f  (cost=200.36..300.37 rows=1 width=8)
+               Recheck Cond: f.id = b.id
+               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..200.36 rows=1 width=0)
+                     Index Cond: f.id = b.id
+ Settings:  enable_hashjoin=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(9 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 
@@ -55,14 +60,16 @@ set enable_seqscan = off;
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=100.26..201.29 rows=2 width=8)
-   ->  Nested Loop  (cost=100.26..201.29 rows=2 width=8)
-         Join Filter: f.id = b.id
-         ->  Bitmap Append-Only Column-Oriented Scan on foo f  (cost=100.26..200.27 rows=1 width=8)
-               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..100.26 rows=1 width=0)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.36..301.39 rows=6 width=8)
+   ->  Nested Loop  (cost=200.36..301.39 rows=2 width=8)
          ->  Seq Scan on bar b  (cost=0.00..1.01 rows=1 width=8)
- Settings:  enable_hashjoin=off; enable_seqscan=off
-(7 rows)
+         ->  Bitmap Append-Only Column-Oriented Scan on foo f  (cost=200.36..300.37 rows=1 width=8)
+               Recheck Cond: f.id = b.id
+               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..200.36 rows=1 width=0)
+                     Index Cond: f.id = b.id
+ Settings:  enable_hashjoin=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(9 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 

--- a/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
+++ b/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
@@ -6,23 +6,23 @@ create table co_nestloop_idxscan.foo (id bigint, data text) with (appendonly=tru
 distributed by (id);
 create table co_nestloop_idxscan.bar (id bigint) distributed by (id);
 -- Changing the text to be smaller doesn't repro the issue
-insert into co_nestloop_idxscan.foo select 1, repeat('xxxxxxxxxx', 100000);
+insert into co_nestloop_idxscan.foo select i, repeat('xxxxxxxxxx', 100000) from generate_series(1,50) i;
 insert into co_nestloop_idxscan.bar values (1);
 create index foo_id_idx on co_nestloop_idxscan.foo(id);
 -- test with hash join
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..431.09 rows=1 width=8)
-   ->  Nested Loop  (cost=0.00..431.09 rows=1 width=8)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..499.13 rows=1 width=8)
+   ->  Nested Loop  (cost=0.00..499.13 rows=1 width=8)
          Join Filter: true
          ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
-         ->  Bitmap Table Scan on foo  (cost=0.00..0.09 rows=1 width=8)
+         ->  Bitmap Table Scan on foo  (cost=0.00..68.13 rows=1 width=8)
                Recheck Cond: foo.id = bar.id
                ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..0.00 rows=0 width=0)
                      Index Cond: foo.id = bar.id
- Settings:  optimizer=on; optimizer_segments=3
-(10 rows)
+ Optimizer status: PQO version 3.72.0
+(9 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 
@@ -34,17 +34,18 @@ select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id
 set optimizer_enable_hashjoin = off;
 set enable_hashjoin=off;
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..431.09 rows=1 width=8)
-   ->  Nested Loop  (cost=0.00..431.09 rows=1 width=8)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..499.13 rows=1 width=8)
+   ->  Nested Loop  (cost=0.00..499.13 rows=1 width=8)
          Join Filter: true
          ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
-         ->  Bitmap Table Scan on foo  (cost=0.00..0.09 rows=1 width=8)
+         ->  Bitmap Table Scan on foo  (cost=0.00..68.13 rows=1 width=8)
                Recheck Cond: foo.id = bar.id
                ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..0.00 rows=0 width=0)
                      Index Cond: foo.id = bar.id
- Settings:  enable_hashjoin=off; optimizer=on; optimizer_segments=3
+ Settings:  enable_hashjoin=off
+ Optimizer status: PQO version 3.72.0
 (10 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
@@ -59,17 +60,18 @@ set enable_seqscan = off;
 -- Known_opt_diff: OPT-929
 -- end_ignore
 explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..431.09 rows=1 width=8)
-   ->  Nested Loop  (cost=0.00..431.09 rows=1 width=8)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..499.13 rows=1 width=8)
+   ->  Nested Loop  (cost=0.00..499.13 rows=1 width=8)
          Join Filter: true
          ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
-         ->  Bitmap Table Scan on foo  (cost=0.00..0.09 rows=1 width=8)
+         ->  Bitmap Table Scan on foo  (cost=0.00..68.13 rows=1 width=8)
                Recheck Cond: foo.id = bar.id
                ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..0.00 rows=0 width=0)
                      Index Cond: foo.id = bar.id
- Settings:  enable_hashjoin=off; enable_seqscan=off; optimizer=on; optimizer_segments=3
+ Settings:  enable_hashjoin=off; enable_seqscan=off
+ Optimizer status: PQO version 3.72.0
 (10 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;

--- a/src/test/regress/sql/co_nestloop_idxscan.sql
+++ b/src/test/regress/sql/co_nestloop_idxscan.sql
@@ -9,7 +9,7 @@ distributed by (id);
 create table co_nestloop_idxscan.bar (id bigint) distributed by (id);
 
 -- Changing the text to be smaller doesn't repro the issue
-insert into co_nestloop_idxscan.foo select 1, repeat('xxxxxxxxxx', 100000);
+insert into co_nestloop_idxscan.foo select i, repeat('xxxxxxxxxx', 100000) from generate_series(1,50) i;
 insert into co_nestloop_idxscan.bar values (1);
 
 create index foo_id_idx on co_nestloop_idxscan.foo(id);


### PR DESCRIPTION
Previously, GPDB sent btree indexes on AO tables to ORCA as type bitmap
as btree indexes were not allowed on AO tables. This was a bit hacky, so 
instead, send it over as type btree and let ORCA handle it properly.

Corresponding ORCA PR: https://github.com/greenplum-db/gporca/pull/537

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
