### PR TITLE
6X_STABLE: Enable -Wimplicit-fallthrough by default if GCC >=7

### DIFF
--- a/configure
+++ b/configure
@@ -5703,6 +5703,80 @@ if test x"$pgac_cv_prog_cc_cflags__Wno_address" = x"yes"; then
 fi
 
 
+  gccversion=`$CC -dumpversion | cut -d . -f1`
+  if test "$gccversion" -ge 7 ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wimplicit-fallthrough" >&5
+$as_echo_n "checking whether $CC supports -Wimplicit-fallthrough... " >&6; }
+if ${pgac_cv_prog_cc_cflags__Wimplicit_fallthrough+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -Wimplicit-fallthrough"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__Wimplicit_fallthrough=yes
+else
+  pgac_cv_prog_cc_cflags__Wimplicit_fallthrough=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Wimplicit_fallthrough" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__Wimplicit_fallthrough" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__Wimplicit_fallthrough" = x"yes"; then
+  CFLAGS="$CFLAGS -Wimplicit-fallthrough"
+fi
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-fallthrough" >&5
+$as_echo_n "checking whether $CC supports -Werror=implicit-fallthrough... " >&6; }
+if ${pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -Werror=implicit-fallthrough"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough=yes
+else
+  pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough" = x"yes"; then
+  CFLAGS="$CFLAGS -Werror=implicit-fallthrough"
+fi
+
+  fi
+
   #-Wno-error=enum-compare -Wno-error=address -Wno-error=maybe-uninitialized
 
   # Optimization flags for specific files that benefit from vectorization

--- a/configure
+++ b/configure
@@ -5703,9 +5703,7 @@ if test x"$pgac_cv_prog_cc_cflags__Wno_address" = x"yes"; then
 fi
 
 
-  gccversion=`$CC -dumpversion | cut -d . -f1`
-  if test "$gccversion" -ge 7 ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wimplicit-fallthrough" >&5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wimplicit-fallthrough" >&5
 $as_echo_n "checking whether $CC supports -Wimplicit-fallthrough... " >&6; }
 if ${pgac_cv_prog_cc_cflags__Wimplicit_fallthrough+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5740,7 +5738,7 @@ if test x"$pgac_cv_prog_cc_cflags__Wimplicit_fallthrough" = x"yes"; then
   CFLAGS="$CFLAGS -Wimplicit-fallthrough"
 fi
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-fallthrough" >&5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-fallthrough" >&5
 $as_echo_n "checking whether $CC supports -Werror=implicit-fallthrough... " >&6; }
 if ${pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5775,7 +5773,6 @@ if test x"$pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough" = x"yes"; then
   CFLAGS="$CFLAGS -Werror=implicit-fallthrough"
 fi
 
-  fi
 
   #-Wno-error=enum-compare -Wno-error=address -Wno-error=maybe-uninitialized
 

--- a/configure.in
+++ b/configure.in
@@ -615,11 +615,8 @@ if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-Wno-unused-but-set-variable])
   PGAC_PROG_CC_CFLAGS_OPT([-Wno-address])
 
-  gccversion=`$CC -dumpversion | cut -d . -f1`
-  if test "$gccversion" -ge 7 ; then
-    PGAC_PROG_CC_CFLAGS_OPT([-Wimplicit-fallthrough])
-    PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-fallthrough])
-  fi
+  PGAC_PROG_CC_CFLAGS_OPT([-Wimplicit-fallthrough])
+  PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-fallthrough])
 
   #-Wno-error=enum-compare -Wno-error=address -Wno-error=maybe-uninitialized
 

--- a/configure.in
+++ b/configure.in
@@ -615,6 +615,12 @@ if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-Wno-unused-but-set-variable])
   PGAC_PROG_CC_CFLAGS_OPT([-Wno-address])
 
+  gccversion=`$CC -dumpversion | cut -d . -f1`
+  if test "$gccversion" -ge 7 ; then
+    PGAC_PROG_CC_CFLAGS_OPT([-Wimplicit-fallthrough])
+    PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-fallthrough])
+  fi
+
   #-Wno-error=enum-compare -Wno-error=address -Wno-error=maybe-uninitialized
 
   # Optimization flags for specific files that benefit from vectorization

