### PR TITLE
Add a flag to print cmockery failed output and summary to file

### DIFF
--- a/contrib/pg_upgrade/test/integration/Makefile
+++ b/contrib/pg_upgrade/test/integration/Makefile
@@ -16,6 +16,11 @@ OBJS = bdd-library/bdd.o \
 EXS = scripts/gpdb6-cluster scripts/gpdb5-cluster
 TARGETS = greenplum_five_to_greenplum_six_upgrade_test_suite
 
+#
+# TESTING FLAGS
+#
+CMOCKERY_TEST_FLAGS+="--cmockery_output_to_file=cmockery.out"
+
 include $(top_srcdir)/src/Makefile.global
 include $(top_srcdir)/src/Makefile.mock
 

--- a/src/Makefile.mock
+++ b/src/Makefile.mock
@@ -22,7 +22,7 @@ check: $(patsubst %,%-check,$(TARGETS))
 
 .PHONY:
 %-check: %.t
-	./$*.t
+	./$*.t $(CMOCKERY_TEST_FLAGS)
 
 .PHONY:
 clean: $(patsubst %,%-clean,$(TARGETS))

--- a/src/test/unit/README.txt
+++ b/src/test/unit/README.txt
@@ -149,7 +149,18 @@ The test framework accepts command line arguments:
   and will_ calls, it is helpful to setup the test environment. This is 
   especially true, if the test only deals with a certain line in a very long 
   function.
-  
+
+- --cmockery_output_to_file=<arg>
+  In certain situations, is helpful to call the test executable with
+  --cmockery_output_to_file=<arg>. When this option is activated or if the
+  cmockery_output_to_file(arg) function is called, cmockery outputs _error and
+  _fail function outputs to the file passed. Additionally the result of a
+  specific test is added to the output as is a summary of the whole suit.
+
+  While in most cases the output of the unit tests run in a suit is
+  straightforward and easy to read, in long running suites or with verbose
+  output, it is useful to have a cleaner or permanent output.
+
 - --run_disabled_tests
   Certain test cases can be disabled with the disable_unit_test() function. 
   If cmockery is called with --run_disabled_tests, these tests are executed 

--- a/src/test/unit/cmockery/cmockery.h
+++ b/src/test/unit/cmockery/cmockery.h
@@ -584,6 +584,9 @@ void cmockery_enable_generate_suppression(void);
 // Runs also disabled tests
 void cmockery_run_disabled_tests(void);
 
+// Print test output also to file whose full name is passed as an argument
+void cmockery_enable_output_to_file(const char *);
+
 // Prints a message that a test is temporarily disabled
 int cmockery_test_deactivated_(const char * const function, const char* file, const int line);
 


### PR DESCRIPTION
Also use it in upgrade tests.

In certain situations, is helpful to call the test executable with
--cmockery_output_to_file=<arg>. When this option is activated or if the
cmockery_output_to_file(arg) function is called, cmockery outputs _error and
_fail function outputs to the file passed. Additionally the result of a specific
test is added to the output as is a summary of the whole suit.

This does not work on windows installations as they might have a debugging
session attached to them.

Finally this is a minimal effort approach.
