### PR TITLE
6X backport: Fix heap-use-after-free in gp_inject_fault()

### DIFF
--- a/gpcontrib/gp_inject_fault/gp_inject_fault.c
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault.c
@@ -133,16 +133,11 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 			elog(ERROR, "invalid response from %s:%d", hostname, port);
 		}
 
-		response = PQgetvalue(res, 0, Anum_fault_message_response_status);
-		if (strncmp(response, "Success:",  strlen("Success:")) != 0)
-		{
-			PQclear(res);
-			PQfinish(conn);
-			elog(ERROR, "%s", response);
-		}
-
+		response = pstrdup(PQgetvalue(res, 0, Anum_fault_message_response_status));
 		PQclear(res);
 		PQfinish(conn);
+		if (strncmp(response, "Success:",  strlen("Success:")) != 0)
+			elog(ERROR, "%s", response);
 	}
 	PG_RETURN_TEXT_P(cstring_to_text(response));
 }


### PR DESCRIPTION
This backports to 6X: #8871

In postgres libpq document, it says:

>  The pointer returned by PQgetvalue points to storage that is part of
>  the PGresult structure. One should not modify the data it points to,
>  and one must explicitly copy the data into other storage if it is to
>  be used past the lifetime of the PGresult structure itself.

So we should call pstrdup() on the result of PQgetvalue() because
response will be used past the lifetime of the PGresult structure
returned by PQexec().

(cherry picked from commit 61042efb2039c3aa2f11b65d5c738e5ac710de2b)
