### PR TITLE
Speed up pg_basebackup in isolation2 tests.

### DIFF
--- a/src/test/isolation2/helpers/gp_management_utils_helpers.sql
+++ b/src/test/isolation2/helpers/gp_management_utils_helpers.sql
@@ -14,7 +14,7 @@ create or replace language plpythonu;
 create or replace function pg_basebackup(host text, dbid int, port int, slotname text, datadir text, force_overwrite boolean, xlog_method text) returns text as $$
     import subprocess
     import os
-    cmd = 'pg_basebackup -h %s -p %d -R -D %s --target-gp-dbid %d' % (host, port, datadir, dbid)
+    cmd = 'pg_basebackup --checkpoint=fast -h %s -p %d -R -D %s --target-gp-dbid %d' % (host, port, datadir, dbid)
 
     if slotname is not None:
         cmd += ' --slot %s' % (slotname)


### PR DESCRIPTION
Don't spread the checkpoint in pg_basebackup tests. It's useful in
production, to not disrupt concurrent queries, but in testing we just want
to get things done as quickly as possible. Hopefully this makes the
isolation2 test suite finish faster.
