### PR TITLE
6x bakcport: A volatile LIMIT should not pushdown.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1721,6 +1721,24 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	gp_motion_cost_per_row :
 	2.0 * cpu_tuple_cost;
 
+	/*
+	 * If limit clause contains volatile functions, they should be
+	 * evaluated only once. For such cases, we should not push down
+	 * the limit.
+	 *
+	 * Words on multi-stage limit: current interconnect implementation
+	 * model is sender will send when buffer is full. Under such
+	 * condition, multi-stage limit might improve performance for
+	 * some cases.
+	 *
+	 * TODO: we might investigate that evaluating limit clause first,
+	 * and then doing pushdown it in future.
+	 */
+	bool        limit_contain_volatile_functions;
+	limit_contain_volatile_functions = (contain_volatile_functions(parse->limitCount)
+										|| contain_volatile_functions(parse->limitOffset));
+
+
 	CdbPathLocus_MakeNull(&current_locus, GP_POLICY_INVALID_NUMSEGMENTS());
 
 	/* Tweak caller-supplied tuple_fraction if have LIMIT/OFFSET */
@@ -2929,7 +2947,8 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 					 * the entire sorted result-set by plunking a limit on the
 					 * top of the unique-node.
 					 */
-					if (parse->limitCount)
+					if (parse->limitCount &&
+						!limit_contain_volatile_functions)
 					{
 						/*
 						 * Our extra limit operation is basically a
@@ -3151,23 +3170,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			(result_plan->flow->flotype == FLOW_PARTITIONED ||
 			 result_plan->flow->locustype == CdbLocusType_SegmentGeneral))
 		{
-			/*
-			 * If limit clause contains volatile functions, they should be
-			 * evaluated only once. For such cases, we should not push down
-			 * the limit.
-			 *
-			 * Words on multi-stage limit: current interconnect implementation
-			 * model is sender will send when buffer is full. Under such
-			 * condition, multi-stage limit might improve performance for
-			 * some cases.
-			 *
-			 * TODO: we might investigate that evaluating limit clause first,
-			 * and then doing pushdown it in future.
-			 */
-			bool        limit_contain_volatile_functions;
-
-			limit_contain_volatile_functions = (contain_volatile_functions(parse->limitCount)
-												|| contain_volatile_functions(parse->limitOffset));
 
 			if (result_plan->flow->flotype == FLOW_PARTITIONED &&
 				!limit_contain_volatile_functions)

--- a/src/test/regress/expected/limit_gp.out
+++ b/src/test/regress/expected/limit_gp.out
@@ -88,7 +88,7 @@ LINE 1: select * from generate_series(1,10) g limit count(*);
 create table t_volatile_limit (i int4);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into t_volatile_limit select generate_series(1, 100);
+create table t_volatile_limit_1 (a int, b int) distributed randomly;
 -- Greenplum may generate two-stage limit plan to improve performance.
 -- But for limit clause contains volatile functions, if we push them down
 -- below the final gather motion, those volatile functions will be evaluated
@@ -123,4 +123,57 @@ explain select * from t_volatile_limit order by i limit 2 offset (random()*5);
  Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
 (7 rows)
 
+explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit (random()+3);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=1593.65..1595.65 rows=100 width=12)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1593.65..1613.64 rows=999 width=12)
+         Merge Key: t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+         ->  Unique  (cost=1593.65..1593.66 rows=333 width=12)
+               Group Key: t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+               ->  Sort  (cost=1593.65..1593.65 rows=1 width=12)
+                     Sort Key (Distinct): t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1586.13..1593.64 rows=1 width=12)
+                           Hash Key: t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+                           ->  Unique  (cost=1586.13..1593.62 rows=1 width=12)
+                                 Group Key: t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+                                 ->  Sort  (cost=1586.13..1588.62 rows=333 width=12)
+                                       Sort Key (Distinct): t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+                                       ->  HashAggregate  (cost=1526.37..1536.36 rows=333 width=12)
+                                             Group Key: t_volatile_limit_1.a
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1391.50..1481.41 rows=999 width=12)
+                                                   Hash Key: t_volatile_limit_1.a
+                                                   ->  HashAggregate  (cost=1391.50..1421.47 rows=999 width=12)
+                                                         Group Key: t_volatile_limit_1.a
+                                                         ->  Seq Scan on t_volatile_limit_1  (cost=0.00..961.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit 2 offset (random()*2);
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=1595.65..1595.69 rows=2 width=12)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1593.65..1613.64 rows=999 width=12)
+         Merge Key: t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+         ->  Unique  (cost=1593.65..1593.66 rows=333 width=12)
+               Group Key: t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+               ->  Sort  (cost=1593.65..1593.65 rows=1 width=12)
+                     Sort Key (Distinct): t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1586.13..1593.64 rows=1 width=12)
+                           Hash Key: t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+                           ->  Unique  (cost=1586.13..1593.62 rows=1 width=12)
+                                 Group Key: t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+                                 ->  Sort  (cost=1586.13..1588.62 rows=333 width=12)
+                                       Sort Key (Distinct): t_volatile_limit_1.a, (pg_catalog.sum((sum(t_volatile_limit_1.b))))
+                                       ->  HashAggregate  (cost=1526.37..1536.36 rows=333 width=12)
+                                             Group Key: t_volatile_limit_1.a
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1391.50..1481.41 rows=999 width=12)
+                                                   Hash Key: t_volatile_limit_1.a
+                                                   ->  HashAggregate  (cost=1391.50..1421.47 rows=999 width=12)
+                                                         Group Key: t_volatile_limit_1.a
+                                                         ->  Seq Scan on t_volatile_limit_1  (cost=0.00..961.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(21 rows)
+
 drop table t_volatile_limit;
+drop table t_volatile_limit_1;

--- a/src/test/regress/expected/limit_gp_optimizer.out
+++ b/src/test/regress/expected/limit_gp_optimizer.out
@@ -1,0 +1,163 @@
+-- Check for MPP-19310 and MPP-19857 where mksort produces wrong result
+-- on OPT build, and fails assertion on debug build if a "LIMIT" query
+-- spills to disk.
+CREATE TABLE mksort_limit_test_table(dkey INT, jkey INT, rval REAL, tval TEXT default repeat('abcdefghijklmnopqrstuvwxyz', 300)) DISTRIBUTED BY (dkey);
+INSERT INTO mksort_limit_test_table VALUES(generate_series(1, 10000), generate_series(10001, 20000), sqrt(generate_series(10001, 20000)));
+SET gp_enable_mk_sort = on;
+--Should fit LESS (because of overhead) than (20 * 1024 * 1024) / (26 * 300 + 12) => 2684 tuples in memory, after that spills to disk
+SET statement_mem="20MB";
+-- Should work in memory
+SELECT dkey, substring(tval from 1 for 2) as str  from (SELECT * from mksort_limit_test_table ORDER BY dkey LIMIT 200) as temp ORDER BY jkey LIMIT 3;
+ dkey | str 
+------+-----
+    1 | ab
+    2 | ab
+    3 | ab
+(3 rows)
+
+SELECT dkey, substring(tval from 1 for 2) as str  from (SELECT * from mksort_limit_test_table ORDER BY dkey LIMIT 200) as temp ORDER BY jkey DESC LIMIT 3;
+ dkey | str 
+------+-----
+  200 | ab
+  199 | ab
+  198 | ab
+(3 rows)
+
+-- Should spill to disk (tested with 2 segments, for more segments it may not spill)
+SELECT dkey, substring(tval from 1 for 2) as str  from (SELECT * from mksort_limit_test_table ORDER BY dkey LIMIT 5000) as temp ORDER BY jkey LIMIT 3;
+ dkey | str 
+------+-----
+    1 | ab
+    2 | ab
+    3 | ab
+(3 rows)
+
+SELECT dkey, substring(tval from 1 for 2) as str  from (SELECT * from mksort_limit_test_table ORDER BY dkey LIMIT 5000) as temp ORDER BY jkey DESC LIMIT 3;
+ dkey | str 
+------+-----
+ 5000 | ab
+ 4999 | ab
+ 4998 | ab
+(3 rows)
+
+-- In memory descending sort
+SELECT dkey, substring(tval from 1 for 2) as str  from (SELECT * from mksort_limit_test_table ORDER BY dkey DESC LIMIT 200) as temp ORDER BY jkey LIMIT 3;
+ dkey | str 
+------+-----
+ 9801 | ab
+ 9802 | ab
+ 9803 | ab
+(3 rows)
+
+SELECT dkey, substring(tval from 1 for 2) as str  from (SELECT * from mksort_limit_test_table ORDER BY dkey DESC LIMIT 200) as temp ORDER BY jkey DESC LIMIT 3;
+ dkey  | str 
+-------+-----
+ 10000 | ab
+  9999 | ab
+  9998 | ab
+(3 rows)
+
+-- Spilled descending sort (tested with 2 segments, for more segments it may not spill)
+SELECT dkey, substring(tval from 1 for 2) as str from (SELECT * from mksort_limit_test_table ORDER BY dkey DESC LIMIT 5000) as temp ORDER BY jkey LIMIT 3;
+ dkey | str 
+------+-----
+ 5001 | ab
+ 5002 | ab
+ 5003 | ab
+(3 rows)
+
+SELECT dkey, substring(tval from 1 for 2) as str  from (SELECT * from mksort_limit_test_table ORDER BY dkey DESC LIMIT 5000) as temp ORDER BY jkey DESC LIMIT 3;
+ dkey  | str 
+-------+-----
+ 10000 | ab
+  9999 | ab
+  9998 | ab
+(3 rows)
+
+DROP TABLE  mksort_limit_test_table;
+-- Check invalid things in LIMIT
+select * from generate_series(1,10) g limit g;
+ERROR:  argument of LIMIT must not contain variables
+LINE 1: select * from generate_series(1,10) g limit g;
+                                                    ^
+select * from generate_series(1,10) g limit count(*);
+ERROR:  aggregate functions are not allowed in LIMIT
+LINE 1: select * from generate_series(1,10) g limit count(*);
+                                                    ^
+-- Check volatile limit should not pushdown.
+create table t_volatile_limit (i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t_volatile_limit_1 (a int, b int) distributed randomly;
+-- Greenplum may generate two-stage limit plan to improve performance.
+-- But for limit clause contains volatile functions, if we push them down
+-- below the final gather motion, those volatile functions will be evaluated
+-- many times. For such cases, we should not push down the limit.
+-- Below test cases' limit clause contain function call `random` with order by.
+-- `random()` is a volatile function it may return different results each time
+-- invoked. If we push down to generate two-stage limit plan, `random()` will
+-- execute on each segment which leads to different limit values of QEs
+-- and QD and this cannot guarantee correct results. Suppose seg 0 contains the
+-- top 3 minimum values, but random() returns 1, then you lose 2 values.
+explain select * from t_volatile_limit order by i limit (random() * 10);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Limit  (cost=0.00..431.00 rows=1 width=4)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+         Merge Key: i
+         ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+               Sort Key: i
+               ->  Seq Scan on t_volatile_limit  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
+(7 rows)
+
+explain select * from t_volatile_limit order by i limit 2 offset (random()*5);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Limit  (cost=0.00..431.00 rows=1 width=4)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+         Merge Key: i
+         ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+               Sort Key: i
+               ->  Seq Scan on t_volatile_limit  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
+(7 rows)
+
+explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit (random()+3);
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..431.00 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+         Merge Key: a, (sum(b))
+         ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+               Sort Key: a, (sum(b))
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                     Group Key: a
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: a
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 Hash Key: a
+                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
+(13 rows)
+
+explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit 2 offset (random()*2);
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..431.00 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+         Merge Key: a, (sum(b))
+         ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+               Sort Key: a, (sum(b))
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                     Group Key: a
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: a
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 Hash Key: a
+                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
+(13 rows)
+
+drop table t_volatile_limit;
+drop table t_volatile_limit_1;

--- a/src/test/regress/sql/limit_gp.sql
+++ b/src/test/regress/sql/limit_gp.sql
@@ -35,7 +35,7 @@ select * from generate_series(1,10) g limit count(*);
 
 -- Check volatile limit should not pushdown.
 create table t_volatile_limit (i int4);
-insert into t_volatile_limit select generate_series(1, 100);
+create table t_volatile_limit_1 (a int, b int) distributed randomly;
 
 -- Greenplum may generate two-stage limit plan to improve performance.
 -- But for limit clause contains volatile functions, if we push them down
@@ -51,4 +51,8 @@ insert into t_volatile_limit select generate_series(1, 100);
 explain select * from t_volatile_limit order by i limit (random() * 10);
 explain select * from t_volatile_limit order by i limit 2 offset (random()*5);
 
+explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit (random()+3);
+explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit 2 offset (random()*2);
+
 drop table t_volatile_limit;
+drop table t_volatile_limit_1;


### PR DESCRIPTION
Commit dd11474c fixes such issue but missing one place.

This missing SQL is like:
```
select  distinct(a), sum(b) from t group by a order by a, sum(b) limit (random()+3);
```
whose query tree contains distinctClause.

This commit fixes the issue totally.

-------------

Cherry-pick 4e753eb8d3948418d3c5a609c651873f38c4cac7  from master.

Commit 4e753eb8d3948418d3c5a609c651873f38c4cac7 has been merged in master already.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
