### PR TITLE
Fix flaky subselect gp2

### DIFF
--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -31,9 +31,9 @@ where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
 (2 rows)
 
 -- Planner test to make sure the initplan is not removed for function scan
--- VACUUM FULL: To generate a deterministic plan for the query below.
-VACUUM FULL pg_database;
-VACUUM FULL pg_authid;
+-- ANALYZE: To generate a deterministic plan for the query below.
+ANALYZE pg_database;
+ANALYZE pg_authid;
 explain (costs off)
 select sess_id from pg_stat_activity
 where query = (select current_query())
@@ -45,12 +45,12 @@ and usename='xxx' and datname='xxx';
    InitPlan 1 (returns $0)
      ->  Result
    ->  Hash Join
-         Hash Cond: (s.datid = d.oid)
-         ->  Function Scan on pg_stat_get_activity s
-               Filter: (query = $0)
+         Hash Cond: (d.oid = s.datid)
+         ->  Seq Scan on pg_database d
+               Filter: (datname = 'xxx'::name)
          ->  Hash
-               ->  Seq Scan on pg_database d
-                     Filter: (datname = 'xxx'::name)
+               ->  Function Scan on pg_stat_get_activity s
+                     Filter: (query = $0)
    ->  Hash
          ->  Seq Scan on pg_authid u
                Filter: (rolname = 'xxx'::name)

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -96,9 +96,7 @@ test: dtm_retry
 
 # The appendonly test cannot be run concurrently with tests that have
 # serializable transactions (may conflict with AO vacuum operations).
-test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish subselect_gp_indexes
-
-test: partial_table
+test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish partial_table subselect_gp_indexes
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.

--- a/src/test/regress/sql/subselect_gp2.sql
+++ b/src/test/regress/sql/subselect_gp2.sql
@@ -22,9 +22,9 @@ select * from test_ext_foo as o
 where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
 
 -- Planner test to make sure the initplan is not removed for function scan
--- VACUUM FULL: To generate a deterministic plan for the query below.
-VACUUM FULL pg_database;
-VACUUM FULL pg_authid;
+-- ANALYZE: To generate a deterministic plan for the query below.
+ANALYZE pg_database;
+ANALYZE pg_authid;
 explain (costs off)
 select sess_id from pg_stat_activity
 where query = (select current_query())


### PR DESCRIPTION
The PR contains 2 commit:
```
commit b8327b0664e95d4485cf098e6d58c621fa870841 (HEAD -> fix-flaky-subselect_gp2, bc/fix-flaky-subselect_gp2)
Author: Bhuvnesh Chaudhary <bhuvnesh2703@gmail.com>
Date:   Fri Oct 11 14:44:11 2019 -0700

    Revert "Move test partial_table to another test group to avoid deadlock"

    This reverts commit d9606d1808645c8776fe34335118c6f54e3a88fa.

    Refer to the commit: Use ANALYZE instead of VACUUM FULL for
    subselect_gp2 test which removes VACUUM FULL which caused the deadlock.

commit 1fcc2527f1b4387642cea04b178401041075a884
Author: Bhuvnesh Chaudhary <bhuvnesh2703@gmail.com>
Date:   Fri Oct 11 14:38:29 2019 -0700

    Use ANALYZE instead of VACUUM FULL for subselect_gp2 test

    There seems to be a random failure due to the deadlock which is caused
    by conflicting locks taken by VACUUM FULL pg_authid and delete / update
    operation on gp_distribution_policy. Instead of moving the test to a
    separate group, use ANALYZE instead of VACUUM to ensure that the
    estimates are mostly accurate.  This hopefully should keep the
    consistency and remove the overhead of locking by VACUUM FULL.

    There was a similar issue which was fixed via commit `d9606d180` which
    describes the deadlock as below:

    `update gp_distribution_policy`'s lock-acquire:
      1. at parsing stage, lock `gp_distribution_policy` in Exclusive Mode
        2. later when it needs to check authentication, lock `pg_authid` in
             AccessShare Mode

    `VACUUM FULL pg_authid`'s lock-acquire:
      1. lock pg_authid in Access Exclusive Mode
        2. later when rebuilding heap, it might delete some dependencies,
             this will do GpPolicyRemove, which locks `gp_distribution_policy`
                  in RowExclusive Mode

    So there is a potential local deadlock.

    Co-Authored-By: Ashwin Agrawal <aagrawal@pivotal.io>
```