### PR TITLE
gp_replica_check: run checks in parallel to cut down time

### DIFF
--- a/gpcontrib/gp_replica_check/gp_replica_check.c
+++ b/gpcontrib/gp_replica_check/gp_replica_check.c
@@ -429,12 +429,12 @@ retry:
 			 */
 			if (!PageIsVerified(primaryFileBuf, blockno))
 			{
-				elog(NOTICE, "invalid page header or checksum in heap file \"%s\", block %u: %m", primaryfilepath, blockno);
+				elog(NOTICE, "invalid page header or checksum in heap file \"%s\", block %u", primaryfilepath, blockno);
 				goto retry;
 			}
 			if (!PageIsVerified(mirrorFileBuf, blockno))
 			{
-				elog(NOTICE, "invalid page header or checksum in heap file \"%s\", block %u: %m", mirrorfilepath, blockno);
+				elog(NOTICE, "invalid page header or checksum in heap file \"%s\", block %u", mirrorfilepath, blockno);
 				goto retry;
 			}
 


### PR DESCRIPTION
gp_replica_check can easily perform checks in parallel for multiple
database directories for various segments. This should help to
significantly cut down time. On my laptop just after install-check,
gp_replica_check finishes in 2 secs compared to 17sec before. I think
in CI this would make huge impact as currently gp_replica_check takes
approximately 10mins after installcheck-world.

I have not implemented any upper bound or batching currently. If it
becomes a problem, we can in future add to spawn N threads at a
time. Let's see first what effect this change has.

Typical (fastest) CI run-time split is:
20 mins - regress
13 mins - isolation2
05 mins - gpcheckcat
10 mins - gp_replica_check
13 mins - upgrade
