### PR TITLE
Avoid panic with DEBUG5 enabled

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4780,8 +4780,6 @@ PostgresMain(int argc, char *argv[],
 	 */
 	if (sigsetjmp(local_sigjmp_buf, 1) != 0)
 	{
-		elog(DEBUG5, "error caught. jumped back to PostgresMain local_sigjmp_buf");
-		
 		/*
 		 * NOTE: if you are tempted to add more code in this if-block,
 		 * consider the high probability that it should be in


### PR DESCRIPTION
elog(DEBUG5) inside PostgresMain() after sigsetjmp() seems bad
idea. This is the place where control jumps in-case error happens in
normal flow. Shouldn't be performing elog() without handling that
error first. write_stderr() exists to write the exact thing being
intended with this elog(). Having elog(DEBUG5) is causing SIGSEGV.

Simple repro for the same is:
```sql
SET log_min_messages=debug5;
SELECT xmlconcat('bad', '<syntax');
```
This fixes #8733 github issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
