### PR TITLE
6X: configure: disable -Wimplicit-fallthrough on clang

### DIFF
--- a/configure
+++ b/configure
@@ -5703,13 +5703,17 @@ if test x"$pgac_cv_prog_cc_cflags__Wno_address" = x"yes"; then
 fi
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wimplicit-fallthrough" >&5
-$as_echo_n "checking whether $CC supports -Wimplicit-fallthrough... " >&6; }
-if ${pgac_cv_prog_cc_cflags__Wimplicit_fallthrough+:} false; then :
+  # We rely on /* fallthrough */ comments to signal explicit fallthrough, but
+  # some compilers (clang) don't recognize those and give spurious errors. Make
+  # sure the compiler supports fallthrough comments by explicitly requesting
+  # implicit-fallthrough level 3 (GCC's default).
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-fallthrough=3" >&5
+$as_echo_n "checking whether $CC supports -Werror=implicit-fallthrough=3... " >&6; }
+if ${pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough_3+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   pgac_save_CFLAGS=$CFLAGS
-CFLAGS="$pgac_save_CFLAGS -Wimplicit-fallthrough"
+CFLAGS="$pgac_save_CFLAGS -Werror=implicit-fallthrough=3"
 ac_save_c_werror_flag=$ac_c_werror_flag
 ac_c_werror_flag=yes
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -5724,53 +5728,18 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  pgac_cv_prog_cc_cflags__Wimplicit_fallthrough=yes
+  pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough_3=yes
 else
-  pgac_cv_prog_cc_cflags__Wimplicit_fallthrough=no
+  pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough_3=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 ac_c_werror_flag=$ac_save_c_werror_flag
 CFLAGS="$pgac_save_CFLAGS"
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Wimplicit_fallthrough" >&5
-$as_echo "$pgac_cv_prog_cc_cflags__Wimplicit_fallthrough" >&6; }
-if test x"$pgac_cv_prog_cc_cflags__Wimplicit_fallthrough" = x"yes"; then
-  CFLAGS="$CFLAGS -Wimplicit-fallthrough"
-fi
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-fallthrough" >&5
-$as_echo_n "checking whether $CC supports -Werror=implicit-fallthrough... " >&6; }
-if ${pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  pgac_save_CFLAGS=$CFLAGS
-CFLAGS="$pgac_save_CFLAGS -Werror=implicit-fallthrough"
-ac_save_c_werror_flag=$ac_c_werror_flag
-ac_c_werror_flag=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough=yes
-else
-  pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-ac_c_werror_flag=$ac_save_c_werror_flag
-CFLAGS="$pgac_save_CFLAGS"
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough" >&5
-$as_echo "$pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough" >&6; }
-if test x"$pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough" = x"yes"; then
-  CFLAGS="$CFLAGS -Werror=implicit-fallthrough"
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough_3" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough_3" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__Werror_implicit_fallthrough_3" = x"yes"; then
+  CFLAGS="$CFLAGS -Werror=implicit-fallthrough=3"
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -615,8 +615,11 @@ if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-Wno-unused-but-set-variable])
   PGAC_PROG_CC_CFLAGS_OPT([-Wno-address])
 
-  PGAC_PROG_CC_CFLAGS_OPT([-Wimplicit-fallthrough])
-  PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-fallthrough])
+  # We rely on /* fallthrough */ comments to signal explicit fallthrough, but
+  # some compilers (clang) don't recognize those and give spurious errors. Make
+  # sure the compiler supports fallthrough comments by explicitly requesting
+  # implicit-fallthrough level 3 (GCC's default).
+  PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-fallthrough=3])
 
   #-Wno-error=enum-compare -Wno-error=address -Wno-error=maybe-uninitialized
 


### PR DESCRIPTION
_This is a 6X_STABLE backport of https://github.com/greenplum-db/gpdb/pull/8999._

Clang's g++ implementation doesn't seem to understand `/* fallthrough */` comments when using `-Wimplicit-fallthrough`, which prevents gpcloud from compiling on Mac. Since we rely on the fallthrough comment technique, change the configure check to explicitly request implicit-fallthrough level 3, which GCC will understand and Clang will not.