### PR TITLE
Enable optimizer_use_gpdb_allocators guc by default

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2799,7 +2799,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_use_gpdb_allocators,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
This guc makes ORCA use gpdb allocators. This allows for faster
optimization due to less overhead, reduced memory during optimization
due to smaller/fewer headers, and makes ORCA observe vmem limits instead
of crashing.

Authored-by: Chris Hajas <chajas@pivotal.io>