### PR TITLE
Include the output of getversion in git-info.json

### DIFF
--- a/concourse/scripts/git_info.bash
+++ b/concourse/scripts/git_info.bash
@@ -13,11 +13,12 @@ for COMMAND in ${PREREQ_COMMANDS}; do
 done
 
 # ----------------------------------------------------------------------
-# Retrieve root URI and commit SHA1
+# Retrieve root URI, full commit SHA1, and version
 # ----------------------------------------------------------------------
 
 URI=$( git remote -v | grep "fetch" | grep "origin" | awk '{print $2}' )
 SHA1=$( git rev-parse HEAD )
+VERSION=$( ./getversion --short )
 
 # ----------------------------------------------------------------------
 # Generate root JSON record
@@ -26,7 +27,8 @@ SHA1=$( git rev-parse HEAD )
 echo -n "
 {\"root\": {
   \"uri\": \"${URI}\",
-  \"sha1\": \"${SHA1}\"},
+  \"sha1\": \"${SHA1}\",
+  \"version\": \"${VERSION}\"},
   \"submodules\": ["
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Cherry-Pick of a commit in master/6X_STABLE to add more information to git-info.json

This file gets used in integration testing pipelines and helps with pre-release candidate naming. Specifically, the version here gets used in the filename once it reaches that process. In the integration testing pipeline the object passed around is not gpdb source, therefore it's much, much easier to have this information with the bin_gpdb.

Authored-by: Bradford D. Boyle <bboyle@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
