### PR TITLE
ic: tcp: init incoming conns before outgoing conns

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1279,10 +1279,6 @@ SetupTCPInterconnect(EState *estate)
 
 	gp_set_monotonic_begin_time(&startTime);
 
-	/* Initiate outgoing connections. */
-	if (mySlice->parentIndex != -1)
-		sendingChunkTransportState = startOutgoingConnections(interconnect_context, mySlice, &expectedTotalOutgoing);
-
 	/* now we'll do some setup for each of our Receiving Motion Nodes. */
 	foreach(cell, mySlice->children)
 	{
@@ -1311,6 +1307,17 @@ SetupTCPInterconnect(EState *estate)
 
 		(void) createChunkTransportState(interconnect_context, aSlice, mySlice, totalNumProcs);
 	}
+
+	/*
+	 * Initiate outgoing connections.
+	 *
+	 * startOutgoingConnections() and createChunkTransportState() must not be
+	 * called during the lifecycle of sendingChunkTransportState, they will
+	 * repalloc() interconnect_context->states so sendingChunkTransportState
+	 * points to invalid memory.
+	 */
+	if (mySlice->parentIndex != -1)
+		sendingChunkTransportState = startOutgoingConnections(interconnect_context, mySlice, &expectedTotalOutgoing);
 
 	if (expectedTotalIncoming > listenerBacklog)
 		ereport(WARNING, (errmsg("SetupTCPInterconnect: too many expected incoming connections(%d), Interconnect setup might possibly fail", expectedTotalIncoming),


### PR DESCRIPTION
In SetupTCPInterconnect() we initialize both incoming and outgoing
connections, a state pointer sendingChunkTransportState is created to
track the status of outgoing connections, it is an entry of the states
array, we expect the pointer to be valid during the function.

However, after we get this pointer we will initialize the incoming
connections, they will resize the states array with repalloc(), so
sendingChunkTransportState will point to invalid memory and crash at
runtime.

To fix that we should initialize the incoming connections before the
outgoing ones, so the sendingChunkTransportState pointer stays valid
during its lifecycle.

Tests are not added as it has chances to be triggered by existing tests.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
