### PR TITLE
Enable python extensions on the upgrade CI

### DIFF
--- a/contrib/pg_upgrade/ci/run-test-as-gpadmin.sh
+++ b/contrib/pg_upgrade/ci/run-test-as-gpadmin.sh
@@ -7,7 +7,7 @@ install_gpdb5() {
 
 	pushd "$gpdb5_source_path"
 
-	./configure --disable-orca --prefix="$gpdb5_installation_path" &&
+	./configure --disable-orca --prefix="$gpdb5_installation_path" --with-python &&
 		make -j 4 -l 4 &&
 		make install
 
@@ -22,7 +22,7 @@ install_gpdb6() {
 
 	pushd "$gpdb6_source_path"
 
-	./configure --disable-orca --prefix="$gpdb6_installation_path" --without-zstd &&
+	./configure --disable-orca --prefix="$gpdb6_installation_path" --without-zstd --with-python &&
 		make -j 4 -l 4 &&
 		make install
 


### PR DESCRIPTION
This is required in CI to test upgrade of plpythonu functions in
test_a_plpython_function_can_be_upgraded() introduced in commit
58444dad971

Caused upgrade CI errors like: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/pg-upgrade-5-to-6/jobs/end-to-end-test/builds/182