### PR TITLE
Add missing break and fallthrough comment within switch-case

### DIFF
--- a/gpAux/extensions/gpcloud/lib/http_parser.cpp
+++ b/gpAux/extensions/gpcloud/lib/http_parser.cpp
@@ -2401,7 +2401,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
         case s_req_server_with_at:
             found_at = 1;
 
-            /* FALLTROUGH */
+            /* fallthrough */
         case s_req_server:
             uf = UF_HOST;
             break;

--- a/src/backend/access/hash/hashfunc.c
+++ b/src/backend/access/hash/hashfunc.c
@@ -344,9 +344,12 @@ uint32        initval)         /* the previous hash, or an arbitrary value */
   switch(length)                     /* all the case statements fall through */
   { 
   case 3 : c+=k[2];
+	   /* fallthrough */
   case 2 : b+=k[1];
+	   /* fallthrough */
   case 1 : a+=k[0];
     final(a,b,c);
+	   /* fallthrough */
   case 0:     /* case 0: nothing left to add */
     break;
   }
@@ -534,16 +537,27 @@ hashlittle( const void *key, size_t length, uint32 initval)
     switch(length)                   /* all the case statements fall through */
     {
     case 12: c+=((uint32)k[11])<<24;
+	   /* fallthrough */
     case 11: c+=((uint32)k[10])<<16;
+	   /* fallthrough */
     case 10: c+=((uint32)k[9])<<8;
+	   /* fallthrough */
     case 9 : c+=k[8];
+	   /* fallthrough */
     case 8 : b+=((uint32)k[7])<<24;
+	   /* fallthrough */
     case 7 : b+=((uint32)k[6])<<16;
+	   /* fallthrough */
     case 6 : b+=((uint32)k[5])<<8;
+	   /* fallthrough */
     case 5 : b+=k[4];
+	   /* fallthrough */
     case 4 : a+=((uint32)k[3])<<24;
+	   /* fallthrough */
     case 3 : a+=((uint32)k[2])<<16;
+	   /* fallthrough */
     case 2 : a+=((uint32)k[1])<<8;
+	   /* fallthrough */
     case 1 : a+=k[0];
              break;
     case 0 : return UInt32GetDatum(c);
@@ -668,17 +682,17 @@ hashbig( const void *key, size_t length, uint32 initval)
     /*-------------------------------- last block: affect all 32 bits of (c) */
     switch(length)                   /* all the case statements fall through */
     {
-    case 12: c+=k[11];
-    case 11: c+=((uint32)k[10])<<8;
-    case 10: c+=((uint32)k[9])<<16;
-    case 9 : c+=((uint32)k[8])<<24;
-    case 8 : b+=k[7];
-    case 7 : b+=((uint32)k[6])<<8;
-    case 6 : b+=((uint32)k[5])<<16;
-    case 5 : b+=((uint32)k[4])<<24;
-    case 4 : a+=k[3];
-    case 3 : a+=((uint32)k[2])<<8;
-    case 2 : a+=((uint32)k[1])<<16;
+    case 12: c+=k[11]; /* fallthrough */
+    case 11: c+=((uint32)k[10])<<8; /* fallthrough */
+    case 10: c+=((uint32)k[9])<<16; /* fallthrough */
+    case 9 : c+=((uint32)k[8])<<24; /* fallthrough */
+    case 8 : b+=k[7]; /* fallthrough */
+    case 7 : b+=((uint32)k[6])<<8; /* fallthrough */
+    case 6 : b+=((uint32)k[5])<<16; /* fallthrough */
+    case 5 : b+=((uint32)k[4])<<24; /* fallthrough */
+    case 4 : a+=k[3]; /* fallthrough */
+    case 3 : a+=((uint32)k[2])<<8; /* fallthrough */
+    case 2 : a+=((uint32)k[1])<<16; /* fallthrough */
     case 1 : a+=((uint32)k[0])<<24;
              break;
     case 0 : return UInt32GetDatum(c);

--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -447,6 +447,7 @@ AuxiliaryProcessMain(int argc, char *argv[])
 			bootstrap_signals();
 			CheckerModeMain();
 			proc_exit(1);		/* should never return */
+			break;
 
 		case BootstrapProcess:
 			bootstrap_signals();
@@ -454,61 +455,73 @@ AuxiliaryProcessMain(int argc, char *argv[])
 			StartupXLOG();
 			BootstrapModeMain();
 			proc_exit(1);		/* should never return */
+			break;
 
 		case StartupProcess:
 			/* don't set signals, startup process has its own agenda */
 			StartupProcessMain(1);
 			proc_exit(1);		/* should never return */
+			break;
 
 		case StartupPass2Process:
 			/* don't set signals, startup process has its own agenda */
 			StartupProcessMain(2);
 			proc_exit(1);		/* should never return */
+			break;
 
 		case StartupPass3Process:
 			/* don't set signals, startup process has its own agenda */
 			StartupProcessMain(3);
 			proc_exit(1);		/* should never return */
+			break;
 
 		case StartupPass4Process:
 			/* don't set signals, startup process has its own agenda */
 			StartupProcessMain(4);
 			proc_exit(1);		/* should never return */
+			break;
 
 		case BgWriterProcess:
 			/* don't set signals, bgwriter has its own agenda */
 			InitXLOGAccess();
 			BackgroundWriterMain();
 			proc_exit(1);		/* should never return */
+			break;
 
 		case CheckpointerProcess:
 			/* don't set signals, checkpointer is similar to bgwriter and has its own agenda */
 			InitXLOGAccess();
 			CheckpointerMain();
 			proc_exit(1);		/* should never return */
+			break;
 
 		case WalReceiverProcess:
 			/* don't set signals, walreceiver has its own agenda */
 			WalReceiverMain();
 			proc_exit(1);		/* should never return */
+			break;
 
 		case WalWriterProcess:
 			/* don't set signals, walwriter has its own agenda */
 			InitXLOGAccess();
 			WalWriterMain();
 			proc_exit(1);		/* should never return */
+			break;
 
 		case FilerepProcess:
 			FileRep_Main();
 			proc_exit(1); /* should never return */
+			break;
 
 		case FilerepResetPeerProcess:
 			FileRepResetPeer_Main();
 			proc_exit(1); /* should never return */
+			break;
 
 		default:
 			elog(PANIC, "unrecognized process type: %d", MyAuxProcType);
 			proc_exit(1);
+			break;
 	}
 }
 

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -357,6 +357,7 @@ zlib_decompress(PG_FUNCTION_ARGS)
 				 * convergence' for data corruption :-).
 				 */
 				elog(ERROR, "zlib encountered data in an unexpected format");
