### PR TITLE
Empty CDB Segment IP cache on disconnect

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -451,6 +451,17 @@ getCdbComponentDatabases(void)
 	return cdbs;
 }
 
+/*
+ * destroyCdbSegmentIPCache
+ *
+ * Empties the segment IP cache
+ */
+void
+destroyCdbSegmentIPCache(void)
+{
+	hash_destroy(segment_ip_cache_htab);
+	segment_ip_cache_htab = NULL;
+}
 
 /*
  * freeCdbComponentDatabases
@@ -466,8 +477,7 @@ freeCdbComponentDatabases(CdbComponentDatabases *pDBs)
 	if (pDBs == NULL)
 		return;
 
-	hash_destroy(segment_ip_cache_htab);
-	segment_ip_cache_htab = NULL;
+	destroyCdbSegmentIPCache();
 
 	if (pDBs->segment_db_info != NULL)
 	{

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -1207,6 +1207,7 @@ void DisconnectAndDestroyAllGangs(bool resetSession)
 	 */
 	if (NULL != GangContext)
 	{
+		destroyCdbSegmentIPCache();
 		MemoryContextReset(GangContext);
 		cdb_component_dbs = NULL;
 	}

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -132,6 +132,11 @@ extern void cdb_cleanup(int code, Datum arg  __attribute__((unused)) );
 extern CdbComponentDatabases *getCdbComponentDatabases(void);
 
 /*
+ * destroyCdbSegmentIPCache empties the segment IP cache
+ */
+extern void destroyCdbSegmentIPCache(void);
+
+/*
  * freeCdbComponentDatabases() releases the palloc'd storage returned by
  * getCdbComponentDatabases().
  */


### PR DESCRIPTION
After a disconnect, the same cdbgang will never attempt to re-resolve
the hostname of a segment. If the segment IP changes, the cdbgang will
never be able to reconnect (unless a new session is initiated). By
emptying the segment IP cache, the cdbgang will lookup the new IP and be
able to reconnect to the segment.

[Dev pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-5x-cdbgang-ip-cache)

Tested this fix manually with a couple GCP VMs, simulating an IP failover. Will wait for ICW pipeline to pass as well.

This fix was derived from previous work on GPDB 6/7 that was not backported to 5:
* https://github.com/greenplum-db/gpdb/pull/5424
* https://github.com/greenplum-db/gpdb/pull/5701