### PR TITLE
Use Explicit Motion, instead of Redistribute, on top of Split Updates.

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1406,6 +1406,10 @@ _copySplitUpdate(const SplitUpdate *from)
 	COPY_NODE_FIELD(insertColIdx);
 	COPY_NODE_FIELD(deleteColIdx);
 
+	COPY_SCALAR_FIELD(numHashAttrs);
+	COPY_POINTER_FIELD(hashAttnos, from->numHashAttrs * sizeof(AttrNumber));
+	COPY_POINTER_FIELD(hashFuncs, from->numHashAttrs * sizeof(Oid));
+
 	return newnode;
 }
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1250,6 +1250,19 @@ _outSplitUpdate(StringInfo str, const SplitUpdate *node)
 	WRITE_NODE_FIELD(insertColIdx);
 	WRITE_NODE_FIELD(deleteColIdx);
 
+	WRITE_INT_FIELD(numHashAttrs);
+#ifdef COMPILING_BINARY_FUNCS
+	WRITE_INT_ARRAY(hashAttnos, node->numHashAttrs, AttrNumber);
+	WRITE_OID_ARRAY(hashFuncs, node->numHashAttrs);
+#else
+	appendStringInfoLiteral(str, " :hashAttnos");
+	for (int i = 0; i < node->numHashAttrs; i++)
+		appendStringInfo(str, " %d", node->hashAttnos[i]);
+	appendStringInfoLiteral(str, " :hashFuncs");
+	for (int i = 0; i < node->numHashAttrs; i++)
+		appendStringInfo(str, " %u", node->hashFuncs[i]);
+#endif
+
 	_outPlanInfo(str, (Plan *) node);
 }
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2364,6 +2364,10 @@ _readSplitUpdate(void)
 	READ_NODE_FIELD(insertColIdx);
 	READ_NODE_FIELD(deleteColIdx);
 
+	READ_INT_FIELD(numHashAttrs);
+	READ_INT_ARRAY(hashAttnos, local_node->numHashAttrs, AttrNumber);
+	READ_OID_ARRAY(hashFuncs, local_node->numHashAttrs);
+
 	readPlanInfo((Plan *)local_node);
 
 	READ_DONE();

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -121,6 +121,7 @@ static bool fix_scan_expr_walker(Node *node, fix_scan_expr_context *context);
 static void set_join_references(PlannerInfo *root, Join *join, int rtoffset);
 static void set_upper_references(PlannerInfo *root, Plan *plan, int rtoffset);
 static void set_dummy_tlist_references(Plan *plan, int rtoffset);
+static void set_splitupdate_tlist_references(Plan *plan, int rtoffset);
 static indexed_tlist *build_tlist_index(List *tlist);
 static Var *search_indexed_tlist_for_var(Var *var,
 							 indexed_tlist *itlist,
@@ -1219,10 +1220,8 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 			}
 			break;
 		case T_SplitUpdate:
-			/*
-			 * when we make the target list for SplitUpdate node, we
-			 * have used the OUTER as the varno, so we can skip to fix the varno.
-			 */
+			Assert(plan->qual == NIL);
+			set_splitupdate_tlist_references(plan, rtoffset);
 			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d",
@@ -2096,6 +2095,67 @@ set_dummy_tlist_references(Plan *plan, int rtoffset)
 
 	/* We don't touch plan->qual here */
 }
