### PR TITLE
Retry if duplicate entries for dbid found for getCdbComponentInfo()

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -531,6 +531,12 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 			cdbinfo = &cdb_component_dbs->segment_db_info[i];
 			if (SEGMENT_IS_ACTIVE_PRIMARY(cdbinfo))
 			{
+				if (segCount >= size)
+				{
+					FtsReConfigureMPP(false);
+					elog(ERROR, "Not all primary segment instances are active and connected");
+				}
+
 				segdbDesc = &newGangDefinition->db_descriptors[segCount];
 				cdbInfoCopy = copyCdbComponentDatabaseInfo(cdbinfo);
 				cdbconn_initSegmentDescriptor(segdbDesc, cdbInfoCopy);
@@ -544,6 +550,7 @@ buildGangDefinition(GangType type, int gang_id, int size, int content)
 			FtsReConfigureMPP(false);
 			elog(ERROR, "Not all primary segment instances are active and connected");
 		}
+
 		break;
 
 	default:

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -74,6 +74,7 @@
 
 #define GpConfigHistoryRelName    "gp_configuration_history"
 
+bool am_ftsprobe = false;
 
 /*
  * STATIC VARIABLES
@@ -81,8 +82,6 @@
 
 /* one byte of status for each segment */
 static uint8 scan_status[MAX_NUM_OF_SEGMENTS];
-
-static bool am_ftsprobe = false;
 
 static volatile bool shutdown_requested = false;
 static volatile bool rescan_requested = false;

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -369,6 +369,9 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault during gang creation, before check for interrupts */
 	_("decrease_toast_max_chunk_size"),
 		/* inject fault when creating new TOAST tables, to modify the chunk size */
+
+	_("add_duplicate_segment_component_db_entry"),
+	/* injecting this fault creates in-memory duplicate entry for segment */
 	_("not recognized"),
 };
 
@@ -1079,6 +1082,7 @@ FaultInjector_NewHashEntry(
 
 			case DecreaseToastMaxChunkSize:
 			case ProcessStartupPacketFault:
+			case AddDuplicateSegmentComponentDBEntry:
 
 				break;
 			default:

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -16,6 +16,7 @@
 #ifndef FTS_H
 #define FTS_H
 
+extern bool am_ftsprobe;
 
 /*
  * ENUMS

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -250,6 +250,8 @@ typedef enum FaultInjectorIdentifier_e {
 
 	DecreaseToastMaxChunkSize,
 
+	AddDuplicateSegmentComponentDBEntry,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/isolation2/expected/build_gang.out
+++ b/src/test/isolation2/expected/build_gang.out
@@ -1,0 +1,50 @@
+-- SnapshotNow and AccessShareLock is used while scanning
+-- gp_segment_configuration table for building gangs for
+-- query. SnapshotNow scans have the undesirable property that, in the
+-- face of concurrent updates, the scan can fail to see either the old
+-- or the new versions of the row. Given this is rare occurrence, fix
+-- is to retry if duplicate rows with same dbid are found. So, this
+-- test introduces duplicates (in-memory only) after
+-- gp_segment_configuration table scan using fault injector and
+-- validates the retry logic.
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+CREATE TABLE build_gang_test(a int);
+CREATE
+
+-- inject fault infinitely to simulate duplicate entries fetched from
+-- gp_segment_configuration during scan
+SELECT gp_inject_fault_infinite('add_duplicate_segment_component_db_entry', 'skip', 1);
+gp_inject_fault_infinite
+------------------------
+t                       
+(1 row)
+-- this query is expected to fail, as building gang should error out
+-- after maximum retries
+1: SELECT * from build_gang_test;
+ERROR:  duplicate entries encountered on gp_segment_configuration scan for dbid = 2, even after retries (cdbutil.c:387)
+SELECT gp_inject_fault_new('add_duplicate_segment_component_db_entry', 'reset', 1);
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+
+-- inject fault "twice" to simulate duplicate entries fetched from
+-- gp_segment_configuration during scan
+SELECT gp_inject_fault_new('add_duplicate_segment_component_db_entry', 'skip', '', '', '', 1, 2, 0, 1);
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+-- build gang will retry for 2 times and then should be able to
+-- successfully run the query
+1: SELECT * from build_gang_test;
+a
+-
+(0 rows)
+SELECT gp_inject_fault_new('add_duplicate_segment_component_db_entry', 'reset', 1);
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -19,6 +19,7 @@ test: vacuum_full_recently_dead_tuple_due_to_distributed_snapshot
 test: resync_xlog_hints
 test: invalidated_toast_index
 test: dml_on_root_locks_all_parts
+test: build_gang
 
 # Tests on Append-Optimized tables (row-oriented).
 test: uao/alter_while_vacuum_row

--- a/src/test/isolation2/sql/build_gang.sql
+++ b/src/test/isolation2/sql/build_gang.sql
@@ -1,0 +1,28 @@
+-- SnapshotNow and AccessShareLock is used while scanning
+-- gp_segment_configuration table for building gangs for
+-- query. SnapshotNow scans have the undesirable property that, in the
+-- face of concurrent updates, the scan can fail to see either the old
+-- or the new versions of the row. Given this is rare occurrence, fix
+-- is to retry if duplicate rows with same dbid are found. So, this
+-- test introduces duplicates (in-memory only) after
+-- gp_segment_configuration table scan using fault injector and
+-- validates the retry logic.
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE TABLE build_gang_test(a int);
+
+-- inject fault infinitely to simulate duplicate entries fetched from
+-- gp_segment_configuration during scan
+SELECT gp_inject_fault_infinite('add_duplicate_segment_component_db_entry', 'skip', 1);
+-- this query is expected to fail, as building gang should error out
+-- after maximum retries
+1: SELECT * from build_gang_test;
+SELECT gp_inject_fault_new('add_duplicate_segment_component_db_entry', 'reset', 1);
+
+-- inject fault "twice" to simulate duplicate entries fetched from
+-- gp_segment_configuration during scan
+SELECT gp_inject_fault_new('add_duplicate_segment_component_db_entry', 'skip', '', '', '', 1, 2, 0, 1);
+-- build gang will retry for 2 times and then should be able to
+-- successfully run the query
+1: SELECT * from build_gang_test;
+SELECT gp_inject_fault_new('add_duplicate_segment_component_db_entry', 'reset', 1);


### PR DESCRIPTION
getCdbComponentInfo() is used for building gangs and some other
things. SnapshotNow with AccessShareLock is used to scan
gp_segment_configuration table for getCdbComponentInfo(). SnapshotNow
scans have the undesirable property that, in the face of concurrent
updates, the scan can fail to see either the old or the new versions
of the row. As a result, getCdbComponentInfo() may see duplicate
entries for dbid, if concurrent updates are performed mostly by FTS.

This is rare scenario and happens occassionaly. Instead of elevating
RowExclusiveLock to AccessExclusiveLock in FTS, we decided to add
retry to scan gp_segment_configuration if duplicates are detected. We
retry for 5 times and ERROR out if continue to see the duplicates.

The PR also has commit to add check to avoid memory-corruption if this
situation happens, due to which server used to SIGSEGV.

In separate commit, also adds test using fault injector. I first tried writing
just a unit test. But it gets very tricky as need to mock lot of heap
access functions and hence decided to add fault point and use the same
instead.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
