### PR TITLE
Add pg_upgrade integration test for partitioned ao tables

### DIFF
--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -4,6 +4,7 @@
 
 #include "cmockery.h"
 
+#include "scenarios/partitioned_ao_table.h"
 #include "scenarios/partitioned_heap_table.h"
 #include "scenarios/heap_table.h"
 #include "scenarios/subpartitioned_heap_table.h"
@@ -44,6 +45,7 @@ main(int argc, char *argv[])
 		unit_test_setup_teardown(test_a_heap_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_subpartitioned_heap_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_partitioned_heap_table_with_data_can_be_upgraded, setup, teardown),
+		unit_test_setup_teardown(test_a_partitioned_ao_table_with_data_can_be_upgraded, setup, teardown),
 	};
 
 	return run_tests(tests);

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_ao_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_ao_table.c
@@ -1,0 +1,57 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include "cmockery.h"
+
+#include "partitioned_ao_table.h"
+#include "utilities/upgrade-helpers.h"
+#include "utilities/query-helpers.h"
+#include "utilities/test-helpers.h"
+#include "bdd-library/bdd.h"
+
+static void
+partitionedAOTableShouldHaveDataUpgradedToSixCluster()
+{
+	PGconn	   *connection = connectToSix();
+	PGresult   *result;
+
+	executeQuery(connection, "SET search_path TO five_to_six_upgrade;");
+
+	result = executeQuery(connection, "SELECT * FROM users_1_prt_1 WHERE id=1 AND name='Jane';");
+	assert_int_equal(1, PQntuples(result));
+
+	result = executeQuery(connection, "SELECT * FROM users_1_prt_2 WHERE id=2 AND name='John';");
+	assert_int_equal(1, PQntuples(result));
+
+	result = executeQuery(connection, "SELECT * FROM users;");
+	assert_int_equal(2, PQntuples(result));
+
+	PQfinish(connection);
+}
+
+static void
+anAdministratorPerformsAnUpgrade()
+{
+	performUpgrade();
+}
+
+static void
+createPartitionedAOTableWithDataInFiveCluster(void)
+{
+	PGconn	   *connection = connectToFive();
+
+	executeQuery(connection, "CREATE SCHEMA five_to_six_upgrade;");
+	executeQuery(connection, "SET search_path TO five_to_six_upgrade");
+	executeQuery(connection, "CREATE TABLE users (id integer, name text) WITH (appendonly=true) DISTRIBUTED BY (id) PARTITION BY RANGE(id) (START(1) END(3) EVERY(1));");
+	executeQuery(connection, "INSERT INTO users VALUES (1, 'Jane')");
+	executeQuery(connection, "INSERT INTO users VALUES (2, 'John')");
+	PQfinish(connection);
+}
+
+void test_a_partitioned_ao_table_with_data_can_be_upgraded(void **state)
+{
+	given(createPartitionedAOTableWithDataInFiveCluster);
+	when(anAdministratorPerformsAnUpgrade);
+	then(partitionedAOTableShouldHaveDataUpgradedToSixCluster);
+}

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_ao_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_ao_table.h
@@ -1,0 +1,1 @@
+void test_a_partitioned_ao_table_with_data_can_be_upgraded(void **state);


### PR DESCRIPTION
Tests that a user can upgrade a partitioned ao table from 5X to 6X and
validates that the data exists on the upgraded cluster.
