### PR TITLE
Fixing setting flow->hashExpr plan references

### DIFF
--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -655,3 +655,110 @@ select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t
 (4 rows)
 
 drop table t1, t2, t3;
+-- test that flow->hashExpr variables can be resolved
+CREATE TABLE hexpr_t1 (c1 int, c2 character varying(16)) DISTRIBUTED BY (c1);
+CREATE TABLE hexpr_t2 (c3 character varying(16)) DISTRIBUTED BY (c3);
+INSERT INTO hexpr_t1 SELECT i, i::character varying FROM generate_series(1,10)i;
+INSERT INTO hexpr_t2 SELECT i::character varying FROM generate_series(1,10)i;
+EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=3.43..6.93 rows=10 width=2)
+   ->  Hash Left Join  (cost=3.43..6.93 rows=4 width=2)
+         Hash Cond: btrim(hexpr_t1.c2::text) = hexpr_t2.c3::text
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=4 width=2)
+               Hash Key: btrim(hexpr_t1.c2::text)
+               ->  Seq Scan on hexpr_t1  (cost=0.00..3.10 rows=4 width=2)
+         ->  Hash  (cost=3.30..3.30 rows=4 width=2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.30 rows=4 width=2)
+                     Hash Key: hexpr_t2.c3
+                     ->  Seq Scan on hexpr_t2  (cost=0.00..3.10 rows=4 width=2)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=3.43..6.93 rows=10 width=2)
+   ->  Hash Left Join  (cost=3.43..6.93 rows=4 width=2)
+         Hash Cond: btrim(hexpr_t1.c2::text) = hexpr_t2.c3::text
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=4 width=2)
+               Hash Key: btrim(hexpr_t1.c2::text)
+               ->  Seq Scan on hexpr_t1  (cost=0.00..3.10 rows=4 width=2)
+         ->  Hash  (cost=3.30..3.30 rows=4 width=2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.30 rows=4 width=2)
+                     Hash Key: hexpr_t2.c3
+                     ->  Seq Scan on hexpr_t2  (cost=0.00..3.10 rows=4 width=2)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=3.43..6.93 rows=10 width=2)
+   ->  Hash Left Join  (cost=3.43..6.93 rows=4 width=2)
+         Hash Cond: btrim(hexpr_t1.c2::text) = hexpr_t2.c3::text
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=4 width=2)
+               Hash Key: btrim(hexpr_t1.c2::text)
+               ->  Seq Scan on hexpr_t1  (cost=0.00..3.10 rows=4 width=2)
+         ->  Hash  (cost=3.30..3.30 rows=4 width=2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.30 rows=4 width=2)
+                     Hash Key: hexpr_t2.c3
+                     ->  Seq Scan on hexpr_t2  (cost=0.00..3.10 rows=4 width=2)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+ foo 
+-----
+ 2
+ 5
+ 8
+ 3
+ 6
+ 9
+ 10
+ 1
+ 4
+ 7
+(10 rows)
+
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+ foo 
+-----
+ 9
+ 10
+ 3
+ 6
+ 2
+ 5
+ 8
+ 1
+ 4
+ 7
+(10 rows)
+
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+ foo 
+-----
+ 3
+ 6
+ 9
+ 10
+ 2
+ 5
+ 8
+ 1
+ 4
+ 7
+(10 rows)
+

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -661,3 +661,104 @@ select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t
 (4 rows)
 
 drop table t1, t2, t3;
