### PR TITLE
Test split default part

### DIFF
--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -47,6 +47,7 @@ main(int argc, char *argv[])
 
 	const		UnitTest tests[] = {
 		unit_test_setup_teardown(test_a_readable_external_table_can_be_upgraded, setup, teardown),
+		unit_test_setup_teardown(test_a_partition_table_with_default_partition_after_split_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_partition_table_with_newly_added_range_partition_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_a_partition_table_with_newly_added_list_partition_can_be_upgraded, setup, teardown),
 		unit_test_setup_teardown(test_clusters_with_different_checksum_version_cannot_be_upgraded, setup, teardown),

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.h
@@ -1,4 +1,4 @@
 void test_a_partitioned_heap_table_with_data_can_be_upgraded(void **state);
 void test_a_partition_table_with_newly_added_list_partition_can_be_upgraded(void **state);
 void test_a_partition_table_with_newly_added_range_partition_can_be_upgraded(void **state);
-
+void test_a_partition_table_with_default_partition_after_split_can_be_upgraded(void **state);


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

Refer to the test test_a_partition_table_with_default_partition_after_split_can_be_upgraded in this commit. This PR is based on another PR: https://github.com/greenplum-db/gpdb/pull/8961
