### PR TITLE
Facilitate upgrade testing

### DIFF
--- a/contrib/pg_upgrade/ci/ci.yml
+++ b/contrib/pg_upgrade/ci/ci.yml
@@ -41,6 +41,7 @@ jobs:
           trigger: true
       - task: run-test
         file: gpdb6/contrib/pg_upgrade/ci/run-test.yml
+        timeout: 1h
 
   - name: pull-request-end-to-end-test
     plan:
@@ -51,3 +52,4 @@ jobs:
         - get: gpdb5
       - task: run-test
         file: gpdb6/contrib/pg_upgrade/ci/run-test.yml
+        timeout: 1h

--- a/contrib/pg_upgrade/test/integration/scripts/shared/init_cluster.bash
+++ b/contrib/pg_upgrade/test/integration/scripts/shared/init_cluster.bash
@@ -23,7 +23,7 @@ create_demo_cluster() {
 		make -C "$gpdb_source_path/gpAux/gpdemo" &&
 		source "$gpdb_source_path/gpAux/gpdemo/gpdemo-env.sh" &&
 		after_cluster_created &&
-		"./$installation_path/bin/gpstop" -a
+		"./$installation_path/bin/gpstop" -af
 }
 
 create_backup_of_data_dirs() {

--- a/contrib/pg_upgrade/test/integration/utilities/gpdb5-cluster.c
+++ b/contrib/pg_upgrade/test/integration/utilities/gpdb5-cluster.c
@@ -20,7 +20,7 @@ stopGpdbFiveCluster(void)
 		   ". $PWD/gpdb5/greenplum_path.sh; \n"
 		   "export PGPORT=50000; \n"
 		   "export MASTER_DATA_DIRECTORY=$PWD/gpdb5-data/qddir/demoDataDir-1; \n"
-		   "$PWD/gpdb5/bin/gpstop -a"
+		   "$PWD/gpdb5/bin/gpstop -af"
 		);
 }
 

--- a/contrib/pg_upgrade/test/integration/utilities/gpdb6-cluster.c
+++ b/contrib/pg_upgrade/test/integration/utilities/gpdb6-cluster.c
@@ -20,6 +20,6 @@ stopGpdbSixCluster(void)
 		   ". ./gpdb6/greenplum_path.sh; \n"
 		   ". ./configuration/gpdb6-env.sh; \n"
 		   "export MASTER_DATA_DIRECTORY=./gpdb6-data/qddir/demoDataDir-1; \n"
-		   "./gpdb6/bin/gpstop -a"
+		   "./gpdb6/bin/gpstop -af"
 		);
 }


### PR DESCRIPTION
The CI environment has been hang in several PRs because the upgrade tests failed
on assertions while still keeping a connection open. For stoping the cluster
the gpstop script defaulted in interactive mode, which cause the hang.

Now the gpstop script is invoked in fast mode. Also set a logical timeout to the
pipeline.