--- a/gpcontrib/gpcloud/lib/http_parser.cpp
+++ b/gpcontrib/gpcloud/lib/http_parser.cpp
@@ -2401,7 +2401,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
         case s_req_server_with_at:
             found_at = 1;
 
-            /* FALLTROUGH */
+            /* fallthrough */
         case s_req_server:
             uf = UF_HOST;
             break;

--- a/gpcontrib/gpmapreduce/Makefile
+++ b/gpcontrib/gpmapreduce/Makefile
@@ -22,6 +22,13 @@ include $(top_srcdir)/src/Makefile.shlib
 
 override CPPFLAGS += -I$(SRCDIR) -I$(INCDIR) -I$(libpq_srcdir)
 
+# Disable -Wimplicit-fallthrough for this module, since it is hard to change some
+# macros using switch-case.
+# -Wimplicit-fallthrough is appended to CFLAGS, so we append it to CFLAGS as well.
+ifeq ($(shell echo "$(CFLAGS)" | grep -q "implicit-fallthrough" && echo yes), yes)
+override CFLAGS += -Wno-implicit-fallthrough
+endif
+
 FILES     = main.o mapred.o parse.o yaml_scan.o yaml_parse.o 
 GENFILES  = yaml_parse.h yaml_parse.c yaml_scan.c yaml_scan.h
 

--- a/gpcontrib/orafce/Makefile
+++ b/gpcontrib/orafce/Makefile
@@ -30,6 +30,14 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 endif
 
+# Disable -Wimplicit-fallthrough for this module, since it is hard to change some
+# macros using case clauses. It might be a bug in gcc, so to minimize the workload,
+# we simply disable this compile option.
+# -Wimplicit-fallthrough is appended to CFLAGS, so we append it to CFLAGS as well.
+ifeq ($(shell echo "$(CFLAGS)" | grep -q "implicit-fallthrough" && echo yes), yes)
+override CFLAGS += -Wno-implicit-fallthrough
+endif
+
 ifneq ($(PORTNAME), darwin)
 REGRESS += nlssort
 endif

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -65,7 +65,7 @@ ifneq ($(PORTNAME), win32)
 ifneq ($(PORTNAME), aix)
 
 postgres: $(OBJS)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(call expand_subsys,$^) $(LIBS) -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(call expand_subsys,$^) $(LIBS) -o $@
 
 endif
 endif
@@ -74,7 +74,7 @@ endif
 ifeq ($(PORTNAME), cygwin)
 
 postgres: $(OBJS)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) -Wl,--stack,$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$^) $(LIBS) -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) -Wl,--stack,$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$^) $(LIBS) -o $@
 
 # libpostgres.a is actually built in the preceding rule, but we need this to
 # ensure it's newer than postgres; see notes in src/backend/parser/Makefile
@@ -87,7 +87,7 @@ ifeq ($(PORTNAME), win32)
 LIBS += -lsecur32
 
 postgres: $(OBJS) $(WIN32RES)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LIBS) -o $@$(X)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LIBS) -o $@$(X)
 
 # libpostgres.a is actually built in the preceding rule, but we need this to
 # ensure it's newer than postgres; see notes in src/backend/parser/Makefile
@@ -99,7 +99,7 @@ endif # win32
 ifeq ($(PORTNAME), aix)
 
 postgres: $(POSTGRES_IMP)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(call expand_subsys,$(OBJS)) -Wl,-bE:$(top_builddir)/src/backend/$(POSTGRES_IMP) $(LIBS) -Wl,-brtllib -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(call expand_subsys,$(OBJS)) -Wl,-bE:$(top_builddir)/src/backend/$(POSTGRES_IMP) $(LIBS) -Wl,-brtllib -o $@
 
 $(POSTGRES_IMP): $(OBJS)
 	$(LD) $(LDREL) $(LDOUT) SUBSYS.o $(call expand_subsys,$^)
