### PR TITLE
Fix several issues in Gang management

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -843,7 +843,10 @@ cleanupQE(SegmentDatabaseDescriptor *segdbDesc)
 
 	/* Note, we cancel all "still running" queries */
 	if (!cdbconn_discardResults(segdbDesc, 20))
-		elog(FATAL, "cleanup called when a segworker is still busy");
+	{
+		elog(LOG, "cleaning up seg%d while it is still busy", segdbDesc->segindex);
+		return false;
+	}
 
 	/* QE is no longer associated with a slice. */
 	cdbconn_setQEIdentifier(segdbDesc, /* slice index */ -1);	

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2623,6 +2623,10 @@ DoCopyTo(CopyState cstate)
 	bool		fe_copy = (pipe && whereToSendOutput == DestRemote);
 	uint64		processed;
 
+#ifdef FAULT_INJECTOR
+	FaultInjector_InjectFaultIfSet("DoCopyToFail", DDLNotSpecified, "", "");
+#endif
+
 	PG_TRY();
 	{
 		if (fe_copy)

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1543,7 +1543,6 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		if (qeError)
 		{
 			estate->dispatcherState = NULL;
-			cdbdisp_destroyDispatcherState(ds);
 			ReThrowError(qeError);
 		}
 

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -4,6 +4,32 @@ SELECT min_val, max_val FROM pg_settings WHERE name = 'gp_resqueue_priority_cpuc
  0.1     | 512
 (1 row)
 
+-- Test cursor gang should not be reused if SET command happens.
+CREATE OR REPLACE FUNCTION test_set_cursor_func() RETURNS text as $$
+DECLARE
+  result text;
+BEGIN
+  EXECUTE 'select setting from pg_settings where name=''temp_buffers''' INTO result;
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+SET temp_buffers = 2000;
+BEGIN;
+  DECLARE set_cusor CURSOR FOR SELECT relname FROM gp_dist_random('pg_class');
+  -- The GUC setting should not be dispatched to the cursor gang.
+  SET temp_buffers = 3000;
+END;
+-- Verify the cursor gang is not reused. If the gang is reused, the
+-- temp_buffers value on that gang should be old one, i.e. 2000 instead of
+-- the new committed 3000.
+SELECT * from (SELECT test_set_cursor_func() FROM gp_dist_random('pg_class') limit 1) t1
+  JOIN (SELECT test_set_cursor_func() FROM gp_dist_random('pg_class') limit 1) t2 ON TRUE;
+ test_set_cursor_func | test_set_cursor_func 
+----------------------+----------------------
+ 3000                 | 3000
+(1 row)
+
+RESET temp_buffers;
 --
 -- Test GUC if cursor is opened
 --

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -19,6 +19,28 @@ select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 select gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
+-- Test cdbdisp_getDispatchResults() fail in CdbDispatchCopyStart()
+
+create table dispatch_tbl (a int) distributed by (a);
+insert into dispatch_tbl values (2),(1),(5);
+
+-- fault on seg1 to block insert command into the dispatch_tbl table
+select gp_inject_fault('DoCopyToFail', 'error', '', '', '',
+   1, 1, 0, dbid) from gp_segment_configuration
+   where content = 1 and role = 'p';
+
+copy dispatch_tbl to stdout;
+
+--select gp_wait_until_triggered_fault('DoCopyToFail', 1, dbid)
+--  from gp_segment_configuration where content = 1 and role = 'p';
+
+select gp_inject_fault('DoCopyToFail', 'reset', dbid)
+   from gp_segment_configuration
+   where content = 1 and role = 'p';
+
+select * from dispatch_tbl;
+drop table dispatch_tbl;
+
 -- Test quoting of GUC values and database names when they're sent to segments
 set client_min_messages='warning';
 DROP DATABASE IF EXISTS "funny""db'with\\quotes";

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -30,6 +30,39 @@ select gp_wait_until_triggered_fault('fts_probe', 1, 1);
  Success:
 (1 row)
 
+-- Test cdbdisp_getDispatchResults() fail in CdbDispatchCopyStart()
+create table dispatch_tbl (a int) distributed by (a);
+insert into dispatch_tbl values (2),(1),(5);
+-- fault on seg1 to block insert command into the dispatch_tbl table
+select gp_inject_fault('DoCopyToFail', 'error', '', '', '',
+   1, 1, 0, dbid) from gp_segment_configuration
+   where content = 1 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+copy dispatch_tbl to stdout;
+ERROR:  fault triggered, fault name:'DoCopyToFail' fault type:'error'  (seg1 192.168.235.128:7003 pid=68980)
+--select gp_wait_until_triggered_fault('DoCopyToFail', 1, dbid)
+--  from gp_segment_configuration where content = 1 and role = 'p';
+select gp_inject_fault('DoCopyToFail', 'reset', dbid)
+   from gp_segment_configuration
+   where content = 1 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select * from dispatch_tbl;
+ a 
+---
+ 1
+ 5
+ 2
+(3 rows)
+
+drop table dispatch_tbl;
 -- Test quoting of GUC values and database names when they're sent to segments
 set client_min_messages='warning';
 DROP DATABASE IF EXISTS "funny""db'with\\quotes";

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -1,5 +1,30 @@
 SELECT min_val, max_val FROM pg_settings WHERE name = 'gp_resqueue_priority_cpucores_per_segment';
 
+-- Test cursor gang should not be reused if SET command happens.
+CREATE OR REPLACE FUNCTION test_set_cursor_func() RETURNS text as $$
+DECLARE
+  result text;
+BEGIN
+  EXECUTE 'select setting from pg_settings where name=''temp_buffers''' INTO result;
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+
+SET temp_buffers = 2000;
+BEGIN;
+  DECLARE set_cusor CURSOR FOR SELECT relname FROM gp_dist_random('pg_class');
+  -- The GUC setting should not be dispatched to the cursor gang.
+  SET temp_buffers = 3000;
+END;
+
+-- Verify the cursor gang is not reused. If the gang is reused, the
+-- temp_buffers value on that gang should be old one, i.e. 2000 instead of
+-- the new committed 3000.
+SELECT * from (SELECT test_set_cursor_func() FROM gp_dist_random('pg_class') limit 1) t1
+  JOIN (SELECT test_set_cursor_func() FROM gp_dist_random('pg_class') limit 1) t2 ON TRUE;
+
+RESET temp_buffers;
+
 --
 -- Test GUC if cursor is opened
 --


### PR DESCRIPTION
1. Do not call elog(FATAL) in cleanupQE() since it could be called in
cdbdisp_destroyDispatcherState() to destroy CdbDispatcherState.  This leads to
reentrance of cdbdisp_destroyDispatcherState() which is not supported. Changing
the code to return false instead and to sanity check the reentrance. Returning
false should be ok since that leads to gang destroying and thus QE resources
should be destroyed themselves. Here is a typical stack of reentrance.

0x0000000000b8ffeb in cdbdisp_destroyDispatcherState (ds=0x2eff168) at cdbdisp.c:345
0x0000000000b90385 in cleanup_dispatcher_handle (h=0x2eff0d8) at cdbdisp.c:488
0x0000000000b904c0 in cdbdisp_cleanupDispatcherHandle (owner=0x2e80de0) at cdbdisp.c:555
0x0000000000b27fb7 in CdbResourceOwnerWalker (owner=0x2e80de0, callback=0xb90479 <cdbdisp_cleanupDispatcherHandle>) at resowner.c:1375
0x0000000000b27fd8 in CdbResourceOwnerWalker (owner=0x2f30358, callback=0xb90479 <cdbdisp_cleanupDispatcherHandle>) at resowner.c:1379
0x0000000000b903d9 in AtAbort_DispatcherState () at cdbdisp.c:511
0x000000000053b8ab in AbortTransaction () at xact.c:3319
0x000000000053e057 in AbortOutOfAnyTransaction () at xact.c:5248
0x00000000005c6869 in RemoveTempRelationsCallback (code=1, arg=0) at namespace.c:4088
0x000000000093c193 in shmem_exit (code=1) at ipc.c:257
0x000000000093c088 in proc_exit_prepare (code=1) at ipc.c:214
0x000000000093bf86 in proc_exit (code=1) at ipc.c:104
0x0000000000adb6e2 in errfinish (dummy=0) at elog.c:754
0x0000000000ade465 in elog_finish (elevel=21, fmt=0xe847c0 "cleanup called when a segworker is still busy") at elog.c:1735
0x0000000000beca81 in cleanupQE (segdbDesc=0x2ee9048) at cdbutil.c:846
0x0000000000becbc8 in cdbcomponent_recycleIdleQE (segdbDesc=0x2ee9048, forceDestroy=0 '\000') at cdbutil.c:871
0x0000000000b9815a in RecycleGang (gp=0x2eff7f0, forceDestroy=0 '\000') at cdbgang.c:861
0x0000000000b9009e in cdbdisp_destroyDispatcherState (ds=0x2eff168) at cdbdisp.c:372
0x0000000000b96957 in CdbDispatchCopyStart (cdbCopy=0x2f23828, stmt=0x2e364d0, flags=5) at cdbdisp_query.c:1442

2. Force to drop the reader gang for named portal if set command happens
previously since that setting was not dispatched to that gang and thus we
should not reuse them.

3. Now that we have the mechanism of destroying DispatcherState in resource
owner callback when aborting transaction. It is not needed to destroy in some
dispatcher code.

The added test cases and some existing test cases cover almost all code change
except the change in cdbdisp_dispatchX() (I can not find a solution to test
this, and I'll keep it in my mind to see how to test that or similar code).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
