### PR TITLE
6X: Don't create symbolic links to absolute paths

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -27,7 +27,7 @@ installprograms: installdirs
 	done
 	# Symlink gpcheckcat from bin to bin/lib to maintain backward compatibility
 	if [ ! -L $(DESTDIR)$(bindir)/lib/gpcheckcat  ]; then \
-		$(LN_S) $(bindir)/gpcheckcat $(DESTDIR)$(bindir)/lib/gpcheckcat; \
+		$(LN_S) ../gpcheckcat $(DESTDIR)$(bindir)/lib/gpcheckcat; \
 	fi
 	$(INSTALL_DATA) gpload.bat '$(DESTDIR)$(bindir)/gpload.bat'
 

--- a/gpMgmt/bin/stream/Makefile
+++ b/gpMgmt/bin/stream/Makefile
@@ -20,7 +20,7 @@ install: stream installdirs
 	$(INSTALL_PROGRAM) stream$(X) '$(DESTDIR)$(bindir)/lib/stream$(X)'
 	# Symlink bin/lib/stream to bin/stream to maintain backward compatibility
 	if [ ! -f $(DESTDIR)$(bindir)/stream/stream$(X) ] && [ ! -L $(DESTDIR)$(bindir)/stream/stream$(X) ]; then \
-		$(LN_S) $(DESTDIR)$(bindir)/lib/stream$(X) $(DESTDIR)$(bindir)/stream/stream$(X); \
+		$(LN_S) ../lib/stream$(X) $(DESTDIR)$(bindir)/stream/stream$(X); \
 	fi
 
 uninstall:


### PR DESCRIPTION
The DESTDIR would be determined while installation if with a tarball or
shell binary package, which is probably not the same as the DESTDIR we
used to make the tarball, in this case, the symbolic would link to a
non-existing or wrong file.

Use relative paths instead.

(cherry picked from commit ccb1e8ea37150b9c4f402776ce97bbce257368c9)

PR on the master branch: #8891