+				break;
 
 			default:
 				/* shouldn't get here */

--- a/src/backend/cdb/cdbexplain.c
+++ b/src/backend/cdb/cdbexplain.c
@@ -1593,6 +1593,7 @@ cdbexplain_showExecStats(struct PlanState *planstate,
 				show_cumulative_sort_info(str, indent, sort_method_enum_str[idx], DISK_STR_SORT_SPACE_TYPE, &ns->sortSpaceUsed[DISK_SORT_SPACE_TYPE-1][idx]);
 			}
 			/* no break */
+			/* fallthrough */
 		default:
 			if (ns->ntuples.vcnt > 1)
 				appendStringInfo(str,

--- a/src/backend/cdb/cdbfilerepmirror.c
+++ b/src/backend/cdb/cdbfilerepmirror.c
@@ -832,6 +832,7 @@ FileRepMirror_RunConsumer(void)
 								break;
 							}
 							/* no break */
+							/* fallthrough */
 
 						case FileRepRelationTypeFlatFile:
 						case FileRepRelationTypeBufferPool:
@@ -1853,6 +1854,7 @@ FileRepMirror_RunConsumer(void)
 							break;
 						}
 						/* NO BREAK */
+						/* fallthrough */
 					case FileRepRelationTypeAppendOnly:
 					case FileRepRelationTypeFlatFile:
 						

