### PR TITLE
docs - add step to set selinux_provider in sssd.conf

### DIFF
--- a/gpdb-doc/dita/install_guide/prep_os.xml
+++ b/gpdb-doc/dita/install_guide/prep_os.xml
@@ -70,7 +70,7 @@ SELinuxstatus: disabled</codeblock></li>
             follows:<codeblock>SELINUX=disabled</codeblock></li>
           <li>If the System Security Services Daemon (SSSD) is installed on your systems, edit the
             SSSD configuration file and set the <codeph>selinux_provider</codeph> parameter to
-              <codeph>none</codeph> to prevent SELinux-related ssh authentication denials that could
+              <codeph>none</codeph> to prevent SELinux-related SSH authentication denials that could
             occur even with SELinux disabled. As root, edit <codeph>/etc/sssd/sssd.conf</codeph> and
             add this parameter:<codeblock>selinux_provider=none</codeblock></li>
           <li>Reboot the system to apply any changes that you made and verify that SELinux is

--- a/gpdb-doc/dita/install_guide/prep_os.xml
+++ b/gpdb-doc/dita/install_guide/prep_os.xml
@@ -68,8 +68,13 @@ SELinuxstatus: disabled</codeblock></li>
               <codeph>/etc/selinux/config</codeph> file. As root, change the value of the
               <codeph>SELINUX</codeph> parameter in the <codeph>config</codeph> file as
             follows:<codeblock>SELINUX=disabled</codeblock></li>
-          <li>Reboot the system to apply any changes that you made to
-              <codeph>/etc/selinux/config</codeph> and verify that SELinux is disabled.</li>
+          <li>If the System Security Services Daemon (SSSD) is installed on your systems, edit the
+            SSSD configuration file and set the <codeph>selinux_provider</codeph> parameter to
+              <codeph>none</codeph> to prevent SELinux-related ssh authentication denials that could
+            occur even with SELinux disabled. As root, edit <codeph>/etc/sssd/sssd.conf</codeph> and
+            add this parameter:<codeblock>selinux_provider=none</codeblock></li>
+          <li>Reboot the system to apply any changes that you made and verify that SELinux is
+            disabled.</li>
         </ol></p>
       <p>For information about disabling SELinux, see the SELinux documentation.</p>
       <p>You should also disable firewall software such as <codeph>iptables</codeph> (on systems


### PR DESCRIPTION
Without selinux_provider=none in sssd.conf, spurious ssh auth denials can occur. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
