### PR TITLE
Remove unnecessary noise from test.

### DIFF
--- a/src/test/regress/expected/table_statistics.out
+++ b/src/test/regress/expected/table_statistics.out
@@ -1,14 +1,7 @@
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_heap1 cascade;
-ERROR:  schema "stat_heap1" does not exist
-create schema stat_heap1;
-set search_path=stat_heap1,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
+create schema table_stats;
+set search_path=table_stats;
 set optimizer_print_missing_stats = off;
 -- Regular Table
-Drop table if exists stat_heap_t1;
 NOTICE:  table "stat_heap_t1" does not exist, skipping
 Create table stat_heap_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 Insert into stat_heap_t1 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -37,9 +30,7 @@ select  count(*) from pg_class where relname like 'stat_heap_t1%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t1;
-NOTICE:  table "stat_part_heap_t1" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_heap_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -85,17 +76,7 @@ select  count(*) from pg_class where relname like 'stat_part_heap_t1';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_ao1 cascade;
-ERROR:  schema "stat_ao1" does not exist
-create schema stat_ao1;
-set search_path=stat_ao1,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_ao_t1;
-NOTICE:  table "stat_ao_t1" does not exist, skipping
 Create table stat_ao_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 Insert into stat_ao_t1 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_ao_t1;
@@ -113,9 +94,7 @@ select  count(*) from pg_class where relname like 'stat_ao_t1%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t1;
-NOTICE:  table "stat_part_ao_t1" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_ao_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -166,17 +145,7 @@ select  count(*) from pg_class where relname like 'stat_part_ao_t1';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_co1 cascade;
-ERROR:  schema "stat_co1" does not exist
-create schema stat_co1;
-set search_path=stat_co1,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_co_t1;
-NOTICE:  table "stat_co_t1" does not exist, skipping
 Create table stat_co_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 Insert into stat_co_t1 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_co_t1;
@@ -194,9 +163,7 @@ select  count(*) from pg_class where relname like 'stat_co_t1%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_co_t1;
-NOTICE:  table "stat_part_co_t1" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_co_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -234,17 +201,7 @@ select  count(*) from pg_class where relname like 'stat_part_co_t1';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_heap2 cascade;
-ERROR:  schema "stat_heap2" does not exist
-create schema stat_heap2;
-set search_path=stat_heap2,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_heap_t2;
-NOTICE:  table "stat_heap_t2" does not exist, skipping
 Create table stat_heap_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 Insert into stat_heap_t2 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_heap_t2;
@@ -263,9 +220,7 @@ select  count(*) from pg_class where relname like 'stat_heap_t2%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t2;
-NOTICE:  table "stat_part_heap_t2" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_heap_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -303,17 +258,7 @@ select  count(*) from pg_class where relname like 'stat_part_heap_t2';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_ao2 cascade;
-ERROR:  schema "stat_ao2" does not exist
-create schema stat_ao2;
-set search_path=stat_ao2,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_ao_t2;
-NOTICE:  table "stat_ao_t2" does not exist, skipping
 Create table stat_ao_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 Insert into stat_ao_t2 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_ao_t2;
@@ -331,9 +276,7 @@ select  count(*) from pg_class where relname like 'stat_ao_t2%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t2;
-NOTICE:  table "stat_part_ao_t2" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_ao_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -371,17 +314,7 @@ select  count(*) from pg_class where relname like 'stat_part_ao_t2';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_co2 cascade;
-ERROR:  schema "stat_co2" does not exist
-create schema stat_co2;
-set search_path=stat_co2,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_co_t2;
-NOTICE:  table "stat_co_t2" does not exist, skipping
 Create table stat_co_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 Insert into stat_co_t2 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_co_t2;
