### PR TITLE
docs - update pxf supported platforms for hadoop/hive 3

### DIFF
--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -8,11 +8,14 @@ You can query the external table via Greenplum Database, leaving the referenced 
 
 ## <a id="suppplat"></a> Supported Platforms
 
-PXF bundles all of the JAR files on which it depends, including the following Hadoop libraries:
+PXF bundles all of the Hadoop JAR files on which it depends, and supports the following Hadoop component versions:
 
-- Hadoop version 2.9.2
-- Hive version 1.2.2
-- HBase version 1.3.2
+| PXF Version | Hadoop Version | Hive Server Version | HBase Server Version |
+|-------------|----------------|---------------------|-------------|
+| 5.9.1 | 2.x, 3.1.1 | 2.x, 3.1 | 1.3.2 |
+| 5.9.0 | 2.x, 3.1.1 | 2.x, 3.1 | 1.3.2 |
+| 5.8.2 | 2.9.2 | 1.2.2 | 1.3.2 |
+| 5.8.1 | 2.9.2 | 1.2.2 | 1.3.2 |
 
 ## <a id="arch"></a> Architectural Overview
 

--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -12,10 +12,10 @@ PXF bundles all of the Hadoop JAR files on which it depends, and supports the fo
 
 | PXF Version | Hadoop Version | Hive Server Version | HBase Server Version |
 |-------------|----------------|---------------------|-------------|
-| 5.9.1 | 2.x, 3.1.1 | 2.x, 3.1 | 1.3.2 |
-| 5.9.0 | 2.x, 3.1.1 | 2.x, 3.1 | 1.3.2 |
-| 5.8.2 | 2.9.2 | 1.2.2 | 1.3.2 |
-| 5.8.1 | 2.9.2 | 1.2.2 | 1.3.2 |
+| 5.9.1 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
+| 5.9.0 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
+| 5.8.2 | 2.x | 1.x | 1.3.2 |
+| 5.8.1 | 2.x | 1.x | 1.3.2 |
 
 ## <a id="arch"></a> Architectural Overview
 


### PR DESCRIPTION
update the pxf supported hadoop platform versions in the pxf doc section.  including all of the pxf versions since greenplum 6.0 has been released, i.e. v5.8.1+.

this info will be updated 6X_STABLE and its install quide supported platforms topic when pxf v5.9.0+ is included in a 6.x release.
