### PR TITLE
Changed references to 'current_query' to 'query' for pg_stat_activity change

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/monitor.xml
+++ b/gpdb-doc/dita/admin_guide/managing/monitor.xml
@@ -373,30 +373,31 @@ Distributed by: (sale_id)
       <topic id="topic_nby_j1b_dq">
         <title>Creating the session_level_memory_consumption View</title>
         <body>
-          <p>To create the <i>session_level_memory_consumption</i> view in a Greenplum Database, run
-            the script <codeph>CREATE EXTENSION gp_internal_tools;</codeph> once
-            for each database. For example, to install the view in the database
-              <codeph>testdb</codeph>, use this
+        <p>To create the <i>session_state.session_level_memory_consumption</i> view in a Greenplum
+          Database, run the script <codeph>CREATE EXTENSION gp_internal_tools;</codeph> once for
+          each database. For example, to install the view in the database <codeph>testdb</codeph>,
+          use this
             command:<codeblock>$ psql -d testdb -c "CREATE EXTENSION gp_internal_tools;"</codeblock></p>
         </body>
       </topic>
       <topic id="topic7" xml:lang="en">
         <title id="ff142493">The session_level_memory_consumption View</title>
         <body>
-          <p>The <i>session_level_memory_consumption</i> view provides information about memory
-            consumption and idle time for sessions that are running SQL queries. </p>
+        <p>The <i>session_state.session_level_memory_consumption</i> view provides information about
+          memory consumption and idle time for sessions that are running SQL queries. </p>
           <p>When resource queue-based resource management is active, the column
-            <codeph>is_runaway</codeph> indicates whether Greenplum
-            Database considers the session a runaway session based on the vmem memory consumption of
-            the session's queries. Under the resource queue-based resource management scheme, Greenplum
-            Database considers the session a runaway when the queries consume an excessive amount of
-            memory. The Greenplum Database server configuration
-            parameter <codeph>runaway_detector_activation_percent</codeph> governs the
-            conditions under which Greenplum Database considers a session a runaway session. </p>
+            <codeph>is_runaway</codeph> indicates whether Greenplum Database considers the session a
+          runaway session based on the vmem memory consumption of the session's queries. Under the
+          resource queue-based resource management scheme, Greenplum Database considers the session
+          a runaway when the queries consume an excessive amount of memory. The Greenplum Database
+          server configuration parameter <codeph>runaway_detector_activation_percent</codeph>
+          governs the conditions under which Greenplum Database considers a session a runaway
+          session. </p>
           <p>The <codeph>is_runaway</codeph>, <codeph>runaway_vmem_mb</codeph>, and
-            <codeph>runaway_command_cnt</codeph> columns are not applicable when resource group-based resource management is active.</p>
+            <codeph>runaway_command_cnt</codeph> columns are not applicable when resource
+          group-based resource management is active.</p>
           <table id="session_level_memory_consumption_table">
-            <title>session_level_memory_consumption</title>
+          <title>session_state.session_level_memory_consumption</title>
             <tgroup cols="4">
               <colspec colnum="1" colname="col1" colwidth="131pt"/>
               <colspec colnum="2" colname="col2" colwidth="86pt"/>
@@ -438,7 +439,7 @@ Distributed by: (sale_id)
                 </row>
                 <row>
                   <entry colname="col1">
-                    <codeph>current_query</codeph>
+                  <codeph>query</codeph>
                   </entry>
                   <entry colname="col2">text</entry>
                   <entry colname="col3"/>

--- a/gpdb-doc/dita/admin_guide/managing/startstop.xml
+++ b/gpdb-doc/dita/admin_guide/managing/startstop.xml
@@ -162,19 +162,28 @@
         <li><codeph>pg_terminate_backend( pid int4 )</codeph></li>
         <li><codeph>pg_terminate_backend( pid int4, msg text )</codeph></li>
       </ul></p>