@@ -399,9 +332,7 @@ select  count(*) from pg_class where relname like 'stat_co_t2%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_co_t2;
-NOTICE:  table "stat_part_co_t2" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_co_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -439,17 +370,7 @@ select  count(*) from pg_class where relname like 'stat_part_co_t2';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_heap3 cascade;
-ERROR:  schema "stat_heap3" does not exist
-create schema stat_heap3;
-set search_path=stat_heap3,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_heap_t3;
-NOTICE:  table "stat_heap_t3" does not exist, skipping
 Create table stat_heap_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 Insert into stat_heap_t3 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_heap_t3;
@@ -468,9 +389,7 @@ select  count(*) from pg_class where relname like 'stat_heap_t3%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t3;
-NOTICE:  table "stat_part_heap_t3" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_heap_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed by (i)  partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -521,17 +440,7 @@ select  count(*) from pg_class where relname like 'stat_part_heap_t3';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_ao3 cascade;
-ERROR:  schema "stat_ao3" does not exist
-create schema stat_ao3;
-set search_path=stat_ao3,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_ao_t3;
-NOTICE:  table "stat_ao_t3" does not exist, skipping
 Create table stat_ao_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 Insert into stat_ao_t3 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_ao_t3;
@@ -549,9 +458,7 @@ select  count(*) from pg_class where relname like 'stat_ao_t3%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t3;
-NOTICE:  table "stat_part_ao_t3" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_ao_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -589,17 +496,7 @@ select  count(*) from pg_class where relname like 'stat_part_ao_t3';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_co3 cascade;
-ERROR:  schema "stat_co3" does not exist
-create schema stat_co3;
-set search_path=stat_co3,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_co_t3;
-NOTICE:  table "stat_co_t3" does not exist, skipping
 Create table stat_co_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 Insert into stat_co_t3 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_co_t3;
@@ -617,9 +514,7 @@ select  count(*) from pg_class where relname like 'stat_co_t3%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_co_t3;
-NOTICE:  table "stat_part_co_t3" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_co_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -657,17 +552,7 @@ select  count(*) from pg_class where relname like 'stat_part_co_t3';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_heap4 cascade;
-ERROR:  schema "stat_heap4" does not exist
-create schema stat_heap4;
-set search_path=stat_heap4,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_heap_t4;
-NOTICE:  table "stat_heap_t4" does not exist, skipping
 Create table stat_heap_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 Insert into stat_heap_t4 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_heap_t4;
@@ -693,9 +578,7 @@ select  count(*) from pg_class where relname like 'stat_heap_t4%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t4;
-NOTICE:  table "stat_part_heap_t4" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_heap_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed by (i)  partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -740,17 +623,7 @@ select  count(*) from pg_class where relname like 'stat_part_heap_t4';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_ao4 cascade;
-ERROR:  schema "stat_ao4" does not exist
-create schema stat_ao4;
-set search_path=stat_ao4,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_ao_t4;
-NOTICE:  table "stat_ao_t4" does not exist, skipping
 Create table stat_ao_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 Insert into stat_ao_t4 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_ao_t4;
@@ -775,9 +648,7 @@ select  count(*) from pg_class where relname like 'stat_ao_t4%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t4;
-NOTICE:  table "stat_part_ao_t4" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_ao_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -822,17 +693,7 @@ select  count(*) from pg_class where relname like 'stat_part_ao_t4';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_co4 cascade;
-ERROR:  schema "stat_co4" does not exist
-create schema stat_co4;
-set search_path=stat_co4,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_co_t4;
-NOTICE:  table "stat_co_t4" does not exist, skipping
 Create table stat_co_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 Insert into stat_co_t4 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_co_t4;
@@ -857,9 +718,7 @@ select  count(*) from pg_class where relname like 'stat_co_t4%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_co_t4;
-NOTICE:  table "stat_part_co_t4" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_co_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -904,17 +763,7 @@ select  count(*) from pg_class where relname like 'stat_part_co_t4';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_heap5 cascade;
-ERROR:  schema "stat_heap5" does not exist
-create schema stat_heap5;
-set search_path=stat_heap5,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_heap_t5;
-NOTICE:  table "stat_heap_t5" does not exist, skipping
 Create table stat_heap_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed randomly;
 Insert into stat_heap_t5 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_heap_t5;