+-- test that flow->hashExpr variables can be resolved
+CREATE TABLE hexpr_t1 (c1 int, c2 character varying(16)) DISTRIBUTED BY (c1);
+CREATE TABLE hexpr_t2 (c3 character varying(16)) DISTRIBUTED BY (c3);
+INSERT INTO hexpr_t1 SELECT i, i::character varying FROM generate_series(1,10)i;
+INSERT INTO hexpr_t2 SELECT i::character varying FROM generate_series(1,10)i;
+EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=5 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=14 width=2)
+         ->  Hash Left Join  (cost=0.00..862.00 rows=5 width=2)
+               Hash Cond: btrim(hexpr_t1.c2::text) = hexpr_t2.c3::text
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=2)
+                     Hash Key: btrim(hexpr_t1.c2::text)
+                     ->  Table Scan on hexpr_t1  (cost=0.00..431.00 rows=4 width=2)
+               ->  Hash  (cost=431.00..431.00 rows=4 width=2)
+                     ->  Table Scan on hexpr_t2  (cost=0.00..431.00 rows=4 width=2)
+ Optimizer status: PQO version 3.78.0
+(10 rows)
+
+EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=5 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=14 width=2)
+         ->  Hash Left Join  (cost=0.00..862.00 rows=5 width=2)
+               Hash Cond: btrim(hexpr_t1.c2::text) = hexpr_t2.c3::text
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=2)
+                     Hash Key: btrim(hexpr_t1.c2::text)
+                     ->  Table Scan on hexpr_t1  (cost=0.00..431.00 rows=4 width=2)
+               ->  Hash  (cost=431.00..431.00 rows=4 width=2)
+                     ->  Table Scan on hexpr_t2  (cost=0.00..431.00 rows=4 width=2)
+ Optimizer status: PQO version 3.78.0
+(10 rows)
+
+EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=5 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=14 width=2)
+         ->  Hash Left Join  (cost=0.00..862.00 rows=5 width=2)
+               Hash Cond: btrim(hexpr_t1.c2::text) = hexpr_t2.c3::text
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=2)
+                     Hash Key: btrim(hexpr_t1.c2::text)
+                     ->  Table Scan on hexpr_t1  (cost=0.00..431.00 rows=4 width=2)
+               ->  Hash  (cost=431.00..431.00 rows=4 width=2)
+                     ->  Table Scan on hexpr_t2  (cost=0.00..431.00 rows=4 width=2)
+ Optimizer status: PQO version 3.78.0
+(10 rows)
+
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+ foo 
+-----
+ 2
+ 5
+ 8
+ 3
+ 6
+ 9
+ 10
+ 1
+ 4
+ 7
+(10 rows)
+
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+ foo 
+-----
+ 8
+ 2
+ 5
+ 9
+ 10
+ 3
+ 6
+ 1
+ 4
+ 7
+(10 rows)
+
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+ foo 
+-----
+ 9
+ 10
+ 3
+ 6
+ 2
+ 8
+ 5
+ 1
+ 4
+ 7
+(10 rows)
+

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -337,3 +337,20 @@ select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t
   join t3 t3_1 on tt1.t1b = t3_1.b and (tt1.t2a is NULL OR tt1.t1b = t3.b);
 
 drop table t1, t2, t3;
+-- test that flow->hashExpr variables can be resolved
+CREATE TABLE hexpr_t1 (c1 int, c2 character varying(16)) DISTRIBUTED BY (c1);
+CREATE TABLE hexpr_t2 (c3 character varying(16)) DISTRIBUTED BY (c3);
+INSERT INTO hexpr_t1 SELECT i, i::character varying FROM generate_series(1,10)i;
+INSERT INTO hexpr_t2 SELECT i::character varying FROM generate_series(1,10)i;
+EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);


### PR DESCRIPTION
When flow->hashExpr is created, we ignore the relable node while
checking the existence of the expression in the targetlist, if a match
is not found in the targetlist, hashExpr is added to the targetlist with
resjunk=true.
```
In create_join_plan
	/**
	 * If plan has a flow node, ensure all entries of hashExpr
	 * are in the targetlist.
	 */
	if (plan->flow && plan->flow->hashExpr)
	{
		plan->targetlist = add_to_flat_tlist(plan->targetlist, plan->flow->hashExpr, true /* resjunk */ );
	}

add_to_flat_tlist uses tlist_member_ignore_relabel
```

Later, in set_plan_refs, the references of the vars are updated. This
commit ensures that the contract of ignoring the relable node is
held while trying to update the references in hashExpr. Prior to this
commit, in set_plan_refs while checking the existing of hashExpr in
targetlist relable node were not ignored which resulted in not finding
the coressponding projection element and the planning used to fail with
`ERROR:  variable not found in subplan target list`

fix_upper_expr ensures that the cast/type of the variable in the upper
plan node is not ignore, thus it considered a plain match for non vars
expression. Thus, added a new method to perform special handling of
flow->hashExpr as they have to be matched with the target list at the
same level (not of the child).

This has been a bug in 5 and previous version of greenplum since long,
this is a greenplum specific fix, so may be was never caught.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
