### PR TITLE
Add --build-with-post-release to getversion

### DIFF
--- a/getversion
+++ b/getversion
@@ -2,27 +2,27 @@
 
 # Make sure we're running from the root git repository, not whatever submodule
 # we could have been called from.
-pushd $(dirname "$0") > /dev/null
+pushd $(dirname "$0") >/dev/null
 
-VERSION=$(perl -e 'while(<>){print $1 if (/^PACKAGE_VERSION='\''(.+)'\''$/)}' < configure)
+VERSION=$(perl -e 'while(<>){print $1 if (/^PACKAGE_VERSION='\''(.+)'\''$/)}' <configure)
 BUILDNUMBER=dev
 
 # Call git describe, and convert it to a semi-semantic version, like
 # 5.0.0-alpha.0+dev.52.g123abc
 generate_dev_version() {
-    git describe | perl -pe 's/(.*)-([0-9]*)-(g[0-9a-f]*)/\1+dev.\2.\3/'
+	git describe | perl -pe 's/(.*)-([0-9]*)-(g[0-9a-f]*)/\1+dev.\2.\3/'
 }
 
 # If we are in a Git repository and have git installed, build the version
 # string using the latest tag in case it's reachable
-if type git >/dev/null 2>&1 && [ -d '.git' ] ; then
+if type git >/dev/null 2>&1 && [ -d '.git' ]; then
 
 	# Check for tag reachability, in case of shallow clones we might not
 	# be able to use git describe since the commit which was tagged is
 	# unreachable even if we have pulled the tags. If we can reach it,
 	# overwrite the VERSION from autoconf with the output, else append
 	# HEAD commit info
-	if git describe >/dev/null 2>&1 ; then
+	if git describe >/dev/null 2>&1; then
 		VERSION=$(generate_dev_version)
 	else
 		VERSION+=+
@@ -31,12 +31,12 @@ if type git >/dev/null 2>&1 && [ -d '.git' ] ; then
 fi
 
 FLAG="${1:-noflag}"
-if [ "$FLAG" = '--short' ] ; then
-    echo "${VERSION}"
+if [ "$FLAG" = '--short' ]; then
+	echo "${VERSION}"
 else
-    if [ -f BUILD_NUMBER ] ; then
-        BUILDNUMBER=`cat BUILD_NUMBER`
-    fi
-    echo "${VERSION} build ${BUILDNUMBER}"
+	if [ -f BUILD_NUMBER ]; then
+		BUILDNUMBER=$(cat BUILD_NUMBER)
+	fi
+	echo "${VERSION} build ${BUILDNUMBER}"
 fi
-popd > /dev/null
+popd >/dev/null

--- a/getversion
+++ b/getversion
@@ -2,7 +2,7 @@
 
 # Make sure we're running from the root git repository, not whatever submodule
 # we could have been called from.
-pushd $(dirname "$0") >/dev/null
+pushd "$(dirname "$0")" >/dev/null || exit
 
 VERSION=$(perl -e 'while(<>){print $1 if (/^PACKAGE_VERSION='\''(.+)'\''$/)}' <configure)
 BUILDNUMBER=dev
@@ -39,4 +39,4 @@ else
 	fi
 	echo "${VERSION} build ${BUILDNUMBER}"
 fi
-popd >/dev/null
+popd >/dev/null || exit

--- a/getversion
+++ b/getversion
@@ -1,11 +1,71 @@
 #!/usr/bin/env bash
 
-# Make sure we're running from the root git repository, not whatever submodule
-# we could have been called from.
-pushd "$(dirname "$0")" >/dev/null || exit
+append_to_post_release() {
+	# given a valid semi-semantic version string and a suffix string,
+	# output a valid semi-semantic version string that includes suffix in the post_release
+	local separator
+	case "${1}" in
+	*+*) separator="." ;;
+	*) separator="+" ;;
+	esac
+	printf "%s${separator}%s" "${1}" "${2}"
+}
 
