### PR TITLE
docs - aggregate-related updates

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
@@ -783,8 +783,7 @@ SELECT foo();</codeblock>
         <title id="in184703">Advanced Aggregate Functions</title>
         <body>
             <p>The following built-in advanced aggregate functions are Greenplum extensions of the
-                PostgreSQL database. These functions are <i>immutable</i>. Greenplum Database does
-                not support the PostgreSQL ordered-set aggregate functions.
+                PostgreSQL database. These functions are <i>immutable</i>.
                 <note>The Greenplum MADlib Extension for Analytics provides additional advanced
                     functions to perform statistical analysis and machine learning with Greenplum
                     Database data. See <xref href="../../../ref_guide/extensions/madlib.xml#topic1"

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -42,8 +42,7 @@
               <li><cmdname>FIELDSELECT</cmdname></li>
             </ul></li>
           <li>Aggregate functions that take set operators as input arguments.</li>
-          <li><cmdname>percentile_*</cmdname> window functions (Greenplum Database does not support
-            ordered-set aggregate functions).</li>
+          <li><cmdname>percentile_*</cmdname> window functions (ordered-set aggregate functions).</li>
           <li>Inverse distribution functions.</li>
           <li>Queries that execute functions that are defined with the <codeph>ON MASTER</codeph> or
               <codeph>ON ALL SEGMENTS</codeph> attribute.</li>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_AGGREGATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_AGGREGATE.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="ag20941">ALTER AGGREGATE</title><body><p id="sql_command_desc">Changes the definition of an aggregate function</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">ALTER AGGREGATE <varname>name</varname> ( <varname>type</varname> [ , ... ] ) RENAME TO <varname>new_name</varname>
+<topic id="topic1"><title id="ag20941">ALTER AGGREGATE</title><body><p id="sql_command_desc">Changes the definition of an aggregate function</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">ALTER AGGREGATE <varname>name</varname> ( <varname>aggregate_signature</varname> )  RENAME TO <varname>new_name</varname>
 
-ALTER AGGREGATE <varname>name</varname> ( <varname>type</varname> [ , ... ] ) OWNER TO <varname>new_owner</varname>
+ALTER AGGREGATE <varname>name</varname> ( <varname>aggregate_signature</varname> ) OWNER TO <varname>new_owner</varname>
 
-ALTER AGGREGATE <varname>name</varname> ( <varname>type</varname> [ , ... ] ) SET SCHEMA <varname>new_schema</varname></codeblock></section><section id="section3"><title>Description</title><p><codeph>ALTER AGGREGATE</codeph> changes the definition of an aggregate
+ALTER AGGREGATE <varname>name</varname> ( <varname>aggregate_signature</varname> ) SET SCHEMA <varname>new_schema</varname></codeblock>
+<p>where <varname>aggregate_signature</varname> is:</p>
+  <codeblock>* |
+[ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] |
+[ [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] ] ORDER BY [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ]</codeblock>
+</section><section id="section3"><title>Description</title><p><codeph>ALTER AGGREGATE</codeph> changes the definition of an aggregate
 function. </p><p>You must own the aggregate function to use <codeph>ALTER AGGREGATE</codeph>.
 To change the schema of an aggregate function, you must also have <codeph>CREATE</codeph>
 privilege on the new schema. To alter the owner, you must also be a direct
@@ -14,9 +19,39 @@ privilege on the aggregate function's schema. (These restrictions enforce
 that altering the owner does not do anything you could not do by dropping
 and recreating the aggregate function. However, a superuser can alter
 ownership of any aggregate function anyway.)</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of an existing aggregate function.