--- a/src/backend/cdb/cdbfilerepprimary.c
+++ b/src/backend/cdb/cdbfilerepprimary.c
@@ -209,6 +209,7 @@ FileRepPrimary_IsMirroringRequired(
 					}
 				}
 				/* no break */
+				/* fallthrough */
 			case DataStateInSync:
 				/*
 				 * FileRep backend processes have to exit in order to be able to transition

--- a/src/backend/cdb/cdbfilerepprimaryack.c
+++ b/src/backend/cdb/cdbfilerepprimaryack.c
@@ -792,6 +792,7 @@ FileRepAckPrimary_IsOperationCompleted(
 				xLogEof = entry->xLogEof;
 				mirrorStatus = entry->mirrorStatus;
 				/* no BREAK */
+				/* fallthrough */
 			case FileRepAckStateMirrorInFault:
 				
 				isCompleted = TRUE;

--- a/src/backend/cdb/cdbfilerepservice.c
+++ b/src/backend/cdb/cdbfilerepservice.c
@@ -339,6 +339,7 @@ FileRepSubProcess_IsStateTransitionRequested(void)
 				FileRep_InsertConfigLogEntry("failure is detected in segment mirroring during backend shutdown, abort requested");
 			}
 			/* no break */
+			/* fallthrough */
 		default:
 			
 			if (fileRepProcessType != FileRepProcessTypeNotInitialized)

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -2205,35 +2205,35 @@ make_plan_for_one_dqa(PlannerInfo *root, MppGroupContext *ctx, int dqa_index,
 	 
 	switch (coplan_type)
 	{
-	case DQACOPLAN_GSH:
-		/* pre-sort required on grouping key */
-		result_plan = (Plan *)
-			make_sort_from_groupcols(root,
-									 root->parse->groupClause,
-									 prelimGroupColIdx,
-									 false,
-									 result_plan);
-		groups_sorted = true;
-		current_pathkeys = root->group_pathkeys;
-		mark_sort_locus(result_plan);
-		/* Fall though. */
-		
-	case DQACOPLAN_GGS:
-		aggstrategy = AGG_SORTED;
-		break;
-		
-	case DQACOPLAN_SHH:
-	case DQACOPLAN_HH:
-		aggstrategy = AGG_HASHED;
-		groups_sorted = false;
-		break;
-		
-	case DQACOPLAN_PGS:
-	case DQACOPLAN_PH:
-		/* plainagg */
-		aggstrategy = AGG_PLAIN;
-		groups_sorted = false;
-		break;
+		case DQACOPLAN_GSH:
+			/* pre-sort required on grouping key */
+			result_plan = (Plan *)
+				make_sort_from_groupcols(root,
+										 root->parse->groupClause,
+										 prelimGroupColIdx,
+										 false,
+										 result_plan);
+			groups_sorted = true;
+			current_pathkeys = root->group_pathkeys;
+			mark_sort_locus(result_plan);
+			/* fallthrough */
+
+		case DQACOPLAN_GGS:
+			aggstrategy = AGG_SORTED;
+			break;
+
+		case DQACOPLAN_SHH:
+		case DQACOPLAN_HH:
+			aggstrategy = AGG_HASHED;
+			groups_sorted = false;
+			break;
+
+		case DQACOPLAN_PGS:
+		case DQACOPLAN_PH:
+			/* plainagg */
+			aggstrategy = AGG_PLAIN;
+			groups_sorted = false;
+			break;
 	}
 
 	/**

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -2205,35 +2205,35 @@ make_plan_for_one_dqa(PlannerInfo *root, MppGroupContext *ctx, int dqa_index,
 	 
 	switch (coplan_type)
 	{
-		case DQACOPLAN_GSH:
-			/* pre-sort required on grouping key */
-			result_plan = (Plan *)
-				make_sort_from_groupcols(root,
-										 root->parse->groupClause,
-										 prelimGroupColIdx,
-										 false,
-										 result_plan);
-			groups_sorted = true;
-			current_pathkeys = root->group_pathkeys;
-			mark_sort_locus(result_plan);
-			/* fallthrough */
-
-		case DQACOPLAN_GGS:
-			aggstrategy = AGG_SORTED;
-			break;
-
-		case DQACOPLAN_SHH:
-		case DQACOPLAN_HH:
-			aggstrategy = AGG_HASHED;
-			groups_sorted = false;
-			break;
-
-		case DQACOPLAN_PGS:
-		case DQACOPLAN_PH:
-			/* plainagg */
-			aggstrategy = AGG_PLAIN;
-			groups_sorted = false;
-			break;
+	case DQACOPLAN_GSH:
+		/* pre-sort required on grouping key */
+		result_plan = (Plan *)
+			make_sort_from_groupcols(root,
+									 root->parse->groupClause,
+									 prelimGroupColIdx,
+									 false,
+									 result_plan);
+		groups_sorted = true;
+		current_pathkeys = root->group_pathkeys;
+		mark_sort_locus(result_plan);
+		/* fallthrough */
+		
+	case DQACOPLAN_GGS:
+		aggstrategy = AGG_SORTED;
+		break;
+		
+	case DQACOPLAN_SHH:
+	case DQACOPLAN_HH:
+		aggstrategy = AGG_HASHED;
+		groups_sorted = false;
+		break;
+		
+	case DQACOPLAN_PGS:
+	case DQACOPLAN_PH:
+		/* plainagg */
+		aggstrategy = AGG_PLAIN;
+		groups_sorted = false;
+		break;
 	}
 
 	/**

--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -166,6 +166,7 @@ plan_tree_mutator(Node *node,
 		case T_Plan:
 			/* Abstract: Should see only subclasses. */
 			elog(ERROR, "abstract node type not allowed: T_Plan");
