### PR TITLE
For non partition table, consider a is null consistent with a = 1 constrain.

### DIFF
--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -292,7 +292,6 @@ PlannerConfig *DefaultPlannerConfig(void)
 	c1->enable_hashjoin = enable_hashjoin;
 	c1->gp_enable_hashjoin_size_heuristic = gp_enable_hashjoin_size_heuristic;
 	c1->gp_enable_predicate_propagation = gp_enable_predicate_propagation;
-	c1->constraint_exclusion = constraint_exclusion;
 
 	c1->gp_enable_minmax_optimization = gp_enable_minmax_optimization;
 	c1->gp_enable_multiphase_agg = gp_enable_multiphase_agg;

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -1407,7 +1407,6 @@ relation_excluded_by_constraints(PlannerInfo *root,
 	List	   *constraint_pred;
 	List	   *safe_constraints;
 	ListCell   *lc;
-	int			constraint_exclusion = root->config->constraint_exclusion;
 
 	/* Skip the test if constraint exclusion is disabled for the rel */
 	if (constraint_exclusion == CONSTRAINT_EXCLUSION_OFF ||

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -47,6 +47,7 @@
 #include "utils/snapmgr.h"
 
 #include "cdb/cdbappendonlyam.h"
+#include "cdb/cdbpartition.h"
 #include "cdb/cdbrelsize.h"
 #include "catalog/pg_appendonly_fn.h"
 #include "catalog/pg_exttable.h"
@@ -1407,6 +1408,7 @@ relation_excluded_by_constraints(PlannerInfo *root,
 	List	   *constraint_pred;
 	List	   *safe_constraints;
 	ListCell   *lc;
+	bool        is_leaf_part = rel_is_leaf_partition(rte->relid);
 
 	/* Skip the test if constraint exclusion is disabled for the rel */
 	if (constraint_exclusion == CONSTRAINT_EXCLUSION_OFF ||
@@ -1499,7 +1501,9 @@ relation_excluded_by_constraints(PlannerInfo *root,
 	if (predicate_refuted_by(safe_constraints, rel->baserestrictinfo))
 		return true;
 
-	return false;
+	return simple_equality_predicate_refuted((Node *) (rel->baserestrictinfo),
+											 (Node *) safe_constraints,
+											 is_leaf_part);
 }
 
 

--- a/src/backend/optimizer/util/predtest.c
+++ b/src/backend/optimizer/util/predtest.c
@@ -32,8 +32,6 @@
 #include "catalog/pg_operator.h"
 #include "optimizer/paths.h"
 
-static const bool kUseFnEvaluationForPredicates = true;
-
 /*
  * Proof attempts involving large arrays in ScalarArrayOpExpr nodes are
  * likely to require O(N^2) time, and more often than not fail anyway.
@@ -220,8 +218,6 @@ predicate_refuted_by(List *predicate_list, List *restrictinfo_list)
 	if ( predicate_refuted_by_recurse(r, p))
         return true;
 
-    if ( ! kUseFnEvaluationForPredicates )
-        return false;
     return simple_equality_predicate_refuted((Node*)restrictinfo_list, (Node*)predicate_list);
 }
 

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -21,7 +21,6 @@ typedef struct PlannerConfig
 	bool		enable_hashjoin;
 	bool        gp_enable_hashjoin_size_heuristic;
 	bool        gp_enable_predicate_propagation;
-	int			constraint_exclusion;
 
 	bool		gp_enable_minmax_optimization;
 	bool		gp_enable_multiphase_agg;

--- a/src/include/optimizer/predtest.h
+++ b/src/include/optimizer/predtest.h
@@ -60,6 +60,8 @@ extern void AddUnmatchingValues(PossibleValueSet *pvs, PossibleValueSet *toCheck
 extern void RemoveUnmatchingValues(PossibleValueSet *pvs, PossibleValueSet *toCheck);
 extern bool TryProcessExprForPossibleValues(Node *expr, Node *variable, PossibleValueSet *resultOut);
 
+extern bool simple_equality_predicate_refuted(Node *clause, Node *predicate, bool is_leaf_part);
+
 /**
  * END functions and structures for determining set of possible values from a clause
  ***********************************************************************************

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11401,11 +11401,11 @@ CREATE TABLE tc0 (a int check (a = 5));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO tc0 VALUES (NULL);
--- FIXME: Planner gives wrong result
 SELECT * from tc0 where a IS NULL;
  a 
 ---
-(0 rows)
+  
+(1 row)
 
 CREATE TABLE tc1 (a int check (a between 1 and 2 or a != 3 and a > 5));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11546,7 +11546,6 @@ CREATE TABLE tc0 (a int check (a = 5));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO tc0 VALUES (NULL);
--- FIXME: Planner gives wrong result
 SELECT * from tc0 where a IS NULL;
  a 
 ---

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2200,7 +2200,6 @@ DROP TABLE IF EXISTS tc0, tc1, tc2, tc3, tc4;
 -- end_ignore
 CREATE TABLE tc0 (a int check (a = 5));
 INSERT INTO tc0 VALUES (NULL);
--- FIXME: Planner gives wrong result
 SELECT * from tc0 where a IS NULL;
 
 CREATE TABLE tc1 (a int check (a between 1 and 2 or a != 3 and a > 5));


### PR DESCRIPTION
```
   For non partition table, consider a is null consistent with a = 1 constrain.
 
   Github Issue #8582.

    simple_equality_predicate_refuted is implemented by Greenplum,
    Postgres does not contain such function. It is useful in GPDB
    to do partition pruning. And partition key cannot be null except
    default partition (which means partition table innately contain a
    constrain partition_key is not null for non-default leaves.

    Also notice that constrain `a = 1` does not reject the tuple `null`.
    For non partition tables, we do more test by set a to null, so that

    create table t(a int check(a = 1));
    insert into t values (null);
    select * from t where a is null;

    will not generate dummy plan.
```

Please review commits by commits and see commit message for details.

This fix github issue: https://github.com/greenplum-db/gpdb/issues/8582

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
