### PR TITLE
Subquery's locus should keep general

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -299,6 +299,15 @@ cdbpathlocus_from_subquery(struct PlannerInfo *root,
 				 */
 				if (flow->locustype == CdbLocusType_SegmentGeneral)
 					CdbPathLocus_MakeSegmentGeneral(&locus, numsegments);
+				else if (flow->locustype == CdbLocusType_General)
+				{
+					/*
+					 * If a subquery's locus is general, we should keep it
+					 * general here. And general locus's numsegments should
+					 * be the cluster size.
+					 */
+					CdbPathLocus_MakeGeneral(&locus, getgpsegmentCount());
+				}
 				else
 					CdbPathLocus_MakeSingleQE(&locus, numsegments);
 			}

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -80,7 +80,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 
 -- cte with function scans
 with cte as (select generate_series(1,10) g)  select * from  dd_singlecol_1 t1, cte where t1.a=cte.g and t1.a=1 limit 100;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | b | g 
 ---+---+---

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -5524,12 +5524,12 @@ select * from
     lateral (select q1, coalesce(ss1.x,q2) as y from int8_tbl d) ss2
   ) on c.q2 = ss2.q1,
   lateral (select ss2.y offset 0) ss3;
-                                                                                     QUERY PLAN                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop
+                                                                                        QUERY PLAN                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
    Output: c.q1, c.q2, a.q1, a.q2, b.q1, (COALESCE(b.q2, '42'::bigint)), d.q1, (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)), ((COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)))
-   ->  Gather Motion 3:1  (slice4; segments: 3)
-         Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, '42'::bigint)), (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2))
+   ->  Nested Loop
+         Output: c.q1, c.q2, a.q1, a.q2, b.q1, (COALESCE(b.q2, '42'::bigint)), d.q1, (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)), ((COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)))
          ->  Hash Right Join
                Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, '42'::bigint)), (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2))
                Hash Cond: (d.q1 = c.q2)
@@ -5558,10 +5558,10 @@ select * from
                            Hash Key: c.q2
                            ->  Seq Scan on public.int8_tbl c
                                  Output: c.q1, c.q2
-   ->  Materialize
-         Output: ((COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)))
-         ->  Result
-               Output: (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2))
+         ->  Materialize
+               Output: ((COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)))
+               ->  Result
+                     Output: (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2))
  Optimizer: Postgres query optimizer
  Settings: optimizer=off
 (38 rows)
@@ -5690,9 +5690,9 @@ select * from
   lateral (select f1 from int4_tbl
            where f1 = any (select unique1 from tenk1
                            where unique2 = v.x offset 0)) ss;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Nested Loop
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: "*VALUES*".column1, "*VALUES*".column2, int4_tbl.f1
    ->  Values Scan on "*VALUES*"
          Output: "*VALUES*".column1, "*VALUES*".column2

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1138,3 +1138,28 @@ explain select * from (t_joinsize_1 join t_joinsize_2 on t_joinsize_1.c2 = t_joi
 drop table t_joinsize_1;
 drop table t_joinsize_2;
 drop table t_joinsize_3;
+-- test if subquery locus is general, then
+-- we should keep it general
+create table t_randomly_dist_table(c int) distributed randomly;
+-- the following plan should not contain redistributed motion (for planner)
+explain
+select * from (
+  select a from generate_series(1, 10)a
+  union all
+  select a from generate_series(1, 10)a
+) t_subquery_general
+join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=65.00..27369.76 rows=192600 width=8)
+   ->  Hash Join  (cost=65.00..27369.76 rows=64200 width=8)
+         Hash Cond: (t_randomly_dist_table.c = a.a)
+         ->  Seq Scan on t_randomly_dist_table  (cost=0.00..1063.00 rows=32100 width=4)
+         ->  Hash  (cost=40.00..40.00 rows=667 width=4)
+               ->  Append  (cost=0.00..20.00 rows=667 width=4)
+                     ->  Function Scan on generate_series a  (cost=0.00..10.00 rows=334 width=4)
+                     ->  Function Scan on generate_series a_1  (cost=0.00..10.00 rows=334 width=4)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+drop table t_randomly_dist_table;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1141,3 +1141,32 @@ explain select * from (t_joinsize_1 join t_joinsize_2 on t_joinsize_1.c2 = t_joi
 drop table t_joinsize_1;
 drop table t_joinsize_2;
 drop table t_joinsize_3;
+-- test if subquery locus is general, then
+-- we should keep it general
+create table t_randomly_dist_table(c int) distributed randomly;
+-- the following plan should not contain redistributed motion (for planner)
+explain
+select * from (
+  select a from generate_series(1, 10)a
+  union all
+  select a from generate_series(1, 10)a
+) t_subquery_general
+join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+   ->  Hash Join  (cost=0.00..431.15 rows=1 width=8)
+         Hash Cond: (generate_series.generate_series = t_randomly_dist_table.c)
+         ->  Append  (cost=0.00..0.03 rows=667 width=4)
+               ->  Result  (cost=0.00..0.01 rows=334 width=4)
+                     ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
+               ->  Result  (cost=0.00..0.01 rows=334 width=4)
+                     ->  Function Scan on generate_series generate_series_1  (cost=0.00..0.00 rows=334 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     Hash Key: t_randomly_dist_table.c
+                     ->  Seq Scan on t_randomly_dist_table  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.77.0
+(13 rows)
+
+drop table t_randomly_dist_table;

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -5617,12 +5617,12 @@ select * from
     lateral (select q1, coalesce(ss1.x,q2) as y from int8_tbl d) ss2
   ) on c.q2 = ss2.q1,
   lateral (select ss2.y offset 0) ss3;
-                                                                                     QUERY PLAN                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop
+                                                                                        QUERY PLAN                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
    Output: c.q1, c.q2, a.q1, a.q2, b.q1, (COALESCE(b.q2, '42'::bigint)), d.q1, (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)), ((COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)))
