### PR TITLE
Use user-provided shutdown mode for standby master in gpstop

### DIFF
--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -569,10 +569,10 @@ class GpStop:
         if self.gparray.standbyMaster:
             standby = self.gparray.standbyMaster
 
-            logger.info("Stopping master standby host %s mode=fast" % standby.hostname)
+            logger.info("Stopping master standby host %s mode=%s" % (standby.hostname, self.mode))
             try:
                 cmd = SegmentStop("stopping master standby",
-                                     standby.datadir, mode='fast',
+                                     standby.datadir, mode=self.mode,
                                      timeout=self.timeout,
                                      ctxt=base.REMOTE,
                                      remoteHost=standby.hostname)


### PR DESCRIPTION
No matter what mode the user provided, the standby master would always
use the default fast shutdown. This is because it was hardcoded to be
fast shutdown (with immediate shutdown being the backup and kill -9
being the last resort). Technically, all modes should be usable for
the standby master so update the logic to accept the user-provided
shutdown mode (smart shutdown will be interesting when GPDB Hot
Standby becomes a thing).

This was found while testing restore points for Point-In-Time Recovery
where the standby master was unable to use the restore point because
fast shutdown had updated the minimum recovery point LSN in the
pg_control file to be after the restore point LSN. Trying to start the
standby master and have it replay up to the restore point would fail
with error "FATAL: requested recovery stop point is before consistent
recovery point".