### PR TITLE
Gpinitsystem exit code 168785723 6x backport

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -80,6 +80,7 @@ INPUT_CONFIG=""
 OUTPUT_CONFIG=""
 GPHOSTCACHELOOKUP=$WORKDIR/lib/gphostcachelookup.py
 STANDBY_RET_CODE=0
+IGNORE_WARNINGS=0
 
 #******************************************************************************
 # DCA Specific Variables
@@ -114,6 +115,7 @@ USAGE () {
 		$ECHO
 		$ECHO "      General options:"
 		$ECHO "      -v, display version information & exit"
+		$ECHO "      --ignore-warnings, exit with status 0 on success, and non-zero for failures"
 		$ECHO
 		$ECHO "      Logging options:"
 		$ECHO "      -a, don't ask to confirm instance creation [default:- ask]"
@@ -166,6 +168,11 @@ USAGE () {
 		$ECHO "      1 - Warning generated, but instance operational"
 		$ECHO "      2 - Fatal error, instance not created/started, or in an inconsistent state,"
 		$ECHO "          see log file for failure reason."
+		$ECHO
+		$ECHO "      Return codes when --ignore-warnings specified:"
+		$ECHO "      0 - Instance operational. May have generated warnings."
+		$ECHO "      non-zero - Fatal error, instance not created/started, or in an inconsistent state,"
+		$ECHO "          see log file for failure reason. Do not depend on a particular non-zero value."
 		$ECHO
 		exit $EXIT_STATUS
 	fi
@@ -1914,12 +1921,13 @@ while getopts ":vaqe:c:l:-:p:m:h:n:s:P:S:b:DB:I:O:" opt
 						"standby-datadir" ) STANDBY_DATADIR=$VAL ;;
 						"help"            ) USAGE "print_doc" ;;
 						"version"         ) print_version ;;
+						"ignore-warnings" ) IGNORE_WARNINGS=1 ;;
 						* ) LOG_MSG "[ERROR]:-Unknown option --$NAME" 1; USAGE ;;
 					esac
 
-					# Check if we are missing the long option value.  Currently all
-					# long options require a value so we can just do the check once.
-					if [ x"$NAME" == x"$VAL" ]; then
+					# Check if we are missing the long option value.  All long options
+					# except ignore-warnings require a value, so do the check once.
+					if [ x"$NAME" == x"$VAL" ] && [ x"$NAME" != x"ignore-warnings" ]; then
 						LOG_MSG "[FATAL]:-Missing value for option --$NAME" 1;
 						USAGE;
 					fi
@@ -2075,4 +2083,13 @@ if [ $STANDBY_RET_CODE -ne 0 ] && [ $STANDBY_RET_CODE -ne 1 ]; then
 fi
 
 LOG_MSG "[INFO]:-End Main"
+
+if [ $IGNORE_WARNINGS -eq 1 ]; then
+	if [ $EXIT_STATUS -eq 1 ]; then
+		EXIT_STATUS=0
+	elif [ $EXIT_STATUS -eq 2 ]; then
+		EXIT_STATUS=1
+	fi
+fi
+
 exit $EXIT_STATUS

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1928,7 +1928,7 @@ while getopts ":vaqe:c:l:-:p:m:h:n:s:P:S:b:DB:I:O:" opt
 					# Check if we are missing the long option value.  All long options
 					# except ignore-warnings require a value, so do the check once.
 					if [ x"$NAME" == x"$VAL" ] && [ x"$NAME" != x"ignore-warnings" ]; then
