### PR TITLE
Re-enable GCC's aggressive loop optimizations.

### DIFF
--- a/configure
+++ b/configure
@@ -5620,43 +5620,6 @@ if test x"$pgac_cv_prog_cc_cflags__fexcess_precision_standard" = x"yes"; then
   CFLAGS="$CFLAGS -fexcess-precision=standard"
 fi
 
-  # Disable loop optimizations that get confused by variable-length struct
-  # declarations in gcc 4.8+
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -fno-aggressive-loop-optimizations" >&5
-$as_echo_n "checking whether $CC supports -fno-aggressive-loop-optimizations... " >&6; }
-if ${pgac_cv_prog_cc_cflags__fno_aggressive_loop_optimizations+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  pgac_save_CFLAGS=$CFLAGS
-CFLAGS="$pgac_save_CFLAGS -fno-aggressive-loop-optimizations"
-ac_save_c_werror_flag=$ac_c_werror_flag
-ac_c_werror_flag=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  pgac_cv_prog_cc_cflags__fno_aggressive_loop_optimizations=yes
-else
-  pgac_cv_prog_cc_cflags__fno_aggressive_loop_optimizations=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-ac_c_werror_flag=$ac_save_c_werror_flag
-CFLAGS="$pgac_save_CFLAGS"
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__fno_aggressive_loop_optimizations" >&5
-$as_echo "$pgac_cv_prog_cc_cflags__fno_aggressive_loop_optimizations" >&6; }
-if test x"$pgac_cv_prog_cc_cflags__fno_aggressive_loop_optimizations" = x"yes"; then
-  CFLAGS="$CFLAGS -fno-aggressive-loop-optimizations"
-fi
-
 
   # Silence compiler warnings that you get with modern versions of GCC.
   # All of these warnings have been fixed in later versions of PostgreSQL,

--- a/configure.in
+++ b/configure.in
@@ -610,9 +610,6 @@ if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-fwrapv])
   # Disable FP optimizations that cause various errors on gcc 4.5+ or maybe 4.6+
   PGAC_PROG_CC_CFLAGS_OPT([-fexcess-precision=standard])
-  # Disable loop optimizations that get confused by variable-length struct
-  # declarations in gcc 4.8+
-  PGAC_PROG_CC_CFLAGS_OPT([-fno-aggressive-loop-optimizations])
 
   # Silence compiler warnings that you get with modern versions of GCC.
   # All of these warnings have been fixed in later versions of PostgreSQL,


### PR DESCRIPTION
We had backported commit 649839dd9f earlier, to work around problems with
variable-length arrays that were embedded in some larger struct. But those
issues were later fixed, by hiding such structs from Form_pg_* structs, and
using FLEXIBLE_ARRAY_MEMBER where appropriate. They were fixed in
PostgreSQL 9.2, so we have those fixes in GPDB 'master' now.