+			break;
 
 		case T_Result:
 			{
@@ -285,6 +286,7 @@ plan_tree_mutator(Node *node,
 		case T_Scan:
 			/* Abstract: Should see only subclasses. */
 			elog(ERROR, "abstract node type not allowed: T_Scan");
+			break;
 
 		case T_SeqScan:
 			{
@@ -505,6 +507,7 @@ plan_tree_mutator(Node *node,
 		case T_Join:
 			/* Abstract: Should see only subclasses. */
 			elog(ERROR, "abstract node type not allowed: T_Join");
+			break;
 
 		case T_NestLoop:
 			{

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -4000,6 +4000,7 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 				case DTX_CONTEXT_QE_READER:
 					elog(FATAL, "Unexpected segment distribute transaction context: '%s'",
 						 DtxContextToString(DistributedTransactionContext));
+					break;
 
 				default:
 					elog(PANIC, "Unexpected segment distribute transaction context value: %d",
@@ -4034,6 +4035,7 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 				case DTX_CONTEXT_QE_READER:
 					elog(PANIC, "Unexpected segment distribute transaction context: '%s'",
 						 DtxContextToString(DistributedTransactionContext));
+					break;
 
 				default:
 					elog(PANIC, "Unexpected segment distribute transaction context value: %d",

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -294,6 +294,7 @@ qdSerializeDtxContextInfo(int *size, bool wantSnapshot, bool inCursor,
 		case DTX_CONTEXT_QE_FINISH_PREPARED:
 			elog(FATAL, "Unexpected distribute transaction context: '%s'",
 				 DtxContextToString(DistributedTransactionContext));
+			break;
 
 		default:
 			elog(FATAL, "Unrecognized DTX transaction context: %d",

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -3943,6 +3943,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 					   (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("Cannot modify subpartition template for partitioned table")));
 			}
+			/* FALL THRU */
 		case AT_PartAdd:				/* Add */
 		case AT_PartAddForSplit:		/* Add, as part of a split */
 		case AT_PartCoalesce:			/* Coalesce */
@@ -12711,6 +12712,7 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation rel,
 		{
 			prepCmd = true; /* if sub-command is split partition then it will require some preprocessing */
 		}
+		/* FALL THRU */
 		case AT_PartAdd:				/* Add */
 		case AT_PartAddForSplit:		/* Add, as part of a split */
 		case AT_PartCoalesce:			/* Coalesce */

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1245,6 +1245,7 @@ get_tablespace_oid(const char *tablespacename, bool missing_ok)
 						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 						 errmsg("could not serialize access to tablespace %s due to concurrent update",
 								tablespacename)));
+				break;
 
 			default:
 				elog(ERROR, "unrecognized heap_lock_tuple_status: %u", lockTest);

--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -586,6 +586,7 @@ ExecMayReturnRawTuples(PlanState *node)
 		case T_MotionState:
 			if (node->lefttree == NULL)
 				return false;
+			/* fallthrough */
 		case T_HashState:
 		case T_MaterialState:
 		case T_UniqueState:

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1057,6 +1057,7 @@ ExecAgg(AggState *node)
 					 * pass through. Be sure that the next case statement
 					 * is HASHAGG_END_OF_PASSES.
 					 */
+					/* fallthrough */
 
 				case HASHAGG_END_OF_PASSES:
 					node->agg_done = true;

--- a/src/backend/regex/regc_lex.c
+++ b/src/backend/regex/regc_lex.c
@@ -854,6 +854,7 @@ lexescape(struct vars * v)
 			/* oops, doesn't look like it's a backref after all... */
 			v->now = save;
 			/* and fall through into octal number */
+			/* fallthrough */
 		case CHR('0'):
 			NOTE(REG_UUNPORT);
 			v->now--;			/* put first digit back */

--- a/src/backend/regex/regcomp.c
+++ b/src/backend/regex/regcomp.c
@@ -863,6 +863,7 @@ parseqatom(struct vars * v,
 			/* legal in EREs due to specification botch */
 			NOTE(REG_UPBOTCH);
 			/* fallthrough into case PLAIN */
+			/* fallthrough */
 		case PLAIN:
 			onechr(v, v->nextvalue, lp, rp);
 			okcolors(v->nfa, v->cm);

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -427,6 +427,7 @@ ProcessRepliesIfAny(void)
 						"Received 'X' as first character in reply from standby. "
 						"Standby is closing down the socket, hence exiting.");
 				proc_exit(0);
+				break;
 
 			default:
 				ereport(FATAL,

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -277,6 +277,7 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid, bool isCommit)
 			case DTX_CONTEXT_QE_FINISH_PREPARED:
 				elog(PANIC, "Unexpected distribute transaction context: '%s'",
 					 DtxContextToString(DistributedTransactionContext));
+				break;
 
 			default:
 				elog(PANIC, "Unrecognized DTX transaction context: %d",

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5455,6 +5455,7 @@ PostgresMain(int argc, char *argv[],
 				 * scenarios.
 				 */
 				proc_exit(0);
+				break;
 
 			case 'd':			/* copy data */
 			case 'c':			/* copy done */

--- a/src/backend/utils/adt/date.c
+++ b/src/backend/utils/adt/date.c
@@ -900,6 +900,7 @@ abstime_date(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				   errmsg("cannot convert reserved abstime value to date")));
+			break;
 
 			/*
 			 * pretend to drop through to make compiler think that result will

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -3448,6 +3448,7 @@ DecodeISO8601Interval(char *str,
 						continue;
 					}
 					/* Else fall through to extended alternative format */
+					/* FALL THROUGH */
 				case '-':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)
@@ -3526,6 +3527,7 @@ DecodeISO8601Interval(char *str,
 						return 0;
 					}
 					/* Else fall through to extended alternative format */
+					/* FALL THROUGH */
 				case ':':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -1102,6 +1102,7 @@ NUMDesc_prepare(NUMDesc *num, FormatNode *n, char *func)
 		case NUM_D:
 			num->flag |= NUM_F_LDECIMAL;
 			num->need_locale = TRUE;
+			/* fallthrough */
 		case NUM_DEC:
 			if (IS_DECIMAL(num))
 			{
@@ -2796,6 +2797,7 @@ DCH_from_char(FormatNode *node, char *in, TmFromChar *out)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("\"TZ\"/\"tz\" format patterns are not supported in to_date")));
+				break;
 			case DCH_A_D:
 			case DCH_B_C:
 			case DCH_a_d:

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -952,6 +952,8 @@ width_bucket_numeric(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 				(errcode(ERRCODE_INVALID_ARGUMENT_FOR_WIDTH_BUCKET_FUNCTION),
 				 errmsg("lower bound cannot equal upper bound")));
+			/* make compiler happy */
+			break;
 
 			/* bound1 < bound2 */
 		case -1:

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -3968,8 +3968,8 @@ isSimpleNode(Node *node, Node *parentNode, int prettyFlags)
 					return false;
 				}
 				/* else do the same stuff as for T_SubLink et al. */
-				/* FALL THROUGH */
 			}
+			/* fallthrough */
 
 		case T_SubLink:
 		case T_NullTest:

--- a/src/backend/utils/adt/timestamp.c
+++ b/src/backend/utils/adt/timestamp.c
@@ -4022,12 +4022,14 @@ timestamp_trunc(PG_FUNCTION_ARGS)
 					tm->tm_year = ((tm->tm_year + 999) / 1000) * 1000 - 999;
 				else
 					tm->tm_year = -((999 - (tm->tm_year - 1)) / 1000) * 1000 + 1;
+				/* FALL THRU */
 			case DTK_CENTURY:
 				/* see comments in timestamptz_trunc */
 				if (tm->tm_year > 0)
 					tm->tm_year = ((tm->tm_year + 99) / 100) * 100 - 99;
 				else
 					tm->tm_year = -((99 - (tm->tm_year - 1)) / 100) * 100 + 1;
+				/* FALL THRU */
 			case DTK_DECADE:
 				/* see comments in timestamptz_trunc */
 				if (val != DTK_MILLENNIUM && val != DTK_CENTURY)
@@ -4037,18 +4039,25 @@ timestamp_trunc(PG_FUNCTION_ARGS)
 					else
 						tm->tm_year = -((8 - (tm->tm_year - 1)) / 10) * 10;
 				}
+				/* FALL THRU */
 			case DTK_YEAR:
 				tm->tm_mon = 1;
+				/* FALL THRU */
 			case DTK_QUARTER:
 				tm->tm_mon = (3 * ((tm->tm_mon - 1) / 3)) + 1;
+				/* FALL THRU */
 			case DTK_MONTH:
 				tm->tm_mday = 1;
+				/* FALL THRU */
 			case DTK_DAY:
 				tm->tm_hour = 0;
+				/* FALL THRU */
 			case DTK_HOUR:
 				tm->tm_min = 0;
+				/* FALL THRU */
 			case DTK_MINUTE:
 				tm->tm_sec = 0;
+				/* FALL THRU */
 			case DTK_SECOND:
 				fsec = 0;
 				break;
@@ -4284,24 +4293,33 @@ interval_trunc(PG_FUNCTION_ARGS)
 				case DTK_MILLENNIUM:
 					/* caution: C division may have negative remainder */
 					tm->tm_year = (tm->tm_year / 1000) * 1000;
+					/* FALL THRU */
 				case DTK_CENTURY:
 					/* caution: C division may have negative remainder */
 					tm->tm_year = (tm->tm_year / 100) * 100;
+					/* FALL THRU */
 				case DTK_DECADE:
 					/* caution: C division may have negative remainder */
 					tm->tm_year = (tm->tm_year / 10) * 10;
+					/* FALL THRU */
 				case DTK_YEAR:
 					tm->tm_mon = 0;
+					/* FALL THRU */
 				case DTK_QUARTER:
 					tm->tm_mon = 3 * (tm->tm_mon / 3);
+					/* FALL THRU */
 				case DTK_MONTH:
 					tm->tm_mday = 0;
+					/* FALL THRU */
 				case DTK_DAY:
 					tm->tm_hour = 0;
+					/* FALL THRU */
 				case DTK_HOUR:
 					tm->tm_min = 0;
+					/* FALL THRU */
 				case DTK_MINUTE:
 					tm->tm_sec = 0;
+					/* FALL THRU */
 				case DTK_SECOND:
 					fsec = 0;
 					break;

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -178,6 +178,7 @@ datumstreamread_getlarge(DatumStreamRead * acc, Datum *datum, bool *null)
 			acc->largeObjectState = DatumStreamLargeObjectState_Consumed;
 
 			/* Fall below to ~_Consumed. */
+			/* fallthrough */
 
 		case DatumStreamLargeObjectState_Consumed:
 			{

--- a/src/backend/utils/error/faultinject.c
+++ b/src/backend/utils/error/faultinject.c
@@ -135,21 +135,26 @@ gp_fault_inject_impl(int32 reason, int64 arg)
 			ereport(ERROR,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("User fault injection raised error")));
+			break;
 		case GP_FAULT_USER_RAISE_FATAL:
 			ereport(FATAL,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("User fault injection raised fatal")));
