### PR TITLE
Fix stack overflow error

### DIFF
--- a/src/backend/access/appendonly/aomd_filehandler.c
+++ b/src/backend/access/appendonly/aomd_filehandler.c
@@ -68,7 +68,7 @@ ao_foreach_extent_file(ao_extent_callback callback, void *ctx)
 {
     int segno;
     int colnum;
-    int concurrency[AOTupleId_MaxSegmentFileNum];
+    int concurrency[MAX_AOREL_CONCURRENCY];
     int concurrencySize;
 
     /*


### PR DESCRIPTION
The `concurrency` as a container stores segment number from **0** through `AOTupleId_MaxSegmentFileNum`, so its capacity should be `AOTupleId_MaxSegmentFileNum + 1`!
