### PR TITLE
Fix heap-use-after-free in gp_inject_fault()

### DIFF
--- a/gpcontrib/gp_inject_fault/gp_inject_fault.c
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault.c
@@ -159,16 +159,11 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 			elog(ERROR, "invalid response from %s:%d", hostname, port);
 		}
 
-		response = PQgetvalue(res, 0, Anum_fault_message_response_status);
-		if (strncmp(response, "Success:",  strlen("Success:")) != 0)
-		{
-			PQclear(res);
-			PQfinish(conn);
-			elog(ERROR, "%s", response);
-		}
-
+		response = pstrdup(PQgetvalue(res, 0, Anum_fault_message_response_status));
 		PQclear(res);
 		PQfinish(conn);
+		if (strncmp(response, "Success:",  strlen("Success:")) != 0)
+			elog(ERROR, "%s", response);
 	}
 	PG_RETURN_TEXT_P(cstring_to_text(response));
 }


### PR DESCRIPTION
In [postgres libpq document](https://www.postgresql.org/docs/9.6/libpq-exec.html), it says:

>  The pointer returned by PQgetvalue points to storage that is part of the PGresult structure. One should not modify the data it points to, and one must explicitly copy the data into other storage if it is to be used past the lifetime of the PGresult structure itself.

So if we compile the Greenplum with GCC Address Sanitizer, and we will get this:
![image](https://user-images.githubusercontent.com/17427025/67157457-0c945080-f35f-11e9-8bb5-c16a84a1ab29.png)
![image](https://user-images.githubusercontent.com/17427025/67157468-203fb700-f35f-11e9-9ed7-bbbf034bd826.png)
