### PR TITLE
Allow the cluster shutdown in some cases when dtx recovery hang happens

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -46,6 +46,7 @@
 #include "cdb/cdbconn.h"
 #include "cdb/cdbfts.h"
 #include "storage/ipc.h"
+#include "storage/proc.h"
 #include "postmaster/fts.h"
 #include "catalog/namespace.h"
 #include "utils/gpexpand.h"
@@ -1028,9 +1029,17 @@ cdb_setup(void)
 	{
 		while (true)
 		{
-			pg_usleep(100 * 1000); /* 100ms */
+			int rc;
 			if (*shmDtmStarted)
 				break;
+			CHECK_FOR_INTERRUPTS();
+			/* wait for 100ms or postmaster dies */
+			rc = WaitLatch(&MyProc->procLatch,
+				   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH, 100);
+
+			ResetLatch(&MyProc->procLatch);
+			if (rc & WL_POSTMASTER_DEATH)
+				proc_exit(1);
 		}
 	}
 }


### PR DESCRIPTION
We've seen this when fts detects 'double fault'. In such case,
dtx recovery can not proceed and newly created postgres backend could
hang, waiting for dtx recovery finishing. Changing the code to make
the cluster be able to stop in fast mode; Also those backends
should quit if postmaster is dead.

Co-Authored-by: Paul Guo <pguo@pivotal.io>
(cherry picked from commit e5043d6838d2d4f244b4dd9)
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
