### PR TITLE
Make regression test dpe unflaky.

### DIFF
--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -26,8 +26,16 @@ NOTICE:  CREATE TABLE will create partition "pt_1_prt_3" for table "pt"
 NOTICE:  CREATE TABLE will create partition "pt_1_prt_4" for table "pt"
 NOTICE:  CREATE TABLE will create partition "pt_1_prt_5" for table "pt"
 NOTICE:  CREATE TABLE will create partition "pt_1_prt_6" for table "pt"
+-- pt1 table is originally created distributed randomly
+-- But a random policy impacts data distribution which
+-- might lead to unstable stats info. Some test cases
+-- test plan thus become flaky. We avoid flakiness by
+-- creating the table distributed hashly and after
+-- loading all the data, changing policy to randomly without
+-- data movement. Thus every time we will have a static
+-- data distribution plus randomly policy.
 create table pt1(dist int, pt1 text, pt2 text, pt3 text, ptid int) 
-DISTRIBUTED RANDOMLY
+DISTRIBUTED BY (dist)
 PARTITION BY RANGE(ptid) 
           (
           START (0) END (5) EVERY (1),
@@ -64,6 +72,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'di
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into pt1 select * from pt;
 insert into pt1 select dist, pt1, pt2, pt3, ptid-100 from pt;
+alter table pt1 set with(REORGANIZE=false) DISTRIBUTED RANDOMLY;
 analyze pt;
 analyze pt1;
 analyze t;

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -26,8 +26,16 @@ NOTICE:  CREATE TABLE will create partition "pt_1_prt_3" for table "pt"
 NOTICE:  CREATE TABLE will create partition "pt_1_prt_4" for table "pt"
 NOTICE:  CREATE TABLE will create partition "pt_1_prt_5" for table "pt"
 NOTICE:  CREATE TABLE will create partition "pt_1_prt_6" for table "pt"
+-- pt1 table is originally created distributed randomly
+-- But a random policy impacts data distribution which
+-- might lead to unstable stats info. Some test cases
+-- test plan thus become flaky. We avoid flakiness by
+-- creating the table distributed hashly and after
+-- loading all the data, changing policy to randomly without
+-- data movement. Thus every time we will have a static
+-- data distribution plus randomly policy.
 create table pt1(dist int, pt1 text, pt2 text, pt3 text, ptid int) 
-DISTRIBUTED RANDOMLY
+DISTRIBUTED BY (dist)
 PARTITION BY RANGE(ptid) 
           (
           START (0) END (5) EVERY (1),
@@ -63,6 +71,7 @@ create table t1 as select * from t;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 insert into pt1 select * from pt;
 insert into pt1 select dist, pt1, pt2, pt3, ptid-100 from pt;
+alter table pt1 set with(REORGANIZE=false) DISTRIBUTED RANDOMLY;
 analyze pt;
 analyze pt1;
 analyze t;

--- a/src/test/regress/sql/dpe.sql
+++ b/src/test/regress/sql/dpe.sql
@@ -18,8 +18,16 @@ PARTITION BY RANGE(ptid)
           )
 ;
 
+-- pt1 table is originally created distributed randomly
+-- But a random policy impacts data distribution which
+-- might lead to unstable stats info. Some test cases
+-- test plan thus become flaky. We avoid flakiness by
+-- creating the table distributed hashly and after
+-- loading all the data, changing policy to randomly without
+-- data movement. Thus every time we will have a static
+-- data distribution plus randomly policy.
 create table pt1(dist int, pt1 text, pt2 text, pt3 text, ptid int) 
-DISTRIBUTED RANDOMLY
+DISTRIBUTED BY (dist)
 PARTITION BY RANGE(ptid) 
           (
           START (0) END (5) EVERY (1),
@@ -40,6 +48,8 @@ create table t1 as select * from t;
 
 insert into pt1 select * from pt;
 insert into pt1 select dist, pt1, pt2, pt3, ptid-100 from pt;
+
+alter table pt1 set with(REORGANIZE=false) DISTRIBUTED RANDOMLY;
 
 analyze pt;
 analyze pt1;


### PR DESCRIPTION
regression/dpe case fails by accident sometimes in the
pipeline. It fails always at the same place for the following
test of plan:

  explain select * from pt, pt1 where pt.ptid = pt1.ptid and
  pt.pt1 = 'hello0' order by pt1.dist;

I found even it fails, the plan is correct, but with different
cost.

The root cause is that pt1 is distribtued randomly, then data
distribution is not stable. For some extreme cases, it may lead
to different stats info that impacts the plan cost.

This commit fixes this by creating the table distributed hashly
and after loading all the data, changing policy to randomly without
data movement. Thus every time we will have a static data distribution
plus randomly policy.

-------------------------------

Before this patch, I run dpe locally 20 times, it fails 2 times. **Also, I found that even it does not fails, the cost changes each time for the following plan.**

After this patch, I run dpe locally 20 times, fails 0 times.

I believe it should fix the issue. I will keep run the case the whole night to see if it is fixed.

--------------------------

Some fails: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/zlv_null_constrain/jobs/icw_planner_centos6/builds/5

https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_pr/jobs/compile_and_test_gpdb/builds/2675

https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_pr/jobs/compile_and_test_gpdb/builds/2716

---------------------------------

Expected plan:

```sql
explain select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt1.dist;
                                                  QUERY PLAN
---------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)  (cost=41.39..41.53 rows=55 width=62)
   Merge Key: pt1_1_prt_junk_data.dist
   ->  Sort  (cost=41.39..41.53 rows=19 width=62)
         Sort Key: pt1_1_prt_junk_data.dist
         ->  Hash Join  (cost=19.14..39.84 rows=19 width=62)
               Hash Cond: (pt1_1_prt_junk_data.ptid = pt_1_prt_junk_data.ptid)
               ->  Append  (cost=0.00..19.08 rows=36 width=31)
                     ->  Result  (cost=0.00..3.63 rows=21 width=31)
                           One-Time Filter: PartSelected
                           ->  Seq Scan on pt1_1_prt_junk_data  (cost=0.00..3.63 rows=21 width=31)
                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
                           One-Time Filter: PartSelected
                           ->  Seq Scan on pt1_1_prt_2  (cost=0.00..3.09 rows=3 width=31)
                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
                           One-Time Filter: PartSelected
                           ->  Seq Scan on pt1_1_prt_3  (cost=0.00..3.09 rows=3 width=31)
                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
                           One-Time Filter: PartSelected
                           ->  Seq Scan on pt1_1_prt_4  (cost=0.00..3.09 rows=3 width=31)
                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
                           One-Time Filter: PartSelected
                           ->  Seq Scan on pt1_1_prt_5  (cost=0.00..3.09 rows=3 width=31)
                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
                           One-Time Filter: PartSelected
                           ->  Seq Scan on pt1_1_prt_6  (cost=0.00..3.09 rows=3 width=31)
               ->  Hash  (cost=18.91..18.91 rows=6 width=31)
                     ->  Partition Selector for pt1 (dynamic scan id: 2)  (cost=0.00..18.91 rows=6 width=31)
                           Filter: pt_1_prt_junk_data.ptid
                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.91 rows=6 width=31)
                                 ->  Append  (cost=0.00..18.68 rows=2 width=31)
                                       ->  Seq Scan on pt_1_prt_junk_data  (cost=0.00..3.11 rows=1 width=31)
                                             Filter: (pt1 = 'hello0'::text)
                                       ->  Seq Scan on pt_1_prt_2  (cost=0.00..3.11 rows=1 width=31)
                                             Filter: (pt1 = 'hello0'::text)
                                       ->  Seq Scan on pt_1_prt_3  (cost=0.00..3.11 rows=1 width=31)
                                             Filter: (pt1 = 'hello0'::text)
                                       ->  Seq Scan on pt_1_prt_4  (cost=0.00..3.11 rows=1 width=31)
                                             Filter: (pt1 = 'hello0'::text)
                                       ->  Seq Scan on pt_1_prt_5  (cost=0.00..3.11 rows=1 width=31)
                                             Filter: (pt1 = 'hello0'::text)
                                       ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.11 rows=1 width=31)
                                             Filter: (pt1 = 'hello0'::text)
```

-----------

Flaky fail plan:

```sql
explain select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt1.dist;
                                            QUERY PLAN
---------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)  (cost=39.69..39.82 rows=55 width=62)
   Merge Key: pt1_1_prt_junk_data.dist
   ->  Sort  (cost=39.69..39.82 rows=19 width=62)
         Sort Key: pt1_1_prt_junk_data.dist
         ->  Hash Join  (cost=18.43..38.13 rows=19 width=62)
               Hash Cond: (pt_1_prt_junk_data.ptid = pt1_1_prt_junk_data.ptid)
               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.91 rows=6 width=31)
                     ->  Append  (cost=0.00..18.68 rows=2 width=31)
                           ->  Seq Scan on pt_1_prt_junk_data  (cost=0.00..3.11 rows=1 width=31)
                                 Filter: (pt1 = 'hello0'::text)
                           ->  Seq Scan on pt_1_prt_2  (cost=0.00..3.11 rows=1 width=31)
                                 Filter: (pt1 = 'hello0'::text)
                           ->  Seq Scan on pt_1_prt_3  (cost=0.00..3.11 rows=1 width=31)
                                 Filter: (pt1 = 'hello0'::text)
                           ->  Seq Scan on pt_1_prt_4  (cost=0.00..3.11 rows=1 width=31)
                                 Filter: (pt1 = 'hello0'::text)
                           ->  Seq Scan on pt_1_prt_5  (cost=0.00..3.11 rows=1 width=31)
                                 Filter: (pt1 = 'hello0'::text)
                           ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.11 rows=1 width=31)
                                 Filter: (pt1 = 'hello0'::text)
               ->  Hash  (cost=17.08..17.08 rows=36 width=31)
                     ->  Append  (cost=0.00..17.08 rows=36 width=31)
                           ->  Seq Scan on pt1_1_prt_junk_data  (cost=0.00..3.63 rows=21 width=31)
                           ->  Seq Scan on pt1_1_prt_2  (cost=0.00..3.09 rows=3 width=31)
                           ->  Seq Scan on pt1_1_prt_3  (cost=0.00..2.09 rows=3 width=31)
                           ->  Seq Scan on pt1_1_prt_4  (cost=0.00..3.09 rows=3 width=31)
                           ->  Seq Scan on pt1_1_prt_5  (cost=0.00..3.09 rows=3 width=31)
                           ->  Seq Scan on pt1_1_prt_6  (cost=0.00..2.09 rows=3 width=31)
 Optimizer: Postgres query optimizer
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
