### PR TITLE
Stop using MK heap in sorted Motion Gather.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -437,7 +437,6 @@ bool		gp_external_enable_filter_pushdown = true;
 
 /* Executor */
 bool		gp_enable_mk_sort = true;
-bool		gp_enable_motion_mk_sort = true;
 
 /* Enable GDD */
 bool		gp_enable_global_deadlock_detector = false;
@@ -838,18 +837,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 
 		},
 		&gp_enable_mk_sort,
-		true,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"gp_enable_motion_mk_sort", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Enable multi-key sort in sorted motion recv."),
-			gettext_noop("A faster sort for recv motion"),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-
-		},
-		&gp_enable_motion_mk_sort,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -676,7 +676,6 @@ extern bool gp_enable_sort_distinct;
 
 /* Greenplum MK Sort */
 extern bool gp_enable_mk_sort;
-extern bool gp_enable_motion_mk_sort;
 
 #ifdef USE_ASSERT_CHECKING
 extern bool gp_mk_sort_check;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -3038,8 +3038,6 @@ typedef struct MotionState
 								 * each source segindex */
 
 	/* For sorted Motion recv */
-	struct MotionMKHeapContext *tupleheap_mk;		/* data structure for match merge in sorted motion node */
-
 	struct binaryheap *tupleheap;
 	struct CdbTupleHeapInfo *tupleheap_entries;
 	struct CdbMergeComparatorContext *tupleheap_cxt;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -17,7 +17,6 @@
 		"gp_default_storage_options",
 		"gp_disable_tuple_hints",
 		"gp_enable_mk_sort",
-		"gp_enable_motion_mk_sort",
 		"gp_enable_segment_copy_checking",
 		"gp_external_enable_filter_pushdown",
 		"gp_gpperfmon_send_interval",

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -2081,16 +2081,16 @@ select x from (select * from int8_tbl order by 1 limit 100) as int8_tbl, extract
 select x from (select * from int8_tbl order by 1 limit 100) as int8_tbl, extractq2_append(int8_tbl) f(x);
          x         
 -------------------
-  4567890123456789
-  4567890123456789
                456
                456
   4567890123456789
   4567890123456789
- -4567890123456789
- -4567890123456789
                123
                123
+  4567890123456789
+  4567890123456789
+ -4567890123456789
+ -4567890123456789
 (10 rows)
 
 create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$      

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -2087,16 +2087,16 @@ select x from (select * from int8_tbl order by 1 limit 100) as int8_tbl, extract
 select x from (select * from int8_tbl order by 1 limit 100) as int8_tbl, extractq2_append(int8_tbl) f(x);
          x         
 -------------------
-  4567890123456789
-  4567890123456789
                456
                456
   4567890123456789
   4567890123456789
- -4567890123456789
- -4567890123456789
                123
                123
+  4567890123456789
+  4567890123456789
+ -4567890123456789
+ -4567890123456789
 (10 rows)
 
 create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$      

--- a/src/test/regress/expected/sort.out
+++ b/src/test/regress/expected/sort.out
@@ -592,36 +592,6 @@ select col1, col2, col3, col4, col5 from gpsort_alltypes order by col5 desc, col
 --
 create table colltest (t text);
 insert into colltest VALUES ('a'), ('A'), ('b'), ('B'), ('c'), ('C'), ('d'), ('D'), (NULL);
-set gp_enable_motion_mk_sort=on;
-select * from colltest order by t COLLATE "C";
- t 
----
- A
- B
- C
- D
- a
- b
- c
- d
- 
-(9 rows)
-
-select * from colltest order by t COLLATE "C" NULLS FIRST;
- t 
----
- 
- A
- B
- C
- D
- a
- b
- c
- d
-(9 rows)
-
-set gp_enable_motion_mk_sort=off;
 select * from colltest order by t COLLATE "C";
  t 
 ---

--- a/src/test/regress/expected/window.out
+++ b/src/test/regress/expected/window.out
@@ -25,29 +25,29 @@ SELECT depname, empno, salary, sum(salary) OVER (PARTITION BY depname) FROM emps
 -----------+-------+--------+-------
  develop   |     7 |   4200 | 25100
  develop   |     9 |   4500 | 25100
