### PR TITLE
Remove duplicated checkForCancelFromQD in SetupTCPInterconnect

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1571,8 +1571,6 @@ SetupTCPInterconnect(EState *estate)
 		ML_CHECK_FOR_INTERRUPTS(interconnect_context->teardownActive);
 		n = select(highsock + 1, (fd_set *) &rset, (fd_set *) &wset, (fd_set *) &eset, &timeout);
 		ML_CHECK_FOR_INTERRUPTS(interconnect_context->teardownActive);
-		if (Gp_role == GP_ROLE_DISPATCH)
-			checkForCancelFromQD(interconnect_context);
 
 		elapsed_ms = gp_get_elapsed_ms(&startTime);
 


### PR DESCRIPTION
    commit 2fa26b introduced additional checkForCancelFromQD inside
    SetupTCPInterconnect. This is useful in 5X_STABLE, but 6X_STABLE
    and master have already added checkForCancelFromQD.

    Note that checkForCancelFromQD is neccessary, since interconnect
    and dispatcher(libpq) are two flows. QE could failed before
    SetupTCPInterconnect stage, and QD could knew it from dispatcher
    flow but could not detect it from interconnect flow(in fact, QD dead
    loop waiting for QE's incoming connection)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
