### PR TITLE
(6X) Put checking dk_opfamily ahead when test equaility for locus.

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -80,6 +80,9 @@ cdbpathlocus_equal(CdbPathLocus a, CdbPathLocus b)
 			DistributionKey *adistkey = (DistributionKey *) lfirst(acell);
 			DistributionKey *bdistkey = (DistributionKey *) lfirst(bcell);
 
+			if (adistkey->dk_opfamily != bdistkey->dk_opfamily)
+				return false;
+
 			foreach(b_ec_cell, bdistkey->dk_eclasses)
 			{
 				EquivalenceClass *b_ec = (EquivalenceClass *) lfirst(b_ec_cell);
@@ -92,9 +95,6 @@ cdbpathlocus_equal(CdbPathLocus a, CdbPathLocus b)
 				EquivalenceClass *a_ec = (EquivalenceClass *) lfirst(a_ec_cell);
 
 				if (!list_member_ptr(bdistkey->dk_eclasses, a_ec))
-					return false;
-
-				if (adistkey->dk_opfamily != bdistkey->dk_opfamily)
 					return false;
 			}
 		}


### PR DESCRIPTION
The code to test dk_opfamily should be put ahead.

--------------

This has been reviewed for master. Cherry-pick it to 6X.

No case needed. It just makes the code more readable.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
