### PR TITLE
Enable optimizer_use_gpdb_allocators guc by default and fix resgroup test

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2799,7 +2799,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_use_gpdb_allocators,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/isolation2/output/resgroup/resgroup_bypass_optimizer.source
+++ b/src/test/isolation2/output/resgroup/resgroup_bypass_optimizer.source
@@ -183,19 +183,16 @@ SELECT * FROM memory_result;
  0           
 (1 row)
 61: SELECT * FROM eat_memory_on_qd;
- hold_memory 
--------------
- 0           
-(1 row)
+ERROR:  Out of memory
+DETAIL:  Resource group memory limit reached
 SELECT * FROM memory_result;
  rsgname        | ismaster | avg_mem 
 ----------------+----------+---------
  rg_bypass_test | 0        | 0.0     
- rg_bypass_test | 1        | 24.0    
+ rg_bypass_test | 1        | 0.0     
 (2 rows)
 61: SELECT * FROM eat_memory_on_qd;
-ERROR:  Out of memory
-DETAIL:  Resource group memory limit reached
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
 61: SELECT * FROM eat_memory_on_qd;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT * FROM memory_result;
@@ -212,7 +209,7 @@ SELECT * FROM memory_result;
  rsgname        | ismaster | avg_mem 
 ----------------+----------+---------
  rg_bypass_test | 0        | 0.0     
- rg_bypass_test | 1        | 24.0    
+ rg_bypass_test | 1        | 20.0    
 (2 rows)
 61q: ... <quitting>
 


### PR DESCRIPTION
This is a followup to #8771 since the resource group tests had some assumptions about startup memory being used.  With setting optimizer_use_gpdb_allocators on, we now track orca's memory
usage within resource groups/vmem. As a result, we go OOM slightly earlier.