### PR TITLE
p.wait() would have deadlock with P.open

### DIFF
--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -133,19 +133,14 @@ def dump_query(connectionInfo, query_file):
         toolkit_f.write(query)
 
     # disable .psqlrc to prevent unexpected timing and format output
-    query_cmd = "psql %s --pset footer --no-psqlrc -Atq -h %s -p %s -U %s -f %s" % (db, host, port, user, toolkit_sql)
+    query_cmd = "psql %s --pset footer --no-psqlrc -v ON_ERROR_STOP=1 -Atq -h %s -p %s -U %s -f %s" % (db, host, port, user, toolkit_sql)
     print(query_cmd)
 
     p = subprocess.Popen(query_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ)
 
-    if p.wait() != 0:
-        errormsg = p.communicate()[1].decode('ascii')
-        sys.stderr.writelines('\nError when executing function gp_dump_query_oids.\n\n' + errormsg + '\n\n')
-        sys.exit(1)
-
     outmsg, errormsg = p.communicate()
-    if errormsg:
-        sys.stderr.writelines('\nError when executing function gp_dump_query_oids.\n\n' + errormsg + '\n\n')
+    if p.returncode != 0:
+        sys.stderr.writelines('\nError when executing function gp_dump_query_oids.\n\n' + errormsg.decode() + '\n\n')
         sys.exit(1)
     return outmsg
 
@@ -185,8 +180,9 @@ def pg_dump_object(mr_query, connectionInfo, envOpts):
         (dmp_cmd, mr_query.relids, mr_query.funcids, Escape(out_file))
     print(dmp_cmd)
     p = subprocess.Popen(dmp_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
-    if p.wait() != 0:
-        sys.stderr.write('\nError while dumping schema.\n\n' + p.communicate()[1].decode('ascii') + '\n\n')
+    _, errormsg = p.communicate()
+    if p.returncode != 0:
+        sys.stderr.writelines('\nError when executing pg_dump.\n\n' + errormsg.decode() + '\n\n')
         sys.exit(1)
 
 def dump_tuple_count(cur, oid_str, f_out):


### PR DESCRIPTION
Issues:

Minirepro would hang because SQL is too big and syntax is wrong.

[gpadmin@smdw tmp]$ minirepro gpadmin -q query2.sql -f test.out
Connecting to database: host=smdw, port=8450, user=gpadmin, db=gpadmin ...
Extracting metadata from query file query2.sql ...
psql gpadmin --pset footer --no-psqlrc -Atq -h smdw -p 8450 -U gpadmin -f /tmp/20191101054341/toolkit.sql


The reason for that is because p.wait() has a deadlock issue with P.open; if the input SQL has a syntax error, it would error out to the pipe buffer and if the error is too large, it would make the mini-repro hang.

Python's explanation is as below:

https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait

I removed the p.wait() code and just use the p.communicate() for error handling

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