@@ -342,4 +342,4 @@ maintainer-clean: distclean
 # are up to date.  It saves the time of doing all the submakes.
 .PHONY: quick
 quick: $(OBJS)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(call expand_subsys,$^) $(LIBS) -o postgres
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(call expand_subsys,$^) $(LIBS) -o postgres

--- a/src/backend/access/hash/hashfunc.c
+++ b/src/backend/access/hash/hashfunc.c
@@ -436,25 +436,35 @@ hash_any(register const unsigned char *k, register int keylen)
 		{
 			case 11:
 				c += ((uint32) k[10] << 8);
+				/* fall through */
 			case 10:
 				c += ((uint32) k[9] << 16);
+				/* fall through */
 			case 9:
 				c += ((uint32) k[8] << 24);
 				/* the lowest byte of c is reserved for the length */
+				/* fall through */
 			case 8:
 				b += k[7];
+				/* fall through */
 			case 7:
 				b += ((uint32) k[6] << 8);
+				/* fall through */
 			case 6:
 				b += ((uint32) k[5] << 16);
+				/* fall through */
 			case 5:
 				b += ((uint32) k[4] << 24);
+				/* fall through */
 			case 4:
 				a += k[3];
+				/* fall through */
 			case 3:
 				a += ((uint32) k[2] << 8);
+				/* fall through */
 			case 2:
 				a += ((uint32) k[1] << 16);
+				/* fall through */
 			case 1:
 				a += ((uint32) k[0] << 24);
 				/* case 0: nothing left to add */
@@ -464,25 +474,35 @@ hash_any(register const unsigned char *k, register int keylen)
 		{
 			case 11:
 				c += ((uint32) k[10] << 24);
+				/* fall through */
 			case 10:
 				c += ((uint32) k[9] << 16);
+				/* fall through */
 			case 9:
 				c += ((uint32) k[8] << 8);
 				/* the lowest byte of c is reserved for the length */
+				/* fall through */
 			case 8:
 				b += ((uint32) k[7] << 24);
+				/* fall through */
 			case 7:
 				b += ((uint32) k[6] << 16);
+				/* fall through */
 			case 6:
 				b += ((uint32) k[5] << 8);
+				/* fall through */
 			case 5:
 				b += k[4];
+				/* fall through */
 			case 4:
 				a += ((uint32) k[3] << 24);
+				/* fall through */
 			case 3:
 				a += ((uint32) k[2] << 16);
+				/* fall through */
 			case 2:
 				a += ((uint32) k[1] << 8);
+				/* fall through */
 			case 1:
 				a += k[0];
 				/* case 0: nothing left to add */

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -6022,10 +6022,12 @@ EndLocalDistribXact(bool isCommit)
 		case DTX_CONTEXT_QE_FINISH_PREPARED:
 			elog(PANIC, "Unexpected distribute transaction context: '%s'",
 				 DtxContextToString(DistributedTransactionContext));
+			break;
 
 		default:
 			elog(PANIC, "Unrecognized DTX transaction context: %d",
 				 (int) DistributedTransactionContext);
+			break;
 	}
 }
 

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -365,6 +365,7 @@ zlib_decompress(PG_FUNCTION_ARGS)
 				 * convergence' for data corruption :-).
 				 */
 				elog(ERROR, "zlib encountered data in an unexpected format");
