### PR TITLE
Remove duplicated tests in 'DML_over_joins'.

### DIFF
--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -4,7 +4,7 @@
 create schema DML_over_joins;
 set search_path to DML_over_joins;
 -- ----------------------------------------------------------------------
--- Test: heap_motion0.sql
+-- Test: heap_motion1.sql
 -- ----------------------------------------------------------------------
 ------------------------------------------------------------
 -- Update with Motion:
@@ -14,12 +14,10 @@ set search_path to DML_over_joins;
 ------------------------------------------------------------
 -- start_ignore
 drop table if exists r;
-NOTICE:  table "r" does not exist, skipping
 drop table if exists s;
-NOTICE:  table "s" does not exist, skipping
 -- end_ignore
-create table r (a int, b int) distributed by (a);
-create table s (a int, b int) distributed by (a);
+create table r (a int4, b int4) distributed by (a);
+create table s (a int4, b int4) distributed by (a);
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update r set b = r.b + 1 from s where r.a = s.a;
@@ -93,57 +91,6 @@ explain delete from s where exists (select 1 from r where s.a = r.b);
  Optimizer: Postgres query optimizer
 (14 rows)
 
-delete from s where exists (select 1 from r where s.a = r.b);
--- ----------------------------------------------------------------------
--- Test: heap_motion1.sql
--- ----------------------------------------------------------------------
-------------------------------------------------------------
--- Update with Motion:
---   r,s colocated on join attributes
---      delete: using clause, subquery, initplan
---      update: join and subsubquery
-------------------------------------------------------------
--- start_ignore
-drop table if exists r;
-drop table if exists s;
--- end_ignore
-create table r (a int4, b int4) distributed by (a);
-create table s (a int4, b int4) distributed by (a);
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-update r set b = r.b + 1 from s where r.a = s.a;
-update r set b = r.b + 1 from s where r.a in (select a from s);
-delete from r using s where r.a = s.a;
-delete from r;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-delete from r where a in (select a from s);
-delete from r;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-delete from r where a = (select max(a) from s);
-------------------------------------------------------------
--- Updates with motion:
--- 	Redistribute s
-------------------------------------------------------------
-delete from r;
-delete from s;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-update r set b = r.b + 4 from s where r.b = s.b;
-update r set b = b + 1 where b in (select b from s);
-delete from s using r where r.a = s.b;
-delete from r;
-delete from s;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-delete from r using s where r.b = s.b; 
-------------------------------------------------------------
--- 	Hash aggregate group by
-------------------------------------------------------------
-delete from r;
-delete from s;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
 delete from s where exists (select 1 from r where s.a = r.b);
 -- ----------------------------------------------------------------------
 -- Test: heap_motion2.sql
@@ -350,46 +297,6 @@ insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
 delete from s where exists (select 1 from r where s.a = r.b);
 -- ----------------------------------------------------------------------
--- Test: unsupported_cases0.sql
--- ----------------------------------------------------------------------
-------------------------------------------------------------
--- Update with Motion: unsupported cases
---     	Updating the distribution key
-------------------------------------------------------------
--- start_ignore
-drop table if exists r;
-drop table if exists s;
-drop table if exists p;
-NOTICE:  table "p" does not exist, skipping
--- end_ignore
-create table r (a int, b int) distributed by (a);
-create table s (a int, b int) distributed by (a);
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-create table p (a int, b int, c int) 
-	partition by range (c) (start(1) end(5) every(1), default partition extra);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  CREATE TABLE will create partition "p_1_prt_extra" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_2" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_3" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
-insert into p select generate_series(1,10000), generate_series(1,10000)*3, generate_series(1,10000)%6;
-update s set a = r.a from r where r.b = s.b;
-------------------------------------------------------------
---	Statement contains correlated subquery
-------------------------------------------------------------
-update s set b = (select min(a) from r where b = s.b);
-delete from s where b = (select min(a) from r where b = s.b);
-------------------------------------------------------------
---	Update partition key (requires moving tuples from one partition to another)
-------------------------------------------------------------
-update p set c = c + 1 where c = 0;
-ERROR:  moving tuple from partition "p_1_prt_extra" to partition "p_1_prt_2" not supported  (seg1 rhel62-vm1:25433 pid=19028)
-update p set c = c + 1 where b in (select b from s) and c = 0;
-ERROR:  moving tuple from partition "p_1_prt_extra" to partition "p_1_prt_2" not supported  (seg2 rhel62-vm1:25434 pid=19030)
--- ----------------------------------------------------------------------
 -- Test: unsupported_cases1.sql
 -- ----------------------------------------------------------------------
 ------------------------------------------------------------