-</pd></plentry><plentry><pt><varname>type</varname></pt><pd>An input data type on which the aggregate function operates. To reference
-a zero-argument aggregate function, write * in place of the list of input
-data types. </pd></plentry><plentry><pt><varname>new_name</varname></pt><pd>The new name of the aggregate function. </pd></plentry><plentry><pt><varname>new_owner</varname></pt><pd>The new owner of the aggregate function. </pd></plentry><plentry><pt><varname>new_schema</varname></pt><pd>The new schema for the aggregate function.</pd></plentry></parml></section><section id="section5"><title>Examples</title><p>To rename the aggregate function <codeph>myavg</codeph> for type <codeph>integer</codeph> to
+</pd></plentry>
+  <plentry>
+    <pt><varname>argmode</varname></pt>
+      <pd>The mode of an argument:  <codeph>IN</codeph> or <codeph>VARIADIC</codeph>.
+        If omitted, the default is <codeph>IN</codeph>.</pd>
+  </plentry>
+  <plentry>
+      <pt><varname>argname</varname></pt>
+      <pd>The name of an argument. Note that <codeph>ALTER AGGREGATE</codeph> does not
+        actually pay any attention to argument names, since only the argument data types
+        are needed to determine the aggregate function's identity.</pd>
+    </plentry>
+    <plentry>
+      <pt><varname>argtype</varname></pt>
+      <pd>An input data type on which the aggregate function operates. To reference
+        a zero-argument aggregate function, write <codeph>*</codeph> in place of the
+        list of input data types. To reference an ordered-set aggregate function, write
+        <codeph>ORDER BY</codeph> between the direct and aggregated argument
+        specifications.</pd>
+    </plentry>
+<plentry><pt><varname>new_name</varname></pt><pd>The new name of the aggregate function. </pd></plentry><plentry><pt><varname>new_owner</varname></pt><pd>The new owner of the aggregate function. </pd></plentry><plentry><pt><varname>new_schema</varname></pt><pd>The new schema for the aggregate function.</pd></plentry></parml></section>
+<section id="notes">
+  <title>Notes</title>
+  <p>The recommended syntax for referencing an ordered-set aggregate is to write
+    <codeph>ORDER BY</codeph> between the direct and aggregated argument specifications,
+    in the same style as in
+    <codeph><xref href="./CREATE_AGGREGATE.xml#topic1" type="topic" format="dita"/></codeph>.
+    However, it will also work to omit <codeph>ORDER BY</codeph> and just run the
+    direct and aggregated argument specifications into a single list. In this
+    abbreviated form, if <codeph>VARIADIC "any"</codeph> was used in both the direct
+    and aggregated argument lists, write <codeph>VARIADIC "any"</codeph> only once.</p>
+</section>
+<section id="section5"><title>Examples</title><p>To rename the aggregate function <codeph>myavg</codeph> for type <codeph>integer</codeph> to
           <codeph>my_average</codeph>:</p><codeblock>ALTER AGGREGATE myavg(integer) RENAME TO my_average;</codeblock><p>To change the owner of the aggregate function <codeph>myavg</codeph> for type
           <codeph>integer</codeph> to <codeph>joe</codeph>:</p><codeblock>ALTER AGGREGATE myavg(integer) OWNER TO joe;</codeblock><p>To move the aggregate function <codeph>myavg</codeph> for type <codeph>integer</codeph> into
         schema <codeph>myschema</codeph>:</p><codeblock>ALTER AGGREGATE myavg(integer) SET SCHEMA myschema;</codeblock></section><section id="section6"><title>Compatibility</title><p>There is no <codeph>ALTER AGGREGATE</codeph> statement in the SQL standard.</p></section><section id="section7"><title>See Also</title><p><codeph><xref href="./CREATE_AGGREGATE.xml#topic1" type="topic" format="dita"/></codeph>,

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_EXTENSION.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_EXTENSION.xml
@@ -44,9 +44,9 @@ where <varname>member_object</varname> is:
 
 and <varname>aggregate_signature</varname> is:
 
-* | [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] |
-  [ [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] ] 
-    ORDER BY [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ]</codeblock>
+* |
+[ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] |
+[ [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] ] ORDER BY [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ]</codeblock>
     </section>
     <section id="section3">
       <title>Description</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/COMMENT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/COMMENT.xml