-						LOG_MSG "[FATAL]:-Missing value for option --$NAME" 1;
+						LOG_MSG "[FATAL]:-Missing value for option --$NAME" 2;
 						USAGE;
 					fi
 					;;

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -283,7 +283,11 @@ ERROR_EXIT () {
 						$ECHO "$RM -f $BACKOUT_FILE" >> $BACKOUT_FILE
 				fi
 		fi
-		exit $2
+		if [ $IGNORE_WARNINGS -eq 1 ]; then
+				exit 1
+		else
+				exit $2
+		fi
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
@@ -595,11 +599,11 @@ GET_REPLY () {
 	$ECHO -n "> "
 	read REPLY
 	if [ -z $REPLY ]; then
-		LOG_MSG "[WARN]:-User abort requested, Script Exits!" 1
+		LOG_MSG "[FATAL]:-User abort requested, Script Exits!" 1
 		exit 1
 	fi
 	if [ $REPLY != Y ] && [ $REPLY != y ]; then
-		LOG_MSG "[WARN]:-User abort requested, Script Exits!" 1
+		LOG_MSG "[FATAL]:-User abort requested, Script Exits!" 1
 		exit 1
 	fi
 }

--- a/gpMgmt/doc/gpinitsystem_help
+++ b/gpMgmt/doc/gpinitsystem_help
@@ -22,6 +22,8 @@ gpinitsystem -c <gpinitsystem_config>
             [--mirror-mode={group|spread}] [-a] [-q] [-l <logfile_directory>] [-D]
             [-I input_configuration_file]
             [-O output_configuration_file]
+            [--help]
+            [--ignore-warnings]
 
 gpinitsystem -v
 
@@ -259,6 +261,11 @@ OPTIONS
 --help
 
  Displays the online help.
+
+
+--ignore-warnings
+
+  Exit with status 0 for warnings and non-zero for fatal errors.
 
 
 *****************************************************

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -17,7 +17,8 @@ def before_all(context):
 
 def before_feature(context, feature):
     # we should be able to run gpexpand without having a cluster initialized
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors', 'gpconfig', 'gpssh-exkeys', 'gpstop']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
+                    'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -91,7 +92,8 @@ def before_scenario(context, scenario):
     if 'gpssh-exkeys' in context.feature.tags:
         context.gpssh_exkeys_context = GpsshExkeysMgmtContext(context)
 
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors', 'gpconfig', 'gpssh-exkeys', 'gpstop']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
+                    'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -118,7 +120,8 @@ def after_scenario(context, scenario):
             ''')
 
     # NOTE: gpconfig after_scenario cleanup is in the step `the gpconfig context is setup`
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpinitstandby', 'gpconfig', 'gpstop']
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpinitstandby',
+                    'gpconfig', 'gpstop', 'gpinitsystem']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -17,7 +17,79 @@ Feature: gpinitsystem tests
         And gpconfig should print "Master  value: off" to stdout
         And gpconfig should print "Segment value: off" to stdout
 
-    Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
+    Scenario: gpinitsystem creates a cluster when the user confirms the dialog when --ignore-warnings is passed in
+        Given create demo cluster config
+         When the user runs command "echo y | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings"
+         Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+         Then gpstate should return a return code of 0
+
+    Scenario: gpinitsystem exits with status 1 when the user enters nothing for the confirmation
+        Given create demo cluster config
+        When the user runs command "echo '' | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
+        Then gpinitsystem should return a return code of 1
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 2
+
+    Scenario: gpinitsystem exits with status 1 when the user enters no for the confirmation
+        Given create demo cluster config
+        When the user runs command "echo no | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
+        Then gpinitsystem should return a return code of 1
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 2
+
+    Scenario: gpinitsystem creates a cluster when the user confirms the dialog
+        Given create demo cluster config
+        # need to remove this log because otherwise SCAN_LOG may pick up a previous error/warning in the log
+        And the user runs command "rm -r ~/gpAdminLogs/gpinitsystem*"
+        When the user runs command "echo y | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
+    Scenario: gpinitsystem fails with exit code 2 when the functions file is not found
+       Given create demo cluster config
+           # force a load error when trying to source gp_bash_functions.sh
+        When the user runs command "ln -s -f `which gpinitsystem` /tmp/gpinitsystem-link; . /tmp/gpinitsystem-link" eok
+        Then gpinitsystem should return a return code of 2
+
+    Scenario: gpinitsystem fails with exit code 2 when the functions file is not found when passing the --ignore-warnings flag
+        Given create demo cluster config
+           # force a load error when trying to source gp_bash_functions.sh
+        When the user runs command "ln -s -f `which gpinitsystem` /tmp/gpinitsystem-link; . /tmp/gpinitsystem-link --ignore-warnings" eok
+        Then gpinitsystem should return a return code of 2
+
+    Scenario: gpinitsystem returns exit code 1 when gpinitstandby fails
+        Given create demo cluster config
+           # force gpinitstandby to fail by specifying a directory that does not exist (gpinitsystem continues successfully)
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -S not-a-real-directory -P 21100 -h ../gpAux/gpdemo/hostfile"
+        Then gpinitsystem should return a return code of 1
+
+    Scenario: gpinitsystem returns exit code 0 when gpinitstandby fails when passing the --ignore-warnings flag
+       Given create demo cluster config
+           # force gpinitstandby to fail by specifying a directory that does not exist (gpinitsystem continues successfully)
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -S not-a-real-directory -P 21100 -h ../gpAux/gpdemo/hostfile --ignore-warnings"
+        Then gpinitsystem should return a return code of 0
+
+    Scenario: after a failed run of gpinitsystem, a re-run should return exit status 0 when using --ignore-warnings
+        Given create demo cluster config
+        # force a failure by passing no args
+        When the user runs "gpinitsystem"
+        Then gpinitsystem should return a return code of 2
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings"
+        Then gpinitsystem should return a return code of 0
+
+      Scenario: after gpinitsystem logs a warning, a re-run should return exit status 0 when using --ignore-warnings
+        Given create demo cluster config
+        # log a warning
+        And the user runs command "echo 'ARRAY_NAME=' >> ../gpAux/gpdemo/clusterConfigFile"
+       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings"
+       Then gpinitsystem should return a return code of 0
+      Given create demo cluster config
+       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings"
+       Then gpinitsystem should return a return code of 0
+
+    Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated when using --ignore-warnings
         Given the database is running
         And all the segments are running
         And the segments are synchronized
@@ -25,7 +97,39 @@ Feature: gpinitsystem tests
         And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
         # stop db and make sure cluster config exists so that we can manually initialize standby
         And the cluster config is generated with data_checksums "1"
-        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -s localhost -P 21100 -S /wrong/path -h ../gpAux/gpdemo/hostfile"
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -S /wrong/path -h ../gpAux/gpdemo/hostfile --ignore-warnings"
+        Then gpinitsystem should return a return code of 0
+        And gpinitsystem should not print "To activate the Standby Master Segment in the event of Master" to stdout
+        And gpinitsystem should print "Cluster setup finished, but Standby Master failed to initialize. Review contents of log files for errors." to stdout
+        And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
+
+    Scenario: after a failed run of gpinitsystem, a re-run should return exit status 1
+        Given create demo cluster config
+        # force a failure by passing no args
+        When the user runs "gpinitsystem"
+        Then gpinitsystem should return a return code of 2
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 1
+
+      Scenario: after gpinitsystem logs a warning, a re-run should return exit status 1
+        Given create demo cluster config
+        # log a warning
+        And the user runs command "echo 'ARRAY_NAME=' >> ../gpAux/gpdemo/clusterConfigFile"
+       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+       Then gpinitsystem should return a return code of 1
+      Given create demo cluster config
+       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+       Then gpinitsystem should return a return code of 1
+
+    Scenario: gpinitsystem should fail when standby cannot be instantiated
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And the standby is not initialized
+        And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
+        # stop db and make sure cluster config exists so that we can manually initialize standby
+        And the cluster config is generated with data_checksums "1"
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -S /wrong/path -h ../gpAux/gpdemo/hostfile"
         Then gpinitsystem should return a return code of 1
         And gpinitsystem should not print "To activate the Standby Master Segment in the event of Master" to stdout
         And gpinitsystem should print "Cluster setup finished, but Standby Master failed to initialize. Review contents of log files for errors." to stdout

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -132,6 +132,10 @@ def impl(context):
 def impl(context):
     create_local_demo_cluster(context, num_primaries=3)
 
+@given('create demo cluster config')
+def impl(context):
+    create_local_demo_cluster(context, extra_config='ONLY_PREPARE_CLUSTER_ENV=true')
+
 @given('the cluster config is generated with HBA_HOSTNAMES "{hba_hostnames_toggle}"')
 def impl(context, hba_hostnames_toggle):
     extra_config = 'env EXTRA_CONFIG="HBA_HOSTNAMES={}" ONLY_PREPARE_CLUSTER_ENV=true'.format(hba_hostnames_toggle)


### PR DESCRIPTION
Previously gpinitsystem returned 1 in case of warnings (2 in case of
errors). We have changed gpinitsystem to return 0 for warnings so that other
tools using gpinitsystem (such as gpupgrade) will not fail when gpinitsystem
generates warnings. This behavior is only available when specifying
the `--ignore-warnings` flag. Existing exit code behavior remains the same
when the flag is not specified.

Also, gpinitsystem was exiting with non-zero return code if certain errors or
warnings had happened on any previous run of gpinitsystem that day. This has
also been fixed in this commit, in the case where `--ignore-warnings` is specified.

The corresponding master PR is #8801 