-      <p>If you provide a <codeph>msg</codeph>, Greenplum Database includes the text in the cancel message returned to the client. <codeph>msg</codeph> is limited to 128 bytes; Greenplum Database truncates anything longer.</p>
-      <p>The <codeph>pg_cancel_backend()</codeph> and <codeph>pg_terminate_backend()</codeph> functions return <codeph>true</codeph> if successful, and <codeph>false</codeph> otherwise.</p>
-      <p>To cancel or terminate a backend process, you must first identify the process ID of the backend. You can obtain the process ID from the <codeph>pid</codeph> column of the <codeph>pg_stat_activity</codeph> view. For example, to view the process information associated with all running and queued queries: <codeblock>=# SELECT usename, pid, waiting, current_query, datname
+      <p>If you provide a <codeph>msg</codeph>, Greenplum Database includes the text in the cancel
+        message returned to the client. <codeph>msg</codeph> is limited to 128 bytes; Greenplum
+        Database truncates anything longer.</p>
+      <p>The <codeph>pg_cancel_backend()</codeph> and <codeph>pg_terminate_backend()</codeph>
+        functions return <codeph>true</codeph> if successful, and <codeph>false</codeph>
+        otherwise.</p>
+      <p>To cancel or terminate a backend process, you must first identify the process ID of the
+        backend. You can obtain the process ID from the <codeph>pid</codeph> column of the
+          <codeph>pg_stat_activity</codeph> view. For example, to view the process information
+        associated with all running and queued queries:
+        <codeblock>=# SELECT usename, pid, waiting, state, query, datname
      FROM pg_stat_activity;</codeblock></p>
       <p>Sample partial query output:</p>
-        <codeblock> usename |  pid     | waiting |     current_query     | datname
----------+----------+---------+-----------------------+---------
-  sammy  |   31861  |    f    | &lt;IDLE&gt; in transaction | testdb
-  billy  |   31905  |    t    | SELECT * FROM topten; | testdb</codeblock>
-      <p>Use the output to identify the process id (<codeph>pid</codeph>) of the query
-        or client connection. </p>
-      <p>For example, to cancel the pending query identified in the sample output above
-        and include "Admin canceled long-running query." in the message returned to the client:</p>
+      <codeblock> usename |  pid     | waiting | state  |         query          | datname
+---------+----------+---------+--------+------------------------+---------
+  sammy  |   31861  |    f    | idle   | SELECT * FROM testtbl; | testdb
+  billy  |   31905  |    t    | active | SELECT * FROM topten;  | testdb</codeblock>
+      <p>Use the output to identify the process id (<codeph>pid</codeph>) of the query or client
+        connection. </p>
+      <p>For example, to cancel the waiting query identified in the sample output above and include
+          <codeph>'Admin canceled long-running query.'</codeph> as the message returned to the
+        client:</p>
       <p>
         <codeblock>=# SELECT pg_cancel_backend(31905 ,'Admin canceled long-running query.');
 ERROR:  canceling statement due to user request: "Admin canceled long-running query."</codeblock>

--- a/gpdb-doc/dita/admin_guide/perf_troubleshoot.xml
+++ b/gpdb-doc/dita/admin_guide/perf_troubleshoot.xml
@@ -73,7 +73,7 @@
                 <p>
                     <codeblock>SELECT locktype, database, c.relname, l.relation, 
 l.transactionid, l.pid, l.mode, l.granted, 
-a.current_query 
+a.query 
         FROM pg_locks l, pg_class c, pg_stat_activity a 
         WHERE l.relation=c.oid AND l.pid=a.pid
         ORDER BY c.relname;
