### PR TITLE
Improve analyzedb performance on partitioned tables

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -340,13 +340,6 @@ class AnalyzeDb(Operation):
             else:
                 logger.warning("No valid state files directories exist. Exiting...")
 
-        if self.analyze_gucs is not None:
-            cmd = create_psql_command(self.dbname, self.analyze_gucs)
-            cmd.run()
-            if not cmd.was_successful():
-                logger.debug("GUCs not supported in this version: " + self.analyze_gucs)
-                self.analyze_gucs = ""
-
         if self.include_cols is not None:
             self.include_cols = self.include_cols.strip().split(',')
 

--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -40,6 +40,7 @@ EXECNAME = 'analyzedb'
 STATEFILE_DIR = 'db_analyze'
 logger = gplog.get_default_logger()
 WRITE_LOCK_FILE_NAME = "write_lock_semaphore"
+ANALYZE_GUCS = "set optimizer_analyze_enable_merge_of_leaf_stats=off; "
 ANALYZE_SQL = """analyze %s"""
 ANALYZE_ROOT_SQL = """analyze rootpartition %s"""
 
@@ -264,6 +265,7 @@ class AnalyzeDb(Operation):
         self.clean_last = options.clean_last
         self.clean_all = options.clean_all
         self.gen_profile_only = options.gen_profile_only
+        self.analyze_gucs = ANALYZE_GUCS
 
         self.success_list = []
 
@@ -337,6 +339,13 @@ class AnalyzeDb(Operation):
                     logger.warning("Folder %s does not exist. Exiting...")
             else:
                 logger.warning("No valid state files directories exist. Exiting...")
+
+        if self.analyze_gucs is not None:
+            cmd = create_psql_command(self.dbname, self.analyze_gucs)
+            cmd.run()
+            if not cmd.was_successful():
+                logger.debug("GUCs not supported in this version: " + self.analyze_gucs)
+                self.analyze_gucs = ""
 
         if self.include_cols is not None:
             self.include_cols = self.include_cols.strip().split(',')
@@ -464,7 +473,7 @@ class AnalyzeDb(Operation):
             can_schema, can_table = can[0], can[1]
             if can in candidates:
                 target = self._get_tablename_with_cols(can_schema, can_table, input_col_dict)
-                cmd = create_psql_command(self.dbname, ANALYZE_SQL % target)
+                cmd = create_psql_command(self.dbname, self.analyze_gucs + ANALYZE_SQL % target)
 
             else:  # can in root_partition_col_dict
                 target = self._get_tablename_with_cols(can_schema, can_table, root_partition_col_dict)

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1217,7 +1217,9 @@ get_rel_oids(Oid relid, const RangeVar *vacrel,
 				{
 					int		elevel = ((options & VACOPT_VERBOSE) ? LOG : DEBUG2);
 
-					if (leaf_parts_analyzed(root_rel_oid, relationOid, va_root_attnums, elevel))
+					if (optimizer_analyze_enable_merge_of_leaf_stats &&
+						leaf_parts_analyzed(root_rel_oid, relationOid, va_root_attnums, elevel))
+						/* remember to merge the partition stats into the root partition */
 						oid_list = lappend_oid(oid_list, root_rel_oid);
 				}
 			}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -404,6 +404,7 @@ bool		optimizer_enable_eageragg;
 /* Analyze related GUCs for Optimizer */
 bool		optimizer_analyze_root_partition;
 bool		optimizer_analyze_midlevel_partition;
+bool		optimizer_analyze_enable_merge_of_leaf_stats;
 
 /* GUCs for replicated table */
 bool		optimizer_replicated_table_insert;
@@ -2601,6 +2602,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_analyze_midlevel_partition,
 		false,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_analyze_enable_merge_of_leaf_stats", PGC_USERSET, STATS_ANALYZE,
+			gettext_noop("Enable merging of leaf stats into the root stats during ANALYZE when analyzing partitions"),
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_analyze_enable_merge_of_leaf_stats,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -562,6 +562,7 @@ extern bool optimizer_enable_associativity;
 /* Analyze related GUCs for Optimizer */
 extern bool optimizer_analyze_root_partition;
 extern bool optimizer_analyze_midlevel_partition;
+extern bool optimizer_analyze_enable_merge_of_leaf_stats;
 
 extern bool optimizer_use_gpdb_allocators;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -327,6 +327,7 @@
 		"min_wal_size",
 		"operator_precedence_warning",
 		"optimizer",
+		"optimizer_analyze_enable_merge_of_leaf_stats",
 		"optimizer_analyze_midlevel_partition",
 		"optimizer_analyze_root_partition",
 		"optimizer_apply_left_outer_to_union_all_disregarding_stats",


### PR DESCRIPTION
Until now, when we issued an "analyze <partition>" command, we would
produce new root-level statistics (merge) for each such command,
assuming we had valid HLL stats for every partition and every column.
That is very expensive, and could take hours to complete, if we
need to update many partitions. The cost is roughly

u * p * c

where u is the number of incrementally updated partitions, p is the
total number of partitions and c is the number of columns.

This commit adds a new guc, optimizer_analyze_enable_merge_of_leaf_stats
that enables creating new root-level stats when we analyze an
individual partition. The guc is set to "on" by default, so there is
no change in the default behavior.

The analyzedb program, however, will turn this guc off and therefore
suppress generating the root stats for every partition. The root-level
stats will be generated when analyzedb issues the final
"analyze rootpartition" command. For tables with very many partitions,
this can speed up the process by several orders of magnitude when we
do a full analyze, the new cost is now p * c.

Co-authored-by: Abhijit Subramanya <asubramanya@pivotal.io>
Co-authored-by: Hans Zeller <hzeller@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
