### PR TITLE
Move server-build publishing to a separate CI job

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -80,6 +80,7 @@ JOBS_THAT_SHOULD_NOT_BLOCK_RELEASE = (
         'MADlib_Test_orca_centos6',
         'MADlib_Test_planner_centos7',
         'MADlib_Test_orca_centos7',
+        'Publish Server Builds',
     ] + RELEASE_VALIDATOR_JOB + JOBS_THAT_ARE_GATES
 )
 

--- a/concourse/pipelines/gpdb_master-generated.yml
+++ b/concourse/pipelines/gpdb_master-generated.yml
@@ -100,6 +100,7 @@ groups:
   jobs:
   - gate_release_candidate_start
   - Release_Candidate
+  - Publish Server Builds
 
 ## ======================================================================
 
@@ -759,9 +760,6 @@ jobs:
     - put: bin_gpdb_clients_centos6
       params:
         file: gpdb_artifacts/gpdb-clients-centos6.tar.gz
-    - put: server-build-centos6
-      params:
-        file: gpdb_artifacts/server-build-*-rhel6*.tar.gz
 
 - name: compile_gpdb_centos7
   plan:
@@ -795,9 +793,6 @@ jobs:
     - put: bin_gpdb_clients_centos7
       params:
         file: gpdb_artifacts/gpdb-clients-centos7.tar.gz
-    - put: server-build-centos7
-      params:
-        file: gpdb_artifacts/server-build-*-rhel7*.tar.gz
 
 - name: compile_gpdb_binary_swap_centos6
   plan:
@@ -860,9 +855,6 @@ jobs:
         - put: bin_gpdb_clients_ubuntu18.04
           params:
             file: gpdb_artifacts/gpdb-clients-ubuntu18.04.tar.gz
-        - put: server-build-ubuntu18.04
-          params:
-            file: gpdb_artifacts/server-build-*-ubuntu18.04*.tar.gz
 
 
 - name: compile_gpdb_clients_windows
@@ -3198,6 +3190,36 @@ jobs:
     - get: bin_gpdb_clients_windows
       passed:
       - test_gpdb_clients_windows
+
+- name: Publish Server Builds
+  plan:
+  - in_parallel:
+    - get: gpdb_src
+      trigger: true
+      passed:
+      - compile_gpdb_centos6
+      - compile_gpdb_centos7
+      - compile_gpdb_ubuntu18.04
+    - get: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb_centos7
+      passed: [compile_gpdb_centos7]
+    - get: bin_gpdb_ubuntu18.04
+      passed: [compile_gpdb_ubuntu18.04]
+  - task: rename server build artifacts
+    file: gpdb_src/concourse/tasks/rename-server-build.yml
+    params:
+      RC_BUILD_TYPE_GCS: ((rc-build-type-gcs))
+  - in_parallel:
+    - put: server-build-centos6
+      params:
+        file: output/server-build-*-rhel6*.tar.gz
+    - put: server-build-centos7
+      params:
+        file: output/server-build-*-rhel7*.tar.gz
+    - put: server-build-ubuntu18.04
+      params:
+        file: output/server-build-*-ubuntu18.04*.tar.gz
 
 - name: Release_Candidate
   plan:

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -141,6 +141,7 @@ groups:
   jobs:
   - gate_release_candidate_start
   - Release_Candidate
+  - Publish Server Builds
 
 {% endif %}
 ## ======================================================================
@@ -922,9 +923,6 @@ jobs:
     - put: bin_gpdb_clients_centos6
       params:
         file: gpdb_artifacts/gpdb-clients-centos6.tar.gz
-    - put: server-build-centos6
-      params:
-        file: gpdb_artifacts/server-build-*-rhel6*.tar.gz
 
 {% endif %}
 {% if "centos7" in os_types %}
@@ -960,9 +958,6 @@ jobs:
     - put: bin_gpdb_clients_centos7
       params:
         file: gpdb_artifacts/gpdb-clients-centos7.tar.gz
-    - put: server-build-centos7
-      params:
-        file: gpdb_artifacts/server-build-*-rhel7*.tar.gz
 
 {% endif %}
 {% if "centos6" in os_types %}
@@ -1029,9 +1024,6 @@ jobs:
         - put: bin_gpdb_clients_ubuntu18.04
           params:
             file: gpdb_artifacts/gpdb-clients-ubuntu18.04.tar.gz
-        - put: server-build-ubuntu18.04
-          params:
-            file: gpdb_artifacts/server-build-*-ubuntu18.04*.tar.gz
 
 {% endif %}
 
@@ -2106,6 +2098,36 @@ jobs:
     - get: bin_gpdb_clients_windows
       passed:
       - test_gpdb_clients_windows
+
+- name: Publish Server Builds
+  plan:
+  - in_parallel:
+    - get: gpdb_src
+      trigger: true
+      passed:
+      - compile_gpdb_centos6
+      - compile_gpdb_centos7
+      - compile_gpdb_ubuntu18.04
+    - get: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb_centos7
+      passed: [compile_gpdb_centos7]
+    - get: bin_gpdb_ubuntu18.04
+      passed: [compile_gpdb_ubuntu18.04]
+  - task: rename server build artifacts
+    file: gpdb_src/concourse/tasks/rename-server-build.yml
+    params:
+      RC_BUILD_TYPE_GCS: ((rc-build-type-gcs))
+  - in_parallel:
+    - put: server-build-centos6
+      params:
+        file: output/server-build-*-rhel6*.tar.gz
+    - put: server-build-centos7
+      params:
+        file: output/server-build-*-rhel7*.tar.gz
+    - put: server-build-ubuntu18.04
+      params:
+        file: output/server-build-*-ubuntu18.04*.tar.gz
 
 - name: Release_Candidate
   plan:

--- a/concourse/tasks/rename-server-build.yml
+++ b/concourse/tasks/rename-server-build.yml
@@ -1,0 +1,28 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/gpdb6-centos6-build
+
+inputs:
+- name: gpdb_src
+- name: bin_gpdb_centos6
+- name: bin_gpdb_centos7
+- name: bin_gpdb_ubuntu18.04
+
+outputs:
+- name: output
+
+params:
+  RC_BUILD_TYPE_GCS:
+
+run:
+  path: bash
+  args:
+  - -ec
+  - |
+    server_version="$(./gpdb_src/getversion --short)"
+    cp bin_gpdb_centos6/bin_gpdb.tar.gz "output/server-build-${server_version}-rhel6_x86_64${RC_BUILD_TYPE_GCS}.tar.gz"
+    cp bin_gpdb_centos7/bin_gpdb.tar.gz "output/server-build-${server_version}-rhel7_x86_64${RC_BUILD_TYPE_GCS}.tar.gz"
+    cp bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz "output/server-build-${server_version}-ubuntu18.04_x86_64${RC_BUILD_TYPE_GCS}.tar.gz"


### PR DESCRIPTION
The `without_asserts` pipeline includes a time-based trigger which can
cause the pipeline to re-run the compilation jobs for the same commit.
When the compilation jobs attempt to re-`put` the server-build artifact,
the job fails because the build artifacts bucket is immutable.

This commit move the server-build publishing to a separate, hidden CI
job that does not block the release.

Authored-by: Bradford D. Boyle <bboyle@pivotal.io>