### PR TITLE
Avoid crash for explain analyze with sort in utility mode

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -741,7 +741,7 @@ ExplainPrintPlan(ExplainState *es, QueryDesc *queryDesc)
 	 */
 	if (es->analyze && !es->showstatctx->stats_gathered)
 	{
-		if (Gp_role == GP_ROLE_DISPATCH && (!es->currentSlice || sliceRunsOnQD(es->currentSlice)))
+		if (Gp_role != GP_ROLE_EXECUTE && (!es->currentSlice || sliceRunsOnQD(es->currentSlice)))
 			cdbexplain_localExecStats(queryDesc->planstate, es->showstatctx);
 
         /* Fill in the plan's Instrumentation with stats from qExecs. */

--- a/src/test/isolation2/expected/misc.out
+++ b/src/test/isolation2/expected/misc.out
@@ -10,3 +10,16 @@ CREATE
 CREATE
 -1U: drop table utilitymode_primary_key_tab;
 DROP
+
+0U: explain analyze select * from gp_segment_configuration order by dbid;
+ QUERY PLAN                                                                                                               
+--------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=0.01..0.02 rows=1 width=108) (actual time=0.255..0.255 rows=0 loops=1)                                       
+   Sort Key: dbid                                                                                                         
+   Sort Method:  quicksort  Memory: 33kB                                                                                  
+   ->  Seq Scan on gp_segment_configuration  (cost=0.00..0.00 rows=1 width=108) (actual time=0.000..0.000 rows=0 loops=1) 
+ Planning time: 2.111 ms                                                                                                  
+   (slice0)    Executor memory: 89K bytes (seg0).  Work_mem: 65K bytes max.                                               
+ Optimizer: Postgres query optimizer                                                                                      
+ Execution time: 0.357 ms                                                                                                 
+(8 rows)

--- a/src/test/isolation2/sql/misc.sql
+++ b/src/test/isolation2/sql/misc.sql
@@ -7,3 +7,5 @@
 -1U: create table utilitymode_primary_key_tab (c1 int);
 -1U: create unique index idx_utilitymode_c1 on utilitymode_primary_key_tab (c1);
 -1U: drop table utilitymode_primary_key_tab;
+
+0U: explain analyze select * from gp_segment_configuration order by dbid;


### PR DESCRIPTION
show_sort_info() crashes if `((PlanState *)
sortstate)->instrument->cdbNodeSummary` is
NULL. cdbexplain_localExecStats() should be called for utility mode
connections or DISPATCH mode on master. Hence, modifying the check to
avoid crash.

In general, utility mode doesn't have much such usecase but definitely
crashing is not good, hence avoid the same.

Fixes #8804 github issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
