### PR TITLE
docs - mention parquet SCHEMA custom option

### DIFF
--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -91,7 +91,7 @@ The PXF `hdfs:parquet` profile supports encoding- and compression-related write 
 | PAGE_SIZE | A row group consists of column chunks that are divided up into pages. `PAGE_SIZE` is the size (in bytes) of such a page. The default page size is `1024 * 1024` bytes. |
 | DICTIONARY\_PAGE\_SIZE | Dictionary encoding is enabled by default when PXF writes Parquet files. There is a single dictionary page per column, per row group. `DICTIONARY_PAGE_SIZE` is similar to `PAGE_SIZE`, but for the dictionary. The default dictionary page size is `512 * 1024` bytes. |
 | PARQUET_VERSION | The Parquet version; values `v1` and `v2` are supported. The default Parquet version is `v1`. |
-| SCHEMA | The local file system location of the parquet schema file. |
+| SCHEMA | The local file system location of the Parquet schema file. |
 
 **Note**: You must explicitly specify `uncompressed` if you do not want PXF to compress the data.
 

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -91,7 +91,7 @@ The PXF `hdfs:parquet` profile supports encoding- and compression-related write 
 | PAGE_SIZE | A row group consists of column chunks that are divided up into pages. `PAGE_SIZE` is the size (in bytes) of such a page. The default page size is `1024 * 1024` bytes. |
 | DICTIONARY\_PAGE\_SIZE | Dictionary encoding is enabled by default when PXF writes Parquet files. There is a single dictionary page per column, per row group. `DICTIONARY_PAGE_SIZE` is similar to `PAGE_SIZE`, but for the dictionary. The default dictionary page size is `512 * 1024` bytes. |
 | PARQUET_VERSION | The Parquet version; values `v1` and `v2` are supported. The default Parquet version is `v1`. |
-| SCHEMA | The file system location on the server of the Parquet schema file. |
+| SCHEMA | The location of the Parquet schema file on the file system of the specified `SERVER`. |
 
 **Note**: You must explicitly specify `uncompressed` if you do not want PXF to compress the data.
 

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -91,7 +91,7 @@ The PXF `hdfs:parquet` profile supports encoding- and compression-related write 
 | PAGE_SIZE | A row group consists of column chunks that are divided up into pages. `PAGE_SIZE` is the size (in bytes) of such a page. The default page size is `1024 * 1024` bytes. |
 | DICTIONARY\_PAGE\_SIZE | Dictionary encoding is enabled by default when PXF writes Parquet files. There is a single dictionary page per column, per row group. `DICTIONARY_PAGE_SIZE` is similar to `PAGE_SIZE`, but for the dictionary. The default dictionary page size is `512 * 1024` bytes. |
 | PARQUET_VERSION | The Parquet version; values `v1` and `v2` are supported. The default Parquet version is `v1`. |
-| SCHEMA | The local file system location of the Parquet schema file. |
+| SCHEMA | The file system location on the server of the Parquet schema file. |
 
 **Note**: You must explicitly specify `uncompressed` if you do not want PXF to compress the data.
 

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -91,6 +91,7 @@ The PXF `hdfs:parquet` profile supports encoding- and compression-related write 
 | PAGE_SIZE | A row group consists of column chunks that are divided up into pages. `PAGE_SIZE` is the size (in bytes) of such a page. The default page size is `1024 * 1024` bytes. |
 | DICTIONARY\_PAGE\_SIZE | Dictionary encoding is enabled by default when PXF writes Parquet files. There is a single dictionary page per column, per row group. `DICTIONARY_PAGE_SIZE` is similar to `PAGE_SIZE`, but for the dictionary. The default dictionary page size is `512 * 1024` bytes. |
 | PARQUET_VERSION | The Parquet version; values `v1` and `v2` are supported. The default Parquet version is `v1`. |
+| SCHEMA | The local file system location of the parquet schema file. |
 
 **Note**: You must explicitly specify `uncompressed` if you do not want PXF to compress the data.
 


### PR DESCRIPTION
use the SCHEMA option (write only) to identify the parquet schema file.  this option was missing from the list of custom options supported when writing parquet data.