+				break;
 
 			default:
 				/* shouldn't get here */

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -2309,7 +2309,7 @@ make_plan_for_one_dqa(PlannerInfo *root, MppGroupContext *ctx, int dqa_index,
 			groups_sorted = true;
 			current_pathkeys = root->group_pathkeys;
 			mark_sort_locus(result_plan);
-			/* Fall though. */
+			/* fallthrough */
 
 		case DQACOPLAN_GGS:
 			aggstrategy = AGG_SORTED;

--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -169,6 +169,7 @@ plan_tree_mutator(Node *node,
 		case T_Plan:
 			/* Abstract: Should see only subclasses. */
 			elog(ERROR, "abstract node type not allowed: T_Plan");
+			break;
 
 		case T_Result:
 			{
@@ -322,6 +323,7 @@ plan_tree_mutator(Node *node,
 		case T_Scan:
 			/* Abstract: Should see only subclasses. */
 			elog(ERROR, "abstract node type not allowed: T_Scan");
+			break;
 
 		case T_SeqScan:
 			{
@@ -521,6 +523,7 @@ plan_tree_mutator(Node *node,
 		case T_Join:
 			/* Abstract: Should see only subclasses. */
 			elog(ERROR, "abstract node type not allowed: T_Join");
+			break;
 
 		case T_NestLoop:
 			{

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2240,6 +2240,7 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 				case DTX_CONTEXT_QE_READER:
 					elog(FATAL, "Unexpected segment distribute transaction context: '%s'",
 						 DtxContextToString(DistributedTransactionContext));
+					break;
 
 				default:
 					elog(PANIC, "Unexpected segment distribute transaction context value: %d",
@@ -2280,6 +2281,7 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 				case DTX_CONTEXT_QE_READER:
 					elog(PANIC, "Unexpected segment distribute transaction context: '%s'",
 						 DtxContextToString(DistributedTransactionContext));
+					break;
 
 				default:
 					elog(PANIC, "Unexpected segment distribute transaction context value: %d",

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -212,6 +212,7 @@ qdSerializeDtxContextInfo(int *size, bool wantSnapshot, bool inCursor,
 		case DTX_CONTEXT_QE_FINISH_PREPARED:
 			elog(FATAL, "Unexpected distribute transaction context: '%s'",
 				 DtxContextToString(DistributedTransactionContext));
+			break;
 
 		default:
 			elog(FATAL, "Unrecognized DTX transaction context: %d",

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5266,6 +5266,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 					   (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot modify subpartition template for partitioned table")));
 			}
+			/* FALL THRU */
 		case AT_PartAdd:				/* Add */
 		case AT_PartAddForSplit:		/* Add, as part of a split */
 		case AT_PartDrop:				/* Drop */
@@ -16153,6 +16154,7 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation *rel,
 		{
 			prepSplit = true; /* if sub-command is split partition then it will require some preprocessing */
 		}
+		/* FALL THRU */
 		case AT_PartAdd:				/* Add */
 		case AT_PartAddForSplit:		/* Add, as part of a split */
 		case AT_PartDrop:				/* Drop */

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1191,6 +1191,7 @@ ExecAgg(AggState *node)
 					 * pass through. Be sure that the next case statement
 					 * is HASHAGG_END_OF_PASSES.
 					 */
+					/* fallthrough */
 
 				case HASHAGG_END_OF_PASSES:
 					node->agg_done = true;

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -834,6 +834,7 @@ processRetry(fts_context *context)
 				if (!(ftsInfo->result.retryRequested &&
 					  SEGMENT_IS_ALIVE(ftsInfo->mirror_cdbinfo)))
 					break;
+				/* else, fallthrough */
 			case FTS_PROBE_FAILED:
 			case FTS_SYNCREP_OFF_FAILED:
 			case FTS_PROMOTE_FAILED:

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1017,6 +1017,7 @@ _outConstraint(StringInfo str, Constraint *node)
 			 */
 			WRITE_BOOL_FIELD(skip_validation);
 			WRITE_BOOL_FIELD(is_no_inherit);
+			/* fallthrough */
 		case CONSTR_DEFAULT:
 			WRITE_NODE_FIELD(raw_expr);
 			WRITE_STRING_FIELD(cooked_expr);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -462,6 +462,7 @@ _readConstraint(void)
 			 */
 			READ_BOOL_FIELD(skip_validation);
 			READ_BOOL_FIELD(is_no_inherit);
+			/* fallthrough */
 		case CONSTR_DEFAULT:
 			READ_NODE_FIELD(raw_expr);
 			READ_STRING_FIELD(cooked_expr);

--- a/src/backend/optimizer/prep/prepsecurity.c
+++ b/src/backend/optimizer/prep/prepsecurity.c
@@ -270,8 +270,10 @@ expand_security_qual(PlannerInfo *root, List *tlist, int rt_index,
 					 */
 					case ROW_MARK_TABLE_SHARE:
 						elog(ERROR, "unexpected ROW_MARK_TABLE_SHARE locking mode encountered while expanding security barrier view");
+						break;
 					case ROW_MARK_TABLE_EXCLUSIVE:
 						elog(ERROR, "unexpected ROW_MARK_TABLE_EXCLUSIVE locking mode encountered while expanding security barrier view");
+						break;
 				}
 				root->rowMarks = list_delete(root->rowMarks, rc);
 			}

--- a/src/backend/regex/regc_lex.c
+++ b/src/backend/regex/regc_lex.c
@@ -854,6 +854,7 @@ lexescape(struct vars * v)
 			/* oops, doesn't look like it's a backref after all... */
 			v->now = save;
 			/* and fall through into octal number */
+			/* fallthrough */
 		case CHR('0'):
 			NOTE(REG_UUNPORT);
 			v->now--;			/* put first digit back */

--- a/src/backend/regex/regcomp.c
+++ b/src/backend/regex/regcomp.c
@@ -903,6 +903,7 @@ parseqatom(struct vars * v,
 			/* legal in EREs due to specification botch */
 			NOTE(REG_UPBOTCH);
 			/* fallthrough into case PLAIN */
+			/* fallthrough */
 		case PLAIN:
 			onechr(v, v->nextvalue, lp, rp);
 			okcolors(v->nfa, v->cm);

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -419,6 +419,7 @@ BufFileRead(BufFile *file, void *ptr, size_t size)
 		case BFS_SEQUENTIAL_WRITING:
 		case BFS_COMPRESSED_WRITING:
 			elog(ERROR, "cannot read from sequential BufFile before rewinding to start");
+			break;
 
 		case BFS_COMPRESSED_READING:
 			return BufFileLoadCompressedBuffer(file, ptr, size);
@@ -508,6 +509,7 @@ BufFileReadFromBuffer(BufFile *file, size_t size)
 		case BFS_SEQUENTIAL_WRITING:
 		case BFS_COMPRESSED_WRITING:
 			elog(ERROR, "cannot read from sequential BufFile before rewinding to start");
+			return NULL;
 
 		case BFS_COMPRESSED_READING:
 			return NULL;

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3578,6 +3578,7 @@ RecoveryConflictInterrupt(ProcSignalReason reason)
 					return;
 
 				/* Intentional drop through to check wait for pin */
+				/* fallthrough */
 
 			case PROCSIG_RECOVERY_CONFLICT_BUFFERPIN:
 
@@ -3591,6 +3592,7 @@ RecoveryConflictInterrupt(ProcSignalReason reason)
 				MyProc->recoveryConflictPending = true;
 
 				/* Intentional drop through to error handling */
+				/* fallthrough */
 
 			case PROCSIG_RECOVERY_CONFLICT_LOCK:
 			case PROCSIG_RECOVERY_CONFLICT_TABLESPACE:
@@ -3635,6 +3637,7 @@ RecoveryConflictInterrupt(ProcSignalReason reason)
 				}
 
 				/* Intentional drop through to session cancel */
+				/* fallthrough */
 
 			case PROCSIG_RECOVERY_CONFLICT_DATABASE:
 				RecoveryConflictPending = true;
@@ -5647,6 +5650,7 @@ PostgresMain(int argc, char *argv[],
 				 * scenarios.
 				 */
 				proc_exit(0);
+				break;
 
 			case 'd':			/* copy data */
 			case 'c':			/* copy done */

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -3660,6 +3660,7 @@ DecodeISO8601Interval(char *str,
 						continue;
 					}
 					/* Else fall through to extended alternative format */
+					/* FALL THROUGH */
 				case '-':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)
@@ -3738,6 +3739,7 @@ DecodeISO8601Interval(char *str,
 						return 0;
 					}
 					/* Else fall through to extended alternative format */
+					/* FALL THROUGH */
 				case ':':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -3040,6 +3040,7 @@ DCH_from_char(FormatNode *node, char *in, TmFromChar *out)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("\"TZ\"/\"tz\"/\"OF\" format patterns are not supported in to_date")));
+				break;
 			case DCH_A_D:
 			case DCH_B_C:
 			case DCH_a_d:

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -1339,6 +1339,8 @@ width_bucket_numeric(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 				(errcode(ERRCODE_INVALID_ARGUMENT_FOR_WIDTH_BUCKET_FUNCTION),
 				 errmsg("lower bound cannot equal upper bound")));
+			/* make compiler happy */
+			break;
 
 			/* bound1 < bound2 */
 		case -1:

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -6811,8 +6811,8 @@ isSimpleNode(Node *node, Node *parentNode, int prettyFlags)
 					return false;
 				}
 				/* else do the same stuff as for T_SubLink et al. */
-				/* FALL THROUGH */
 			}
+			/* fallthrough */
 
 		case T_SubLink:
 		case T_NullTest:

--- a/src/backend/utils/adt/timestamp.c
+++ b/src/backend/utils/adt/timestamp.c
@@ -4616,12 +4616,14 @@ timestamp_trunc(PG_FUNCTION_ARGS)
 					tm->tm_year = ((tm->tm_year + 999) / 1000) * 1000 - 999;
 				else
 					tm->tm_year = -((999 - (tm->tm_year - 1)) / 1000) * 1000 + 1;
+				/* FALL THRU */
 			case DTK_CENTURY:
 				/* see comments in timestamptz_trunc */
 				if (tm->tm_year > 0)
 					tm->tm_year = ((tm->tm_year + 99) / 100) * 100 - 99;
 				else
 					tm->tm_year = -((99 - (tm->tm_year - 1)) / 100) * 100 + 1;
+				/* FALL THRU */
 			case DTK_DECADE:
 				/* see comments in timestamptz_trunc */
 				if (val != DTK_MILLENNIUM && val != DTK_CENTURY)
@@ -4631,18 +4633,25 @@ timestamp_trunc(PG_FUNCTION_ARGS)
 					else
 						tm->tm_year = -((8 - (tm->tm_year - 1)) / 10) * 10;
 				}
+				/* FALL THRU */
 			case DTK_YEAR:
 				tm->tm_mon = 1;
+				/* FALL THRU */
 			case DTK_QUARTER:
 				tm->tm_mon = (3 * ((tm->tm_mon - 1) / 3)) + 1;
+				/* FALL THRU */
 			case DTK_MONTH:
 				tm->tm_mday = 1;
+				/* FALL THRU */
 			case DTK_DAY:
 				tm->tm_hour = 0;
+				/* FALL THRU */
 			case DTK_HOUR:
 				tm->tm_min = 0;
+				/* FALL THRU */
 			case DTK_MINUTE:
 				tm->tm_sec = 0;
+				/* FALL THRU */
 			case DTK_SECOND:
 				fsec = 0;
 				break;
@@ -4877,24 +4886,33 @@ interval_trunc(PG_FUNCTION_ARGS)
 				case DTK_MILLENNIUM:
 					/* caution: C division may have negative remainder */
 					tm->tm_year = (tm->tm_year / 1000) * 1000;
+					/* FALL THRU */
 				case DTK_CENTURY:
 					/* caution: C division may have negative remainder */
 					tm->tm_year = (tm->tm_year / 100) * 100;
+					/* FALL THRU */
 				case DTK_DECADE:
 					/* caution: C division may have negative remainder */
 					tm->tm_year = (tm->tm_year / 10) * 10;
+					/* FALL THRU */
 				case DTK_YEAR:
 					tm->tm_mon = 0;
+					/* FALL THRU */
 				case DTK_QUARTER:
 					tm->tm_mon = 3 * (tm->tm_mon / 3);
+					/* FALL THRU */
 				case DTK_MONTH:
 					tm->tm_mday = 0;
+					/* FALL THRU */
 				case DTK_DAY:
 					tm->tm_hour = 0;
+					/* FALL THRU */
 				case DTK_HOUR:
 					tm->tm_min = 0;
+					/* FALL THRU */
 				case DTK_MINUTE:
 					tm->tm_sec = 0;
+					/* FALL THRU */
 				case DTK_SECOND:
 					fsec = 0;
 					break;

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -178,6 +178,7 @@ datumstreamread_getlarge(DatumStreamRead * acc, Datum *datum, bool *null)
 			acc->largeObjectState = DatumStreamLargeObjectState_Consumed;
 
 			/* Fall below to ~_Consumed. */
+			/* fallthrough */
 
 		case DatumStreamLargeObjectState_Consumed:
 			{

--- a/src/backend/utils/error/faultinject.c
+++ b/src/backend/utils/error/faultinject.c
@@ -131,21 +131,26 @@ gp_fault_inject_impl(int32 reason, int64 arg)
 			ereport(ERROR,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("User fault injection raised error")));
+			break;
 		case GP_FAULT_USER_RAISE_FATAL:
 			ereport(FATAL,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("User fault injection raised fatal")));
+			break;
 		case GP_FAULT_USER_RAISE_PANIC:
 			ereport(PANIC,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("User fault injection raised panic")));
+			break;
 		case GP_FAULT_USER_PROCEXIT:
 			{
 				extern void proc_exit(int);
 				proc_exit((int) arg);
 			}
+			break;
 		case GP_FAULT_USER_ABORT:
 			abort();
+			break;
 
 		case GP_FAULT_USER_INFINITE_LOOP:
 			{

--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -895,11 +895,17 @@ GpMurmurHash64A (const void * key, int len, unsigned int seed)
 
     switch(len & 7) {
         case 7: h ^= (uint64_t)data[6] << 48;
+		/* fallthrough */
         case 6: h ^= (uint64_t)data[5] << 40;
+		/* fallthrough */
         case 5: h ^= (uint64_t)data[4] << 32;
+		/* fallthrough */
         case 4: h ^= (uint64_t)data[3] << 24;
+		/* fallthrough */
         case 3: h ^= (uint64_t)data[2] << 16;
+		/* fallthrough */
         case 2: h ^= (uint64_t)data[1] << 8;
+		/* fallthrough */
         case 1: h ^= (uint64_t)data[0];
         h *= m;
     };

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5013,6 +5013,7 @@ AtEOXact_GUC(bool isCommit, int nestLevel)
 				{
 					case GUC_SAVE:
 						Assert(false);	/* can't get here */
+						break;
 
 					case GUC_SET:
 						/* next level always becomes SET */

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -578,6 +578,7 @@ ResLockPortal(Portal portal, QueryDesc *qDesc)
 					break;
 				}
 			}
+			/* fallthrough */
 
 
 			case T_SelectStmt:

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -1014,6 +1014,7 @@ tuplestore_gettuple(Tuplestorestate *state, bool forward,
 							 errmsg("could not seek in tuplestore temporary file: %m")));
 			state->status = TSS_READFILE;
 			/* FALL THRU into READFILE case */
+			/* fallthrough */
 
 		case TSS_READFILE:
 			*should_free = true;
@@ -1054,6 +1055,7 @@ tuplestore_gettuple(Tuplestorestate *state, bool forward,
 			 */
 
 			ereport(ERROR, (errmsg("Backward scanning of tuplestores are not supported at this time")));
+			return NULL;
 #if 0
 			if (BufFileSeek(state->myfile, readptr->file, -(long) sizeof(unsigned int),
 							SEEK_CUR) != 0)

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -3599,6 +3599,7 @@ create_xlog_or_symlink(void)
 							  "remove or empty the directory \"%s\".\n"),
 							xlog_dir);
 				exit_nicely();
+				break;
 
 			default:
 				/* Trouble accessing directory */

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -538,6 +538,7 @@ verify_dir_is_empty_or_create(char *dirname)
 					_("%s: directory \"%s\" exists but is not empty\n"),
 					progname, dirname);
 			disconnect_and_exit(1);
