### PR TITLE
Elevate force_mirrors_to_catch_up() to gp_inject_fault

### DIFF
--- a/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
@@ -46,3 +46,38 @@ CREATE FUNCTION gp_wait_until_triggered_fault(
 RETURNS text
 AS $$ select gp_inject_fault($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3) $$
 LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION insert_noop_xlog_record()
+    RETURNS VOID
+AS 'MODULE_PATHNAME',
+'insert_noop_xlog_record'
+LANGUAGE C;
+
+-- Force a mirror to have applied as much XLOG as it's primary has shipped.
+CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
+BEGIN
+    -- Switch xlog to have no-op record at far distance from
+    -- previously emitted xlog record. This is required due to
+    -- existing code behavior in startup and walreceiver process. If
+    -- primary writes big (means spanning across multiple pages) xlog
+    -- record, flushes only partial xlog record due to
+    -- XLogBackgroundFlush() but restarts before commiting the
+    -- transaction, mirror only receives partial record and waits to
+    -- get complete record. Meanwhile after recover, no-op record gets
+    -- written in place of that big record, startup process on mirror
+    -- continues to wait to receive xlog beyond previously received
+    -- point to proceed further. Hence, switch xlog as temperory
+    -- workaround before writing no-op record to avoid this test from
+    -- hanging sometimes in CI. Refer
+    -- https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/vR7-LwpPsVs/zKmhIpJ3CAAJ
+
+    PERFORM pg_switch_xlog();
+    PERFORM pg_switch_xlog() from gp_dist_random('gp_id');
+
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM insert_noop_xlog_record();
+    PERFORM insert_noop_xlog_record() from gp_dist_random('gp_id');
+    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
+END;
+$$ LANGUAGE plpgsql;

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -14,11 +14,13 @@
                        Objects in extension "gp_inject_fault"
                                  Object Description                                 
 ------------------------------------------------------------------------------------
+ function force_mirrors_to_catch_up()
  function gp_inject_fault(text,text,integer)
  function gp_inject_fault(text,text,text,text,text,integer,integer,integer,integer)
  function gp_inject_fault_infinite(text,text,integer)
  function gp_wait_until_triggered_fault(text,integer,integer)
-(4 rows)
+ function insert_noop_xlog_record()
+(6 rows)
 
 --
 -- Test extended \du flags

--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -15,30 +15,6 @@ CREATE SCHEMA adst;
 
 SET search_path TO adst,public;
 
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
-    '@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-LANGUAGE C EXECUTE ON MASTER;
-
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON ALL SEGMENTS;
-
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
-BEGIN
-    PERFORM insert_noop_xlog_record_master();
-    PERFORM insert_noop_xlog_record_all_segments();
-END;
-$$LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
-BEGIN
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
-END;
-$$ LANGUAGE plpgsql;
-
 CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
     RETURNS TEXT
 AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'

--- a/src/test/regress/input/createdb.source
+++ b/src/test/regress/input/createdb.source
@@ -12,27 +12,6 @@ p = os.popen(bash_cmd % dboid)
 return p.readlines()
 $$;
 
---this group udf help test case wait mirror catch up
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON MASTER;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON ALL SEGMENTS;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
-BEGIN
-    PERFORM insert_noop_xlog_record_master();
-    PERFORM insert_noop_xlog_record_all_segments();
-END;
-$$LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
-BEGIN
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
-END;
-$$ LANGUAGE plpgsql;
 
 
 --

--- a/src/test/regress/input/gp_tablespace.source
+++ b/src/test/regress/input/gp_tablespace.source
@@ -40,29 +40,6 @@ CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
 	AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'
     LANGUAGE C;
 
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON MASTER;
-
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON ALL SEGMENTS;
-
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
-BEGIN
-    PERFORM insert_noop_xlog_record_master();
-    PERFORM insert_noop_xlog_record_all_segments();
-END;
-$$LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
-BEGIN
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
-END;
-$$ LANGUAGE plpgsql;
 
 -- create tablespaces we can use
 CREATE TABLESPACE testspace LOCATION '@testtablespace@';

--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -130,53 +130,6 @@ create or replace function list_tablespace_dbid_dirs(expected_number_of_tablespa
 $$ language plpythonu;
 
 
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
-    '@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-LANGUAGE C EXECUTE ON MASTER;
-
-
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON ALL SEGMENTS;
-
-
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
-BEGIN
-    PERFORM insert_noop_xlog_record_master();
-    PERFORM insert_noop_xlog_record_all_segments();
-END;
-$$LANGUAGE plpgsql;
-
-
-create or replace function force_mirrors_to_catch_up() returns void as $$
-begin
-
-    -- Switch xlog to have no-op record at far distance from
-    -- previously emitted xlog record. This is required due to
-    -- existing code behavior in startup and walreceiver process. If
-    -- primary writes big (means spanning across multiple pages) xlog
-    -- record, flushes only partial xlog record due to
-    -- XLogBackgroundFlush() but restarts before commiting the
-    -- transaction, mirror only receives partial record and waits to
-    -- get complete record. Meanwhile after recover, no-op record gets
-    -- written in place of that big record, startup process on mirror
-    -- continues to wait to receive xlog beyond previously received
-    -- point to proceed further. Hence, switch xlog as temperory
-    -- workaround before writing no-op record to avoid this test from
-    -- hanging sometimes in CI. Refer
-    -- https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/vR7-LwpPsVs/zKmhIpJ3CAAJ
-
-    PERFORM pg_switch_xlog();
-    PERFORM pg_switch_xlog() from gp_dist_random('gp_id');
-
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
-end;
-$$ language plpgsql;
-
-
 create or replace function wait_for_primaries_to_restart() returns boolean as $$
 	select count(gp_segment_id) > 0 from gp_dist_random('pg_tablespace');
 $$ language sql;

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -11,26 +11,6 @@
 -- end_ignore
 CREATE SCHEMA adst;
 SET search_path TO adst,public;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
-    '@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-LANGUAGE C EXECUTE ON MASTER;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON ALL SEGMENTS;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
-BEGIN
-    PERFORM insert_noop_xlog_record_master();
-    PERFORM insert_noop_xlog_record_all_segments();
-END;
-$$LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
-BEGIN
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
-END;
-$$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
     RETURNS TEXT
 AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'
@@ -1312,12 +1292,8 @@ SELECT force_mirrors_to_catch_up();
 
 -- Final cleanup
 DROP SCHEMA adst CASCADE;
-NOTICE:  drop cascades to 9 other objects
-DETAIL:  drop cascades to function insert_noop_xlog_record_master()
-drop cascades to function insert_noop_xlog_record_all_segments()
-drop cascades to function insert_noop_xlog_record()
-drop cascades to function force_mirrors_to_catch_up()
-drop cascades to function get_tablespace_version_directory_name()
+NOTICE:  drop cascades to 5 other objects
+DETAIL:  drop cascades to function get_tablespace_version_directory_name()
 drop cascades to function setup_tablespace_location_dir_for_test(text)
 drop cascades to function setup()
 drop cascades to function list_db_tablespace(text,text)

--- a/src/test/regress/output/createdb.source
+++ b/src/test/regress/output/createdb.source
@@ -17,27 +17,6 @@ bash_cmd = "find " + os.getcwd() + "/../../ " + "-name %d -type d"
 p = os.popen(bash_cmd % dboid)
 return p.readlines()
 $$;
---this group udf help test case wait mirror catch up
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON MASTER;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON ALL SEGMENTS;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
-BEGIN
-    PERFORM insert_noop_xlog_record_master();
-    PERFORM insert_noop_xlog_record_all_segments();
-END;
-$$LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
-BEGIN
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
-END;
-$$ LANGUAGE plpgsql;
 --
 --CASE 0: createdb do well
 --

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -37,26 +37,6 @@ CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
 	RETURNS TEXT
 	AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'
     LANGUAGE C;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON MASTER;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON ALL SEGMENTS;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
-BEGIN
-    PERFORM insert_noop_xlog_record_master();
-    PERFORM insert_noop_xlog_record_all_segments();
-END;
-$$LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
-BEGIN
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
-END;
-$$ LANGUAGE plpgsql;
 -- create tablespaces we can use
 CREATE TABLESPACE testspace LOCATION '@testtablespace@';
 CREATE TABLESPACE ul_testspace LOCATION '@testtablespace@_unlogged';

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -121,45 +121,6 @@ create or replace function list_tablespace_dbid_dirs(expected_number_of_tablespa
 		result.append(str(row))
 	return result
 $$ language plpythonu;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_master() RETURNS VOID AS
-    '@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-LANGUAGE C EXECUTE ON MASTER;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record_all_segments() RETURNS SETOF VOID AS
-'@abs_builddir@/regress.so', 'insert_noop_xlog_record'
-    LANGUAGE C EXECUTE ON ALL SEGMENTS;
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record() RETURNS VOID AS $$
-BEGIN
-    PERFORM insert_noop_xlog_record_master();
-    PERFORM insert_noop_xlog_record_all_segments();
-END;
-$$LANGUAGE plpgsql;
-create or replace function force_mirrors_to_catch_up() returns void as $$
-begin
-
-    -- Switch xlog to have no-op record at far distance from
-    -- previously emitted xlog record. This is required due to
-    -- existing code behavior in startup and walreceiver process. If
-    -- primary writes big (means spanning across multiple pages) xlog
-    -- record, flushes only partial xlog record due to
-    -- XLogBackgroundFlush() but restarts before commiting the
-    -- transaction, mirror only receives partial record and waits to
-    -- get complete record. Meanwhile after recover, no-op record gets
-    -- written in place of that big record, startup process on mirror
-    -- continues to wait to receive xlog beyond previously received
-    -- point to proceed further. Hence, switch xlog as temperory
-    -- workaround before writing no-op record to avoid this test from
-    -- hanging sometimes in CI. Refer
-    -- https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/vR7-LwpPsVs/zKmhIpJ3CAAJ
-
-    PERFORM pg_switch_xlog();
-    PERFORM pg_switch_xlog() from gp_dist_random('gp_id');
-
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM insert_noop_xlog_record();
-    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
-end;
-$$ language plpgsql;
 create or replace function wait_for_primaries_to_restart() returns boolean as $$
 	select count(gp_segment_id) > 0 from gp_dist_random('pg_tablespace');
 $$ language sql;

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -2150,24 +2150,6 @@ broken_int4out(PG_FUNCTION_ARGS)
 	return DirectFunctionCall1(int4out, Int32GetDatum(arg));
 }
 
-PG_FUNCTION_INFO_V1(insert_noop_xlog_record);
-Datum
-insert_noop_xlog_record(PG_FUNCTION_ARGS)
-{
-	char *no_op_string = "no-op";
-
-	/* Xlog records of length = 0 are disallowed and cause a panic. Thus,
-	 * supplying a dummy non-zero length
-	 */
-	XLogBeginInsert();
-
-	XLogRegisterData(no_op_string, strlen(no_op_string));
-
-	XLogFlush(XLogInsert(RM_XLOG_ID, XLOG_NOOP));
-
-	PG_RETURN_VOID();
-}
-
 PG_FUNCTION_INFO_V1(get_tablespace_version_directory_name);
 Datum
 get_tablespace_version_directory_name(PG_FUNCTION_ARGS)


### PR DESCRIPTION
This also applies the fix in efd76c4c4 to all callers of
force_mirrors_to_catch_up(), thus eliminating flakes such as:

```
-- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
 SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
- gp_wait_until_triggered_fault
--------------------------------
- Success:
- Success:
- Success:
- Success:
-(4 rows)
-
+ERROR:  failed to inject fault: ERROR:  fault not triggered, fault name:'after_drop_database_directories' fault type:'wait_until_triggered' (gp_inject_fault.c:127)
+DETAIL:  DETAIL:  Timed-out as 10 minutes max wait happens until triggered.
```
