### PR TITLE
Removing locking while looking up tablespace using name

### DIFF
--- a/src/test/isolation2/expected/concurrent_drop_truncate_tablespace.out
+++ b/src/test/isolation2/expected/concurrent_drop_truncate_tablespace.out
@@ -1,0 +1,61 @@
+-- While a tablespace is being dropped, if any table is created
+-- in the same tablespace, the data of that table should not be deleted
+
+-- create a tablespace directory
+!\retcode mkdir -p /tmp/concurrent_tblspace;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+CREATE TABLESPACE concurrent_tblspace LOCATION '/tmp/concurrent_tblspace';
+CREATE
+
+-- suspend execution after TablespaceCreateLock is released
+SELECT gp_inject_fault('AfterTablespaceCreateLockRelease', 'suspend', dbid) FROM gp_segment_configuration WHERE content <> -1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1&:DROP TABLESPACE concurrent_tblspace;  <waiting ...>
+
+-- wait for the fault to be triggered
+SELECT gp_wait_until_triggered_fault('AfterTablespaceCreateLockRelease', 1, dbid) from gp_segment_configuration where content <> -1 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- create a table in the same tablespace which is being dropped via a concurrent session
+CREATE TABLE drop_tablespace_tbl(a int, b int) TABLESPACE concurrent_tblspace DISTRIBUTED BY (a);
+CREATE
+INSERT INTO drop_tablespace_tbl SELECT i, i FROM generate_series(1,100)i;
+INSERT 100
+-- reset the fault, drop tablespace command will not delete the data files on the tablespace
+SELECT gp_inject_fault('AfterTablespaceCreateLockRelease', 'reset', dbid) FROM gp_segment_configuration WHERE content <> -1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+DROP
+-- check data exists
+SELECT count(*) FROM drop_tablespace_tbl;
+ count 
+-------
+ 100   
+(1 row)
+-- move to another tablespace and check the data.
+ALTER TABLE drop_tablespace_tbl SET TABLESPACE pg_default;
+ALTER
+SELECT count(*) FROM drop_tablespace_tbl;
+ count 
+-------
+ 100   
+(1 row)

--- a/src/test/isolation2/sql/concurrent_drop_truncate_tablespace.sql
+++ b/src/test/isolation2/sql/concurrent_drop_truncate_tablespace.sql
@@ -1,0 +1,27 @@
+-- While a tablespace is being dropped, if any table is created
+-- in the same tablespace, the data of that table should not be deleted
+
+-- create a tablespace directory
+!\retcode mkdir -p /tmp/concurrent_tblspace;
+
+CREATE TABLESPACE concurrent_tblspace LOCATION '/tmp/concurrent_tblspace';
+
+-- suspend execution after TablespaceCreateLock is released
+SELECT gp_inject_fault('AfterTablespaceCreateLockRelease', 'suspend', dbid) FROM gp_segment_configuration WHERE content <> -1 and role='p';
+1&:DROP TABLESPACE concurrent_tblspace;
+
+-- wait for the fault to be triggered
+SELECT gp_wait_until_triggered_fault('AfterTablespaceCreateLockRelease', 1, dbid)
+   from gp_segment_configuration where content <> -1 and role='p';
+
+-- create a table in the same tablespace which is being dropped via a concurrent session
+CREATE TABLE drop_tablespace_tbl(a int, b int) TABLESPACE concurrent_tblspace DISTRIBUTED BY (a);
+INSERT INTO drop_tablespace_tbl SELECT i, i FROM generate_series(1,100)i;
+-- reset the fault, drop tablespace command will not delete the data files on the tablespace
+SELECT gp_inject_fault('AfterTablespaceCreateLockRelease', 'reset', dbid) FROM gp_segment_configuration WHERE content <> -1 and role='p';
+1<:
+-- check data exists
+SELECT count(*) FROM drop_tablespace_tbl;
+-- move to another tablespace and check the data.
+ALTER TABLE drop_tablespace_tbl SET TABLESPACE pg_default;
+SELECT count(*) FROM drop_tablespace_tbl;

--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -156,6 +156,11 @@ SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;') 
  t
 (1 row)
 
+-- check spilling to a temp tablespace
+CREATE TABLE spill_temptblspace (a numeric) DISTRIBUTED BY (a);
+SET temp_tablespaces=pg_default;
+INSERT INTO spill_temptblspace SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;
+RESET temp_tablespaces;
 RESET statement_mem;
 RESET gp_workfile_compression;
 drop schema hashagg_spill cascade;

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -113,6 +113,12 @@ SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;') 
 SET gp_workfile_compression = ON;
 select overflows >= 1 from hashagg_spill.num_hashagg_overflows('explain analyze
 SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;') overflows;
+
+-- check spilling to a temp tablespace
+CREATE TABLE spill_temptblspace (a numeric) DISTRIBUTED BY (a);
+SET temp_tablespaces=pg_default;
+INSERT INTO spill_temptblspace SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;
+RESET temp_tablespaces;
 RESET statement_mem;
 RESET gp_workfile_compression;
 


### PR DESCRIPTION
While looking up tablespace oid using name, a tuple lock was taken on the
pg_tablespace entry for the tablespace.  This lock was to avoid any concurrent
drop for the same tablespace. However, in queries containing a reader and
writer gang, and if temp_tablespaces GUC is enforced to spill to a specific
tablespace, the reader may try to assign a transaction id for taking a lock,
but a transaction id may no tbe assigned yet. This will cause such queries to
fail.

This commit fixes the issue by removing the requirement to acquire a lock while
looking up a tablespace using name.

Dropping a tablespace mandates that the tablespace must be empty, i.e any
tables created in that tablespace must be dropped before proceeding to drop the
tablespace. If any data exists in the tablespace before drop tablespace being
dispatched to segments, the drop tablespace operation will fail.  In cases,
where data was created in the tablespace directory after the command was
dispatched, the contents in the tablespace directory are not dropped, as
someone might have created a table in the tablespace being dropped in this
small window, but the entry for pg_tablespace is removed. The user can still
run ALTER commands to move the table to another tablespace.

With the above behavior, and considering the usage of DROP tablespace
not frequent, we don't need to take locks while looking up the
tablespace using name as it restricts other use cases. For instance:
```sql
CREATE TABLE hashagg_spill(col1 numeric, col2 int) DISTRIBUTED BY (col1);
INSERT INTO hashagg_spill SELECT id, 1 FROM generate_series(1,20000) id;
ANALYZE hashagg_spill;
SET temp_tablespaces=pg_default;
SET statement_mem='1000kB';
CREATE TABLE spill_temptblspace (a numeric) DISTRIBUTED BY (a);
INSERT INTO spill_tmptblspace SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;
ERROR: AssignTransactionId() called by Segment Reader process...
```

Also, added tests to validate that the data files in the tablespace are not
removed in the case described above.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