+			break;
 		case -1:
 
 			/*

--- a/src/bin/pg_rewind/parsexlog.c
+++ b/src/bin/pg_rewind/parsexlog.c
@@ -945,6 +945,7 @@ extractPageInfo(XLogRecord *record)
 					fprintf(stderr, "unrecognized dbase record type %d\n", info);
 					exit(1);
 			}
+			break;
 
 		case RM_TBLSPC_ID:
 			switch (info)

--- a/src/interfaces/ecpg/pgtypeslib/interval.c
+++ b/src/interfaces/ecpg/pgtypeslib/interval.c
@@ -200,6 +200,7 @@ DecodeISO8601Interval(char *str,
 						continue;
 					}
 					/* Else fall through to extended alternative format */
+					/* FALL THROUGH */
 				case '-':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)
@@ -278,6 +279,7 @@ DecodeISO8601Interval(char *str,
 						return 0;
 					}
 					/* Else fall through to extended alternative format */
+					/* FALL THROUGH */
 				case ':':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)

--- a/src/interfaces/ecpg/preproc/ecpg.c
+++ b/src/interfaces/ecpg/preproc/ecpg.c
@@ -192,6 +192,7 @@ main(int argc, char *const argv[])
 				header_mode = true;
 				/* this must include "-c" to make sense */
 				/* so do not place a "break;" here */
