### PR TITLE
Fix session ID assignment to utility mode connections

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1469,7 +1469,7 @@ LockCheckConflicts(LockMethod lockMethodTable,
 		 * If I'm not part of MPP session, consider I am only one process
 		 * in a session.
 		 */
-		if (mppSessionId <= 0)
+		if (mppSessionId == InvalidGpSessionId)
 		{
 			LOCKMASK	myLocks = proclock->holdMask;
 			if (myLocks & LOCKBIT_ON(i))

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -149,6 +149,7 @@ extern bool Gp_is_writer;
  * session throughout the entire Greenplum array.
  */
 extern int gp_session_id;
+#define InvalidGpSessionId	(-1)
 
 /* The Hostname where this segment's QD is located. This variable is NULL for the QD itself */
 extern char * qdHostname;

--- a/src/test/isolation2/expected/reader_waits_for_lock.out
+++ b/src/test/isolation2/expected/reader_waits_for_lock.out
@@ -18,6 +18,14 @@ CREATE 1
 BEGIN
 0U: LOCK reader_waits_for_lock_table IN ACCESS EXCLUSIVE MODE;
 LOCK
+-- A utility mode connection should not have valid gp_session_id, else
+-- locks aquired by it may not confict with locks requested by a
+-- normal mode backend.
+0U: show gp_session_id;
+ gp_session_id 
+---------------
+ -1            
+(1 row)
 -- creates reader and writer gang
 1&: SELECT t1.* FROM reader_waits_for_lock_table t1 INNER JOIN reader_waits_for_lock_table t2 ON t1.b = t2.b;  <waiting ...>
 -- all processes in the session 1 should be blocked

--- a/src/test/isolation2/expected/vacuum_drop_phase_ao.out
+++ b/src/test/isolation2/expected/vacuum_drop_phase_ao.out
@@ -25,6 +25,14 @@ BEGIN
 -------
  5     
 (1 row)
+-- A utility mode connection should not have valid gp_session_id, else
+-- locks aquired by it may not confict with locks requested by a
+-- normal mode backend.
+0U: show gp_session_id;
+ gp_session_id 
+---------------
+ -1            
+(1 row)
 
 -- And we delete 4/5 rows to trigger vacuum's compaction phase.
 1: DELETE FROM ao_test_drop_phase where b != 5;

--- a/src/test/isolation2/sql/reader_waits_for_lock.sql
+++ b/src/test/isolation2/sql/reader_waits_for_lock.sql
@@ -30,6 +30,10 @@ $$ language plpgsql;
 1: CREATE TABLE reader_waits_for_lock_table_sessionid(a, setting) AS SELECT 1, setting::int FROM pg_settings WHERE name = 'gp_session_id' distributed by (a);
 0U: BEGIN;
 0U: LOCK reader_waits_for_lock_table IN ACCESS EXCLUSIVE MODE;
+-- A utility mode connection should not have valid gp_session_id, else
+-- locks aquired by it may not confict with locks requested by a
+-- normal mode backend.
+0U: show gp_session_id;
 -- creates reader and writer gang
 1&: SELECT t1.* FROM reader_waits_for_lock_table t1 INNER JOIN reader_waits_for_lock_table t2 ON t1.b = t2.b;
 -- all processes in the session 1 should be blocked

--- a/src/test/isolation2/sql/vacuum_drop_phase_ao.sql
+++ b/src/test/isolation2/sql/vacuum_drop_phase_ao.sql
@@ -14,6 +14,10 @@
 -- an access shared lock that would exist on the QE but not on the QD.
 0U: BEGIN;
 0U: SELECT COUNT(*) FROM ao_test_drop_phase;
+-- A utility mode connection should not have valid gp_session_id, else
+-- locks aquired by it may not confict with locks requested by a
+-- normal mode backend.
+0U: show gp_session_id;
 
 -- And we delete 4/5 rows to trigger vacuum's compaction phase.
 1: DELETE FROM ao_test_drop_phase where b != 5;


### PR DESCRIPTION
In utility mode on a segment, a valid value should not be assigned to gp_session_id.  Otherwise, it may conflict with session ID dispatched by master (QD) to QE backends.  One problem with such a conflict is a lock acquired by a utility backend may not block a QE backend when it should. LockCheckConflicts() treats locks acqiured by all processes having the same session ID as one.  We have seen false positives in CI due to this bug, such as reader_waits_for_locks, vacuum_drop_phase_ao.

The patch fixes it such that utility mode connections started on a segment postmaster will not set gp_session_id, leaving it initialized to -1.  Utility connections on master, however, will continue to get a valid gp_session_id.  This will never conflict because session IDs should be generated only on master by incrementing an integer counter atomically.

Co-authored-by: Ning Yu <nyu@pivotal.io>