### PR TITLE
Add retry in test reader_waits_for_lock for lock checking

### DIFF
--- a/src/test/isolation2/expected/reader_waits_for_lock.out
+++ b/src/test/isolation2/expected/reader_waits_for_lock.out
@@ -2,6 +2,10 @@
 -- available. There used to be a bug where reader didn't wait even if lock was
 -- held by some other session.
 
+-- Helper function
+CREATE or REPLACE FUNCTION check_session_processes_are_blocked (session_number int) /*in func*/ RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (SELECT count(case when waiting then 1 end) = count(*) all_waiting FROM pg_stat_activity where sess_id = session_number) then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
 -- setup
 1: create table reader_waits_for_lock_table(a int, b int) distributed by (a);
 CREATE
@@ -17,10 +21,10 @@ LOCK
 -- creates reader and writer gang
 1&: SELECT t1.* FROM reader_waits_for_lock_table t1 INNER JOIN reader_waits_for_lock_table t2 ON t1.b = t2.b;  <waiting ...>
 -- all processes in the session 1 should be blocked
-0U: SELECT count(case when waiting then 1 end) = count(*) all_waiting FROM pg_stat_activity where sess_id = (SELECT setting FROM reader_waits_for_lock_table_sessionid);
- all_waiting 
--------------
- t           
+0U: select check_session_processes_are_blocked((SELECT setting FROM reader_waits_for_lock_table_sessionid));
+ check_session_processes_are_blocked 
+-------------------------------------
+ t                                   
 (1 row)
 0U: COMMIT;
 COMMIT


### PR DESCRIPTION
Command in next session gets executed in parallel to current session
in case "&" is used. Hence, if session 1 command is running very slow,
but session 0 commands gets executed fast, can cause flaky test. To
avoid the same, add retries to check for all processes for session are
blocked or not.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
