### PR TITLE
[6X Backport] Consider non direct dispatch cost for cached plan.

### DIFF
--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -68,6 +68,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 
+#include "cdb/cdbutil.h"
 
 /*
  * We must skip "overhead" operations that involve database access when the
@@ -1105,6 +1106,39 @@ cached_plan_cost(CachedPlan *plan, bool include_planner)
 			int			nrelations = list_length(plannedstmt->rtable);
 
 			result += 1000.0 * cpu_operator_cost * (nrelations + 1);
+		}
+
+		/*
+		 * For generic plan, no params will be passed to planner, which leads
+		 * to plan can not genenrate direct dispatch plan, even if all the
+		 * params are const values. Unfortunately, direct dispatch cost v.s.
+		 * full gang dispatch cost is not included in plan's total cost. But
+		 * this cost is significantly. For query could leverage direct
+		 * dispatch, dispatching it to full gangs will result in unneccessary
+		 * QEs, but these QEs still need to go through volcano model, do two
+		 * phase commit and write xlog for Prepare etc, which not only
+		 * consuming CPU but also IO to disk. 
+		 *
+		 * So correctly generating direct dispatch plan matters.  As for custom
+		 * plan, it would pass the const params to planner and is able to
+		 * generate direct dispatch plan when possible. As a result, when we
+		 * evaluate the cost of generic plan and custom plan, we should not
+		 * only consider the plan's total cost and re-plan cost, but also
+		 * consider the cost of failed to generate direct dispatch.
+		 *
+		 * Since non direct dispatch introduces additional IO, we use
+		 * seq_page_cost as base unit to measure non direct dispatch cost. The
+		 * number of unneccessary QEs also measures the amount of this cost.
+		 * Considering clusters with 100 segments v.s. 10 segments, the non
+		 * direct dispatch cost of the 100 segments cluster is definitely
+		 * higher than 10 segments cluster.
+		 */
+		if (!plannedstmt->planTree->directDispatch.isDirectDispatch)
+		{
+			int			ndirectDispatchContentIds =
+				list_length(plannedstmt->planTree->directDispatch.contentIds);
+			int			nsegments = getgpsegmentCount();
+			result += 10.0 * seq_page_cost * (nsegments - ndirectDispatchContentIds);
 		}
 	}
 

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -529,6 +529,143 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 drop sequence ddtestseq;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- Test prepare statement will choose custom plan instead of generic plan when
+-- considering no direct dispatch cost.
+create table test_prepare(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- insert case
+prepare p1 as insert into test_prepare values($1, 1);
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- the first 5 execute will always use custom plan, focus on the 6th one.
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- update case
+prepare p2 as update test_prepare set j =2 where i =$1;
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- select case
+prepare p3 as select * from test_prepare where i =$1;
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+drop table test_prepare;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -544,6 +544,143 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 drop sequence ddtestseq;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- Test prepare statement will choose custom plan instead of generic plan when
+-- considering no direct dispatch cost.
+create table test_prepare(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- insert case
+prepare p1 as insert into test_prepare values($1, 1);
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- the first 5 execute will always use custom plan, focus on the 6th one.
+execute p1(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- update case
+prepare p2 as update test_prepare set j =2 where i =$1;
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+execute p2(1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- select case
+prepare p3 as select * from test_prepare where i =$1;
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+execute p3(1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ i | j 
+---+---
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+ 1 | 2
+(6 rows)
+
+drop table test_prepare;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -261,6 +261,37 @@ insert into ddtesttab values (1, 1, 5 + nextval('ddtestseq'));
 drop table ddtesttab;
 drop sequence ddtestseq;
 
+-- Test prepare statement will choose custom plan instead of generic plan when
+-- considering no direct dispatch cost.
+create table test_prepare(i int, j int);
+-- insert case
+prepare p1 as insert into test_prepare values($1, 1);
+execute p1(1);
+execute p1(1);
+execute p1(1);
+execute p1(1);
+execute p1(1);
+-- the first 5 execute will always use custom plan, focus on the 6th one.
+execute p1(1);
+
+-- update case
+prepare p2 as update test_prepare set j =2 where i =$1;
+execute p2(1);
+execute p2(1);
+execute p2(1);
+execute p2(1);
+execute p2(1);
+execute p2(1);
+
+-- select case
+prepare p3 as select * from test_prepare where i =$1;
+execute p3(1);
+execute p3(1);
+execute p3(1);
+execute p3(1);
+execute p3(1);
+execute p3(1);
+drop table test_prepare;
 
 -- cleanup
 set test_print_direct_dispatch_info=off;


### PR DESCRIPTION
Prepare statement will bind parameters for each execution. It needs to decide to
use a cached generic plan without params or a custom plan with params. In past,
GPDB use plan cost plus re-plan cost to choose generic and custom plan. But
generic plan does not contain params which leads to it could not generate
direct dispatch plan compared with custom plan.

For non direct dispatch plan it will introduce unneccessary QEs, which still
need to go through volcano model, do two phase commit and write prepare xlog.
So the cost of failed to generate direct dispatch plan would be higher in some
case than the re-plan cost which makes custom plan runs faster than generic
plan even if it needs to re-plan for every execute.

Note that non direct dispatch cost is not considered in planner yet. Planner
treats direct dispatch as an optimization and always enable it when possible.
But for prepare statement, the case is that for generic plan it could not
generate direct dispatch plan at all. But we need to consider this cost here,
as a result, we introduce non direct dispatch cost into total cost only for
cached plans.

Co-authored-by: Ning Yu <nyu@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
