### PR TITLE
docs - Add DROP TABLESPACE note about concurrent create table.

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_TABLESPACE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_TABLESPACE.xml
@@ -1,13 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="dj20941">DROP TABLESPACE</title><body><p id="sql_command_desc">Removes a tablespace.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DROP TABLESPACE [IF EXISTS] <varname>tablespacename</varname></codeblock></section><section id="section3"><title>Description</title><p><codeph>DROP TABLESPACE</codeph> removes a tablespace from the system.
-</p><p>A tablespace can only be dropped by its owner or a superuser. The tablespace must be empty of all
-        database objects before it can be dropped. It is possible that objects in other databases
-        may still reside in the tablespace even if no objects in the current database are using the
-        tablespace. Also, if the tablespace is listed in the <xref
+<topic id="topic1">
+  <title id="dj20941">DROP TABLESPACE</title>
+  <body>
+    <p id="sql_command_desc">Removes a tablespace.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock id="sql_command_synopsis">DROP TABLESPACE [IF EXISTS] <varname>tablespacename</varname></codeblock>
+    </section>
+    <section id="section3">
+      <title>Description</title>
+      <p><codeph>DROP TABLESPACE</codeph> removes a tablespace from the system. </p>
+      <p>A tablespace can only be dropped by its owner or a superuser. The tablespace must be empty
+        of all database objects before it can be dropped. It is possible that objects in other
+        databases may still reside in the tablespace even if no objects in the current database are
+        using the tablespace. Also, if the tablespace is listed in the <xref
           href="../config_params/guc-list.xml#topic_k52_fqm_f3b"/> setting of any active session,
-        the <codeph>DROP</codeph> might fail due to temporary files residing in the tablespace.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt>IF EXISTS</pt><pd>Do not throw an error if the tablespace does not exist. A notice
-is issued in this case.</pd></plentry><plentry><pt><varname>tablespacename</varname></pt><pd>The name of the tablespace to remove.</pd></plentry></parml></section><section id="section5"><title>Examples</title><p>Remove the tablespace <codeph>mystuff</codeph>: </p><codeblock>DROP TABLESPACE mystuff;</codeblock></section><section id="section6"><title>Compatibility</title><p><codeph>DROP TABLESPACE</codeph> is a Greenplum Database extension.</p></section><section id="section7"><title>See Also</title><p><codeph><xref href="CREATE_TABLESPACE.xml#topic1" type="topic" format="dita"/></codeph>,
+          <codeph>DROP TABLESPACE</codeph> might fail due to temporary files residing in the
+        tablespace.</p>
+    </section>
+    <section id="section4">
+      <title>Parameters</title>
+      <parml>
+        <plentry>
+          <pt>IF EXISTS</pt>
+          <pd>Do not throw an error if the tablespace does not exist. A notice is issued in this
+            case.</pd>
+        </plentry>
+        <plentry>
+          <pt><varname>tablespacename</varname></pt>
+          <pd>The name of the tablespace to remove.</pd>
+        </plentry>
+      </parml>
+    </section>
+    <section>
+      <title>Notes</title>
+      <p>The <codeph>DROP TABLESPACE</codeph> command should be run during a period of low activity
+        to avoid issues due to concurrent creation of tables and temporary objects. When a
+        tablespace is dropped, there is a small window in which a table could be created in the
+        tablespace which is currently being dropped. If this occurs, Greenplum Database returns a
+        warning. This is an example of the <codeph>DROP TABLESPACE</codeph> warning.</p>
+      <codeblock>testdb=# DROP TABLESPACE mytest; 
+WARNING:  tablespace with oid "16415" is not empty  (seg1 192.168.8.145:25433 pid=29023)
+WARNING:  tablespace with oid "16415" is not empty  (seg0 192.168.8.145:25432 pid=29022)
+WARNING:  tablespace with oid "16415" is not empty
+DROP TABLESPACE</codeblock>
+      <p>The table data in the tablespace directory is not dropped. You can use the <codeph><xref
+            href="ALTER_TABLE.xml" type="topic" format="dita"/></codeph> command to change the
+        tablespace defined for the table and move the data to an existing tablespace.</p>
+    </section>
+    <section id="section5">
+      <title>Examples</title>
+      <p>Remove the tablespace <codeph>mystuff</codeph>: </p>
+      <codeblock>DROP TABLESPACE mystuff;</codeblock>
+    </section>
+    <section id="section6">
+      <title>Compatibility</title>
+      <p><codeph>DROP TABLESPACE</codeph> is a Greenplum Database extension.</p>
+    </section>
+    <section id="section7">
+      <title>See Also</title>
+      <p><codeph><xref href="CREATE_TABLESPACE.xml#topic1" type="topic" format="dita"/></codeph>,
             <codeph><xref href="ALTER_TABLESPACE.xml#topic1" type="topic" format="dita"
-        /></codeph></p></section></body></topic>
+        /></codeph></p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_TABLESPACE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_TABLESPACE.xml
@@ -36,11 +36,11 @@
     </section>
     <section>
       <title>Notes</title>
-      <p>The <codeph>DROP TABLESPACE</codeph> command should be run during a period of low activity
-        to avoid issues due to concurrent creation of tables and temporary objects. When a
-        tablespace is dropped, there is a small window in which a table could be created in the
-        tablespace which is currently being dropped. If this occurs, Greenplum Database returns a
-        warning. This is an example of the <codeph>DROP TABLESPACE</codeph> warning.</p>
+      <p>Run <codeph>DROP TABLESPACE</codeph> during a period of low activity to avoid issues due to
+        concurrent creation of tables and temporary objects. When a tablespace is dropped, there is
+        a small window in which a table could be created in the tablespace that is currently being
+        dropped. If this occurs, Greenplum Database returns a warning. This is an example of the
+          <codeph>DROP TABLESPACE</codeph> warning.</p>
       <codeblock>testdb=# DROP TABLESPACE mytest; 
 WARNING:  tablespace with oid "16415" is not empty  (seg1 192.168.8.145:25433 pid=29023)
 WARNING:  tablespace with oid "16415" is not empty  (seg0 192.168.8.145:25432 pid=29022)


### PR DESCRIPTION

To be backported to 6X_STABLE

Related dev PR https://github.com/greenplum-db/gpdb/pull/8777