### PR TITLE
Add isjoinable check in judging whether distkey and redis clase are matched

### DIFF
--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1163,3 +1163,27 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 (9 rows)
 
 drop table t_randomly_dist_table;
+-- test the query have equivalence class with const members
+CREATE TABLE gp_timestamp1 (a int, b timestamp) DISTRIBUTED BY (a, b);
+CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09';
+ a  |            b             
+----+--------------------------
+  2 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  6 | Wed Nov 09 00:00:00 2016
+  1 | Wed Nov 09 00:00:00 2016
+  9 | Wed Nov 09 00:00:00 2016
+ 10 | Wed Nov 09 00:00:00 2016
+ 12 | Wed Nov 09 00:00:00 2016
+  4 | Wed Nov 09 00:00:00 2016
+  5 | Wed Nov 09 00:00:00 2016
+  7 | Wed Nov 09 00:00:00 2016
+  8 | Wed Nov 09 00:00:00 2016
+ 11 | Wed Nov 09 00:00:00 2016
+(13 rows)
+

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1169,6 +1169,8 @@ CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
 INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
 INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(1, 12) i;
 INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+ANALYZE gp_timestamp1;
+ANALYZE gp_timestamp2;
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09';
  a  |            b             
 ----+--------------------------

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1176,6 +1176,8 @@ CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
 INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
 INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(1, 12) i;
 INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+ANALYZE gp_timestamp1;
+ANALYZE gp_timestamp2;
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09';
  a  |            b             
 ----+--------------------------

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1170,3 +1170,27 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 (13 rows)
 
 drop table t_randomly_dist_table;
+-- test the query have equivalence class with const members
+CREATE TABLE gp_timestamp1 (a int, b timestamp) DISTRIBUTED BY (a, b);
+CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09';
+ a  |            b             
+----+--------------------------
+  2 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  6 | Wed Nov 09 00:00:00 2016
+  1 | Wed Nov 09 00:00:00 2016
+  9 | Wed Nov 09 00:00:00 2016
+ 10 | Wed Nov 09 00:00:00 2016
+ 12 | Wed Nov 09 00:00:00 2016
+  4 | Wed Nov 09 00:00:00 2016
+  5 | Wed Nov 09 00:00:00 2016
+  7 | Wed Nov 09 00:00:00 2016
+  8 | Wed Nov 09 00:00:00 2016
+ 11 | Wed Nov 09 00:00:00 2016
+(13 rows)
+

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -554,3 +554,15 @@ select * from (
 join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 
 drop table t_randomly_dist_table;
+
+-- test the query have equivalence class with const members
+CREATE TABLE gp_timestamp1 (a int, b timestamp) DISTRIBUTED BY (a, b);
+CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
+
+
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+
+SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09';
+

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -564,5 +564,8 @@ INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day
 INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(1, 12) i;
 INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
 
+ANALYZE gp_timestamp1;
+ANALYZE gp_timestamp2;
+
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09';
 


### PR DESCRIPTION
If we have a ‘constant expr’ in the EquivalenceClass in the distribution
key, we think this distribution key and join condition are matched. This
inference is completely wrong. Equivalence class inference does not
consider ‘oprcanhash’ attributes in ‘pg_operator’. The ‘oprcanhash’
attribute determines whether the values on both sides of the operator
have the same hash value.
Add a function 'cdbpath_eclass_sources_is_hashable' to determine if
the eclass should be considered. And call it in
'cdbpath_match_preds_to_distkey'.

This pr fixed issue https://github.com/greenplum-db/gpdb/issues/8918
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