+			break;
 		case GP_FAULT_USER_RAISE_PANIC:
 			ereport(PANIC,
 					(errcode(ERRCODE_FAULT_INJECT),
 					 errmsg("User fault injection raised panic")));
+			break;
 		case GP_FAULT_USER_PROCEXIT:
 			{
 				extern void proc_exit(int);
 				proc_exit((int) arg);
 			}
+			break;
 		case GP_FAULT_USER_ABORT:
 			abort();
+			break;
 
 		case GP_FAULT_USER_INFINITE_LOOP:
 			{

--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -892,11 +892,17 @@ GpMurmurHash64A (const void * key, int len, unsigned int seed)
 
     switch(len & 7) {
         case 7: h ^= (uint64_t)data[6] << 48;
+		/* fallthrough */
         case 6: h ^= (uint64_t)data[5] << 40;
+		/* fallthrough */
         case 5: h ^= (uint64_t)data[4] << 32;
+		/* fallthrough */
         case 4: h ^= (uint64_t)data[3] << 24;
+		/* fallthrough */
         case 3: h ^= (uint64_t)data[2] << 16;
+		/* fallthrough */
         case 2: h ^= (uint64_t)data[1] << 8;
+		/* fallthrough */
         case 1: h ^= (uint64_t)data[0];
         h *= m;
     };

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -1577,6 +1577,7 @@ FaultInjector_IsFaultInjected(
 			
 			retval = TRUE;
 			/* NO break */
+			/* fallthrough */
 		case FaultInjectorStateFailed:
 			
 			isCompleted = TRUE;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3976,6 +3976,7 @@ AtEOXact_GUC(bool isCommit, int nestLevel)
 				{
 					case GUC_SAVE:
 						Assert(false);	/* can't get here */
+						break;
 
 					case GUC_SET:
 						/* next level always becomes SET */

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1324,6 +1324,7 @@ ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increme
 						costThesholdOvercommitted = true;
 					}
 				}
+				break;
 
 			case RES_MEMORY_LIMIT:
 				{

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -583,6 +583,7 @@ ResLockPortal(Portal portal, QueryDesc *qDesc)
 					break;
 				}
 			}
