### PR TITLE
gpinitsystem: Return 0 on warnings

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -202,23 +202,23 @@ CHK_PARAMS () {
 		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 		LOG_MSG "[INFO]:-Checking configuration parameters, please wait..." 1
 		if [ $USER_NAME == "root" ]; then
-				ERROR_EXIT "[FATAL]:-Unable to run this script as $USER" 2
+				ERROR_EXIT "[FATAL]:-Unable to run this script as $USER"
 		fi
 		if [ x"" = x"$GPHOME" ]; then
 				LOG_MSG "[FATAL]:-Environment variable \$GPHOME not set" 1
-				ERROR_EXIT "[FATAL]:-Unable to continue" 2
+				ERROR_EXIT "[FATAL]:-Unable to continue"
 		fi
 		# Check that we can see initdb
 		if [ x"$INITDB" = x"" ] || [ ! -x $INITDB ];then
-			ERROR_EXIT "[FATAL]:-Unable to locate initdb" 2
+			ERROR_EXIT "[FATAL]:-Unable to locate initdb"
 		fi
 		# Make sure that script has been supplied a config file
 		if [ x"$CLUSTER_CONFIG" = x"" ] && [ x"$INPUT_CONFIG" = x"" ]; then
-			ERROR_EXIT "[FATAL]:-At least one of two options, [-c] or [-I], is required." 2
+			ERROR_EXIT "[FATAL]:-At least one of two options, [-c] or [-I], is required."
 		fi
 
 		if [ -n "$CLUSTER_CONFIG" ] && [ -n "$INPUT_CONFIG" ]; then
-			ERROR_EXIT "[FATAL]:-Options [-c] and [-I] cannot be used at the same time." 2
+			ERROR_EXIT "[FATAL]:-Options [-c] and [-I] cannot be used at the same time."
 		fi
 		
 		if [ x"" != x"$CLUSTER_CONFIG" ] ; then
@@ -226,7 +226,7 @@ CHK_PARAMS () {
 		    CHK_FILE $CLUSTER_CONFIG
 		    
 		    if [ $EXISTS -ne 0 ]; then
-		        ERROR_EXIT "[FATAL]:-Configuration file $CLUSTER_CONFIG does not exist." 2
+		        ERROR_EXIT "[FATAL]:-Configuration file $CLUSTER_CONFIG does not exist."
 		    fi
 		    
 		    # Make sure old CLUSTER_CONFIG settings are not hanging around.
@@ -243,11 +243,11 @@ CHK_PARAMS () {
 		    . $CLUSTER_CONFIG
 		    
 		    if [ x"" != x"$QD_PRIMARY_ARRAY" ] ; then
-			    ERROR_EXIT "[FATAL]:-Cannot specify QD_PRIMARY_ARRAY in '-c <config file>'.  Only valid with '-I <input file>'" 2
+			    ERROR_EXIT "[FATAL]:-Cannot specify QD_PRIMARY_ARRAY in '-c <config file>'.  Only valid with '-I <input file>'"
 		    fi
 
 		    if [ x"" = x"$PORT_BASE" ]; then
-			    ERROR_EXIT "[FATAL]:-PORT_BASE not specified in $CLUSTER_CONFIG file, is this the correct instance configuration file." 2
+			    ERROR_EXIT "[FATAL]:-PORT_BASE not specified in $CLUSTER_CONFIG file, is this the correct instance configuration file."
 		    fi
 
 		    if [ $MIRROR_PORT_BASE ]; then
@@ -269,16 +269,16 @@ CHK_PARAMS () {
 		    # Now check to see if MACHINE_LIST_FILE is still empty
 		    if [ x"" == x"$MACHINE_LIST_FILE" ];then
 			LOG_MSG "[FATAL]:-MACHINE_LIST_FILE variable is unset, and -h option not supplied" 1
-			ERROR_EXIT "[FATAL]:-Unable to continue" 2
+			ERROR_EXIT "[FATAL]:-Unable to continue"
 		    fi
 		fi
 
 		# Check for required definitions in the CLUSTER_CONFIG file
 		if [ x"" = x"$SEG_PREFIX" ]; then
-			ERROR_EXIT "[FATAL]:-SEG_PREFIX not specified in $CLUSTER_CONFIG file, is this the correct instance configuration file." 2
+			ERROR_EXIT "[FATAL]:-SEG_PREFIX not specified in $CLUSTER_CONFIG file, is this the correct instance configuration file."
 		fi
 		if [ x"" = x"$DATA_DIRECTORY" ]; then
-			ERROR_EXIT "[FATAL]:-DATA_DIRECTORY not specified in $CLUSTER_CONFIG file, is this the correct instance configuration file." 2
+			ERROR_EXIT "[FATAL]:-DATA_DIRECTORY not specified in $CLUSTER_CONFIG file, is this the correct instance configuration file."
 		fi
 
 		if [ x"" = x"$HEAP_CHECKSUM" ]; then
@@ -305,7 +305,7 @@ CHK_PARAMS () {
 		$LOCALE >> $LOG_FILE
 		LOG_MSG "[INFO]:-End of system locale dump"
 		if [ ! -f $GPCREATESEG ];then
-			ERROR_EXIT "[FATAL]:-No $GPCREATESEG exists" 2
+			ERROR_EXIT "[FATAL]:-No $GPCREATESEG exists"
 		fi
 
 		if [ x"" == x"$INPUT_CONFIG" ] ; then
@@ -315,7 +315,7 @@ CHK_PARAMS () {
 		    do
 			CHK_FILE $FILE
 			if [ $EXISTS -ne 0 ]; then
-			    ERROR_EXIT "[FATAL]:-Expected file \"$FILE\" not found" 2
+			    ERROR_EXIT "[FATAL]:-Expected file \"$FILE\" not found"
 			else
 			    LOG_MSG "[INFO]:-Completed check of file $FILE"
 			fi
@@ -333,7 +333,7 @@ CHK_PARAMS () {
 		export ARRAY_NAME
 
 		if [ x"" = x"$MASTER_HOSTNAME" ]; then
-			ERROR_EXIT "[FATAL]:MASTER_HOSTNAME variable not set" 2
+			ERROR_EXIT "[FATAL]:MASTER_HOSTNAME variable not set"
 		fi
 
 		# Make sure that this script is running on the QD host
@@ -349,24 +349,24 @@ CHK_PARAMS () {
 				LOG_MSG "[FATAL]:-Master hostname in configuration file is ${MASTER_HOSTNAME}" 1
 				LOG_MSG "[FATAL]:-Operating system command returns `$HOSTNAME`" 1
 				LOG_MSG "[FATAL]:-Unable to resolve $MASTER_HOSTNAME on this host" 1
-				ERROR_EXIT "[FATAL]:-Master hostname in gpinitsystem configuration file must be $MASTER_HOSTNAME" 2
+				ERROR_EXIT "[FATAL]:-Master hostname in gpinitsystem configuration file must be $MASTER_HOSTNAME"
 			fi
 		fi
 
 		# MASTER_PORT
 		if [ x"" = x"$MASTER_PORT" ]; then
-			ERROR_EXIT "[FATAL]:-MASTER_PORT variable not set" 2
+			ERROR_EXIT "[FATAL]:-MASTER_PORT variable not set"
 		fi
 
 		# DATA_DIRECTORY
 		((QE_PRIMARY_COUNT=${#DATA_DIRECTORY[@]}))
 		if [ $QE_PRIMARY_COUNT -eq 0 ]; then
-			ERROR_EXIT "[FATAL]:-Number of primary directories 0 (zero)" 2
+			ERROR_EXIT "[FATAL]:-Number of primary directories 0 (zero)"
 		fi
 
 		# MASTER_DIRECTORY
 		if [ x"" = x"$MASTER_DIRECTORY" ]; then
-			ERROR_EXIT "[FATAL]:-MASTER_DIRECTORY variable not set" 2
+			ERROR_EXIT "[FATAL]:-MASTER_DIRECTORY variable not set"
 		fi
 		# Check that we have write access to the proposed master data directory
 		W_DIR=$MASTER_DIRECTORY
@@ -374,14 +374,14 @@ CHK_PARAMS () {
 		$TOUCH ${W_DIR}/tmp_file_test
 		RETVAL=$?
 		if [ $RETVAL -ne 0 ];then
-			ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on master host " 2
+			ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on master host "
 		else
 			$RM -f ${W_DIR}/tmp_file_test
 			LOG_MSG "[INFO]:-Write test passed $W_DIR directory on master host"
 		fi	
 		# Check that the master segment directory does not exist
 		if [ -d ${MASTER_DIRECTORY}/${SEG_PREFIX}-1 ];then
-			ERROR_EXIT "[FATAL]:-Master host data directory ${MASTER_DIRECTORY}/${SEG_PREFIX}-1 already exists" 2
+			ERROR_EXIT "[FATAL]:-Master host data directory ${MASTER_DIRECTORY}/${SEG_PREFIX}-1 already exists"
 		fi
 		# DATABASE_PREFIX
 		if [ x"" = x"$DATABASE_NAME" ]; then
@@ -390,7 +390,7 @@ CHK_PARAMS () {
 			LOG_MSG "[INFO]:-Will create database $DATABASE_NAME"
 		fi
 		if [ ! $TRUSTED_SHELL ]; then
-				ERROR_EXIT "[FATAL]:-TRUSTED_SHELL variable not set" 2
+				ERROR_EXIT "[FATAL]:-TRUSTED_SHELL variable not set"
 		fi
 		# ENCODING
 		if [ ! $ENCODING ]; then
@@ -398,7 +398,7 @@ CHK_PARAMS () {
 			ENCODING="UTF-8"
 		fi
 		if [ x"SQL_ASCII" = x"$ENCODING" ]; then
-			ERROR_EXIT "[FATAL]:-SQL_ASCII is no longer supported as a server encoding" 2
+			ERROR_EXIT "[FATAL]:-SQL_ASCII is no longer supported as a server encoding"
 		fi
 		# MASTER_MAX_CONNECT
 		if [ ! $MASTER_MAX_CONNECT ];then
@@ -406,7 +406,7 @@ CHK_PARAMS () {
 			MASTER_MAX_CONNECT=$DEFAULT_QD_MAX_CONNECT
 		else
 			if [ $MASTER_MAX_CONNECT -lt 1 ];then
-				ERROR_EXIT "[FATAL]:-MASTER_MAX_CONNECT less than 1" 2
+				ERROR_EXIT "[FATAL]:-MASTER_MAX_CONNECT less than 1"
 			fi
 		fi
 		((QE_MAX_CONNECT=$MASTER_MAX_CONNECT*$QE_CONNECT_FACTOR))
@@ -423,7 +423,7 @@ CHK_PARAMS () {
 		# Number of QE hosts in this configuration
 		((NUM_QES=${#MACHINE_LIST[*]}))
 		if [ $NUM_QES -eq 0 ]; then
-			ERROR_EXIT "[FATAL]:-Number of Segment instances's 0 (zero)" 2
+			ERROR_EXIT "[FATAL]:-Number of Segment instances's 0 (zero)"
 		else
 			LOG_MSG "[INFO]:-Number of segment instance hosts = $NUM_QES"
 			if [ $NUM_QES -eq 1 ];then
@@ -440,7 +440,7 @@ CHK_PARAMS () {
 			((NUM_MIRROR_DIRECTORY=${#MIRROR_DATA_DIRECTORY[@]}))
 			if [ x"" == x"$INPUT_CONFIG" ] ; then
 				if [ $NUM_MIRROR_DIRECTORY -ne $QE_PRIMARY_COUNT ]; then
-					ERROR_EXIT "[FATAL]:-Number of primary directories does not match number of mirror directories" 2
+					ERROR_EXIT "[FATAL]:-Number of primary directories does not match number of mirror directories"
 				fi
 			fi
 			
@@ -449,7 +449,7 @@ CHK_PARAMS () {
 				for mirrordir in "${MIRROR_DATA_DIRECTORY[@]}"
 				do
 					if [ $dir == $mirrordir ] ; then
-						ERROR_EXIT "[FATAL]:-Conflict between data directory and mirror data directory ($dir)." 2
+						ERROR_EXIT "[FATAL]:-Conflict between data directory and mirror data directory ($dir)."
 					fi
 				done
 			done
@@ -489,46 +489,46 @@ CHK_PARAMS () {
 		if [ x"" != x"$REQ_LOCALE_SETTING" ]; then
 			IN_ARRAY $REQ_LOCALE_SETTING "`locale -a`"
 			if [ $? -eq 0 ]; then
-				ERROR_EXIT "[FATAL]-Value $REQ_LOCALE_SETTING is not a valid value for --locale on this system." 2
+				ERROR_EXIT "[FATAL]-Value $REQ_LOCALE_SETTING is not a valid value for --locale on this system."
 			fi
 		fi
 		if [ x"" != x"$LCCOLLATE" ]; then
 			IN_ARRAY $LCCOLLATE "`locale -a`"
 			if [ $? -eq 0 ]; then
-				ERROR_EXIT "[FATAL]-Value $LCCOLLATE is not a valid value for --lc-collate on this system." 2
+				ERROR_EXIT "[FATAL]-Value $LCCOLLATE is not a valid value for --lc-collate on this system."
 			fi	
 		fi
 		if [ x"" != x"$LCCTYPE" ]; then
 			IN_ARRAY $LCCTYPE "`locale -a`"
 			if [ $? -eq 0 ]; then
-				ERROR_EXIT "[FATAL]-Value $LCCTYPE is not a valid value for --lc-ctype on this system." 2
+				ERROR_EXIT "[FATAL]-Value $LCCTYPE is not a valid value for --lc-ctype on this system."
 			fi
 		fi
 		if [ x"" != x"$LCMESSAGES" ]; then
 			IN_ARRAY $LCMESSAGES "`locale -a`"
 			if [ $? -eq 0 ]; then
-				ERROR_EXIT "[FATAL]-Value $LCMESSAGES is not a valid value for --lc-messages on this system." 2
+				ERROR_EXIT "[FATAL]-Value $LCMESSAGES is not a valid value for --lc-messages on this system."
 			fi
 		fi
 		
 		if [ x"" != x"$LCMONETARY" ]; then
 			IN_ARRAY $LCMONETARY "`locale -a`"
 			if [ $? -eq 0 ]; then
-				ERROR_EXIT "[FATAL]-Value $LCMONETARY is not a valid value for --lc-monetary on this system." 2
+				ERROR_EXIT "[FATAL]-Value $LCMONETARY is not a valid value for --lc-monetary on this system."
 			fi
 		fi
 		
 		if [ x"" != x"$LCNUMERIC" ]; then
 			IN_ARRAY $LCNUMERIC "`locale -a`"
 			if [ $? -eq 0 ]; then
-				ERROR_EXIT "[FATAL]-Value $LCNUMERIC is not a valid value for --lc-numeric on this system." 2
+				ERROR_EXIT "[FATAL]-Value $LCNUMERIC is not a valid value for --lc-numeric on this system."
 			fi
 		fi
 		
 		if [ x"" != x"$LCTIME" ]; then
 			IN_ARRAY $LCTIME "`locale -a`"
 			if [ $? -eq 0 ]; then
-				ERROR_EXIT "[FATAL]-Value $LCTIME is not a valid value for --lc-time on this system." 2
+				ERROR_EXIT "[FATAL]-Value $LCTIME is not a valid value for --lc-time on this system."
 			fi
 		fi
 		LOG_MSG "[INFO]:-Checking configuration parameters, Completed" 1
@@ -588,7 +588,7 @@ END_PYTHON_CODE
 			LOG_MSG "[FATAL]:-Check to see that you have setup trusted remote ssh on all hosts"
 			$ECHO "[FATAL]:-Check to see that you have setup trusted remote ssh on all hosts"
 
-			ERROR_EXIT "[FATAL]:-Unable to get hostname output for $MHOST" 2
+			ERROR_EXIT "[FATAL]:-Unable to get hostname output for $MHOST"
 		fi
 		if [ `$ECHO ${T_SEG_ARRAY[@]}|$TR ' ' '\n'|$GREP -c "^${SEG_HOSTNAME}$"` -eq 0 ];then
 			T_SEG_ARRAY=(${T_SEG_ARRAY[@]} $SEG_HOSTNAME)
@@ -618,7 +618,7 @@ END_PYTHON_CODE
                     LOG_MSG "[INFO]:-Have $NUM_DATADIR data directories and $NUM_MHOST_NODE multi-home hostnames for each host" 1
                     LOG_MSG "[INFO]:-For multi-home configuration, number of segment instance data directories per host must be multiple of" 1
                     LOG_MSG "[INFO]:-the number of multi-home hostnames within the GPDB array" 1
-                    ERROR_EXIT "[FATAL]:-Unable to continue" 2
+                    ERROR_EXIT "[FATAL]:-Unable to continue"
                 fi
 
 		if [ $MULTIPLE -gt 1 ] ; then
@@ -655,7 +655,7 @@ END_PYTHON_CODE
 		if [ $NUM_SEP_HOSTS -eq 1 ] || [ $NUM_SEP_HOSTS -le $NUM_DATADIR ];then
 			LOG_MSG "[FATAL]:-Request made for spread mirroring via --mirror-mode option, but insufficient hosts available" 1
 			LOG_MSG "[INFO]:-Number of separate hosts must be greater than number of segment instances per host" 1
-			ERROR_EXIT "[FATAL]:-Unable to continue" 2
+			ERROR_EXIT "[FATAL]:-Unable to continue"
 		else
 			LOG_MSG "[INFO]:-Sufficient hosts for spread mirroring request" 1
 		fi 
@@ -678,7 +678,7 @@ CHK_LOCALE_KNOWN () {
 			LOG_MSG "[FATAL]:-Unable to locate locale value $LOCALE_SETTING on this host" 1
 			LOG_MSG "[INFO]:-Select another locale value via -n option to this utility" 1
 			LOG_MSG "[INFO]:-Available locale values have been dumped to the log file" 1
-			ERROR_EXIT "[FATAL]:-Unable to continue" 2
+			ERROR_EXIT "[FATAL]:-Unable to continue"
 		else
 			LOG_MSG "[INFO]:-Locale check passed on this host" 
 		fi
@@ -690,7 +690,7 @@ CHK_LOCALE_KNOWN () {
 			LOG_MSG "[FATAL]:-Unable to locate locale value $LOCALE_SETTING on $1" 1
 			LOG_MSG "[INFO]:-Select another locale value via -n option to this utility" 1
 			LOG_MSG "[INFO]:-Available locale values have been dumped to the log file" 1 
-			ERROR_EXIT "[FATAL]:-Unable to continue" 2
+			ERROR_EXIT "[FATAL]:-Unable to continue"
 		else
 			LOG_MSG "[INFO]:-Locale check passed on $1" 
 		fi
@@ -702,7 +702,7 @@ CHK_DUPLICATES () {
 		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 		if [ `$ECHO | $CAT $MACHINE_LIST_FILE - |$GREP -v $"^$"|$WC -l` -ne `$CAT $MACHINE_LIST_FILE|$GREP -v "^$"|$SORT -u|$WC -l` ]
 		then
-			ERROR_EXIT "[FATAL]:-Duplicate segment instance hostname exists in $MACHINE_LIST_FILE" 2
+			ERROR_EXIT "[FATAL]:-Duplicate segment instance hostname exists in $MACHINE_LIST_FILE"
 		fi
 		LOG_MSG "[INFO]:-No duplicate segment instance hostnames found, will proceed"
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
@@ -725,11 +725,11 @@ CHK_QES () {
 	SET_VAR $QD_PRIMARY_ARRAY
 	CHK_DIR $GP_DIR
 	if [ $EXISTS -eq 0 ]; then
-		ERROR_EXIT "[FATAL]:-Master directory $GP_DIR already exists" 2
+		ERROR_EXIT "[FATAL]:-Master directory $GP_DIR already exists"
 	fi
 	GET_PG_PID_ACTIVE $GP_PORT
 	if [ $PID -ne 0 ];then
-		ERROR_EXIT "[FATAL]:-Found indication of postmaster process on port $GP_PORT on Master host" 2
+		ERROR_EXIT "[FATAL]:-Found indication of postmaster process on port $GP_PORT on Master host"
 	fi
 	LOG_MSG "[INFO]:-Checking new segment hosts, please wait..." 1
 
@@ -740,7 +740,7 @@ CHK_QES () {
         CHK_OPEN_FILES $GP_HOSTADDRESS
         POSTGRES_VERSION_CHK $GP_HOSTADDRESS
         if [ $VERSION_MATCH -ne 1 ] ; then
-            ERROR_EXIT "Postgres version does not match" 2
+            ERROR_EXIT "Postgres version does not match"
         fi
 
         # Check to ensure have required QE directories
@@ -750,7 +750,7 @@ CHK_QES () {
             LOG_MSG "[INFO]:-Checking segment instance $QE_ID directory $DIR"
             CHK_DIR $DIR $QE_ID
             if [ $EXISTS -ne 0 ]; then
-                ERROR_EXIT "[FATAL]:-No $DIR on segment instance $QE_ID" 2
+                ERROR_EXIT "[FATAL]:-No $DIR on segment instance $QE_ID"
             else
                 LOG_MSG "[INFO]:-$QE_ID $DIR checked"
             fi
@@ -758,7 +758,7 @@ CHK_QES () {
         # Check that we have a GP_LIBRARY_PATH directory on the QE
         CHK_DIR $GP_LIBRARY_PATH $QE_ID
         if [ $EXISTS -ne 0 ]; then
-            ERROR_EXIT "[FATAL]:-No $GP_LIBRARY_PATH on segment instance $QE_ID" 2
+            ERROR_EXIT "[FATAL]:-No $GP_LIBRARY_PATH on segment instance $QE_ID"
         else
             LOG_MSG "[INFO]:-Segment instance $QE_ID $GP_LIBRARY_PATH checked"
         fi
@@ -773,7 +773,7 @@ CHK_QES () {
         LOG_MSG "[INFO]:-Checking $GP_HOSTADDRESS for dir $GP_DIR"
         CHK_DIR $GP_DIR $GP_HOSTADDRESS
         if [ $EXISTS -eq 0 ]; then
-            ERROR_EXIT "[FATAL]:-Instance directory $GP_DIR exists on segment instance $GP_HOSTADDRESS" 2
+            ERROR_EXIT "[FATAL]:-Instance directory $GP_DIR exists on segment instance $GP_HOSTADDRESS"
         fi
         # Check that the hostname is not associated with local host
         LOG_MSG "[INFO]:-Checking $GP_HOSTADDRESS $HOSTFILE for localhost set as $GP_HOSTADDRESS"
@@ -791,7 +791,7 @@ CHK_QES () {
         $TRUSTED_SHELL $GP_HOSTADDRESS "$TOUCH ${W_DIR}/tmp_file_test"
         RETVAL=$?
         if [ $RETVAL -ne 0 ];then
-            ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on $GP_HOSTADDRESS " 2
+            ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on $GP_HOSTADDRESS "
         else
             $TRUSTED_SHELL $GP_HOSTADDRESS "$RM -f ${W_DIR}/tmp_file_test"
             LOG_MSG "[INFO]:-Write test passed on $GP_HOSTADDRESS $W_DIR directory"
@@ -808,7 +808,7 @@ CHK_QES () {
             LOG_MSG "[INFO]:-Checking $GP_HOSTADDRESS for dir $GP_DIR"
             CHK_DIR $GP_DIR $GP_HOSTADDRESS
             if [ $EXISTS -eq 0 ]; then
-                ERROR_EXIT "[FATAL]:-Instance directory $GP_DIR exists on segment instance $GP_HOSTADDRESS" 2
+                ERROR_EXIT "[FATAL]:-Instance directory $GP_DIR exists on segment instance $GP_HOSTADDRESS"
             fi
             # Check that we can write to the QE directory
             W_DIR=`$DIRNAME $GP_DIR`
@@ -816,7 +816,7 @@ CHK_QES () {
             $TRUSTED_SHELL $GP_HOSTADDRESS "$TOUCH ${W_DIR}/tmp_file_test"
             RETVAL=$?
             if [ $RETVAL -ne 0 ];then
-                ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on $GP_HOSTADDRESS " 2
+                ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on $GP_HOSTADDRESS "
             else
                 $TRUSTED_SHELL $GP_HOSTADDRESS "$RM -f ${W_DIR}/tmp_file_test"
                 LOG_MSG "[INFO]:-Write test passed on $GP_HOSTADDRESS $W_DIR directory"
@@ -833,7 +833,7 @@ CHK_QES () {
         # Check standby host directory
         CHK_DIR $MASTER_DIRECTORY $STANDBY_HOSTNAME
         if [ $EXISTS -ne 0 ];then
-            ERROR_EXIT "[FATAL]:-Standby host directory $MASTER_DIRECTORY, does not exist" 2
+            ERROR_EXIT "[FATAL]:-Standby host directory $MASTER_DIRECTORY, does not exist"
         fi
     fi
 
@@ -853,7 +853,7 @@ CHK_SEG () {
 	CHK_OPEN_FILES $GP_HOSTADDRESS
 	POSTGRES_VERSION_CHK $GP_HOSTADDRESS
 	if [ $VERSION_MATCH -ne 1 ] ; then
-	   ERROR_EXIT "Postgres version does not match" 2
+	   ERROR_EXIT "Postgres version does not match"
 	fi
 	
 	#make sure we can write to it.
@@ -863,7 +863,7 @@ CHK_SEG () {
     $TRUSTED_SHELL $GP_HOSTADDRESS "$TOUCH ${W_DIR}/tmp_file_test"
     RETVAL=$?
     if [ $RETVAL -ne 0 ];then
-         ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on $GP_HOSTADDRESS " 2
+         ERROR_EXIT "[FATAL]:-Cannot write to $W_DIR on $GP_HOSTADDRESS "
     else
          $TRUSTED_SHELL $GP_HOSTADDRESS "$RM -f ${W_DIR}/tmp_file_test"
          LOG_MSG "[INFO]:-Write test passed on $GP_HOSTADDRESS $W_DIR directory"
@@ -872,7 +872,7 @@ CHK_SEG () {
 	# Check that we have a GP_LIBRARY_PATH directory on the QE
 	CHK_DIR $GP_LIBRARY_PATH $GP_HOSTADDRESS
 	if [ $EXISTS -ne 0 ]; then
-		ERROR_EXIT "[FATAL]:-No $GP_LIBRARY_PATH on segment $GP_HOSTADDRESS:$GP_DIR" 2
+		ERROR_EXIT "[FATAL]:-No $GP_LIBRARY_PATH on segment $GP_HOSTADDRESS:$GP_DIR"
 	else
 		LOG_MSG "[INFO]:-Segment instance $GP_HOSTADDRESS:$GP_DIR $GP_LIBRARY_PATH checked"
 	fi
@@ -886,11 +886,11 @@ CHK_QES_FROM_INPUTFILE () {
 	SET_VAR $QD_PRIMARY_ARRAY
 	CHK_DIR $GP_DIR
 	if [ $EXISTS -eq 0 ]; then
-		ERROR_EXIT "[FATAL]:-Master directory $GP_DIR already exists" 2
+		ERROR_EXIT "[FATAL]:-Master directory $GP_DIR already exists"
 	fi
 	GET_PG_PID_ACTIVE $GP_PORT
 	if [ $PID -ne 0 ];then
-		ERROR_EXIT "[FATAL]:-Found indication of postmaster process on port $GP_PORT on Master host" 2
+		ERROR_EXIT "[FATAL]:-Found indication of postmaster process on port $GP_PORT on Master host"
 	fi
 	LOG_MSG "[INFO]:-Checking new segment hosts, please wait..." 1
 	
@@ -911,7 +911,7 @@ CHK_QES_FROM_INPUTFILE () {
 		#Check standby host directory
 		CHK_DIR $MASTER_DIRECTORY $STANDBY_HOSTNAME
 		if [ $EXISTS -ne 0 ];then
-			ERROR_EXIT "[FATAL]:-Standby host directory $MASTER_DIRECTORY, does not exist" 2
+			ERROR_EXIT "[FATAL]:-Standby host directory $MASTER_DIRECTORY, does not exist"
 		fi
 	fi
 	
@@ -924,7 +924,7 @@ POSTGRES_PORT_CHK () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	GET_PG_PID_ACTIVE $1 $2
 	if [ x"$PID" != x0 ];then
-		ERROR_EXIT "[FATAL]:-Host $2 has an active database process on port = $1" 2
+		ERROR_EXIT "[FATAL]:-Host $2 has an active database process on port = $1"
 	fi
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
@@ -1231,7 +1231,7 @@ CREATE_QD_DB () {
 		fi    
 		$RM -f ${GP_DIR}.initdb
 		if [ $RETVAL -ne 0 ]; then
-		    ERROR_EXIT "[FATAL]:- Command $cmd failed with error status $RETVAL, see log file $LOG_FILE for more detail" 2
+		    ERROR_EXIT "[FATAL]:- Command $cmd failed with error status $RETVAL, see log file $LOG_FILE for more detail"
 		fi
 
 		BACKOUT_COMMAND "if [ -d $GP_DIR ]; then $RM -Rf $GP_DIR; fi"
@@ -1284,7 +1284,7 @@ CREATE_QD_DB () {
 		RUNNING=`$ECHO $RET_TEXT|$EGREP -c "not running|neither"`
 		if [ $RUNNING -ne 0 ]; then
 				$CAT ${GP_DIR}.log|$TEE -a $LOG_FILE
-				ERROR_EXIT "[FATAL]:-Failed to start the Master database in admin mode" 2
+				ERROR_EXIT "[FATAL]:-Failed to start the Master database in admin mode"
 		fi
 		BACKOUT_COMMAND "$RM -f /tmp/.s.PGSQL.${GP_PORT}*"
 		BACKOUT_COMMAND "$ECHO \"Removing Master lock files\""
@@ -1295,12 +1295,12 @@ CREATE_QD_DB () {
 		LOG_MSG "[INFO]:-Completed starting the Master in admin mode"
 		GP_HOSTNAME=`HOST_LOOKUP $GP_HOSTADDRESS`
 		if [ x"$GP_HOSTNAME" = x"__lookup_of_hostname_failed__" ]; then
-			ERROR_EXIT "[FATAL]:-Hostname lookup for host $GP_HOSTADDRESS failed." 2
+			ERROR_EXIT "[FATAL]:-Hostname lookup for host $GP_HOSTADDRESS failed."
 		fi
 		PING_HOST $GP_HOSTNAME
 		RETVAL=$?
 		if [ $RETVAL -ne 0 ]; then
-			ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration." 2
+			ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration."
 		fi
 		UPDATE_GPCONFIG $GP_PORT $GP_DBID $GP_CONTENT $GP_HOSTNAME $GP_HOSTADDRESS $GP_PORT $GP_DIR p
 		LOAD_QE_SYSTEM_DATA $DEFAULTDB
@@ -1355,13 +1355,13 @@ LOAD_QE_SYSTEM_DATA () {
 				LOG_MSG "[INFO]:-Adding segment $GP_HOSTADDRESS to Master system tables"
 				GP_HOSTNAME=`HOST_LOOKUP $GP_HOSTADDRESS`
 				if [ x"$GP_HOSTNAME" = x"__lookup_of_hostname_failed__" ]; then
-					ERROR_EXIT "[FATAL]:-Hostname lookup for host $GP_HOSTADDRESS failed." 2
+					ERROR_EXIT "[FATAL]:-Hostname lookup for host $GP_HOSTADDRESS failed."
 				fi
 				PING_HOST $GP_HOSTNAME
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
-					ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration." 2
-				fi				
+					ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration."
+				fi
 				UPDATE_GPCONFIG $MASTER_PORT $GP_DBID $GP_CONTENT $GP_HOSTNAME $GP_HOSTADDRESS $GP_PORT $GP_DIR p
 				LOG_MSG "[INFO]:-Successfully added segment $GP_HOSTADDRESS to Master system tables"
 		done
@@ -1469,10 +1469,10 @@ STOP_QD_PRODUCTION () {
 	case $RETVAL in
 	    0 ) LOG_MSG "[INFO]:-Successfully shutdown the new Greenplum instance" ;;
 	    1 ) LOG_MSG "[WARN]:-Non fatal error from Greenplum instance shutdown, check log files, will continue" ;;
-	    * ) ERROR_EXIT "[FATAL]:-Failed to stop new Greenplum instance, check log file" 2
+	    * ) ERROR_EXIT "[FATAL]:-Failed to stop new Greenplum instance, check log file"
 	esac
     else
-	ERROR_EXIT "[FATAL]:-$GPSTOP not located" 2
+	ERROR_EXIT "[FATAL]:-$GPSTOP not located"
     fi
     LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
@@ -1539,7 +1539,7 @@ START_QD_PRODUCTION () {
                 case $RETVAL in
                     0 ) LOG_MSG "[INFO]:-Successfully shutdown the Greenplum instance" 1;;
                     1 ) LOG_MSG "[WARN]:-Non fatal error from Greenplum instance shutdown" 1;;
-                    * ) ERROR_EXIT "[WARN]:-Failed to stop new Greenplum instance" 2
+                    * ) ERROR_EXIT "[WARN]:-Failed to stop new Greenplum instance"
                 esac
             else
                 LOG_MSG "[WARN]:-$GPSTOP not located" 1
@@ -1552,10 +1552,10 @@ START_QD_PRODUCTION () {
             LOG_MSG "[WARN]:- issues.  Not all initialization tasks have completed so the cluster" 1
             LOG_MSG "[WARN]:- should not be used." 1
             LOG_MSG "[WARN]:" 1
-            ERROR_EXIT "[FATAL]: starting new instance failed;" 2
+            ERROR_EXIT "[FATAL]: starting new instance failed;"
         fi
     else
-	ERROR_EXIT "[FATAL]:-$GPSTART not located" 2
+	ERROR_EXIT "[FATAL]:-$GPSTART not located"
     fi
     LOG_MSG "[INFO]:-Completed restart of Greenplum instance in production mode" 1
     LOG_MSG "[INFO]:-End Function $FUNCNAME"
@@ -1586,7 +1586,7 @@ FORCE_FTS_PROBE () {
             $PSQL -p $GP_PORT -d "$DEFAULTDB" -A -t -c "select * from gp_stat_replication where sync_error != 'none' or sync_state != 'sync';" >> $LOG_FILE 2>&1
             LOG_MSG "[WARN]:" 1
             LOG_MSG "[WARN]:-Failed to start Greenplum instance; please review gpinitsystem log to determine failure." 1
-            ERROR_EXIT "[FATAL]:-Some primary/mirror segment pairs were found to be not in sync" 2
+            ERROR_EXIT "[FATAL]:-Some primary/mirror segment pairs were found to be not in sync"
             break;
         fi
 
@@ -1664,7 +1664,7 @@ READ_INPUT_CONFIG () {
    # Check that we have a non-zero configuration file
     CHK_FILE $INPUT_CONFIG
     if [ $EXISTS -ne 0 ]; then
-        ERROR_EXIT "[FATAL]:-Problem with $INPUT_CONFIG file" 2
+        ERROR_EXIT "[FATAL]:-Problem with $INPUT_CONFIG file"
     fi
     
     # Make sure old CLUSTER_CONFIG settings are not hanging around.
@@ -1672,15 +1672,15 @@ READ_INPUT_CONFIG () {
 
     # Validation
     if [ x"" != x"${MASTER_PORT}" ] ; then
-        ERROR_EXIT "[FATAL]:-Problem with configuration. Cannot specify MASTER_PORT and QD_PRIMARY_ARRAY" 2             
+        ERROR_EXIT "[FATAL]:-Problem with configuration. Cannot specify MASTER_PORT and QD_PRIMARY_ARRAY"
     fi
 
     if [ x"" != x"${MASTER_HOSTNAME}" ] ; then
-        ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify MASTER_HOSTNAME and QD_PRIMARY_ARRAY" 2                            
+        ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify MASTER_HOSTNAME and QD_PRIMARY_ARRAY"
     fi
 
     if [ x"" != x"${MASTER_DIRECTORY}" ] ; then
-        ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify MASTER_DIRECTORY and QD_PRIMARY_ARRAY" 2                           
+        ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify MASTER_DIRECTORY and QD_PRIMARY_ARRAY"
     fi
 
     # Make sure it is not a dos file with CTRL M at end of each line
@@ -1742,7 +1742,7 @@ READ_INPUT_CONFIG () {
 
     if [ $TOTAL_MIRRORS -ne 0 ] ; then
         if [ $TOTAL_SEG -ne $TOTAL_MIRRORS ] ; then
-            ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify different number of primary and mirror segments." 2   
+            ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify different number of primary and mirror segments."
         fi
     fi
 }
@@ -1791,24 +1791,24 @@ CHK_QE_ARRAY_PORT_RANGES () {
     #
 
     if CHK_OVERLAP $MASTER_PORT $MASTER_PORT $MIN_PORT $MAX_PORT; then
-	ERROR_EXIT "[FATAL]:-MASTER_PORT overlaps with PORT_BASE." 2
+	ERROR_EXIT "[FATAL]:-MASTER_PORT overlaps with PORT_BASE."
     fi
     
     # Mirror configuration
     if [ $MIRROR_PORT_BASE ]; then
 	
 	if CHK_OVERLAP $MASTER_PORT $MASTER_PORT $MIN_MIRROR_PORT $MAX_MIRROR_PORT; then
-	    ERROR_EXIT "[FATAL]:-MASTER_PORT overlaps with MIRROR_PORT_BASE." 2
+	    ERROR_EXIT "[FATAL]:-MASTER_PORT overlaps with MIRROR_PORT_BASE."
 	fi
 	
 	if CHK_OVERLAP $MIN_PORT $MAX_PORT $MIN_MIRROR_PORT $MAX_MIRROR_PORT; then
-	    ERROR_EXIT "[FATAL]:-PORT_BASE AND MIRROR_PORT_BASE define overlapping ranges." 2
+	    ERROR_EXIT "[FATAL]:-PORT_BASE AND MIRROR_PORT_BASE define overlapping ranges."
 	fi
     fi
 
     # PORT_BASE
     if [ x"" = x"$PORT_BASE" ]; then
-	    ERROR_EXIT "[FATAL]:-PORT_BASE variable not set" 2
+	    ERROR_EXIT "[FATAL]:-PORT_BASE variable not set"
     fi
     QE_PORT=$PORT_BASE
 }
@@ -1845,14 +1845,14 @@ SET_MIRROR_MODE() {
 	elif [ "$mode" == 'spread' ]; then
 		MIRROR_TYPE=1
 	else
-		ERROR_EXIT "[FATAL]:-'$mode' is an invalid mirroring mode.  Valid options are 'group' and 'spread'." 2
+		ERROR_EXIT "[FATAL]:-'$mode' is an invalid mirroring mode.  Valid options are 'group' and 'spread'."
 	fi
 }
 
 #******************************************************************************
 # Main Section
 #******************************************************************************
-trap 'ERROR_EXIT "[FATAL]:-Received INT or TERM signal" 2' INT TERM
+trap 'ERROR_EXIT "[FATAL]:-Received INT or TERM signal"' INT TERM
 while getopts ":vaqe:c:l:-:p:m:h:n:s:P:S:b:DB:I:O:" opt
 		do
 		case $opt in
@@ -1909,13 +1909,13 @@ done
 if [ x"" != x"$PG_CONF_ADD_FILE" ]; then
 	CHK_FILE $PG_CONF_ADD_FILE
 	if [ $EXISTS -ne 0 ]; then
-		ERROR_EXIT "[FATAL]:-Issue with postgres additions file $PG_CONF_ADD_FILE" 2
+		ERROR_EXIT "[FATAL]:-Issue with postgres additions file $PG_CONF_ADD_FILE"
 	fi
 fi
 if [ x"" != x"$LOG_DIR" ];then
         CHK_DIR $LOG_DIR "" 1
         if [ $EXISTS -eq 1 ]; then
-                ERROR_EXIT "[FATAL]:-Log directory $LOG_DIR does not exist!" 2
+                ERROR_EXIT "[FATAL]:-Log directory $LOG_DIR does not exist!"
         else
                 LOG_FILE=$LOG_DIR/${PROG_NAME}_${CUR_DATE}.log
                 BACKOUT_FILE=$LOG_DIR/backout_${PROG_NAME}_${USER_NAME}_${CUR_DATE}_$FILE_TIME
@@ -1974,7 +1974,7 @@ if [ $REPORT_FAIL -ne 0 ];then
 		$RM -f $I
 	done
 	$ECHO "$RM -f $BACKOUT_FILE" >> $BACKOUT_FILE
-	ERROR_EXIT "[FATAL]:-Failures detected, see log file $LOG_FILE for more detail" 2
+	ERROR_EXIT "[FATAL]:-Failures detected, see log file $LOG_FILE for more detail"
 else
 	LOG_MSG "[INFO]:-Deleting distributed backout files" 1
 	for I in ls /tmp/gpsegcreate.sh_backout*

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -328,7 +328,6 @@ CHK_PARAMS () {
 		# Now process contents for the configuration file
 		if [ ! "$ARRAY_NAME" ]; then
 			LOG_MSG "[WARN]:-ARRAY_NAME variable not set, will provide default value" 1
-			EXIT_STATUS=1
 			ARRAY_NAME="Greenplum Instance"
 		fi
 		export ARRAY_NAME
@@ -396,7 +395,6 @@ CHK_PARAMS () {
 		# ENCODING
 		if [ ! $ENCODING ]; then
 			LOG_MSG "[WARN]:-ENCODING variable not set, will set to default UTF-8" 1
-			EXIT_STATUS=1
 			ENCODING="UTF-8"
 		fi
 		if [ x"SQL_ASCII" = x"$ENCODING" ]; then
@@ -461,7 +459,6 @@ CHK_PARAMS () {
 		MASTER_OPEN=`ulimit -n`
 		if [ $MASTER_OPEN -lt $OS_OPENFILES ];then
 			LOG_MSG "[WARN]:-Master open file limit is $MASTER_OPEN should be >= $OS_OPENFILES" 1
-			EXIT_STATUS=1
 			ULIMIT_WARN=1
 		fi
 		# Get IP address of the master host
@@ -481,7 +478,6 @@ CHK_PARAMS () {
 			STANDBY_MASTER_OPEN=`$TRUSTED_SHELL $STANDBY_HOSTNAME "ulimit -n"`
 			if [ $STANDBY_MASTER_OPEN -lt $OS_OPENFILES ];then
 				LOG_MSG "[WARN]:-Standby Master open file limit is $STANDBY_MASTER_OPEN should be >= $OS_OPENFILES" 1
-				EXIT_STATUS=1
 				ULIMIT_WARN=1
 			fi
 		fi
@@ -667,7 +663,6 @@ END_PYTHON_CODE
 	if [ $MIRRORING -eq 0 ] && [ $MIRROR_TYPE -eq 1 ];then
 		LOG_MSG "[WARN]:-Option --mirror-mode supplied, but no mirrors have been defined, ignoring --mirror-mode option" 1
 		MIRROR_TYPE=0
-		EXIT_STATUS=1
 	fi
 	LOG_MSG "[INFO]:-Commencing multi-home checks, Completed" 1
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
@@ -719,7 +714,6 @@ CHK_OPEN_FILES () {
 	OPEN_VALUE=`$TRUSTED_SHELL $1 "ulimit -n"`
 	if [ $OPEN_VALUE -lt $OS_OPENFILES ];then
 		LOG_MSG "[WARN]:-Host $1 open files limit is $OPEN_VALUE should be >= $OS_OPENFILES" 1
-		EXIT_STATUS=1
 		ULIMIT_WARN=1
 	fi
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
@@ -790,7 +784,6 @@ CHK_QES () {
             LOG_MSG "[WARN]:-This will cause segment->master communication failures" 1
             LOG_MSG "[WARN]:-Remove $GP_HOSTADDRESS from local host line in /etc/hosts" 1
             LOG_MSG "[WARN]:-----------------------------------------------------------" 1
-            EXIT_STATUS=1
         fi
         # Check that we can write to the QE directory
         W_DIR=`$DIRNAME $GP_DIR`
@@ -1475,8 +1468,7 @@ STOP_QD_PRODUCTION () {
 	RETVAL=$?
 	case $RETVAL in
 	    0 ) LOG_MSG "[INFO]:-Successfully shutdown the new Greenplum instance" ;;
-	    1 ) LOG_MSG "[WARN]:-Non fatal error from Greenplum instance shutdown, check log files, will continue"
-		EXIT_STATUS=1 ;;
+	    1 ) LOG_MSG "[WARN]:-Non fatal error from Greenplum instance shutdown, check log files, will continue" ;;
 	    * ) ERROR_EXIT "[FATAL]:-Failed to stop new Greenplum instance, check log file" 2
 	esac
     else
@@ -1624,7 +1616,6 @@ SCAN_LOG () {
 		LOG_MSG "[INFO]:-that was called today!" 1
 		fi
 		LOG_MSG "[WARN]:-*******************************************************" 1
-		EXIT_STATUS=1
 	else
 		LOG_MSG "[INFO]:-Log file scan check passed" 1
 	fi

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1462,17 +1462,17 @@ STOP_QD_PRODUCTION () {
     LOG_MSG "[INFO]:-Start Function $FUNCNAME"
     LOG_MSG "[INFO]:-Restarting the Greenplum instance in production mode" 1
     if [ -f $GPSTOP ]; then
-	GPSTOP_OPTS=$(OUTPUT_LEVEL_OPTS)
-	export MASTER_DATA_DIRECTORY=${MASTER_DIRECTORY}/${SEG_PREFIX}-1
-	$GPSTOP -a -l $LOG_DIR -m -d $MASTER_DATA_DIRECTORY $GPSTOP_OPTS
-	RETVAL=$?
-	case $RETVAL in
-	    0 ) LOG_MSG "[INFO]:-Successfully shutdown the new Greenplum instance" ;;
-	    1 ) LOG_MSG "[WARN]:-Non fatal error from Greenplum instance shutdown, check log files, will continue" ;;
-	    * ) ERROR_EXIT "[FATAL]:-Failed to stop new Greenplum instance, check log file"
-	esac
+        GPSTOP_OPTS=$(OUTPUT_LEVEL_OPTS)
+        export MASTER_DATA_DIRECTORY=${MASTER_DIRECTORY}/${SEG_PREFIX}-1
+        $GPSTOP -a -l $LOG_DIR -m -d $MASTER_DATA_DIRECTORY $GPSTOP_OPTS
+        RETVAL=$?
+        if [ $RETVAL -eq 0 ]; then
+            LOG_MSG "[INFO]:-Successfully shutdown the new Greenplum instance"
+        else
+            ERROR_EXIT "[FATAL]:-Error from Greenplum instance shutdown, check log files"
+        fi
     else
-	ERROR_EXIT "[FATAL]:-$GPSTOP not located"
+        ERROR_EXIT "[FATAL]:-$GPSTOP not located"
     fi
     LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
@@ -1536,11 +1536,11 @@ START_QD_PRODUCTION () {
                 $GPSTOP -a -l $LOG_DIR -i -d $MASTER_DATA_DIRECTORY $GPSTOP_OPTS
 
                 RETVAL=$?
-                case $RETVAL in
-                    0 ) LOG_MSG "[INFO]:-Successfully shutdown the Greenplum instance" 1;;
-                    1 ) LOG_MSG "[WARN]:-Non fatal error from Greenplum instance shutdown" 1;;
-                    * ) ERROR_EXIT "[WARN]:-Failed to stop new Greenplum instance"
-                esac
+                if [ $RETVAL -eq 0 ]; then
+                    LOG_MSG "[INFO]:-Successfully shutdown the Greenplum instance" 1
+                else
+                    ERROR_EXIT "[FATAL]:-Error from Greenplum instance shutdown, check log files"
+                fi
             else
                 LOG_MSG "[WARN]:-$GPSTOP not located" 1
             fi

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -31,7 +31,7 @@ if [ -f $FUNCTIONS ]; then
     . $WORKDIR/lib/gp_bash_version.sh
 else
     echo "[FATAL]:-Cannot source $FUNCTIONS file, script Exits!"
-    exit 2
+    exit 1
 fi
 
 #******************************************************************************
@@ -56,7 +56,6 @@ GP_CONFIG_TBL=gp_segment_configuration
 unset PG_CONF_ADD_FILE
 #unset QD_PRIMARY_ARRAY QE_PRIMARY_ARRAY QE_MIRROR_ARRAY
 EXIT_STATUS=0
-STANDBY_FATAL_RET_CODE=2 # copied from gpinitstandby
 # SED_PG_CONF search text values
 PORT_TXT="#port"
 LOG_STATEMENT_TXT="#log_statement ="
@@ -162,8 +161,7 @@ USAGE () {
 		$ECHO
 		$ECHO "      Return codes:"
 		$ECHO "      0 - No problems encountered with requested operation"
-		$ECHO "      1 - Warning generated, but instance operational"
-		$ECHO "      2 - Fatal error, instance not created/started, or in an inconsistent state,"
+		$ECHO "      1 - Fatal error, instance not created/started, or in an inconsistent state,"
 		$ECHO "          see log file for failure reason."
 		$ECHO
 		exit $EXIT_STATUS
@@ -1481,8 +1479,7 @@ CREATE_STANDBY_QD () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	if [ ! -f $INIT_STANDBY_PROG ]; then
 		LOG_MSG "[WARN]:-Unable to locate $INIT_STANDBY_PROG, hence unable to initialize standby master $STANDBY_HOSTNAME"
-		STANDBY_RET_CODE=${STANDBY_FATAL_RET_CODE}
-		EXIT_STATUS=1
+		STANDBY_RET_CODE=1
 	else
 		LOG_MSG "[INFO]:-Starting initialization of standby master $STANDBY_HOSTNAME" 1
 		INIT_STANDBY_ARGS=""
@@ -1497,11 +1494,11 @@ CREATE_STANDBY_QD () {
 		fi
 		export MASTER_DATA_DIRECTORY=${MASTER_DIRECTORY}/${SEG_PREFIX}-1;$INIT_STANDBY_PROG -s $STANDBY_HOSTNAME $INIT_STANDBY_ARGS -a
 		STANDBY_RET_CODE=$?
-		case ${STANDBY_RET_CODE} in
-			0) LOG_MSG "[INFO]:-Successfully completed standby master initialization" 1 ;;
-			1) LOG_MSG "[WARN]:-Non-fatal issue with standby master initialization, check gpstate -f output" 1 ;;
-			*) LOG_MSG "[WARN]:-Failed to complete standby master initialization" 1
-		esac
+		if [ $STANDBY_RET_CODE -eq 0 ]; then
+			LOG_MSG "[INFO]:-Successfully completed standby master initialization" 1
+		else
+			LOG_MSG "[WARN]:-Failed to complete standby master initialization" 1
+		fi
 		BACKOUT_COMMAND "$TRUSTED_SHELL ${STANDBY_HOSTNAME} \"$RM -Rf ${QD_DIR}\""
 		BACKOUT_COMMAND "$ECHO \"Removing standby directory ${QD_DIR} on $STANDBY_HOSTNAME\""
 		BACKOUT_COMMAND "$TRUSTED_SHELL $STANDBY_HOSTNAME \"if [ -d $GP_DIR ]; then ${EXPORT_LIB_PATH};export PGPORT=${MASTER_PORT}; $PG_CTL -w -D ${MASTER_DIRECTORY}/${SEG_PREFIX}-1 -o \"-i -p ${MASTER_PORT}\" -m immediate  stop; fi\""

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -192,9 +192,6 @@ LOG_MSG () {
 		# compare it to WARN/FATAL.
 		level=${1%%]*}
 		case "$level" in
-		*WARN*)
-			EXIT_STATUS=1
-			;;
 		*FATAL*)
 			EXIT_STATUS=2
 			;;
@@ -227,7 +224,6 @@ POSTGRES_VERSION_CHK() {
     VER=`$TRUSTED_SHELL $HOST "$EXPORT_GPHOME; $EXPORT_LIB_PATH; $GPHOME/bin/postgres --gp-version"`
     if [ $? -ne 0 ] ; then
 	LOG_MSG "[WARN]:- Failed to obtain postgres version on $HOST" 1
-	EXIT_STATUS=1
 	VERSION_MATCH=0
     fi
     LOG_MSG "[INFO]:- Current postgres version = $CURRENT_VERSION"
@@ -236,7 +232,6 @@ POSTGRES_VERSION_CHK() {
     if [ x"$VER" != x"$CURRENT_VERSION" ] ; then
 	LOG_MSG "[WARN]:-Postgres version does not match. [$CURRENT_VERSION != $VER]" 1
 	VERSION_MATCH=0
-	EXIT_STATUS=1
     else
 	VERSION_MATCH=1
     fi
@@ -283,7 +278,6 @@ ERROR_CHK () {
 			INITIAL_LEVEL=$DEBUG_LEVEL
 			DEBUG_LEVEL=1
 			LOG_MSG "[WARN]:-Issue with $MSG_TXT"
-			EXIT_STATUS=1
 			DEBUG_LEVEL=$INITIAL_LEVEL
 		else
 			LOG_MSG "[INFO]:-End Function $FUNCNAME"
@@ -593,7 +587,6 @@ CHK_FILE () {
 			RETVAL=$?
 			if [ $RETVAL -ne 0 ];then
 				LOG_MSG "[WARN]:-Failed to obtain details of $FILENAME on $FILE_HOST"
-				EXIT_STATUS=1
 				EXISTS=1
 			fi
 		fi
@@ -613,7 +606,6 @@ CHK_DIR () {
 			RETVAL=$?
 			if [ $RETVAL -ne 0 ];then
 			LOG_MSG "[WARN]:-Failed to obtain details of $DIR_NAME on $DIR_HOST" 1
-			EXIT_STATUS=1
 			EXISTS=1
 			fi
 		fi
@@ -855,7 +847,6 @@ GET_PG_PID_ACTIVE () {
 				#Have a process but no lock file
 					LOG_MSG "[WARN]:-No lock file $PG_LOCK_FILE but process running on port $PORT" 1
 					PID=1
-					EXIT_STATUS=1
 				fi
 				if [ $PG_LOCK_TMP -eq 1 ] && [ x"" == x"$PG_LOCK_NETSTAT" ];then
 				#Have a lock file but no process
@@ -866,7 +857,6 @@ GET_PG_PID_ACTIVE () {
 						PID=1
 					fi
 					LOG_MSG "[WARN]:-Have lock file $PG_LOCK_FILE but no process running on port $PORT" 1
-					EXIT_STATUS=1
 				fi
 				if [ $PG_LOCK_TMP -eq 1 ] && [ x"" != x"$PG_LOCK_NETSTAT" ];then
 				#Have both a lock file and a netstat process
@@ -875,7 +865,6 @@ GET_PG_PID_ACTIVE () {
 					else
 						LOG_MSG "[WARN]:-Unable to access ${PG_LOCK_FILE}" 1
 						PID=1
-						EXIT_STATUS=1
 					fi
 					LOG_MSG "[INFO]:-Have lock file $PG_LOCK_FILE and a process running on port $PORT"
 				fi
@@ -884,7 +873,6 @@ GET_PG_PID_ACTIVE () {
 			PING_HOST $HOST 1
 			if [ $RETVAL -ne 0 ];then
 				PID=0
-				EXIT_STATUS=1
 			else
 				PORT_ARRAY=(`$TRUSTED_SHELL $HOST "$NETSTAT -an 2>/dev/null |$GREP ".s.PGSQL.${PORT}" 2>/dev/null"|$AWK '{print $NF}'|$AWK -F"." '{print $NF}'|$SORT -u`)
 				for P_CHK in ${PORT_ARRAY[@]}
@@ -902,7 +890,6 @@ GET_PG_PID_ACTIVE () {
 					#Have a process but no lock file
 						LOG_MSG "[WARN]:-No lock file $PG_LOCK_FILE but process running on port $PORT on $HOST" 1
 						PID=1
-						EXIT_STATUS=1
 					fi
 					if [ $PG_LOCK_TMP -eq 1 ] && [ x"" == x"$PG_LOCK_NETSTAT" ];then
 					#Have a lock file but no process
@@ -914,7 +901,6 @@ GET_PG_PID_ACTIVE () {
 						fi
 						LOG_MSG "[WARN]:-Have lock file $PG_LOCK_FILE but no process running on port $PORT on $HOST" 1
 						PID=1
-						EXIT_STATUS=1
 					fi
 					if [ $PG_LOCK_TMP -eq 1 ] && [ x"" != x"$PG_LOCK_NETSTAT" ];then
 					#Have both a lock file and a netstat process
@@ -923,7 +909,6 @@ GET_PG_PID_ACTIVE () {
 							PID=`$TRUSTED_SHELL $HOST "$CAT ${PG_LOCK_FILE}|$HEAD -1 2>/dev/null"|$AWK '{print $1}'`
 						else
 							LOG_MSG "[WARN]:-Unable to access ${PG_LOCK_FILE} on $HOST" 1
-							EXIT_STATUS=1
 						fi
 						LOG_MSG "[INFO]:-Have lock file $PG_LOCK_FILE and a process running on port $PORT on $HOST"
 					fi

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -14,7 +14,7 @@
 #Check that SHELL is Bash
 if [ -z $BASH ]; then
 	echo "[FATAL]:-Scripts must be executed using the Bash shell"
-	exit 2
+	exit 1
 fi
 #CMDPATH is the list of locations to search for commands, in precedence order
 declare -a CMDPATH
@@ -27,7 +27,7 @@ if [ ${#GPPATH[@]} -eq 0 ];then
 	echo "[FATAL]:-GPHOME environment variable is required to run GPDB but could not be found."
 	echo "Please set it by sourcing the  greenplum_path.sh  in your GPDB installation directory."
 	echo "Example: ''. /usr/local/gpdb/greenplum_path.sh''"
-	exit 2
+	exit 1
 fi
 
 #GP_UNIQUE_COMMAND is used to identify the binary directory
@@ -114,7 +114,7 @@ PSQLBIN=`findMppPath`
 if [ x"$PSQLBIN" = x"" ];then
 		echo "Problem in gp_bash_functions, command '$GP_UNIQUE_COMMAND' not found in Greenplum path."
 		echo "Try setting GPHOME to the location of your Greenplum distribution."
-		exit 99
+		exit 1
 fi
 
 PSQLBIN=`$DIRNAME $PSQLBIN`
@@ -193,7 +193,7 @@ LOG_MSG () {
 		level=${1%%]*}
 		case "$level" in
 		*FATAL*)
-			EXIT_STATUS=2
+			EXIT_STATUS=1
 			;;
 		esac
 
@@ -252,11 +252,11 @@ ERROR_EXIT () {
 				if [ -s $BACKOUT_FILE ]; then
 						LOG_MSG "[WARN]:-Script has left Greenplum Database in an incomplete state"
 						LOG_MSG "[WARN]:-Run command bash $BACKOUT_FILE to remove these changes"
-						BACKOUT_COMMAND "if [ x$MASTER_HOSTNAME != x\`$HOSTNAME\` ];then $ECHO \"[FATAL]:-Not on original master host $MASTER_HOSTNAME, backout script exiting!\";exit 2;fi"
+						BACKOUT_COMMAND "if [ x$MASTER_HOSTNAME != x\`$HOSTNAME\` ];then $ECHO \"[FATAL]:-Not on original master host $MASTER_HOSTNAME, backout script exiting!\";exit 1;fi"
 						$ECHO "$RM -f $BACKOUT_FILE" >> $BACKOUT_FILE
 				fi
 		fi
-		exit $2
+		exit 1
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
@@ -281,7 +281,7 @@ ERROR_CHK () {
 			DEBUG_LEVEL=$INITIAL_LEVEL
 		else
 			LOG_MSG "[INFO]:-End Function $FUNCNAME"
-			ERROR_EXIT "[FATAL]:-Failed to complete $MSG_TXT " 2
+			ERROR_EXIT "[FATAL]:-Failed to complete $MSG_TXT "
 		fi
 	fi
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
@@ -333,7 +333,7 @@ SED_PG_CONF () {
 				fi
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
-					ERROR_EXIT "[FATAL]:-Failed to replace $SEARCH_TXT in $FILENAME" 2
+					ERROR_EXIT "[FATAL]:-Failed to replace $SEARCH_TXT in $FILENAME"
 				else
 					LOG_MSG "[INFO]:-Replaced line in $FILENAME"
 					$RM -f ${FILENAME}.bak1
@@ -341,7 +341,7 @@ SED_PG_CONF () {
 				$SED -i'.bak2' -e "s/^#${SEARCH_TXT}/${SEARCH_TXT}/" $FILENAME
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
-					ERROR_EXIT "[FATAL]:-Failed to replace #$SEARCH_TXT in $FILENAME" 2
+					ERROR_EXIT "[FATAL]:-Failed to replace #$SEARCH_TXT in $FILENAME"
 				else
 					LOG_MSG "[INFO]:-Replaced line in $FILENAME"
 					$RM -f ${FILENAME}.bak2
@@ -363,7 +363,7 @@ SED_PG_CONF () {
 		if [ `$TRUSTED_SHELL $SED_HOST "$GREP -c \"${SEARCH_TXT}\" $FILENAME"` -eq 0 ] || [ $APPEND -eq 1 ]; then
 			$TRUSTED_SHELL $SED_HOST "$ECHO \"$SUB_TXT\" >> $FILENAME"
 			if [ $RETVAL -ne 0 ]; then
-				ERROR_EXIT "[FATAL]:-Failed to append line $SUB_TXT to $FILENAME on $SED_HOST" 2
+				ERROR_EXIT "[FATAL]:-Failed to append line $SUB_TXT to $FILENAME on $SED_HOST"
 			else
 				LOG_MSG "[INFO]:-Appended line $SUB_TXT to $FILENAME on $SED_HOST" 1
 			fi
@@ -375,7 +375,7 @@ SED_PG_CONF () {
 			fi
 			$TRUSTED_SHELL $SED_HOST sed -i'.bak1' -f /dev/stdin "$FILENAME" <<< "$SED_COMMAND" > /dev/null 2>&1
 			if [ $RETVAL -ne 0 ]; then
-				ERROR_EXIT "[FATAL]:-Failed to insert $SUB_TXT in $FILENAME on $SED_HOST" 2
+				ERROR_EXIT "[FATAL]:-Failed to insert $SUB_TXT in $FILENAME on $SED_HOST"
 			else
 				LOG_MSG "[INFO]:-Replaced line in $FILENAME on $SED_HOST"
 				$TRUSTED_SHELL $SED_HOST "$RM -f ${FILENAME}.bak1" > /dev/null 2>&1
@@ -384,7 +384,7 @@ SED_PG_CONF () {
 			SED_COMMAND="s/^#${SEARCH_TXT}/${SEARCH_TXT}/"
 			$TRUSTED_SHELL $SED_HOST sed -i'.bak2' -f /dev/stdin "$FILENAME" <<< "$SED_COMMAND" > /dev/null 2>&1
 			if [ $RETVAL -ne 0 ]; then
-				ERROR_EXIT "[FATAL]:-Failed to substitute #${SEARCH_TXT} in $FILENAME on $SED_HOST" 2
+				ERROR_EXIT "[FATAL]:-Failed to substitute #${SEARCH_TXT} in $FILENAME on $SED_HOST"
 			else
 				LOG_MSG "[INFO]:-Replaced line in $FILENAME on $SED_HOST"
 				$TRUSTED_SHELL $SED_HOST "$RM -f ${FILENAME}.bak2" > /dev/null 2>&1
@@ -400,7 +400,7 @@ POSTGRES_PORT_CHK () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	GET_PG_PID_ACTIVE $1 $2
 	if [ $PID -ne 0 ];then
-		ERROR_EXIT "[FATAL]:-Host $2 has an active database process on port = $1" 2
+		ERROR_EXIT "[FATAL]:-Host $2 has an active database process on port = $1"
 	fi
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
@@ -618,9 +618,9 @@ GET_MASTER_PORT () {
 		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 		MASTER_DATA_DIRECTORY=$1
 		if [ x"" == x"$MASTER_DATA_DIRECTORY" ];then
-			ERROR_EXIT "[FATAL]:-MASTER_DATA_DIRECTORY variable not set" 2;fi
+			ERROR_EXIT "[FATAL]:-MASTER_DATA_DIRECTORY variable not set";fi
 		if [ ! -d $MASTER_DATA_DIRECTORY ]; then
-				ERROR_EXIT "[FATAL]:-No $MASTER_DATA_DIRECTORY directory" 2
+				ERROR_EXIT "[FATAL]:-No $MASTER_DATA_DIRECTORY directory"
 		fi
 		if [ -r $MASTER_DATA_DIRECTORY/$PG_CONF ];then
 			MASTER_PORT=`$AWK 'split($0,a,"#")>0 && split(a[1],b,"=")>1 {print b[1] " " b[2]}' $MASTER_DATA_DIRECTORY/$PG_CONF | $AWK '$1=="port" {print $2}' | $TAIL -1`
@@ -634,11 +634,11 @@ GET_MASTER_PORT () {
                     fi
                 done
                 if [ x"" == x"$MASTER_PORT" ] ; then
-			        ERROR_EXIT "[FATAL]:-Failed to obtain master port number from $MASTER_DATA_DIRECTORY/$PG_CONF" 2
+			        ERROR_EXIT "[FATAL]:-Failed to obtain master port number from $MASTER_DATA_DIRECTORY/$PG_CONF"
                 fi
 			fi
 		else
-			ERROR_EXIT "[FATAL]:-Do not have read access to $MASTER_DATA_DIRECTORY/$PG_CONF" 2
+			ERROR_EXIT "[FATAL]:-Do not have read access to $MASTER_DATA_DIRECTORY/$PG_CONF"
 		fi
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
@@ -682,7 +682,7 @@ GET_CIDRADDR () {
 
 BUILD_MASTER_PG_HBA_FILE () {
         LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	if [ $# -eq 0 ];then ERROR_EXIT "[FATAL]:-Passed zero parameters, expected at least 2" 2;fi
+	if [ $# -eq 0 ];then ERROR_EXIT "[FATAL]:-Passed zero parameters, expected at least 2";fi
 	GP_DIR=$1
 	HBA_HOSTNAMES=${2:-0}
         LOG_MSG "[INFO]:-Clearing values in Master $PG_HBA"
@@ -731,7 +731,7 @@ BUILD_MASTER_PG_HBA_FILE () {
 
 BUILD_GPSSH_CONF () {
         LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-        if [ $# -eq 0 ];then ERROR_EXIT "[FATAL]:-Passed zero parameters, expected at least 1" 2;fi
+        if [ $# -eq 0 ];then ERROR_EXIT "[FATAL]:-Passed zero parameters, expected at least 1";fi
         GP_DIR=$1
         $CAT <<_EOF_ >> $GP_DIR/gpssh.conf
 [gpssh]
@@ -972,19 +972,19 @@ PING_HOST () {
 		0) LOG_MSG "[INFO]:-$TARGET_HOST contact established"
                    ;;
 		1) if [ $PING_EXIT -eq 0 ];then
-			ERROR_EXIT "[FATAL]:-Unable to contact $TARGET_HOST: $OUTPUT" 2
+			ERROR_EXIT "[FATAL]:-Unable to contact $TARGET_HOST: $OUTPUT"
 		   else
 			LOG_MSG "[WARN]:-Unable to contact $TARGET_HOST: $OUTPUT" 1
 		   fi
                    ;;
 		2) if [ $PING_EXIT -eq 0 ];then
-			ERROR_EXIT "[FATAL]:-Unknown host $TARGET_HOST: $OUTPUT" 2
+			ERROR_EXIT "[FATAL]:-Unknown host $TARGET_HOST: $OUTPUT"
 		   else
 			LOG_MSG "[WARN]:-Unknown host $TARGET_HOST: $OUTPUT" 1
 		   fi
                    ;;
 		*) if [ $PING_EXIT -eq 0 ];then
-			ERROR_EXIT "[FATAL]:-Cannot ping host $TARGET_HOST: $OUTPUT" 2
+			ERROR_EXIT "[FATAL]:-Cannot ping host $TARGET_HOST: $OUTPUT"
 		   else
 			LOG_MSG "[WARN]:-Cannot ping host $TARGET_HOST: $OUTPUT" 1
 		   fi
@@ -1009,7 +1009,7 @@ PARALLEL_SETUP () {
 
 PARALLEL_COUNT () {
         LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-	if [ $# -ne 2 ];then ERROR_EXIT "[FATAL]:-Incorrect number of parameters passed to $FUNCNAME" 2;fi
+	if [ $# -ne 2 ];then ERROR_EXIT "[FATAL]:-Incorrect number of parameters passed to $FUNCNAME";fi
 	BATCH_LIMIT=$1
 	BATCH_DEFAULT=$2
 	((INST_COUNT=$INST_COUNT+1))
@@ -1040,7 +1040,7 @@ PARALLEL_WAIT () {
 			if [ $DEBUG_LEVEL -eq 0 ] && [ x"" != x"$VERBOSE" ];then $NOLINE_ECHO ".\c";fi
 			LOG_MSG "[FATAL]:-Failed to process this batch of segments within $WAIT_LIMIT seconds" 1
 			LOG_MSG "[INFO]:-Review contents of $LOG_FILE" 1
-			ERROR_EXIT "[FATAL]:-Process timeout failure" 2
+			ERROR_EXIT "[FATAL]:-Process timeout failure"
 		fi
 	done
 	if [ $DEBUG_LEVEL -eq 0 ] && [ x"" != x"$VERBOSE" ];then $ECHO;fi
@@ -1073,7 +1073,7 @@ PARALLEL_SUMMARY_STATUS_REPORT () {
                 fi
                 LOG_MSG "[INFO]:------------------------------------------------" 1
 	else
-		 LOG_MSG "[WARN]:-Could not locate status file $1" 1
+		LOG_MSG "[WARN]:-Could not locate status file $1" 1
 		REPORT_FAIL=1
 	fi
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -561,11 +561,11 @@ GET_REPLY () {
 	$ECHO -n "> "
 	read REPLY
 	if [ -z $REPLY ]; then
-		LOG_MSG "[WARN]:-User abort requested, Script Exits!" 1
+		LOG_MSG "[FATAL]:-User abort requested, Script Exits!" 1
 		exit 1
 	fi
 	if [ $REPLY != Y ] && [ $REPLY != y ]; then
-		LOG_MSG "[WARN]:-User abort requested, Script Exits!" 1
+		LOG_MSG "[FATAL]:-User abort requested, Script Exits!" 1
 		exit 1
 	fi
 }

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -256,7 +256,7 @@ START_QE() {
 #******************************************************************************
 # Main Section
 #******************************************************************************
-trap '$ECHO "KILLED:$SEGMENT_TO_CREATE" >> $PARALLEL_STATUS_FILE;ERROR_EXIT "[FATAL]:-[$INST_COUNT]-Recieved INT or TERM signal" 2' INT TERM
+trap '$ECHO "KILLED:$SEGMENT_TO_CREATE" >> $PARALLEL_STATUS_FILE;ERROR_EXIT "[FATAL]:-[$INST_COUNT]-Recieved INT or TERM signal"' INT TERM
 while getopts ":qp:" opt
 do
 	case $opt in

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -18,7 +18,8 @@ def before_all(context):
 
 def before_feature(context, feature):
     # we should be able to run gpexpand without having a cluster initialized
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors', 'gpconfig', 'gpssh-exkeys', 'gpstop']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
+                    'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -97,7 +98,8 @@ def before_scenario(context, scenario):
     if 'gpssh-exkeys' in context.feature.tags:
         context.gpssh_exkeys_context = GpsshExkeysMgmtContext(context)
 
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors', 'gpconfig', 'gpssh-exkeys', 'gpstop']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
+                    'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -126,7 +126,8 @@ def after_scenario(context, scenario):
             ''')
 
     # NOTE: gpconfig after_scenario cleanup is in the step `the gpconfig context is setup`
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpinitstandby', 'gpconfig', 'gpstop']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpinitstandby',
+                    'gpconfig', 'gpstop', 'gpinitsystem']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -17,6 +17,24 @@ Feature: gpinitsystem tests
         And gpconfig should print "Master  value: off" to stdout
         And gpconfig should print "Segment value: off" to stdout
 
+    Scenario: after a failed run of gpinitsystem, a re-run should return exit status 0
+        Given create demo cluster config
+        # force a failure by passing no args
+        When the user runs "gpinitsystem"
+        Then gpinitsystem should return a return code of 2
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -h ../gpAux/gpdemo/hostfile"
+        Then gpinitsystem should return a return code of 0
+
+      Scenario: after gpinitsystem logs a warning, a re-run should return exit status 0
+        Given create demo cluster config
+        # log a warning
+        And the user runs command "echo 'ARRAY_NAME=' >> ../gpAux/gpdemo/clusterConfigFile"
+       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -h ../gpAux/gpdemo/hostfile"
+       Then gpinitsystem should return a return code of 0
+      Given create demo cluster config
+       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -h ../gpAux/gpdemo/hostfile"
+       Then gpinitsystem should return a return code of 0
+
     Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
         Given the database is running
         And all the segments are running
@@ -25,8 +43,8 @@ Feature: gpinitsystem tests
         And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
         # stop db and make sure cluster config exists so that we can manually initialize standby
         And the cluster config is generated with data_checksums "1"
-        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -s localhost -P 21100 -S /wrong/path -h ../gpAux/gpdemo/hostfile"
-        Then gpinitsystem should return a return code of 1
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -S /wrong/path -h ../gpAux/gpdemo/hostfile"
+        Then gpinitsystem should return a return code of 0
         And gpinitsystem should not print "To activate the Standby Master Segment in the event of Master" to stdout
         And gpinitsystem should print "Cluster setup finished, but Standby Master failed to initialize. Review contents of log files for errors." to stdout
         And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -21,7 +21,7 @@ Feature: gpinitsystem tests
         Given create demo cluster config
         # force a failure by passing no args
         When the user runs "gpinitsystem"
-        Then gpinitsystem should return a return code of 2
+        Then gpinitsystem should return a return code of 1
         When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -h ../gpAux/gpdemo/hostfile"
         Then gpinitsystem should return a return code of 0
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -132,6 +132,10 @@ def impl(context):
 def impl(context):
     create_local_demo_cluster(context, num_primaries=3)
 
+@given('create demo cluster config')
+def impl(context):
+    create_local_demo_cluster(context, extra_config='ONLY_PREPARE_CLUSTER_ENV=true')
+
 @given('the cluster config is generated with HBA_HOSTNAMES "{hba_hostnames_toggle}"')
 def impl(context, hba_hostnames_toggle):
     extra_config = 'env EXTRA_CONFIG="HBA_HOSTNAMES={}" ONLY_PREPARE_CLUSTER_ENV=true'.format(hba_hostnames_toggle)


### PR DESCRIPTION
Previously gpinitsystem returned 1 in case of warngings (2 in case of
errors). We have changed gpinitsystem to return 0 for warnings so that other
tools using gpinitsystem (such as gpupgrade) will not fail when gpinitsystem
generates warnings.

Also, gpinitsystem was exiting with non-zero return code if certain errors or
warnings had happened on any previous run of gpinitsystem that day. This has
also been fixed in this commit

Co-authored-by: Kalen Krempely <kkrempely@pivotal.io>
Co-authored-by: Shoaib Lari <slari@pivotal.io>

## Here are some reminders before you submit the pull request

The corresponding 6X Backport is #8847 