### PR TITLE
Drop some test tables at end of tests, to make regression db smaller.

### DIFF
--- a/src/test/regress/expected/eagerfree.out
+++ b/src/test/regress/expected/eagerfree.out
@@ -1,15 +1,11 @@
-drop table if exists smallt;
-NOTICE:  table "smallt" does not exist, skipping
+create schema eagerfree;
+set search_path=eagerfree;
 create table smallt (i int, t text, d date) distributed by (i);
 insert into smallt select i%10, 'text ' || (i%15), '2011-01-01'::date + ((i%20) || ' days')::interval
 from generate_series(0, 99) i;
-drop table if exists bigt;
-NOTICE:  table "bigt" does not exist, skipping
 create table bigt (i int, t text, d date) distributed by (i);
 insert into bigt select i/10, 'text ' || (i/15), '2011-01-01'::date + ((i/20) || ' days')::interval
 from generate_series(0, 999999) i;
-drop table if exists smallt2;
-NOTICE:  table "smallt2" does not exist, skipping
 create table smallt2 (i int, t text, d date) distributed by (i);
 insert into smallt2 select i%5, 'text ' || (i%10), '2011-01-01'::date + ((i%15) || ' days')::interval
 from generate_series(0, 49) i;
@@ -1920,12 +1916,6 @@ and i = 0 order by 1,2,3; --order 1,2,3
 (3 rows)
 
 -- Nested Subplan