+
+/*
+ * Split update is a bit special. It doesn't evaluate targetlist expressions,
+ * but it adds an extra DMLActionExpr attribute to the output. Also, because
+ * there is an assertion in ModifyTable that its subplan must contain a NULL
+ * Const for any dropped columns, we must represent NULL constants as Const
+ * node, even though they are passed through from the node below, rather than
+ * evaluated at the Split Update node. So this is mostly the same as
+ * set_dummy_tlist_references(), except for the special handling of
+ * DMLActionExpr and Consts.
+ */
+static void
+set_splitupdate_tlist_references(Plan *plan, int rtoffset)
+{
+	List	   *output_targetlist;
+	ListCell   *l;
+
+	output_targetlist = NIL;
+	foreach(l, plan->targetlist)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(l);
+		Var		   *oldvar = (Var *) tle->expr;
+		Var		   *newvar;
+
+		if (IsA(tle->expr, DMLActionExpr))
+		{
+			output_targetlist = lappend(output_targetlist, tle);
+			continue;
+		}
+		else if (IsA(tle->expr, Const))
+		{
+			output_targetlist = lappend(output_targetlist, tle);
+			continue;
+		}
+
+		newvar = makeVar(OUTER_VAR,
+						 tle->resno,
+						 exprType((Node *) oldvar),
+						 exprTypmod((Node *) oldvar),
+						 exprCollation((Node *) oldvar),
+						 0);
+		if (IsA(oldvar, Var))
+		{
+			newvar->varnoold = oldvar->varno + rtoffset;
+			newvar->varoattno = oldvar->varattno;
+		}
+		else
+		{
+			newvar->varnoold = 0;		/* wasn't ever a plain Var */
+			newvar->varoattno = 0;
+		}
+
+		tle = flatCopyTargetEntry(tle);
+		tle->expr = (Expr *) newvar;
+		output_targetlist = lappend(output_targetlist, tle);
+	}
+	plan->targetlist = output_targetlist;
+
+	/* We don't touch plan->qual here */
+}
+
 
 
 /*

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2954,6 +2954,12 @@ typedef struct SplitUpdateState
 								 * action. */
 	TupleTableSlot *insertTuple;	/* tuple to Insert */
 	TupleTableSlot *deleteTuple;	/* tuple to Delete */
+
+	AttrNumber	input_segid_attno;		/* attribute number of "gp_segment_id" in subplan's target list */
+	AttrNumber	output_segid_attno;		/* attribute number of "gp_segment_id" in output target list */
+
+	struct CdbHash *cdbhash;	/* hash api object */
+
 } SplitUpdateState;
 
 /*

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1333,6 +1333,10 @@ typedef struct SplitUpdate
 	AttrNumber	tupleoidColIdx;		/* index of tuple oid column into the target list */
 	List		*insertColIdx;		/* list of columns to INSERT into the target list */
 	List		*deleteColIdx;		/* list of columns to DELETE into the target list */
+
+	int			numHashAttrs;
+	AttrNumber *hashAttnos;
+	Oid		   *hashFuncs;			/* corresponding hash functions */
 } SplitUpdate;
 
 /*

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1520,16 +1520,6 @@ typedef struct OnConflictExpr
 	List	   *exclRelTlist;	/* tlist of the EXCLUDED pseudo relation */
 } OnConflictExpr;
 
