### PR TITLE
Silence incompatible type warnings

### DIFF
--- a/gpcontrib/orafce/convert.c
+++ b/gpcontrib/orafce/convert.c
@@ -136,7 +136,7 @@ orafce_to_char_timestamp(PG_FUNCTION_ARGS)
 		/* it will return the DATE in nls_date_format*/
 		result = DatumGetTextP(DirectFunctionCall2(timestamp_to_char,
 							TimestampGetDatum(ts),
-								CStringGetDatum(cstring_to_text(nls_date_format))));
+								PointerGetDatum(cstring_to_text(nls_date_format))));
 	}
 	else
 	{

--- a/gpcontrib/orafce/datefce.c
+++ b/gpcontrib/orafce/datefce.c
@@ -664,8 +664,8 @@ ora_to_date(PG_FUNCTION_ARGS)
 
 		/* it will return timestamp at GMT */
 		newDate = DirectFunctionCall2(to_timestamp,
-							CStringGetDatum(date_txt),
-							CStringGetDatum(cstring_to_text(nls_date_format)));
+							PointerGetDatum(date_txt),
+							PointerGetDatum(cstring_to_text(nls_date_format)));
 
 		/* convert to local timestamp */
 		result = DatumGetTimestamp(DirectFunctionCall1(timestamptz_timestamp, newDate));


### PR DESCRIPTION
Current master got this via the 9.5 merge cycle but 6X_STABLE still suffers from
it.

Tested with gcc-8.3 and -Wincompatible-pointer-types flag.

