### PR TITLE
Change default for gp_statistics_use_fkeys to 'off', and deprecate it.

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -616,9 +616,6 @@
               </stentry>
               <stentry>
                 <p>
-                  <codeph>gp_statistics_use_fkeys</codeph>
-                </p>
-                <p>
                   <codeph>gp_workfile_compression</codeph>
                 </p>
               </stentry>
@@ -641,6 +638,9 @@
             </li>
             <li id="kh167484">
               <codeph>gp_statistics_pullup_from_child_partition</codeph>
+            </li>
+            <li>
+              <codeph>gp_statistics_use_fkeys</codeph>
             </li>
           </ul>
         </body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4777,8 +4777,10 @@
   <topic id="gp_statistics_use_fkeys">
     <title>gp_statistics_use_fkeys</title>
     <body>
-      <p>When enabled, allows the Postgres Planner to use foreign key information
-        stored in the system catalog to optimize joins between foreign keys and primary keys. </p>
+      <p>When enabled, the Postgres Planner will use the statistics of the referenced column in
+         the parent table when a column is foreign key reference to another table instead of
+         the statistics of the column itself.</p>
+      <note>This option is deprecated and will be removed in a future Greenplum release.</note>
       <table id="gp_statistics_use_fkeys_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -618,10 +618,6 @@
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#gp_statistics_use_fkeys" type="section"
-                  >gp_statistics_use_fkeys</xref>
-              </p>
-              <p>
                 <xref href="guc-list.xml#gp_workfile_compression" type="section"
                   >gp_workfile_compression</xref>
               </p>
@@ -650,6 +646,10 @@
               <p>
                 <xref href="guc-list.xml#gp_statistics_pullup_from_child_partition" type="section"
                   >gp_statistics_pullup_from_child_partition</xref>
+              </p>
+              <p>
+                <xref href="guc-list.xml#gp_statistics_use_fkeys" type="section"
+                  >gp_statistics_use_fkeys</xref>
               </p>
             </stentry>
           </strow>

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1603,7 +1603,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			NULL
 		},
 		&gp_statistics_use_fkeys,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 	{

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -27,20 +27,20 @@ WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in G
 --- Check Explain Text format output
 -- explain_processing_off
 EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=4626.75..9520.88 rows=77900 width=84)
-   ->  Hash Left Join  (cost=4626.75..9520.88 rows=25967 width=84)
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=3577.00..11272.25 rows=77900 width=84)
+   ->  Hash Left Join  (cost=3577.00..9714.25 rows=25967 width=84)
          Hash Cond: (boxes.location_id = box_locations.id)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3410.75..7233.75 rows=25967 width=48)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2361.00..7427.12 rows=25967 width=48)
                Hash Key: boxes.location_id
-               ->  Hash Right Join  (cost=3410.75..5675.75 rows=25967 width=48)
-                     Hash Cond: (apples.id = boxes.apple_id)
-                     ->  Seq Scan on apples  (cost=0.00..1111.00 rows=33334 width=36)
-                     ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
-                                 Hash Key: boxes.apple_id
-                                 ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
+               ->  Hash Left Join  (cost=2361.00..5869.12 rows=25967 width=48)
+                     Hash Cond: (boxes.apple_id = apples.id)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+                           Hash Key: boxes.apple_id
+                           ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
+                     ->  Hash  (cost=1111.00..1111.00 rows=33334 width=36)
+                           ->  Seq Scan on apples  (cost=0.00..1111.00 rows=33334 width=36)
          ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
                ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36)
  Optimizer: Postgres query optimizer
@@ -50,30 +50,30 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
 --- Check Explain Analyze Text output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=4626.75..9520.88 rows=77900 width=84) (actual time=7.762..7.762 rows=0 loops=1)
-   ->  Hash Left Join  (cost=4626.75..9520.88 rows=25967 width=84) (never executed)
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=3577.00..11272.25 rows=77900 width=84) (actual time=45.646..45.646 rows=0 loops=1)
+   ->  Hash Left Join  (cost=3577.00..9714.25 rows=25967 width=84) (never executed)
          Hash Cond: (boxes.location_id = box_locations.id)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3410.75..7233.75 rows=25967 width=48) (never executed)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2361.00..7427.12 rows=25967 width=48) (never executed)
                Hash Key: boxes.location_id
