### PR TITLE
Add tests for data checksum mismatch between 5 and 6 clusters

### DIFF
--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -12,6 +12,7 @@
 #include "scenarios/subpartitioned_heap_table.h"
 #include "scenarios/ao_table.h"
 #include "scenarios/aocs_table.h"
+#include "scenarios/data_checksum_mismatch.h"
 
 #include "utilities/gpdb5-cluster.h"
 #include "utilities/gpdb6-cluster.h"
@@ -42,6 +43,7 @@ main(int argc, char *argv[])
 	cmockery_parse_arguments(argc, argv);
 
 	const		UnitTest tests[] = {
+		unit_test_setup_teardown(test_clusters_with_different_checksum_version_cannot_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_an_ao_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_an_aocs_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_heap_table_with_data_can_be_upgraded, setup, teardown),

--- a/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.c
@@ -1,0 +1,50 @@
+#include <stdarg.h>
+#include <setjmp.h>
+#include <stdlib.h>
+
+#include "cmockery.h"
+
+#include "data_checksum_mismatch.h"
+#include "utilities/upgrade-helpers.h"
+#include "utilities/test-helpers.h"
+#include "bdd-library/bdd.h"
+
+static void setDataChecksum(char *binaryDirectory, char *dataDirectory, int checksumValue)
+{
+	char buffer[500];
+
+	sprintf(buffer, "echo yes | %s/pg_resetxlog -k %d %s", binaryDirectory, checksumValue, dataDirectory);
+	system(buffer);
+}
+
+static void
+upgradeCheckFailsType1()
+{
+	performUpgradeCheckFailsWithError("old cluster uses data checksums but the new one does not\n");
+}
+
+static void
+upgradeCheckFailsType2()
+{
+	performUpgradeCheckFailsWithError("old cluster does not use data checksums but the new one does\n");
+}
+static void aFiveClusterWithoutChecksumsAndASixClusterWithChecksums()
+{
+	setDataChecksum("./gpdb5/bin", "./gpdb5-data/qddir/demoDataDir-1", 1);
+	setDataChecksum("./gpdb6/bin", "./gpdb6-data/qddir/demoDataDir-1", 0);
+}
+
+static void aFiveClusterWithChecksumsAndASixClusterWithoutChecksums()
+{
+	setDataChecksum("./gpdb5/bin", "./gpdb5-data/qddir/demoDataDir-1", 0);
+	setDataChecksum("./gpdb6/bin", "./gpdb6-data/qddir/demoDataDir-1", 1);
+}
+
+void
+test_clusters_with_different_checksum_version_cannot_be_upgraded(void ** state) {
+	given(aFiveClusterWithoutChecksumsAndASixClusterWithChecksums);
+	then(upgradeCheckFailsType1);
+	given(aFiveClusterWithChecksumsAndASixClusterWithoutChecksums);
+	then(upgradeCheckFailsType2);
+}
+

--- a/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.c
@@ -9,7 +9,8 @@
 #include "utilities/test-helpers.h"
 #include "bdd-library/bdd.h"
 
-static void setDataChecksum(char *binaryDirectory, char *dataDirectory, int checksumValue)
+static void
+setDataChecksum(char *binaryDirectory, char *dataDirectory, int checksumValue)
 {
 	char buffer[500];
 
@@ -28,13 +29,16 @@ upgradeCheckFailsType2()
 {
 	performUpgradeCheckFailsWithError("old cluster does not use data checksums but the new one does\n");
 }
-static void aFiveClusterWithoutChecksumsAndASixClusterWithChecksums()
+
+static void
+aFiveClusterWithoutChecksumsAndASixClusterWithChecksums()
 {
 	setDataChecksum("./gpdb5/bin", "./gpdb5-data/qddir/demoDataDir-1", 1);
 	setDataChecksum("./gpdb6/bin", "./gpdb6-data/qddir/demoDataDir-1", 0);
 }
 
-static void aFiveClusterWithChecksumsAndASixClusterWithoutChecksums()
+static void
+aFiveClusterWithChecksumsAndASixClusterWithoutChecksums()
 {
 	setDataChecksum("./gpdb5/bin", "./gpdb5-data/qddir/demoDataDir-1", 0);
 	setDataChecksum("./gpdb6/bin", "./gpdb6-data/qddir/demoDataDir-1", 1);

--- a/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.h
@@ -1,0 +1,1 @@
+void test_clusters_with_different_checksum_version_cannot_be_upgraded(void ** state);


### PR DESCRIPTION
Add tests for data checksum mismatch between 5 and 6 clusters

Co-Authored-By: David Kimura<dkimura@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
