### PR TITLE
Simplify cost_agg() function's signature, improve comments.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6110,8 +6110,9 @@ add_agg_cost(PlannerInfo *root, Plan *plan,
 				 numGroupCols, numGroups,
 				 plan->startup_cost,
 				 plan->total_cost,
-				 plan->plan_rows, hash_info.workmem_per_entry,
-				 hash_info.nbatches, hash_info.hashentry_width, streaming);
+				 plan->plan_rows,
+				 &hash_info,
+				 streaming);
 	}
 	else
 		cost_agg(&agg_path, root,
@@ -6119,8 +6120,9 @@ add_agg_cost(PlannerInfo *root, Plan *plan,
 				 numGroupCols, numGroups,
 				 plan->startup_cost,
 				 plan->total_cost,
-				 plan->plan_rows, 0.0, 0.0,
-				 0.0, false);
+				 plan->plan_rows,
+				 NULL,
+				 false);
 
 	plan->startup_cost = agg_path.startup_cost;
 	plan->total_cost = agg_path.total_cost;

--- a/src/backend/optimizer/plan/planagg.c
+++ b/src/backend/optimizer/plan/planagg.c
@@ -245,7 +245,7 @@ optimize_minmax_aggregates(PlannerInfo *root, List *tlist,
 	cost_agg(&agg_p, root, AGG_PLAIN, aggcosts,
 			 0, 0,
 			 best_path->startup_cost, best_path->total_cost,
-			 best_path->parent->rows, 0.0, 0.0, 0.0, false);
+			 best_path->parent->rows, NULL, false);
 
 	if (total_cost > agg_p.total_cost)
 		return NULL;			/* too expensive */

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -4956,8 +4956,9 @@ choose_hashed_grouping(PlannerInfo *root,
 	cost_agg(&hashed_p, root, AGG_HASHED, agg_costs,
 			 numGroupCols, dNumGroups / planner_segment_count(NULL),
 			 cheapest_path->startup_cost, cheapest_path->total_cost,
-			 path_rows, hash_info.workmem_per_entry,
-			 hash_info.nbatches, hash_info.hashentry_width, false);
+			 path_rows,
+			 &hash_info,
+			 false);
 	/* Result of hashed agg is always unsorted */
 	if (target_pathkeys)
 		cost_sort(&hashed_p, root, target_pathkeys, hashed_p.total_cost,
@@ -4988,7 +4989,7 @@ choose_hashed_grouping(PlannerInfo *root,
 		cost_agg(&sorted_p, root, AGG_SORTED, agg_costs,
 				 numGroupCols, dNumGroups / planner_segment_count(NULL),
 				 sorted_p.startup_cost, sorted_p.total_cost,
-				 path_rows, 0.0, 0.0, 0.0, false);
+				 path_rows, NULL, false);
 	else
 		cost_group(&sorted_p, root, numGroupCols, dNumGroups,
 				   sorted_p.startup_cost, sorted_p.total_cost,
@@ -5123,9 +5124,7 @@ choose_hashed_distinct(PlannerInfo *root,
 			 numDistinctCols, dNumDistinctRows / planner_segment_count(NULL),
 			 cheapest_startup_cost, cheapest_total_cost,
 			 path_rows,
-			 hash_info.workmem_per_entry,
-			 hash_info.nbatches,
-			 hash_info.hashentry_width,
+			 &hash_info,
 			 false /* hash_streaming */);
 
 	/*

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -964,6 +964,17 @@ choose_hashed_setop(PlannerInfo *root, List *groupClauses,
 	/*
 	 * Don't do it if it doesn't look like the hashtable will fit into
 	 * work_mem.
+	 *
+	 * GPDB: In other places where we are building a Hash Aggregate, we use
+	 * calcHashAggTableSizes(), which takes into account that in GPDB, a Hash
+	 * Aggregate can spill to disk. We must *not* do that here, because we
+	 * might be building a Hashed SetOp, not a Hash Aggregate. A Hashed SetOp
+	 * uses the upstream hash table implementation unmodified, and cannot
+	 * spill.
+	 * FIXME: It's a bit lame that Hashed SetOp cannot spill to disk. And it's
+	 * even more lame that we don't account the spilling correctly, if we are
+	 * in fact constructing a Hash Aggregate. A UNION is implemented with a
+	 * Hash Aggregate, only INTERSECT and EXCEPT use Hashed SetOp.
 	 */
 	hashentrysize = MAXALIGN(input_plan->plan_width) + MAXALIGN(SizeofMinimalTupleHeader);
 
@@ -985,9 +996,8 @@ choose_hashed_setop(PlannerInfo *root, List *groupClauses,
 			 numGroupCols, dNumGroups / planner_segment_count(NULL),
 			 input_plan->startup_cost, input_plan->total_cost,
 			 input_plan->plan_rows,
-			 hashentrysize, /* input_width */
-			 0, /* hash_batches - so spilling expected with TupleHashTable */
-			 hashentrysize, /* hashentry_width */
+			 NULL, /* GPDB: We are using the upstream hash table implementation,
+					* which does not spill. */
 			 false /* hash_streaming */);
 
 	/*

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -130,13 +130,16 @@ extern void cost_merge_append(Path *path, PlannerInfo *root,
 extern void cost_material(Path *path, PlannerInfo *root,
 			  Cost input_startup_cost, Cost input_total_cost,
 			  double tuples, int width);
+
+struct HashAggTableSizes; /* defined in execHHashagg.h */
 extern void cost_agg(Path *path, PlannerInfo *root,
 		 AggStrategy aggstrategy, const AggClauseCosts *aggcosts,
 		 int numGroupCols, double numGroups,
 		 Cost input_startup_cost, Cost input_total_cost,
 		 double input_tuples,
-		 double input_width, double hash_batches,
-		 double hashentry_width, bool hash_streaming);
+		 struct HashAggTableSizes *hash_info,
+		 bool hash_streaming);
+
 extern void cost_windowagg(Path *path, PlannerInfo *root,
 			   List *windowFuncs, int numPartCols, int numOrderCols,
 			   Cost input_startup_cost, Cost input_total_cost,

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -9,7 +9,7 @@
 -- m/DETAIL:  Failing row contains \(.*\)/
 -- s/DETAIL:  Failing row contains \(.*\)/DETAIL:  Failing row contains (#####)/
 -- end_matchsubs
-SET statement_mem='250 MB';
+SET statement_mem='300 MB';
 CREATE TABLE dml_ao_check_r (
 	a int default 100 CHECK( a between 1 and 105),
 	b float8 CONSTRAINT rcheck_b CHECK( b <> 0.00 and b IS NOT NULL),

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -9,7 +9,7 @@
 -- m/DETAIL:  Failing row contains \(.*\)/
 -- s/DETAIL:  Failing row contains \(.*\)/DETAIL:  Failing row contains (#####)/
 -- end_matchsubs
-SET statement_mem='250 MB';
+SET statement_mem='300 MB';
 CREATE TABLE dml_ao_check_r (
 	a int default 100 CHECK( a between 1 and 105),
 	b float8 CONSTRAINT rcheck_b CHECK( b <> 0.00 and b IS NOT NULL),

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -14,7 +14,7 @@
 -- m/DETAIL:  Failing row contains \(.*\)/
 -- s/DETAIL:  Failing row contains \(.*\)/DETAIL:  Failing row contains (#####)/
 -- end_matchsubs
-SET statement_mem='250 MB';
+SET statement_mem='300 MB';
 
 CREATE TABLE dml_ao_check_r (
 	a int default 100 CHECK( a between 1 and 105),


### PR DESCRIPTION
In upstream, all the callers of cost_agg that pass AGG_HASHED first
computed if the hash table would be too large to fit in work_mem. In GPDB,
the corresponding idiom is to call calcHashAggTableSizes(). Simplify the
signature to cost_agg(), so that you pass the whole HashAggTableSizes
struct, returned by calcHashAggTableSizes(), instead of extracting the
individual fields from it. That makes it easier to do the right thing and
harder to do the wrong thing; the only way to get a valid
HashAggTableSizes struct is to call calcHashAggTableSizes(), so it's not
so easy to just pass zeros anymore.

We've been carrying this difference in the cost_agg() signature as a diff
vs. upstream for a long time, through many upstream merges, but to be
honest, I never fully understood how this was supposed to work, until now.

We were previously not using this spilling-aware logic when estimating the
cost of a Hash Aggregate for Unique paths. That seemed like an oversight,
revealed by the new signature, so change it to use the spilling-aware
logic like most callers. That made the qp_dml_joins test to fail, because
we now chose a Hash Aggregate for one of the queries. Bump up
statement_mem for the test to work around that. Without setting a high
enough statement_mem, many of the test quries in the file fail in a
similar manner, this just raises the bar a little bit (see also commit
a5ff65ace5).

Improve comments in choose_hashed_setop() around the cost_agg() call.
At first, I thought that it should be using calcHashAggTableSizes() too,
and we had just forgotten to change it. But looking closer, it might be
building a Hash Setop, which doesn't spill to disk, so the upstream logic
is more appropriate. Add a comment explaining that.
