### PR TITLE
Upgrade exchange partition check

### DIFF
--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -6,6 +6,7 @@
 
 #include "scenarios/partitioned_ao_table.h"
 #include "scenarios/partitioned_heap_table.h"
+#include "scenarios/exchange_partitioned_heap_table.h"
 #include "scenarios/heap_table.h"
 #include "scenarios/subpartitioned_heap_table.h"
 #include "scenarios/ao_table.h"
@@ -46,6 +47,7 @@ main(int argc, char *argv[])
 		unit_test_setup_teardown(test_a_subpartitioned_heap_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_partitioned_heap_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_partitioned_ao_table_with_data_can_be_upgraded, setup, teardown),
+		unit_test_setup_teardown(test_an_exchange_partitioned_heap_table_cannot_be_upgraded, setup, teardown),
 	};
 
 	return run_tests(tests);

--- a/contrib/pg_upgrade/test/integration/scenarios/exchange_partitioned_heap_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/exchange_partitioned_heap_table.c
@@ -1,0 +1,33 @@
+#include "utilities/upgrade-helpers.h"
+#include "utilities/query-helpers.h"
+#include "utilities/test-helpers.h"
+#include "bdd-library/bdd.h"
+
+#include "exchange_partitioned_heap_table.h"
+
+static void
+createExchangePartitionedHeapTableInFiveCluster()
+{
+	PGconn	   *connection = connectToFive();
+
+	executeQuery(connection, "CREATE SCHEMA five_to_six_upgrade;");
+	executeQuery(connection, "SET search_path TO five_to_six_upgrade");
+
+	executeQuery(connection, "CREATE TABLE table_part(a INT, b INT) PARTITION BY RANGE(b) (PARTITION part1 START(0) END(42));");
+	executeQuery(connection, "CREATE TABLE replacement(LIKE table_part);");
+	executeQuery(connection, "ALTER TABLE table_part EXCHANGE PARTITION part1 WITH TABLE replacement;");
+	executeQuery(connection, "CREATE TABLE dependant(d table_part_1_prt_part1[]);");
+	PQfinish(connection);
+}
+
+static void
+anAdministratorPerformsAnUpgradeCheck()
+{
+	performUpgradeCheckFailsWithError("Array types derived from partitions of a partitioned table must not have dependants.");
+}
+
+void test_an_exchange_partitioned_heap_table_cannot_be_upgraded(void ** state)
+{
+	given(createExchangePartitionedHeapTableInFiveCluster);
+	when(anAdministratorPerformsAnUpgradeCheck);
+}

--- a/contrib/pg_upgrade/test/integration/scenarios/exchange_partitioned_heap_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/exchange_partitioned_heap_table.h
@@ -1,0 +1,1 @@
+void test_an_exchange_partitioned_heap_table_cannot_be_upgraded(void ** state);

--- a/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.h
+++ b/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.h
@@ -3,5 +3,6 @@
 #define PG_UPGRADE_INTEGRATION_TEST_UPGRADE_HELPERS
 
 void		performUpgrade(void);
+void		performUpgradeCheckFailsWithError(char *message);
 
 #endif							/* PG_UPGRADE_INTEGRATION_TEST_UPGRADE_HELPERS */


### PR DESCRIPTION
This backports from master https://github.com/greenplum-db/gpdb/commit/219f3a50bec75d40307be1de2991bff2d6e1136b which adds check in pg_upgrade for tables with array dependencies on exchanged partitions.  It also adds corresponding integration test.