-VERSION=$(perl -e 'while(<>){print $1 if (/^PACKAGE_VERSION='\''(.+)'\''$/)}' <configure)
-BUILDNUMBER=dev
+drop_commit_sha() {
+	if [ -z "${1+set}" ]; then
+		printf >&2 'git_describe_output is missing'
+		return 1
+	fi
+	local git_describe_output="${1}"
+
+	local tag
+	local build
+
+	local regexp
+	regexp='^(.*)\-([0-9]*)\-g([0-9a-f]*)$'
+	# case where we are not at a tag and git describe is tag-###-gabc
+	if [[ "${git_describe_output}" =~ $regexp ]]; then
+		tag="${BASH_REMATCH[1]}"
+		build="${BASH_REMATCH[2]}"
+	else
+		# this case where git describe is giving us the tag
+		tag="${git_describe_output}"
+		build=""
+	fi
+
+	local final_version="${tag}"
+	if [ -n "${build}" ]; then
+		final_version="$(append_to_post_release "${final_version}" "${build}")"
+	fi
+
+	printf "%s" "${final_version}"
+}
+
+generate_build_version() {
+	if [ -z "${1+set}" ]; then
+		printf >&2 'git_describe_output is missing'
+		return 1
+	fi
+	local git_describe_output="${1}"
+
+	if [ -z "${2+set}" ]; then
+		printf >&2 'post_release_suffix is missing'
+		return 1
+	fi
+	local post_release_suffix="${2}"
+
+	if [[ "${post_release_suffix}" =~ \+ ]]; then
+		printf >&2 'post_release_suffix cannot contain a +'
+		return 1
+	fi
+
+	final_version="$(drop_commit_sha "${git_describe_output}")"
+	if [ -n "${post_release_suffix}" ]; then
+		final_version="$(append_to_post_release "${final_version}" "${post_release_suffix}")"
+	fi
+
+	printf "%s" "${final_version}"
+}
 
 # Call git describe, and convert it to a semi-semantic version, like
 # 5.0.0-alpha.0+dev.52.g123abc
@@ -13,30 +73,45 @@ generate_dev_version() {
 	git describe | perl -pe 's/(.*)-([0-9]*)-(g[0-9a-f]*)/\1+dev.\2.\3/'
 }
 
-# If we are in a Git repository and have git installed, build the version
-# string using the latest tag in case it's reachable
-if type git >/dev/null 2>&1 && [ -d '.git' ]; then
+getversion() {
+	# Make sure we're running from the root git repository, not whatever submodule
+	# we could have been called from.
+	pushd "$(dirname "$0")" >/dev/null || return
 
-	# Check for tag reachability, in case of shallow clones we might not
-	# be able to use git describe since the commit which was tagged is
-	# unreachable even if we have pulled the tags. If we can reach it,
-	# overwrite the VERSION from autoconf with the output, else append
-	# HEAD commit info
-	if git describe >/dev/null 2>&1; then
-		VERSION=$(generate_dev_version)
+	VERSION=$(perl -e 'while(<>){print $1 if (/^PACKAGE_VERSION='\''(.+)'\''$/)}' <configure)
+	BUILDNUMBER=dev
+
+	# If we are in a Git repository and have git installed, build the version
+	# string using the latest tag in case it's reachable
+	if type git >/dev/null 2>&1 && [ -d '.git' ]; then
+		# Check for tag reachability, in case of shallow clones we might not
+		# be able to use git describe since the commit which was tagged is
+		# unreachable even if we have pulled the tags. If we can reach it,
+		# overwrite the VERSION from autoconf with the output, else append
+		# HEAD commit info
+		if git describe >/dev/null 2>&1; then
+			VERSION=$(generate_dev_version)
+		else
+			VERSION+=+
+			VERSION+=$(git rev-parse --short HEAD)
+		fi
+	fi
+
+	FLAG="${1:-noflag}"
+	if [ "$FLAG" = '--short' ]; then
+		echo "${VERSION}"
+	elif [ "${FLAG}" = '--build-with-post-release' ]; then
+		build_version="$(generate_build_version "$(git describe)" "${2}")" || return 1
+		echo "${build_version}"
 	else
-		VERSION+=+
-		VERSION+=$(git rev-parse --short HEAD)
+		if [ -f BUILD_NUMBER ]; then
+			BUILDNUMBER=$(cat BUILD_NUMBER)
+		fi
+		echo "${VERSION} build ${BUILDNUMBER}"
 	fi
-fi
+	popd >/dev/null || return
+}
 
-FLAG="${1:-noflag}"
-if [ "$FLAG" = '--short' ]; then
-	echo "${VERSION}"
-else
-	if [ -f BUILD_NUMBER ]; then
-		BUILDNUMBER=$(cat BUILD_NUMBER)
-	fi
-	echo "${VERSION} build ${BUILDNUMBER}"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	getversion "$@"
 fi
-popd >/dev/null || exit

