### PR TITLE
Fix upgrade integration test ports

### DIFF
--- a/contrib/pg_upgrade/test/integration/configuration/gpdb6-env.sh
+++ b/contrib/pg_upgrade/test/integration/configuration/gpdb6-env.sh
@@ -1,6 +1,6 @@
 export MASTER_PORT=60000
 export STANDBY_PORT=60001
-export PORT_BASE=60002
+export PORT_BASE=60000
 export DATADIRS="$PWD/gpdb6-data"
 export PGPORT=60000
 export MASTER_DATA_DIRECTORY="$DATADIRS/qddir/demoDataDir-1"

--- a/contrib/pg_upgrade/test/integration/utilities/gpdb6-cluster.c
+++ b/contrib/pg_upgrade/test/integration/utilities/gpdb6-cluster.c
@@ -7,7 +7,7 @@ startGpdbSixCluster(void)
 {
 	system(""
 		   ". ./gpdb6/greenplum_path.sh; "
-		   "export PGPORT=60000; "
+		   ". ./configuration/gpdb6-env.sh; "
 		   "export MASTER_DATA_DIRECTORY=./gpdb6-data/qddir/demoDataDir-1; "
 		   "./gpdb6/bin/gpstart -a --skip_standby_check --no_standby"
 		);
@@ -18,7 +18,7 @@ stopGpdbSixCluster(void)
 {
 	system(""
 		   ". ./gpdb6/greenplum_path.sh; \n"
-		   "export PGPORT=60000; \n"
+		   ". ./configuration/gpdb6-env.sh; \n"
 		   "export MASTER_DATA_DIRECTORY=./gpdb6-data/qddir/demoDataDir-1; \n"
 		   "./gpdb6/bin/gpstop -a"
 		);


### PR DESCRIPTION
Commit 660a28433f9 updated port assignments for demo cluster. There are
places where port is hardcoded in the upgrade integration framework
which needed to be updated accordingly.

Upgrade pipeline to failed here: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/pg-upgrade-5-to-6/jobs/end-to-end-test/builds/168