### PR TITLE
Enlarge disable_cost.

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -108,7 +108,7 @@ double		cpu_operator_cost = DEFAULT_CPU_OPERATOR_COST;
 
 int			effective_cache_size = DEFAULT_EFFECTIVE_CACHE_SIZE;
 
-Cost		disable_cost = 1.0e10;
+Cost		disable_cost = 1.0e40;
 
 bool		enable_seqscan = true;
 bool		enable_indexscan = true;


### PR DESCRIPTION
Disable_cost is added to path's cost when corresponding GUC
is set off. Greenplum is MPP database, the old value might be
too small.

I encounter this problem when I was working with performance issue
for TPCDS 1TBytes data. Planner generates nestloop join even if
enable_nestloop is set off, which leads to the query cannot finish for
a long time. After I enlarge the disable_cost, we can get hash join
plan, and the query finishes soon.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
