### PR TITLE
Remove ExplainStateExtra compatibility hack.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -51,10 +51,6 @@ extern const char *OptVersion();
 #endif
 
 
-/* Crude hack to avoid changing sizeof(ExplainState) in released branches */
-#define grouping_stack extra->groupingstack
-#define deparse_cxt extra->deparsecxt
-
 /* Hook for plugins to get control in ExplainOneQuery() */
 ExplainOneQuery_hook_type ExplainOneQuery_hook = NULL;
 
@@ -302,8 +298,6 @@ NewExplainState(void)
 	es->costs = true;
 	/* Prepare output buffer. */
 	es->str = makeStringInfo();
-	/* Kluge to avoid changing sizeof(ExplainState) in released branches. */
-	es->extra = (ExplainStateExtra *) palloc0(sizeof(ExplainStateExtra));
 
 	return es;
 }

--- a/src/include/commands/explain.h
+++ b/src/include/commands/explain.h
@@ -24,13 +24,6 @@ typedef enum ExplainFormat
 	EXPLAIN_FORMAT_YAML
 } ExplainFormat;
 
-/* Crude hack to avoid changing sizeof(ExplainState) in released branches */
-typedef struct ExplainStateExtra
-{
-	List	   *groupingstack;	/* format-specific grouping state */
-	List	   *deparsecxt;		/* context list for deparsing expressions */
-} ExplainStateExtra;
-
 typedef struct ExplainState
 {
 	StringInfo	str;			/* output buffer */
@@ -47,8 +40,9 @@ typedef struct ExplainState
 	PlannedStmt *pstmt;			/* top of plan */
 	List	   *rtable;			/* range table */
 	List	   *rtable_names;	/* alias names for RTEs */
+	List	   *deparse_cxt;	/* context list for deparsing expressions */
 	int			indent;			/* current indentation level */
-	ExplainStateExtra *extra;	/* pointer to additional data */
+	List	   *grouping_stack; /* format-specific grouping state */
 
     /* CDB */
     struct CdbExplain_ShowStatCtx  *showstatctx;    /* EXPLAIN ANALYZE info */


### PR DESCRIPTION
The ExplainStateExtra struct was added as part of upstream commit
a5cd70dcbc, but only in back-branches. In master, changing the size of
the ExplainState struct was OK, and the hack was not needed. We picked up
the back-patched version of that commit as part of merging with the latest
9.4.X minor version, but we don't need the compatibility hack in GPDB
master. Remove it, syncing us up with the version of the commit that went
into PostgreSQL master branch at the time.