+			/* fallthrough */
 
 
 			case T_SelectStmt:

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -868,6 +868,7 @@ tuplestore_gettuple(Tuplestorestate *state, bool forward,
 					elog(ERROR, "tuplestore seek failed");
 			state->status = TSS_READFILE;
 			/* FALL THRU into READFILE case */
+			/* fallthrough */
 
 		case TSS_READFILE:
 			*should_free = true;

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -3557,6 +3557,7 @@ main(int argc, char *argv[])
 						  "remove or empty the directory \"%s\".\n"),
 						xlog_dir);
 				exit_nicely();
+				break;
 
 			default:
 				/* Trouble accessing directory */

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -385,6 +385,7 @@ verify_dir_is_empty_or_create(char *dirname)
 					_("%s: directory \"%s\" exists but is not empty\n"),
 					progname, dirname);
 			disconnect_and_exit(1);
+			break;
 		case -1:
 
 			/*

--- a/src/interfaces/ecpg/pgtypeslib/interval.c
+++ b/src/interfaces/ecpg/pgtypeslib/interval.c
@@ -200,6 +200,7 @@ DecodeISO8601Interval(char *str,
 						continue;
 					}
 					/* Else fall through to extended alternative format */
+					/* FALL THROUGH */
 				case '-':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)
@@ -278,6 +279,7 @@ DecodeISO8601Interval(char *str,
 						return 0;
 					}
 					/* Else fall through to extended alternative format */