-   ->  Gather Motion 3:1  (slice4; segments: 3)
-         Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, '42'::bigint)), (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2))
+   ->  Nested Loop
+         Output: c.q1, c.q2, a.q1, a.q2, b.q1, (COALESCE(b.q2, '42'::bigint)), d.q1, (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)), ((COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)))
          ->  Hash Right Join
                Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, '42'::bigint)), (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2))
                Hash Cond: (d.q1 = c.q2)
@@ -5651,13 +5651,12 @@ select * from
                            Hash Key: c.q2
                            ->  Seq Scan on public.int8_tbl c
                                  Output: c.q1, c.q2
-   ->  Materialize
-         Output: ((COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)))
-         ->  Result
-               Output: (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2))
+         ->  Materialize
+               Output: ((COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)))
+               ->  Result
+                     Output: (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2))
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(38 rows)
+(37 rows)
 
 -- case that breaks the old ph_may_need optimization
 explain (verbose, costs off)
@@ -5782,31 +5781,29 @@ select * from
   lateral (select f1 from int4_tbl
            where f1 = any (select unique1 from tenk1
                            where unique2 = v.x offset 0)) ss;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: "*VALUES*".column1, "*VALUES*".column2, int4_tbl.f1
    ->  Nested Loop
          Output: "*VALUES*".column1, "*VALUES*".column2, int4_tbl.f1
-         Join Filter: (SubPlan 1)
          ->  Values Scan on "*VALUES*"
                Output: "*VALUES*".column1, "*VALUES*".column2
-         ->  Materialize
+         ->  Seq Scan on public.int4_tbl
                Output: int4_tbl.f1
-               ->  Seq Scan on public.int4_tbl
-                     Output: int4_tbl.f1
-         SubPlan 1
-           ->  Result
-                 Output: tenk1.unique1
-                 Filter: (tenk1.unique2 = "*VALUES*".column2)
-                 ->  Materialize
-                       Output: tenk1.unique1, tenk1.unique2
-                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+               Filter: (SubPlan 1)
+               SubPlan 1
+                 ->  Result
+                       Output: tenk1.unique1
+                       Filter: (tenk1.unique2 = "*VALUES*".column2)
+                       ->  Materialize
                              Output: tenk1.unique1, tenk1.unique2
-                             ->  Seq Scan on public.tenk1
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                    Output: tenk1.unique1, tenk1.unique2
+                                   ->  Seq Scan on public.tenk1
+                                         Output: tenk1.unique1, tenk1.unique2
  Optimizer: Postgres query optimizer
-(22 rows)
+(20 rows)
 
 select * from
   (values (0,9998), (1,1000)) v(id,x),

--- a/src/test/regress/expected/qp_functions_in_subquery.out
+++ b/src/test/regress/expected/qp_functions_in_subquery.out
@@ -334,9 +334,9 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(5)) r order by 1,2,3;
 
 -- @description function_in_subqry_12.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(5)) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_13.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(5)) r order by 1,2,3;
@@ -365,7 +365,7 @@ rollback;
 -- @description function_in_subqry_16.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(5)) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
@@ -3360,25 +3360,25 @@ PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_110.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_113.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_116.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_118.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_119.sql
 begin;
@@ -3389,50 +3389,50 @@ PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_120.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_121.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_stb(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_122.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_imm(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_123.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_124.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_stb(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_125.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_imm(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_126.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_127.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_stb(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_128.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_129.sql
 begin;
@@ -3683,32 +3683,28 @@ rollback;
 -- @description function_in_subqry_withfunc2_150.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_153.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_156.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_158.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
@@ -3722,63 +3718,63 @@ rollback;
 -- @description function_in_subqry_withfunc2_160.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_161.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_stb(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_162.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_imm(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_163.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_164.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_stb(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_165.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_imm(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_166.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_167.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_stb(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_168.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;

--- a/src/test/regress/expected/qp_functions_in_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_functions_in_subquery_optimizer.out
@@ -3368,25 +3368,25 @@ PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_110.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=28827)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_113.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=28827)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_116.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=28827)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_118.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=28827)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_119.sql
 begin;
@@ -3397,9 +3397,9 @@ PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_120.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=28827)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_121.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg1 slice1 172.17.0.6:25433 pid=118087)
@@ -3412,9 +3412,9 @@ CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_123.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=28827)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_124.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg1 slice1 172.17.0.6:25433 pid=118087)
@@ -3427,9 +3427,9 @@ CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_126.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=28827)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_127.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg1 slice1 172.17.0.6:25433 pid=118087)
@@ -3438,9 +3438,9 @@ PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT r
 -- @description function_in_subqry_withfunc2_128.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=28827)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_129.sql
 begin;
