### PR TITLE
Change fix for Motion node's tdhasoids confusion, and add tests.

### DIFF
--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -293,3 +293,37 @@ select * from execinsert_test;
 (1 row)
 
 drop table execinsert_test;
+--
+-- Test RETURNING on a table with OIDs.
+--
+-- See https://github.com/greenplum-db/gpdb/issues/8765
+-- This was also coincidentally covered by the upstream tests in
+-- 'rowsecurity', but better to have an explicit test.
+--
+CREATE TABLE tabwithoids (a int, b text) WITH OIDS;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+NOTICE:  OIDS=TRUE is not recommended for user-created tables
+insert into tabwithoids values (1, 'foo') RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (1,foo)
+(1 row)
+
+update tabwithoids set b = 'foobar' RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (1,foobar)
+(1 row)
+
+update tabwithoids set a = a + 1 RETURNING oid > 1000, tabwithoids; -- split update
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (2,foobar)
+(1 row)
+
+delete from tabwithoids RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (2,foobar)
+(1 row)
+

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -300,3 +300,37 @@ select * from execinsert_test;
 (1 row)
 
 drop table execinsert_test;
+--
+-- Test RETURNING on a table with OIDs.
+--
+-- See https://github.com/greenplum-db/gpdb/issues/8765
+-- This was also coincidentally covered by the upstream tests in
+-- 'rowsecurity', but better to have an explicit test.
+--
+CREATE TABLE tabwithoids (a int, b text) WITH OIDS;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+NOTICE:  OIDS=TRUE is not recommended for user-created tables
+insert into tabwithoids values (1, 'foo') RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (1,foo)
+(1 row)
+
+update tabwithoids set b = 'foobar' RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (1,foobar)
+(1 row)
+
+update tabwithoids set a = a + 1 RETURNING oid > 1000, tabwithoids; -- split update
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (2,foobar)
+(1 row)
+
+delete from tabwithoids RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (2,foobar)
+(1 row)
+

--- a/src/test/regress/sql/bfv_dml.sql
+++ b/src/test/regress/sql/bfv_dml.sql
@@ -198,3 +198,18 @@ rollback;
 select * from execinsert_test;
 
 drop table execinsert_test;
+
+
+--
+-- Test RETURNING on a table with OIDs.
+--
+-- See https://github.com/greenplum-db/gpdb/issues/8765
+-- This was also coincidentally covered by the upstream tests in
+-- 'rowsecurity', but better to have an explicit test.
+--
+CREATE TABLE tabwithoids (a int, b text) WITH OIDS;
+
+insert into tabwithoids values (1, 'foo') RETURNING oid > 1000, tabwithoids;
+update tabwithoids set b = 'foobar' RETURNING oid > 1000, tabwithoids;
+update tabwithoids set a = a + 1 RETURNING oid > 1000, tabwithoids; -- split update
+delete from tabwithoids RETURNING oid > 1000, tabwithoids;


### PR DESCRIPTION
In master, we already got this fix as part of the 9.5 merge. Change it
slightly, so that we don't use the subplan's tuple descriptor as is, but
only copy the "tdhasoid" flag from it. It's in principle possible that
some unimportant information, like attribute names or typmods, are not
set up in the subplan's result type, and should be computed from the
Motion's target list. We're not seeing problems like that on master, but
on the 9.6 merge branch we are.

More importantly, this adds bespoken tests for this scenario.

We didn't backport the fix to 6X_STABLE before, so do that now.

Fixes https://github.com/greenplum-db/gpdb/issues/8765.