-               ->  Hash Right Join  (cost=3410.75..5675.75 rows=25967 width=48) (never executed)
-                     Hash Cond: (apples.id = boxes.apple_id)
-                     ->  Seq Scan on apples  (cost=0.00..1111.00 rows=33334 width=36) (never executed)
-                     ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12) (never executed)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12) (never executed)
-                                 Hash Key: boxes.apple_id
-                                 ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12) (never executed)
+               ->  Hash Left Join  (cost=2361.00..5869.12 rows=25967 width=48) (never executed)
+                     Hash Cond: (boxes.apple_id = apples.id)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12) (never executed)
+                           Hash Key: boxes.apple_id
+                           ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12) (never executed)
+                     ->  Hash  (cost=1111.00..1111.00 rows=33334 width=36) (actual time=39.093..39.093 rows=33462 loops=1)
+                           ->  Seq Scan on apples  (cost=0.00..1111.00 rows=33334 width=36) (actual time=0.075..10.163 rows=33462 loops=1)
          ->  Hash  (cost=596.00..596.00 rows=16534 width=36) (never executed)
                ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36) (never executed)
- Planning time: 0.791 ms
+ Planning time: 2.219 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice2)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).  Work_mem: 2048K bytes max.
+   (slice2)    Executor memory: 2162K bytes avg x 3 workers, 2162K bytes max (seg0).  Work_mem: 2070K bytes max.
    (slice3)    Executor memory: 1104K bytes avg x 3 workers, 1104K bytes max (seg0).  Work_mem: 1024K bytes max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 29.929 ms
+ Execution time: 59.644 ms
 (22 rows)
 
 -- explain_processing_on
@@ -124,8 +124,8 @@ QUERY PLAN
     Segments: 3
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 4626.75
-    Total Cost: 9520.88
+    Startup Cost: 3577.00
+    Total Cost: 11272.25
     Plan Rows: 77900
     Plan Width: 84
     Plans: 
@@ -136,8 +136,8 @@ QUERY PLAN
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 4626.75
-        Total Cost: 9520.88
+        Startup Cost: 3577.00
+        Total Cost: 9714.25
         Plan Rows: 77900
         Plan Width: 84
         Hash Cond: "(boxes.location_id = box_locations.id)"
@@ -150,8 +150,8 @@ QUERY PLAN
             Segments: 3
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 3410.75
-            Total Cost: 7233.75
+            Startup Cost: 2361.00
+            Total Cost: 7427.12
             Plan Rows: 77900
             Plan Width: 48
             Hash Key: "boxes.location_id"
@@ -162,62 +162,62 @@ QUERY PLAN
                 Segments: 3
                 Gang Type: "primary reader"
                 Parallel Aware: false
-                Join Type: "Right"
-                Startup Cost: 3410.75
-                Total Cost: 5675.75
+                Join Type: "Left"
+                Startup Cost: 2361.00
+                Total Cost: 5869.12
                 Plan Rows: 77900
                 Plan Width: 48
-                Hash Cond: "(apples.id = boxes.apple_id)"
+                Hash Cond: "(boxes.apple_id = apples.id)"
                 Plans: 
-                  - Node Type: "Seq Scan"
+                  - Node Type: "Redistribute Motion"
+                    Senders: 3
+                    Receivers: 3
                     Parent Relationship: "Outer"
-                    Slice: 2
+                    Slice: 1
                     Segments: 3
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Relation Name: "apples"
-                    Alias: "apples"
                     Startup Cost: 0.00
-                    Total Cost: 1111.00
-                    Plan Rows: 100000
-                    Plan Width: 36
+                    Total Cost: 2437.00
+                    Plan Rows: 77900
+                    Plan Width: 12
+                    Hash Key: "boxes.apple_id"
+                    Plans: 
+                      - Node Type: "Seq Scan"
+                        Parent Relationship: "Outer"
+                        Slice: 1
+                        Segments: 3
+                        Gang Type: "primary reader"
+                        Parallel Aware: false
+                        Relation Name: "boxes"
+                        Alias: "boxes"
+                        Startup Cost: 0.00
+                        Total Cost: 879.00
+                        Plan Rows: 77900
+                        Plan Width: 12
                   - Node Type: "Hash"
                     Parent Relationship: "Inner"
                     Slice: 2
                     Segments: 3
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 2437.00
-                    Total Cost: 2437.00
-                    Plan Rows: 77900
-                    Plan Width: 12
+                    Startup Cost: 1111.00
+                    Total Cost: 1111.00
+                    Plan Rows: 100000
+                    Plan Width: 36
                     Plans: 
