### PR TITLE
Bump ORCA version to 3.78.0, Optimize CMemoryPoolPalloc in ORCA

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.77.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.78.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.77.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.78.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.77.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.78.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.77.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.78.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.77.0@gpdb/stable
+orca/v3.78.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.77.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.78.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
@@ -36,9 +36,23 @@ CMemoryPoolPallocManager::NewMemoryPool()
 	return GPOS_NEW(GetInternalMemoryPool()) CMemoryPoolPalloc();
 }
 
+void
+CMemoryPoolPallocManager::DeleteImpl(void* ptr, CMemoryPool::EAllocationType eat)
+{
+	CMemoryPoolPalloc::DeleteImpl(ptr, eat);
+}
+
+// get user requested size of allocation
+ULONG
+CMemoryPoolPallocManager::UserSizeOfAlloc(const void* ptr)
+{
+	return CMemoryPoolPalloc::UserSizeOfAlloc(ptr);
+}
+
 GPOS_RESULT
 CMemoryPoolPallocManager::Init()
 {
-	return CMemoryPoolManager::SetupMemoryPoolManager<CMemoryPoolPallocManager, CMemoryPoolPalloc>();
+	return CMemoryPoolManager::SetupGlobalMemoryPoolManager<CMemoryPoolPallocManager, CMemoryPoolPalloc>();
 }
+
 // EOF

--- a/src/include/gpopt/utils/CMemoryPoolPalloc.h
+++ b/src/include/gpopt/utils/CMemoryPoolPalloc.h
@@ -27,27 +27,39 @@ namespace gpos
 
 			MemoryContext m_cxt;
 
+			// When destroying arrays, we need to call the destructor of each element
+			// To do this, we need the size of the allocation, which we then divide by the
+			// the size of the element to get number of elements to iterate through.
+			// This struct is only used for array allocations (GPOS_NEW_ARRAY())
+			struct SArrayAllocHeader
+			{
+				ULONG m_user_size;
+			};
 		public:
 
 			// ctor
 			CMemoryPoolPalloc();
 
 			// allocate memory
-			void *Allocate
+			void *NewImpl
 				(
 				const ULONG bytes,
 				const CHAR *file,
-				const ULONG line
+				const ULONG line,
+				CMemoryPool::EAllocationType eat
 				);
 
 			// free memory
-			void Free(void *ptr);
+			static void DeleteImpl(void *ptr, CMemoryPool::EAllocationType eat);
 
 			// prepare the memory pool to be deleted
 			void TearDown();
 
 			// return total allocated size include management overhead
 			ULLONG TotalAllocatedSize() const;
+
+			// get user requested size of allocation
+			static ULONG UserSizeOfAlloc(const void *ptr);
 
 	};
 }

--- a/src/include/gpopt/utils/CMemoryPoolPallocManager.h
+++ b/src/include/gpopt/utils/CMemoryPoolPallocManager.h
@@ -33,7 +33,15 @@ namespace gpos
 			// ctor
 			CMemoryPoolPallocManager(CMemoryPool *internal, EMemoryPoolType memory_pool_type);
 
+			// allocate new memorypool
 			virtual CMemoryPool *NewMemoryPool();
+
+			// free allocation
+			void DeleteImpl(void* ptr, CMemoryPool::EAllocationType eat);
+
+			// get user requested size of allocation
+			ULONG UserSizeOfAlloc(const void* ptr);
+
 
 			static
 			GPOS_RESULT Init();


### PR DESCRIPTION
CMemoryPoolPalloc previously used headers and logic that were only
needed in CMemoryPoolTracker. For each allocation, a fairly large header
was added, which caused memory intensive operations in ORCA to use large
amounts of memory. Now, we only store the size of array allocations in a
header if needed. Otherwise, no header information is needed/stored on
the ORCA side. This reduces the memory utilization for some queries by
30%+. For TPC-DS q72 on my laptop, peak memory utilization went from 1.1GB to
720MB. This header accounted for ~20MB of the 720MB peak usage in q72.

This functionality can be enabled with the
`optimizer_use_gpdb_allocators` GUC.

Corresponding ORCA commit: https://github.com/greenplum-db/gporca/commit/d828eed2bea47b30fd4cd0c29176488d1238e588 "Simplify CMemoryPool to reduce unnecessary headers and logic"

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Shreedhar Hardikar <shardikar@pivotal.io>