### PR TITLE
6x backport: Set Recursive CTE plan's flow correctly.

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1849,7 +1849,26 @@ set_worktable_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	 */
 	required_outer = rel->lateral_relids;
 
-	ctelocus = cteplan->flow->locustype;
+	/*
+	 * Between Recursive union plannode node and WorkTableScan plannode
+	 * there must be no Motion nodes because the execution of WorkTableScan
+	 * depends on the Recursive union's data structure.
+	 *
+	 * And the logic here is always use cteplan's locus as WTS's locus.
+	 * Remember WTS path cannot be turned to replicated(means broadcast)
+	 * when dealing with join. Most of the cases, it is OK. But for
+	 * replicated table whose locus is CdbLocusType_SegmentGeneral,
+	 * it can not be taken as everywhere, we will gather it to singleQE
+	 * or redistribute it when joining.
+	 *
+	 * To avoid such case, if cteplan's locus is CdbLocusType_SegmentGeneral,
+	 * we build WTS path using singlQE, and later in the function
+	 * `set_recursive_union_flow` to add a gather on the top of cteplan.
+	 */
+	if (cteplan->flow->locustype == CdbLocusType_SegmentGeneral)
+		ctelocus = CdbLocusType_SingleQE;
+	else
+		ctelocus = cteplan->flow->locustype;
 
 	/* Generate appropriate path */
 	add_path(rel, create_worktablescan_path(root, rel, ctelocus, required_outer));

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -121,7 +121,6 @@ static Relids adjust_relid_set(Relids relids, Index oldrelid, Index newrelid);
 static List *adjust_inherited_tlist(List *tlist,
 					   AppendRelInfo *context);
 
-
 /*
  * plan_set_operations
  *
@@ -445,6 +444,47 @@ generate_recursion_plan(SetOperationStmt *setOp, PlannerInfo *root,
 
 		/* Also convert to long int --- but 'ware overflow! */
 		numGroups = (long) Min(dNumGroups, (double) LONG_MAX);
+	}
+
+	/*
+	 * When building worktable scan path, its locus is set
+	 * the same as the non-recursive plan's locus. But in
+	 * Greenplum, locus may change by motion if worktable
+	 * join with other relations. In `cdbpath_motion_for_join`,
+	 * paths contains worktable scan are set ok_replicated to false
+	 * and movable to false, so if lplan's locus does not equal to
+	 * rplan's, rplan's locus must be singleQE or entry. Then we just make
+	 * them the same locus.
+	 */
+	if (lplan->flow->locustype != rplan->flow->locustype &&
+		lplan->flow->flotype == FLOW_SINGLETON &&
+		rplan->flow->flotype == FLOW_SINGLETON)
+	{
+		if (rplan->flow->locustype != CdbLocusType_SingleQE &&
+			rplan->flow->locustype != CdbLocusType_Entry)
+		{
+			elog(ERROR,
+				 "expect rplan's locus to be singleQE or entry, "
+				 "but found %d", rplan->flow->locustype);
+		}
+
+		if (lplan->flow->locustype == CdbLocusType_General ||
+			lplan->flow->locustype == CdbLocusType_Entry)
+		{
+			/* do nothing, will set flow correct at the end of the function */
+		}
+		else if (lplan->flow->locustype == CdbLocusType_SegmentGeneral)
+			lplan = (Plan *) make_motion_gather(root, lplan, NIL);
+		else
+		{
+			elog(ERROR,
+				 "expect lplan's locus to be either general or segmentgeneral, "
+				 "but found %d", lplan->flow->locustype);
+		}
+		/* set lplan's flow same as rplan's */
+		lplan->flow->locustype = rplan->flow->locustype;
+		lplan->flow->segindex = rplan->flow->segindex;
+		lplan->flow->numsegments = rplan->flow->numsegments;
 	}
 
 	/*

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2869,7 +2869,14 @@ create_worktablescan_path(PlannerInfo *root, RelOptInfo *rel,
 	else if (ctelocus == CdbLocusType_General)
 		CdbPathLocus_MakeGeneral(&result, numsegments);
 	else if (ctelocus == CdbLocusType_SegmentGeneral)
-		CdbPathLocus_MakeSegmentGeneral(&result, numsegments);
+	{
+		/* See comments in set_worktable_pathlist */
+		elog(ERROR,
+			 "worktable scan path can never have "
+			 "segmentgeneral locus.");
+	}
+	else if (ctelocus == CdbLocusType_OuterQuery)
+		CdbPathLocus_MakeOuterQuery(&result, numsegments);
 	else
 		CdbPathLocus_MakeStrewn(&result, numsegments);
 