@@ -3691,32 +3691,28 @@ rollback;
 -- @description function_in_subqry_withfunc2_150.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=28827)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_153.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=28827)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_156.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=28827)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_158.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=28827)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
@@ -3730,7 +3726,7 @@ rollback;
 -- @description function_in_subqry_withfunc2_160.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=28827)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
@@ -3751,7 +3747,7 @@ rollback;
 -- @description function_in_subqry_withfunc2_163.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=28827)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
@@ -3772,7 +3768,7 @@ rollback;
 -- @description function_in_subqry_withfunc2_166.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=28827)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
@@ -3786,7 +3782,7 @@ rollback;
 -- @description function_in_subqry_withfunc2_168.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=28827)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -1997,20 +1997,21 @@ create function extractq2_2(t int8_tbl) returns table(ret1 int8) as $$
 $$ language sql immutable;
 explain (verbose, costs off)
 select x from int8_tbl, extractq2_2(int8_tbl) f(x);
-                   QUERY PLAN                   
-------------------------------------------------
- Nested Loop
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ((int8_tbl.*).q2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ((int8_tbl.*).q2)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ((int8_tbl.*).q2)
-         ->  Result
-               Output: (int8_tbl.*).q2
+         ->  Materialize
+               Output: ((int8_tbl.*).q2)
+               ->  Result
+                     Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer
-(11 rows)
+ Settings: optimizer=off
+(12 rows)
 
 select x from int8_tbl, extractq2_2(int8_tbl) f(x);
          x         
@@ -2054,23 +2055,24 @@ create function extractq2_append(t int8_tbl) returns table(ret1 int8) as $$
 $$ language sql immutable;
 explain (verbose, costs off)
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
-                   QUERY PLAN                   
-------------------------------------------------
- Nested Loop
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ((int8_tbl.*).q2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ((int8_tbl.*).q2)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ((int8_tbl.*).q2)
-         ->  Append
-               ->  Result
-                     Output: (int8_tbl.*).q2
-               ->  Result
-                     Output: (int8_tbl.*).q2
+         ->  Materialize
+               Output: ((int8_tbl.*).q2)
+               ->  Append
+                     ->  Result
+                           Output: (int8_tbl.*).q2
+                     ->  Result
+                           Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer
-(14 rows)
+ Settings: optimizer=off
+(15 rows)
 
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
          x         

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -1999,20 +1999,21 @@ create function extractq2_2(t int8_tbl) returns table(ret1 int8) as $$
 $$ language sql immutable;
 explain (verbose, costs off)
 select x from int8_tbl, extractq2_2(int8_tbl) f(x);
-                   QUERY PLAN                   
-------------------------------------------------
- Nested Loop
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ((int8_tbl.*).q2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ((int8_tbl.*).q2)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ((int8_tbl.*).q2)
-         ->  Result
-               Output: (int8_tbl.*).q2
+         ->  Materialize
+               Output: ((int8_tbl.*).q2)
+               ->  Result
+                     Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer
-(11 rows)
+ Settings: optimizer=on
+(12 rows)
 
 select x from int8_tbl, extractq2_2(int8_tbl) f(x);
          x         
@@ -2056,23 +2057,24 @@ create function extractq2_append(t int8_tbl) returns table(ret1 int8) as $$
 $$ language sql immutable;
 explain (verbose, costs off)
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
-                   QUERY PLAN                   
-------------------------------------------------
- Nested Loop
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ((int8_tbl.*).q2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ((int8_tbl.*).q2)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ((int8_tbl.*).q2)
-         ->  Append
-               ->  Result
-                     Output: (int8_tbl.*).q2
-               ->  Result
-                     Output: (int8_tbl.*).q2
+         ->  Materialize
+               Output: ((int8_tbl.*).q2)
+               ->  Append
+                     ->  Result
+                           Output: (int8_tbl.*).q2
+                     ->  Result
+                           Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer
-(14 rows)
+ Settings: optimizer=on
+(15 rows)
 
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
          x         

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -539,3 +539,18 @@ explain select * from (t_joinsize_1 join t_joinsize_2 on t_joinsize_1.c2 = t_joi
 drop table t_joinsize_1;
 drop table t_joinsize_2;
 drop table t_joinsize_3;
+
+-- test if subquery locus is general, then
+-- we should keep it general
+create table t_randomly_dist_table(c int) distributed randomly;
+
+-- the following plan should not contain redistributed motion (for planner)
+explain
+select * from (
+  select a from generate_series(1, 10)a
+  union all
+  select a from generate_series(1, 10)a
+) t_subquery_general
+join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
+
+drop table t_randomly_dist_table;


### PR DESCRIPTION
If a subquery's locus is general, we should keep it general here.
And general locus's numsegments should be the cluster size.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
