### PR TITLE
6X: Enable materialized view in greenplum

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1133,7 +1133,7 @@ validateAppendOnlyRelOptions(bool ao,
 							 char relkind,
 							 bool co)
 {
-	if (relkind != RELKIND_RELATION)
+	if (relkind != RELKIND_RELATION  && relkind != RELKIND_MATVIEW)
 	{
 		if (ao)
 			ereport(ERROR,

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1412,7 +1412,7 @@ heap_create_with_catalog(const char *relname,
 	 * Was "appendonly" specified in the relopts? If yes, fix our relstorage.
 	 * Also, check for override (debug) GUCs.
 	 */
-	if (relkind == RELKIND_RELATION)
+	if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW)
 	{
 		stdRdOptions = (StdRdOptions*) heap_reloptions(
 			relkind, reloptions, !valid_opts);
@@ -2465,13 +2465,13 @@ heap_drop_with_catalog(Oid relid)
 	/*
 	 * Remove distribution policy, if any.
  	 */
-	if (relkind == RELKIND_RELATION)
+	if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW)
 		GpPolicyRemove(relid);
 
 	/*
 	 * Attribute encoding
 	 */
-	if (relkind == RELKIND_RELATION)
+	if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW)
 		RemoveAttributeEncodingsByRelid(relid);
 
 	/* MPP-6929: metadata tracking */

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -636,7 +636,8 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 	/* Create the transient table that will receive the re-ordered data */
 	OIDNewHeap = make_new_heap(tableOid, tableSpace,false,
 							   AccessExclusiveLock,
-							   true /* createAoBlockDirectory */);
+							   true /* createAoBlockDirectory */,
+							   false);
 
 	/* Copy the heap data into the new table in the desired order */
 	copy_heap_data(OIDNewHeap, tableOid, indexOid, verbose,
@@ -667,7 +668,8 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 Oid
 make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, bool forcetemp,
 			  LOCKMODE lockmode,
-			  bool createAoBlockDirectory)
+			  bool createAoBlockDirectory,
+			  bool makeCdbPolicy)
 {
 	TupleDesc	OldHeapDesc;
 	char		NewHeapName[NAMEDATALEN];
@@ -760,7 +762,7 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, bool forcetemp,
 										  true,
 										  0,
 										  ONCOMMIT_NOOP,
-                                          NULL,                         /*CDB*/
+										  makeCdbPolicy? OldHeap->rd_cdbpolicy: NULL,/*CDB*/
 										  reloptions,
 										  false,
 										  true,

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -170,7 +170,7 @@ create_ctas_internal(List *attrList, IntoClause *into, QueryDesc *queryDesc, boo
 	create->attr_encodings = NULL; /* Handle by AddDefaultRelationAttributeOptions() */
 
 	/* Save them in CreateStmt for dispatching. */
-	create->relKind = RELKIND_RELATION;
+	create->relKind = relkind;
 	create->relStorage = relstorage;
 	create->ownerid = GetUserId();
 
@@ -405,8 +405,8 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 	queryDesc = CreateQueryDesc(plan, queryString,
 								GetActiveSnapshot(), InvalidSnapshot,
 								dest, params, 0);
-
-	if (into->skipData)
+	
+	if (into->skipData && !is_matview)
 	{
 		/*
 		 * If WITH NO DATA was specified, do not go through the rewriter,

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5796,7 +5796,7 @@ ATRewriteTables(List **wqueue, LOCKMODE lockmode)
 
 			/* Create transient table that will receive the modified data */
 			OIDNewHeap = make_new_heap(tab->relid, newTableSpace, false,
-									   lockmode, hasIndexes);
+									   lockmode, hasIndexes, false);
 
 			/*
 			 * Copy the heap data into the new table with the desired

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1957,6 +1957,7 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 			switch (relation->rd_rel->relkind)
 			{
 				case RELKIND_RELATION:
+				case RELKIND_MATVIEW:
 					/* OK */
 					break;
 				case RELKIND_SEQUENCE:
@@ -2157,7 +2158,8 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 		queryDesc->dest = CreateCopyDestReceiver();
 		((DR_copy*)queryDesc->dest)->queryDesc = queryDesc;
 	}
-
+	else if (queryDesc->plannedstmt->refreshClause != NULL && Gp_role == GP_ROLE_EXECUTE)
+		transientrel_init(queryDesc);
 	if (DEBUG1 >= log_min_messages)
 			{
 				char		msec_str[32];
@@ -4988,7 +4990,7 @@ FillSliceTable(EState *estate, PlannedStmt *stmt)
 	cxt.estate = estate;
 	cxt.currentSliceId = 0;
 
-	if (stmt->intoClause != NULL || stmt->copyIntoClause != NULL)
+	if (stmt->intoClause != NULL || stmt->copyIntoClause != NULL || stmt->refreshClause)
 	{
 		Slice	   *currentSlice = (Slice *) linitial(sliceTable->slices);
 		int			numsegments;

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -439,7 +439,11 @@ CTranslatorQueryToDXL::CheckSupportedCmdType
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("COPY. Copy select statement to file on segment is not supported with GPORCA"));
 		}
-		
+		if (query->parentStmtType == PARENTSTMTTYPE_REFRESH_MATVIEW)
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Refresh matview is not supported with GPORCA"));
+		}
+
 		// supported: regular select or CTAS when it is enabled
 		return;
 	}

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -132,6 +132,7 @@ _copyPlannedStmt(const PlannedStmt *from)
 
 	COPY_NODE_FIELD(intoClause);
 	COPY_NODE_FIELD(copyIntoClause);