--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -578,3 +578,45 @@ union
  10.00000000000000000000
 (10 rows)
 
+-- WTIH RECURSIVE and replicated table
+create table t_rep_test_rcte(c int) distributed replicated;
+create table t_rand_test_rcte(c int) distributed by (c);
+insert into t_rep_test_rcte values (1);
+insert into t_rand_test_rcte values (1), (2), (3);
+analyze t_rep_test_rcte;
+analyze t_rand_test_rcte;
+explain
+with recursive the_cte_here(n) as (
+  select * from t_rep_test_rcte
+  union all
+  select n+1 from the_cte_here join t_rand_test_rcte
+	              on t_rand_test_rcte.c = the_cte_here.n)
+select * from the_cte_here;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Recursive Union  (cost=0.00..25.76 rows=35 width=4)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1.02 rows=1 width=4)
+         ->  Seq Scan on t_rep_test_rcte  (cost=0.00..1.01 rows=1 width=4)
+   ->  Hash Join  (cost=2.13..2.41 rows=4 width=4)
+         Hash Cond: (the_cte_here.n = t_rand_test_rcte.c)
+         ->  WorkTable Scan on the_cte_here  (cost=0.00..0.20 rows=10 width=4)
+         ->  Hash  (cost=2.09..2.09 rows=1 width=4)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.09 rows=3 width=4)
+                     ->  Seq Scan on t_rand_test_rcte  (cost=0.00..2.03 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with recursive the_cte_here(n) as (
+  select * from t_rep_test_rcte
+  union all
+  select n+1 from the_cte_here join t_rand_test_rcte
+	              on t_rand_test_rcte.c = the_cte_here.n)
+select * from the_cte_here;
+ n 
+---
+ 1
+ 2
+ 3
+ 4
+(4 rows)
+

--- a/src/test/regress/sql/gp_recursive_cte.sql
+++ b/src/test/regress/sql/gp_recursive_cte.sql
@@ -408,3 +408,27 @@ z(i) as (
 (select * from y limit 5)
 union
 (select * from z limit 10);
+
+-- WTIH RECURSIVE and replicated table
+create table t_rep_test_rcte(c int) distributed replicated;
+create table t_rand_test_rcte(c int) distributed by (c);
+insert into t_rep_test_rcte values (1);
+insert into t_rand_test_rcte values (1), (2), (3);
+
+analyze t_rep_test_rcte;
+analyze t_rand_test_rcte;
+
+explain
+with recursive the_cte_here(n) as (
+  select * from t_rep_test_rcte
+  union all
+  select n+1 from the_cte_here join t_rand_test_rcte
+	              on t_rand_test_rcte.c = the_cte_here.n)
+select * from the_cte_here;
+
+with recursive the_cte_here(n) as (
+  select * from t_rep_test_rcte
+  union all
+  select n+1 from the_cte_here join t_rand_test_rcte
+	              on t_rand_test_rcte.c = the_cte_here.n)
+select * from the_cte_here;


### PR DESCRIPTION
Recursive union plannode contains two non-empty subplan trees,
so that this plannode's flow and locus should take both trees
into consideration.

Besides, between Recursive union plannode node and WorkTableScan plannode
there must be no Motion nodes because the execution of WorkTableScan
depends on the Recursive union's data structure. And we always use cteplan's
locus as WTS's locus. Remember WTS path cannot be turned to replicated(means
broadcast) when dealing with join. Most of the cases, it is OK. But for
replicated table whose locus is CdbLocusType_SegmentGeneral, it can not be
taken as everywhere, we will gather it to singleQE or redistribute it when joining.

To avoid such case, if cteplan's locus is CdbLocusType_SegmentGeneral,
we build WTS path using singlQE, and later in the function
`set_recursive_union_flow` to add a gather on the top of cteplan.

-----------------

This is backport of https://github.com/greenplum-db/gpdb/pull/8859, that pr has been merged into master and reviewed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
