### PR TITLE
Put udp tx buff in correct memory context.

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -2589,6 +2589,10 @@ getSndBuffer(MotionConn *conn)
 	{
 		if (snd_buffer_pool.count < snd_buffer_pool.maxCount)
 		{
+			MemoryContext oldContext;
+
+			oldContext = MemoryContextSwitchTo(InterconnectContext);
+
 			ret = (ICBuffer *) palloc0(Gp_max_packet_size + sizeof(ICBuffer));
 			snd_buffer_pool.count++;
 			ret->conn = NULL;
@@ -2596,6 +2600,8 @@ getSndBuffer(MotionConn *conn)
 			icBufferListInitHeadLink(&ret->primary);
 			icBufferListInitHeadLink(&ret->secondary);
 			ret->unackQueueRingSlot = 0;
+
+			MemoryContextSwitchTo(oldContext);
 		}
 		else
 		{


### PR DESCRIPTION
This fixes a panic in udp interconnect code. Previously that buffer could be
allocated in either InterconnectContext (correct) or ExecutorState memory
context (wrong).

For the late wrong case, the palloc-ed memory could be earlier freed in
AbortTransaction()->AtAbort_Portals() so later access in TeardownInterconnect()
would panic.

See stack below for details.

(gdb) bt
0  0x00007f0219e324ab in raise (sig=11) at ../nptl/sysdeps/unix/sysv/linux/pt-raise.c:37
1  0x0000000000ae579b in StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=0xdd1f02 "Segment process", postgres_signal_arg=11) at elog.c:5571
2  0x000000000096f7e8 in CdbProgramErrorHandler (postgres_signal_arg=11) at postgres.c:3518
3  <signal handler called>
4  0x0000000000b836ea in icBufferListCheck (prefix=0xe6c86e "icBufferListAppend", list=0x11db188 <snd_buffer_pool+8>) at ic_udpifc.c:2266
5  0x0000000000b839e1 in icBufferListAppend (list=0x11db188 <snd_buffer_pool+8>, buf=0x28ab018) at ic_udpifc.c:2435
6  0x0000000000b83afa in icBufferListReturn (list=0x287ac98, inExpirationQueue=0 '\000') at ic_udpifc.c:2478
7  0x0000000000b85f0d in TeardownUDPIFCInterconnect_Internal (transportStates=0x2879e68, forceEOS=1 '\001') at ic_udpifc.c:3468
8  0x0000000000b867bc in TeardownUDPIFCInterconnect (transportStates=0x2879e68, forceEOS=1 '\001') at ic_udpifc.c:3667
9  0x0000000000b77ed6 in TeardownInterconnect (transportStates=0x2879e68, forceEOS=1 '\001', hasError=1 '\001') at ic_common.c:579
10 0x0000000000b787ef in cleanup_interconnect_handle (h=0x2879dd8) at ic_common.c:860
11 0x0000000000b78885 in interconnect_abort_callback (phase=RESOURCE_RELEASE_AFTER_LOCKS, isCommit=0 '\000', isTopLevel=1 '\001', arg=0x0) at ic_common.c:886
12 0x0000000000b26511 in ResourceOwnerReleaseInternal (owner=0x2844d98, phase=RESOURCE_RELEASE_AFTER_LOCKS, isCommit=0 '\000', isTopLevel=1 '\001') at resowner.c:423
13 0x0000000000b25f9f in ResourceOwnerReleaseInternal (owner=0x27e28f8, phase=RESOURCE_RELEASE_AFTER_LOCKS, isCommit=0 '\000', isTopLevel=1 '\001') at resowner.c:248
14 0x0000000000b25f18 in ResourceOwnerRelease (owner=0x27e28f8, phase=RESOURCE_RELEASE_AFTER_LOCKS, isCommit=0 '\000', isTopLevel=1 '\001') at resowner.c:225
15 0x000000000053ba23 in AbortTransaction () at xact.c:3373
16 0x000000000053e0a7 in AbortOutOfAnyTransaction () at xact.c:5248
17 0x0000000000af7691 in ShutdownPostgres (code=1, arg=0) at postinit.c:1341
18 0x000000000093c371 in shmem_exit (code=1) at ipc.c:257
19 0x000000000093c266 in proc_exit_prepare (code=1) at ipc.c:214
20 0x000000000093c164 in proc_exit (code=1) at ipc.c:104
21 0x0000000000adb94e in errfinish (dummy=0) at elog.c:754
22 0x000000000096fd27 in ProcessInterrupts (filename=0xe6b8c0 "../../../../src/include/cdb/cdbicudpfaultinjection.h", lineno=109) at postgres.c:3751
23 0x0000000000b8033c in testmode_check_interrupts (caller_name=0xe6f098 <__func__.41735> "pollAcks", teardownActive=0 '\000')
   at ../../../../src/include/cdb/cdbicudpfaultinjection.h:109
24 0x0000000000b89712 in pollAcks (transportStates=0x2879e68, fd=7, timeout=20) at ic_udpifc.c:5215
25 0x0000000000b8a3c2 in SendEosUDPIFC (transportStates=0x2879e68, motNodeID=1, tcItem=0x11d8c80 <s_eos_buffer>) at ic_udpifc.c:5599
26 0x0000000000b725d3 in SendEndOfStream (mlStates=0x27de568, transportStates=0x2879e68, motNodeID=1) at cdbmotion.c:544
27 0x0000000000791d28 in doSendEndOfStream (motion=0x288ca18, node=0x2878128) at nodeMotion.c:1453
28 0x000000000078fd8e in execMotionSender (node=0x2878128) at nodeMotion.c:318
29 0x000000000078fc2f in ExecMotion (node=0x2878128) at nodeMotion.c:252
30 0x000000000073f139 in ExecProcNode (node=0x2878128) at execProcnode.c:1121
31 0x00000000007395f7 in ExecutePlan (estate=0x2877db8, planstate=0x2878128, operation=CMD_SELECT, sendTuples=0 '\000', numberTuples=0,
   direction=ForwardScanDirection, dest=0x2890380) at execMain.c:2979
32 0x0000000000735db5 in standard_ExecutorRun (queryDesc=0x27de148, direction=ForwardScanDirection, count=0) at execMain.c:951
33 0x0000000000735a6d in ExecutorRun (queryDesc=0x27de148, direction=ForwardScanDirection, count=0) at execMain.c:834
34 0x0000000000974b4f in PortalRunSelect (portal=0x28877a8, forward=1 '\001', count=0, dest=0x2890380) at pquery.c:1149
35 0x00000000009747c8 in PortalRun (portal=0x28877a8, count=9223372036854775807, isTopLevel=1 '\001', dest=0x2890380, altdest=0x2890380,
    completionTag=0x7ffe5e46f9e0 "") at pquery.c:990