+	COPY_NODE_FIELD(refreshClause);
 	COPY_SCALAR_FIELD(metricsQueryType);
 
 	return newnode;
@@ -1496,6 +1497,20 @@ _copyCopyIntoClause(const CopyIntoClause *from)
 	COPY_STRING_FIELD(filename);
 	COPY_NODE_FIELD(options);
 	COPY_NODE_FIELD(ao_segnos);
+
+	return newnode;
+}
+
+/*
+ * _copyRefreshClause
+ */
+static RefreshClause *
+_copyRefreshClause(const RefreshClause *from)
+{
+	RefreshClause *newnode = makeNode(RefreshClause);
+
+	COPY_SCALAR_FIELD(concurrent);
+	COPY_NODE_FIELD(relation);
 
 	return newnode;
 }
@@ -5286,6 +5301,9 @@ copyObject(const void *from)
 			break;
 		case T_CopyIntoClause:
 			retval = _copyCopyIntoClause(from);
+			break;
+		case T_RefreshClause:
+			retval = _copyRefreshClause(from);
 			break;
 		case T_Var:
 			retval = _copyVar(from);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -379,6 +379,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
+	WRITE_NODE_FIELD(refreshClause);
 	WRITE_INT8_FIELD(metricsQueryType);
 }
 
@@ -1479,6 +1480,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_CopyIntoClause:
 				_outCopyIntoClause(str, obj);
+				break;
+			case T_RefreshClause:
+				_outRefreshClause(str, obj);
 				break;
 			case T_Var:
 				_outVar(str, obj);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -324,6 +324,7 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
+	WRITE_NODE_FIELD(refreshClause);
 	WRITE_INT_FIELD(metricsQueryType);
 }
 #endif /* COMPILING_BINARY_FUNCS */
@@ -1339,6 +1340,15 @@ _outCopyIntoClause(StringInfo str, const CopyIntoClause *node)
 	WRITE_NODE_FIELD(options);
 	WRITE_NODE_FIELD(ao_segnos);
 
+}
+
+static void
+_outRefreshClause(StringInfo str, const RefreshClause *node)
+{
+	WRITE_NODE_TYPE("REFRESHCLAUSE");
+
+	WRITE_BOOL_FIELD(concurrent);
+	WRITE_NODE_FIELD(relation);
 }
 
 static void
@@ -4851,6 +4861,9 @@ _outNode(StringInfo str, const void *obj)
 				break;
 			case T_CopyIntoClause:
 				_outCopyIntoClause(str, obj);
+				break;
+			case T_RefreshClause:
+				_outRefreshClause(str, obj);
 				break;
 			case T_Var:
 				_outVar(str, obj);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1086,6 +1086,7 @@ _readCreateStmt_common(CreateStmt *local_node)
 		   local_node->relKind == RELKIND_COMPOSITE_TYPE ||
 		   local_node->relKind == RELKIND_FOREIGN_TABLE ||
 		   local_node->relKind == RELKIND_UNCATALOGED ||
+		   local_node->relKind == RELKIND_MATVIEW ||
 		   IsAppendonlyMetadataRelkind(local_node->relKind));
 	Assert(local_node->oncommit <= ONCOMMIT_DROP);
 }
@@ -1431,6 +1432,7 @@ _readPlannedStmt(void)
 	READ_UINT64_FIELD(query_mem);
 	READ_NODE_FIELD(intoClause);
 	READ_NODE_FIELD(copyIntoClause);