@@ -933,9 +782,7 @@ select  count(*) from pg_class where relname like 'stat_heap_t5%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t5;
-NOTICE:  table "stat_part_heap_t5" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_heap_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly  partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -973,17 +820,7 @@ select  count(*) from pg_class where relname like 'stat_part_heap_t5';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_ao5 cascade;
-ERROR:  schema "stat_ao5" does not exist
-create schema stat_ao5;
-set search_path=stat_ao5,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_ao_t5;
-NOTICE:  table "stat_ao_t5" does not exist, skipping
 Create table stat_ao_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed randomly ;
 Insert into stat_ao_t5 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_ao_t5;
@@ -1001,9 +838,7 @@ select  count(*) from pg_class where relname like 'stat_ao_t5%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t5;
-NOTICE:  table "stat_part_ao_t5" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_ao_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1041,17 +876,7 @@ select  count(*) from pg_class where relname like 'stat_part_ao_t5';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_co5 cascade;
-ERROR:  schema "stat_co5" does not exist
-create schema stat_co5;
-set search_path=stat_co5,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_co_t5;
-NOTICE:  table "stat_co_t5" does not exist, skipping
 Create table stat_co_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed randomly;
 Insert into stat_co_t5 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_co_t5;
@@ -1069,9 +894,7 @@ select  count(*) from pg_class where relname like 'stat_co_t5%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_co_t5;
-NOTICE:  table "stat_part_co_t5" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_co_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1109,17 +932,7 @@ select  count(*) from pg_class where relname like 'stat_part_co_t5';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_heap6 cascade;
-ERROR:  schema "stat_heap6" does not exist
-create schema stat_heap6;
-set search_path=stat_heap6,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_heap_t6;
-NOTICE:  table "stat_heap_t6" does not exist, skipping
 Create table stat_heap_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 Insert into stat_heap_t6 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_heap_t6;
@@ -1146,9 +959,7 @@ select  count(*) from pg_class where relname like 'stat_heap_t6%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t6;
-NOTICE:  table "stat_part_heap_t6" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_heap_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed by (i)  partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1207,17 +1018,7 @@ select  count(*) from pg_class where relname like 'stat_part_heap_t6';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_ao6 cascade;
-ERROR:  schema "stat_ao6" does not exist
-create schema stat_ao6;
-set search_path=stat_ao6,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_ao_t6;
-NOTICE:  table "stat_ao_t6" does not exist, skipping
 Create table stat_ao_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 Insert into stat_ao_t6 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_ao_t6;
@@ -1243,9 +1044,7 @@ select  count(*) from pg_class where relname like 'stat_ao_t6%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t6;
-NOTICE:  table "stat_part_ao_t6" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_ao_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1291,17 +1090,7 @@ select  count(*) from pg_class where relname like 'stat_part_ao_t6';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_co6 cascade;
-ERROR:  schema "stat_co6" does not exist
-create schema stat_co6;
-set search_path=stat_co6,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_co_t6;
-NOTICE:  table "stat_co_t6" does not exist, skipping
 Create table stat_co_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 Insert into stat_co_t6 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_co_t6;
@@ -1327,9 +1116,7 @@ select  count(*) from pg_class where relname like 'stat_co_t6%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_co_t6;
-NOTICE:  table "stat_part_co_t6" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_co_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1375,17 +1162,7 @@ select  count(*) from pg_class where relname like 'stat_part_co_t6';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_heap7 cascade;
-ERROR:  schema "stat_heap7" does not exist
-create schema stat_heap7;
-set search_path=stat_heap7,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_heap_t7;
-NOTICE:  table "stat_heap_t7" does not exist, skipping
 Create table stat_heap_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 Insert into stat_heap_t7 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_heap_t7;