- develop   |    10 |   5200 | 25100
  develop   |    11 |   5200 | 25100
+ develop   |    10 |   5200 | 25100
  develop   |     8 |   6000 | 25100
  personnel |     5 |   3500 |  7400
  personnel |     2 |   3900 |  7400
- sales     |     4 |   4800 | 14600
  sales     |     3 |   4800 | 14600
+ sales     |     4 |   4800 | 14600
  sales     |     1 |   5000 | 14600
 (10 rows)
 
 SELECT depname, empno, salary, rank() OVER (PARTITION BY depname ORDER BY salary) FROM empsalary;
   depname  | empno | salary | rank 
 -----------+-------+--------+------
+ develop   |     7 |   4200 |    1
+ develop   |     9 |   4500 |    2
+ develop   |    11 |   5200 |    3
+ develop   |    10 |   5200 |    3
+ develop   |     8 |   6000 |    5
  personnel |     5 |   3500 |    1
  personnel |     2 |   3900 |    2
  sales     |     3 |   4800 |    1
  sales     |     4 |   4800 |    1
  sales     |     1 |   5000 |    3
- develop   |     7 |   4200 |    1
- develop   |     9 |   4500 |    2
- develop   |    10 |   5200 |    3
- develop   |    11 |   5200 |    3
- develop   |     8 |   6000 |    5
 (10 rows)
 
 -- with GROUP BY
@@ -928,16 +928,16 @@ FROM tenk1 WHERE unique1 < 10
 WINDOW w AS (order by four range between current row and unbounded following);
  first_value | nth_2 | last_value | unique1 | four 
 -------------+-------+------------+---------+------
-           0 |     8 |          3 |       0 |    0
-           0 |     8 |          3 |       8 |    0
-           0 |     8 |          3 |       4 |    0
-           5 |     9 |          3 |       5 |    1
-           5 |     9 |          3 |       9 |    1
-           5 |     9 |          3 |       1 |    1
-           2 |     6 |          3 |       2 |    2
-           2 |     6 |          3 |       6 |    2
-           7 |     3 |          3 |       7 |    3
-           7 |     3 |          3 |       3 |    3
+           4 |     0 |          7 |       4 |    0
+           4 |     0 |          7 |       0 |    0
+           4 |     0 |          7 |       8 |    0
+           1 |     5 |          7 |       1 |    1
+           1 |     5 |          7 |       5 |    1
+           1 |     5 |          7 |       9 |    1
+           6 |     2 |          7 |       6 |    2
+           6 |     2 |          7 |       2 |    2
+           3 |     7 |          7 |       3 |    3
+           3 |     7 |          7 |       7 |    3
 (10 rows)
 
 SELECT sum(unique1) over

--- a/src/test/regress/expected/window_optimizer.out
+++ b/src/test/regress/expected/window_optimizer.out
@@ -25,29 +25,29 @@ SELECT depname, empno, salary, sum(salary) OVER (PARTITION BY depname) FROM emps
 -----------+-------+--------+-------
  develop   |     7 |   4200 | 25100
  develop   |     9 |   4500 | 25100
- develop   |    10 |   5200 | 25100
  develop   |    11 |   5200 | 25100
+ develop   |    10 |   5200 | 25100
  develop   |     8 |   6000 | 25100
  personnel |     5 |   3500 |  7400
  personnel |     2 |   3900 |  7400
- sales     |     4 |   4800 | 14600
  sales     |     3 |   4800 | 14600
+ sales     |     4 |   4800 | 14600
  sales     |     1 |   5000 | 14600
 (10 rows)
 
 SELECT depname, empno, salary, rank() OVER (PARTITION BY depname ORDER BY salary) FROM empsalary;
   depname  | empno | salary | rank 
 -----------+-------+--------+------
+ develop   |     7 |   4200 |    1
+ develop   |     9 |   4500 |    2
+ develop   |    11 |   5200 |    3
+ develop   |    10 |   5200 |    3
+ develop   |     8 |   6000 |    5
  personnel |     5 |   3500 |    1
  personnel |     2 |   3900 |    2
  sales     |     3 |   4800 |    1
  sales     |     4 |   4800 |    1
  sales     |     1 |   5000 |    3
