### PR TITLE
Use a different temp schema name pattern in utility mode

### DIFF
--- a/src/test/isolation2/expected/misc.out
+++ b/src/test/isolation2/expected/misc.out
@@ -23,3 +23,25 @@ DROP
  Optimizer: Postgres query optimizer                                                                                      
  Execution time: 0.357 ms                                                                                                 
 (8 rows)
+
+--
+-- Temp tables should have a different schema name pattern in utility mode.
+--
+-- A temp table's schema name used to be pg_temp_<session_id> in normal mode
+-- and pg_temp_<backend_id> in utility mode, once the normal-mode session id
+-- equals to the utility-mode backend id they will conflict with each other and
+-- cause catalog corruption on the segment.
+--
+-- We have changed the name to pg_temp_0<backend_id> in utility mode.
+0U: CREATE TEMP TABLE utilitymode_tmp_tab (c1 int) DISTRIBUTED BY (c1);
+CREATE
+0U: SELECT substring(n.nspname FROM 1 FOR 9) FROM pg_namespace n JOIN pg_class c ON n.oid = c.relnamespace WHERE c.relname = 'utilitymode_tmp_tab';
+ substring 
+-----------
+ pg_temp_0 
+(1 row)
+0U: SELECT substring(n2.nspname FROM 1 FOR 15) FROM pg_namespace n1 JOIN pg_class c ON n1.oid = c.relnamespace JOIN pg_namespace n2 ON n2.nspname = 'pg_toast_temp_0' || substring(n1.nspname FROM 10) WHERE c.relname = 'utilitymode_tmp_tab';
+ substring       
+-----------------
+ pg_toast_temp_0 
+(1 row)

--- a/src/test/isolation2/sql/misc.sql
+++ b/src/test/isolation2/sql/misc.sql
@@ -9,3 +9,26 @@
 -1U: drop table utilitymode_primary_key_tab;
 
 0U: explain analyze select * from gp_segment_configuration order by dbid;
+
+--
+-- Temp tables should have a different schema name pattern in utility mode.
+--
+-- A temp table's schema name used to be pg_temp_<session_id> in normal mode
+-- and pg_temp_<backend_id> in utility mode, once the normal-mode session id
+-- equals to the utility-mode backend id they will conflict with each other and
+-- cause catalog corruption on the segment.
+--
+-- We have changed the name to pg_temp_0<backend_id> in utility mode.
+0U: CREATE TEMP TABLE utilitymode_tmp_tab (c1 int) DISTRIBUTED BY (c1);
+0U: SELECT substring(n.nspname FROM 1 FOR 9)
+      FROM pg_namespace n
+      JOIN pg_class c
+        ON n.oid = c.relnamespace
+     WHERE c.relname = 'utilitymode_tmp_tab';
+0U: SELECT substring(n2.nspname FROM 1 FOR 15)
+      FROM pg_namespace n1
+      JOIN pg_class c
+        ON n1.oid = c.relnamespace
+      JOIN pg_namespace n2
+        ON n2.nspname = 'pg_toast_temp_0' || substring(n1.nspname FROM 10)
+     WHERE c.relname = 'utilitymode_tmp_tab';


### PR DESCRIPTION
A temp table's schema name is pg_temp_<session_id> in normal mode, in
utility mode the name is pg_temp_<backend_id>, however once the
normal-mode session id equals to the utility-mode backend id they will
conflict with each other and cause catalog corruption on the segment.

To fix this issue we changed the name to pg_temp_0<backend_id> in
utility mode, this still matches the pattern "pg_temp_[0-9]+", which is
expected for temp schema names.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
