### PR TITLE
Backport 6X: Remove vacuum_drop_phase_ao from parallel group

### DIFF
--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -42,7 +42,9 @@ test: gdd/end
 # concurrent test, so run the test by itself.
 test: deadlock_under_entry_db_singleton
 
-test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc vacuum_drop_phase_ao
+test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc
+test: vacuum_drop_phase_ao
+
 # below test(s) inject faults so each of them need to be in a separate group
 test: pg_terminate_backend
 


### PR DESCRIPTION
- as an experiment. We want to see if it becomes less flakey.

(cherry picked from commit b99920ffd8f1f72679d99987d7406207fb312ada)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
