### PR TITLE
Change CFLAGS to CXXFLAGS when using CXX to do link

### DIFF
--- a/configure
+++ b/configure
@@ -5733,9 +5733,7 @@ if test x"$pgac_cv_prog_cc_cflags__Wno_address" = x"yes"; then
 fi
 
 
-  gccversion=`$CC -dumpversion | cut -d . -f1`
-  if test "$gccversion" -ge 7 ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wimplicit-fallthrough" >&5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wimplicit-fallthrough" >&5
 $as_echo_n "checking whether $CC supports -Wimplicit-fallthrough... " >&6; }
 if ${pgac_cv_prog_cc_cflags__Wimplicit_fallthrough+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5770,7 +5768,7 @@ if test x"$pgac_cv_prog_cc_cflags__Wimplicit_fallthrough" = x"yes"; then
   CFLAGS="$CFLAGS -Wimplicit-fallthrough"
 fi
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-fallthrough" >&5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-fallthrough" >&5
 $as_echo_n "checking whether $CC supports -Werror=implicit-fallthrough... " >&6; }
 if ${pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5805,7 +5803,6 @@ if test x"$pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough" = x"yes"; then
   CFLAGS="$CFLAGS -Werror=implicit-fallthrough"
 fi
 
-  fi
 
   #-Wno-error=enum-compare -Wno-error=address -Wno-error=maybe-uninitialized
 

--- a/configure.in
+++ b/configure.in
@@ -621,11 +621,8 @@ if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-Wno-unused-but-set-variable])
   PGAC_PROG_CC_CFLAGS_OPT([-Wno-address])
 
-  gccversion=`$CC -dumpversion | cut -d . -f1`
-  if test "$gccversion" -ge 7 ; then
-    PGAC_PROG_CC_CFLAGS_OPT([-Wimplicit-fallthrough])
-    PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-fallthrough])
-  fi
+  PGAC_PROG_CC_CFLAGS_OPT([-Wimplicit-fallthrough])
+  PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-fallthrough])
 
   #-Wno-error=enum-compare -Wno-error=address -Wno-error=maybe-uninitialized
 

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -65,7 +65,7 @@ ifneq ($(PORTNAME), win32)
 ifneq ($(PORTNAME), aix)
 
 postgres: $(OBJS)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(call expand_subsys,$^) $(LIBS) -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(call expand_subsys,$^) $(LIBS) -o $@
 
 endif
 endif
@@ -74,7 +74,7 @@ endif
 ifeq ($(PORTNAME), cygwin)
 
 postgres: $(OBJS)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) -Wl,--stack,$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$^) $(LIBS) -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) -Wl,--stack,$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$^) $(LIBS) -o $@
 
 # libpostgres.a is actually built in the preceding rule, but we need this to
 # ensure it's newer than postgres; see notes in src/backend/parser/Makefile
@@ -87,7 +87,7 @@ ifeq ($(PORTNAME), win32)
 LIBS += -lsecur32
 
 postgres: $(OBJS) $(WIN32RES)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LIBS) -o $@$(X)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LIBS) -o $@$(X)
 
 # libpostgres.a is actually built in the preceding rule, but we need this to
 # ensure it's newer than postgres; see notes in src/backend/parser/Makefile
@@ -99,7 +99,7 @@ endif # win32
 ifeq ($(PORTNAME), aix)
 
 postgres: $(POSTGRES_IMP)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(call expand_subsys,$(OBJS)) -Wl,-bE:$(top_builddir)/src/backend/$(POSTGRES_IMP) $(LIBS) -Wl,-brtllib -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(call expand_subsys,$(OBJS)) -Wl,-bE:$(top_builddir)/src/backend/$(POSTGRES_IMP) $(LIBS) -Wl,-brtllib -o $@
 
 $(POSTGRES_IMP): $(OBJS)
 	$(LD) $(LDREL) $(LDOUT) SUBSYS.o $(call expand_subsys,$^)
@@ -342,4 +342,4 @@ maintainer-clean: distclean
 # are up to date.  It saves the time of doing all the submakes.
 .PHONY: quick
 quick: $(OBJS)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(call expand_subsys,$^) $(LIBS) -o postgres
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(call expand_subsys,$^) $(LIBS) -o postgres


### PR DESCRIPTION
Currently, we use CXX to link postgres due to add some c++ code(glue
code of orca). But the Makefile still passes CFLAGS to the compiler.
This behavior will cause an error if a compiler option is supported by
CC, but not supported by CXX.
NB: Using CXX to link happens only to create postgres executable or to
merge object files into postgres.o

The error happens in https://travis-ci.org/greenplum-db/gpdb/jobs/598499168
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