@@ -1404,9 +1181,7 @@ select  count(*) from pg_class where relname like 'stat_heap_t7%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t7;
-NOTICE:  table "stat_part_heap_t7" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_heap_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1445,17 +1220,7 @@ select  count(*) from pg_class where relname like 'stat_part_heap_t7';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_ao7 cascade;
-ERROR:  schema "stat_ao7" does not exist
-create schema stat_ao7;
-set search_path=stat_ao7,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_ao_t7;
-NOTICE:  table "stat_ao_t7" does not exist, skipping
 Create table stat_ao_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 Insert into stat_ao_t7 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_ao_t7;
@@ -1473,9 +1238,7 @@ select  count(*) from pg_class where relname like 'stat_ao_t7%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t7;
-NOTICE:  table "stat_part_ao_t7" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_ao_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1513,17 +1276,7 @@ select  count(*) from pg_class where relname like 'stat_part_ao_t7';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_co7 cascade;
-ERROR:  schema "stat_co7" does not exist
-create schema stat_co7;
-set search_path=stat_co7,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_co_t7;
-NOTICE:  table "stat_co_t7" does not exist, skipping
 Create table stat_co_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 Insert into stat_co_t7 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_co_t7;
@@ -1541,9 +1294,7 @@ select  count(*) from pg_class where relname like 'stat_co_t7%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_co_t7;
-NOTICE:  table "stat_part_co_t7" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_co_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1582,17 +1333,7 @@ select  count(*) from pg_class where relname like 'stat_part_co_t7';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_heap8 cascade;
-ERROR:  schema "stat_heap8" does not exist
-create schema stat_heap8;
-set search_path=stat_heap8,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_heap_t8;
-NOTICE:  table "stat_heap_t8" does not exist, skipping
 Create table stat_heap_t8 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 Insert into stat_heap_t8 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_heap_t8;
@@ -1612,9 +1353,7 @@ select  count(*) from pg_class where relname like 'stat_heap_t8%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t8;
-NOTICE:  table "stat_part_heap_t8" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_heap_t8 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1666,17 +1405,7 @@ select  count(*) from pg_class where relname like 'stat_part_heap_t8';
      1
 (1 row)
 
-\echo '-- start_ignore'
--- start_ignore
-drop schema stat_heap9 cascade;
-ERROR:  schema "stat_heap9" does not exist
-create schema stat_heap9;
-set search_path=stat_heap9,"$user",public;
-\echo '-- end_ignore'
--- end_ignore
 -- Regular Table
-Drop table if exists stat_heap_t9;
-NOTICE:  table "stat_heap_t9" does not exist, skipping
 Create table stat_heap_t9 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 Insert into stat_heap_t9 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
 Analyze stat_heap_t9;
@@ -1705,9 +1434,7 @@ select  count(*) from pg_class where relname like 'stat_heap_t9%';
      1
 (1 row)
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t9;
-NOTICE:  table "stat_part_heap_t9" does not exist, skipping
+-- Partitioned Table
 Create table stat_part_heap_t9 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 

--- a/src/test/regress/sql/table_statistics.sql
+++ b/src/test/regress/sql/table_statistics.sql
@@ -1,12 +1,7 @@
-\echo '-- start_ignore'
-drop schema stat_heap1 cascade;
-create schema stat_heap1;
-set search_path=stat_heap1,"$user",public;
-\echo '-- end_ignore'
+create schema table_stats;
+set search_path=table_stats;
 set optimizer_print_missing_stats = off;
 -- Regular Table
-Drop table if exists stat_heap_t1;
-
 Create table stat_heap_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 
 Insert into stat_heap_t1 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -27,9 +22,7 @@ Alter table stat_heap_t1 add column new_col2 text default 'new column with new v
 
 select  count(*) from pg_class where relname like 'stat_heap_t1%';
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t1;
-
+-- Partitioned Table
 Create table stat_part_heap_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -56,15 +49,7 @@ Alter table stat_part_heap_t1 add column new_col2 text default 'new column with 
 
 select  count(*) from pg_class where relname like 'stat_part_heap_t1';
 
