### PR TITLE
Handle dispatching of rule statements

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1738,15 +1738,6 @@ ProcessUtilitySlow(Node *parsetree,
 
 			case T_RuleStmt:	/* CREATE RULE */
 				address = DefineRule((RuleStmt *) parsetree, queryString);
-				if (Gp_role == GP_ROLE_DISPATCH)
-				{
-					CdbDispatchUtilityStatement((Node *) parsetree,
-												DF_CANCEL_ON_ERROR|
-												DF_WITH_SNAPSHOT|
-												DF_NEED_TWO_PHASE,
-												GetAssignedOidsForDispatch(),
-												NULL);
-				}
 				break;
 
 			case T_CreateSeqStmt:

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -5872,6 +5872,13 @@ select test();
 (1 row)
 
 --
+-- Test that rules with functions can be serialized correctly
+-- This is tested here because the rules tests are not enabled
+--
+create table  qp_misc_jiras.rules (a integer);
+create rule "_RETURN" as on select to qp_misc_jiras.rules do instead
+  select * from generate_series(1,5) x(a);
+--
 -- Test gp_enable_relsize_collection's effect on ORCA plan generation
 --
 create table tbl_z(x int) distributed by (x);

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -5855,6 +5855,13 @@ select test();
 (1 row)
 
 --
+-- Test that rules with functions can be serialized correctly
+-- This is tested here because the rules tests are not enabled
+--
+create table  qp_misc_jiras.rules (a integer);
+create rule "_RETURN" as on select to qp_misc_jiras.rules do instead
+  select * from generate_series(1,5) x(a);
+--
 -- Test gp_enable_relsize_collection's effect on ORCA plan generation
 --
 create table tbl_z(x int) distributed by (x);

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -2556,6 +2556,14 @@ select test();
 
 
 --
+-- Test that rules with functions can be serialized correctly
+-- This is tested here because the rules tests are not enabled
+--
+create table  qp_misc_jiras.rules (a integer);
+create rule "_RETURN" as on select to qp_misc_jiras.rules do instead
+  select * from generate_series(1,5) x(a);
+
+--
 -- Test gp_enable_relsize_collection's effect on ORCA plan generation
 --
 create table tbl_z(x int) distributed by (x);


### PR DESCRIPTION
This was fixed in 6X_STABLE by https://github.com/greenplum-db/gpdb/pull/8790, but we need to fix it in 'master', too. This is a cherry-pick of commit c1eb1795627ecf4640b0af9a5492f30797b1ab39 to master. I created this PR to have a pass through the PR pipeline before pushing.