@@ -584,66 +491,6 @@ update p set c = c + 1 where c = 0;
 ERROR:  moving tuple from partition "p_1_prt_extra" to partition "p_1_prt_2" not supported  (seg1 rhel62-vm1:25433 pid=19028)
 update p set c = c + 1 where b in (select b from s) and c = 0;
 ERROR:  moving tuple from partition "p_1_prt_extra" to partition "p_1_prt_2" not supported  (seg1 rhel62-vm1:25433 pid=19028)
--- ----------------------------------------------------------------------
--- Test: partition_motion0.sql
--- ----------------------------------------------------------------------
-------------------------------------------------------------
--- Update with Motion:
-------------------------------------------------------------
--- start_ignore
-drop table if exists r;
-drop table if exists s;
-drop table if exists p;
--- end_ignore
-create table r (a int, b int) distributed by (a);
-create table s (a int, b int) distributed by (a);
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 3;
-create table p (a int, b int, c int)
-	distributed by (a)
-        partition by range (c) (start(1) end(5) every(1), default partition extra);
-NOTICE:  CREATE TABLE will create partition "p_1_prt_extra" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_2" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_3" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
-	
-insert into p select generate_series(1,10000), generate_series(1,10000) * 3, generate_series(1,10000) % 6;
-------------------------------------------------------------
--- Update with Motion:
---	Motion on p, append node, hash agg
-------------------------------------------------------------
-update p set b = b + 1 where a in (select b from r where a = p.c);
-delete from p where p.a in (select b from r where a = p.c);
-delete from p using r where p.a = r.b and r.a = p.c;
-------------------------------------------------------------
--- Updates with motion:
--- 	No motion, colocated distribution key
-------------------------------------------------------------
-delete from p where a in (select a from r where a = p.c);
-delete from p using r where p.a = r.a and r.a = p.c;
-------------------------------------------------------------
--- 	No motion of s
-------------------------------------------------------------
-delete from s where a in (select a from p where p.b = s.b);
-select count(*) from s;
- count 
--------
-     6
-(1 row)
-
-select * from s;
- a | b  
----+----
- 3 |  9
- 4 | 12
- 5 | 15
- 9 | 27
- 1 |  3
- 2 |  6
-(6 rows)
-
-delete from s where b in (select a from p where p.c = s.b);
 -- ----------------------------------------------------------------------
 -- Test: partition_motion1.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -4,7 +4,7 @@
 create schema DML_over_joins;
 set search_path to DML_over_joins;
 -- ----------------------------------------------------------------------
--- Test: heap_motion0.sql
+-- Test: heap_motion1.sql
 -- ----------------------------------------------------------------------
 ------------------------------------------------------------
 -- Update with Motion:
@@ -14,17 +14,15 @@ set search_path to DML_over_joins;
 ------------------------------------------------------------
 -- start_ignore
 drop table if exists r;
-NOTICE:  table "r" does not exist, skipping
 drop table if exists s;
-NOTICE:  table "s" does not exist, skipping
 -- end_ignore
-create table r (a int, b int) distributed by (a);
-create table s (a int, b int) distributed by (a);
+create table r (a int4, b int4) distributed by (a);
+create table s (a int4, b int4) distributed by (a);
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update r set b = r.b + 1 from s where r.a = s.a;
 update r set b = r.b + 1 from s where r.a in (select a from s);
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 rhel62-vm1:25432 pid=32303)
+ERROR:  multiple updates to a row by the same query is not allowed  (seg2 rhel62-vm1:25434 pid=32307)
 delete from r using s where r.a = s.a;
 delete from r;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
@@ -90,58 +88,6 @@ explain delete from s where exists (select 1 from r where s.a = r.b);
  Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (11 rows)
 
-delete from s where exists (select 1 from r where s.a = r.b);
--- ----------------------------------------------------------------------
--- Test: heap_motion1.sql
--- ----------------------------------------------------------------------
-------------------------------------------------------------
--- Update with Motion:
---   r,s colocated on join attributes
---      delete: using clause, subquery, initplan
---      update: join and subsubquery
-------------------------------------------------------------
--- start_ignore
-drop table if exists r;
-drop table if exists s;
--- end_ignore
-create table r (a int4, b int4) distributed by (a);
-create table s (a int4, b int4) distributed by (a);
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-update r set b = r.b + 1 from s where r.a = s.a;
-update r set b = r.b + 1 from s where r.a in (select a from s);
-ERROR:  multiple updates to a row by the same query is not allowed  (seg2 rhel62-vm1:25434 pid=32307)
-delete from r using s where r.a = s.a;
-delete from r;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-delete from r where a in (select a from s);
-delete from r;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-delete from r where a = (select max(a) from s);
-------------------------------------------------------------
--- Updates with motion:
--- 	Redistribute s
-------------------------------------------------------------
-delete from r;
-delete from s;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-update r set b = r.b + 4 from s where r.b = s.b;
-update r set b = b + 1 where b in (select b from s);
-delete from s using r where r.a = s.b;
-delete from r;
-delete from s;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-delete from r using s where r.b = s.b; 
-------------------------------------------------------------
--- 	Hash aggregate group by
-------------------------------------------------------------
-delete from r;
-delete from s;
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
 delete from s where exists (select 1 from r where s.a = r.b);
 -- ----------------------------------------------------------------------
 -- Test: heap_motion2.sql