-\echo '-- start_ignore'
-drop schema stat_ao1 cascade;
-create schema stat_ao1;
-set search_path=stat_ao1,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_ao_t1;
-
 Create table stat_ao_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 
 Insert into stat_ao_t1 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -78,9 +63,7 @@ Alter table stat_ao_t1 add column new_col2 text default 'new column with new val
 
 select  count(*) from pg_class where relname like 'stat_ao_t1%';
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t1;
-
+-- Partitioned Table
 Create table stat_part_ao_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -104,15 +87,7 @@ Alter table stat_part_ao_t1 add column new_col2 text default 'new column with ne
 
 select  count(*) from pg_class where relname like 'stat_part_ao_t1';
 
-\echo '-- start_ignore'
-drop schema stat_co1 cascade;
-create schema stat_co1;
-set search_path=stat_co1,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_co_t1;
-
 Create table stat_co_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 
 Insert into stat_co_t1 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -126,9 +101,7 @@ Alter table stat_co_t1 add column new_col2 text default 'new column with new val
 
 select  count(*) from pg_class where relname like 'stat_co_t1%';
 
--- Partiiton Table
-Drop table if exists stat_part_co_t1;
-
+-- Partitioned Table
 Create table stat_part_co_t1 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -150,15 +123,7 @@ Alter table stat_part_co_t1 add column new_col2 text default 'new column with ne
 
 select  count(*) from pg_class where relname like 'stat_part_co_t1';
 
-\echo '-- start_ignore'
-drop schema stat_heap2 cascade;
-create schema stat_heap2;
-set search_path=stat_heap2,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_heap_t2;
-
 Create table stat_heap_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 
 Insert into stat_heap_t2 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -172,9 +137,7 @@ Alter table stat_heap_t2 drop column d;
  
 select  count(*) from pg_class where relname like 'stat_heap_t2%';
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t2;
-
+-- Partitioned Table
 Create table stat_part_heap_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -196,15 +159,7 @@ Alter table stat_part_heap_t2 drop column d;
 
 select  count(*) from pg_class where relname like 'stat_part_heap_t2';
 
-\echo '-- start_ignore'
-drop schema stat_ao2 cascade;
-create schema stat_ao2;
-set search_path=stat_ao2,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_ao_t2;
-
 Create table stat_ao_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 
 Insert into stat_ao_t2 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -218,9 +173,7 @@ Alter table stat_ao_t2 drop column t;
 
 select  count(*) from pg_class where relname like 'stat_ao_t2%';
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t2;
-
+-- Partitioned Table
 Create table stat_part_ao_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -242,15 +195,7 @@ Alter table stat_part_ao_t2 drop column t;
 
 select  count(*) from pg_class where relname like 'stat_part_ao_t2';
 
-\echo '-- start_ignore'
-drop schema stat_co2 cascade;
-create schema stat_co2;
-set search_path=stat_co2,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_co_t2;
-
 Create table stat_co_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 
 Insert into stat_co_t2 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -265,9 +210,7 @@ Alter table stat_co_t2 drop column t;
 
 select  count(*) from pg_class where relname like 'stat_co_t2%';
 
--- Partiiton Table
-Drop table if exists stat_part_co_t2;
-
+-- Partitioned Table
 Create table stat_part_co_t2 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -289,15 +232,7 @@ Alter table stat_part_co_t2 drop column t;
 
 select  count(*) from pg_class where relname like 'stat_part_co_t2';
 
-\echo '-- start_ignore'
-drop schema stat_heap3 cascade;
-create schema stat_heap3;
-set search_path=stat_heap3,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_heap_t3;
-
 Create table stat_heap_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 
 Insert into stat_heap_t3 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -311,9 +246,7 @@ Alter table stat_heap_t3 set distributed by (j);
  
 select  count(*) from pg_class where relname like 'stat_heap_t3%';
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t3;
-
+-- Partitioned Table
 Create table stat_part_heap_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed by (i)  partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -337,15 +270,7 @@ Alter table stat_part_heap_t3 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_heap_t3';
 