+					/* FALL THROUGH */
 				case ':':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)

--- a/src/interfaces/ecpg/preproc/ecpg.c
+++ b/src/interfaces/ecpg/preproc/ecpg.c
@@ -200,6 +200,7 @@ main(int argc, char *const argv[])
 				header_mode = true;
 				/* this must include "-c" to make sense */
 				/* so do not place a "break;" here */
+				/* fallthrough */
 			case 'c':
 				auto_create_c = true;
 				break;

--- a/src/interfaces/libpq/fe-secure.c
+++ b/src/interfaces/libpq/fe-secure.c
@@ -642,9 +642,9 @@ retry_masked:
 				case EPIPE:
 					/* Set flag for EPIPE */
 					REMEMBER_EPIPE(spinfo, true);
-					/* FALL THRU */
 
 #ifdef ECONNRESET
+					/* fallthrough */
 				case ECONNRESET:
 #endif
 					printfPQExpBuffer(&conn->errorMessage,

--- a/src/pl/plpgsql/src/pl_exec.c
+++ b/src/pl/plpgsql/src/pl_exec.c
@@ -2466,14 +2466,17 @@ exec_prepare_plan(PLpgSQL_execstate *estate,
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("cannot COPY to/from client in PL/pgSQL")));
+				break;
 			case SPI_ERROR_TRANSACTION:
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("cannot begin/end transactions in PL/pgSQL"),
 						 errhint("Use a BEGIN block with an EXCEPTION clause instead.")));
