### PR TITLE
Fix compile error: initialize static variables via const expr.

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -39,7 +39,7 @@
 #include "cdb/cdbexplain.h"
 #include "cdb/cdbvars.h"
 
-
+#define BUFFER_INCREMENT_SIZE 1024
 #define HHA_MSG_LVL DEBUG2
 
 
@@ -1570,8 +1570,7 @@ writeHashEntry(AggState *aggstate, BatchFileInfo *file_info,
 	 * with 1024 whenever the buffer + datum_size exceeds the current buffer size
 	 */
 	static char *aggDataBuffer = NULL;
-	const int bufferIncrementSize = 1024;
-	static int aggDataBufferSize = bufferIncrementSize;
+	static int aggDataBufferSize = BUFFER_INCREMENT_SIZE;
 	int32 aggDataOffset = 0;
 	if (aggDataBuffer == NULL)
 		aggDataBuffer = MemoryContextAlloc(TopMemoryContext, aggDataBufferSize);
@@ -1632,7 +1631,7 @@ writeHashEntry(AggState *aggstate, BatchFileInfo *file_info,
 
 		if ((aggDataOffset + MAXALIGN(datum_size)) >= aggDataBufferSize)
 		{
-			aggDataBufferSize += bufferIncrementSize;
+			aggDataBufferSize += BUFFER_INCREMENT_SIZE;
 			MemoryContext oldAggContext = MemoryContextSwitchTo(TopMemoryContext);
 			aggDataBuffer = repalloc(aggDataBuffer, aggDataBufferSize);
 			MemoryContextSwitchTo(oldAggContext);


### PR DESCRIPTION
Commit 6b25396e2 introduces following code:
```
  static char *aggDataBuffer = NULL;
  const int bufferIncrementSize = 1024;
  static int aggDataBufferSize = bufferIncrementSize;
```

static variable can only be initialized by const expression or
string literal in C99 standard.

This commit fixes this by replace bufferIncrementSize with Macro.

---------

This is to fix cmpile error. No tests added.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