-                      - Node Type: "Redistribute Motion"
-                        Senders: 3
-                        Receivers: 3
+                      - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 1
+                        Slice: 2
                         Segments: 3
                         Gang Type: "primary reader"
                         Parallel Aware: false
+                        Relation Name: "apples"
+                        Alias: "apples"
                         Startup Cost: 0.00
-                        Total Cost: 2437.00
-                        Plan Rows: 77900
-                        Plan Width: 12
-                        Hash Key: "boxes.apple_id"
-                        Plans: 
-                          - Node Type: "Seq Scan"
-                            Parent Relationship: "Outer"
-                            Slice: 1
-                            Segments: 3
-                            Gang Type: "primary reader"
-                            Parallel Aware: false
-                            Relation Name: "boxes"
-                            Alias: "boxes"
-                            Startup Cost: 0.00
-                            Total Cost: 879.00
-                            Plan Rows: 77900
-                            Plan Width: 12
+                        Total Cost: 1111.00
+                        Plan Rows: 100000
+                        Plan Width: 36
           - Node Type: "Hash"
             Parent Relationship: "Inner"
             Slice: 3
@@ -256,12 +256,12 @@ QUERY PLAN
     Segments: 3
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 4626.75
-    Total Cost: 9520.88
+    Startup Cost: 3577.00
+    Total Cost: 11272.25
     Plan Rows: 77900
     Plan Width: 84
-    Actual Startup Time: 7.816
-    Actual Total Time: 7.816
+    Actual Startup Time: 70.104
+    Actual Total Time: 70.104
     Actual Rows: 0
     Actual Loops: 1
     Plans: 
@@ -272,8 +272,8 @@ QUERY PLAN
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 4626.75
-        Total Cost: 9520.88
+        Startup Cost: 3577.00
+        Total Cost: 9714.25
         Plan Rows: 77900
         Plan Width: 84
         Actual Startup Time: 0.000
@@ -290,8 +290,8 @@ QUERY PLAN
             Segments: 3
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 3410.75
-            Total Cost: 7233.75
+            Startup Cost: 2361.00
+            Total Cost: 7427.12
             Plan Rows: 77900
             Plan Width: 48
             Actual Startup Time: 0.000
@@ -306,40 +306,26 @@ QUERY PLAN
                 Segments: 3
                 Gang Type: "primary reader"
                 Parallel Aware: false
-                Join Type: "Right"
-                Startup Cost: 3410.75
-                Total Cost: 5675.75
+                Join Type: "Left"
+                Startup Cost: 2361.00
+                Total Cost: 5869.12
                 Plan Rows: 77900
                 Plan Width: 48
                 Actual Startup Time: 0.000
                 Actual Total Time: 0.000
                 Actual Rows: 0
                 Actual Loops: 0
-                Hash Cond: "(apples.id = boxes.apple_id)"
+                Hash Cond: "(boxes.apple_id = apples.id)"
                 Plans: 
-                  - Node Type: "Seq Scan"
+                  - Node Type: "Redistribute Motion"
+                    Senders: 3
+                    Receivers: 3
                     Parent Relationship: "Outer"
-                    Slice: 2
+                    Slice: 1
                     Segments: 3
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Relation Name: "apples"
-                    Alias: "apples"
                     Startup Cost: 0.00
-                    Total Cost: 1111.00
-                    Plan Rows: 100000
-                    Plan Width: 36
-                    Actual Startup Time: 0.000
-                    Actual Total Time: 0.000
-                    Actual Rows: 0
-                    Actual Loops: 0
-                  - Node Type: "Hash"
-                    Parent Relationship: "Inner"
-                    Slice: 2
-                    Segments: 3
-                    Gang Type: "primary reader"
-                    Parallel Aware: false
-                    Startup Cost: 2437.00
                     Total Cost: 2437.00
                     Plan Rows: 77900
                     Plan Width: 12
@@ -347,41 +333,55 @@ QUERY PLAN
                     Actual Total Time: 0.000
                     Actual Rows: 0
                     Actual Loops: 0
+                    Hash Key: "boxes.apple_id"
                     Plans: 
