### PR TITLE
Improve analyzedb performance on partitioned tables

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -43,6 +43,7 @@ EXECNAME = 'analyzedb'
 STATEFILE_DIR = 'db_analyze'
 logger = gplog.get_default_logger()
 WRITE_LOCK_FILE_NAME = "write_lock_semaphore"
+ANALYZE_GUCS = "set optimizer_analyze_enable_merge_of_leaf_stats=off; "
 ANALYZE_SQL = """analyze %s"""
 ANALYZE_ROOT_SQL = """analyze rootpartition %s"""
 
@@ -181,6 +182,7 @@ class AnalyzeDb(Operation):
         self.clean_last = options.clean_last
         self.clean_all = options.clean_all
         self.gen_profile_only = options.gen_profile_only
+        self.analyze_gucs = ANALYZE_GUCS
 
         self.success_list = []
 
@@ -386,7 +388,7 @@ class AnalyzeDb(Operation):
             can_schema, can_table = can[0], can[1]
             if can in candidates:
                 target = self._get_tablename_with_cols(can_schema, can_table, input_col_dict)
-                cmd = create_psql_command(self.dbname, ANALYZE_SQL % target)
+                cmd = create_psql_command(self.dbname, self.analyze_gucs + ANALYZE_SQL % target)
 
             else:  # can in root_partition_col_dict
                 target = self._get_tablename_with_cols(can_schema, can_table, root_partition_col_dict)

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1558,7 +1558,9 @@ get_rel_oids(List *relids, VacuumStmt *vacstmt, bool isVacuum)
 					}
 					RelationClose(onerel);
 				}
-				if(leaf_parts_analyzed(root_rel_oid, relationOid, va_root_attnums))
+				if(optimizer_analyze_enable_merge_of_leaf_stats &&
+				   leaf_parts_analyzed(root_rel_oid, relationOid, va_root_attnums))
+					/* remember to merge the partition stats into the root partition */
 					oid_list = lappend_oid(oid_list, root_rel_oid);
 			}
 			else if (ps == PART_STATUS_INTERIOR) /* analyze an interior partition directly */

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -588,6 +588,7 @@ bool		optimizer_prune_unused_columns;
 /* Analyze related GUCs for Optimizer */
 bool		optimizer_analyze_root_partition;
 bool		optimizer_analyze_midlevel_partition;
+bool		optimizer_analyze_enable_merge_of_leaf_stats;
 
 /* GUCs for slice table*/
 int			gp_max_slices;
@@ -3104,6 +3105,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_analyze_midlevel_partition,
 		false, NULL, NULL
+	},
+
+	{
+		{"optimizer_analyze_enable_merge_of_leaf_stats", PGC_USERSET, STATS_ANALYZE,
+			gettext_noop("Enable merging of leaf stats into the root stats during ANALYZE when analyzing partitions"),
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_analyze_enable_merge_of_leaf_stats,
+		true, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -502,6 +502,7 @@ extern bool optimizer_prune_unused_columns;
 /* Analyze related GUCs for Optimizer */
 extern bool optimizer_analyze_root_partition;
 extern bool optimizer_analyze_midlevel_partition;
+extern bool optimizer_analyze_enable_merge_of_leaf_stats;
 
 extern bool optimizer_use_gpdb_allocators;
 


### PR DESCRIPTION
Until now, when we issued an "analyze " command, we would
produce new root-level statistics (merge) for each such command,
assuming we had valid HLL stats for every partition and every column.
That is very expensive, and could take hours to complete, if we
need to update many partitions. The cost is roughly

u * p * c

where u is the number of incrementally updated partitions, p is the
total number of partitions and c is the number of columns.

This commit adds a new guc, optimizer_analyze_enable_merge_of_leaf_stats
that enables creating new root-level stats when we analyze an
individual partition. The guc is set to "on" by default, so there is
no change in the default behavior.

The analyzedb program, however, will turn this guc off and therefore
suppress generating the root stats for every partition. The root-level
stats will be generated when analyzedb issues the final
"analyze rootpartition" command. For tables with very many partitions,
this can speed up the process by several orders of magnitude when we
do a full analyze, the new cost is now p * c.

Co-authored-by: Abhijit Subramanya <asubramanya@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Hans Zeller <hzeller@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
