### PR TITLE
The PXF JDBC user identity in the documentation is incorrect for one

### DIFF
--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -350,7 +350,7 @@ Table heading key:
 | `KERBEROS` | `TRUE` | Identity provided in the PXF Kerberos principal, typically `gpadmin` | None |
 | `KERBEROS` | `TRUE` | User name that you provide  | Set `hive.server2.proxy.user` in `jdbc.url`  |
 | `KERBEROS` | `TRUE` | Greenplum user name  | Set `pxf.impersonation.jdbc` = `true` |
-| `KERBEROS` | `FALSE` | Identity provided in the PXF Kerberos principal, typically `gpadmin` |  None |
+| `KERBEROS` | `FALSE` | Identity provided in the `jdbc.url` `principal` parameter, typically `hive` |  None |
 
 **Note**: There are additional configuration steps required when Hive utilizes Kerberos authentication.
 


### PR DESCRIPTION
For one of the Hive authentication methods, the PXF documentation states
the incorrect identity used when Kerberos is enabled for Hive and the
hive.server2.enable.doAs property is false. The correct identity is the
Kerberos principal defined in the jdbc.url to connect to the Hive
database. Cherry-picked from 99784205b45216580e08d5beb5c28c92a8cf4020 
