### PR TITLE
Fix and enable generate_ao_xlog and generate_aoco_xlog tests

### DIFF
--- a/src/test/walrep/expected/generate_ao_xlog.out
+++ b/src/test/walrep/expected/generate_ao_xlog.out
@@ -8,10 +8,7 @@ CREATE TEMP TABLE tmp(dummy int, dbid int, startpoint pg_lsn) distributed by (du
 INSERT INTO tmp SELECT 1, gp_execution_segment(), pg_current_xlog_location()
 FROM gp_dist_random('gp_id');
 -- Generate some xlog records for AO
-INSERT INTO generate_ao_xlog_table VALUES(1, 10), (2, 10), (8, 10), (3, 10);
--- GPDB_94_MERGE_FIXME: c function test_xlog_ao() call walrcv_connect() in sql function test_xlog_ao_wrapper(), will fail with message
--- ERROR:  could not connect to the primary server: FATAL:  no pg_hba.conf entry for replication connection from host "[local]", user "gpadmin", SSL off (libpqwalreceiver.c:111)
--- start_ignore
+INSERT INTO generate_ao_xlog_table SELECT i,i+3 FROM generate_series(1,15)i;
 -- Verify that the insert AO xlog record was received
 SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
   FROM test_xlog_ao_wrapper(
@@ -25,14 +22,13 @@ ORDER BY gp_segment_id, xrecoff;
  gp_segment_id |        relname         |      record_type       | segment_filenum | recordlen | file_offset 
 ---------------+------------------------+------------------------+-----------------+-----------+-------------
              0 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        24 |           0
-             0 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        64 |           0
+             0 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |       152 |           0
              1 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        24 |           0
-             1 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        64 |           0
+             1 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |       112 |           0
              2 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        24 |           0
-             2 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        96 |           0
+             2 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT |               1 |       184 |           0
 (6 rows)
 
--- end_ignore
 -- Store the latest xlog offset
 DELETE FROM tmp;
 INSERT INTO tmp SELECT 1, gp_execution_segment(), pg_current_xlog_location()
@@ -42,9 +38,6 @@ BEGIN;
 INSERT INTO generate_ao_xlog_table SELECT i,i FROM generate_series(1,10)i;
 ABORT;
 VACUUM generate_ao_xlog_table;
--- GPDB_94_MERGE_FIXME: c function test_xlog_ao() call walrcv_connect() in sql function test_xlog_ao_wrapper(), will fail with message
--- ERROR:  could not connect to the primary server: FATAL:  no pg_hba.conf entry for replication connection from host "[local]", user "gpadmin", SSL off (libpqwalreceiver.c:111)
--- start_ignore
 -- Verify that truncate AO xlog record was received
 SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
   FROM test_xlog_ao_wrapper(
@@ -57,15 +50,14 @@ AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
 ORDER BY gp_segment_id, xrecoff;
  gp_segment_id |        relname         |       record_type        | segment_filenum | recordlen | file_offset 
 ---------------+------------------------+--------------------------+-----------------+-----------+-------------
-             0 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |       112 |          40
-             0 | generate_ao_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          40
+             0 | generate_ao_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |         128
+             0 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |       152 |         128
              0 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               2 |        24 |           0
-             1 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |       152 |          40
-             1 | generate_ao_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          40
+             1 | generate_ao_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          88
+             1 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        64 |          88
              1 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               2 |        24 |           0
-             2 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        96 |          72
-             2 | generate_ao_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          72
+             2 | generate_ao_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |         160
+             2 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |       128 |         160
              2 | generate_ao_xlog_table | XLOG_APPENDONLY_INSERT   |               2 |        24 |           0
 (9 rows)
 
--- end_ignore

--- a/src/test/walrep/expected/generate_aoco_xlog.out
+++ b/src/test/walrep/expected/generate_aoco_xlog.out
@@ -8,10 +8,7 @@ CREATE TEMP TABLE tmp(dummy int, dbid int, startpoint pg_lsn) distributed by (du
 INSERT INTO tmp SELECT 1, gp_execution_segment(),pg_current_xlog_location() FROM
 gp_dist_random('gp_id');
 -- Generate some xlog records for AOCO
-INSERT INTO generate_aoco_xlog_table VALUES (1, 10), (2, 10), (8, 10), (3, 10);
--- GPDB_94_MERGE_FIXME: c function test_xlog_ao() call walrcv_connect() in sql function test_xlog_ao_wrapper(), will fail with message
--- ERROR:  could not connect to the primary server: FATAL:  no pg_hba.conf entry for replication connection from host "[local]", user "gpadmin", SSL off (libpqwalreceiver.c:111)
--- start_ignore
+INSERT INTO generate_aoco_xlog_table SELECT i,i+3 FROM generate_series(1,15)i;
 -- Verify that AO xlog record was received
 SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
   FROM test_xlog_ao_wrapper(
@@ -24,21 +21,20 @@ AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
 ORDER BY gp_segment_id, xrecoff;
  gp_segment_id |         relname          |      record_type       | segment_filenum | recordlen | file_offset 
 ---------------+--------------------------+------------------------+-----------------+-----------+-------------
-             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        24 |           0
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        88 |           0
              0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        24 |           0
-             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        72 |           0
-             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        72 |           0
-             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        24 |           0
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        24 |           0
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        88 |           0
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        80 |           0
              1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        24 |           0
-             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        72 |           0
-             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        72 |           0
-             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        24 |           0
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        24 |           0
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        80 |           0
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        96 |           0
              2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        24 |           0
-             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        72 |           0
-             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        72 |           0
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |               1 |        24 |           0
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT |             129 |        96 |           0
 (12 rows)
 
--- end_ignore
 -- Store the latest xlog offset
 DELETE FROM tmp;
 INSERT INTO tmp SELECT 1, gp_execution_segment(),pg_current_xlog_location()
@@ -48,9 +44,6 @@ BEGIN;
 INSERT INTO generate_aoco_xlog_table SELECT i,i FROM generate_series(1,10)i;
 ABORT;
 VACUUM generate_aoco_xlog_table;
--- GPDB_94_MERGE_FIXME: c function test_xlog_ao() call walrcv_connect() in sql function test_xlog_ao_wrapper(), will fail with message
--- ERROR:  could not connect to the primary server: FATAL:  no pg_hba.conf entry for replication connection from host "[local]", user "gpadmin", SSL off (libpqwalreceiver.c:111)
--- start_ignore
 -- Verify that truncate AO xlog record was received
 SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
   FROM test_xlog_ao_wrapper(
@@ -63,23 +56,23 @@ AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
 ORDER BY gp_segment_id, xrecoff;
  gp_segment_id |         relname          |       record_type        | segment_filenum | recordlen | file_offset 
 ---------------+--------------------------+--------------------------+-----------------+-----------+-------------
-             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        80 |          48
-             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             129 |        80 |          48
-             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          48
-             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |             129 |        24 |          48
              0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               2 |        24 |           0
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |             129 |        24 |          64
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          64
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             129 |        88 |          64
+             0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        88 |          64
              0 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             130 |        24 |           0
-             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        88 |          48
-             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             129 |        88 |          48
-             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          48
-             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |             129 |        24 |          48
              1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               2 |        24 |           0
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |             129 |        24 |          56
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          56
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             129 |        72 |          56
+             1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        72 |          56
              1 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             130 |        24 |           0
-             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        72 |          48
-             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             129 |        72 |          48
-             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          48
-             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |             129 |        24 |          48
              2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               2 |        24 |           0
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |             129 |        24 |          72
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_TRUNCATE |               1 |        24 |          72
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             129 |        80 |          72
+             2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |               1 |        80 |          72
              2 | generate_aoco_xlog_table | XLOG_APPENDONLY_INSERT   |             130 |        24 |           0
 (18 rows)
--- end_ignore
+

--- a/src/test/walrep/sql/generate_ao_xlog.sql
+++ b/src/test/walrep/sql/generate_ao_xlog.sql
@@ -8,11 +8,8 @@ INSERT INTO tmp SELECT 1, gp_execution_segment(), pg_current_xlog_location()
 FROM gp_dist_random('gp_id');
 
 -- Generate some xlog records for AO
-INSERT INTO generate_ao_xlog_table VALUES(1, 10), (2, 10), (8, 10), (3, 10);
+INSERT INTO generate_ao_xlog_table SELECT i,i+3 FROM generate_series(1,15)i;
 
--- GPDB_94_MERGE_FIXME: c function test_xlog_ao() call walrcv_connect() in sql function test_xlog_ao_wrapper(), will fail with message
--- ERROR:  could not connect to the primary server: FATAL:  no pg_hba.conf entry for replication connection from host "[local]", user "gpadmin", SSL off (libpqwalreceiver.c:111)
--- start_ignore
 -- Verify that the insert AO xlog record was received
 SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
   FROM test_xlog_ao_wrapper(
@@ -23,7 +20,6 @@ SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_off
 WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
 AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
 ORDER BY gp_segment_id, xrecoff;
--- end_ignore
 
 -- Store the latest xlog offset
 DELETE FROM tmp;
@@ -36,9 +32,6 @@ INSERT INTO generate_ao_xlog_table SELECT i,i FROM generate_series(1,10)i;
 ABORT;
 VACUUM generate_ao_xlog_table;
 
--- GPDB_94_MERGE_FIXME: c function test_xlog_ao() call walrcv_connect() in sql function test_xlog_ao_wrapper(), will fail with message
--- ERROR:  could not connect to the primary server: FATAL:  no pg_hba.conf entry for replication connection from host "[local]", user "gpadmin", SSL off (libpqwalreceiver.c:111)
--- start_ignore
 -- Verify that truncate AO xlog record was received
 SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
   FROM test_xlog_ao_wrapper(
@@ -49,5 +42,3 @@ SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_off
 WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
 AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
 ORDER BY gp_segment_id, xrecoff;
-
--- end_ignore

--- a/src/test/walrep/sql/generate_aoco_xlog.sql
+++ b/src/test/walrep/sql/generate_aoco_xlog.sql
@@ -8,11 +8,8 @@ INSERT INTO tmp SELECT 1, gp_execution_segment(),pg_current_xlog_location() FROM
 gp_dist_random('gp_id');
 
 -- Generate some xlog records for AOCO
-INSERT INTO generate_aoco_xlog_table VALUES (1, 10), (2, 10), (8, 10), (3, 10);
+INSERT INTO generate_aoco_xlog_table SELECT i,i+3 FROM generate_series(1,15)i;
 
--- GPDB_94_MERGE_FIXME: c function test_xlog_ao() call walrcv_connect() in sql function test_xlog_ao_wrapper(), will fail with message
--- ERROR:  could not connect to the primary server: FATAL:  no pg_hba.conf entry for replication connection from host "[local]", user "gpadmin", SSL off (libpqwalreceiver.c:111)
--- start_ignore
 -- Verify that AO xlog record was received
 SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
   FROM test_xlog_ao_wrapper(
@@ -23,7 +20,6 @@ SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_off
 WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
 AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
 ORDER BY gp_segment_id, xrecoff;
--- end_ignore
 
 -- Store the latest xlog offset
 DELETE FROM tmp;
@@ -36,9 +32,6 @@ INSERT INTO generate_aoco_xlog_table SELECT i,i FROM generate_series(1,10)i;
 ABORT;
 VACUUM generate_aoco_xlog_table;
 
--- GPDB_94_MERGE_FIXME: c function test_xlog_ao() call walrcv_connect() in sql function test_xlog_ao_wrapper(), will fail with message
--- ERROR:  could not connect to the primary server: FATAL:  no pg_hba.conf entry for replication connection from host "[local]", user "gpadmin", SSL off (libpqwalreceiver.c:111)
--- start_ignore
 -- Verify that truncate AO xlog record was received
 SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_offset
   FROM test_xlog_ao_wrapper(
@@ -49,4 +42,3 @@ SELECT gp_segment_id, relname, record_type, segment_filenum, recordlen, file_off
 WHERE spcNode = (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_default')
 AND dbNode = (SELECT oid FROM pg_database WHERE datname = current_database())
 ORDER BY gp_segment_id, xrecoff;
--- end_ignore


### PR DESCRIPTION
Given the new 9.5 WAL format and read interface, its very simple to
get the records. All the complexity of continuation records is
absorbed in XLogReadRecord(). So, check_ao_record_present() can be
very simple now.

Also, resolves the GPDB_94_MERGE_FIXME and enables the test again. I
am not seeing the ERROR mentioned. This test runs against the demo
cluster which should have the replication connection enabled.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