@@ -10,7 +10,7 @@
       <codeblock id="sql_command_synopsis">COMMENT ON
 { TABLE <varname>object_name</varname> |
   COLUMN <varname>relation_name.column_name</varname> |
-  AGGREGATE <varname>agg_name</varname> (<varname>agg_type</varname> [, ...]) |
+  AGGREGATE <varname>agg_name</varname> (<varname>agg_signature</varname>) |
   CAST (<varname>source_type</varname> AS <varname>target_type</varname>) |
   COLLATION <varname>object_name</varname>
   CONSTRAINT <varname>constraint_name</varname> ON <varname>table_name</varname> |
@@ -38,6 +38,10 @@
   TYPE <varname>object_name</varname> |
   VIEW <varname>object_name</varname> } 
 IS '<varname>text</varname>'</codeblock>
+<p>where <varname>agg_signature</varname> is:</p>
+<codeblock>* |
+[ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] |
+[ [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] ] ORDER BY [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ]</codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -74,12 +78,6 @@ IS '<varname>text</varname>'</codeblock>
               not support triggers.</note></pd>
         </plentry>
         <plentry>
-          <pt><varname>aggregate_type</varname></pt>
-          <pd>An input data type on which the aggregate function operates. To reference a
-            zero-argument aggregate function, write <codeph>*</codeph> in place of the list of input
-            data types. </pd>
-        </plentry>
-        <plentry>
           <pt><varname>source_type</varname></pt>
           <pd>The name of the source data type of the cast. </pd>
         </plentry>
@@ -89,9 +87,9 @@ IS '<varname>text</varname>'</codeblock>
         </plentry>
         <plentry>
           <pt><varname>argmode</varname></pt>
-          <pd>The mode of a function argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>,
+          <pd>The mode of a function or aggregate argument: either <codeph>IN</codeph>, <codeph>OUT</codeph>,
               <codeph>INOUT</codeph>, or <codeph>VARIADIC</codeph>. If omitted, the default is
-              <codeph>IN</codeph>. Note that <codeph>COMMENT ON FUNCTION</codeph> does not actually
+              <codeph>IN</codeph>. Note that <codeph>COMMENT</codeph> does not actually
             pay any attention to <codeph>OUT</codeph> arguments, since only the input arguments are
             needed to determine the function's identity. So it is sufficient to list the
               <codeph>IN</codeph>, <codeph>INOUT</codeph>, and <codeph>VARIADIC</codeph> arguments.
@@ -99,13 +97,13 @@ IS '<varname>text</varname>'</codeblock>
         </plentry>
         <plentry>
           <pt><varname>argname</varname></pt>
-          <pd>The name of a function argument. Note that <codeph>COMMENT ON FUNCTION</codeph> does
+          <pd>The name of a function or aggregate argument. Note that <codeph>COMMENT ON FUNCTION</codeph> does
             not actually pay any attention to argument names, since only the argument data types are
             needed to determine the function's identity. </pd>
         </plentry>
         <plentry>
           <pt><varname>argtype</varname></pt>
-          <pd>The data type(s) of the function's arguments (optionally schema-qualified), if any.
+          <pd>The data type of a function or aggregate argument.
           </pd>
         </plentry>
         <plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_AGGREGATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_AGGREGATE.xml
@@ -6,7 +6,7 @@
   <body>
     <p id="sql_command_desc">Defines a new aggregate function.</p>
     <section id="section2"
