### PR TITLE
WIP: Test if / how fast the tests pass with gp_cached_segworkers_threshold=10

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3510,7 +3510,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&gp_cached_gang_threshold,
-		5, 1, INT_MAX,
+		10, 1, INT_MAX,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
Testing on my laptop, this seems to speed up at least the 'qp_derived_table'
test somewhat. Let's see what the overall effect might be, if we bumped
the default or at least changed it for installcheck-world.