@@ -352,44 +298,6 @@ insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
 delete from s where exists (select 1 from r where s.a = r.b);
 -- ----------------------------------------------------------------------
--- Test: unsupported_cases0.sql
--- ----------------------------------------------------------------------
-------------------------------------------------------------
--- Update with Motion: unsupported cases
---     	Updating the distribution key
-------------------------------------------------------------
--- start_ignore
-drop table if exists r;
-drop table if exists s;
-drop table if exists p;
-NOTICE:  table "p" does not exist, skipping
--- end_ignore
-create table r (a int, b int) distributed by (a);
-create table s (a int, b int) distributed by (a);
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
-create table p (a int, b int, c int) 
-	partition by range (c) (start(1) end(5) every(1), default partition extra);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  CREATE TABLE will create partition "p_1_prt_extra" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_2" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_3" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
-insert into p select generate_series(1,10000), generate_series(1,10000)*3, generate_series(1,10000)%6;
-update s set a = r.a from r where r.b = s.b;
-------------------------------------------------------------
---	Statement contains correlated subquery
-------------------------------------------------------------
-update s set b = (select min(a) from r where b = s.b);
-delete from s where b = (select min(a) from r where b = s.b);
-------------------------------------------------------------
---	Update partition key (requires moving tuples from one partition to another)
-------------------------------------------------------------
-update p set c = c + 1 where c = 0;
-update p set c = c + 1 where b in (select b from s) and c = 0;
--- ----------------------------------------------------------------------
 -- Test: unsupported_cases1.sql
 -- ----------------------------------------------------------------------
 ------------------------------------------------------------
@@ -574,66 +482,6 @@ delete from s where b = (select min(a) from r where b = s.b);
 ------------------------------------------------------------
 update p set c = c + 1 where c = 0;
 update p set c = c + 1 where b in (select b from s) and c = 0;
--- ----------------------------------------------------------------------
--- Test: partition_motion0.sql
--- ----------------------------------------------------------------------
-------------------------------------------------------------
--- Update with Motion:
-------------------------------------------------------------
--- start_ignore
-drop table if exists r;
-drop table if exists s;
-drop table if exists p;
--- end_ignore
-create table r (a int, b int) distributed by (a);
-create table s (a int, b int) distributed by (a);
-insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
-insert into s select generate_series(1, 100), generate_series(1, 100) * 3;
-create table p (a int, b int, c int)
-	distributed by (a)
-        partition by range (c) (start(1) end(5) every(1), default partition extra);
-NOTICE:  CREATE TABLE will create partition "p_1_prt_extra" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_2" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_3" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_4" for table "p"
-NOTICE:  CREATE TABLE will create partition "p_1_prt_5" for table "p"
-	
-insert into p select generate_series(1,10000), generate_series(1,10000) * 3, generate_series(1,10000) % 6;
-------------------------------------------------------------
--- Update with Motion:
---	Motion on p, append node, hash agg
-------------------------------------------------------------
-update p set b = b + 1 where a in (select b from r where a = p.c);
-delete from p where p.a in (select b from r where a = p.c);
-delete from p using r where p.a = r.b and r.a = p.c;
-------------------------------------------------------------
--- Updates with motion:
--- 	No motion, colocated distribution key
-------------------------------------------------------------
-delete from p where a in (select a from r where a = p.c);
-delete from p using r where p.a = r.a and r.a = p.c;
-------------------------------------------------------------
--- 	No motion of s
-------------------------------------------------------------
-delete from s where a in (select a from p where p.b = s.b);
-select count(*) from s;
- count 
--------
-     6
-(1 row)
-
-select * from s;
- a | b  
----+----
- 3 |  9
- 4 | 12
- 5 | 15
- 1 |  3
- 2 |  6
- 9 | 27
-(6 rows)
-
-delete from s where b in (select a from p where p.c = s.b);
 -- ----------------------------------------------------------------------
 -- Test: partition_motion1.sql
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
The 'heap_motion0.sql', 'unsupported_cases0.sql' and
'partition_motion0.sql' tests are redundant with the 'heap_motion1.sql',
'unsupported_cases1.sql' and 'partition_motion1.sql' tests. The only
difference is that the 0-variants use 'int' as the datatype, and 1-variants
use 'int4'. But they are the same thing, 'int' is mapped to 'int4' early
in the parser, so we surely don't need to test both here.
