### PR TITLE
Align walreceiver.c code to upstream

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3504,15 +3504,6 @@ struct config_int ConfigureNamesInt_gp[] =
 
 
 	{
-#ifdef USE_ASSERT_CHECKING
-		{"gp_debug_linger", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Number of seconds for QD/QE process to linger upon fatal internal error."),
-			gettext_noop("Allows an opportunity to debug the backend process before it terminates."),
-			GUC_NOT_IN_SAMPLE | GUC_NO_RESET_ALL | GUC_UNIT_S
-		},
-		&gp_debug_linger,
-		120, 0, 3600,
-#else
 		{"gp_debug_linger", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Number of seconds for QD/QE process to linger upon fatal internal error."),
 			gettext_noop("Allows an opportunity to debug the backend process before it terminates."),
@@ -3520,7 +3511,6 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_debug_linger,
 		0, 0, 3600,
-#endif
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
I couldn't think of nor able to find reason for having these diffs against upstream. Hence, seems best to get rid of them.

Only thing is for the same I have to add commit "Avoid elog_debug_linger() for walreceiver process" If any error happens in walreceiver process after commit 725c68, similar to upstream it would get converted to `FATAL` (as `PG_exception_stack == NULL` for walreceiver process) and walreceiver will exit. But in GPDB on `FATAL` in assert enabled builds, process hangs around for `gp_debug_linger` time (which being 2 mins by default). This causes unnecessary weird test failures in assert builds, hence avoid lingering of walreceiver process.

I many times fell we should set `gp_debug_linger` to 0 irrespective of assert build or not. When required to hold the process for debugging should set it explicitly instead of defaulting it this way. If that's done then will not need to have this exception for walreceiver. Thoughts?

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