-drop table if exists eager_free_r;
-NOTICE:  table "eager_free_r" does not exist, skipping
-drop table if exists eager_free_s;
-NOTICE:  table "eager_free_s" does not exist, skipping
-drop table if exists eager_free_t;
-NOTICE:  table "eager_free_t" does not exist, skipping
 create table eager_free_r (r1 int, r2 int, r3 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1968,3 +1958,12 @@ select * from eager_free_t where t1 > (select min(r1) from eager_free_r where r2
 (24 rows)
 
 reset optimizer_segments;
+reset search_path;
+drop schema eagerfree cascade;
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to table eagerfree.smallt
+drop cascades to table eagerfree.bigt
+drop cascades to table eagerfree.smallt2
+drop cascades to table eagerfree.eager_free_r
+drop cascades to table eagerfree.eager_free_s
+drop cascades to table eagerfree.eager_free_t

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -1,15 +1,11 @@
-drop table if exists smallt;
-NOTICE:  table "smallt" does not exist, skipping
+create schema eagerfree;
+set search_path=eagerfree;
 create table smallt (i int, t text, d date) distributed by (i);
 insert into smallt select i%10, 'text ' || (i%15), '2011-01-01'::date + ((i%20) || ' days')::interval
 from generate_series(0, 99) i;
-drop table if exists bigt;
-NOTICE:  table "bigt" does not exist, skipping
 create table bigt (i int, t text, d date) distributed by (i);
 insert into bigt select i/10, 'text ' || (i/15), '2011-01-01'::date + ((i/20) || ' days')::interval
 from generate_series(0, 999999) i;
-drop table if exists smallt2;
-NOTICE:  table "smallt2" does not exist, skipping
 create table smallt2 (i int, t text, d date) distributed by (i);
 insert into smallt2 select i%5, 'text ' || (i%10), '2011-01-01'::date + ((i%15) || ' days')::interval
 from generate_series(0, 49) i;
@@ -1935,12 +1931,6 @@ and i = 0 order by 1,2,3; --order 1,2,3
 (3 rows)
 
 -- Nested Subplan
-drop table if exists eager_free_r;
-NOTICE:  table "eager_free_r" does not exist, skipping
-drop table if exists eager_free_s;
-NOTICE:  table "eager_free_s" does not exist, skipping
-drop table if exists eager_free_t;
-NOTICE:  table "eager_free_t" does not exist, skipping
 create table eager_free_r (r1 int, r2 int, r3 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1983,3 +1973,12 @@ select * from eager_free_t where t1 > (select min(r1) from eager_free_r where r2
 (24 rows)
 
 reset optimizer_segments;
+reset search_path;
+drop schema eagerfree cascade;
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to table eagerfree.smallt
+drop cascades to table eagerfree.bigt
+drop cascades to table eagerfree.smallt2
+drop cascades to table eagerfree.eager_free_r
+drop cascades to table eagerfree.eager_free_s
+drop cascades to table eagerfree.eager_free_t

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -180,3 +180,4 @@ select gp_inject_fault('fts_probe', 'reset', 1);
 
 drop table _tmp_table1;
 drop table _tmp_table2;
+drop table testsisc;

--- a/src/test/regress/expected/rle_delta.out
+++ b/src/test/regress/expected/rle_delta.out
@@ -683,6 +683,9 @@ Select a1,a2,a6 from delta_blocks where a4 = '20:13:11.232421' order by a1 limit
   4 |  4 | 2014-07-22 14:12:23.776892-07
 (10 rows)
 
+-- The dl_bt_ix index is quite large, over 600 MB. Let's drop the table, along
+-- with the indexes, to keep the regression database size in check.
+drop table delta_blocks;
 --
 -- Table with  delta + none compression on some columns
 --

--- a/src/test/regress/expected/segspace.out
+++ b/src/test/regress/expected/segspace.out
@@ -372,6 +372,7 @@ select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used
    0 |   0
 (1 row)
 
+drop table testsort;
 ------------ workfile_limit_per_segment leak check during UPDATE of SHARE_SORT_XSLICE -------------------
 drop table if exists testsisc;
 create table testsisc (i1 int, i2 int, i3 int, i4 int);
@@ -467,3 +468,4 @@ NOTICE:  caught exception: invalid input syntax for integer: "bogus"
  t
 (1 row)
 
+drop table segspace_test_hj_skew;

--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -72,6 +72,7 @@ select * from hashagg_spill.is_workfile_created('explain (analyze, verbose) sele
 
 -- Test HashAgg with increasing amount of overflows
 reset all;
+set search_path to hashagg_spill;
 -- Returns the number of overflows from EXPLAIN ANALYZE output
 create or replace function hashagg_spill.num_hashagg_overflows(explain_query text)
 returns setof int as
@@ -92,7 +93,6 @@ return result
 $$
 language plpythonu;
 -- Test agg spilling scenarios
-drop table if exists aggspill;
 create table aggspill (i int, j int, t text) distributed by (i);
 insert into aggspill select i, i*2, i::text from generate_series(1, 10000) i;
 insert into aggspill select i, i*2, i::text from generate_series(1, 100000) i;
@@ -170,7 +170,10 @@ RESET temp_tablespaces;
 RESET statement_mem;
 RESET gp_workfile_compression;
 drop schema hashagg_spill cascade;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to function hashagg_spill.is_workfile_created(text)
-drop cascades to table hashagg_spill.testhagg
-drop cascades to function hashagg_spill.num_hashagg_overflows(text)
+DETAIL:  drop cascades to function is_workfile_created(text)
+NOTICE:  drop cascades to 6 other objects
+drop cascades to table testhagg
+drop cascades to function num_hashagg_overflows(text)
+drop cascades to table aggspill
+drop cascades to table hashagg_spill
+drop cascades to table spill_temptblspace

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -138,6 +138,7 @@ select gp_inject_fault('workfile_creation_failure', 'status', 2);
 drop function FuncA();
 drop table test_zlib;
 drop table test_zlib_t1;
+drop table test_zlib_hashjoin;
 select gp_inject_fault('workfile_creation_failure', 'reset', 2);
  gp_inject_fault 
 -----------------

--- a/src/test/regress/sql/eagerfree.sql
+++ b/src/test/regress/sql/eagerfree.sql
@@ -1,16 +1,14 @@
-drop table if exists smallt;
+create schema eagerfree;
+set search_path=eagerfree;
 
 create table smallt (i int, t text, d date) distributed by (i);
 insert into smallt select i%10, 'text ' || (i%15), '2011-01-01'::date + ((i%20) || ' days')::interval
 from generate_series(0, 99) i;
 
-drop table if exists bigt;
-
 create table bigt (i int, t text, d date) distributed by (i);
 insert into bigt select i/10, 'text ' || (i/15), '2011-01-01'::date + ((i/20) || ' days')::interval
 from generate_series(0, 999999) i;
 
-drop table if exists smallt2;
 create table smallt2 (i int, t text, d date) distributed by (i);
 insert into smallt2 select i%5, 'text ' || (i%10), '2011-01-01'::date + ((i%15) || ' days')::interval
 from generate_series(0, 49) i;
@@ -158,9 +156,6 @@ where i < all (select total from (select d, sum(i) as total from smallt group by
 and i = 0 order by 1,2,3; --order 1,2,3
 
 -- Nested Subplan
-drop table if exists eager_free_r;
-drop table if exists eager_free_s;
-drop table if exists eager_free_t;
 create table eager_free_r (r1 int, r2 int, r3 int);
 create table eager_free_s (s1 int, s2 int, s3 int);
 create table eager_free_t (t1 int, t2 int, t3 int);
@@ -170,3 +165,6 @@ insert into eager_free_t select generate_series(1, 30), generate_series(1, 6), g
 
 select * from eager_free_t where t1 > (select min(r1) from eager_free_r where r2<t2 and r3 > (Select min(s3) from eager_free_s where s1<r1));
 reset optimizer_segments;
+
+reset search_path;
+drop schema eagerfree cascade;

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -84,3 +84,4 @@ select gp_inject_fault('fts_probe', 'reset', 1);
 
 drop table _tmp_table1;
 drop table _tmp_table2;
+drop table testsisc;

--- a/src/test/regress/sql/rle_delta.sql
+++ b/src/test/regress/sql/rle_delta.sql
@@ -352,6 +352,10 @@ Insert into delta_blocks select
 Select a1,a2,a6 from delta_blocks where a4 = '20:13:11.232421' order by a1 limit 10;
 
 
+-- The dl_bt_ix index is quite large, over 600 MB. Let's drop the table, along
+-- with the indexes, to keep the regression database size in check.
+drop table delta_blocks;
+
 --
 -- Table with  delta + none compression on some columns
 --

--- a/src/test/regress/sql/segspace.sql
+++ b/src/test/regress/sql/segspace.sql
@@ -255,6 +255,8 @@ update foo set d = i1 from (select i1,i2 from testsort order by i2) x;
 -- check counter leak
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;
 
+drop table testsort;
+
 ------------ workfile_limit_per_segment leak check during UPDATE of SHARE_SORT_XSLICE -------------------
 
 drop table if exists testsisc;
@@ -323,3 +325,5 @@ end;
 $func$ language plpgsql;
 
 select workset_cleanup_test();
+
+drop table segspace_test_hj_skew;

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -55,6 +55,7 @@ select * from hashagg_spill.is_workfile_created('explain (analyze, verbose) sele
 -- Test HashAgg with increasing amount of overflows
 
 reset all;
+set search_path to hashagg_spill;
 
 -- Returns the number of overflows from EXPLAIN ANALYZE output
 create or replace function hashagg_spill.num_hashagg_overflows(explain_query text)
@@ -77,7 +78,6 @@ $$
 language plpythonu;
 
 -- Test agg spilling scenarios
-drop table if exists aggspill;
 create table aggspill (i int, j int, t text) distributed by (i);
 insert into aggspill select i, i*2, i::text from generate_series(1, 10000) i;
 insert into aggspill select i, i*2, i::text from generate_series(1, 100000) i;

--- a/src/test/regress/sql/zlib.sql
+++ b/src/test/regress/sql/zlib.sql
@@ -80,5 +80,6 @@ select gp_inject_fault('workfile_creation_failure', 'status', 2);
 drop function FuncA();
 drop table test_zlib;
 drop table test_zlib_t1;
+drop table test_zlib_hashjoin;
 
 select gp_inject_fault('workfile_creation_failure', 'reset', 2);


### PR DESCRIPTION
The largest one was the 'dl_bt_ix' index on 'delta_blocks' table. Dropping
it saves over 600 MB. In addition to that, a bunch of other tables in the
10-50 MB range. After these changes, the regression database after running
"make installcheck-good" is about 4 GB on my laptop.

It is generally a good idea to *not* drop test objects at end of each
test, so that they take part in the pg_upgrade testing at the end of
installcheck-world. But these test tables are not very interesting from
upgrade point of view, there is nothing special about them. We might want
to test pg_upgrade with larger relations, too, but these are not large
enough to be interesting for that either.
