### PR TITLE
Add error detail when cached plan and query result types differ

### DIFF
--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -740,7 +740,11 @@ RevalidateCachedQuery(CachedPlanSource *plansource, IntoClause *intoClause)
 		if (plansource->fixed_result)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("cached plan must not change result type")));
+					 errmsg("cached plan must not change result type"),
+					 errdetail("resultDesc is%s NULL. plansource->resulDesc is%s NULL.",
+							   resultDesc ? " not":"",
+							   plansource->resultDesc ? " not":"")));
+
 		oldcxt = MemoryContextSwitchTo(plansource->context);
 		if (resultDesc)
 			resultDesc = CreateTupleDescCopy(resultDesc);

--- a/src/test/regress/expected/plancache.out
+++ b/src/test/regress/expected/plancache.out
@@ -54,8 +54,10 @@ EXECUTE prepstmt2(123);
 ALTER TABLE pcachetest ADD COLUMN q3 bigint;
 EXECUTE prepstmt;
 ERROR:  cached plan must not change result type
+DETAIL:  resultDesc is not NULL. plansource->resulDesc is not NULL.
 EXECUTE prepstmt2(123);
 ERROR:  cached plan must not change result type
+DETAIL:  resultDesc is not NULL. plansource->resulDesc is not NULL.
 -- but we're nice guys and will let you undo your mistake
 ALTER TABLE pcachetest DROP COLUMN q3;
 EXECUTE prepstmt;


### PR DESCRIPTION
It's difficult to determine from the error message in
RevalidateCachedQuery() the way in which the cached plan result tuple
type differed from the result type in the rewritten query tree:
- both produced tuples but tuples are not equivalent
- one produced tuples and the other does not

Add error detail to clarify to above. This is mainly for the benefit
of the developer.

Co-authored-by: Melanie Plageman <mplageman@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
