### PR TITLE
docs - fix custom hash operator class example

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-table.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-table.xml
@@ -271,7 +271,7 @@ CREATE OPERATOR |=| (
             <p>Now, create a hash function and operator class that uses the
               operator.<codeblock>CREATE FUNCTION abshashfunc(int) RETURNS int AS
 $$
-  begin return hashint(abs($1)); end;
+  begin return hashint4(abs($1)); end;
 $$ LANGUAGE plpgsql STRICT IMMUTABLE;
 
 CREATE OPERATOR CLASS abs_int_hash_ops FOR TYPE int4
@@ -319,25 +319,37 @@ CREATE TABLE btab (b int) DISTRIBUTED BY (b abs_int_hash_ops);
 INSERT INTO atab VALUES (-1), (0), (1);
 INSERT INTO btab VALUES (-1), (0), (1), (2);</codeblock></p>
             <p>Queries that perform a join that use the custom equality operator
-                <codeph>|=|</codeph> can take advantage of the co-location. With the default integer
-              opclass, this query would require Redistribute Motion nodes, but with the custom
-              opclass, a more efficient plan is
-              possible.<codeblock>EXPLAIN (COSTS OFF) SELECT a, b FROM atab, btab WHERE a = b;
+                <codeph>|=|</codeph> can take advantage of the co-location. </p>
+            <p>With the default integer opclass, this query requires Redistribute Motion nodes.</p>
+            <p>
+              <codeblock>EXPLAIN (COSTS OFF) SELECT a, b FROM atab, btab WHERE a = b;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Gather Motion 4:1  (slice3; segments: 4)
+   ->  Hash Join
+         Hash Cond: (atab.a = btab.b)
+         ->  Redistribute Motion 4:4  (slice1; segments: 4)
+               Hash Key: atab.a
+               ->  Seq Scan on atab
+         ->  Hash
+               ->  Redistribute Motion 4:4  (slice2; segments: 4)
+                     Hash Key: btab.b
+                     ->  Seq Scan on btab
+ Optimizer: Postgres query optimizer
+(11 rows)</codeblock>
+            </p>
+            <p> With the custom opclass, a more efficient plan is
+              possible.<codeblock>EXPLAIN (COSTS OFF) SELECT a, b FROM atab, btab WHERE a |=| b;
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
-   -&gt;  Hash Join
-         Hash Cond: (btab.b = atab.a)
-         -&gt;  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: btab.b
-               -&gt;  Seq Scan on btab
-         -&gt;  Hash
-               -&gt;  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: atab.a
-                     -&gt;  Seq Scan on atab
+  Gather Motion 4:1  (slice1; segments: 4)
+   ->  Hash Join
+         Hash Cond: (atab.a |=| btab.b)
+         ->  Seq Scan on atab
+         ->  Hash
+               ->  Seq Scan on btab
  Optimizer: Postgres query optimizer
-(11 rows)
-</codeblock></p>
+(7 rows)</codeblock></p>
           </section>
         </body>
       </topic>


### PR DESCRIPTION
- The hash function needs to call hashint4(), not hashint().

- Add a join example using the custom operator |=| to demonstrate difference in plans. 



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
