### PR TITLE
Reduce fts_errors test time by setting gp_fts_probe_interval

### DIFF
--- a/src/test/regress/expected/fts_error.out
+++ b/src/test/regress/expected/fts_error.out
@@ -1,3 +1,13 @@
+-- set these values purely to cut down test time, as default fts trigger is
+-- every min and 5 retries
+alter system set gp_fts_probe_interval to 10;
+alter system set gp_fts_probe_retries to 1;
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
 select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';
  in_sync 
@@ -65,6 +75,14 @@ select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';
  in_sync 
 ---------
+ t
+(1 row)
+
+alter system reset gp_fts_probe_interval;
+alter system reset gp_fts_probe_retries;
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
  t
 (1 row)
 

--- a/src/test/regress/sql/fts_error.sql
+++ b/src/test/regress/sql/fts_error.sql
@@ -1,5 +1,12 @@
+-- set these values purely to cut down test time, as default fts trigger is
+-- every min and 5 retries
+alter system set gp_fts_probe_interval to 10;
+alter system set gp_fts_probe_retries to 1;
+select pg_reload_conf();
+
 select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';
+
 -- Once this fault is hit, FTS process should abort current
 -- transaction and exit.
 select gp_inject_fault_infinite('fts_update_config', 'error', 1);
@@ -29,3 +36,7 @@ relation = 'gp_configuration_history'::regclass;
 
 select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';
+
+alter system reset gp_fts_probe_interval;
+alter system reset gp_fts_probe_retries;
+select pg_reload_conf();


### PR DESCRIPTION
Given by default fts triggers every min and retries for 5 times on errors, the
test takes around 60 secs currently to run. Cut down its waiting time by setting
lower gp_fts_probe_interval to 10 secs (minimum allowed value) and
gp_fts_probe_retries to 1. With this now the test runs approximately in 13 secs.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