--- a/getversion.bats
+++ b/getversion.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+setup() {
+  # shellcheck source=/dev/null
+  source "${BATS_TEST_DIRNAME}"/getversion
+}
+
+@test 'append_to_post_release without a post-release' {
+  run append_to_post_release '1.2.3' '4'
+  echo "${output}"
+  [ "${output}" = '1.2.3+4' ]
+}
+
+@test 'append_to_post_release with a post-release' {
+  run append_to_post_release '1.2.3+4' '5'
+  echo "${output}"
+  [ "${output}" = '1.2.3+4.5' ]
+}
+
+@test 'drop_commit_sha removes SHA from git describe output' {
+  run drop_commit_sha 'tag-123-gabcef'
+  echo "${output}"
+  [ "${output}" = "tag+123" ]
+}
+
+@test 'drop_commit_sha removes SHA from git describe output for a tag with a post_release segment' {
+  run drop_commit_sha 'tag+with_post_release-123-gabcef'
+  echo "${output}"
+  [ "${output}" = "tag+with_post_release.123" ]
+}
+
+@test 'drop_commit_sha does not modify git describe output for tag' {
+  run drop_commit_sha 'tag'
+  echo "${output}"
+  [ "${output}" = "tag" ]
+}
+
+@test 'drop_commit_sha does not modify git describe output for tag with post_release segment' {
+  run drop_commit_sha 'tag+with_post_release'
+  echo "${output}"
+  [ "${output}" = "tag+with_post_release" ]
+}
+
+@test 'generate_build_version() fails with missing params' {
+  run generate_build_version
+  echo "${output}"
+  [ "${status}" -eq 1 ]
+  [ "${output}" = 'git_describe_output is missing' ]
+
+  run generate_build_version ''
+  echo "${output}"
+  [ "${status}" -eq 1 ]
+  [ "${output}" = 'post_release_suffix is missing' ]
+}
+
+@test 'generate_build_version() does not append an empty suffix to a simple tag' {
+  run generate_build_version '6.0.0' ''
+  echo "${output}"
+  [ "${output}" = '6.0.0' ]
+}
+
+@test 'generate_build_version() appends the suffix to a simple tag' {
+  run generate_build_version '6.0.0' 'suffix.0'
+  echo "${output}"
+  [ "${output}" = '6.0.0+suffix.0' ]
+}
+
+@test 'generate_build_version() for post release' {
+  run generate_build_version '6.0.0+dev.130' 'a.b.0'
+  echo "${output}"
+  [ "${output}" = '6.0.0+dev.130.a.b.0' ]
+}
+
+@test 'generate_build_version() appends the suffix to a tag with a SHA' {
+  run generate_build_version '7.0.0-2853-g8fc73277cd' 'suffix.0'
+  echo "${output}"
+  [ "${output}" = '7.0.0+2853.suffix.0' ]
+}
+
+@test 'generate_build_version() for post release with build' {
+  run generate_build_version '6.0.0+dev.130-1234-gabcdef' 'a.b.0'
+  echo "${output}"
+  [ "${output}" = '6.0.0+dev.130.1234.a.b.0' ]
+}
+
+@test 'generate_build_version() fails for suffix with a +' {
+  run generate_build_version '6.0.0' '+'
+  echo "${output}"
+  [ "${output}" = 'post_release_suffix cannot contain a +' ]
+  [ "${status}" -ne 0 ]
+
+  run generate_build_version '6.0.0' '1+2'
+  [ "${status}" -ne 0 ]
+
+  run generate_build_version '6.0.0' '++'
+  [ "${status}" -ne 0 ]
+}
+
+@test './getversion --build-with-post-release with no parameters passes' {
+  run "${BATS_TEST_DIRNAME}"/getversion --build-with-post-release
+  echo "${output}"
+  [ "${status}" -eq 0 ]
+}
+
+@test './getversion --build-with-post-release suffix.0 works' {
+  run "${BATS_TEST_DIRNAME}"/getversion --build-with-post-release 'suffix.0'
+  echo "${output}"
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
- this allows users to append a post release suffix (e.g. suffix.0) to the
  output of getversion and still generate a valid semi-semver, such as:
  - 6.0.0 => 6.0.0+suffix.0
  - 5.0.0-beta.1 => 5.0.0-beta.1+suffix.0
  - 7.0.0-2853-g8fc73277cd => 7.0.0+2853.suffix.0
  - 6.0.0+dev.130 => 6.0.0+dev.130.suffix.0
  - for more, see .bats file
- prior to this, getversion could only support pre-release
- the use case is if we wanted to make a special release for a special
  feature or customer, we could generate a custom gpdb version
- refactor getversion script by wrapping into bash functions

[#167357085]

Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>
Co-authored-by: Xin Zhang <xzhang@pivotal.io>
Co-authored-by: Amil Khanzada <akhanzada@pivotal.io>