### PR TITLE
5X_STABLE: Fix size calculation for non-default tablespaces

### DIFF
--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -287,7 +287,12 @@ calculate_tablespace_size(Oid tblspcOid)
 	else if (tblspcOid == GLOBALTABLESPACE_OID)
 		snprintf(tblspcPath, MAXPGPATH, "global");
 	else
-		snprintf(tblspcPath, MAXPGPATH, "pg_tblspc/%u", tblspcOid);
+	{
+		char *primaryFs, *mirrorFs;
+		PersistentTablespace_GetPrimaryAndMirrorFilespaces(
+			tblspcOid, &primaryFs, &mirrorFs);
+		snprintf(tblspcPath, MAXPGPATH, "%s/%u", primaryFs, tblspcOid);
+	}
 
 	dirdesc = AllocateDir(tblspcPath);
 

--- a/src/test/regress/input/filespace.source
+++ b/src/test/regress/input/filespace.source
@@ -27,6 +27,11 @@ insert into fstest select i, i from generate_series (1,1000) i;
 
 select * from fstest;
 
+-- The size output is found to differ based on platform (e.g. on OSX
+-- it returns 97kB, on Ubuntu 112kB).  Pass the test as long as the
+-- size is greater than 50kB.
+SELECT pg_tablespace_size('regressionts1') > (50 * 1024) as result;
+
 comment on filespace regressionfs1 is 'groovy';
 comment on tablespace regressionts1 is 'also groovy';
 

--- a/src/test/regress/output/filespace.source
+++ b/src/test/regress/output/filespace.source
@@ -1026,6 +1026,15 @@ select * from fstest;
   999 |  999
 (1000 rows)
 
+-- The size output is found to differ based on platform (e.g. on OSX
+-- it returns 97kB, on Ubuntu 112kB).  Pass the test as long as the
+-- size is greater than 50kB.
+SELECT pg_tablespace_size('regressionts1') > (50 * 1024) as result;
+ result 
+--------
+ t
+(1 row)
+
 comment on filespace regressionfs1 is 'groovy';
 comment on tablespace regressionts1 is 'also groovy';
 -- partition coverage


### PR DESCRIPTION
This is second attempt, based on Deep's feedback on PR #8702.  The patch uses filespace location to construct path to a non-default tablespace directory before computing its size.  The filespace path was missing, causing pg_tablespace_size() function to always fail for
non-default tablespaces.
