### PR TITLE
Handle dispatching of rules

### DIFF
--- a/src/backend/rewrite/rewriteDefine.c
+++ b/src/backend/rewrite/rewriteDefine.c
@@ -44,6 +44,9 @@
 #include "utils/syscache.h"
 #include "utils/tqual.h"
 
+#include "catalog/oid_dispatch.h"
+#include "cdb/cdbdisp_query.h"
+#include "cdb/cdbvars.h"
 
 static void checkRuleResultList(List *targetList, TupleDesc resultDesc,
 					bool isSelect, bool requireColumnNameMatch);
@@ -199,9 +202,18 @@ DefineRule(RuleStmt *stmt, const char *queryString)
 	List	   *actions;
 	Node	   *whereClause;
 	Oid			relId;
+	Oid			result;
+	RuleStmt   *copyStmt;
 
 	/* Parse analysis. */
-	transformRuleStmt(stmt, queryString, &actions, &whereClause);
+	if (Gp_role == GP_ROLE_EXECUTE)
+	{
+		/* ... unless we are in a segment where the analysis is already done */
+		actions = stmt->actions;
+		whereClause = stmt->whereClause;
+	}
+	else
+		transformRuleStmt(stmt, queryString, &actions, &whereClause);
 
 	/*
 	 * Find and lock the relation.  Lock level should match
@@ -210,13 +222,29 @@ DefineRule(RuleStmt *stmt, const char *queryString)
 	relId = RangeVarGetRelid(stmt->relation, AccessExclusiveLock, false);
 
 	/* ... and execute */
-	return DefineQueryRewrite(stmt->rulename,
+	result = DefineQueryRewrite(stmt->rulename,
 							  relId,
 							  whereClause,
 							  stmt->event,
 							  stmt->instead,
 							  stmt->replace,
 							  actions);
+
+	/* ... and dispatch if neccessary */
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		copyStmt = copyObject(stmt);
+		copyStmt->actions = actions;
+		copyStmt->whereClause = whereClause;
+		CdbDispatchUtilityStatement((Node *) copyStmt,
+									DF_CANCEL_ON_ERROR |
+									DF_WITH_SNAPSHOT |
+									DF_NEED_TWO_PHASE,
+									GetAssignedOidsForDispatch(),
+									NULL);
+	}
+
+	return result;
 }
 
 

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1593,15 +1593,6 @@ ProcessUtilitySlow(Node *parsetree,
 
 			case T_RuleStmt:	/* CREATE RULE */
 				DefineRule((RuleStmt *) parsetree, queryString);
-				if (Gp_role == GP_ROLE_DISPATCH)
-				{
-					CdbDispatchUtilityStatement((Node *) parsetree,
-												DF_CANCEL_ON_ERROR|
-												DF_WITH_SNAPSHOT|
-												DF_NEED_TWO_PHASE,
-												GetAssignedOidsForDispatch(),
-												NULL);
-				}
 				break;
 
 			case T_CreateSeqStmt:

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -4482,6 +4482,13 @@ select test();
 (1 row)
 
 --
+-- Test that rules with functions can be serialized correctly
+-- This is tested here because the rules tests are not enabled
+--
+create table  qp_misc_jiras.rules (a integer);
+create rule "_RETURN" as on select to qp_misc_jiras.rules do instead
+  select * from generate_series(1,5) x(a);
+--
 -- Test gp_enable_relsize_collection's effect on ORCA plan generation
 --
 create table tbl_z(x int) distributed by (x);

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -4473,6 +4473,13 @@ select test();
 (1 row)
 
 --
+-- Test that rules with functions can be serialized correctly
+-- This is tested here because the rules tests are not enabled
+--
+create table  qp_misc_jiras.rules (a integer);
+create rule "_RETURN" as on select to qp_misc_jiras.rules do instead
+  select * from generate_series(1,5) x(a);
+--
 -- Test gp_enable_relsize_collection's effect on ORCA plan generation
 --
 create table tbl_z(x int) distributed by (x);

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -2556,6 +2556,14 @@ select test();
 
 
 --
+-- Test that rules with functions can be serialized correctly
+-- This is tested here because the rules tests are not enabled
+--
+create table  qp_misc_jiras.rules (a integer);
+create rule "_RETURN" as on select to qp_misc_jiras.rules do instead
+  select * from generate_series(1,5) x(a);
+
+--
 -- Test gp_enable_relsize_collection's effect on ORCA plan generation
 --
 create table tbl_z(x int) distributed by (x);


### PR DESCRIPTION
The common practice is to dispatch already-analysed statements. However for
rules raw statements where dispatched. As a consequence all the possible nodes
in the tree would have to be serialised. This was (and still) is not the case.

Follow the common practice and dispatch the already analysed query tree for
rules.

The issue rose during the 9.6 merge cycle in 'rowsecurity' tests by coincidence.
Rule tests are dissabled for quite some time now and even if this case was
included it was never tested. A specific test is added now.

Addresses issue #8787

Reported, reviewed and heavily modified by Heikki Linnakangas.