### PR TITLE
Fix gpstart know nothing about unavailable segments.

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -449,11 +449,6 @@ class GpStart:
         # segments marked down
         invalid_segs = self.gparray.get_invalid_segdbs()
 
-        inactiveDbIds = {}
-        for segment in invalid_segs:
-            inactiveDbIds[segment.getSegmentDbId()] = True
-        invalid_segs = [segment for segment in invalid_segs if inactiveDbIds.get(segment.getSegmentDbId()) is None]
-
         # now produce the list of segments to actually start
         dbIdsToNotStart = {}
         for segment in invalid_segs:


### PR DESCRIPTION
The code snippet about `inactiveDbIds` in `_prepare_segment_start()` 
make `invalid_segs` always empty, so gpstart will think that there are no segments that are not up.

In this test, we have a down segment:

```bash
[adbpg@HIDVA.COM /u01/adbpg/project/org/greenplum-db/gpdb]
$psql -c "select dbid,content,role,mode from gp_segment_configuration where status = 'd';" -t
    3 |       1 | m    | n    # a down segment.
```

But when we run the gpstart(before the fix), we got nothing about unavailable segments from the log output by gpstart. 

The diff between logs output by gpstart(before the fix) and output by gpstart(after the fix) is:

```diff
--- beforefix.log	2019-10-30 21:09:55.858869153 +0800
+++ afterfix.log	2019-10-30 21:07:10.675161250 +0800
@@ -9,18 +9,26 @@
 gpstart:HIDVA.COM-[INFO]:-Setting new master era
 gpstart:HIDVA.COM-[INFO]:-Master Started...
 gpstart:HIDVA.COM-[INFO]:-Shutting down master
+gpstart:HIDVA.COM-[WARNING]:-Skipping startup of segment marked down in configuration: on zhanyi-rd011158142195.na61 directory /u01/adbpg/gpdata/dbfast2/demoDataDir1 <<<<<
 gpstart:HIDVA.COM-[INFO]:-Commencing parallel primary and mirror segment instance startup, please wait...
 gpstart:HIDVA.COM-[INFO]:-Process results...
 gpstart:HIDVA.COM-[INFO]:-----------------------------------------------------
 gpstart:HIDVA.COM-[INFO]:-   Successful segment starts                                            = 5
 gpstart:HIDVA.COM-[INFO]:-   Failed segment starts                                                = 0
-gpstart:HIDVA.COM-[INFO]:-   Skipped segment starts (segments are marked down in configuration)   = 0
+gpstart:HIDVA.COM-[WARNING]:-Skipped segment starts (segments are marked down in configuration)   = 1   <<<<<<<<
 gpstart:HIDVA.COM-[INFO]:-----------------------------------------------------
-gpstart:HIDVA.COM-[INFO]:-Successfully started 5 of 5 segment instances 
+gpstart:HIDVA.COM-[INFO]:-Successfully started 5 of 5 segment instances, skipped 1 other segments 
 gpstart:HIDVA.COM-[INFO]:-----------------------------------------------------
+gpstart:HIDVA.COM-[WARNING]:-****************************************************************************
+gpstart:HIDVA.COM-[WARNING]:-There are 1 segment(s) marked down in the database
+gpstart:HIDVA.COM-[WARNING]:-To recover from this current state, review usage of the gprecoverseg
+gpstart:HIDVA.COM-[WARNING]:-management utility which will recover failed segment instance databases.
+gpstart:HIDVA.COM-[WARNING]:-****************************************************************************
 gpstart:HIDVA.COM-[INFO]:-Starting Master instance zhanyi-rd011158142195.na61 directory /u01/adbpg/gpdata/qddir/demoDataDir-1 
 gpstart:HIDVA.COM-[INFO]:-Command pg_ctl reports Master zhanyi-rd011158142195.na61 instance active
 gpstart:HIDVA.COM-[INFO]:-Connecting to dbname='template1' connect_timeout=15 options='-c search_path= -c CLIENT_MIN_MESSAGES=ERROR'
 gpstart:HIDVA.COM-[INFO]:-Starting standby master
 gpstart:HIDVA.COM-[INFO]:-Checking if standby master is running on host: zhanyi-rd011158142195.na61  in directory: /u01/adbpg/gpdata/standby
-gpstart:HIDVA.COM-[INFO]:-Database successfully started
+gpstart:HIDVA.COM-[WARNING]:-Number of segments not attempted to start: 1
+gpstart:HIDVA.COM-[INFO]:-Check status of database with gpstate utility
```
Now we know something was wrong.