### PR TITLE
Fix cdb_sequence_nextval_qe if connection is terminated

### DIFF
--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1883,9 +1883,14 @@ cdb_sequence_nextval_qe(Relation	seqrel,
 		if (retval == EOF)
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("nextval: QD closed the connection")));
+					 errmsg("nextval: connection is gone unexpectedly!")));
 	} while (retval != 1);
-	Assert(qtype == SEQ_NEXTVAL_QUERY_RESPONSE);
+	if (qtype == 'X')
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("nextval: QD closed the connection")));
+	if (qtype != SEQ_NEXTVAL_QUERY_RESPONSE)
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("unexpected message type='%c'", qtype)));
 
 	initStringInfo(&buf);
 	if (pq_getmessage(&buf, 0) != 0)

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1883,18 +1883,18 @@ cdb_sequence_nextval_qe(Relation	seqrel,
 		if (retval == EOF)
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("nextval: connection is gone unexpectedly!")));
+					 errmsg("nextval: connection is gone unexpectedly")));
 	} while (retval != 1);
 	if (qtype == 'X')
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("nextval: QD closed the connection")));
+				errmsg("nextval: QD closed the connection")));
 	if (qtype != SEQ_NEXTVAL_QUERY_RESPONSE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("unexpected message type='%c'", qtype)));
+				errmsg("nextval: unexpected message type='%c'", qtype)));
 
 	initStringInfo(&buf);
 	if (pq_getmessage(&buf, 0) != 0)
-		elog(ERROR, "unable to parse nextval response from QD");
+		elog(ERROR, "nextval: unable to parse nextval response from QD");
 
 	current = buf.data;
 

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1887,10 +1887,10 @@ cdb_sequence_nextval_qe(Relation	seqrel,
 	} while (retval != 1);
 	if (qtype == 'X')
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-				errmsg("nextval: QD closed the connection")));
+						errmsg("nextval: QD closed the connection")));
 	if (qtype != SEQ_NEXTVAL_QUERY_RESPONSE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-				errmsg("nextval: unexpected message type='%c'", qtype)));
+						errmsg("nextval: unexpected message type='%c'", qtype)));
 
 	initStringInfo(&buf);
 	if (pq_getmessage(&buf, 0) != 0)


### PR DESCRIPTION
Fix an assert failure in cdb_sequence_nextval_qe().
When QE wants to wait a message from QD to allocate the next value,
it receives a message with type 'X', which QD notifies QE to terminate.
Message with type 'X' is valid. So, cdb_sequence_nextval_qe should
handle it correctly.

No test for this commit. Because we need to register a fault injector in
cdb_sequence_nextval_qe() to suspend the execution of the QE process,
and later we want to resume the execution of cdb_sequence_nextval_qe()
by reset the registered fault inject. It works in normal cases. But we
need to kill the postmaster of the blocked QE process between suspending
the QE and resuming the QE. Resuming of the blocked QE failed because of
the postmaster of the QE is dead.

Co-authored-by: Paul Guo <pguo@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