+				break;
 			default:
 				elog(ERROR, "SPI_prepare_cursor failed for \"%s\": %s",
 					 expr->query, SPI_result_code_string(SPI_result));
+				break;
 		}
 	}
 	expr->plan = SPI_saveplan(plan);
@@ -2628,6 +2631,7 @@ exec_stmt_execsql(PLpgSQL_execstate *estate,
 					 errmsg("cannot COPY to/from client in PL/pgSQL")));
 
 			/* Fixes MPP-3344 */
+			break;
 		case SPI_ERROR_TRANSACTION:
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -2638,6 +2642,7 @@ exec_stmt_execsql(PLpgSQL_execstate *estate,
 		default:
 			elog(ERROR, "SPI_execute_plan failed executing query \"%s\": %s",
 				 expr->query, SPI_result_code_string(rc));
+			break;
 	}
 
 	/* All variants should save result info for GET DIAGNOSTICS */
@@ -2798,11 +2803,13 @@ exec_stmt_dynexecute(PLpgSQL_execstate *estate,
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot COPY to/from client in PL/pgSQL")));
+			break;
 		case SPI_ERROR_TRANSACTION:
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot begin/end transactions in PL/pgSQL"),
 			errhint("Use a BEGIN block with an EXCEPTION clause instead.")));
+			break;
 
 		default:
 			elog(ERROR, "SPI_execute failed executing query \"%s\": %s",

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2490,9 +2490,11 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 			case 'h':
 				help();
 				exit_nicely(0);
+				break;
 			case 'V':
 				puts("pg_regress (PostgreSQL) " PG_VERSION);
 				exit_nicely(0);
+				break;
 			case 1:
 
 				/*


### PR DESCRIPTION
GCC 7+ has a compiling option, -Wimplicit-fallthrough, which will
generate a warning/error if the code falls through cases(or default)
implicitly. The implicity may cause some bugs that are hardly to catch.

1. Append a comment line /* fallthrough */ or like at the end of case block.
2. Add break clause at the end of case block, if the last statement is
  ereport(ERROR) or like.

This PR is related to #8798 , but without changing configure.in and configure.
Because 5X_STABLE is compiled with a lower version of GCC which does not
support `-Wimplicit-fallthrough`

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
