### PR TITLE
Refactor ExecInsert/Update/Delete.

### DIFF
--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -1008,6 +1008,15 @@ Oid MemTupleGetOid(MemTuple mtup, MemTupleBinding *pbind)
 	return ((Oid *) mtup)[1];
 }
 
+/*
+ * Like MemTuleGetOid(), but must only be used if the caller is sure that the
+ * tuple has an OID (or at least it has space for it; it can be invalid).
+ */
+Oid MemTupleGetOidDirect(MemTuple mtup)
+{
+	return ((Oid *) mtup)[1];
+}
+
 void MemTupleSetOid(MemTuple mtup, MemTupleBinding *pbind pg_attribute_unused(), Oid oid)
 {
 	Assert(pbind && mtbind_has_oid(pbind));

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -153,6 +153,7 @@ extern void memtuple_deform(MemTuple mtup, MemTupleBinding *pbind, Datum *datum,
 extern void memtuple_deform_misaligned(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 
 extern Oid MemTupleGetOid(MemTuple mtup, MemTupleBinding *pbind);
+extern Oid MemTupleGetOidDirect(MemTuple mtup);
 extern void MemTupleSetOid(MemTuple mtup, MemTupleBinding *pbind, Oid oid);
 
 static inline bool


### PR DESCRIPTION
Add new table_insert/update/delete() functions to stand in place of
heap_insert/update_delete(), and move the logic to dispatch the call to
AO, AOCO or external table function, depending on what kind of a table it
is. This moves the GPDB specific code out of the upstream functions,
making the diff vs upstream nicer to read.

PostgreSQL v12 introduced a new Table AM API. These new functions sit in
the same spot as the calls to the new API are made in v12. The signatures
don't quite match, but this is similar interface in spirit.
