### PR TITLE
Remove VACUUM FREEZE in pg_upgrade at set_frozenxids

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -972,18 +972,6 @@ set_frozenxids(bool minmxid_only)
 		 */
 		PQclear(executeQueryOrDie(conn, "set allow_system_table_mods=true"));
 
-		/*
-		 * Instead of assuming template0 will be frozen by initdb, its worth
-		 * making sure we freeze it here before updating the relfrozenxid
-		 * directly for the tables in pg_class and datfrozenxid for the
-		 * database in pg_database. Its fast and safe worth than assuming for
-		 * template0.
-		 */
-		if (!minmxid_only && strcmp(datallowconn, "f") == 0)
-		{
-			PQclear(executeQueryOrDie(conn, "VACUUM FREEZE"));
-		}
-
 		if (!minmxid_only)
 			/* set pg_class.relfrozenxid */
 			PQclear(executeQueryOrDie(conn,

--- a/contrib/pg_upgrade/test/integration/scenarios/ao_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/ao_table.c
@@ -123,8 +123,6 @@ createAoTableWithDataInFiveCluster(void)
 
 	executeQuery(con1, "END;");
 	executeQuery(con2, "END;");
-	/* FIXME: why do we need this ?? */
-	executeQuery(con1, "VACUUM FREEZE;");
 
 	PQfinish(con2);
 	PQfinish(con1);

--- a/contrib/pg_upgrade/test/integration/scenarios/aocs_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/aocs_table.c
@@ -97,8 +97,6 @@ static void anAocsTableExistsWithDataInFiveCluster(void)
 
 	executeQuery(con1, "END;");
 	executeQuery(con2, "END;");
-	/* FIXME: why do we need this ?? */
-	executeQuery(con1, "VACUUM FREEZE;");
 
 	PQfinish(con2);
 	PQfinish(con1);

--- a/contrib/pg_upgrade/test/integration/scenarios/heap_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/heap_table.c
@@ -231,8 +231,6 @@ createHeapTableWithDataInFiveCluster(void)
 	executeQuery(connection, "insert into users values (1, 'Jane')");
 	executeQuery(connection, "insert into users values (2, 'John')");
 	executeQuery(connection, "insert into users values (3, 'Joe')");
-	/* FIXME: why do we need this ?? */
-	executeQuery(connection, "VACUUM FREEZE;");
 	PQfinish(connection);
 }
 


### PR DESCRIPTION
Issue is when new cluster has higher next xid than old cluster. In that
case, new cluster moves next xid backwards in `copy_xact_xlog_xid()`.
This is problematic as subsequent tuple inserts are not frozen, but will
have a lower xmin then the relfrozenxid defined on the relation. That
violates the definition of relfrozenxid and VACUUM FREEZE will choke.

This was identified by the upgrade integration tests which create a
fresh GPDB5 and GPDB6 cluster. In this scenario immediately after
initdb, GPDB6 has higher next xid than GPDB5.

Given that template0 is not connectable, it should not need vacuum.
Solution is to remove VACUUM FREEZE on template0 since it does not work
in all scenarios. Additionally this removes a difference with upstream
postgres.

This was introduced by https://github.com/greenplum-db/gpdb-postgres-merge/commit/04634d50ba62.
It may be worth noting that I ran ICW and upgrade without hitting the issue
alluded to in the commit comment.