+				/* fallthrough */
 			case 'c':
 				auto_create_c = true;
 				break;

--- a/src/interfaces/libpq/fe-secure.c
+++ b/src/interfaces/libpq/fe-secure.c
@@ -654,9 +654,9 @@ retry_masked:
 				case EPIPE:
 					/* Set flag for EPIPE */
 					REMEMBER_EPIPE(spinfo, true);
-					/* FALL THRU */
 
 #ifdef ECONNRESET
+					/* fallthrough */
 				case ECONNRESET:
 #endif
 					printfPQExpBuffer(&conn->errorMessage,

--- a/src/pl/plpgsql/src/pl_exec.c
+++ b/src/pl/plpgsql/src/pl_exec.c
@@ -3237,14 +3237,17 @@ exec_prepare_plan(PLpgSQL_execstate *estate,
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("cannot COPY to/from client in PL/pgSQL")));
+				break;
 			case SPI_ERROR_TRANSACTION:
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("cannot begin/end transactions in PL/pgSQL"),
 						 errhint("Use a BEGIN block with an EXCEPTION clause instead.")));
+				break;
 			default:
 				elog(ERROR, "SPI_prepare_params failed for \"%s\": %s",
 					 expr->query, SPI_result_code_string(SPI_result));
+				break;
 		}
 	}
 	SPI_keepplan(plan);