-\echo '-- start_ignore'
-drop schema stat_ao3 cascade;
-create schema stat_ao3;
-set search_path=stat_ao3,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_ao_t3;
-
 Create table stat_ao_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 
 Insert into stat_ao_t3 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -359,9 +284,7 @@ Alter table stat_ao_t3 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_ao_t3%';
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t3;
-
+-- Partitioned Table
 Create table stat_part_ao_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -383,15 +306,7 @@ Alter table stat_part_ao_t3 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_ao_t3';
 
-\echo '-- start_ignore'
-drop schema stat_co3 cascade;
-create schema stat_co3;
-set search_path=stat_co3,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_co_t3;
-
 Create table stat_co_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 
 Insert into stat_co_t3 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -406,9 +321,7 @@ Alter table stat_co_t3 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_co_t3%';
 
--- Partiiton Table
-Drop table if exists stat_part_co_t3;
-
+-- Partitioned Table
 Create table stat_part_co_t3 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -430,15 +343,7 @@ Alter table stat_part_co_t3 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t3';
 
-\echo '-- start_ignore'
-drop schema stat_heap4 cascade;
-create schema stat_heap4;
-set search_path=stat_heap4,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_heap_t4;
-
 Create table stat_heap_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 
 Insert into stat_heap_t4 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -456,9 +361,7 @@ Alter table stat_heap_t4 set with (reorganize=true);
 
 select  count(*) from pg_class where relname like 'stat_heap_t4%';
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t4;
-
+-- Partitioned Table
 Create table stat_part_heap_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed by (i)  partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -484,15 +387,7 @@ Alter table stat_part_heap_t4 set with (reorganize=true);
 
 select  count(*) from pg_class where relname like 'stat_part_heap_t4';
 
-\echo '-- start_ignore'
-drop schema stat_ao4 cascade;
-create schema stat_ao4;
-set search_path=stat_ao4,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_ao_t4;
-
 Create table stat_ao_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 
 Insert into stat_ao_t4 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -510,9 +405,7 @@ Alter table stat_ao_t4 set with (reorganize=true);
 
 select  count(*) from pg_class where relname like 'stat_ao_t4%';
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t4;
-
+-- Partitioned Table
 Create table stat_part_ao_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -538,15 +431,7 @@ Alter table stat_part_ao_t4 set with (reorganize=true);
 
 select  count(*) from pg_class where relname like 'stat_part_ao_t4';
 
-\echo '-- start_ignore'
-drop schema stat_co4 cascade;
-create schema stat_co4;
-set search_path=stat_co4,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_co_t4;
-
 Create table stat_co_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 
 Insert into stat_co_t4 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -564,9 +449,7 @@ Alter table stat_co_t4 set with (reorganize=true);
 
 select  count(*) from pg_class where relname like 'stat_co_t4%';
 
--- Partiiton Table
-Drop table if exists stat_part_co_t4;
-
+-- Partitioned Table
 Create table stat_part_co_t4 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -593,15 +476,7 @@ Alter table stat_part_co_t4 set with (reorganize=true);
 select  count(*) from pg_class where relname like 'stat_part_co_t4';
 
 
-\echo '-- start_ignore'
-drop schema stat_heap5 cascade;
-create schema stat_heap5;
-set search_path=stat_heap5,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_heap_t5;
-
 Create table stat_heap_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed randomly;
 
 Insert into stat_heap_t5 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -615,9 +490,7 @@ Alter table stat_heap_t5 set distributed by (j);
  
 select  count(*) from pg_class where relname like 'stat_heap_t5%';
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t5;
-
+-- Partitioned Table
 Create table stat_part_heap_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly  partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -639,15 +512,7 @@ Alter table stat_part_heap_t5 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_heap_t5';
 
