### PR TITLE
Allow the cluster shutdown in some cases when dtx recovery hang happens.

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1027,10 +1027,9 @@ cdb_setup(void)
 		Gp_role == GP_ROLE_DISPATCH &&
 		!*shmDtmStarted)
 	{
-		int rc;
-
 		while (true)
 		{
+			int rc;
 			if (*shmDtmStarted)
 				break;
 			CHECK_FOR_INTERRUPTS();


### PR DESCRIPTION
We've seen this when fts detects 'double fault'. In such case,
dtx recovery can not proceed and newly created postgres backend could
hang, waiting for dtx recovery finishing. Changing the code to make
the cluster be able to stop in fast mode; Also those backends
should quit if postmaster is dead.

Co-Authored-By: Paul Guo <pguo@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
