### PR TITLE
5X: Introduce startup memory to vmem tracker

### DIFF
--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -39,9 +39,12 @@
 #include "utils/vmem_tracker.h"
 #include "utils/session_state.h"
 #include "utils/gp_alloc.h"
+#include "utils/guc.h"
 
 #define SHMEM_OOM_TIME "last vmem oom time"
 #define MAX_REQUESTABLE_SIZE 0x7fffffff
+
+static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz);
 
 /*
  * Last OOM time of a segment. Maintained in shared memory.
@@ -196,9 +199,72 @@ void GPMemoryProtect_Shutdown()
 		return;
 	}
 
+	VmemTracker_UnregisterStartupMemory();
+
 	gp_mp_inited = false;
 
 	VmemTracker_Shutdown();
+}
+
+/*
+ * Add the per-process startup committed memory to vmem tracker.
+ *
+ * Postgresql suggests setting vm.overcommit_memory to 2, so system level OOM
+ * is triggered by committed memory size.  Each postgres process has several MB
+ * committed memory since it being forked, in practice the size can be 6~16 MB,
+ * depends on build-time and runtime configurations.
+ *
+ * These memory were not tracked by vmem tracker however, as a result an idle
+ * (just gets launched, or just finished execution) QE process has 0 chunks in
+ * track, but it might have 16MB committed memory.  The vmem tracker protect
+ * limit will never be reached no matter how many such processes there are, but
+ * when there are enough such processes the system level OOM will be triggered,
+ * which will lead to unpredictable failures on not only postgres but also all
+ * the other processes on the system.
+ *
+ * To prevent this worst case we add a startup cost to the vmem tracker, so the
+ * vmem tracker OOM will happen instead of the system one, this is less harmful
+ * and easier to handle.  The startup cost, however, is a hard coded value from
+ * practice for now, we may want to make a better estimation at runtime in the
+ * future.  Another thing to improve is that this startup cost should only be
+ * added when vm.overcommit_memory is 2.
+ */
+void
+GPMemoryProtect_TrackStartupMemory(void)
+{
+	MemoryAllocationStatus status;
+	int64		bytes = 0;
+
+	Assert(gp_mp_inited);
+
+	/*
+	 * When compile without ORCA a postgress process will commit 6MB, this
+	 * includes the memory allocated before vmem tracker initialization.
+	 */
+	bytes += 6L << BITS_IN_MB;
+
+#ifdef USE_ORCA
+	/* When compile with ORCA it will commit 6MB more */
+	bytes += 6L << BITS_IN_MB;
+
+	/*
+	 * When optimizer_use_gpdb_allocators is on, at least 2MB of above will be
+	 * tracked by vmem tracker later, so do not recount them.  This GUC is not
+	 * available until gpdb 5.1.0 .
+	 */
+#if GP_VERSION_NUM >= 50100
+	if (optimizer_use_gpdb_allocators)
+		bytes -= 2L << BITS_IN_MB;
+#endif  /* GP_VERSION_NUM */
+#endif  /* USE_ORCA */
+
+	/* Leave some buffer for extensions like metrics_collector */
+	bytes += 2L << BITS_IN_MB;
+
+	/* Register the startup memory */
+	status = VmemTracker_RegisterStartupMemory(bytes);
+	if (status != MemoryAllocation_Success)
+		gp_failed_to_alloc(status, 0, bytes);
 }
 
 /*

--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -50,6 +50,9 @@ static int32 maxVmemChunksTracked = 0;
 /* Number of bytes tracked (i.e., allocated under the tutelage of vmem tracker) */
 static int64 trackedBytes = 0;
 
+static int64 startupBytes = 0;
+static int32 startupChunks = 0;
+
 /* Vmem quota in chunk unit */
 static int32 vmemChunksQuota = 0;
 /*
@@ -200,7 +203,7 @@ VmemTracker_ReserveVmemChunks(int32 numChunksToReserve)
 	Assert(vmemTrackerInited);
 	Assert(NULL != MySessionState);
 
-	Assert(0 < numChunksToReserve);
+	Assert(0 <= numChunksToReserve);
 	int32 total = pg_atomic_add_fetch_u32((pg_atomic_uint32 *)&MySessionState->sessionVmem, numChunksToReserve);
 	Assert(total > (int32) 0);
 
@@ -383,7 +386,7 @@ VmemTracker_ConvertVmemBytesToChunks(int64 bytes)
 int64
 VmemTracker_GetMaxReservedVmemChunks(void)
 {
-	Assert(maxVmemChunksTracked >= trackedVmemChunks);
+	Assert(maxVmemChunksTracked >= trackedVmemChunks - startupChunks);
 	return maxVmemChunksTracked;
 }
 
@@ -393,7 +396,7 @@ VmemTracker_GetMaxReservedVmemChunks(void)
 int64
 VmemTracker_GetMaxReservedVmemMB(void)
 {
-	Assert(maxVmemChunksTracked >= trackedVmemChunks);
+	Assert(maxVmemChunksTracked >= trackedVmemChunks - startupChunks);
 	return CHUNKS_TO_MB(maxVmemChunksTracked);
 }
 
@@ -403,7 +406,7 @@ VmemTracker_GetMaxReservedVmemMB(void)
 int64
 VmemTracker_GetMaxReservedVmemBytes(void)
 {
-	Assert(maxVmemChunksTracked >= trackedVmemChunks);
+	Assert(maxVmemChunksTracked >= trackedVmemChunks - startupChunks);
 	return CHUNKS_TO_BYTES(maxVmemChunksTracked);
 }
 
@@ -519,7 +522,7 @@ VmemTracker_ReserveVmem(int64 newlyRequestedBytes)
 {
 	if (!VmemTrackerIsActivated())
 	{
-		Assert(0 == trackedVmemChunks);
+		Assert(0 == trackedVmemChunks - startupChunks);
 		return MemoryAllocation_Success;
 	}
 
@@ -601,7 +604,7 @@ VmemTracker_ReleaseVmem(int64 toBeFreedRequested)
 	   (IsResGroupEnabled() &&
 		!IsResGroupActivated()))
 	{
-		Assert(0 == trackedVmemChunks);
+		Assert(0 == trackedVmemChunks - startupChunks);
 		return;
 	}
 
@@ -612,10 +615,10 @@ VmemTracker_ReleaseVmem(int64 toBeFreedRequested)
 	 * because a bug somewhere that tries to release vmem for allocations made before the vmem
 	 * system was initialized.
 	 */