-\echo '-- start_ignore'
-drop schema stat_ao5 cascade;
-create schema stat_ao5;
-set search_path=stat_ao5,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_ao_t5;
-
 Create table stat_ao_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed randomly ;
 
 Insert into stat_ao_t5 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -661,9 +526,7 @@ Alter table stat_ao_t5 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_ao_t5%';
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t5;
-
+-- Partitioned Table
 Create table stat_part_ao_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -685,15 +548,7 @@ Alter table stat_part_ao_t5 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_ao_t5';
 
-\echo '-- start_ignore'
-drop schema stat_co5 cascade;
-create schema stat_co5;
-set search_path=stat_co5,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_co_t5;
-
 Create table stat_co_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed randomly;
 
 Insert into stat_co_t5 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -708,9 +563,7 @@ Alter table stat_co_t5 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_co_t5%';
 
--- Partiiton Table
-Drop table if exists stat_part_co_t5;
-
+-- Partitioned Table
 Create table stat_part_co_t5 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -732,15 +585,7 @@ Alter table stat_part_co_t5 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t5';
 
-\echo '-- start_ignore'
-drop schema stat_heap6 cascade;
-create schema stat_heap6;
-set search_path=stat_heap6,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_heap_t6;
-
 Create table stat_heap_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 
 Insert into stat_heap_t6 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -759,9 +604,7 @@ Alter table stat_heap_t6 set with (reorganize=false);
 
 select  count(*) from pg_class where relname like 'stat_heap_t6%';
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t6;
-
+-- Partitioned Table
 Create table stat_part_heap_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed by (i)  partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -790,15 +633,7 @@ Alter table stat_part_heap_t6 set with (reorganize=false);
 
 select  count(*) from pg_class where relname like 'stat_part_heap_t6';
 
-\echo '-- start_ignore'
-drop schema stat_ao6 cascade;
-create schema stat_ao6;
-set search_path=stat_ao6,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_ao_t6;
-
 Create table stat_ao_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 
 Insert into stat_ao_t6 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -817,9 +652,7 @@ Alter table stat_ao_t6 set with (reorganize=false);
 
 select  count(*) from pg_class where relname like 'stat_ao_t6%';
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t6;
-
+-- Partitioned Table
 Create table stat_part_ao_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -846,15 +679,7 @@ Alter table stat_part_ao_t6 set with (reorganize=false);
 
 select  count(*) from pg_class where relname like 'stat_part_ao_t6';
 
-\echo '-- start_ignore'
-drop schema stat_co6 cascade;
-create schema stat_co6;
-set search_path=stat_co6,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_co_t6;
-
 Create table stat_co_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 
 Insert into stat_co_t6 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -873,9 +698,7 @@ Alter table stat_co_t6 set with (reorganize=false);
 
 select  count(*) from pg_class where relname like 'stat_co_t6%';
 
--- Partiiton Table
-Drop table if exists stat_part_co_t6;
-
+-- Partitioned Table
 Create table stat_part_co_t6 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -903,15 +726,7 @@ Alter table stat_part_co_t6 set with (reorganize=true);
 select  count(*) from pg_class where relname like 'stat_part_co_t6';
 
 
-\echo '-- start_ignore'
-drop schema stat_heap7 cascade;
-create schema stat_heap7;
-set search_path=stat_heap7,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_heap_t7;
-
 Create table stat_heap_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 
 Insert into stat_heap_t7 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -925,9 +740,7 @@ Alter table stat_heap_t7 alter column c type varchar;
  
 select  count(*) from pg_class where relname like 'stat_heap_t7%';
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t7;
-
+-- Partitioned Table
 Create table stat_part_heap_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -950,15 +763,7 @@ Alter table stat_part_heap_t7 alter column j type numeric;
 select  count(*) from pg_class where relname like 'stat_part_heap_t7';
 
 