-typedef enum Movement
-{
-	MOVEMENT_NONE,			/* No motion required. */
-	MOVEMENT_FOCUS,			/* Fixed motion to a single segment. */
-	MOVEMENT_BROADCAST,		/* Broadcast motion. */
-	MOVEMENT_REPARTITION,	/* Hash motion */
-	MOVEMENT_LIM_RESTRUCT,	/* Restructure a Limit node into three stages */
-	MOVEMENT_EXPLICIT		/* Move tuples to the segments specified in the segid column */
-} Movement;
-
 /*----------
  * Flow - describes a tuple flow in a parallelized plan
  *

--- a/src/test/isolation2/expected/modifytable_with_bad_distribution.out
+++ b/src/test/isolation2/expected/modifytable_with_bad_distribution.out
@@ -47,11 +47,24 @@ ANALYZE
 analyze help_distribution;
 ANALYZE
 
--- Test update on distribution key. Expect error.
+-- Test update on distribution key.
+--
+-- This used throw an error, because the old row is in wrong segment. But we
+-- no longer check that, because there's no particular reason why an UPDATE
+-- in particular should care about whether the old row was on the right
+-- segment; the old row is deleted, and the new row is inserted to the
+-- correct segment, in any case. A misplaced row is no worse for an UPDATE,
+-- than it is for other queries or DML commands.
+--
+-- This still throws an error with ORCA, however, because ORCA generates a
+-- slightly different Split Update plan. It uses a Redistribute Motion on top
+-- of the Split Update, which computes the old segment based on the old
+-- values, instead of an Explicit Motion. With a Redistribute Motion, if the
+-- old row is not on the correct segment, the deletion would fail to find it.
 update bad_distribution1 set a=a+1;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg2) (nodeModifyTable.c:1856)  (seg0 127.0.0.1:25432 pid=24218) (nodeModifyTable.c:1856)
+UPDATE 4
 update pbad_distribution1 set a=a+1;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg2) (nodeModifyTable.c:1856)  (seg0 127.0.0.1:25432 pid=24218) (nodeModifyTable.c:1856)
+UPDATE 4
 
 -- Test delete. Expect error for orca plan.
 explain verbose delete from bad_distribution1 using (select * from help_distribution where b < 20) s where s.a = bad_distribution1.b;

--- a/src/test/isolation2/expected/modifytable_with_bad_distribution_optimizer.out
+++ b/src/test/isolation2/expected/modifytable_with_bad_distribution_optimizer.out
@@ -47,7 +47,20 @@ ANALYZE
 analyze help_distribution;
 ANALYZE
 
--- Test update on distribution key. Expect error.
+-- Test update on distribution key.
+--
+-- This used throw an error, because the old row is in wrong segment. But we
+-- no longer check that, because there's no particular reason why an UPDATE
+-- in particular should care about whether the old row was on the right
+-- segment; the old row is deleted, and the new row is inserted to the
+-- correct segment, in any case. A misplaced row is no worse for an UPDATE,
+-- than it is for other queries or DML commands.
+--
+-- This still throws an error with ORCA, however, because ORCA generates a
+-- slightly different Split Update plan. It uses a Redistribute Motion on top
+-- of the Split Update, which computes the old segment based on the old
+-- values, instead of an Explicit Motion. With a Redistribute Motion, if the
+-- old row is not on the correct segment, the deletion would fail to find it.
 update bad_distribution1 set a=a+1;
 ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg2) (nodeDML.c:149)  (seg0 127.0.0.1:25432 pid=21878) (nodeDML.c:149)
 update pbad_distribution1 set a=a+1;

--- a/src/test/isolation2/sql/modifytable_with_bad_distribution.sql
+++ b/src/test/isolation2/sql/modifytable_with_bad_distribution.sql
@@ -27,7 +27,20 @@ analyze bad_distribution1;
 analyze pbad_distribution1;
 analyze help_distribution;
 
--- Test update on distribution key. Expect error.
+-- Test update on distribution key.
+--
+-- This used throw an error, because the old row is in wrong segment. But we
+-- no longer check that, because there's no particular reason why an UPDATE
+-- in particular should care about whether the old row was on the right
+-- segment; the old row is deleted, and the new row is inserted to the
+-- correct segment, in any case. A misplaced row is no worse for an UPDATE,
+-- than it is for other queries or DML commands.
+--
+-- This still throws an error with ORCA, however, because ORCA generates a
+-- slightly different Split Update plan. It uses a Redistribute Motion on top
+-- of the Split Update, which computes the old segment based on the old
+-- values, instead of an Explicit Motion. With a Redistribute Motion, if the
+-- old row is not on the correct segment, the deletion would fail to find it.
 update bad_distribution1 set a=a+1;
 update pbad_distribution1 set a=a+1;
 

--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -197,15 +197,14 @@ select * from update_pk_test order by 1,2;
 (1 row)
 
 explain update update_pk_test set a = 5;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Update on update_pk_test  (cost=0.00..1.01 rows=1 width=14)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=14)
-         Hash Key: a
-         ->  Split  (cost=0.00..1.01 rows=1 width=14)
-               ->  Seq Scan on update_pk_test  (cost=0.00..1.01 rows=1 width=14)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on update_pk_test  (cost=0.00..1.05 rows=1 width=22)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=22)
+         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+               ->  Seq Scan on update_pk_test  (cost=0.00..1.01 rows=1 width=22)
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 update update_pk_test set a = 5;
 select * from update_pk_test order by 1,2;

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -26,15 +26,14 @@ explain insert into constr_tab values (1,2,3);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
-         Hash Key: a
-         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=22)
+         ->  Split  (cost=0.00..1.03 rows=1 width=22)
                ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 explain update constr_tab set b = 10;
                            QUERY PLAN                            
@@ -59,15 +58,14 @@ CREATE TABLE constr_tab ( a int NOT NULL, b int, c int, d int, CHECK (a+b>5)) DI
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
-         Hash Key: a
-         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=22)
+         ->  Split  (cost=0.00..1.03 rows=1 width=22)
                ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int NOT NULL, b int NOT NULL, c int NOT NULL, d int NOT NULL) DISTRIBUTED BY (a,b);
@@ -75,15 +73,14 @@ INSERT INTO constr_tab VALUES(1,5,3,4);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set b = 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
-         Hash Key: a, b
-         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=22)
+         ->  Split  (cost=0.00..1.03 rows=1 width=22)
                ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int, b int, c int, d int) DISTRIBUTED BY (a);
@@ -91,15 +88,14 @@ INSERT INTO constr_tab VALUES(1,5,3,4);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
-         Hash Key: a
-         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=22)
+         ->  Split  (cost=0.00..1.03 rows=1 width=22)
                ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 -- Test ORCA fallback on "FROM ONLY"
 CREATE TABLE homer (a int, b int, c int)

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -35,15 +35,14 @@ set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: UPDATE with constraints
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
-         Hash Key: a
-         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=22)
+         ->  Split  (cost=0.00..1.03 rows=1 width=22)
                ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 explain update constr_tab set b = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
@@ -75,15 +74,14 @@ set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: UPDATE with constraints
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
-         Hash Key: a
-         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=22)
+         ->  Split  (cost=0.00..1.03 rows=1 width=22)
                ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int NOT NULL, b int NOT NULL, c int NOT NULL, d int NOT NULL) DISTRIBUTED BY (a,b);
@@ -97,15 +95,14 @@ set optimizer_enable_dml_constraints=off;
 explain update constr_tab set b = 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: UPDATE with constraints
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=22)
-         Hash Key: a, b
-         ->  Split  (cost=0.00..1.01 rows=1 width=22)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=22)
+         ->  Split  (cost=0.00..1.03 rows=1 width=22)
                ->  Seq Scan on constr_tab  (cost=0.00..1.01 rows=1 width=22)
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int, b int, c int, d int) DISTRIBUTED BY (a);

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -402,16 +402,15 @@ SELECT * FROM base_tbl;
 (6 rows)
 
 EXPLAIN (costs off) UPDATE rw_view1 SET a=6 WHERE a=5;
-                      QUERY PLAN                      
-------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Update on base_tbl
-   ->  Redistribute Motion 1:3  (slice1; segments: 1)
-         Hash Key: "outer".a
+   ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)
          ->  Split
                ->  Seq Scan on base_tbl
                      Filter: ((a > 0) AND (a = 5))
  Optimizer: Postgres query optimizer
-(7 rows)
+(6 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view1 WHERE a=5;
               QUERY PLAN               
@@ -480,13 +479,12 @@ EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Update on base_tbl
-   ->  Redistribute Motion 1:3  (slice1; segments: 1)
-         Hash Key: "outer".aaa
+   ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)
          ->  Split
                ->  Seq Scan on base_tbl
                      Filter: ((a < 10) AND (a > 0) AND (a = 4))
  Optimizer: Postgres query optimizer
-(7 rows)
+(6 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE aaa=4;
                      QUERY PLAN                     
@@ -1683,8 +1681,7 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Update on base_tbl b
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Hash Key: ((b.a + 5))
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
          ->  Split
                ->  Hash Join
                      Hash Cond: (r.a = b.a)
@@ -1927,8 +1924,8 @@ EXPLAIN (costs off) SELECT * FROM rw_view1 WHERE snoop(person);
 (6 rows)
 
 EXPLAIN (costs off) UPDATE rw_view1 SET person=person WHERE snoop(person);
-                        QUERY PLAN                         
------------------------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Update on base_tbl base_tbl_1
    ->  Subquery Scan on base_tbl
          Filter: snoop(base_tbl.person)
@@ -1938,8 +1935,8 @@ EXPLAIN (costs off) UPDATE rw_view1 SET person=person WHERE snoop(person);
 (6 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view1 WHERE NOT snoop(person);
-                        QUERY PLAN                         
------------------------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Delete on base_tbl base_tbl_1
    ->  Subquery Scan on base_tbl
          Filter: (NOT snoop(base_tbl.person))
@@ -2011,8 +2008,8 @@ EXPLAIN (costs off) SELECT * FROM rw_view2 WHERE snoop(person);
 (8 rows)
 
 EXPLAIN (costs off) UPDATE rw_view2 SET person=person WHERE snoop(person);
-                           QUERY PLAN                            
------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Update on base_tbl base_tbl_1
    ->  Subquery Scan on base_tbl
          Filter: snoop(base_tbl.person)
@@ -2024,8 +2021,8 @@ EXPLAIN (costs off) UPDATE rw_view2 SET person=person WHERE snoop(person);
 (8 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE NOT snoop(person);
-                           QUERY PLAN                            
------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Delete on base_tbl base_tbl_1
    ->  Subquery Scan on base_tbl
          Filter: (NOT snoop(base_tbl.person))
@@ -2076,8 +2073,8 @@ EXPLAIN (costs off) DELETE FROM rw_view1 WHERE id = 1 AND snoop(data);
 DELETE FROM rw_view1 WHERE id = 1 AND snoop(data);
 NOTICE:  snooped value: Row 1
 EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
-                       QUERY PLAN                       
---------------------------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Insert on base_tbl
    InitPlan 1 (returns $0)  (slice2)
      ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -2153,13 +2150,14 @@ SELECT * FROM v1 WHERE a=8;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a = 3;
-                         QUERY PLAN                         
-------------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Result
-   Output: 100, t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id
+   Output: 100, t1.b, t1.c, t1.ctid, t1.gp_segment_id
    One-Time Filter: false
  Optimizer: Postgres query optimizer
-(4 rows)
+ Settings: optimizer=off
+(5 rows)
 
 UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a = 3;
 SELECT * FROM v1 WHERE a=100; -- Nothing should have been changed to 100
@@ -2181,13 +2179,12 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
    Update on public.t11 t1
    Update on public.t12 t1
    Update on public.t111 t1
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Output: ((t1.a + 1)), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id, (DMLAction)
-         Hash Key: ((t1.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: ((t1.a + 1)), t1.b, t1.c, t1.ctid, t1.gp_segment_id, (DMLAction)
          ->  Split
-               Output: ((t1.a + 1)), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id, DMLAction
+               Output: ((t1.a + 1)), t1.b, t1.c, t1.ctid, t1.gp_segment_id, DMLAction
                ->  Subquery Scan on t1
-                     Output: (t1.a + 1), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id
+                     Output: (t1.a + 1), t1.b, t1.c, t1.ctid, t1.gp_segment_id
                      Filter: snoop(t1.a)
                      ->  Nested Loop Semi Join
                            Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c, t1_5.ctid, t12.ctid, t12.tableoid
@@ -2201,13 +2198,12 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                  ->  Seq Scan on public.t111
                                        Output: t111.ctid, t111.tableoid, t111.a
                                        Filter: ((t111.a > 5) AND (t111.a = 8))
-   ->  Redistribute Motion 3:3  (slice2; segments: 3)
-         Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
-         Hash Key: ((t1_1.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
+         Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
-               Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id, DMLAction
+               Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, DMLAction
                ->  Subquery Scan on t1_1
-                     Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id
+                     Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id
                      Filter: snoop(t1_1.a)
                      ->  Nested Loop Semi Join
                            Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d, t11.ctid, t12_1.ctid, t12_1.tableoid
@@ -2221,13 +2217,12 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                  ->  Seq Scan on public.t111 t111_1
                                        Output: t111_1.ctid, t111_1.tableoid, t111_1.a
                                        Filter: ((t111_1.a > 5) AND (t111_1.a = 8))
-   ->  Redistribute Motion 3:3  (slice3; segments: 3)
-         Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
-         Hash Key: ((t1_2.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
+         Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
          ->  Split
-               Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id, DMLAction
+               Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
                ->  Subquery Scan on t1_2
-                     Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id
+                     Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
                      Filter: snoop(t1_2.a)
                      ->  Nested Loop Semi Join
                            Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e, t12_2.ctid, t12_3.ctid, t12_3.tableoid
@@ -2241,13 +2236,12 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                  ->  Seq Scan on public.t111 t111_2
                                        Output: t111_2.ctid, t111_2.tableoid, t111_2.a
                                        Filter: ((t111_2.a > 5) AND (t111_2.a = 8))
-   ->  Redistribute Motion 3:3  (slice4; segments: 3)
-         Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
-         Hash Key: ((t1_3.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice4; segments: 3)
+         Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
-               Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id, DMLAction
+               Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, DMLAction
                ->  Subquery Scan on t1_3
-                     Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id
+                     Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id
                      Filter: snoop(t1_3.a)
                      ->  Nested Loop Semi Join
                            Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e, t111_3.ctid, t12_4.ctid, t12_4.tableoid
@@ -2262,7 +2256,8 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                        Output: t111_4.ctid, t111_4.tableoid, t111_4.a
                                        Filter: ((t111_4.a > 5) AND (t111_4.a = 8))
  Optimizer: Postgres query optimizer
-(94 rows)
+ Settings: optimizer=off
+(83 rows)
 
 UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
 NOTICE:  snooped value: 8  (seg0 slice4 127.0.0.1:40000 pid=26920)

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -1700,8 +1700,7 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Update on base_tbl b
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Hash Key: ((b.a + 5))
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
          ->  Split
                ->  Hash Join
                      Hash Cond: (r.a = b.a)
@@ -2184,13 +2183,14 @@ SELECT * FROM v1 WHERE a=8;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a = 3;
-                         QUERY PLAN                         
-------------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Result
-   Output: 100, t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id
+   Output: 100, t1.b, t1.c, t1.ctid, t1.gp_segment_id
    One-Time Filter: false
  Optimizer: Postgres query optimizer
-(4 rows)
+ Settings: optimizer=off
+(5 rows)
 
 UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a = 3;
 SELECT * FROM v1 WHERE a=100; -- Nothing should have been changed to 100
@@ -2212,13 +2212,12 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
    Update on public.t11 t1
    Update on public.t12 t1
    Update on public.t111 t1
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Output: ((t1.a + 1)), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id, (DMLAction)
-         Hash Key: ((t1.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: ((t1.a + 1)), t1.b, t1.c, t1.ctid, t1.gp_segment_id, (DMLAction)
          ->  Split
-               Output: ((t1.a + 1)), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id, DMLAction
+               Output: ((t1.a + 1)), t1.b, t1.c, t1.ctid, t1.gp_segment_id, DMLAction
                ->  Subquery Scan on t1
-                     Output: (t1.a + 1), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id
+                     Output: (t1.a + 1), t1.b, t1.c, t1.ctid, t1.gp_segment_id
                      Filter: snoop(t1.a)
                      ->  Nested Loop Semi Join
                            Output: t1_5.a, t1_5.ctid, t1_5.gp_segment_id, t1_5.b, t1_5.c, t1_5.ctid, t12.ctid, t12.tableoid
@@ -2232,13 +2231,12 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                  ->  Seq Scan on public.t111
                                        Output: t111.ctid, t111.tableoid, t111.a
                                        Filter: ((t111.a > 5) AND (t111.a = 8))
-   ->  Redistribute Motion 3:3  (slice2; segments: 3)
-         Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
-         Hash Key: ((t1_1.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
+         Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
-               Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id, DMLAction
+               Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, DMLAction
                ->  Subquery Scan on t1_1
-                     Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id
+                     Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id
                      Filter: snoop(t1_1.a)
                      ->  Nested Loop Semi Join
                            Output: t11.a, t11.ctid, t11.gp_segment_id, t11.b, t11.c, t11.d, t11.ctid, t12_1.ctid, t12_1.tableoid
@@ -2252,13 +2250,12 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                  ->  Seq Scan on public.t111 t111_1
                                        Output: t111_1.ctid, t111_1.tableoid, t111_1.a
                                        Filter: ((t111_1.a > 5) AND (t111_1.a = 8))
-   ->  Redistribute Motion 3:3  (slice3; segments: 3)
-         Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
-         Hash Key: ((t1_2.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
+         Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
          ->  Split
-               Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id, DMLAction
+               Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
                ->  Subquery Scan on t1_2
-                     Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id
+                     Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
                      Filter: snoop(t1_2.a)
                      ->  Nested Loop Semi Join
                            Output: t12_2.a, t12_2.ctid, t12_2.gp_segment_id, t12_2.b, t12_2.c, t12_2.e, t12_2.ctid, t12_3.ctid, t12_3.tableoid
@@ -2272,13 +2269,12 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                  ->  Seq Scan on public.t111 t111_2
                                        Output: t111_2.ctid, t111_2.tableoid, t111_2.a
                                        Filter: ((t111_2.a > 5) AND (t111_2.a = 8))
-   ->  Redistribute Motion 3:3  (slice4; segments: 3)
-         Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
-         Hash Key: ((t1_3.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice4; segments: 3)
+         Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
-               Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id, DMLAction
+               Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, DMLAction
                ->  Subquery Scan on t1_3
-                     Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id
+                     Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id
                      Filter: snoop(t1_3.a)
                      ->  Nested Loop Semi Join
                            Output: t111_3.a, t111_3.ctid, t111_3.gp_segment_id, t111_3.b, t111_3.c, t111_3.d, t111_3.e, t111_3.ctid, t12_4.ctid, t12_4.tableoid
@@ -2293,7 +2289,7 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                        Output: t111_4.ctid, t111_4.tableoid, t111_4.a
                                        Filter: ((t111_4.a > 5) AND (t111_4.a = 8))
  Optimizer: Postgres query optimizer
-(94 rows)
+(82 rows)
 
 UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
 NOTICE:  snooped value: 8  (seg0 slice4 127.0.0.1:40000 pid=26920)

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -419,15 +419,14 @@ SELECT gp_segment_id, * FROM tab5;
 (10 rows)
 
 EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
-                      QUERY PLAN
-------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Update on tab3
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Hash Key: ((c1 + 1)), c2, c3
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
          ->  Split
                ->  Seq Scan on tab3
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 -- clean up
 drop table tab3;

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -88,17 +88,15 @@ explain (costs off) update base_tbl set a=a+1;
    Update on base_tbl
    Update on child_a
    Update on child_b
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Hash Key: ((base_tbl.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
          ->  Split
                ->  Seq Scan on base_tbl
-   ->  Redistribute Motion 3:3  (slice2; segments: 3)
-         Hash Key: ((child_a.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
          ->  Split
                ->  Seq Scan on child_a
    ->  Seq Scan on child_b
  Optimizer: Postgres query optimizer
-(14 rows)
+(12 rows)
 
 update base_tbl set a = 5;
 --
@@ -515,8 +513,7 @@ explain update tsplit_entry set c = s.a from (select count(*) as a from gp_segme
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
  Update on tsplit_entry  (cost=10000000001.00..10000000003.18 rows=3 width=54)
-   ->  Redistribute Motion 1:3  (slice2)  (cost=10000000001.00..10000000003.18 rows=7 width=54)
-         Hash Key: ((s.a)::integer)
+   ->  Explicit Redistribute Motion 1:3  (slice2)  (cost=10000000001.00..10000000003.18 rows=7 width=54)
          ->  Split  (cost=10000000001.00..10000000003.18 rows=7 width=54)
                ->  Nested Loop  (cost=10000000001.00..10000000003.12 rows=4 width=54)
                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.06 rows=2 width=14)
@@ -525,9 +522,8 @@ explain update tsplit_entry set c = s.a from (select count(*) as a from gp_segme
                            ->  Subquery Scan on s  (cost=1.00..1.02 rows=1 width=40)
                                  ->  Aggregate  (cost=1.00..1.01 rows=1 width=8)
                                        ->  Seq Scan on gp_segment_configuration  (cost=0.00..1.00 rows=1 width=0)
- Planning time: 1.088 ms
  Optimizer: Postgres query optimizer
-(13 rows)
+(11 rows)
 
 update tsplit_entry set c = s.a from (select count(*) as a from gp_segment_configuration) s;
 CREATE TABLE update_gp_foo (

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -88,17 +88,15 @@ explain (costs off) update base_tbl set a=a+1;
    Update on base_tbl
    Update on child_a
    Update on child_b
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Hash Key: ((base_tbl.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
          ->  Split
                ->  Seq Scan on base_tbl
-   ->  Redistribute Motion 3:3  (slice2; segments: 3)
-         Hash Key: ((child_a.a + 1))
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
          ->  Split
                ->  Seq Scan on child_a
    ->  Seq Scan on child_b
  Optimizer: Postgres query optimizer
-(14 rows)
+(12 rows)
 
 update base_tbl set a = 5;
 --
@@ -521,8 +519,7 @@ explain update tsplit_entry set c = s.a from (select count(*) as a from gp_segme
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
  Update on tsplit_entry  (cost=10000000001.00..10000000003.18 rows=3 width=54)
-   ->  Redistribute Motion 1:3  (slice2)  (cost=10000000001.00..10000000003.18 rows=7 width=54)
-         Hash Key: ((s.a)::integer)
+   ->  Explicit Redistribute Motion 1:3  (slice2)  (cost=10000000001.00..10000000003.18 rows=7 width=54)
          ->  Split  (cost=10000000001.00..10000000003.18 rows=7 width=54)
                ->  Nested Loop  (cost=10000000001.00..10000000003.12 rows=4 width=54)
                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.06 rows=2 width=14)
@@ -531,9 +528,8 @@ explain update tsplit_entry set c = s.a from (select count(*) as a from gp_segme
                            ->  Subquery Scan on s  (cost=1.00..1.02 rows=1 width=40)
                                  ->  Aggregate  (cost=1.00..1.01 rows=1 width=8)
                                        ->  Seq Scan on gp_segment_configuration  (cost=0.00..1.00 rows=1 width=0)
- Planning time: 13.063 ms
  Optimizer: Postgres query optimizer
-(13 rows)
+(11 rows)
 
 update tsplit_entry set c = s.a from (select count(*) as a from gp_segment_configuration) s;
 CREATE TABLE update_gp_foo (


### PR DESCRIPTION

SplitUpdate no longer needs the old row's distribution key columns, to
calculate the segment where the old row should be deleted from. Instead,
we get the old target segment directly from the "gp_segment_id" junk
column, like a normal non-split update does. So we now use an Explicit
Motion on top Split Updates, instead of a Redistribute Motion. For the new
row, the SplitUpdate node computes the target segment from by hashing the
distribution key columns, like a Redistribute Motion does.

The reason to do this now is that with the 9.6 merge, and the
"pathification" of Split Updates, it became hard to represent the same
columns old and new value in the Motion's hash expression, before the
set_plan_references() has run. I' sure there would be other solutions,
but this seems like a good idea anyway.
