### PR TITLE
Use different database for fsyc, heap_checksum and walrep tests

### DIFF
--- a/src/test/fsync/Makefile
+++ b/src/test/fsync/Makefile
@@ -2,13 +2,14 @@ MODULES=fsync_helper
 PG_CONFIG=pg_config
 
 REGRESS = setup bgwriter_checkpoint
-REGRESS_OPTS = --dbname="fsync_regression" --load-extension=gp_inject_fault
+REGRESS_OPTS = --load-extension=gp_inject_fault
 
 subdir = src/test/fsync/
 top_builddir = ../../..
 
 include $(top_builddir)/src/Makefile.global
 
+USE_MODULE_DB=1
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk
 

--- a/src/test/heap_checksum/Makefile
+++ b/src/test/heap_checksum/Makefile
@@ -2,13 +2,14 @@ MODULES=heap_checksum_helper
 PG_CONFIG=pg_config
 
 REGRESS = setup heap_checksum_corruption
-REGRESS_OPTS = --init-file=../regress/init_file --dbname="heap_checksum_regression" --load-extension=gp_inject_fault
+REGRESS_OPTS = --init-file=../regress/init_file --load-extension=gp_inject_fault
 
 subdir = src/test/heap_checksum/
 top_builddir = ../../..
 
 include $(top_builddir)/src/Makefile.global
 
+USE_MODULE_DB=1
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk
 

--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -8,8 +8,9 @@ include $(top_builddir)/src/Makefile.global
 
 REGRESS = setup
 REGRESS += replication_views_mirrored missing_xlog walreceiver generate_ao_xlog generate_aoco_xlog
-REGRESS_OPTS = --dbname="walrep_regression" --load-extension=gp_inject_fault
+REGRESS_OPTS = --load-extension=gp_inject_fault
 
+USE_MODULE_DB=1
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk
 


### PR DESCRIPTION
Previously, fsyc, heap_checksum and walrep tests used separate
databases. But seems with merge when src/makefiles/pgxs.mk added
--dbname to REGRESS_OPTS, all of these tests started using
`contrib_regression` database even if each of these tests defined
--dbname=<>, it was overridden from src/makefiles/pgxs.mk.

Hence, set USE_MODULE_DB=1 which makes these tests to use
--dbname=$(CONTRIB_TESTDB_MODULE) instead of
`contrib_regression`. This way these will again start having separate
database.

The reason we need different database, to help investigate if test fails, else the artifacts are lost.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