+	READ_NODE_FIELD(refreshClause);
 	READ_INT8_FIELD(metricsQueryType);
 	READ_DONE();
 }
@@ -3228,6 +3230,9 @@ readNodeBinary(void)
 				break;
 			case T_CopyIntoClause:
 				return_value = _readCopyIntoClause();
+				break;
+			case T_RefreshClause:
+				return_value = _readRefreshClause();
 				break;
 			case T_Var:
 				return_value = _readVar();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -707,6 +707,17 @@ _readCopyIntoClause(void)
 	READ_DONE();
 }
 
+static RefreshClause *
+_readRefreshClause(void)
+{
+	READ_LOCALS(RefreshClause);
+
+	READ_BOOL_FIELD(concurrent);
+	READ_NODE_FIELD(relation);
+
+	READ_DONE();
+}
+
 /*
  * _readVar
  */
@@ -2966,8 +2977,10 @@ parseNodeString(void)
 		return_value = _readRangeVar();
 	else if (MATCH("INTOCLAUSE", 10))
 		return_value = _readIntoClause();
-	else if (MATCH("COPYINTOCLAUSE", 10))
+	else if (MATCH("COPYINTOCLAUSE", 14))
 		return_value = _readCopyIntoClause();
+	else if (MATCH("REFRESHCLAUSE", 13))
+		return_value = _readRefreshClause();
 	else if (MATCH("VAR", 3))
 		return_value = _readVar();
 	else if (MATCH("CONST", 5))

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3287,10 +3287,6 @@ transformCreateTableAsStmt(ParseState *pstate, CreateTableAsStmt *stmt)
 	/* additional work needed for CREATE MATERIALIZED VIEW */
 	if (stmt->relkind == OBJECT_MATVIEW)
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("materialized view is not supported on greenplum")));
-
 		/*
 		 * Prohibit a data-modifying CTE in the query used to create a
 		 * materialized view. It's not sufficiently clear what the user would
@@ -3350,7 +3346,11 @@ transformCreateTableAsStmt(ParseState *pstate, CreateTableAsStmt *stmt)
 	/* GPDB: Set parentStmtType to PARENTSTMTTYPE_CTAS as we know this query is for CTAS */
 	((Query*)stmt->query)->parentStmtType = PARENTSTMTTYPE_CTAS;
 
-	if (stmt->into->distributedBy && Gp_role == GP_ROLE_DISPATCH)
+	/*
+	 * In binary upgrade mode, we need to create materialize view in utility mode. So we
+	 * should enable the setQryDistributionPolicy function in binary upgrade mode.
+	 */
+	if (stmt->into->distributedBy && (Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade))
 		setQryDistributionPolicy(stmt->into, (Query *)stmt->query);
 
 	return result;
@@ -3716,7 +3716,11 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 	ListCell   *lc;
 	DistributedBy *dist;
 
-	Assert(Gp_role == GP_ROLE_DISPATCH);
+	/*
+	 * In binary upgrade mode, we need to create materialize view in utility mode. So we
+	 * should enable the setQryDistributionPolicy function in binary upgrade mode.
+	 */
+	Assert(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY);
 	Assert(into != NULL);
 	Assert(into->distributedBy != NULL);
 

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -5746,7 +5746,7 @@ ext_opt_encoding_item:
  *****************************************************************************/
 
 CreateMatViewStmt:
-		CREATE OptNoLog MATERIALIZED VIEW create_mv_target AS SelectStmt opt_with_data
+		CREATE OptNoLog MATERIALIZED VIEW create_mv_target AS SelectStmt opt_with_data OptDistributedBy
 				{
 					CreateTableAsStmt *ctas = makeNode(CreateTableAsStmt);
 					ctas->query = $7;
@@ -5756,6 +5756,8 @@ CreateMatViewStmt:
 					/* cram additional flags into the IntoClause */
 					$5->rel->relpersistence = $2;
 					$5->skipData = !($8);
+					ctas->into->distributedBy = $9;
+
 					$$ = (Node *) ctas;
 				}
 		;

--- a/src/backend/tcop/dest.c
+++ b/src/backend/tcop/dest.c
@@ -130,7 +130,7 @@ CreateDestReceiver(CommandDest dest)
 			return CreateSQLFunctionDestReceiver();
 
 		case DestTransientRel:
