### PR TITLE
control LOG messages using trace_recovery_messages

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7321,7 +7321,7 @@ StartupXLOG(void)
 	 */
 	EndOfLogTLI = xlogreader->readPageTLI;
 
-	elog(LOG,"end of transaction log location is %X/%X",
+	elog(trace_recovery(DEBUG1),"end of transaction log location is %X/%X",
 		 (uint32) (EndOfLog >> 32), (uint32) EndOfLog);
 
 	/*
@@ -7674,7 +7674,7 @@ StartupXLOG(void)
 	LWLockAcquire(ProcArrayLock, LW_EXCLUSIVE);
 	ShmemVariableCache->latestCompletedXid = ShmemVariableCache->nextXid;
 	TransactionIdRetreat(ShmemVariableCache->latestCompletedXid);
-	elog(LOG, "latest completed transaction id is %u and next transaction id is %u",
+	elog(trace_recovery(DEBUG1), "latest completed transaction id is %u and next transaction id is %u",
 		ShmemVariableCache->latestCompletedXid,
 		ShmemVariableCache->nextXid);
 	LWLockRelease(ProcArrayLock);
@@ -7701,7 +7701,7 @@ StartupXLOG(void)
 	/* Reload shared-memory state for prepared transactions */
 	RecoverPreparedTransactions();
 
-	ereport(LOG, (errmsg("database system is ready")));
+	ereport(trace_recovery(DEBUG1), (errmsg("database system is ready")));
 
 	/*
 	 * Shutdown the recovery environment. This must occur after


### PR DESCRIPTION
Without this patch, initdb will output:

```
creating template1 database in data-master/base/1 ... 2019-10-15 17:32:43.566646 CST,,,p73904,th345056704,,,,0,,,seg-10000,,,,,"LOG","00000","end of transaction log location is 0/4000098",,,,,,,,"StartupXLOG","xlog.c",7417,
2019-10-15 17:32:43.567223 CST,,,p73904,th345056704,,,,0,,,seg-10000,,,,,"LOG","00000","latest completed transaction id is 4294967295 and next transaction id is 3",,,,,,,,"StartupXLOG","xlog.c",7705,
2019-10-15 17:32:43.567528 CST,,,p73904,th345056704,,,,0,,,seg-10000,,,,,"LOG","00000","database system is ready",,,,,,,,"StartupXLOG","xlog.c",7729,
ok
initializing pg_authid ... 2019-10-15 17:32:45.008956 CST,,,p73906,th83031488,,,,0,,,seg-10000,,,,,"LOG","00000","end of transaction log location is 0/40101D8",,,,,,,,"StartupXLOG","xlog.c",7417,
2019-10-15 17:32:45.009424 CST,,,p73906,th83031488,,,,0,,,seg-10000,,,,,"LOG","00000","latest completed transaction id is 4294967295 and next transaction id is 3",,,,,,,,"StartupXLOG","xlog.c",7705,
2019-10-15 17:32:45.010083 CST,,,p73906,th83031488,,,,0,,,seg-10000,,,,,"LOG","00000","database system is ready",,,,,,,,"StartupXLOG","xlog.c",7729,
ok
```

With this patch, initdb is more readable:

```
creating template1 database in data-master/base/1 ... ok
initializing pg_authid ... ok
initializing dependencies ... ok
creating system views ... ok
loading system objects' descriptions ... ok
creating conversions ... ok
```