### PR TITLE
6X: Fix array overflow in AO concurrency handling(cherry pick from master)

### DIFF
--- a/src/backend/access/appendonly/aomd_filehandler.c
+++ b/src/backend/access/appendonly/aomd_filehandler.c
@@ -68,7 +68,7 @@ ao_foreach_extent_file(ao_extent_callback callback, void *ctx)
 {
     int segno;
     int colnum;
-    int concurrency[AOTupleId_MaxSegmentFileNum];
+    int concurrency[MAX_AOREL_CONCURRENCY];
     int concurrencySize;
 
     /*


### PR DESCRIPTION
In the function ao_foreach_extent_file() an array concurrency is used to
store the concurrent levels, its size was AOTupleId_MaxSegmentFileNum,
which equals to (MAX_AOREL_CONCURRENCY - 1).  However the possible index
range is [0, MAX_AOREL_CONCURRENCY - 1], it exceeds the original size of
the array, so an array overflow can happen at runtime.

Fixed by correcting the array size, also define the size with
MAX_AOREL_CONCURRENCY instead of AOTupleId_MaxSegmentFileNum.

-----

This is cherry pick from master (d72e2a197523ca68121f6f8122f41a5ba6210e62) to 6X.

The commit is already in master and should be backported to 6x.
