### PR TITLE
Add support for update extension

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4604,6 +4604,7 @@ _copyAlterExtensionStmt(const AlterExtensionStmt *from)
 
 	COPY_STRING_FIELD(extname);
 	COPY_NODE_FIELD(options);
+	COPY_SCALAR_FIELD(update_ext_state);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1902,6 +1902,7 @@ _equalAlterExtensionStmt(const AlterExtensionStmt *a, const AlterExtensionStmt *
 {
 	COMPARE_STRING_FIELD(extname);
 	COMPARE_NODE_FIELD(options);
+	COMPARE_SCALAR_FIELD(update_ext_state);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4828,6 +4828,7 @@ _outAlterExtensionStmt(StringInfo str, const AlterExtensionStmt *node)
 
 	WRITE_STRING_FIELD(extname);
 	WRITE_NODE_FIELD(options);
+	WRITE_ENUM_FIELD(update_ext_state, UpdateExtensionState);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2747,7 +2747,7 @@ _readAlterExtensionStmt(void)
 	READ_LOCALS(AlterExtensionStmt);
 	READ_STRING_FIELD(extname);
 	READ_NODE_FIELD(options);
-
+	READ_ENUM_FIELD(update_ext_state, UpdateExtensionState);
 	READ_DONE();
 }
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2303,6 +2303,13 @@ typedef enum CreateExtensionState
 	CREATE_EXTENSION_END		/* finish to create extension */
 } CreateExtensionState;
 
+typedef enum UpdateExtensionState
+{
+	UPDATE_EXTENSION_INIT,		/* not start to update extension */
+	UPDATE_EXTENSION_BEGIN,     /* start to update extension */
+	UPDATE_EXTENSION_END		/* finish to update extension */
+} UpdateExtensionState;
+
 typedef struct CreateExtensionStmt
 {
 	NodeTag		type;
@@ -2318,6 +2325,7 @@ typedef struct AlterExtensionStmt
 	NodeTag		type;
 	char	   *extname;
 	List	   *options;		/* List of DefElem nodes */
+	UpdateExtensionState update_ext_state;	/* update extension state, only used for ALTER EXTENSION UPDATE */
 } AlterExtensionStmt;
 
 typedef struct AlterExtensionContentsStmt


### PR DESCRIPTION
The implementation of UPDATE EXTENSION is very similar to CREATE
EXTENSION.

First, on QD, we update the pg_extension row to the new version, and
update extension's dependency entries according
to the new requires introduced by the new version specified control
file.

Second, we dispatch the UPDATE EXTENSION statement to QEs to update
pg_extension row and extension's dependency entries on QEs, and the
global status like creating_extension, CurrentExtensionObject of QEs
will be set.

Finally, we execute the update script file on QD. because of the correct
set of creating_extension, CurrentExtensionObject on QEs, the dependency
between object and extension will be handled correctly, so the
CREATE/DROP object statement will be executed successfully.

Fixes #8862 github issue.
