### PR TITLE
Ignore workfile compresssion is not supported by this build failure

### DIFF
--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -1,3 +1,9 @@
+-- Ignore "workfile compresssion is not supported by this build" (see
+-- 'zlib' test):
+--
+-- start_matchignore
+-- m/ERROR:  workfile compresssion is not supported by this build/
+-- end_matchignore
 create schema hashagg_spill;
 set search_path to hashagg_spill;
 -- start_ignore

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -1,3 +1,9 @@
+-- Ignore "workfile compresssion is not supported by this build" (see
+-- 'zlib' test):
+--
+-- start_matchignore
+-- m/ERROR:  workfile compresssion is not supported by this build/
+-- end_matchignore
 create schema hashagg_spill;
 set search_path to hashagg_spill;
 


### PR DESCRIPTION
Add match pattern to ignore "workfile compresssion is not supported by this
build" failures. Some of the existing tests already have this failure ignored.
This enables successful run for tests which run on builds without compression.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