-			return CreateTransientRelDestReceiver(InvalidOid);
+			return CreateTransientRelDestReceiver(InvalidOid, InvalidOid, false, false);
 	}
 
 	/* should never get here */

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -412,7 +412,8 @@ ChoosePortalStrategy(List *stmts)
 				if (pstmt->commandType == CMD_SELECT &&
 					pstmt->utilityStmt == NULL &&
 					pstmt->intoClause == NULL &&
-					pstmt->copyIntoClause == NULL)
+					pstmt->copyIntoClause == NULL &&
+					pstmt->refreshClause == NULL)
 				{
 					if (pstmt->hasModifyingCTE)
 						return PORTAL_ONE_MOD_WITH;
@@ -538,7 +539,8 @@ FetchStatementTargetList(Node *stmt)
 		if (pstmt->commandType == CMD_SELECT &&
 			pstmt->utilityStmt == NULL &&
 			pstmt->intoClause == NULL &&
-			pstmt->copyIntoClause == NULL)
+			pstmt->copyIntoClause == NULL &&
+			pstmt->refreshClause == NULL)
 			return pstmt->planTree->targetlist;
 		if (pstmt->hasReturning)
 			return pstmt->planTree->targetlist;

--- a/src/include/commands/cluster.h
+++ b/src/include/commands/cluster.h
@@ -27,7 +27,8 @@ extern void mark_index_clustered(Relation rel, Oid indexOid, bool is_internal);
 
 extern Oid make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, bool forcetemp,
 			  LOCKMODE lockmode,
-			  bool createAoBlockDirectory);
+			  bool createAoBlockDirectory,
+			  bool makeCdbPolicy);
 extern void finish_heap_swap(Oid OIDOldHeap, Oid OIDNewHeap,
 				 bool is_system_catalog,
 				 bool swap_toast_by_content,

--- a/src/include/commands/matview.h
+++ b/src/include/commands/matview.h
@@ -14,6 +14,8 @@
 #ifndef MATVIEW_H
 #define MATVIEW_H
 
+#include "catalog/objectaddress.h"
+#include "executor/execdesc.h"
 #include "nodes/params.h"
 #include "nodes/parsenodes.h"
 #include "tcop/dest.h"
@@ -25,8 +27,11 @@ extern void SetMatViewPopulatedState(Relation relation, bool newstate);
 extern void ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 				   ParamListInfo params, char *completionTag);
 
-extern DestReceiver *CreateTransientRelDestReceiver(Oid oid);
+extern DestReceiver *CreateTransientRelDestReceiver(Oid oid, Oid oldreloid, bool concurrent,
+													bool skipdata);
 
 extern bool MatViewIncrementalMaintenanceIsEnabled(void);
+
+extern void transientrel_init(QueryDesc *queryDesc);
 
 #endif   /* MATVIEW_H */

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -228,6 +228,7 @@ typedef enum NodeTag
 	T_FromExpr,
 	T_IntoClause,
 	T_CopyIntoClause,
+	T_RefreshClause,
 	T_Flow,
 	T_Grouping,
 	T_GroupId,

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -94,6 +94,7 @@ typedef uint32 AclMode;			/* a bitmask of privilege bits */
  * PARENTSTMTTYPE_NONE		query is not included in a utility stmt.
  * PARENTSTMTTYPE_CTAS		query is included in a CreateTableAsStmt.
  * PARENTSTMTTYPE_COPY		query is included in a CopyStmt.
+ * PARENTSTMTTYPE_REFRESH_MATVIEW		query is included in a RefreshMatviewStmt.
  *
  * Previously we added the isCtas field to Query to indicate that
  * the query is included in CreateTableAsStmt. For this type of
@@ -111,6 +112,7 @@ typedef uint8 ParentStmtType;
 #define PARENTSTMTTYPE_NONE	0
 #define PARENTSTMTTYPE_CTAS	1
 #define PARENTSTMTTYPE_COPY	2
+#define PARENTSTMTTYPE_REFRESH_MATVIEW	3
 
 /*
  * Query -

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -144,6 +144,7 @@ typedef struct PlannedStmt
 	 */
 	IntoClause *intoClause;
 	CopyIntoClause *copyIntoClause;
+	RefreshClause   *refreshClause;		/* relation to insert into */
 
 	/* 
  	 * GPDB: whether a query is a SPI inner query for extension usage 

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -117,6 +117,15 @@ typedef struct CopyIntoClause
 	List	   *ao_segnos;		/* AO segno map */
 } CopyIntoClause;
 