- develop   |     7 |   4200 |    1
- develop   |     9 |   4500 |    2
- develop   |    10 |   5200 |    3
- develop   |    11 |   5200 |    3
- develop   |     8 |   6000 |    5
 (10 rows)
 
 -- with GROUP BY
@@ -930,16 +930,16 @@ FROM tenk1 WHERE unique1 < 10
 WINDOW w AS (order by four range between current row and unbounded following);
  first_value | nth_2 | last_value | unique1 | four 
 -------------+-------+------------+---------+------
-           0 |     8 |          3 |       0 |    0
-           0 |     8 |          3 |       8 |    0
-           0 |     8 |          3 |       4 |    0
-           5 |     9 |          3 |       5 |    1
-           5 |     9 |          3 |       9 |    1
-           5 |     9 |          3 |       1 |    1
-           2 |     6 |          3 |       2 |    2
-           2 |     6 |          3 |       6 |    2
-           7 |     3 |          3 |       7 |    3
-           7 |     3 |          3 |       3 |    3
+           4 |     0 |          7 |       4 |    0
+           4 |     0 |          7 |       0 |    0
+           4 |     0 |          7 |       8 |    0
+           1 |     5 |          7 |       1 |    1
+           1 |     5 |          7 |       5 |    1
+           1 |     5 |          7 |       9 |    1
+           6 |     2 |          7 |       6 |    2
+           6 |     2 |          7 |       2 |    2
+           3 |     7 |          7 |       3 |    3
+           3 |     7 |          7 |       7 |    3
 (10 rows)
 
 SELECT sum(unique1) over

--- a/src/test/regress/sql/sort.sql
+++ b/src/test/regress/sql/sort.sql
@@ -117,10 +117,5 @@ select col1, col2, col3, col4, col5 from gpsort_alltypes order by col5 desc, col
 create table colltest (t text);
 insert into colltest VALUES ('a'), ('A'), ('b'), ('B'), ('c'), ('C'), ('d'), ('D'), (NULL);
 
-set gp_enable_motion_mk_sort=on;
-select * from colltest order by t COLLATE "C";
-select * from colltest order by t COLLATE "C" NULLS FIRST;
-
-set gp_enable_motion_mk_sort=off;
 select * from colltest order by t COLLATE "C";
 select * from colltest order by t COLLATE "C" NULLS FIRST;


### PR DESCRIPTION
We now always use the PostgreSQL binary heap implementation, the one you
previously got with gp_enable_motion_mk_sort=off.

There is no user-visible difference, the option was just a performance
thing. Quick testing on my laptop suggests that the simple binary heap
implementation is always faster. I tested two test cases with
gp_enable_motion_mk_sort=on and off:

```
--
-- Test with a single integer column.
--
set enable_sort=off;
create table mgtest1 (i int4);
insert into mgtest1 select g from generate_series(1, 10000000) g;
create index on mgtest1(i);

select * from mgtest1 order by i offset 10000000 - 5;

--
-- Two columns. Leading column has the same value for every row.
-- This should be pretty much the best case scenario for MK sort.
--
create table mgtest2 (t text, i int4);
insert into mgtest2 select 'a sentence of a few words', g from generate_series(1, 10000000) g;

create index on mgtest2(t, i);

select * from mgtest2 order by t, i offset 10000000 - 5;
```

There was little difference in the first test,
gp_enable_motion_mk_sort=off was maybe 5-10% faster. In the second test,
the gp_enable_motion_mk_sort=on was *much* slower, about 14s vs 4s. Turns
out that almost all the CPU time was spent in strxfrm() calls. It seems
that using strxfrm() is a very bad idea in the heap. That makes sense, in
a heap you only compare each element a few times, although that might
depend somewhat on the number of nodes. I then disabled strxfrm() in the
code, and after that gp_enable_motion_mk_sort=on was about the same speed
as gp_enable_motion_mk_sort=off. But not faster.

All in all, it doesn't seem like gp_enable_motion_mk_sort=on is giving us
any meaningful performance benefit. Even if there is some other scenario
where it's somewhat faster, keeping it around would mean more code
to maintain, so it doesn't seem worth it. Let's get rid of it.
