### PR TITLE
5X: resgroup: use proper memory context when checking bypass mode

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3473,7 +3473,8 @@ groupWaitQueueFind(ResGroupData *group, const PGPROC *proc)
 static bool
 shouldBypassQuery(const char *query_string)
 {
-	MemoryContext oldcontext;
+	MemoryContext oldcontext = NULL;
+	MemoryContext tmpcontext = NULL;
 	List *parsetree_list; 
 	ListCell *parsetree_item;
 	Node *parsetree;
@@ -3486,8 +3487,27 @@ shouldBypassQuery(const char *query_string)
 
 	/*
 	 * Switch to appropriate context for constructing parsetrees.
+	 *
+	 * It is possible that MessageContext is NULL, for example in a bgworker:
+	 *
+	 *     debug_query_string = "select 1";
+	 *     StartTransactionCommand();
+	 *
+	 * This is not the recommended order of setting debug_query_string, but we
+	 * should not put a constraint on the order by resource group anyway.
 	 */
-	oldcontext = MemoryContextSwitchTo(MessageContext);
+	if (MessageContext)
+		oldcontext = MemoryContextSwitchTo(MessageContext);
+	else
+	{
+		/* Create a temp memory context to prevent memory leaks */
+		tmpcontext = AllocSetContextCreate(CurrentMemoryContext,
+										   "resgroup temporary context",
+										   ALLOCSET_DEFAULT_MINSIZE,
+										   ALLOCSET_DEFAULT_INITSIZE,
+										   ALLOCSET_DEFAULT_MAXSIZE);
+		oldcontext = MemoryContextSwitchTo(tmpcontext);
+	}
 
 	parsetree_list = pg_parse_query(query_string);
 
@@ -3505,6 +3525,11 @@ shouldBypassQuery(const char *query_string)
 			nodeTag(parsetree) != T_VariableShowStmt)
 			return false;
 	}
+
+	list_free_deep(parsetree_list);
+
+	if (tmpcontext)
+		MemoryContextDelete(tmpcontext);
 
 	return true;
 }

--- a/src/backend/utils/resgroup/test/resgroup_test.c
+++ b/src/backend/utils/resgroup/test/resgroup_test.c
@@ -8,11 +8,18 @@
 #define test_with_setup_and_teardown(test_func) \
 	unit_test_setup_teardown(test_func, setup, teardown)
 
+MemoryContext *OrigMessageContext;
+
 void
 setup(void **state)
 {
 	/* reset the hook function pointer to avoid test pollution. */
 	resgroup_assign_hook = NULL;
+
+	/* initializations for shouldBypassQuery() */
+	gp_resource_group_bypass = false;
+	debug_query_string = NULL;
+	MessageContext = OrigMessageContext;
 }
 
 void
@@ -280,6 +287,66 @@ test_CpusetOperation(void **state)
 	//assert_string_equal(cpuset, "0");
 }
 
+static void
+test__shouldBypassQuery__null_query(void **state)
+{
+	assert_false(shouldBypassQuery(NULL));
+}
+
+static void
+test__shouldBypassQuery__empty_query(void **state)
+{
+	assert_false(shouldBypassQuery(""));
+}
+
+static void
+test__shouldBypassQuery__cmd_select(void **state)
+{
+	assert_false(shouldBypassQuery("select 1"));
+}
+
+static void
+test__shouldBypassQuery__cmd_set(void **state)
+{
+	assert_true(shouldBypassQuery("set enable_sort to off"));
+}
+
+static void
+test__shouldBypassQuery__cmd_reset(void **state)
+{
+	assert_true(shouldBypassQuery("reset enable_sort"));
+}
+
+static void
+test__shouldBypassQuery__cmd_show(void **state)
+{
+	assert_true(shouldBypassQuery("show enable_sort"));
+}
+
+static void
+test__shouldBypassQuery__cmd_mixed(void **state)
+{
+	assert_false(shouldBypassQuery("select 1; show enable_sort;"));
+	assert_false(shouldBypassQuery("show enable_sort; select 1;"));
+	assert_true(shouldBypassQuery("reset enable_sort; show enable_sort;"));
+}
+
+static void
+test__shouldBypassQuery__forced_bypass_mode(void **state)
+{
+	gp_resource_group_bypass = true;
+
+	assert_true(shouldBypassQuery("select 1"));
+}
+
+static void
+test__shouldBypassQuery__message_context_is_null(void **state)
+{
+	MessageContext = NULL;
+
+	assert_false(shouldBypassQuery("select 1"));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -294,8 +361,22 @@ main(int argc, char *argv[])
 			unit_test(test__CpusetToBitset_abnormal_case),
 			unit_test(test_BitsetToCpuset),
 			unit_test(test_CpusetOperation),
+			test_with_setup_and_teardown(test__shouldBypassQuery__null_query),
+			test_with_setup_and_teardown(test__shouldBypassQuery__empty_query),
+			test_with_setup_and_teardown(test__shouldBypassQuery__cmd_select),
+			test_with_setup_and_teardown(test__shouldBypassQuery__cmd_set),
+			test_with_setup_and_teardown(test__shouldBypassQuery__cmd_reset),
+			test_with_setup_and_teardown(test__shouldBypassQuery__cmd_show),
+			test_with_setup_and_teardown(test__shouldBypassQuery__cmd_mixed),
+			test_with_setup_and_teardown(test__shouldBypassQuery__forced_bypass_mode),
+			test_with_setup_and_teardown(test__shouldBypassQuery__message_context_is_null),
 	};
 
 	MemoryContextInit();
+	OrigMessageContext = AllocSetContextCreate(TopMemoryContext,
+											   "MessageContext",
+											   ALLOCSET_DEFAULT_MINSIZE,
+											   ALLOCSET_DEFAULT_INITSIZE,
+											   ALLOCSET_DEFAULT_MAXSIZE);
 	run_tests(tests);
 }


### PR DESCRIPTION
In shouldBypassQuery() we used to parse the query_string with the memory
context MessageContext, however when it is NULL we would crash at
runtime, this is possible by extensions or bgworkers when executing like
below:

    debug_query_string = "select 1";
    StartTransactionCommand();

This is not the recommended order to set debug_query_string, however we
should not put a constraint on the order by resource group anyway.

To fix this we create and switch to a temporary memory context when
MessageContext is NULL.

Reviewed-by: Georgios Kokolatos <gkokolatos@pivotal.io>
Reviewed-by: Haozhou Wang <hawang@pivotal.io>

(cherry picked from commit c4012ffa69112a126572b72e612878449a16cb3e)

This is the 5X version of https://github.com/greenplum-db/gpdb/pull/8981

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
- [x] Greenlight from PM team