-\echo '-- start_ignore'
-drop schema stat_ao7 cascade;
-create schema stat_ao7;
-set search_path=stat_ao7,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_ao_t7;
-
 Create table stat_ao_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5) distributed by (i) ;
 
 Insert into stat_ao_t7 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -972,9 +777,7 @@ Alter table stat_ao_t7 alter column j type numeric;
 
 select  count(*) from pg_class where relname like 'stat_ao_t7%';
 
--- Partiiton Table
-Drop table if exists stat_part_ao_t7;
-
+-- Partitioned Table
 Create table stat_part_ao_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -996,15 +799,7 @@ Alter table stat_part_ao_t7 alter column c type varchar;
 
 select  count(*) from pg_class where relname like 'stat_part_ao_t7';
 
-\echo '-- start_ignore'
-drop schema stat_co7 cascade;
-create schema stat_co7;
-set search_path=stat_co7,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_co_t7;
-
 Create table stat_co_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) with(appendonly=true,compresslevel=5, orientation=column) distributed by (i) ;
 
 Insert into stat_co_t7 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -1018,9 +813,7 @@ Alter table stat_co_t7 alter column j type float;
 
 select  count(*) from pg_class where relname like 'stat_co_t7%';
 
--- Partiiton Table
-Drop table if exists stat_part_co_t7;
-
+-- Partitioned Table
 Create table stat_part_co_t7 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 with(appendonly=true,compresslevel=5, orientation=column) distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1042,15 +835,7 @@ Alter table stat_part_co_t7 alter column i type numeric;
 
 select  count(*) from pg_class where relname like 'stat_part_co_t7';
 
-\echo '-- start_ignore'
-drop schema stat_heap8 cascade;
-create schema stat_heap8;
-set search_path=stat_heap8,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_heap_t8;
-
 Create table stat_heap_t8 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 
 Insert into stat_heap_t8 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -1067,9 +852,7 @@ Cluster stat_idx_heap_t8 on stat_heap_t8;
 
 select  count(*) from pg_class where relname like 'stat_heap_t8%';
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t8;
-
+-- Partitioned Table
 Create table stat_part_heap_t8 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 
@@ -1094,15 +877,7 @@ Cluster stat_part_idx_heap_t8 on stat_part_heap_t8;
 
 select  count(*) from pg_class where relname like 'stat_part_heap_t8';
 
-\echo '-- start_ignore'
-drop schema stat_heap9 cascade;
-create schema stat_heap9;
-set search_path=stat_heap9,"$user",public;
-\echo '-- end_ignore'
-
 -- Regular Table
-Drop table if exists stat_heap_t9;
-
 Create table stat_heap_t9 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone) distributed by (i);
 
 Insert into stat_heap_t9 values(generate_series(1,10),500,'table statistics should be kept after alter','s', 'regular table','12-11-2012',3,'2012-10-09 10:23:54', '2011-08-19 10:23:54+02');
@@ -1127,9 +902,7 @@ Cluster stat_heap_t9;
 select  count(*) from pg_class where relname like 'stat_heap_t9%';
 
 
--- Partiiton Table
-Drop table if exists stat_part_heap_t9;
-
+-- Partitioned Table
 Create table stat_part_heap_t9 (i int,j int, x text,c char,v varchar, d date, n numeric, t timestamp without time zone, tz time with time zone)  
 distributed randomly partition by range (i) 
 subpartition by list (j) subpartition template 


### PR DESCRIPTION
No need to create a separate schema for every test table. And no need to
try dropping every table, since we're creating them in a schema; you can
easily drop the whole schema to start from clean slate, if you're running
the test locally.

Fix typo "Partiiton Table".

To be honest, these tests don't seem too useful to me. There are queries
on pg_class after each step that seem useless to me; surely we don't
expect the whole table to suddenly be gone? The test data contains
"table statistics should be kept after alter", which gives a hint on what
these test might be supposed to test, but I don't see anything to actually
verify that statistics are kept. But I'm not changing that in this commit.
