### PR TITLE
Fix lock mode in heap_close

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1554,7 +1554,7 @@ dbid_get_dbinfo(int16 dbid)
 	}
 
 	systable_endscan(scan);
-	heap_close(rel, NoLock);
+	heap_close(rel, AccessShareLock);
 
 	return i;
 }


### PR DESCRIPTION
Lock mode in heap_close is not consistent with heap_open

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
