### PR TITLE
Add a plpgsql test case for upgrade from 5X to 6X

### DIFF
--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -12,6 +12,7 @@
 #include "scenarios/subpartitioned_heap_table.h"
 #include "scenarios/ao_table.h"
 #include "scenarios/aocs_table.h"
+#include "scenarios/plpgsql_function.h"
 
 #include "utilities/gpdb5-cluster.h"
 #include "utilities/gpdb6-cluster.h"
@@ -50,6 +51,7 @@ main(int argc, char *argv[])
 		unit_test_setup_teardown(test_a_partitioned_ao_table_with_data_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_an_exchange_partitioned_heap_table_cannot_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_partitioned_heap_table_with_a_dropped_column_can_be_upgraded, setup, teardown),
+		unit_test_setup_teardown(test_a_plpgsql_function_can_be_upgraded, setup, teardown),
 	};
 
 	return run_tests(tests);

--- a/contrib/pg_upgrade/test/integration/scenarios/plpgsql_function.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/plpgsql_function.c
@@ -1,0 +1,78 @@
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "cmockery.h"
+#include "libpq-fe.h"
+
+#include "utilities/bdd-helpers.h"
+#include "utilities/gpdb5-cluster.h"
+#include "utilities/gpdb6-cluster.h"
+#include "utilities/query-helpers.h"
+#include "utilities/test-helpers.h"
+#include "utilities/upgrade-helpers.h"
+
+#include "plpgsql_function.h"
+
+static void
+createPlpgsqlFunctionInFiveCluster(void)
+{
+	PGconn	   *conn1 = connectToFive();
+	PGresult   *result;
+
+	result = executeQuery(conn1, "CREATE SCHEMA five_to_six_upgrade;");
+	PQclear(result);
+
+	result = executeQuery(conn1, "SET search_path TO five_to_six_upgrade;");
+	PQclear(result);
+
+	result = executeQuery(conn1, "                                  \
+		CREATE FUNCTION someimmutablefunction(foo integer)          \
+		RETURNS integer                                             \
+		LANGUAGE plpgsql IMMUTABLE STRICT AS                        \
+		$$                                                          \
+		BEGIN                                                       \
+			return 42 + foo;                                        \
+		END                                                         \
+		$$;                                                         \
+	");
+	PQclear(result);
+
+	PQfinish(conn1);
+}
+
+static void
+anAdministratorPerformsAnUpgrade(void)
+{
+	performUpgrade();
+}
+
+static void
+thePlpgsqlFunctionIsUsable(void)
+{
+	PGconn	   *connection = connectToSix();
+	PGresult   *result = NULL;
+	char	   *resvalue = NULL;
+	int			nrows;
+	int			actual;
+
+	result = executeQuery(connection, "SELECT five_to_six_upgrade.someimmutablefunction(0) as f;");
+	nrows = PQntuples(result);
+	resvalue = PQgetvalue(result, 0, PQfnumber(result, "f"));
+	actual = atoi((resvalue != NULL) ? resvalue : 0);
+
+	PQclear(result);
+	PQfinish(connection);
+
+	assert_int_equal(1, nrows);
+	assert_int_equal(42, actual);
+}
+
+void
+test_a_plpgsql_function_can_be_upgraded(void **state)
+{
+	given(withinGpdbFiveCluster(createPlpgsqlFunctionInFiveCluster));
+	when(anAdministratorPerformsAnUpgrade);
+	then(withinGpdbSixCluster(thePlpgsqlFunctionIsUsable));
+}

--- a/contrib/pg_upgrade/test/integration/scenarios/plpgsql_function.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/plpgsql_function.h
@@ -1,0 +1,1 @@
+void test_a_plpgsql_function_can_be_upgraded(void **state);


### PR DESCRIPTION
This is the most basic case scenario where a simple immutable function can be
successfully upgraded. More elaborate cases of plpgsql syntax and/or usage are
not needed to be tested as the same catalog entries are used.

Co-authored-by: Adam Berlin <aberlin@pivotal.io>

