### PR TITLE
Clean up out/readfuncs.c

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -657,42 +657,6 @@ _outJoinExpr(StringInfo str, JoinExpr *node)
 
 /*****************************************************************************
  *
- *	Stuff from relation.h.
- *
- *****************************************************************************/
-
-static void
-_outIndexOptInfo(StringInfo str, IndexOptInfo *node)
-{
-	WRITE_NODE_TYPE("INDEXOPTINFO");
-
-	/* NB: this isn't a complete set of fields */
-	WRITE_OID_FIELD(indexoid);
-	/* Do NOT print rel field, else infinite recursion */
-	WRITE_UINT_FIELD(pages);
-	WRITE_FLOAT_FIELD(tuples, "%.0f");
-	WRITE_INT_FIELD(ncolumns);
-
-	WRITE_OID_ARRAY(opfamily, node->ncolumns);
-	WRITE_INT_ARRAY(indexkeys, node->ncolumns, int);
-	WRITE_OID_ARRAY(sortopfamily, node->ncolumns);
-
-	WRITE_BOOL_FIELD(reverse_sort);
-	WRITE_BOOL_FIELD(nulls_first);
-
-    WRITE_OID_FIELD(relam);
-	WRITE_OID_FIELD(amcostestimate);
-	WRITE_NODE_FIELD(indexprs);
-	WRITE_NODE_FIELD(indpred);
-	WRITE_BOOL_FIELD(predOK);
-	WRITE_BOOL_FIELD(unique);
-	WRITE_BOOL_FIELD(hypothetical);
-
-	WRITE_BOOL_FIELD(amoptionalkey);
-}
-
-/*****************************************************************************
- *
  *	Stuff from parsenodes.h.
  *
  *****************************************************************************/
@@ -1701,95 +1665,10 @@ _outNode(StringInfo str, void *obj)
 			case T_OnConflictExpr:
 				_outOnConflictExpr(str, obj);
 				break;
-			case T_Path:
-				_outPath(str, obj);
-				break;
-			case T_IndexPath:
-				_outIndexPath(str, obj);
-				break;
-			case T_BitmapHeapPath:
-				_outBitmapHeapPath(str, obj);
-				break;
-			case T_BitmapAndPath:
-				_outBitmapAndPath(str, obj);
-				break;
-			case T_BitmapOrPath:
-				_outBitmapOrPath(str, obj);
-				break;
-			case T_TidPath:
-				_outTidPath(str, obj);
-				break;
-			case T_ForeignPath:
-				_outForeignPath(str, obj);
-				break;
-			case T_AppendPath:
-				_outAppendPath(str, obj);
-				break;
-			case T_MergeAppendPath:
-				_outMergeAppendPath(str, obj);
-				break;
-			case T_AppendOnlyPath:
-				_outAppendOnlyPath(str, obj);
-				break;
-			case T_AOCSPath:
-				_outAOCSPath(str, obj);
-				break;
-			case T_ResultPath:
-				_outResultPath(str, obj);
-				break;
-			case T_MaterialPath:
-				_outMaterialPath(str, obj);
-				break;
-			case T_UniquePath:
-				_outUniquePath(str, obj);
-				break;
-			case T_NestPath:
-				_outNestPath(str, obj);
-				break;
-			case T_MergePath:
-				_outMergePath(str, obj);
-				break;
-			case T_HashPath:
-				_outHashPath(str, obj);
-				break;
-            case T_CdbMotionPath:
-                _outCdbMotionPath(str, obj);
-                break;
-			case T_PlannerInfo:
-				_outPlannerInfo(str, obj);
-				break;
-			case T_PlannerParamItem:
-				_outPlannerParamItem(str, obj);
-				break;
-			case T_RelOptInfo:
-				_outRelOptInfo(str, obj);
-				break;
-			case T_IndexOptInfo:
-				_outIndexOptInfo(str, obj);
-				break;
-			case T_PathKey:
-				_outPathKey(str, obj);
-				break;
-			case T_ParamPathInfo:
-				_outParamPathInfo(str, obj);
-				break;
-			case T_RestrictInfo:
-				_outRestrictInfo(str, obj);
-				break;
-			case T_SpecialJoinInfo:
-				_outSpecialJoinInfo(str, obj);
-				break;
-			case T_LateralJoinInfo:
-				_outLateralJoinInfo(str, obj);
-				break;
-			case T_AppendRelInfo:
-				_outAppendRelInfo(str, obj);
-				break;
+
 			case T_CreateExtensionStmt:
 				_outCreateExtensionStmt(str, obj);
 				break;
