### PR TITLE
Revert using Postmaster ListenAddress as BackgroundListenAddress

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -151,9 +151,9 @@ setupTCPListeningSocket(int backlog, int *listenerSocketFd, uint16 *listenerPort
 	snprintf(service, 32, "%d", 0);
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
-	hints.ai_socktype = SOCK_STREAM;	/* TCP socket */
+	hints.ai_socktype = SOCK_STREAM;	/* Two-way, out of band connection */
 	hints.ai_flags = AI_PASSIVE;	/* For wildcard IP address */
-	hints.ai_protocol = 0;		/* Any protocol */
+	hints.ai_protocol = 0;		/* Any protocol - TCP implied for network use due to SOCK_STREAM */
 
 	/*
 	 * We use INADDR_ANY if we don't have a valid address for ourselves (e.g.

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -38,7 +38,6 @@
 #include "port/pg_crc32c.h"
 #include "storage/latch.h"
 #include "storage/pmsignal.h"
-#include "postmaster/postmaster.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
@@ -1188,7 +1187,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 #endif
 
 	fun = "getaddrinfo";
-	s = getaddrinfo(BackendListenAddress, service, &hints, &addrs);
+	s = getaddrinfo(NULL, service, &hints, &addrs);
 	if (s != 0)
 		elog(ERROR, "getaddrinfo says %s", gai_strerror(s));
 

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1180,7 +1180,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
 	hints.ai_socktype = SOCK_DGRAM; /* Datagram socket */
 	hints.ai_flags = AI_PASSIVE;	/* For wildcard IP address */
-	hints.ai_protocol = 0;		/* Any protocol */
+	hints.ai_protocol = 0;		/* Any protocol - UDP implied for network use due to SOCK_DGRAM */
 
 #ifdef USE_ASSERT_CHECKING
 	if (gp_udpic_network_disable_ipv6)

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -215,7 +215,6 @@ char	   *Unix_socket_directories;
 
 /* The TCP listen address(es) */
 char	   *ListenAddresses;
-char	   *BackendListenAddress;
 
 /*
  * ReservedBackends is the number of backends reserved for superuser use.
@@ -1175,12 +1174,6 @@ PostmasterMain(int argc, char *argv[])
 					 errmsg("invalid list syntax in parameter \"%s\"",
 							"listen_addresses")));
 		}
-
-		/* If there are more than one listen address, backend bind on all addresses*/
-		if (list_length(elemlist) > 1 || strcmp(ListenAddresses, "*") == 0)
-			BackendListenAddress = NULL;
-		else
-			BackendListenAddress = ListenAddresses;
 
 		foreach(l, elemlist)
 		{

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -21,7 +21,6 @@ extern int	Unix_socket_permissions;
 extern char *Unix_socket_group;
 extern char *Unix_socket_directories;
 extern char *ListenAddresses;
-extern char *BackendListenAddress;
 extern bool ClientAuthInProgress;
 extern int	PreAuthDelay;
 extern int	AuthenticationTimeout;


### PR DESCRIPTION
Revert c93bb171637769d3ce64cd5f1367d831e0469924
  
The logic used in the initial commit is faulty and fragile.
    
In the event that we want to force the master postmaster process to
listen on a subset of addresses available on the system, it is most
likely that we don't want to use the address(es) used by the
interconnect.
    
In the event of an external network and internal interconnect, the
binding of "backend" listening sockets to the "external" network would
break the interconnect.
