### PR TITLE
Add a debugging aid for outfast/readfast serialization.

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -114,9 +114,29 @@
 #define WRITE_LOCATION_FIELD(fldname) \
 	{ appendBinaryStringInfo(str, (const char *)&node->fldname, sizeof(int)); }
 
-/* Write a Node field */
+/*
+ * Write a Node field
+ *
+ * If compiled with GP_SERIALIZATION_DEBUG, write the field name in the
+ * serialized form, and check that it matches in the read function
+ * (READ_NODE_FIELD in readfast.c). That makes it much easier to debug bugs
+ * where the out and read functions are not in sync, as you get an error
+ * much earlier, and it can print the field name where the mismatch occurred.
+ * It makes the serialized plans much larger, though, so we don't want to do
+ * it production.
+ */
+#ifdef GP_SERIALIZATION_DEBUG
+#define WRITE_NODE_FIELD(fldname) \
+	do { \
+		const char *xx = CppAsString(fldname); \
+		appendBinaryStringInfo(str, xx, strlen(xx) + 1); \
+		(_outNode(str, node->fldname)); \
+	} while (0)
+#else
 #define WRITE_NODE_FIELD(fldname) \
 	(_outNode(str, node->fldname))
+#endif
+
 
 /* Write a bitmapset field */
 #define WRITE_BITMAPSET_FIELD(fldname) \


### PR DESCRIPTION
If you compile with GP_SERIALIZATION_DEBUG, the serialized format includes
the field name for each serialized field, which makes it *much* easier to
find serialization bugs. Especially useful when merging with a new upstream
version, which always changes many of the serialized structs.