-
-
 			case T_GrantStmt:
 				_outGrantStmt(str, obj);
 				break;
@@ -2270,15 +2149,6 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_AlterTSDictionaryStmt:
 				_outAlterTSDictionaryStmt(str, obj);
-				break;
-			case T_PlaceHolderVar:
-				_outPlaceHolderVar(str, obj);
-				break;
-			case T_PlaceHolderInfo:
-				_outPlaceHolderInfo(str, obj);
-				break;
-			case T_MinMaxAggInfo:
-				_outMinMaxAggInfo(str, obj);
 				break;
 
 			case T_CookedConstraint:

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1430,16 +1430,6 @@ _readGrantRoleStmt(void)
 	READ_DONE();
 }
 
-static PlannerParamItem *
-_readPlannerParamItem(void)
-{
-	READ_LOCALS(PlannerParamItem);
-	READ_NODE_FIELD(item);
-	READ_INT_FIELD(paramId);
-
-	READ_DONE();
-}
-
 /*
  * _readPlannedStmt
  */
@@ -2304,8 +2294,7 @@ _readFlow(void)
 	READ_INT_FIELD(segindex);
 	READ_INT_FIELD(numsegments);
 
-	READ_NODE_FIELD(hashExprs);
-	READ_NODE_FIELD(hashOpfamilies);
+	/* hashExprs and hashOpfamilies are omitted */
 
 	READ_DONE();
 }
@@ -2783,34 +2772,6 @@ _readAlterTSDictionaryStmt(void)
 	READ_DONE();
 }
 
-static PlaceHolderVar *
-_readPlaceHolderVar(void)
-{
-	READ_LOCALS(PlaceHolderVar);
-
-	READ_NODE_FIELD(phexpr);
-	READ_BITMAPSET_FIELD(phrels);
-	READ_INT_FIELD(phid);
-	READ_INT_FIELD(phlevelsup);
-
-	READ_DONE();
-}
-
-static PlaceHolderInfo *
-_readPlaceHolderInfo(void)
-{
-	READ_LOCALS(PlaceHolderInfo);
-
-	READ_INT_FIELD(phid);
-	READ_NODE_FIELD(ph_var);
-	READ_BITMAPSET_FIELD(ph_eval_at);
-	READ_BITMAPSET_FIELD(ph_lateral);
-	READ_BITMAPSET_FIELD(ph_needed);
-	READ_INT_FIELD(ph_width);
-
-	READ_DONE();
-}
-
 static CookedConstraint *
 _readCookedConstraint(void)
 {
@@ -3165,10 +3126,7 @@ readNodeBinary(void)
 				return_value = _readOidAssignment();
 				break;
 			case T_Plan:
-					return_value = _readPlan();
-					break;
-			case T_PlannerParamItem:
-				return_value = _readPlannerParamItem();
+				return_value = _readPlan();
 				break;
 			case T_Result:
 				return_value = _readResult();
@@ -3933,12 +3891,6 @@ readNodeBinary(void)
 				break;
 			case T_AlterTSDictionaryStmt:
 				return_value = _readAlterTSDictionaryStmt();
-				break;
-			case T_PlaceHolderVar:
-				return_value = _readPlaceHolderVar();
-				break;
-			case T_PlaceHolderInfo:
-				return_value = _readPlaceHolderInfo();
 				break;
 
 			case T_CookedConstraint:


### PR DESCRIPTION
- Don't write Path->parent, to avoid infinite recursion, and revert the
  GPDB changes in outPlannerInfo that were previously used to avoid it.
  There's no need to differ from upstream in this area, so let's not.

- Add missing window_pathkeys handling from outPlannerInfo. Was missed in
  a merge, I guess. No reason to differ from upstream.

- Remove out/readfast support for Paths and other structs that are only
  used within the planner, and not needed in segments.

- Don't serialize Flow->hashExprs. It's also not needed in segments, and
  it might contain PlaceHolderVars because it's not processed by
  set_plan_references()

The infinite recursion issue was spotted by Melanie and Deep.
