### PR TITLE
Change fix for Motion node's tdhasoids confusion, and add tests. (6X_STABLE)

### DIFF
--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -885,6 +885,7 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 	Slice	   *sendSlice = NULL;
 	Slice	   *recvSlice = NULL;
 	SliceTable *sliceTable = estate->es_sliceTable;
+	PlanState  *outerPlan;
 
 #ifdef CDB_MOTION_DEBUG
 	int			i;
@@ -1017,9 +1018,37 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 	 * initialize tuple type.  no need to initialize projection info because
 	 * this node doesn't do projections.
 	 */
-	ExecAssignResultTypeFromTL(&motionstate->ps);
+	outerPlan = outerPlanState(motionstate);
+
+	/*
+	 * The advertised 'tdhasoid' flag in our result tuple desc must match what
+	 * the outer plan produces. Otherwise, the sender will send tuples that
+	 * have OIDs, but the receiver treats the tuples as if they doesn't have
+	 * OIDs, or vice versa. This isn't so important for HeapTuples, which have
+	 * an HAS_OIDS flag on every tuple, but for MemTuples it is critical,
+	 * because it affects the way the they are deformed.
+	 *
+	 * GPDB_95_MERGE_FIXME: Should we force ORCA to always use the TL for
+	 * motion nodes or modify ORCA to use the TL from the outer node?
+	 */
+	if (outerPlan && ExecGetResultType(outerPlan) && estate->es_plannedstmt->planGen == PLANGEN_PLANNER)
+	{
+		/*
+		 * This is like ExecAssignResultTypeFromTL(), but we copy the tdhasoid
+		 * flag from the subplan.
+		 */
+		bool		hasoid = ExecGetResultType(outerPlan)->tdhasoid;
+
+		tupDesc = ExecTypeFromTL(motionstate->ps.plan->targetlist, hasoid);
+		ExecAssignResultType(&motionstate->ps, tupDesc);
+	}
+	else
+	{
+		ExecAssignResultTypeFromTL(&motionstate->ps);
+		tupDesc = ExecGetResultType(&motionstate->ps);
+	}
+
 	motionstate->ps.ps_ProjInfo = NULL;
-	tupDesc = ExecGetResultType(&motionstate->ps);
 
 	/* Set up motion send data structures */
 	if (motionstate->mstype == MOTIONSTATE_SEND && node->motionType == MOTIONTYPE_HASH)

--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -293,3 +293,37 @@ select * from execinsert_test;
 (1 row)
 
 drop table execinsert_test;
+--
+-- Test RETURNING on a table with OIDs.
+--
+-- See https://github.com/greenplum-db/gpdb/issues/8765
+-- This was also coincidentally covered by the upstream tests in
+-- 'rowsecurity', but better to have an explicit test.
+--
+CREATE TABLE tabwithoids (a int, b text) WITH OIDS;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+NOTICE:  OIDS=TRUE is not recommended for user-created tables
+insert into tabwithoids values (1, 'foo') RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (1,foo)
+(1 row)
+
+update tabwithoids set b = 'foobar' RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (1,foobar)
+(1 row)
+
+update tabwithoids set a = a + 1 RETURNING oid > 1000, tabwithoids; -- split update
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (2,foobar)
+(1 row)
+
+delete from tabwithoids RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (2,foobar)
+(1 row)
+

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -300,3 +300,37 @@ select * from execinsert_test;
 (1 row)
 
 drop table execinsert_test;
+--
+-- Test RETURNING on a table with OIDs.
+--
+-- See https://github.com/greenplum-db/gpdb/issues/8765
+-- This was also coincidentally covered by the upstream tests in
+-- 'rowsecurity', but better to have an explicit test.
+--
+CREATE TABLE tabwithoids (a int, b text) WITH OIDS;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+NOTICE:  OIDS=TRUE is not recommended for user-created tables
+insert into tabwithoids values (1, 'foo') RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (1,foo)
+(1 row)
+
+update tabwithoids set b = 'foobar' RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (1,foobar)
+(1 row)
+
+update tabwithoids set a = a + 1 RETURNING oid > 1000, tabwithoids; -- split update
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (2,foobar)
+(1 row)
+
+delete from tabwithoids RETURNING oid > 1000, tabwithoids;
+ ?column? | tabwithoids 
+----------+-------------
+ t        | (2,foobar)
+(1 row)
+

--- a/src/test/regress/sql/bfv_dml.sql
+++ b/src/test/regress/sql/bfv_dml.sql
@@ -198,3 +198,18 @@ rollback;
 select * from execinsert_test;
 
 drop table execinsert_test;
+
+
+--
+-- Test RETURNING on a table with OIDs.
+--
+-- See https://github.com/greenplum-db/gpdb/issues/8765
+-- This was also coincidentally covered by the upstream tests in
+-- 'rowsecurity', but better to have an explicit test.
+--
+CREATE TABLE tabwithoids (a int, b text) WITH OIDS;
+
+insert into tabwithoids values (1, 'foo') RETURNING oid > 1000, tabwithoids;
+update tabwithoids set b = 'foobar' RETURNING oid > 1000, tabwithoids;
+update tabwithoids set a = a + 1 RETURNING oid > 1000, tabwithoids; -- split update
+delete from tabwithoids RETURNING oid > 1000, tabwithoids;


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/8766 to 6X_STABLE.