-                      - Node Type: "Redistribute Motion"
-                        Senders: 3
-                        Receivers: 3
+                      - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
                         Slice: 1
                         Segments: 3
                         Gang Type: "primary reader"
                         Parallel Aware: false
+                        Relation Name: "boxes"
+                        Alias: "boxes"
                         Startup Cost: 0.00
-                        Total Cost: 2437.00
+                        Total Cost: 879.00
                         Plan Rows: 77900
                         Plan Width: 12
                         Actual Startup Time: 0.000
                         Actual Total Time: 0.000
                         Actual Rows: 0
                         Actual Loops: 0
-                        Hash Key: "boxes.apple_id"
-                        Plans: 
-                          - Node Type: "Seq Scan"
-                            Parent Relationship: "Outer"
-                            Slice: 1
-                            Segments: 3
-                            Gang Type: "primary reader"
-                            Parallel Aware: false
-                            Relation Name: "boxes"
-                            Alias: "boxes"
-                            Startup Cost: 0.00
-                            Total Cost: 879.00
-                            Plan Rows: 77900
-                            Plan Width: 12
-                            Actual Startup Time: 0.000
-                            Actual Total Time: 0.000
-                            Actual Rows: 0
-                            Actual Loops: 0
+                  - Node Type: "Hash"
+                    Parent Relationship: "Inner"
+                    Slice: 2
+                    Segments: 3
+                    Gang Type: "primary reader"
+                    Parallel Aware: false
+                    Startup Cost: 1111.00
+                    Total Cost: 1111.00
+                    Plan Rows: 100000
+                    Plan Width: 36
+                    Actual Startup Time: 58.354
+                    Actual Total Time: 58.354
+                    Actual Rows: 33462
+                    Actual Loops: 1
+                    Plans: 
+                      - Node Type: "Seq Scan"
+                        Parent Relationship: "Outer"
+                        Slice: 2
+                        Segments: 3
+                        Gang Type: "primary reader"
+                        Parallel Aware: false
+                        Relation Name: "apples"
+                        Alias: "apples"
+                        Startup Cost: 0.00
+                        Total Cost: 1111.00
+                        Plan Rows: 100000
+                        Plan Width: 36
+                        Actual Startup Time: 0.088
+                        Actual Total Time: 14.932
+                        Actual Rows: 33462
+                        Actual Loops: 1
           - Node Type: "Hash"
             Parent Relationship: "Inner"
             Slice: 3
@@ -413,25 +413,25 @@ QUERY PLAN
                 Actual Total Time: 0.000
                 Actual Rows: 0
                 Actual Loops: 0
-  Planning Time: 0.661
+  Planning Time: 5.148
   Triggers: 
   Slice statistics: 
     - Slice: 0
       Executor Memory: 130048
     - Slice: 1
       Executor Memory: 
-        Average: 60584
+        Average: 60624
         Workers: 3
-        Maximum Memory Used: 60584
+        Maximum Memory Used: 60624
     - Slice: 2
       Executor Memory: 
-        Average: 2178096
+        Average: 2213776
         Workers: 3
-        Maximum Memory Used: 2178104
-      Work Maximum Memory: 2097152
+        Maximum Memory Used: 2213776
+      Work Maximum Memory: 2119360
     - Slice: 3
       Executor Memory: 
-        Average: 1129520
+        Average: 1129528
         Workers: 3
         Maximum Memory Used: 1129528
       Work Maximum Memory: 1048576
@@ -439,7 +439,7 @@ QUERY PLAN
     Memory used: 128000
   Settings: 
     Optimizer: "Postgres query optimizer"
-  Execution Time: 8.490
+  Execution Time: 72.942
 (1 row)
 -- explain_processing_on
 --


### PR DESCRIPTION
It's not hard to come up with an example where 'on' produces worse
estimates than 'off', but I can't come up with a realistic scenario where
'on' would produce a better plan than 'off'. Let's disable it, and save
some cycles on catalog lookups during planning. I'd like to remove it
altogether, but let's play it safe and mark it as deprecated for a release
or two first.

The documentation already claimed that the default was 'off', which was
wrong before. Move it from the "Join Operator Configuration Parameters"
section to "Other Query Planner Configuration Parameters", as it's not
really related to joins. Change the description of the GUC more accurate
in the docs, and mention that it is deprecated and will be removed in the
future.

Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/dipq82v83PU/ro4gT1EXAgAJ