-      ><title>Synopsis</title><varname>argname</varname><codeblock id="sql_command_synopsis">CREATE AGGREGATE <varname>name</varname> ( [ <varname>argmode</varname> ] [  ] <varname>arg_data_type</varname> [ , ... ] ) (
+      ><title>Synopsis</title><codeblock id="sql_command_synopsis">CREATE AGGREGATE <varname>name</varname> ( [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>arg_data_type</varname> [ , ... ] ) (
     SFUNC = <varname>statefunc</varname>,
     STYPE = <varname>state_data_type</varname>
     [ , SSPACE = <varname>state_data_size</varname> ]
@@ -126,7 +126,8 @@
         single-level aggregation that sends all the rows to the master and then applies only the
             <codeph><varname>statefunc</varname></codeph>  to the rows.</p>
       <p>An aggregate function can provide an optional initial condition, an initial value for the
-        internal state value. This is specified and stored in the database as a value of type text,
+        internal state value. This is specified and stored in the database as a value of type
+        <codeph>text</codeph>,
         but it must be a valid external representation of a constant of the state value data type.
         If it is not supplied then the state value starts out <codeph>NULL</codeph>. </p>
       <p>If  <codeph><varname>statefunc</varname></codeph>  is declared <codeph>STRICT</codeph>,
@@ -138,11 +139,11 @@
         subsequent rows with all non-null input values. This is useful for implementing aggregates
         like <codeph>max</codeph>. Note that this behavior is only available when
           <varname>state_data_type</varname> is the same as the first
-          <varname>input_data_type</varname>. When these types are different, you must supply a
+          <varname>arg_data_type</varname>. When these types are different, you must supply a
         non-null initial condition or use a nonstrict transition function.</p>
       <p>If  <varname>statefunc</varname> is not declared <codeph>STRICT</codeph>, then it will be
         called unconditionally at each input row, and must deal with <codeph>NULL</codeph> inputs
-        and <codeph>NULL</codeph> transition values for itself. This allows the aggregate author to
+        and <codeph>NULL</codeph> state values for itself. This allows the aggregate author to
         have full control over the aggregate's handling of <codeph>NULL</codeph> values.</p>
       <p>If the final function (<codeph><varname>ffunc</varname></codeph>) is declared
           <codeph>STRICT</codeph>, then it will not be called when the ending state value is
@@ -164,7 +165,7 @@
           href="https://www.postgresql.org/docs/9.4/xaggr.html#XAGGR-MOVING-AGGREGATES"
           scope="external" format="html">Moving-Aggregate Mode</xref> in the PostgreSQL
         documentation. This requires specifying the <codeph><varname>msfunc</varname></codeph>,
-            <codeph><varname>minfunc</varname></codeph>, and
+            <codeph><varname>minvfunc</varname></codeph>, and
           <codeph><varname>mstype</varname></codeph> functions, and optionally the
             <codeph><varname>mspace</varname></codeph>,
           <codeph><varname>mfinalfunc</varname></codeph>,
@@ -184,9 +185,10 @@
         direct arguments are required to match, in number and data types, the aggregated argument
         columns. This allows the values of those direct arguments to be added to the collection of
         aggregate-input rows as an additional "hypothetical" row. </p>
-      <p>Single argument aggregate functions, such as min or max, can sometimes be optimized by
+      <p>Single argument aggregate functions, such as <codeph>min</codeph> or
+        <codeph>max</codeph>, can sometimes be optimized by
         looking into an index instead of scanning every input row. If this aggregate can be so
-        optimized, indicate it by specifying a sort operator. The basic requirement is that the
+        optimized, indicate it by specifying a <i>sort operator</i>. The basic requirement is that the
         aggregate must yield the first element in the sort ordering induced by the operator; in
         other words:</p>
       <codeblock>SELECT <varname>agg</varname>(<varname>col</varname>) FROM <varname>tab</varname>; </codeblock>
@@ -200,7 +202,7 @@
         the specified operator is the "less than" or "greater than" strategy member of a B-tree
         index operator class.</p>
       <p> To be able to create an aggregate function, you must have <codeph>USAGE</codeph> privilege
-        on the argument types, the state type, and the return type, as well as
+        on the argument types, the state type(s), and the return type, as well as
           <codeph>EXECUTE</codeph> privilege on the transition and final functions. </p>
     </section>
     <section id="section5">
@@ -253,7 +255,7 @@
         </plentry>
         <plentry>
           <pt><varname>state_data_type</varname></pt>
-          <pd>The data type for the aggregate state value.</pd>
+          <pd>The data type for the aggregate's state value.</pd>
         </plentry>
         <plentry>
           <pt><varname>state_data_size</varname></pt>
@@ -278,6 +280,20 @@
             corresponding to the aggregate's regular (aggregated) arguments. This is mainly useful
             to allow correct resolution of the aggregate result type when a polymorphic aggregate is
             being defined. </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>combinefunc</varname></pt>
+          <pd>The name of a combine function. This is a function of two arguments, both of type
+              <varname>state_data_type</varname>. It must return a value of
+              <varname>state_data_type</varname>. A combine function takes two transition state
+            values and returns a new transition state value representing the combined aggregation.
+            In Greenplum Database, if the result of the aggregate function is computed in a
+            segmented fashion, the combine function is invoked on the individual internal states in
+            order to combine them into an ending internal state.</pd>
+          <pd>Note that this function is also called in hash aggregate mode within a segment.
+            Therefore, if you call this aggregate function without a combine function, hash
+            aggregate is never chosen. Since hash aggregate is efficient, consider defining a
+            combine function whenever possible.</pd>
         </plentry>
         <plentry>
           <pt><varname>serialfunc</varname></pt>
@@ -358,20 +374,6 @@
               (<codeph>WITHIN GROUP</codeph>) arguments. The <codeph>HYPOTHETICAL</codeph> flag has
             no effect on run-time behavior, only on parse-time resolution of the data types and
             collations of the aggregate's arguments. </pd>
-        </plentry>
-        <plentry>
-          <pt><varname>combinefunc</varname></pt>
-          <pd>The name of a combine function. This is a function of two arguments, both of type
-              <varname>state_data_type</varname>. It must return a value of
-              <varname>state_data_type</varname>. A combine function takes two transition state
-            values and returns a new transition state value representing the combined aggregation.
-            In Greenplum Database, if the result of the aggregate function is computed in a
-            segmented fashion, the combine function is invoked on the individual internal states in
-            order to combine them into an ending internal state.</pd>
-          <pd>Note that this function is also called in hash aggregate mode within a segment.
-            Therefore, if you call this aggregate function without a combine function, hash
-            aggregate is never chosen. Since hash aggregate is efficient, consider defining a
-            combine function whenever possible.</pd>
         </plentry>
       </parml>
     </section>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_AGGREGATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_AGGREGATE.xml
@@ -1,15 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="co20941">DROP AGGREGATE</title><body><p id="sql_command_desc">Removes an aggregate function.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DROP AGGREGATE [IF EXISTS] <varname>name</varname> ( <varname>type</varname> [, ...] ) [CASCADE | RESTRICT]</codeblock></section><section id="section3"><title>Description</title><p><codeph>DROP AGGREGATE</codeph> will delete an existing aggregate function.
+<topic id="topic1"><title id="co20941">DROP AGGREGATE</title><body><p id="sql_command_desc">Removes an aggregate function.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DROP AGGREGATE [IF EXISTS] <varname>name</varname> ( <varname>aggregate_signature</varname> ) [CASCADE | RESTRICT]</codeblock>
+  <p>where <varname>aggregate_signature</varname> is:</p>
+  <codeblock>* |
+[ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] |
+[ [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ] ] ORDER BY [ <varname>argmode</varname> ] [ <varname>argname</varname> ] <varname>argtype</varname> [ , ... ]</codeblock>
+</section><section id="section3"><title>Description</title><p><codeph>DROP AGGREGATE</codeph> will delete an existing aggregate function.
 To execute this command the current user must be the owner of the aggregate
 function.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt>IF EXISTS</pt><pd>Do not throw an error if the aggregate does not exist. A notice is
-issued in this case. </pd></plentry><plentry><pt><varname>name</varname></pt><pd>The name (optionally schema-qualified) of an existing aggregate function.
-</pd></plentry><plentry><pt><varname>type</varname></pt><pd>An input data type on which the aggregate function operates. To reference
-a zero-argument aggregate function, write <codeph>*</codeph> in place
-of the list of input data types. </pd></plentry><plentry><pt>CASCADE</pt><pd>Automatically drop objects that depend on the aggregate function.
+issued in this case. </pd></plentry>
+    <plentry>
+      <pt><varname>name</varname></pt>
+      <pd>The name (optionally schema-qualified) of an existing aggregate function.</pd>
+    </plentry>
+    <plentry>
+      <pt><varname>argmode</varname></pt>
+      <pd>The mode of an argument:  <codeph>IN</codeph> or <codeph>VARIADIC</codeph>.
+        If omitted, the default is <codeph>IN</codeph>.</pd>
+    </plentry>
+    <plentry>
+      <pt><varname>argname</varname></pt>
+      <pd>The name of an argument. Note that <codeph>DROP AGGREGATE</codeph> does not
+        actually pay any attention to argument names, since only the argument data types
+        are needed to determine the aggregate function's identity.</pd>
+    </plentry>
+    <plentry>
+      <pt><varname>argtype</varname></pt>
+      <pd>An input data type on which the aggregate function operates. To reference
+        a zero-argument aggregate function, write <codeph>*</codeph> in place of the
+        list of input data types. To reference an ordered-set aggregate function, write
+        <codeph>ORDER BY</codeph> between the direct and aggregated argument
+        specifications.</pd>
+    </plentry>
+    <plentry><pt>CASCADE</pt><pd>Automatically drop objects that depend on the aggregate function.
 </pd></plentry><plentry><pt>RESTRICT</pt><pd>Refuse to drop the aggregate function if any objects depend on it.
-This is the default. </pd></plentry></parml></section><section id="section5"><title>Examples</title><p>To remove the aggregate function <codeph>myavg</codeph> for type <codeph>integer</codeph>:</p><codeblock>DROP AGGREGATE myavg(integer);</codeblock></section><section id="section6"><title>Compatibility</title><p>There is no <codeph>DROP AGGREGATE</codeph> statement in the SQL standard.
+This is the default. </pd></plentry></parml></section>
+<section id="notes">
+  <title>Notes</title>
+  <p>Alternative syntaxes for referencing ordered-set aggregates are described under
+    <codeph>ALTER AGGREGATE</codeph>.</p>
+</section>
+<section id="section5"><title>Examples</title><p>To remove the aggregate function <codeph>myavg</codeph> for type <codeph>integer</codeph>:</p><codeblock>DROP AGGREGATE myavg(integer);</codeblock>
+  <p>To remove the hypothetical-set aggregate function <codeph>myrank</codeph>,
+    which takes an arbitrary list of ordering columns and a matching list of direct
+    arguments:</p>
+  <codeblock>DROP AGGREGATE myrank(VARIADIC "any" ORDER BY VARIADIC "any");</codeblock>
+</section><section id="section6"><title>Compatibility</title><p>There is no <codeph>DROP AGGREGATE</codeph> statement in the SQL standard.
 </p></section><section id="section7"><title>See Also</title><p><codeph><xref href="ALTER_AGGREGATE.xml#topic1" type="topic" format="dita"/></codeph>,
             <codeph><xref href="CREATE_AGGREGATE.xml#topic1" type="topic" format="dita"
         /></codeph></p></section></body></topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_aggregate.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_aggregate.xml
@@ -1,26 +1,177 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1" xml:lang="en"><title id="fu141670">pg_aggregate</title><body><p>The <codeph>pg_aggregate</codeph> table stores information about aggregate
-functions. An aggregate function is a function that operates on a set
-of values (typically one column from each row that matches a query condition)
-and returns a single value computed from all these values. Typical aggregate
-functions are <codeph>sum</codeph>, <codeph>count</codeph>, and <codeph>max</codeph>.
-Each entry in <codeph>pg_aggregate</codeph> is an extension of an entry
-in <codeph>pg_proc</codeph>. The <codeph>pg_proc</codeph> entry carries
-the aggregate's name, input and output data types, and other information
-that is similar to ordinary functions.</p><table id="fu141982"><title>pg_catalog.pg_aggregate</title><tgroup cols="4"><colspec colnum="1" colname="col1" colwidth="131pt"/><colspec colnum="2" colname="col2" colwidth="86pt"/><colspec colnum="3" colname="col3" colwidth="85pt"/><colspec colnum="4" colname="col4" colwidth="147pt"/><thead><row><entry colname="col1">column</entry><entry colname="col2">type</entry><entry colname="col3">references</entry><entry colname="col4">description</entry></row></thead><tbody>
-<row><entry colname="col1"><codeph>aggfnoid</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">Aggregate function OID</entry></row>
-<row><entry colname="col1"><codeph>aggtransfn</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">Transition function OID</entry></row>
-<row><entry colname="col1"><codeph>aggcombinefn</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3"/><entry colname="col4">Combine function OID (zero if none)</entry></row>
-<row><entry colname="col1"><codeph>aggfinalfn</codeph></entry><entry colname="col2">regproc</entry><entry colname="col3">pg_proc.oid</entry><entry colname="col4">Final function OID (zero if none)</entry></row>
-<row><entry colname="col1"><codeph>agginitval</codeph></entry><entry colname="col2">text</entry><entry colname="col3"/><entry colname="col4">The initial value of the transition state. This
-is a text field containing the initial value in its external string representation.
-If this field is NULL, the transition state value starts out NULL</entry></row>
-<row><entry colname="col1"><codeph>aggordered</codeph></entry><entry colname="col2">Boolean</entry><entry colname="col3"/><entry colname="col4">If <codeph>true</codeph>, the aggregate is defined
-as <codeph>ORDERED</codeph>.</entry></row>
-<row><entry colname="col1"><codeph>aggsortop</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_operator.oid</entry><entry colname="col4">Associated sort operator OID (zero if none)</entry></row>
-<row><entry colname="col1"><codeph>aggtranstype</codeph></entry><entry colname="col2">oid</entry><entry colname="col3">pg_type.oid</entry><entry colname="col4">Data type of the aggregate function's internal
-transition (state) data</entry></row>
-<row><entry colname="col1"><codeph>aggtransspace</codeph></entry><entry colname="col2">int4</entry><entry colname="col3">pg_type.int4</entry><entry colname="col4">Estimated size of state data (0 for default estimate)</entry></row>
-</tbody></tgroup></table></body></topic>
+<topic id="topic1" xml:lang="en">
+  <title id="fu141670">pg_aggregate</title>
+  <body>
+    <p>The <codeph>pg_aggregate</codeph> table stores information about aggregate functions. An
+      aggregate function is a function that operates on a set of values (typically one column from
+      each row that matches a query condition) and returns a single value computed from all these
+      values. Typical aggregate functions are <codeph>sum</codeph>, <codeph>count</codeph>, and
+        <codeph>max</codeph>. Each entry in <codeph>pg_aggregate</codeph> is an extension of an
+      entry in <codeph>pg_proc</codeph>. The <codeph>pg_proc</codeph> entry carries the aggregate's
+      name, input and output data types, and other information that is similar to ordinary
+      functions.</p>
+    <table id="fu141982">
+      <title>pg_catalog.pg_aggregate</title>
+      <tgroup cols="4">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="86pt"/>
+        <colspec colnum="3" colname="col3" colwidth="85pt"/>
+        <colspec colnum="4" colname="col4" colwidth="147pt"/>
+        <thead>
+          <row>
+            <entry colname="col1">column</entry>
+            <entry colname="col2">type</entry>
+            <entry colname="col3">references</entry>
+            <entry colname="col4">description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry colname="col1"><codeph>aggfnoid</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">OID of the aggregate function</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggkind</codeph></entry>
+            <entry colname="col2">char</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Aggregate kind: <codeph>n</codeph> for <i>normal</i>
+              aggregates, <codeph>o</codeph> for <i>ordered-set</i> aggregates, or
+              <codeph>h</codeph> for <i>hypothetical-set</i> aggregates</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggnumdirectargs</codeph></entry>
+            <entry colname="col2">int2</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Number of direct (non-aggregated) arguments of an
+              ordered-set or hypothetical-set aggregate, counting a variadic array as
+              one argument. If equal to <codeph>pronargs</codeph>, the aggregate must be
+              variadic and the variadic array describes the aggregated arguments as well
+              as the final direct arguments. Always zero for normal aggregates.</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggtransfn</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Transition function OID</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggfinalfn</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Final function OID (zero if none)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggcombinefn</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Combine function OID (zero if none)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggserialfn</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">OID of the serialization function to convert
+              transtype to <codeph>bytea</codeph> (zero if none)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggdeserialfn</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">OID of the deserialization function to convert
+              <codeph>bytea</codeph> to transtype (zero if none)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggmtransfn</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Forward transition function OID for moving-aggregate mode
+              (zero if none)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggminvtransfn</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Inverse transition function OID for moving-aggregate mode
+              (zero if none)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggmfinalfn</codeph></entry>
+            <entry colname="col2">regproc</entry>
+            <entry colname="col3">pg_proc.oid</entry>
+            <entry colname="col4">Final function OID for moving-aggregate mode (zero if
+              none)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggfinalextra</codeph></entry>
+            <entry colname="col2">bool</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">True to pass extra dummy arguments to
+              <codeph>aggfinalfn</codeph></entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggmfinalextra</codeph></entry>
+            <entry colname="col2">bool</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">True to pass extra dummy arguments to
+              <codeph>aggmfinalfn</codeph></entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggsortop</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_operator.oid</entry>
+            <entry colname="col4">Associated sort operator OID (zero if none)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggtranstype</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_type.oid</entry>
+            <entry colname="col4">Data type of the aggregate function's internal transition (state)
+              data</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggtransspace</codeph></entry>
+            <entry colname="col2">int4</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Approximate average size (in bytes) of the transition state
+              data, or zero to use a default estimate</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggmtranstype</codeph></entry>
+            <entry colname="col2">oid</entry>
+            <entry colname="col3">pg_type.oid</entry>
+            <entry colname="col4">Data type of the aggregate function's internal transition (state)
+              data for moving-aggregate mode (zero if none)</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggmtransspace</codeph></entry>
+            <entry colname="col2">int4</entry>
+            <entry colname="col3"></entry>
+            <entry colname="col4">Approximate average size (in bytes) of the transition state
+              data for moving-aggregate mode, or zero to use a default estimate</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>agginitval</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The initial value of the transition state. This is a text field
+              containing the initial value in its external string representation. If this field is
+              NULL, the transition state value starts out NULL</entry>
+          </row>
+          <row>
+            <entry colname="col1"><codeph>aggminitval</codeph></entry>
+            <entry colname="col2">text</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The initial value of the transition state for moving-
+              aggregate mode. This is a text field containing the initial value in its
+              external string representation. If this field is NULL, the transition state
+              value starts out NULL</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_aggregate.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_aggregate.xml
@@ -159,7 +159,7 @@
             <entry colname="col3"/>
             <entry colname="col4">The initial value of the transition state. This is a text field
               containing the initial value in its external string representation. If this field is
-              NULL, the transition state value starts out NULL</entry>
+              NULL, the transition state value starts out NULL.</entry>
           </row>
           <row>
             <entry colname="col1"><codeph>aggminitval</codeph></entry>
@@ -168,7 +168,7 @@
             <entry colname="col4">The initial value of the transition state for moving-
               aggregate mode. This is a text field containing the initial value in its
               external string representation. If this field is NULL, the transition state
-              value starts out NULL</entry>
+              value starts out NULL.</entry>
           </row>
         </tbody>
       </tgroup>


### PR DESCRIPTION
the pg_aggregate system table and aggregate SQL commands were not accurate.  bring them up to par with 6.0 greenplum implementation - planner supports ordered-set aggregates and moving-aggregates.

in this PR:
- reformatted the pg_aggregate file to be more readable
- updated pg_aggregate and the alter/create/delete aggregate ref pages;  mostly focused on the signature and parameter descriptions
- misc edits to other content and sql ref pages

doc review site links:
- pg_aggregate:  http://docs-lisa-agg.cfapps.io/6-0/ref_guide/system_catalogs/pg_aggregate.html
- ALTER AGGREGATE:  http://docs-lisa-agg.cfapps.io/6-0/ref_guide/sql_commands/ALTER_AGGREGATE.html
- CREATE AGGREGATE:  http://docs-lisa-agg.cfapps.io/6-0/ref_guide/sql_commands/CREATE_AGGREGATE.html
- DROP AGGREGATE:  http://docs-lisa-agg.cfapps.io/6-0/ref_guide/sql_commands/DROP_AGGREGATE.html

