### PR TITLE
6X: resgroup: use proper memory context when checking bypass mode

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3440,7 +3440,8 @@ groupWaitQueueFind(ResGroupData *group, const PGPROC *proc)
 static bool
 shouldBypassQuery(const char *query_string)
 {
-	MemoryContext oldcontext;
+	MemoryContext oldcontext = NULL;
+	MemoryContext tmpcontext = NULL;
 	List *parsetree_list; 
 	ListCell *parsetree_item;
 	Node *parsetree;
@@ -3454,8 +3455,27 @@ shouldBypassQuery(const char *query_string)
 
 	/*
 	 * Switch to appropriate context for constructing parsetrees.
+	 *
+	 * It is possible that MessageContext is NULL, for example in a bgworker:
+	 *
+	 *     debug_query_string = "select 1";
+	 *     StartTransactionCommand();
+	 *
+	 * This is not the recommended order of setting debug_query_string, but we
+	 * should not put a constraint on the order by resource group anyway.
 	 */
-	oldcontext = MemoryContextSwitchTo(MessageContext);
+	if (MessageContext)
+		oldcontext = MemoryContextSwitchTo(MessageContext);
+	else
+	{
+		/* Create a temp memory context to prevent memory leaks */
+		tmpcontext = AllocSetContextCreate(CurrentMemoryContext,
+										   "resgroup temporary context",
+										   ALLOCSET_DEFAULT_MINSIZE,
+										   ALLOCSET_DEFAULT_INITSIZE,
+										   ALLOCSET_DEFAULT_MAXSIZE);
+		oldcontext = MemoryContextSwitchTo(tmpcontext);
+	}
 
 	parsetree_list = pg_parse_query(query_string);
 
@@ -3479,6 +3499,10 @@ shouldBypassQuery(const char *query_string)
 	}
 
 	list_free_deep(parsetree_list);
+
+	if (tmpcontext)
+		MemoryContextDelete(tmpcontext);
+
 	return bypass;
 }
 


### PR DESCRIPTION
In shouldBypassQuery() we used to parse the query_string with the memory
context MessageContext, however when it is NULL we would crash at
runtime, this is possible by extensions or bgworkers when executing like
below:

    debug_query_string = "select 1";
    StartTransactionCommand();

This is not the recommended order to set debug_query_string, however we
should not put a constraint on the order by resource group anyway.

To fix this we create and switch to a temporary memory context when
MessageContext is NULL.

Reviewed-by: Georgios Kokolatos <gkokolatos@pivotal.io>
Reviewed-by: Haozhou Wang <hawang@pivotal.io>

(cherry picked from commit c4012ffa69112a126572b72e612878449a16cb3e)

This is the 6X version of https://github.com/greenplum-db/gpdb/pull/8981

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