-	int64 toBeFreed = Min(trackedBytes, toBeFreedRequested);
+	int64 toBeFreed = Min(trackedBytes - startupBytes, toBeFreedRequested);
 	if (0 == toBeFreed)
 	{
-		Assert(0 == trackedVmemChunks);
+		Assert(0 == trackedVmemChunks - startupChunks);
 		return;
 	}
 
@@ -629,6 +632,72 @@ VmemTracker_ReleaseVmem(int64 toBeFreedRequested)
 
 		VmemTracker_ReleaseVmemChunks(reduction);
 	}
+}
+
+/*
+ * Register the startup memory to vmem tracker.
+ *
+ * The startup memory will always be tracked, but an OOM error will be raised
+ * if the memory usage exceeds the limits.
+ */
+MemoryAllocationStatus
+VmemTracker_RegisterStartupMemory(int64 bytes)
+{
+	int64		chunkSizeInBytes;
+
+	Assert(vmemTrackerInited);
+
+	chunkSizeInBytes = 1L << VmemTracker_GetChunkSizeInBits();
+
+	/* Align to chunks */
+	startupChunks = BYTES_TO_CHUNKS(bytes + chunkSizeInBytes - 1);
+	startupBytes = CHUNKS_TO_BYTES(startupChunks);
+
+	/*
+	 * Step 1, add the startup memory forcefully as these memory were already
+	 * in-use before the call to this function.
+	 *
+	 * Do not add the startup memory to resource group as resource group only
+	 * tracks memory allocated via vmem tracker.
+	 */
+
+	trackedBytes += startupBytes;
+	trackedVmemChunks += startupChunks;
+
+	if (MySessionState)
+		pg_atomic_add_fetch_u32((pg_atomic_uint32 *) &MySessionState->sessionVmem,
+								startupChunks);
+
+	pg_atomic_add_fetch_u32((pg_atomic_uint32 *) segmentVmemChunks,
+							startupChunks);
+
+	/*
+	 * Step 2, check if an OOM error should be raised by allocating 0 chunk.
+	 */
+
+	return VmemTracker_ReserveVmemChunks(0);
+}
+
+/*
+ * Unregister the startup memory from vmem tracker.
+ */
+void
+VmemTracker_UnregisterStartupMemory(void)
+{
+	Assert(vmemTrackerInited);
+
+	pg_atomic_sub_fetch_u32((pg_atomic_uint32 *) segmentVmemChunks,
+							startupChunks);
+
+	if (MySessionState)
+		pg_atomic_sub_fetch_u32((pg_atomic_uint32 *) &MySessionState->sessionVmem,
+								startupChunks);
+
+	trackedBytes -= startupBytes;
+	trackedVmemChunks -= startupChunks;
+
+	startupBytes = 0;
+	startupChunks = 0;
 }
 
 /*

--- a/src/backend/utils/resource_manager/resource_manager.c
+++ b/src/backend/utils/resource_manager/resource_manager.c
@@ -19,6 +19,7 @@
 #include "utils/guc.h"
 #include "utils/resource_manager.h"
 #include "utils/resgroup-ops.h"
+#include "utils/session_state.h"
 #include "replication/walsender.h"
 #include "executor/spi.h"
 
@@ -117,4 +118,9 @@ InitResManager(void)
 	{
 		SPI_InitMemoryReservation();
 	}
+
+	if (MySessionState &&
+		!am_walsender &&
+		(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE))
+		GPMemoryProtect_TrackStartupMemory();
 }

--- a/src/include/utils/palloc.h
+++ b/src/include/utils/palloc.h
@@ -175,6 +175,7 @@ extern void InitPerProcessOOMTracking(void);
 extern void GPMemoryProtect_ShmemInit(void);
 extern void GPMemoryProtect_Init(void);
 extern void GPMemoryProtect_Shutdown(void);
+extern void GPMemoryProtect_TrackStartupMemory(void);
 extern void UpdateTimeAtomically(volatile OOMTimeType* time_var);
 
 /*

--- a/src/include/utils/vmem_tracker.h
+++ b/src/include/utils/vmem_tracker.h
@@ -61,6 +61,8 @@ extern void VmemTracker_Shutdown(void);
 extern void VmemTracker_ResetMaxVmemReserved(void);
 extern MemoryAllocationStatus VmemTracker_ReserveVmem(int64 newly_requested);
 extern void VmemTracker_ReleaseVmem(int64 to_be_freed_requested);
+extern MemoryAllocationStatus VmemTracker_RegisterStartupMemory(int64 bytes);
+extern void VmemTracker_UnregisterStartupMemory(void);
 extern void VmemTracker_RequestWaiver(int64 waiver_bytes);
 extern void VmemTracker_ResetWaiver(void);
 extern int64 VmemTracker_Fault(int32 reason, int64 arg);

--- a/src/test/isolation2/expected/oom_startup_memory.out
+++ b/src/test/isolation2/expected/oom_startup_memory.out
@@ -1,0 +1,102 @@
+-- OOM should be raised when there are too many idle processes.
+--
+-- We have below assumptions in the tests:
+-- - number of primary segments: 3;
+-- - the startup memory cost for a postgres process: 8MB ~ 14MB;
+-- - per query limit: 20MB;
+-- - per segment limit: 60MB;
+
+-- start_matchsubs
+--
+-- m/DETAIL:  Per-query VM protect limit reached: current limit is \d+ kB, requested \d+ bytes, available \d+ MB/
+-- s/\d+/XXX/g
+--
+-- m/DETAIL:  VM Protect failed to allocate \d+ bytes, \d+ MB available/
+-- s/\d+/XXX/g
+--
+-- m/(seg\d+ \d+.\d+.\d+.\d+:\d+)/
+-- s/(.*)/(seg<ID> IP:PORT)/
+--
+-- end_matchsubs
+
+--
+-- To reach the per query limit we need at least 3 slices in one query.
+--
+
+1: select * from gp_dist_random('gp_id') t1 join gp_dist_random('gp_id') t2 using(gpname) join gp_dist_random('gp_id') t3 using(gpname) join gp_dist_random('gp_id') t4 using(gpname) ;
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  FATAL:  Out of memory
+DETAIL:  Per-query VM protect limit reached: current limit is 20480 kB, requested 8388608 bytes, available 0 MB
+ (seg0 192.168.99.100:25432)
+1q: ... <quitting>
+
+--
+-- To reach the per segment limit we need at least 8 concurrent sessions.
+--
+
+-- However the per segment limit is not enforced on QD, so below QD-only
+-- sessions could all run successfully.
+1: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+3: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+4: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+5: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+6: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+7: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+8: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+-- The per segment limit should be reached on one or more QEs in below
+-- sessions, we only care about the last one.
+-- start_ignore
+1: set gp_vmem_idle_resource_timeout to '1h';
+SET
+2: set gp_vmem_idle_resource_timeout to '1h';
+SET
+3: set gp_vmem_idle_resource_timeout to '1h';
+SET
+4: set gp_vmem_idle_resource_timeout to '1h';
+SET
+5: set gp_vmem_idle_resource_timeout to '1h';
+SET
+6: set gp_vmem_idle_resource_timeout to '1h';
+SET
+7: set gp_vmem_idle_resource_timeout to '1h';
+SET
+-- end_ignore
+8: set gp_vmem_idle_resource_timeout to '1h';
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  FATAL:  Out of memory
+DETAIL:  VM Protect failed to allocate 8388608 bytes, 0 MB available
+ (seg0 192.168.99.100:25432)

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -9,18 +9,18 @@ CREATE LANGUAGE plpythonu;
 ! mkdir @cgroup_mnt_point@/cpuset/gpdb;
 -- end_ignore
 
--- we want to simulate a 3-primary cluster with 2GB memory and
--- gp_resource_group_memory_limit=100%, suppose:
+-- we want to simulate a 3-segment (both master and primary) cluster with 2GB
+-- memory and gp_resource_group_memory_limit=100%, suppose:
 --
 -- - total: the total memory on the system;
--- - nseg: the max per-host segment count (including both master and primaries);
+-- - nsegs: the max per-host segment count (including both master and primaries);
 -- - limit: the gp_resource_group_memory_limit used for the simulation;
 --
 -- then we have: total * limit / nsegs = 2GB * 1.0 / 3
 -- so: limit = 2GB * 1.0 / 3 * nsegs / total
 --
 -- with the simulation each primary segment should manage 682MB memory.
-CREATE OR REPLACE FUNCTION adjust_memory_limit(nsegs bigint) RETURNS int AS $$
+DO LANGUAGE plpythonu $$
     import os
     import psutil
 
@@ -29,17 +29,18 @@ CREATE OR REPLACE FUNCTION adjust_memory_limit(nsegs bigint) RETURNS int AS $$
     overcommit = int(open('/proc/sys/vm/overcommit_ratio').readline())
     total = swap + mem * overcommit / 100.
 
+    nsegs = int(plpy.execute('''
+        SELECT count(hostname) as nsegs
+          FROM gp_segment_configuration
+         WHERE preferred_role = 'p'
+         GROUP BY hostname
+         ORDER BY count(hostname) DESC
+         LIMIT 1
+    ''')[0]['nsegs'])
+
     limit = (2 << 30) * 1.0 * nsegs / 3 / total
-    return os.system('gpconfig -c gp_resource_group_memory_limit -v {:f}'.format(limit))
-$$ LANGUAGE plpythonu VOLATILE;
-
-SELECT adjust_memory_limit(count(hostname)) FROM gp_segment_configuration
- WHERE preferred_role = 'p'
- GROUP BY hostname
- ORDER BY count(hostname) DESC
- LIMIT 1;
-
-DROP FUNCTION adjust_memory_limit(bigint);
+    os.system('gpconfig -c gp_resource_group_memory_limit -v {:f}'.format(limit))
+$$;
 
 -- enable resource group and restart cluster.
 -- start_ignore

--- a/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
@@ -1,7 +1,5 @@
 -- start_ignore
-DROP VIEW IF EXISTS busy;
 DROP VIEW IF EXISTS cancel_all;
-DROP TABLE IF EXISTS bigtable;
 DROP ROLE IF EXISTS role1_cpu_test;
 DROP ROLE IF EXISTS role2_cpu_test;
 DROP RESOURCE GROUP rg1_cpu_test;
@@ -60,29 +58,29 @@ def verify_cpu_usage():
 return verify_cpu_usage()
 $$ LANGUAGE plpythonu;
 
-CREATE TABLE bigtable AS
-    SELECT i AS c1, 'abc' AS c2
-    FROM generate_series(1,50000) i;
+CREATE OR REPLACE FUNCTION busy() RETURNS void AS $$
+    import os
+    import signal
 
-CREATE VIEW busy AS
-    SELECT count(*)
-    FROM
-    bigtable t1,
-    bigtable t2,
-    bigtable t3,
-    bigtable t4,
-    bigtable t5
-    WHERE 0 = (t1.c1 % 2 + 10000)!
-      AND 0 = (t2.c1 % 2 + 10000)!
-      AND 0 = (t3.c1 % 2 + 10000)!
-      AND 0 = (t4.c1 % 2 + 10000)!
-      AND 0 = (t5.c1 % 2 + 10000)!
-    ;
+    n = 15
+    for i in xrange(n):
+        if os.fork() == 0:
+			# children must quit without invoking the atexit hooks
+            signal.signal(signal.SIGINT,  lambda a, b: os._exit(0))
+            signal.signal(signal.SIGQUIT, lambda a, b: os._exit(0))
+            signal.signal(signal.SIGTERM, lambda a, b: os._exit(0))
+
+            # generate pure cpu load
+            while True:
+                pass
+
+    os.wait()
+$$ LANGUAGE plpythonu;
 
 CREATE VIEW cancel_all AS
     SELECT pg_cancel_backend(procpid)
     FROM pg_stat_activity
-    WHERE current_query LIKE 'SELECT * FROM busy%';
+    WHERE current_query LIKE 'SELECT * FROM % WHERE busy%';
 
 --
 -- check gpdb cgroup configuration
@@ -121,8 +119,8 @@ CREATE RESOURCE GROUP rg2_cpu_test WITH (concurrency=5, cpu_rate_limit=20, memor
 -- create two roles and assign them to above groups
 CREATE ROLE role1_cpu_test RESOURCE GROUP rg1_cpu_test;
 CREATE ROLE role2_cpu_test RESOURCE GROUP rg2_cpu_test;
-GRANT ALL ON busy TO role1_cpu_test;
-GRANT ALL ON busy TO role2_cpu_test;
+GRANT ALL ON FUNCTION busy() TO role1_cpu_test;
+GRANT ALL ON FUNCTION busy() TO role2_cpu_test;
 
 -- prepare parallel queries in the two groups
 10: SET ROLE TO role1_cpu_test;
@@ -153,11 +151,11 @@ GRANT ALL ON busy TO role2_cpu_test;
 -- so the cpu usage shall be 90%
 --
 
-10&: SELECT * FROM busy;
-11&: SELECT * FROM busy;
-12&: SELECT * FROM busy;
-13&: SELECT * FROM busy;
-14&: SELECT * FROM busy;
+10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
 
 -- start_ignore
 TRUNCATE TABLE cpu_usage_samples;
@@ -196,6 +194,18 @@ SELECT * FROM cancel_all;
 14<:
 -- end_ignore
 
+10q:
+11q:
+12q:
+13q:
+14q:
+
+10: SET ROLE TO role1_cpu_test;
+11: SET ROLE TO role1_cpu_test;
+12: SET ROLE TO role1_cpu_test;
+13: SET ROLE TO role1_cpu_test;
+14: SET ROLE TO role1_cpu_test;
+
 --
 -- when there are multiple groups with parallel queries,
 -- they should share the cpu usage by their cpu_usage settings,
@@ -206,17 +216,17 @@ SELECT * FROM cancel_all;
 -- - rg2_cpu_test gets 90% * 2/3 => 60%;
 --
 
-10&: SELECT * FROM busy;
-11&: SELECT * FROM busy;
-12&: SELECT * FROM busy;
-13&: SELECT * FROM busy;
-14&: SELECT * FROM busy;
+10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
 
-20&: SELECT * FROM busy;
-21&: SELECT * FROM busy;
-22&: SELECT * FROM busy;
-23&: SELECT * FROM busy;
-24&: SELECT * FROM busy;
+20&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+21&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+22&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+23&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+24&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
 
 -- start_ignore
 TRUNCATE TABLE cpu_usage_samples;
@@ -266,8 +276,8 @@ SELECT * FROM cancel_all;
 ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 10;
 
 -- cleanup
-REVOKE ALL ON busy FROM role1_cpu_test;
-REVOKE ALL ON busy FROM role2_cpu_test;
+REVOKE ALL ON FUNCTION busy() FROM role1_cpu_test;
+REVOKE ALL ON FUNCTION busy() FROM role2_cpu_test;
 DROP ROLE role1_cpu_test;
 DROP ROLE role2_cpu_test;
 DROP RESOURCE GROUP rg1_cpu_test;

--- a/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
@@ -4,13 +4,13 @@ DROP ROLE IF EXISTS role1_cpu_test;
 DROP ROLE IF EXISTS role2_cpu_test;
 DROP RESOURCE GROUP rg1_cpu_test;
 DROP RESOURCE GROUP rg2_cpu_test;
-DROP LANGUAGE IF EXISTS plpythonu;
+
+CREATE LANGUAGE plpythonu;
 -- end_ignore
 
 --
 -- helper functions, tables and views
 --
-CREATE LANGUAGE plpythonu;
 
 DROP TABLE IF EXISTS cpu_usage_samples;
 CREATE TABLE cpu_usage_samples (sample text);
@@ -19,16 +19,17 @@ CREATE TABLE cpu_usage_samples (sample text);
 -- and dump them into text in json format then save them in db for
 -- further analysis.
 CREATE OR REPLACE FUNCTION fetch_sample() RETURNS text AS $$
-import pygresql.pg as pg
-import json
+    import json
 
-conn = pg.connect(dbname="isolation2resgrouptest")
-group_cpus = conn.query("select rsgname, cpu_usage from gp_toolkit.gp_resgroup_status")\
-                 .getresult()
-json_text = json.dumps(dict([(name, json.loads(cpu)) for name, cpu in group_cpus]))
-sql = "insert into cpu_usage_samples values ('{value}')".format(value=json_text)
-conn.query(sql)
-return json_text
+    group_cpus = plpy.execute('''
+        SELECT rsgname, cpu_usage FROM gp_toolkit.gp_resgroup_status
+    ''')
+    json_text = json.dumps(dict([(row['rsgname'], json.loads(row['cpu_usage']))
+                                 for row in group_cpus]))
+    plpy.execute('''
+        INSERT INTO cpu_usage_samples VALUES ('{value}')
+    '''.format(value=json_text))
+    return json_text
 $$ LANGUAGE plpythonu;
 
 -- verify_cpu_usage: calculate each QE's average cpu usage using all the data in
@@ -36,26 +37,26 @@ $$ LANGUAGE plpythonu;
 -- return true if the practical value is close to the expected value.
 CREATE OR REPLACE FUNCTION verify_cpu_usage(groupname TEXT, expect_cpu_usage INT, err_rate INT)
 RETURNS BOOL AS $$
-import pygresql.pg as pg
-import json
+    import json
 
-conn = pg.connect(dbname="isolation2resgrouptest")
+    def add_vector(vec1, vec2):
+        r = dict()
+        for seg_id1, value1 in vec1.items():
+            r[seg_id1] = value1 + vec2[seg_id1]
+        return r
 
-def add_vector(vec1, vec2):
-    r = dict()
-    for seg_id1, value1 in vec1.items():
-        r[seg_id1] = value1 + vec2[seg_id1]
-    return r
+    def verify_cpu_usage():
+        all_info = plpy.execute('''
+            SELECT sample::json->'{name}' AS cpu FROM cpu_usage_samples
+        '''.format(name=groupname))
+        usage_sum = reduce(add_vector,
+                           [json.loads(row['cpu']) for row in all_info])
+        usage = [(float(v) / all_info.nrows())
+                 for k, v in usage_sum.items() if k != "-1"]
+        avg = sum(usage) / len(usage)
+        return abs(avg - expect_cpu_usage) <= err_rate
 
-
-def verify_cpu_usage():
-    all_info = conn.query("select sample from cpu_usage_samples").getresult()
-    usage_sum = reduce(add_vector, [json.loads(info)[groupname] for info, in all_info])
-    usage = [(float(v) / len(all_info)) for k, v in usage_sum.items() if k != "-1"]
-    avg = sum(usage) / len(usage)
-    return abs(avg - expect_cpu_usage) <= err_rate
-
-return verify_cpu_usage()
+    return verify_cpu_usage()
 $$ LANGUAGE plpythonu;
 
 CREATE OR REPLACE FUNCTION busy() RETURNS void AS $$
@@ -82,39 +83,76 @@ CREATE VIEW cancel_all AS
     FROM pg_stat_activity
     WHERE current_query LIKE 'SELECT * FROM % WHERE busy%';
 
---
--- check gpdb cgroup configuration
---
--- cfs_quota_us := cfs_period_us * ncores * gp_resource_group_cpu_limit
--- shares := 1024 * gp_resource_group_cpu_priority
---
-
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_quota_us) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_period_us) * $(nproc) * $(psql -d isolation2resgrouptest -Aqtc "SHOW gp_resource_group_cpu_limit"))";
-
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * $(psql -d isolation2resgrouptest -Aqtc "SHOW gp_resource_group_cpu_priority")";
-
---
--- check default groups configuration
---
--- SUB/shares := TOP/shares * cpu_rate_limit
---
-
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/$(psql -d isolation2resgrouptest -Aqtc "SELECT oid FROM pg_resgroup WHERE rsgname='default_group'")/cpu.shares) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) * $(psql -d isolation2resgrouptest -Aqtc "SELECT value FROM pg_resgroupcapability c, pg_resgroup g WHERE c.resgroupid=g.oid AND reslimittype=2 AND g.rsgname='default_group'") / 100)";
-
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/$(psql -d isolation2resgrouptest -Aqtc "SELECT oid FROM pg_resgroup WHERE rsgname='admin_group'")/cpu.shares) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) * $(psql -d isolation2resgrouptest -Aqtc "SELECT value FROM pg_resgroupcapability c, pg_resgroup g WHERE c.resgroupid=g.oid AND reslimittype=2 AND g.rsgname='admin_group'") / 100)";
-
--- lower admin_group's cpu_rate_limit to minimize its side effect
-ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 1;
-
 -- create two resource groups
 CREATE RESOURCE GROUP rg1_cpu_test WITH (concurrency=5, cpu_rate_limit=10, memory_limit=20);
 CREATE RESOURCE GROUP rg2_cpu_test WITH (concurrency=5, cpu_rate_limit=20, memory_limit=20);
 
--- check rg1_cpu_test configuration
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/$(psql -d isolation2resgrouptest -Aqtc "SELECT oid FROM pg_resgroup WHERE rsgname='rg1_cpu_test'")/cpu.shares) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) * 0.1)";
+--
+-- check gpdb cgroup configuration
+--
+DO LANGUAGE PLPYTHONU $$
+    import subprocess
 
--- check rg2_cpu_test configuration
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/$(psql -d isolation2resgrouptest -Aqtc "SELECT oid FROM pg_resgroup WHERE rsgname='rg2_cpu_test'")/cpu.shares) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) * 0.2)";
+    cgroot = '@cgroup_mnt_point@'
+
+    def get_cgroup_prop(prop):
+        fullpath = cgroot + '/' + prop
+        return int(open(fullpath).readline())
+
+    def run_command(cmd):
+        return subprocess.check_output(cmd.split())
+
+    def show_guc(guc):
+        return plpy.execute('SHOW {}'.format(guc))[0][guc]
+
+    #
+    # check gpdb top-level cgroup configuration
+    #
+
+    # get top-level cgroup props
+    cfs_quota_us = get_cgroup_prop('/cpu/gpdb/cpu.cfs_quota_us')
+    cfs_period_us = get_cgroup_prop('/cpu/gpdb/cpu.cfs_period_us')
+    shares = get_cgroup_prop('/cpu/gpdb/cpu.shares')
+
+    # get system props
+    ncores = int(run_command('nproc'))
+
+    # get global gucs
+    gp_resource_group_cpu_limit = float(show_guc('gp_resource_group_cpu_limit'))
+    gp_resource_group_cpu_priority = int(show_guc('gp_resource_group_cpu_priority'))
+
+    # cfs_quota_us := cfs_period_us * ncores * gp_resource_group_cpu_limit
+    assert cfs_quota_us == cfs_period_us * ncores * gp_resource_group_cpu_limit
+
+    # shares := 1024 * gp_resource_group_cpu_priority
+    assert shares == 1024 * gp_resource_group_cpu_priority
+
+    # SUB/shares := TOP/shares * cpu_rate_limit
+    def check_group_shares(name):
+        cpu_rate_limit = int(plpy.execute('''
+            SELECT value
+              FROM pg_resgroupcapability c, pg_resgroup g
+             WHERE c.resgroupid=g.oid
+               AND reslimittype=2
+               AND g.rsgname='{}'
+        '''.format(name))[0]['value'])
+        oid = int(plpy.execute('''
+            SELECT oid FROM pg_resgroup WHERE rsgname='{}'
+        '''.format(name))[0]['oid'])
+        sub_shares = get_cgroup_prop('/cpu/gpdb/{}/cpu.shares'.format(oid))
+        assert sub_shares == shares * cpu_rate_limit / 100
+
+    # check default groups
+    check_group_shares('default_group')
+    check_group_shares('admin_group')
+
+    # check user groups
+    check_group_shares('rg1_cpu_test')
+    check_group_shares('rg2_cpu_test')
+$$;
+
+-- lower admin_group's cpu_rate_limit to minimize its side effect
+ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 1;
 
 -- create two roles and assign them to above groups
 CREATE ROLE role1_cpu_test RESOURCE GROUP rg1_cpu_test;

--- a/src/test/isolation2/output/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup.source
@@ -16,30 +16,22 @@ CREATE
 
 -- end_ignore
 
--- we want to simulate a 3-primary cluster with 2GB memory and
--- gp_resource_group_memory_limit=100%, suppose:
+-- we want to simulate a 3-segment (both master and primary) cluster with 2GB
+-- memory and gp_resource_group_memory_limit=100%, suppose:
 --
 -- - total: the total memory on the system;
--- - nseg: the max per-host segment count (including both master and primaries);
+-- - nsegs: the max per-host segment count (including both master and primaries);
 -- - limit: the gp_resource_group_memory_limit used for the simulation;
 --
 -- then we have: total * limit / nsegs = 2GB * 1.0 / 3
 -- so: limit = 2GB * 1.0 / 3 * nsegs / total
 --
 -- with the simulation each primary segment should manage 682MB memory.
-CREATE OR REPLACE FUNCTION adjust_memory_limit(nsegs bigint) RETURNS int AS $$ import os import psutil 
+DO LANGUAGE plpythonu $$ import os import psutil 
 mem = psutil.virtual_memory().total swap = psutil.swap_memory().total overcommit = int(open('/proc/sys/vm/overcommit_ratio').readline()) total = swap + mem * overcommit / 100. 
-limit = (2 << 30) * 1.0 * nsegs / 3 / total return os.system('gpconfig -c gp_resource_group_memory_limit -v {:f}'.format(limit)) $$ LANGUAGE plpythonu VOLATILE;
-CREATE
-
-SELECT adjust_memory_limit(count(hostname)) FROM gp_segment_configuration WHERE preferred_role = 'p' GROUP BY hostname ORDER BY count(hostname) DESC LIMIT 1;
-adjust_memory_limit
--------------------
-0                  
-(1 row)
-
-DROP FUNCTION adjust_memory_limit(bigint);
-DROP
+nsegs = int(plpy.execute(''' SELECT count(hostname) as nsegs FROM gp_segment_configuration WHERE preferred_role = 'p' GROUP BY hostname ORDER BY count(hostname) DESC LIMIT 1 ''')[0]['nsegs']) 
+limit = (2 << 30) * 1.0 * nsegs / 3 / total os.system('gpconfig -c gp_resource_group_memory_limit -v {:f}'.format(limit)) $$;
+DO
 
 -- enable resource group and restart cluster.
 -- start_ignore

--- a/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
@@ -9,15 +9,14 @@ DROP RESOURCE GROUP rg1_cpu_test;
 ERROR:  resource group "rg1_cpu_test" does not exist
 DROP RESOURCE GROUP rg2_cpu_test;
 ERROR:  resource group "rg2_cpu_test" does not exist
-DROP LANGUAGE IF EXISTS plpythonu;
-DROP
+
+CREATE LANGUAGE plpythonu;
+CREATE
 -- end_ignore
 
 --
 -- helper functions, tables and views
 --
-CREATE LANGUAGE plpythonu;
-CREATE
 
 DROP TABLE IF EXISTS cpu_usage_samples;
 DROP
@@ -27,18 +26,16 @@ CREATE
 -- fetch_sample: select cpu_usage from gp_toolkit.gp_resgroup_status
 -- and dump them into text in json format then save them in db for
 -- further analysis.
-CREATE OR REPLACE FUNCTION fetch_sample() RETURNS text AS $$ import pygresql.pg as pg import json 
-conn = pg.connect(dbname="isolation2resgrouptest") group_cpus = conn.query("select rsgname, cpu_usage from gp_toolkit.gp_resgroup_status")\ .getresult() json_text = json.dumps(dict([(name, json.loads(cpu)) for name, cpu in group_cpus])) sql = "insert into cpu_usage_samples values ('{value}')".format(value=json_text) conn.query(sql) return json_text $$ LANGUAGE plpythonu;
+CREATE OR REPLACE FUNCTION fetch_sample() RETURNS text AS $$ import json 
+group_cpus = plpy.execute(''' SELECT rsgname, cpu_usage FROM gp_toolkit.gp_resgroup_status ''') json_text = json.dumps(dict([(row['rsgname'], json.loads(row['cpu_usage'])) for row in group_cpus])) plpy.execute(''' INSERT INTO cpu_usage_samples VALUES ('{value}') '''.format(value=json_text)) return json_text $$ LANGUAGE plpythonu;
 CREATE
 
 -- verify_cpu_usage: calculate each QE's average cpu usage using all the data in
 -- the table cpu_usage_sample. And compare the average value to the expected value.
 -- return true if the practical value is close to the expected value.
-CREATE OR REPLACE FUNCTION verify_cpu_usage(groupname TEXT, expect_cpu_usage INT, err_rate INT) RETURNS BOOL AS $$ import pygresql.pg as pg import json 
-conn = pg.connect(dbname="isolation2resgrouptest") 
+CREATE OR REPLACE FUNCTION verify_cpu_usage(groupname TEXT, expect_cpu_usage INT, err_rate INT) RETURNS BOOL AS $$ import json 
 def add_vector(vec1, vec2): r = dict() for seg_id1, value1 in vec1.items(): r[seg_id1] = value1 + vec2[seg_id1] return r 
-
-def verify_cpu_usage(): all_info = conn.query("select sample from cpu_usage_samples").getresult() usage_sum = reduce(add_vector, [json.loads(info)[groupname] for info, in all_info]) usage = [(float(v) / len(all_info)) for k, v in usage_sum.items() if k != "-1"] avg = sum(usage) / len(usage) return abs(avg - expect_cpu_usage) <= err_rate 
+def verify_cpu_usage(): all_info = plpy.execute(''' SELECT sample::json->'{name}' AS cpu FROM cpu_usage_samples '''.format(name=groupname)) usage_sum = reduce(add_vector, [json.loads(row['cpu']) for row in all_info]) usage = [(float(v) / all_info.nrows()) for k, v in usage_sum.items() if k != "-1"] avg = sum(usage) / len(usage) return abs(avg - expect_cpu_usage) <= err_rate 
 return verify_cpu_usage() $$ LANGUAGE plpythonu;
 CREATE
 
@@ -51,54 +48,34 @@ CREATE
 CREATE VIEW cancel_all AS SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE current_query LIKE 'SELECT * FROM % WHERE busy%';
 CREATE
 
---
--- check gpdb cgroup configuration
---
--- cfs_quota_us := cfs_period_us * ncores * gp_resource_group_cpu_limit
--- shares := 1024 * gp_resource_group_cpu_priority
---
-
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_quota_us) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.cfs_period_us) * $(nproc) * $(psql -d isolation2resgrouptest -Aqtc "SHOW gp_resource_group_cpu_limit"))";
-True
-
-
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) == 1024 * $(psql -d isolation2resgrouptest -Aqtc "SHOW gp_resource_group_cpu_priority")";
-True
-
-
---
--- check default groups configuration
---
--- SUB/shares := TOP/shares * cpu_rate_limit
---
-
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/$(psql -d isolation2resgrouptest -Aqtc "SELECT oid FROM pg_resgroup WHERE rsgname='default_group'")/cpu.shares) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) * $(psql -d isolation2resgrouptest -Aqtc "SELECT value FROM pg_resgroupcapability c, pg_resgroup g WHERE c.resgroupid=g.oid AND reslimittype=2 AND g.rsgname='default_group'") / 100)";
-True
-
-
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/$(psql -d isolation2resgrouptest -Aqtc "SELECT oid FROM pg_resgroup WHERE rsgname='admin_group'")/cpu.shares) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) * $(psql -d isolation2resgrouptest -Aqtc "SELECT value FROM pg_resgroupcapability c, pg_resgroup g WHERE c.resgroupid=g.oid AND reslimittype=2 AND g.rsgname='admin_group'") / 100)";
-True
-
-
--- lower admin_group's cpu_rate_limit to minimize its side effect
-ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 1;
-ALTER
-
 -- create two resource groups
 CREATE RESOURCE GROUP rg1_cpu_test WITH (concurrency=5, cpu_rate_limit=10, memory_limit=20);
 CREATE
 CREATE RESOURCE GROUP rg2_cpu_test WITH (concurrency=5, cpu_rate_limit=20, memory_limit=20);
 CREATE
 
--- check rg1_cpu_test configuration
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/$(psql -d isolation2resgrouptest -Aqtc "SELECT oid FROM pg_resgroup WHERE rsgname='rg1_cpu_test'")/cpu.shares) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) * 0.1)";
-True
+--
+-- check gpdb cgroup configuration
+--
+DO LANGUAGE PLPYTHONU $$ import subprocess 
+cgroot = '@cgroup_mnt_point@' 
+def get_cgroup_prop(prop): fullpath = cgroot + '/' + prop return int(open(fullpath).readline()) 
+def run_command(cmd): return subprocess.check_output(cmd.split()) 
+def show_guc(guc): return plpy.execute('SHOW {}'.format(guc))[0][guc] 
+# # check gpdb top-level cgroup configuration # 
+# get top-level cgroup props cfs_quota_us = get_cgroup_prop('/cpu/gpdb/cpu.cfs_quota_us') cfs_period_us = get_cgroup_prop('/cpu/gpdb/cpu.cfs_period_us') shares = get_cgroup_prop('/cpu/gpdb/cpu.shares') 
+# get system props ncores = int(run_command('nproc')) 
+# get global gucs gp_resource_group_cpu_limit = float(show_guc('gp_resource_group_cpu_limit')) gp_resource_group_cpu_priority = int(show_guc('gp_resource_group_cpu_priority')) 
+# cfs_quota_us := cfs_period_us * ncores * gp_resource_group_cpu_limit assert cfs_quota_us == cfs_period_us * ncores * gp_resource_group_cpu_limit 
+# shares := 1024 * gp_resource_group_cpu_priority assert shares == 1024 * gp_resource_group_cpu_priority 
+# SUB/shares := TOP/shares * cpu_rate_limit def check_group_shares(name): cpu_rate_limit = int(plpy.execute(''' SELECT value FROM pg_resgroupcapability c, pg_resgroup g WHERE c.resgroupid=g.oid AND reslimittype=2 AND g.rsgname='{}' '''.format(name))[0]['value']) oid = int(plpy.execute(''' SELECT oid FROM pg_resgroup WHERE rsgname='{}' '''.format(name))[0]['oid']) sub_shares = get_cgroup_prop('/cpu/gpdb/{}/cpu.shares'.format(oid)) assert sub_shares == shares * cpu_rate_limit / 100 
+# check default groups check_group_shares('default_group') check_group_shares('admin_group') 
+# check user groups check_group_shares('rg1_cpu_test') check_group_shares('rg2_cpu_test') $$;
+DO
 
-
--- check rg2_cpu_test configuration
-! python -c "print $(cat @cgroup_mnt_point@/cpu/gpdb/$(psql -d isolation2resgrouptest -Aqtc "SELECT oid FROM pg_resgroup WHERE rsgname='rg2_cpu_test'")/cpu.shares) == int($(cat @cgroup_mnt_point@/cpu/gpdb/cpu.shares) * 0.2)";
-True
-
+-- lower admin_group's cpu_rate_limit to minimize its side effect
+ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 1;
+ALTER
 
 -- create two roles and assign them to above groups
 CREATE ROLE role1_cpu_test RESOURCE GROUP rg1_cpu_test;

--- a/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
@@ -1,9 +1,5 @@
 -- start_ignore
-DROP VIEW IF EXISTS busy;
-DROP
 DROP VIEW IF EXISTS cancel_all;
-DROP
-DROP TABLE IF EXISTS bigtable;
 DROP
 DROP ROLE IF EXISTS role1_cpu_test;
 DROP
@@ -46,13 +42,13 @@ def verify_cpu_usage(): all_info = conn.query("select sample from cpu_usage_samp
 return verify_cpu_usage() $$ LANGUAGE plpythonu;
 CREATE
 
-CREATE TABLE bigtable AS SELECT i AS c1, 'abc' AS c2 FROM generate_series(1,50000) i;
-CREATE 50000
-
-CREATE VIEW busy AS SELECT count(*) FROM bigtable t1, bigtable t2, bigtable t3, bigtable t4, bigtable t5 WHERE 0 = (t1.c1 % 2 + 10000)! AND 0 = (t2.c1 % 2 + 10000)! AND 0 = (t3.c1 % 2 + 10000)! AND 0 = (t4.c1 % 2 + 10000)! AND 0 = (t5.c1 % 2 + 10000)! ;
+CREATE OR REPLACE FUNCTION busy() RETURNS void AS $$ import os import signal 
+n = 15 for i in xrange(n): if os.fork() == 0: # children must quit without invoking the atexit hooks signal.signal(signal.SIGINT,  lambda a, b: os._exit(0)) signal.signal(signal.SIGQUIT, lambda a, b: os._exit(0)) signal.signal(signal.SIGTERM, lambda a, b: os._exit(0)) 
+# generate pure cpu load while True: pass 
+os.wait() $$ LANGUAGE plpythonu;
 CREATE
 
-CREATE VIEW cancel_all AS SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE current_query LIKE 'SELECT * FROM busy%';
+CREATE VIEW cancel_all AS SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE current_query LIKE 'SELECT * FROM % WHERE busy%';
 CREATE
 
 --
@@ -109,9 +105,9 @@ CREATE ROLE role1_cpu_test RESOURCE GROUP rg1_cpu_test;
 CREATE
 CREATE ROLE role2_cpu_test RESOURCE GROUP rg2_cpu_test;
 CREATE
-GRANT ALL ON busy TO role1_cpu_test;
+GRANT ALL ON FUNCTION busy() TO role1_cpu_test;
 GRANT
-GRANT ALL ON busy TO role2_cpu_test;
+GRANT ALL ON FUNCTION busy() TO role2_cpu_test;
 GRANT
 
 -- prepare parallel queries in the two groups
@@ -153,11 +149,11 @@ SET
 -- so the cpu usage shall be 90%
 --
 
-10&: SELECT * FROM busy;  <waiting ...>
-11&: SELECT * FROM busy;  <waiting ...>
-12&: SELECT * FROM busy;  <waiting ...>
-13&: SELECT * FROM busy;  <waiting ...>
-14&: SELECT * FROM busy;  <waiting ...>
+10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
 
 -- start_ignore
 TRUNCATE TABLE cpu_usage_samples;
@@ -295,6 +291,23 @@ ERROR:  canceling statement due to user request
 ERROR:  canceling statement due to user request
 -- end_ignore
 
+10q: ... <quitting>
+11q: ... <quitting>
+12q: ... <quitting>
+13q: ... <quitting>
+14q: ... <quitting>
+
+10: SET ROLE TO role1_cpu_test;
+SET
+11: SET ROLE TO role1_cpu_test;
+SET
+12: SET ROLE TO role1_cpu_test;
+SET
+13: SET ROLE TO role1_cpu_test;
+SET
+14: SET ROLE TO role1_cpu_test;
+SET
+
 --
 -- when there are multiple groups with parallel queries,
 -- they should share the cpu usage by their cpu_usage settings,
@@ -305,17 +318,17 @@ ERROR:  canceling statement due to user request
 -- - rg2_cpu_test gets 90% * 2/3 => 60%;
 --
 
-10&: SELECT * FROM busy;  <waiting ...>
-11&: SELECT * FROM busy;  <waiting ...>
-12&: SELECT * FROM busy;  <waiting ...>
-13&: SELECT * FROM busy;  <waiting ...>
-14&: SELECT * FROM busy;  <waiting ...>
+10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
 
-20&: SELECT * FROM busy;  <waiting ...>
-21&: SELECT * FROM busy;  <waiting ...>
-22&: SELECT * FROM busy;  <waiting ...>
-23&: SELECT * FROM busy;  <waiting ...>
-24&: SELECT * FROM busy;  <waiting ...>
+20&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+21&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+22&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+23&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+24&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
 
 -- start_ignore
 TRUNCATE TABLE cpu_usage_samples;
@@ -479,9 +492,9 @@ ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 10;
 ALTER
 
 -- cleanup
-REVOKE ALL ON busy FROM role1_cpu_test;
+REVOKE ALL ON FUNCTION busy() FROM role1_cpu_test;
 REVOKE
-REVOKE ALL ON busy FROM role2_cpu_test;
+REVOKE ALL ON FUNCTION busy() FROM role2_cpu_test;
 REVOKE
 DROP ROLE role1_cpu_test;
 DROP

--- a/src/test/isolation2/sql/oom_startup_memory.sql
+++ b/src/test/isolation2/sql/oom_startup_memory.sql
@@ -1,0 +1,60 @@
+-- OOM should be raised when there are too many idle processes.
+--
+-- We have below assumptions in the tests:
+-- - number of primary segments: 3;
+-- - the startup memory cost for a postgres process: 8MB ~ 14MB;
+-- - per query limit: 20MB;
+-- - per segment limit: 60MB;
+
+-- start_matchsubs
+--
+-- m/DETAIL:  Per-query VM protect limit reached: current limit is \d+ kB, requested \d+ bytes, available \d+ MB/
+-- s/\d+/XXX/g
+--
+-- m/DETAIL:  VM Protect failed to allocate \d+ bytes, \d+ MB available/
+-- s/\d+/XXX/g
+--
+-- m/(seg\d+ \d+.\d+.\d+.\d+:\d+)/
+-- s/(.*)/(seg<ID> IP:PORT)/
+--
+-- end_matchsubs
+
+--
+-- To reach the per query limit we need at least 3 slices in one query.
+--
+
+1: select *
+     from gp_dist_random('gp_id') t1
+     join gp_dist_random('gp_id') t2 using(gpname)
+     join gp_dist_random('gp_id') t3 using(gpname)
+     join gp_dist_random('gp_id') t4 using(gpname)
+   ;
+1q:
+
+--
+-- To reach the per segment limit we need at least 8 concurrent sessions.
+--
+
+-- However the per segment limit is not enforced on QD, so below QD-only
+-- sessions could all run successfully.
+1: select 1;
+2: select 1;
+3: select 1;
+4: select 1;
+5: select 1;
+6: select 1;
+7: select 1;
+8: select 1;
+
+-- The per segment limit should be reached on one or more QEs in below
+-- sessions, we only care about the last one.
+-- start_ignore
+1: set gp_vmem_idle_resource_timeout to '1h';
+2: set gp_vmem_idle_resource_timeout to '1h';
+3: set gp_vmem_idle_resource_timeout to '1h';
+4: set gp_vmem_idle_resource_timeout to '1h';
+5: set gp_vmem_idle_resource_timeout to '1h';
+6: set gp_vmem_idle_resource_timeout to '1h';
+7: set gp_vmem_idle_resource_timeout to '1h';
+-- end_ignore
+8: set gp_vmem_idle_resource_timeout to '1h';

--- a/src/test/isolation2/sql/setup_startup_memory_accounting.sql
+++ b/src/test/isolation2/sql/setup_startup_memory_accounting.sql
@@ -1,0 +1,6 @@
+-- start_ignore
+! gpconfig -c gp_vmem_limit_per_query -v '20MB' --skipvalidation
+! gpconfig -c gp_vmem_protect_limit -v '60'
+! gpconfig -c runaway_detector_activation_percent -v 0
+! gpstop -rai;
+-- end_ignore


### PR DESCRIPTION
Add the per-process startup committed memory to vmem tracker

Postgresql suggests setting vm.overcommit_memory to 2, so system level
OOM is triggered by committed memory size.  Each postgres process has
several MB committed memory since it being forked, in practice the size
can be 6~16 MB, depends on build-time and runtime configurations.

These memory were not tracked by vmem tracker however, as a result an
idle (just gets launched, or just finished execution) QE process has 0
chunks in track, but it might have 16MB committed memory.  The vmem
tracker protect limit will never be reached no matter how many such
processes there are, but when there are enough such processes the system
level OOM will be triggered, which will lead to unpredictable failures
on not only postgres but also other processes on the system.

To prevent this worst case we add a startup memory cost to the vmem
tracker, so the vmem tracker OOM will happen instead of the system one,
this is less harmful and easier to handle.  The startup cost, however,
is a hard coded value from practice for now.  It will have different
values when the gpdb binary is compiled with or without ORCA, but anyway
it's hard coded.  We may want to make a better detection / estimation at
runtime in the future.  Another improvement to make is that this startup
cost should only be added when vm.overcommit_memory is 2.

The startup memory is only tracked at vmem tracker, resource group does
not track or check it.

A startup memory OOM test is provided, however we have to disable the
original isolation2 OOM tests as they rely on a small per-query limit
which should be just 2MB greater than the startup memory, but as the
startup memory size varies we could not set a fixed limit for the tests.

This is the 5X version of https://github.com/greenplum-db/gpdb/pull/8800 .

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
- [x] Greenlight from PM team