+typedef struct RefreshClause
+{
+	NodeTag		type;
+
+	bool		concurrent;		/* allow concurrent access? */
+	bool		skipData;
+	RangeVar   *relation;		/* relation to insert into */
+} RefreshClause;
+
 
 /* ----------------------------------------------------------------
  *					node types for executable expressions

--- a/src/test/regress/expected/matview_ao.out
+++ b/src/test/regress/expected/matview_ao.out
@@ -1,0 +1,97 @@
+CREATE TABLE t_matview_ao (id int NOT NULL PRIMARY KEY, type text NOT NULL, amt numeric NOT NULL);
+INSERT INTO t_matview_ao VALUES
+  (1, 'x', 2),
+  (2, 'x', 3),
+  (3, 'y', 5),
+  (4, 'y', 7),
+  (5, 'z', 11);
+CREATE MATERIALIZED VIEW m_heap AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA distributed by(type);
+CREATE UNIQUE INDEX m_heap_index ON m_heap(type);
+SELECT * from m_heap;
+ERROR:  materialized view "m_heap" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
+ERROR:  CONCURRENTLY cannot be used when the materialized view is not populated
+REFRESH MATERIALIZED VIEW m_heap;
+SELECT * FROM m_heap;
+ type | totamt 
+------+--------
+ z    |     11
+ y    |     12
+ x    |      5
+(3 rows)
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
+SELECT * FROM m_heap;
+ type | totamt 
+------+--------
+ y    |     12
+ x    |      5
+ z    |     11
+(3 rows)
+
+REFRESH MATERIALIZED VIEW m_heap WITH NO DATA;
+SELECT * FROM m_heap;
+ERROR:  materialized view "m_heap" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW m_heap;
+SELECT * FROM m_heap;
+ type | totamt 
+------+--------
+ y    |     12
+ x    |      5
+ z    |     11
+(3 rows)
+
+CREATE MATERIALIZED VIEW m_ao with (appendonly=true) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+SELECT * from m_ao;
+ERROR:  materialized view "m_ao" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW m_ao;
+SELECT * FROM m_ao;
+ type | totamt 
+------+--------
+ y    |     12
+ x    |      5
+ z    |     11
+(3 rows)
+
+REFRESH MATERIALIZED VIEW m_ao WITH NO DATA;
+SELECT * FROM m_ao;
+ERROR:  materialized view "m_ao" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW m_ao;
+SELECT * FROM m_ao;
+ type | totamt 
+------+--------
+ y    |     12
+ x    |      5
+ z    |     11
+(3 rows)
+
+CREATE MATERIALIZED VIEW m_aocs with (appendonly=true, orientation=column) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+SELECT * from m_aocs;
+ERROR:  materialized view "m_aocs" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW m_aocs;
+SELECT * FROM m_aocs;
+ type | totamt 
+------+--------
+ z    |     11
+ y    |     12
+ x    |      5
+(3 rows)
+
+REFRESH MATERIALIZED VIEW m_aocs WITH NO DATA;
+SELECT * FROM m_aocs;
+ERROR:  materialized view "m_aocs" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW m_aocs;
+SELECT * FROM m_aocs;
+ type | totamt 
+------+--------
+ z    |     11
+ y    |     12
+ x    |      5
+(3 rows)
+

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -19,17 +19,19 @@ SELECT * FROM tv ORDER BY type;
 -- create a materialized view with no data, and confirm correct behavior
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW tm AS SELECT type, sum(amt) AS totamt FROM t GROUP BY type WITH NO DATA distributed by(type);
-                      QUERY PLAN                      
-------------------------------------------------------
- HashAggregate
-   Group Key: t.type
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Hash Key: t.type
-         ->  HashAggregate
-               Group Key: t.type
-               ->  Seq Scan on t
- Optimizer: Postgres query optimizer
-(8 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Result
+   ->  Result
+         ->  GroupAggregate
+               Group Key: type
+               ->  Sort
+                     Sort Key: type
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: type
+                           ->  Seq Scan on t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.71.0
+(10 rows)
 
 CREATE MATERIALIZED VIEW tm AS SELECT type, sum(amt) AS totamt FROM t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'tm'::regclass;
@@ -60,21 +62,23 @@ SELECT * FROM tm;
 -- create various views
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW tvm AS SELECT * FROM tv ORDER BY type;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'type' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-                         QUERY PLAN                         
-------------------------------------------------------------
- Sort
-   Sort Key: t.type
-   ->  HashAggregate
-         Group Key: t.type
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: t.type
-               ->  HashAggregate
-                     Group Key: t.type
-                     ->  Seq Scan on t
- Optimizer: Postgres query optimizer
-(10 rows)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Result
+   ->  Result
+         ->  Sort
+               Sort Key: type
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     ->  Result
+                           ->  GroupAggregate
+                                 Group Key: type
+                                 ->  Sort
+                                       Sort Key: type
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                             Hash Key: type
+                                             ->  Seq Scan on t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.71.0
+(14 rows)
 
 CREATE MATERIALIZED VIEW tvm AS SELECT * FROM tv ORDER BY type;
 SELECT * FROM tvm;
@@ -91,24 +95,22 @@ CREATE UNIQUE INDEX tvmm_expr ON tvmm (grandtot);
 CREATE VIEW tvv AS SELECT sum(totamt) AS grandtot FROM tv;
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW tvvm AS SELECT * FROM tvv;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'grandtot' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Redistribute Motion 1:3  (slice3; segments: 1)
-   Hash Key: (pg_catalog.sum((sum(tv.totamt))))
-   ->  Aggregate
-         ->  Gather Motion 3:1  (slice2; segments: 3)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Result
+   ->  Result
+         ->  Redistribute Motion 1:3  (slice3; segments: 1)
                ->  Aggregate
-                     ->  Subquery Scan on tv
-                           ->  HashAggregate
-                                 Group Key: t.type
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                       Hash Key: t.type
-                                       ->  HashAggregate
-                                             Group Key: t.type
-                                             ->  Seq Scan on t
- Optimizer: Postgres query optimizer
+                     ->  Gather Motion 3:1  (slice2; segments: 3)
+                           ->  Aggregate
+                                 ->  GroupAggregate
+                                       Group Key: type
+                                       ->  Sort
+                                             Sort Key: type
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                                   Hash Key: type
+                                                   ->  Seq Scan on t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.71.0
 (14 rows)
 
 CREATE MATERIALIZED VIEW tvvm AS SELECT * FROM tvv;
@@ -127,7 +129,7 @@ View definition:
     tv.totamt
    FROM tv
   ORDER BY tv.type;
-Distributed by: (type)
+Distributed randomly
 
 \d+ tvm
                     Materialized view "public.tvm"
@@ -140,7 +142,7 @@ View definition:
     tv.totamt
    FROM tv
   ORDER BY tv.type;
-Distributed by: (type)
+Distributed randomly
 
 \d+ tvvm
                     Materialized view "public.tvvm"
@@ -150,7 +152,7 @@ Distributed by: (type)
 View definition:
  SELECT tvv.grandtot
    FROM tvv;
-Distributed by: (grandtot)
+Distributed randomly
 
 \d+ bb
                      Materialized view "public.bb"
@@ -162,7 +164,7 @@ Indexes:
 View definition:
  SELECT tvvmv.grandtot
    FROM tvvmv;
-Distributed by: (grandtot)
+Distributed randomly
 
 -- test schema behavior
 CREATE SCHEMA mvschema;
@@ -192,7 +194,7 @@ View definition:
     tv.totamt
    FROM tv
   ORDER BY tv.type;
-Distributed by: (type)
+Distributed randomly
 
 -- modify the underlying table data
 INSERT INTO t VALUES (6, 'z', 13);
@@ -409,7 +411,7 @@ UNION ALL
  SELECT v_test2.moo,
     3 * v_test2.moo
    FROM v_test2;
-Distributed by: (moo)
+Distributed randomly
 
 CREATE MATERIALIZED VIEW mv_test3 AS SELECT * FROM mv_test2 WHERE moo = 12345;
 SELECT relispopulated FROM pg_class WHERE oid = 'mv_test3'::regclass;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -37,7 +37,7 @@ test: gp_tablespace
 test: temp_tablespaces
 test: default_tablespace
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views create_table_like_gp
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views create_table_like_gp matview_ao
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -113,7 +113,7 @@ test: namespace
 test: privileges security_label collate lock replica_identity
 
 # MATERIALIZED_VIEW_FIXME : matview is not supported on greenplum. Enable the test when the feature is ready.
-#test: matview
+test: matview
 
 # ----------
 # Another group of parallel tests

--- a/src/test/regress/sql/matview.sql
+++ b/src/test/regress/sql/matview.sql
@@ -13,8 +13,8 @@ SELECT * FROM tv ORDER BY type;
 
 -- create a materialized view with no data, and confirm correct behavior
 EXPLAIN (costs off)
-  CREATE MATERIALIZED VIEW tm AS SELECT type, sum(amt) AS totamt FROM t GROUP BY type WITH NO DATA;
-CREATE MATERIALIZED VIEW tm AS SELECT type, sum(amt) AS totamt FROM t GROUP BY type WITH NO DATA;
+  CREATE MATERIALIZED VIEW tm AS SELECT type, sum(amt) AS totamt FROM t GROUP BY type WITH NO DATA distributed by(type);
+CREATE MATERIALIZED VIEW tm AS SELECT type, sum(amt) AS totamt FROM t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'tm'::regclass;
 SELECT * FROM tm;
 REFRESH MATERIALIZED VIEW tm;
@@ -28,9 +28,8 @@ EXPLAIN (costs off)
 CREATE MATERIALIZED VIEW tvm AS SELECT * FROM tv ORDER BY type;
 SELECT * FROM tvm;
 CREATE MATERIALIZED VIEW tmm AS SELECT sum(totamt) AS grandtot FROM tm;
-CREATE MATERIALIZED VIEW tvmm AS SELECT sum(totamt) AS grandtot FROM tvm;
-CREATE UNIQUE INDEX tvmm_expr ON tvmm ((grandtot > 0));
-CREATE UNIQUE INDEX tvmm_pred ON tvmm (grandtot) WHERE grandtot < 0;
+CREATE MATERIALIZED VIEW tvmm AS SELECT sum(totamt) AS grandtot FROM tvm distributed by(grandtot);
+CREATE UNIQUE INDEX tvmm_expr ON tvmm (grandtot);
 CREATE VIEW tvv AS SELECT sum(totamt) AS grandtot FROM tv;
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW tvvm AS SELECT * FROM tvv;
@@ -96,7 +95,9 @@ DROP MATERIALIZED VIEW IF EXISTS no_such_mv;
 REFRESH MATERIALIZED VIEW CONCURRENTLY tvmm WITH NO DATA;
 
 -- no tuple locks on materialized views
+-- start_ignore
 SELECT * FROM tvvm FOR SHARE;
+-- end_ignore
 
 -- test join of mv and view
 SELECT type, m.totamt AS mtot, v.totamt AS vtot FROM tm m LEFT JOIN tv v USING (type) ORDER BY type;
@@ -124,7 +125,7 @@ DROP VIEW v_test1 CASCADE;
 
 -- test that duplicate values on unique index prevent refresh
 CREATE TABLE foo(a, b) AS VALUES(1, 10);
-CREATE MATERIALIZED VIEW mv AS SELECT * FROM foo;
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM foo distributed by(a);
 CREATE UNIQUE INDEX ON mv(a);
 INSERT INTO foo SELECT * FROM foo;
 REFRESH MATERIALIZED VIEW mv;
@@ -133,10 +134,8 @@ DROP TABLE foo CASCADE;
 
 -- make sure that all columns covered by unique indexes works
 CREATE TABLE foo(a, b, c) AS VALUES(1, 2, 3);
-CREATE MATERIALIZED VIEW mv AS SELECT * FROM foo;
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM foo distributed by(a);
 CREATE UNIQUE INDEX ON mv (a);
-CREATE UNIQUE INDEX ON mv (b);
-CREATE UNIQUE INDEX on mv (c);
 INSERT INTO foo VALUES(2, 3, 4);
 INSERT INTO foo VALUES(3, 4, 5);
 REFRESH MATERIALIZED VIEW mv;
@@ -155,7 +154,7 @@ INSERT INTO boxes (b) VALUES
   ('(32,32),(31,31)'),
   ('(2.0000004,2.0000004),(1,1)'),
   ('(1.9999996,1.9999996),(1,1)');
-CREATE MATERIALIZED VIEW boxmv AS SELECT * FROM boxes;
+CREATE MATERIALIZED VIEW boxmv AS SELECT * FROM boxes distributed by(id);
 CREATE UNIQUE INDEX boxmv_id ON boxmv (id);
 UPDATE boxes SET b = '(2,2),(1,1)' WHERE id = 2;
 REFRESH MATERIALIZED VIEW CONCURRENTLY boxmv;
@@ -165,7 +164,7 @@ DROP TABLE boxes CASCADE;
 -- make sure that column names are handled correctly
 CREATE TABLE mvtest_v (i int, j int);
 CREATE MATERIALIZED VIEW mvtest_mv_v (ii, jj, kk) AS SELECT i, j FROM mvtest_v; -- error
-CREATE MATERIALIZED VIEW mvtest_mv_v (ii, jj) AS SELECT i, j FROM mvtest_v; -- ok
+CREATE MATERIALIZED VIEW mvtest_mv_v (ii, jj) AS SELECT i, j FROM mvtest_v distributed by(ii); -- ok
 CREATE MATERIALIZED VIEW mvtest_mv_v_2 (ii) AS SELECT i, j FROM mvtest_v; -- ok
 CREATE MATERIALIZED VIEW mvtest_mv_v_3 (ii, jj, kk) AS SELECT i, j FROM mvtest_v WITH NO DATA; -- error
 CREATE MATERIALIZED VIEW mvtest_mv_v_3 (ii, jj) AS SELECT i, j FROM mvtest_v WITH NO DATA; -- ok
@@ -189,8 +188,6 @@ DROP TABLE mvtest_v CASCADE;
 -- make sure that create WITH NO DATA does not plan the query (bug #13907)
 create materialized view mvtest_error as select 1/0 as x;  -- fail
 create materialized view mvtest_error as select 1/0 as x with no data;
-refresh materialized view mvtest_error;  -- fail here
-drop materialized view mvtest_error;
 
 -- make sure that matview rows can be referenced as source rows (bug #9398)
 CREATE TABLE v AS SELECT generate_series(1,10) AS a;
@@ -205,7 +202,7 @@ CREATE ROLE user_dw;
 SET ROLE user_dw;
 CREATE TABLE foo_data AS SELECT i, md5(random()::text)
   FROM generate_series(1, 10) i;
-CREATE MATERIALIZED VIEW mv_foo AS SELECT * FROM foo_data;
+CREATE MATERIALIZED VIEW mv_foo AS SELECT * FROM foo_data distributed by(i);
 CREATE UNIQUE INDEX ON mv_foo (i);
 RESET ROLE;
 REFRESH MATERIALIZED VIEW mv_foo;

--- a/src/test/regress/sql/matview_ao.sql
+++ b/src/test/regress/sql/matview_ao.sql
@@ -1,0 +1,40 @@
+CREATE TABLE t_matview_ao (id int NOT NULL PRIMARY KEY, type text NOT NULL, amt numeric NOT NULL);
+INSERT INTO t_matview_ao VALUES
+  (1, 'x', 2),
+  (2, 'x', 3),
+  (3, 'y', 5),
+  (4, 'y', 7),
+  (5, 'z', 11);
+
+CREATE MATERIALIZED VIEW m_heap AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA distributed by(type);
+CREATE UNIQUE INDEX m_heap_index ON m_heap(type);
+SELECT * from m_heap;
+REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
+REFRESH MATERIALIZED VIEW m_heap;
+SELECT * FROM m_heap;
+REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
+SELECT * FROM m_heap;
+REFRESH MATERIALIZED VIEW m_heap WITH NO DATA;
+SELECT * FROM m_heap;
+REFRESH MATERIALIZED VIEW m_heap;
+SELECT * FROM m_heap;
+
+CREATE MATERIALIZED VIEW m_ao with (appendonly=true) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+SELECT * from m_ao;
+REFRESH MATERIALIZED VIEW m_ao;
+SELECT * FROM m_ao;
+REFRESH MATERIALIZED VIEW m_ao WITH NO DATA;
+SELECT * FROM m_ao;
+REFRESH MATERIALIZED VIEW m_ao;
+SELECT * FROM m_ao;
+
+
+CREATE MATERIALIZED VIEW m_aocs with (appendonly=true, orientation=column) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+SELECT * from m_aocs;
+REFRESH MATERIALIZED VIEW m_aocs;
+SELECT * FROM m_aocs;
+REFRESH MATERIALIZED VIEW m_aocs WITH NO DATA;
+SELECT * FROM m_aocs;
+REFRESH MATERIALIZED VIEW m_aocs;
+SELECT * FROM m_aocs;
+


### PR DESCRIPTION
The commit enabled materialized view on both swap file and
concurrently mode. There are four main change on the code.
1. Add a new type 'PARENTSTMTTYPE_REFRESH_MATVIEW' on ParentStmtType in
Query struct. So that we can make the right query plan without gather
motion.
2. add a new 'transientrel_init' function which was called on
'initplan' to create temp table on segment.
3. Call the swap function on both master and segment.
4. Change the spi query to make the right diff on parallel system.

This is a backport from master "81a20f60a66a3b8ee8aee1107b0893772c10d0b4"

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>

Fix create index test

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
