### PR TITLE
On MAC WEXITSTATUS fails with cannot take the address of an rvalue of…

### DIFF
--- a/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.c
+++ b/contrib/pg_upgrade/test/integration/utilities/upgrade-helpers.c
@@ -154,10 +154,10 @@ void
 performUpgradeCheck(void)
 {
 	char		buffer[2000];
-	int			count = 0;
 	char	   *master_data_directory_path = "qddir/demoDataDir-1";
 	FILE	   *output_file;
 	char	   *output;
+	int 	   cmdstatus = 0;
 
 	sprintf(buffer, ""
 			"./gpdb6/bin/pg_upgrade "
@@ -173,8 +173,8 @@ performUpgradeCheck(void)
 
 	while ((output = fgets(buffer, sizeof(buffer), output_file)) != NULL)
 		appendPQExpBufferStr(&pg_upgrade_output, output);
-
-	pg_upgrade_exit_status = WEXITSTATUS(pclose(output_file));
+	cmdstatus = pclose(output_file);
+	pg_upgrade_exit_status = WEXITSTATUS(cmdstatus);
 #endif
 }
 


### PR DESCRIPTION
… type int

On MAC, implementation of WEXITSTATUS uses the address-of operator (unary &)
on its argument, effectively requiring that its argument have storage. Currently,
it being called with the return value of a function, which doesn't have
storage, so the compiler complains.

To workaround the problem, assign the return value of pclose() to a
variable before using WEXITSTATUS
```
utilities/upgrade-helpers.c:177:27: error: cannot take the address of an rvalue of type 'int'
        pg_upgrade_exit_status = WEXITSTATUS(pclose(output_file));
                                 ^           ~~~~~~~~~~~~~~~~~~~
/usr/include/sys/wait.h:144:27: note: expanded from macro 'WEXITSTATUS'
                          ^      ~
/usr/include/sys/wait.h:131:34: note: expanded from macro '_W_INT'
                                 ^ ~
1 error generated.
make: *** [utilities/upgrade-helpers.o] Error 1
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
