### PR TITLE
docs - add pxf upgrade topic for greenplum 6.x

### DIFF
--- a/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -40,6 +40,7 @@
               <li><a href="/6-0/pxf/cfghostport.html" format="markdown">Configuring the PXF Agent Host and Port (Optional)</a> </li>
             </ul>
           </li>
+          <li><a href="/6-0/pxf/upgrade_pxf_6x.html" format="markdown">Upgrading PXF</a></li>
           <li><a href="/6-0/pxf/cfginitstart_pxf.html" format="markdown">Starting, Stopping, and Restarting PXF</a></li>
           <li><a href="/6-0/pxf/using_pxf.html" format="markdown">Granting Users Access to PXF</a></li>
           <li><a href="/6-0/pxf/reg_jar_depend.html" format="markdown">Registering PXF JAR Dependencies</a></li>

--- a/gpdb-doc/dita/install_guide/upgrading.xml
+++ b/gpdb-doc/dita/install_guide/upgrading.xml
@@ -53,7 +53,7 @@
     <p>If you have configured the Greenplum Platform Extension Framework (PXF) in your previous
       Greenplum Database installation, you must stop the PXF service, and you might need to back up
       PXF configuration files before upgrading to a new version of Greenplum Database. Refer to
-        <xref href="../pxf/upgrade_pxf.html#pxfpre" type="topic" format="html">PXF Pre-Upgrade
+        <xref href="../pxf/upgrade_pxf_6x.html#pxfpre" type="topic" format="html">PXF Pre-Upgrade
         Actions</xref> for instructions.</p>
     <p>If you have not yet configured PXF, no action is necessary.</p>
   </body>
@@ -126,7 +126,7 @@ $ ln -s /usr/local/greenplum-db-&lt;new_version> /usr/local/greenplum-db</codebl
 $ gpstart</codeblock></li>
         <li>If you configured PXF in your previous Greenplum Database installation, you must
           re-initialize the PXF service after you upgrade Greenplum Database. Refer to <xref
-            href="../pxf/upgrade_pxf.html#pxfup" type="topic" format="html">Upgrading PXF</xref> for
+            href="../pxf/upgrade_pxf_6x.html#pxfup" type="topic" format="html">Upgrading PXF</xref> for
           instructions.</li>
       </ol>
       <p>After upgrading Greenplum Database, ensure that all features work as expected. For example,

--- a/gpdb-doc/markdown/pxf/upgrade_pxf_6x.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf_6x.html.md.erb
@@ -1,0 +1,51 @@
+---
+title: Upgrading PXF in Greenplum 6.x
+---
+
+If you are using PXF in your current Greenplum Database 6.x installation, you must upgrade the PXF service when you upgrade to a new version of Greenplum Database.
+
+The PXF upgrade procedure describes how to upgrade PXF in your Greenplum Database installation. This procedure uses *PXF.from* to refer to your currently-installed PXF version and *PXF.to* to refer to the PXF version installed when you upgrade to the new version of Greenplum Database.
+
+The PXF upgrade procedure has two parts. You perform one procedure before, and one procedure after, you upgrade to a new version of Greenplum Database:
+
+-   [Step 1: PXF Pre-Upgrade Actions](#pxfpre)
+-   Upgrade to a new Greenplum Database version
+-   [Step 2: Upgrading PXF](#pxfup)
+
+
+## <a id="pxfpre"></a>Step 1: PXF Pre-Upgrade Actions
+
+Perform this procedure before you upgrade to a new version of Greenplum Database:
+
+1. Log in to the Greenplum Database master node. For example:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    ```
+
+2. Stop PXF on each segment host as described in [Stopping PXF](cfginitstart_pxf.html#stop_pxf).
+
+3. Upgrade to the new version of Greenplum Database and then continue your PXF upgrade with [Step 2: Upgrading PXF](#pxfup).
+
+
+## <a id="pxfup"></a>Step 2: Upgrading PXF
+
+After you upgrade to the new version of Greenplum Database, perform the following procedure to upgrade and configure the *PXF.to* software:
+
+1. Log in to the Greenplum Database master node. For example:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    ```
+
+2. Initialize PXF on each segment host as described in [Initializing PXF](init_pxf.html). You may choose to use your existing `$PXF_CONF` for the initialization.
+
+
+3. Synchronize the PXF configuration from the master host to the standby master and each Greenplum Database segment host. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
+    ```
+ 
+4. Start PXF on each segment host as described in [Starting PXF](cfginitstart_pxf.html#start_pxf).
+

--- a/gpdb-doc/markdown/pxf/upgrade_pxf_6x.html.md.erb
+++ b/gpdb-doc/markdown/pxf/upgrade_pxf_6x.html.md.erb
@@ -2,7 +2,7 @@
 title: Upgrading PXF in Greenplum 6.x
 ---
 
-If you are using PXF in your current Greenplum Database 6.x installation, you must upgrade the PXF service when you upgrade to a new version of Greenplum Database.
+If you are using PXF in your current Greenplum Database 6.x installation, you must upgrade the PXF service when you upgrade to a newer version of Greenplum Database 6.x.
 
 The PXF upgrade procedure describes how to upgrade PXF in your Greenplum Database installation. This procedure uses *PXF.from* to refer to your currently-installed PXF version and *PXF.to* to refer to the PXF version installed when you upgrade to the new version of Greenplum Database.
 


### PR DESCRIPTION
add a basic 6.x->6.x upgrade topic for pxf.  similar to the 5.x topic, includes pre-greenplum-upgrade and post-greenplum-upgrade tasks.

doc review site link:  http://docs-lisa-pxfupg6x.cfapps.io/6-0/pxf/upgrade_pxf_6x.html
