### PR TITLE
docs - add supported GPDB versions to gpbackup/restore requirements

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpbackup.xml
@@ -33,8 +33,13 @@
   <topic id="topic_vh5_1hd_tbb">
     <title>Requirements and Limitations</title>
     <body>
-      <p>The <codeph>gpbackup</codeph> and <codeph>gprestore</codeph> utilities are available with
-        Greenplum Database 5.5.0 and later. </p>
+      <p>The <codeph>gpbackup</codeph> and <codeph>gprestore</codeph> utilities are compatible with
+        these Greenplum Database versions:</p>
+      <ul id="ul_jlm_wnd_hjb">
+        <li>Pivotal Greenplum Database 4.3.22 and later</li>
+        <li>Pivotal Greenplum Database 5.5.0 and later</li>
+        <li>Pivotal Greenplum Database 6.0.0 and later</li>
+      </ul>
       <p><codeph>gpbackup</codeph> and <codeph>gprestore</codeph> have the following limitations:<ul
           id="ul_uqh_hhd_tbb">
           <li>If you create an index on a parent partitioned table, <codeph>gpbackup</codeph> does


### PR DESCRIPTION
The doc omits 4.3.x and 6.x from versions of GPDB gpbackup supports. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