@@ -3378,15 +3381,18 @@ exec_stmt_execsql(PLpgSQL_execstate *estate,
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot COPY to/from client in PL/pgSQL")));
+			break;
 		case SPI_ERROR_TRANSACTION:
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot begin/end transactions in PL/pgSQL"),
 			errhint("Use a BEGIN block with an EXCEPTION clause instead.")));
+			break;
 
 		default:
 			elog(ERROR, "SPI_execute_plan_with_paramlist failed executing query \"%s\": %s",
 				 expr->query, SPI_result_code_string(rc));
+			break;
 	}
 
 	/* All variants should save result info for GET DIAGNOSTICS */
@@ -3569,11 +3575,13 @@ exec_stmt_dynexecute(PLpgSQL_execstate *estate,
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot COPY to/from client in PL/pgSQL")));
+			break;
 		case SPI_ERROR_TRANSACTION:
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot begin/end transactions in PL/pgSQL"),
 			errhint("Use a BEGIN block with an EXCEPTION clause instead.")));
+			break;
 
 		default:
 			elog(ERROR, "SPI_execute failed executing query \"%s\": %s",


### PR DESCRIPTION
GCC 7+ has a compiling option, -Wimplicit-fallthrough, which will
generate a warning/error if the code falls through cases(or default)
implicitly. The implicity may cause some bugs that are hardly to catch.

To enable this compile option, all switch-cases are not allowed to
fall through implicitly. To accomplish this target, 2 steps are done:
1. Append a comment line /* fallthrough */ or like at the end of case block.
2. Add break clause at the end of case block, if the last statement is
  ereport(ERROR) or like.

When -Wimplicit-fallthrough is enabled, -Werror=implicit-fallthrough
is also set. So fallthrough must be done explicitly.
Re-generate configure after modifying configure.in

No implicit-fallthrough for gpmapreduce and orafce

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