@@ -192,7 +192,7 @@ con6 /gpdata/*/pg_log/gpdb*.csv' &gt; seglog.out
                     information from a Greenplum Database system. You can then send the information
                     to Pivotal Customer Support to aid the diagnosis of Greenplum Database errors or
                     system failures.</p>
-                <p>The GPMT  utility is available from the <xref
+                <p>The GPMT utility is available from the <xref
                         href="https://discuss.pivotal.io/hc/en-us/categories/200072608-Pivotal-Greenplum-Knowledge-Base"
                         format="html" scope="external">Pivotal Knowledge Base</xref> on the <xref
                         href="https://discuss.pivotal.io/hc/en-us/articles/217546277-Greenplum-Magic-Tool-GPMT-"

--- a/gpdb-doc/dita/admin_guide/workload_mgmt.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt.xml
@@ -730,8 +730,8 @@ MEMORY_LIMIT='2000MB');
         <p>For example, to see process information about all statements currently active or waiting
           in all resource queues, run the following query:</p>
         <p>
-          <codeblock>=# SELECT rolname, rsqname, pid, granted,
-          current_query, datname 
+          <codeblock>=# SELECT rolname, rsqname, pg_locks.pid as pid, granted, state,
+          query, datname 
    FROM pg_roles, gp_toolkit.gp_resqueue_status, pg_locks,
         pg_stat_activity 
    WHERE pg_roles.rolresqueue=pg_locks.objid 
@@ -743,10 +743,10 @@ MEMORY_LIMIT='2000MB');
         <p>If this query returns no results, then that means there are currently no statements in a
           resource queue. A sample of a resource queue with two statements in it looks something
           like this:</p>
-        <codeblock>rolname | rsqname |  pid  | granted |     current_query      | datname 
------------------------------------------------------------------------ 
-  sammy | webuser | 31861 | t       | &lt;IDLE&gt; in transaction  | namesdb
-  daria | webuser | 31905 | f       | SELECT * FROM topten;  | namesdb</codeblock>
+        <codeblock>rolname | rsqname |  pid  | granted | state  |         query          | datname 
+--------+---------+-------+---------+--------+------------------------+--------- 
+  sammy | webuser | 31861 | t       | idle   | SELECT * FROM testtbl; | namesdb
+  daria | webuser | 31905 | f       | active | SELECT * FROM topten;  | namesdb</codeblock>
         <p>Use this output to identify the process id (pid) of the statement you want to clear from
           the resource queue. To clear the statement, you would then open a terminal window (as the
             <codeph>gpadmin</codeph> database superuser or as root) on the master host and cancel
@@ -755,9 +755,7 @@ MEMORY_LIMIT='2000MB');
           <codeblock>=# pg_cancel_backend(31905)
 </codeblock>
         </p>
-        <note type="note">
-          <p>Do not use any operating system <codeph>KILL</codeph> command.</p>
-        </note>
+        <note type="important">Do not use the operating system <codeph>KILL</codeph> command.</note>
       </body>
     </topic>
     <topic id="topic28" xml:lang="en">

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -959,7 +959,7 @@ gpstart
               href="../ref_guide/system_catalogs/pg_stat_activity.xml" type="topic" format="dita"
             /></codeph> system catalog table:</p>
         <p>
-          <codeblock>=# SELECT current_query, waiting, rsgname, rsgqueueduration 
+          <codeblock>=# SELECT query, waiting, rsgname, rsgqueueduration 
      FROM pg_stat_activity;
 </codeblock>
         </p>
@@ -990,19 +990,19 @@ gpstart
           active or waiting in all resource groups, run the following query. If the query returns no
           results, then there are no running or queued transactions in any resource group.</p>
         <p>
-          <codeblock>=# SELECT rolname, g.rsgname, pid, waiting, current_query, datname 
+          <codeblock>=# SELECT rolname, g.rsgname, pid, waiting, state, query, datname 
      FROM pg_roles, gp_toolkit.gp_resgroup_status g, pg_stat_activity 
      WHERE pg_roles.rolresgroup=g.groupid
         AND pg_stat_activity.usename=pg_roles.rolname;
 </codeblock>
         </p>
         <p>Sample partial query output:</p>
-        <codeblock> rolname | rsgname  | pid     | waiting |     current_query     | datname 
----------+----------+---------+---------+-----------------------+---------
-  sammy  | rg_light |  31861  |    f    | &lt;IDLE&gt; in transaction | testdb
-  billy  | rg_light |  31905  |    t    | SELECT * FROM topten; | testdb</codeblock>
-        <p>Use this output to identify the process id (<codeph>pid</codeph>) of the transaction
-          you want to cancel, and then cancel the process. For example, to cancel the pending query
+        <codeblock> rolname | rsgname  | pid     | waiting | state  |          query           | datname 
+---------+----------+---------+---------+--------+------------------------ -+---------
+  sammy  | rg_light |  31861  |    f    | idle   | SELECT * FROM mytesttbl; | testdb
+  billy  | rg_light |  31905  |    t    | active | SELECT * FROM topten;    | testdb</codeblock>
+        <p>Use this output to identify the process id (<codeph>pid</codeph>) of the transaction you
+          want to cancel, and then cancel the process. For example, to cancel the pending query
           identified in the sample output above:</p>
         <p>
           <codeblock>=# SELECT pg_cancel_backend(31905);</codeblock>
@@ -1041,7 +1041,6 @@ gpstart
                   CPU usage is higher than the configured limit.</li>
               </ul></p></li>
         </ul>
-        <p/>
       </section>
       <section id="topic795" xml:lang="en">
         <title>Memory</title>

--- a/gpdb-doc/dita/install_guide/migrate.xml
+++ b/gpdb-doc/dita/install_guide/migrate.xml
@@ -113,7 +113,9 @@
                 <codeph>procpid</codeph> column is renamed to <codeph>pid</codeph>.</li>
             <li>In the <codeph>pg_stat_activity</codeph> system table, the <codeph>procpid</codeph>
               column is renamed to <codeph>pid</codeph>. The <codeph>current_query</codeph> column
-              is removed. </li>
+              is replaced by two columns <codeph>state</codeph>: the state of the backend, and
+                <codeph>query</codeph>: the last run query, or currently running query if
+                <codeph>state</codeph> is <codeph>active</codeph>. </li>
             <li>In the <codeph>gp_distribution_policy</codeph> system table, the
                 <codeph>attrnums</codeph> column is renamed to <codeph>distkey</codeph> and its data
               type is changed to <codeph>int2vector</codeph>. A backend function

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -8737,9 +8737,8 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
   <topic id="track_activity_query_size">
     <title>track_activity_query_size</title>
     <body>
-      <p>Sets the maximum length limit for the query text stored in <codeph>current_query</codeph>
-        column of the system catalog view <i>pg_stat_activity</i>. The minimum length is 1024
-        characters. </p>
+      <p>Sets the maximum length limit for the query text stored in <codeph>query</codeph> column of
+        the system catalog view <i>pg_stat_activity</i>. The minimum length is 1024 characters. </p>
       <table id="track_activity_query_size_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1903,7 +1903,7 @@
             </tbody>
           </tgroup>
         </table>
-        <p>Query output for this view is similar to that of the 
+        <p>Query output for this view is similar to that of the
           <codeph>gp_resgroup_status_per_host</codeph> view, and breaks out the CPU and
           memory (used and available) for each segment instance on each host.</p>
       </body>
@@ -2260,7 +2260,7 @@
         <p>This view contains one row for each operator using disk space for workfiles on a segment
           at the current time. The view is accessible to all users, however non-superusers only to
           see information for the databases that they have permission to access.</p>
-        <table id="ie202617" class="- topic/table ">
+        <table class="- topic/table " id="table_zt5_yl1_gjb">
           <title class="- topic/title ">gp_workfile_entries</title>
           <tgroup cols="4" class="- topic/tgroup ">
             <colspec colnum="1" colname="col1" colwidth="131pt" class="- topic/colspec "/>
@@ -2278,32 +2278,6 @@
             <tbody class="- topic/tbody ">
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">command_cnt</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">integer</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">Command ID of the query.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">content</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">smallint</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The content identifier for a segment
-                  instance.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">current_query</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">text</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">Current query that the process is
-                  running.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
                   <codeph class="+ topic/ph pr-d/codeph ">datname</codeph>
                 </entry>
                 <entry colname="col2" class="- topic/entry ">name</entry>
@@ -2312,24 +2286,7 @@
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">directory</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">text</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">Path to the work file.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">optype</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">text</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The query operator type that created
-                  the work file.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">procpid </codeph>
+                  <codeph class="+ topic/ph pr-d/codeph ">pid </codeph>
                 </entry>
                 <entry colname="col2" class="- topic/entry ">integer</entry>
                 <entry colname="col3" class="- topic/entry "/>
@@ -2346,38 +2303,11 @@
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">size </codeph>
+                  <codeph class="+ topic/ph pr-d/codeph ">command_cnt</codeph>
                 </entry>
-                <entry colname="col2" class="- topic/entry ">bigint</entry>
+                <entry colname="col2" class="- topic/entry ">integer</entry>
                 <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The size of the work file in
-                  bytes.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">numfiles</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">bigint</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The number of files created.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">slice</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">smallint</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The query plan slice. The portion of
-                  the query plan that is being executed.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">state</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">text</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The state of the query that created the
-                  work file.</entry>
+                <entry colname="col4" class="- topic/entry ">Command ID of the query.</entry>
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
@@ -2389,12 +2319,62 @@
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">workmem</codeph>
+                  <codeph class="+ topic/ph pr-d/codeph ">query</codeph>
+                </entry>
+                <entry colname="col2" class="- topic/entry ">text</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">Current query that the process is
+                  running.</entry>
+              </row>
+              <row>
+                <entry colname="col1" class="- topic/entry ">
+                  <codeph>segid</codeph></entry>
+                <entry colname="col2" class="- topic/entry ">integer</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">Segment ID.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">
+                  <codeph class="+ topic/ph pr-d/codeph ">slice</codeph>
                 </entry>
                 <entry colname="col2" class="- topic/entry ">integer</entry>
                 <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The amount of memory allocated to the
-                  operator in KB.</entry>
+                <entry colname="col4" class="- topic/entry ">The query plan slice. The portion of
+                  the query plan that is being executed.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">
+                  <codeph class="+ topic/ph pr-d/codeph ">optype</codeph>
+                </entry>
+                <entry colname="col2" class="- topic/entry ">text</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">The query operator type that created
+                  the work file.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">
+                  <codeph class="+ topic/ph pr-d/codeph ">size</codeph>
+                </entry>
+                <entry colname="col2" class="- topic/entry ">bigint</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">The size of the work file in
+                  bytes.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">
+                  <codeph class="+ topic/ph pr-d/codeph ">numfiles</codeph>
+                </entry>
+                <entry colname="col2" class="- topic/entry ">integer</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">The number of files created.</entry>
+              </row>
+              <row>
+                <entry colname="col1" class="- topic/entry ">
+                  <codeph>prefix</codeph></entry>
+                <entry colname="col2" class="- topic/entry ">text</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">Prefix used when naming a related set
+                  of workfiles.</entry>
               </row>
             </tbody>
           </tgroup>
@@ -2427,32 +2407,6 @@
             <tbody class="- topic/tbody ">
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">command_cnt</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">integer</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">Command ID of the query.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">content</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">smallint</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The content identifier for a segment
-                  instance.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">current_query</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">text</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">Current query that the process is
-                  running.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
                   <codeph class="+ topic/ph pr-d/codeph ">datname</codeph>
                 </entry>
                 <entry colname="col2" class="- topic/entry ">name</entry>
@@ -2461,7 +2415,7 @@
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">procpid </codeph>
+                  <codeph class="+ topic/ph pr-d/codeph ">pid </codeph>
                 </entry>
                 <entry colname="col2" class="- topic/entry ">integer</entry>
                 <entry colname="col3" class="- topic/entry "/>
@@ -2478,9 +2432,41 @@
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
+                  <codeph class="+ topic/ph pr-d/codeph ">command_cnt</codeph>
+                </entry>
+                <entry colname="col2" class="- topic/entry ">integer</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">Command ID of the query.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">
+                  <codeph class="+ topic/ph pr-d/codeph ">usename</codeph>
+                </entry>
+                <entry colname="col2" class="- topic/entry ">name</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">Role name.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">
+                  <codeph class="+ topic/ph pr-d/codeph ">query</codeph>
+                </entry>
+                <entry colname="col2" class="- topic/entry ">text</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">Current query that the process is
+                  running.</entry>
+              </row>
+              <row>
+                <entry colname="col1" class="- topic/entry ">
+                  <codeph>segid</codeph></entry>
+                <entry colname="col2" class="- topic/entry ">integer</entry>
+                <entry colname="col3" class="- topic/entry "/>
+                <entry colname="col4" class="- topic/entry ">Segment ID.</entry>
+              </row>
+              <row class="- topic/row ">
+                <entry colname="col1" class="- topic/entry ">
                   <codeph class="+ topic/ph pr-d/codeph ">size</codeph>
                 </entry>
-                <entry colname="col2" class="- topic/entry ">bigint</entry>
+                <entry colname="col2" class="- topic/entry ">numeric</entry>
                 <entry colname="col3" class="- topic/entry "/>
                 <entry colname="col4" class="- topic/entry ">The size of the work file in
                   bytes.</entry>
@@ -2492,23 +2478,6 @@
                 <entry colname="col2" class="- topic/entry ">bigint</entry>
                 <entry colname="col3" class="- topic/entry "/>
                 <entry colname="col4" class="- topic/entry ">The number of files created.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">state</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">text</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The state of the query that created the
-                  work file.</entry>
-              </row>
-              <row class="- topic/row ">
-                <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">usename</codeph>
-                </entry>
-                <entry colname="col2" class="- topic/entry ">name</entry>
-                <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">Role name.</entry>
               </row>
             </tbody>
           </tgroup>
@@ -2542,18 +2511,17 @@
             <tbody class="- topic/tbody ">
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
-                  <codeph class="+ topic/ph pr-d/codeph ">content</codeph>
+                  <codeph class="+ topic/ph pr-d/codeph ">segid</codeph>
                 </entry>
                 <entry colname="col2" class="- topic/entry ">smallint</entry>
                 <entry colname="col3" class="- topic/entry "/>
-                <entry colname="col4" class="- topic/entry ">The content identifier for a segment
-                  instance.</entry>
+                <entry colname="col4" class="- topic/entry ">Segment ID.</entry>
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">
                   <codeph class="+ topic/ph pr-d/codeph ">size</codeph>
                 </entry>
-                <entry colname="col2" class="- topic/entry ">bigint</entry>
+                <entry colname="col2" class="- topic/entry ">numeric</entry>
                 <entry colname="col3" class="- topic/entry "/>
                 <entry colname="col4" class="- topic/entry ">The total size of the work files on a
                   segment.</entry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_RESOURCE_GROUP.xml
@@ -1,25 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="dc20941">DROP RESOURCE GROUP</title><body>
-    <p id="sql_command_desc">Removes a resource group.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DROP RESOURCE GROUP <varname>group_name</varname></codeblock></section><section id="section3"><title>Description</title><p>This command removes a resource group from Greenplum
-Database. Only a superuser
-can drop a resource group. When you drop a resource group, the memory and CPU resources reserved by the group are returned to Greenplum Database.</p><p>To drop a role resource group, the group cannot be assigned to any roles,
-nor can it have any statements pending or running in the group. If you drop a resource group that you created for an external component, the behavior is determined by the external component. For example, dropping a resource group that you assigned to a PL/Container runtime kills running containers in the group. </p><p>You cannot drop the pre-defined <codeph>admin_group</codeph> and <codeph>default_group</codeph> resource groups.</p>
-</section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>group_name</varname></pt><pd>The name of the resource group to remove.</pd></plentry></parml></section><section id="section5"><title>Notes</title><p>You cannot submit a <codeph>DROP RESOURCE GROUP</codeph> command in an explicit transaction or sub-transaction.</p><p>Use <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to remove a resource group assigned
-        to a specific user/role.</p><p> Perform the following query to view all of the currently active
-        queries for all resource groups:</p><codeblock>SELECT usename, current_query, waiting, pid,
+<topic id="topic1">
+  <title id="dc20941">DROP RESOURCE GROUP</title>
+  <body>
+    <p id="sql_command_desc">Removes a resource group.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock id="sql_command_synopsis">DROP RESOURCE GROUP <varname>group_name</varname></codeblock>
+    </section>
+    <section id="section3">
+      <title>Description</title>
+      <p>This command removes a resource group from Greenplum Database. Only a superuser can drop a
+        resource group. When you drop a resource group, the memory and CPU resources reserved by the
+        group are returned to Greenplum Database.</p>
+      <p>To drop a role resource group, the group cannot be assigned to any roles, nor can it have
+        any statements pending or running in the group. If you drop a resource group that you
+        created for an external component, the behavior is determined by the external component. For
+        example, dropping a resource group that you assigned to a PL/Container runtime kills running
+        containers in the group. </p>
+      <p>You cannot drop the pre-defined <codeph>admin_group</codeph> and
+          <codeph>default_group</codeph> resource groups.</p>
+    </section>
+    <section id="section4">
+      <title>Parameters</title>
+      <parml>
+        <plentry>
+          <pt><varname>group_name</varname></pt>
+          <pd>The name of the resource group to remove.</pd>
+        </plentry>
+      </parml>
+    </section>
+    <section id="section5">
+      <title>Notes</title>
+      <p>You cannot submit a <codeph>DROP RESOURCE GROUP</codeph> command in an explicit transaction
+        or sub-transaction.</p>
+      <p>Use <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"/></codeph> to
+        remove a resource group assigned to a specific user/role.</p>
+      <p> Perform the following query to view all of the currently active queries for all resource
+        groups:</p>
+      <codeblock>SELECT usename, query, waiting, pid,
     rsgid, rsgname, rsgqueueduration 
   FROM pg_stat_activity;
-</codeblock><p>To view the resource group assignments, perform the following query
-on the <codeph>pg_roles</codeph> and <codeph>pg_resgroup</codeph> system
-catalog tables:</p><codeblock>SELECT rolname, rsgname 
+</codeblock>
+      <p>To view the resource group assignments, perform the following query on the
+          <codeph>pg_roles</codeph> and <codeph>pg_resgroup</codeph> system catalog tables:</p>
+      <codeblock>SELECT rolname, rsgname 
   FROM pg_roles, pg_resgroup
-  WHERE pg_roles.rolresgroup=pg_resgroup.oid;</codeblock></section><section id="section6"><title>Examples</title>
-<p>Remove the resource group assigned to a role. This operation then assigns the default
-resource group <codeph>default_group</codeph> to the role:</p><codeblock>ALTER ROLE bob RESOURCE GROUP NONE;</codeblock>
-<p>Remove the resource group named <codeph>adhoc</codeph>:</p><codeblock>DROP RESOURCE GROUP adhoc;</codeblock></section>
-<section id="section7"><title>Compatibility</title><p>The <codeph>DROP RESOURCE GROUP</codeph> statement is a Greenplum Database extension. </p></section><section id="section8"><title>See Also</title><p><codeph><xref href="ALTER_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/></codeph>,
+  WHERE pg_roles.rolresgroup=pg_resgroup.oid;</codeblock>
+    </section>
+    <section id="section6">
+      <title>Examples</title>
+      <p>Remove the resource group assigned to a role. This operation then assigns the default
+        resource group <codeph>default_group</codeph> to the role:</p>
+      <codeblock>ALTER ROLE bob RESOURCE GROUP NONE;</codeblock>
+      <p>Remove the resource group named <codeph>adhoc</codeph>:</p>
+      <codeblock>DROP RESOURCE GROUP adhoc;</codeblock>
+    </section>
+    <section id="section7">
+      <title>Compatibility</title>
+      <p>The <codeph>DROP RESOURCE GROUP</codeph> statement is a Greenplum Database extension. </p>
+    </section>
+    <section id="section8">
+      <title>See Also</title>
+      <p><codeph><xref href="ALTER_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"/></codeph>,
             <codeph><xref href="CREATE_RESOURCE_GROUP.xml#topic1" type="topic" format="dita"
           /></codeph>, <codeph><xref href="ALTER_ROLE.xml#topic1" type="topic" format="dita"
-          /></codeph></p></section></body></topic>
+          /></codeph></p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_activity.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_activity.xml
@@ -9,8 +9,8 @@
       are available unless the parameter <codeph>stats_command_string</codeph> has been turned off.
       Furthermore, these columns are only visible if the user examining the view is a superuser or
       the same as the user owning the process being reported on.</p>
-    <p>The maximum length of the query text string stored in the column
-        <codeph>current_query</codeph> can be controlled with the server configuration parameter
+    <p>The maximum length of the query text string stored in the column <codeph>query</codeph> can
+      be controlled with the server configuration parameter
         <codeph>track_activity_query_size</codeph>. </p>
     <table id="hq141982">
       <title>pg_catalog.pg_stat_activity</title>
@@ -65,7 +65,7 @@
             <entry>Name of the user logged into this backend</entry>
           </row>
           <row>
-            <entry>application_name</entry>
+            <entry><codeph>application_name</codeph></entry>
             <entry>text</entry>
             <entry/>
             <entry>Name of the application that is connected to this backend</entry>


### PR DESCRIPTION
Other changes
--updated some queries and results to use state column from pg_stat_activity.
--update gp_toolkit.gp_workfile_* tables -based on replacing workfiles with buffiles dev PR https://github.com/greenplum-db/gpdb/pull/6508

@hlinnaka Can you review the changes to gp_workfile_* tables. Updates to these tables were missed with your original PR.

Updates in HTML format

Changed references to current_query to query, change some queries
http://docs-msk-gpdb6-dev.cfapps.io/6-0/admin_guide/perf_troubleshoot.html#topic5
http://docs-msk-gpdb6-dev.cfapps.io/6-0/admin_guide/workload_mgmt.html#topic27
http://docs-msk-gpdb6-dev.cfapps.io/6-0/admin_guide/workload_mgmt_resgroups.html
http://docs-msk-gpdb6-dev.cfapps.io/6-0/admin_guide/managing/startstop.html
http://docs-msk-gpdb6-dev.cfapps.io/6-0/ref_guide/config_params/guc-list.html#track_activity_query_size
http://docs-msk-gpdb6-dev.cfapps.io/6-0/ref_guide/sql_commands/DROP_RESOURCE_GROUP.html

Minor edit to column name
http://docs-msk-gpdb6-dev.cfapps.io/6-0/ref_guide/system_catalogs/pg_stat_activity.html

Reword change of column name from current_query to query.
http://docs-msk-gpdb6-dev.cfapps.io/6-0/install_guide/migrate.html

update gp_toolkit.gp_workfile_* tables -based on replacing workfiles with buffiles
http://docs-msk-gpdb6-dev.cfapps.io/6-0/ref_guide/gp_toolkit.html#topic32

Add schema to tablename
http://docs-msk-gpdb6-dev.cfapps.io/6-0/admin_guide/managing/monitor.html
