### PR TITLE
WIP: Rearrange running upgrade integration tests

### DIFF
--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -4,6 +4,8 @@
 
 #include "cmockery.h"
 
+#include "greenplum_five_to_greenplum_six_upgrade_test_suite.h"
+
 #include "scenarios/partitioned_ao_table.h"
 #include "scenarios/partitioned_heap_table.h"
 #include "scenarios/heterogeneous_partitioned_heap_table.h"
@@ -24,6 +26,7 @@
 #include "utilities/upgrade-helpers.h"
 #include "utilities/test-helpers.h"
 #include "utilities/row-assertions.h"
+#include "utilities/upgrade-helpers.h"
 
 static void
 setup(void **state)
@@ -44,35 +47,104 @@ teardown(void **state)
 	stopGpdbSixCluster();
 }
 
+int givens_index = 0;
+int thens_index = 0;
+
+#define MAX_TESTCASES 100
+
+UnitTest givens[MAX_TESTCASES];
+UnitTest thens[MAX_TESTCASES];
+
+void
+unit_test_given(UnitTestFunction f, char *n)
+{
+	givens[givens_index++] = (UnitTest) { n, f, UNIT_TEST_FUNCTION_TYPE_SETUP};
+	assert(givens_index < MAX_TESTCASES);
+}
+void
+unit_test_then(UnitTestFunction f, char *n)
+{
+	thens[thens_index++] = (UnitTest) { n, f, UNIT_TEST_FUNCTION_TYPE_TEST};
+	assert(thens_index < MAX_TESTCASES);
+}
+
+static void
+_startGpdbFiveCluster(void **state)
+{
+	startGpdbFiveCluster();
+}
+
+static void
+_stopGpdbFiveCluster(void **state)
+{
+	stopGpdbFiveCluster();
+}
+
+static void
+_performUpgrade(void **state)
+{
+	performUpgrade();
+}
+
+static void
+_startGpdbSixCluster(void **state)
+{
+	startGpdbSixCluster();
+}
+
+static void
+test_suite_setup()
+{
+	unit_test_given(_startGpdbFiveCluster, "startGpdbFiveCluster");
+	unit_test_then(_startGpdbSixCluster, "startGpdbSixCluster");
+}
+
+static void
+test_suite_finalize()
+{
+	unit_test_given(_stopGpdbFiveCluster, "stopGpdbFiveCluster");
+	unit_test_given(_performUpgrade, "performUpgrade");
+}
+
 int
 main(int argc, char *argv[])
 {
+	int rc = 0;
 	cmockery_parse_arguments(argc, argv);
 
-	const		UnitTest tests[] = {
-		unit_test_setup_teardown(test_a_readable_external_table_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partition_table_with_default_partition_after_split_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partition_table_with_newly_added_range_partition_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partition_table_with_newly_added_list_partition_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_clusters_with_different_checksum_version_cannot_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_an_ao_table_with_data_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_an_aocs_table_with_data_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_heap_table_with_data_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_subpartitioned_heap_table_with_data_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partitioned_heap_table_with_data_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partitioned_ao_table_with_data_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partitioned_ao_table_with_data_on_multiple_segfiles_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partitioned_aoco_table_with_data_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partitioned_aoco_table_with_data_on_multiple_segfiles_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_an_exchange_partitioned_heap_table_cannot_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partitioned_heap_table_with_a_dropped_column_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partitioned_heap_table_with_differently_sized_dropped_columns_cannot_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partitioned_heap_table_with_differently_aligned_fixed_dropped_columns_cannot_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_partitioned_heap_table_with_differently_aligned_varlen_dropped_columns_cannot_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_plpgsql_function_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_a_plpython_function_can_be_upgraded, setup, teardown),
-		unit_test_setup_teardown(test_an_user_defined_type_extension_can_be_upgraded, setup, teardown),
-	};
+	resetGpdbFiveDataDirectories();
+	resetGpdbSixDataDirectories();
 
-	return run_tests(tests);
+	test_suite_setup();
+	test_a_readable_external_table_can_be_upgraded();
+	test_an_ao_table_with_data_can_be_upgraded();
+	test_an_aocs_table_with_data_can_be_upgraded();
+	test_a_heap_table_with_data_can_be_upgraded();
+	test_a_subpartitioned_heap_table_with_data_can_be_upgraded();
+	test_a_partition_table_with_default_partition_after_split_can_be_upgraded();
+	test_a_partition_table_with_newly_added_range_partition_can_be_upgraded();
+	test_a_partition_table_with_newly_added_list_partition_can_be_upgraded();
+	test_a_partitioned_heap_table_with_data_can_be_upgraded();
+	test_a_partitioned_aoco_table_with_data_on_multiple_segfiles_can_be_upgraded();
+	test_a_partitioned_aoco_table_with_data_can_be_upgraded();
+	test_a_partitioned_ao_table_with_data_on_multiple_segfiles_can_be_upgraded();
+	test_a_partitioned_ao_table_with_data_can_be_upgraded();
+	test_a_partitioned_heap_table_with_a_dropped_column_can_be_upgraded();
+	test_a_plpgsql_function_can_be_upgraded();
+	test_a_plpython_function_can_be_upgraded();
+	test_an_user_defined_type_extension_can_be_upgraded();
+	test_suite_finalize();
+
+	_run_tests(givens, givens_index);
+	rc = _run_tests(thens, thens_index);
+
+	stopGpdbSixCluster();
+
+	UnitTest check_tests[] = {
+		unit_test_setup_teardown(test_an_exchange_partitioned_heap_table_cannot_be_upgraded, setup, teardown),
+		unit_test_setup_teardown(test_clusters_with_different_checksum_version_cannot_be_upgraded, setup, teardown),
+	};
+	rc += run_tests(check_tests);
+
+	return rc;
 }

--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.h
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.h
@@ -1,0 +1,7 @@
+#ifndef GREENPLUM_CMOCKERY_H_
+#include "cmockery.h"
+
+void unit_test_given(UnitTestFunction f, char *n);
+void unit_test_then(UnitTestFunction f, char *n);
+
+#endif

--- a/contrib/pg_upgrade/test/integration/scenarios/ao_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/ao_table.h
@@ -1,1 +1,1 @@
-void test_an_ao_table_with_data_can_be_upgraded(void **state);
+void test_an_ao_table_with_data_can_be_upgraded(void);

--- a/contrib/pg_upgrade/test/integration/scenarios/aocs_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/aocs_table.c
@@ -16,6 +16,7 @@
 
 #include "utilities/bdd-helpers.h"
 #include "aocs_table.h"
+#include "greenplum_five_to_greenplum_six_upgrade_test_suite.h"
 
 typedef struct UserData
 {
@@ -82,38 +83,32 @@ extract_user_rows(PGresult *result, Rows *rows)
 }
 
 
-static void anAocsTableExistsWithDataInFiveCluster(void)
+static void anAocsTableExistsWithDataInFiveCluster(void **state)
 {
 	PGconn	   *con1 = connectToFive();
 
-	executeQuery(con1, "CREATE SCHEMA five_to_six_upgrade;");
-	executeQuery(con1, "CREATE TABLE five_to_six_upgrade.aocs_users (id integer, name text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (id);");
-	executeQuery(con1, "BEGIN;");
-	executeQuery(con1, "INSERT INTO five_to_six_upgrade.aocs_users VALUES (1, 'Jane')");
-	executeQuery(con1, "INSERT INTO five_to_six_upgrade.aocs_users VALUES (2, 'John')");
+	executeQueryClearResult(con1, "CREATE TABLE aocs_users (id integer, name text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (id);");
+	executeQueryClearResult(con1, "BEGIN;");
+	executeQueryClearResult(con1, "INSERT INTO aocs_users VALUES (1, 'Jane')");
+	executeQueryClearResult(con1, "INSERT INTO aocs_users VALUES (2, 'John')");
 
 	PGconn	   *con2 = connectToFive();
 
-	executeQuery(con2, "BEGIN;");
-	executeQuery(con2, "INSERT INTO five_to_six_upgrade.aocs_users VALUES (3, 'Joe')");
+	executeQueryClearResult(con2, "BEGIN;");
+	executeQueryClearResult(con2, "INSERT INTO aocs_users VALUES (3, 'Joe')");
 
-	executeQuery(con1, "END;");
-	executeQuery(con2, "END;");
+	executeQueryClearResult(con1, "END;");
+	executeQueryClearResult(con2, "END;");
 
 	PQfinish(con2);
 	PQfinish(con1);
 }
 
-static void anAdministratorPerformsAnUpgrade(void)
-{
-	performUpgrade();
-}
-
 static void
-theAocsTableShouldHaveDataUpgradedToSixCluster(void)
+theAocsTableShouldHaveDataUpgradedToSixCluster(void **state)
 {
 	PGconn	   *connection = connectToSix();
-	PGresult   *result = executeQuery(connection, "SELECT * FROM five_to_six_upgrade.aocs_users;");
+	PGresult   *result = executeQuery(connection, "SELECT * FROM aocs_users;");
 
 	Rows		rows = {};
 
@@ -133,9 +128,8 @@ theAocsTableShouldHaveDataUpgradedToSixCluster(void)
 	PQfinish(connection);
 }
 
-void test_an_aocs_table_with_data_can_be_upgraded(void **state)
+void test_an_aocs_table_with_data_can_be_upgraded(void)
 {
-	given(withinGpdbFiveCluster(anAocsTableExistsWithDataInFiveCluster));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(theAocsTableShouldHaveDataUpgradedToSixCluster));
+	unit_test_given(anAocsTableExistsWithDataInFiveCluster, "test_an_aocs_table_with_data_can_be_upgraded");
+	unit_test_then(theAocsTableShouldHaveDataUpgradedToSixCluster, "test_an_aocs_table_with_data_can_be_upgraded");
 }

--- a/contrib/pg_upgrade/test/integration/scenarios/aocs_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/aocs_table.h
@@ -1,1 +1,1 @@
-void test_an_aocs_table_with_data_can_be_upgraded(void **state);
+void test_an_aocs_table_with_data_can_be_upgraded(void);

--- a/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.h
@@ -1,1 +1,1 @@
-void test_clusters_with_different_checksum_version_cannot_be_upgraded(void ** state);
+void test_clusters_with_different_checksum_version_cannot_be_upgraded(void **state);

--- a/contrib/pg_upgrade/test/integration/scenarios/external_tables.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/external_tables.c
@@ -10,9 +10,10 @@
 #include "utilities/query-helpers.h"
 #include "utilities/bdd-helpers.h"
 #include "scenarios/external_tables.h"
+#include "greenplum_five_to_greenplum_six_upgrade_test_suite.h"
 
-static void
-readableExternalTableHaveBeenUpgraded(void)
+void
+readableExternalTableHaveBeenUpgraded(void **state)
 {
 	PGconn *connection = connectToSix();
 	PGresult *result;
@@ -23,8 +24,8 @@ readableExternalTableHaveBeenUpgraded(void)
 	PQfinish(connection);
 }
 
-static void
-createReadableExternalTable(void)
+void
+createReadableExternalTable(void **state)
 {
 	PGconn *connection = connectToFive();
 	char hostname[100];
@@ -40,16 +41,9 @@ createReadableExternalTable(void)
 	PQfinish(connection);
 }
 
-static void
-anAdministratorPerformsAnUpgrade()
-{
-	performUpgrade();
-}
-
 void
-test_a_readable_external_table_can_be_upgraded(void ** state) 
+test_a_readable_external_table_can_be_upgraded(void)
 {
-	given(withinGpdbFiveCluster(createReadableExternalTable));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(readableExternalTableHaveBeenUpgraded));
+	unit_test_given(createReadableExternalTable, "test_a_readable_external_table_can_be_upgraded");
+	unit_test_then(readableExternalTableHaveBeenUpgraded, "test_a_readable_external_table_can_be_upgraded");
 }

--- a/contrib/pg_upgrade/test/integration/scenarios/external_tables.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/external_tables.h
@@ -1,1 +1,3 @@
-void test_a_readable_external_table_can_be_upgraded(void ** state);
+void test_a_readable_external_table_can_be_upgraded(void);
+void readableExternalTableHaveBeenUpgraded(void **state);
+void createReadableExternalTable(void **state);

--- a/contrib/pg_upgrade/test/integration/scenarios/heap_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/heap_table.h
@@ -1,1 +1,1 @@
-void test_a_heap_table_with_data_can_be_upgraded(void **state);
+void test_a_heap_table_with_data_can_be_upgraded(void);

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_ao_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_ao_table.c
@@ -3,6 +3,7 @@
 #include <setjmp.h>
 
 #include "cmockery.h"
+#include "greenplum_five_to_greenplum_six_upgrade_test_suite.h"
 
 #include "partitioned_ao_table.h"
 
@@ -14,45 +15,59 @@
 #include "utilities/bdd-helpers.h"
 
 static void
-partitionedTableShouldHaveDataUpgradedToSixCluster()
+partitionedAoTableShouldHaveDataUpgradedToSixCluster(void **state)
 {
 	PGconn	   *connection = connectToSix();
 	PGresult   *result;
 
-	executeQueryClearResult(connection, "SET search_path TO five_to_six_upgrade;");
-
-	result = executeQuery(connection, "SELECT * FROM users_1_prt_1 WHERE id=1 AND name='Jane';");
+	result = executeQuery(connection, "SELECT * FROM users_ao_singlelevel_part_1_prt_1 WHERE id=1 AND name='Jane';");
 	assert_int_equal(1, PQntuples(result));
 
-	result = executeQuery(connection, "SELECT * FROM users_1_prt_2 WHERE id=2 AND name='John';");
+	result = executeQuery(connection, "SELECT * FROM users_ao_singlelevel_part_1_prt_2 WHERE id=2 AND name='John';");
 	assert_int_equal(1, PQntuples(result));
 
-	result = executeQuery(connection, "SELECT * FROM users;");
+	result = executeQuery(connection, "SELECT * FROM users_ao_singlelevel_part;");
 	assert_int_equal(2, PQntuples(result));
 
 	PQfinish(connection);
 }
 
 static void
-partitionedTableShouldHaveDataOnMultipleSegfilesUpgradedToSixCluster()
+partitionedAocoTableShouldHaveDataUpgradedToSixCluster(void **state)
 {
 	PGconn	   *connection = connectToSix();
 	PGresult   *result;
 
-	executeQueryClearResult(connection, "SET search_path TO five_to_six_upgrade;");
+	result = executeQuery(connection, "SELECT * FROM users_aoco_singlelevel_part_1_prt_1 WHERE id=1 AND name='Jane';");
+	assert_int_equal(1, PQntuples(result));
 
-	executeQueryClearResult(connection, "CREATE INDEX name_index ON users(name);");
+	result = executeQuery(connection, "SELECT * FROM users_aoco_singlelevel_part_1_prt_2 WHERE id=2 AND name='John';");
+	assert_int_equal(1, PQntuples(result));
+
+	result = executeQuery(connection, "SELECT * FROM users_aoco_singlelevel_part;");
+	assert_int_equal(2, PQntuples(result));
+
+	PQfinish(connection);
+}
+
+static void
+partitionedAoTableShouldHaveDataOnMultipleSegfilesUpgradedToSixCluster(void **state)
+{
+	PGconn	   *connection = connectToSix();
+	PGresult   *result;
+
+	executeQueryClearResult(connection, "CREATE INDEX users_ao_index ON users_ao(name);");
 	executeQueryClearResult(connection, "SET enable_seqscan=OFF");
 
-	result = executeQuery(connection, "SELECT * FROM users;");
+	result = executeQuery(connection, "SELECT * FROM users_ao;");
 	assert_int_equal(5, PQntuples(result));
 	PQclear(result);
 
-	result = executeQuery(connection, "SET enable_seqscan=OFF; SELECT * FROM users WHERE name='Carolyn';");
+	result = executeQuery(connection, "SET enable_seqscan=OFF; SELECT * FROM users_ao WHERE name='Carolyn';");
 	assert_int_equal(1, PQntuples(result));
 	PQclear(result);
 
-	result = executeQuery(connection, "SET enable_seqscan=OFF; SELECT * FROM users WHERE name='Bob';");
+	result = executeQuery(connection, "SET enable_seqscan=OFF; SELECT * FROM users_ao WHERE name='Bob';");
 	assert_int_equal(0, PQntuples(result));
 	PQclear(result);
 
@@ -60,50 +75,66 @@ partitionedTableShouldHaveDataOnMultipleSegfilesUpgradedToSixCluster()
 }
 
 static void
-anAdministratorPerformsAnUpgrade()
+partitionedAocoTableShouldHaveDataOnMultipleSegfilesUpgradedToSixCluster(void **state)
 {
-	performUpgrade();
-}
+	PGconn	   *connection = connectToSix();
+	PGresult   *result;
 
-static void
-createPartitionedTableWithDataInFiveCluster(char *options)
-{
-	PGconn	   *connection = connectToFive();
-	char buffer[1000];
+	executeQueryClearResult(connection, "CREATE INDEX users_aoco_index ON users_aoco(name);");
+	executeQueryClearResult(connection, "SET enable_seqscan=OFF");
 
-	executeQueryClearResult(connection, "CREATE SCHEMA five_to_six_upgrade;");
-	executeQueryClearResult(connection, "SET search_path TO five_to_six_upgrade");
-	sprintf(buffer, "CREATE TABLE users (id integer, name text) %s DISTRIBUTED BY (id) PARTITION BY RANGE(id) (START(1) END(3) EVERY(1));", options);
-	executeQueryClearResult(connection,buffer);
-	executeQueryClearResult(connection, "INSERT INTO users VALUES (1, 'Jane')");
-	executeQueryClearResult(connection, "INSERT INTO users VALUES (2, 'John')");
+	result = executeQuery(connection, "SELECT * FROM users_aoco;");
+	assert_int_equal(5, PQntuples(result));
+	PQclear(result);
+
+	result = executeQuery(connection, "SET enable_seqscan=OFF; SELECT * FROM users_aoco WHERE name='Carolyn';");
+	assert_int_equal(1, PQntuples(result));
+	PQclear(result);
+
+	result = executeQuery(connection, "SET enable_seqscan=OFF; SELECT * FROM users_aoco WHERE name='Bob';");
+	assert_int_equal(0, PQntuples(result));
+	PQclear(result);
+
 	PQfinish(connection);
 }
 
 static void
-createPartitionedAOTableWithDataInFiveCluster()
+createPartitionedAOTableWithDataInFiveCluster(void **state)
 {
-	createPartitionedTableWithDataInFiveCluster("WITH (appendonly=true)");
+	PGconn	   *connection = connectToFive();
+	char buffer[1000];
+
+	sprintf(buffer, "CREATE TABLE users_ao_singlelevel_part (id integer, name text) WITH (appendonly=true) DISTRIBUTED BY (id) PARTITION BY RANGE(id) (START(1) END(3) EVERY(1));");
+	executeQueryClearResult(connection,buffer);
+	executeQueryClearResult(connection, "INSERT INTO users_ao_singlelevel_part VALUES (1, 'Jane')");
+	executeQueryClearResult(connection, "INSERT INTO users_ao_singlelevel_part VALUES (2, 'John')");
+	PQfinish(connection);
 }
 
 static void
-createPartitionedAOCOTableWithDataInFiveCluster()
+createPartitionedAOCOTableWithDataInFiveCluster(void **state)
 {
-	createPartitionedTableWithDataInFiveCluster("WITH (appendonly=true, orientation=column)");
+
+	PGconn	   *connection = connectToFive();
+	char buffer[1000];
+
+	sprintf(buffer, "CREATE TABLE users_aoco_singlelevel_part (id integer, name text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (id) PARTITION BY RANGE(id) (START(1) END(3) EVERY(1));");
+	executeQueryClearResult(connection,buffer);
+	executeQueryClearResult(connection, "INSERT INTO users_aoco_singlelevel_part VALUES (1, 'Jane')");
+	executeQueryClearResult(connection, "INSERT INTO users_aoco_singlelevel_part VALUES (2, 'John')");
+	PQfinish(connection);
+
 }
 
 static void
-createPartitionedTableWithDataOnMultipleSegfilesInFiveCluster(char *options)
+createPartitionedAOTableWithDataOnMultipleSegfilesInFiveCluster(void **state)
 {
 	PGconn	   *connection1 = connectToFive();
 	PGconn	   *connection2 = connectToFive();
 	char buffer[1000];
 
-	executeQueryClearResult(connection1, "CREATE SCHEMA five_to_six_upgrade;");
-	executeQueryClearResult(connection1, "SET search_path TO five_to_six_upgrade");
-
 	sprintf(buffer,
-			"CREATE TABLE users (id int, name text) %s DISTRIBUTED BY (id) "
+			"CREATE TABLE users_ao (id int, name text) WITH (appendonly=true) DISTRIBUTED BY (id) "
 			"PARTITION BY RANGE (id) "
 			"    SUBPARTITION BY LIST (name) "
 			"        SUBPARTITION TEMPLATE ( "
@@ -111,26 +142,25 @@ createPartitionedTableWithDataOnMultipleSegfilesInFiveCluster(char *options)
 			"          SUBPARTITION john VALUES ('John'), "
 			"           DEFAULT SUBPARTITION other_names ) "
 			"(START (1) END (2) EVERY (1), "
-			"    DEFAULT PARTITION other_ids );", options);
+			"    DEFAULT PARTITION other_ids );");
 	executeQueryClearResult(connection1, buffer);
 	/*
 	 * Table has indexes which will be dropped before upgrade and be re-created
 	 * after upgrade.
 	 */
-	executeQueryClearResult(connection1, "CREATE INDEX name_index ON users(name);");
+	executeQueryClearResult(connection1, "CREATE INDEX users_ao_index ON users_ao(name);");
 	executeQueryClearResult(connection1, "BEGIN;");
-	executeQueryClearResult(connection1, "INSERT INTO users VALUES (1, 'Jane')");
-	executeQueryClearResult(connection1, "INSERT INTO users VALUES (2, 'Jane')");
+	executeQueryClearResult(connection1, "INSERT INTO users_ao VALUES (1, 'Jane')");
+	executeQueryClearResult(connection1, "INSERT INTO users_ao VALUES (2, 'Jane')");
 
-	executeQueryClearResult(connection2, "SET search_path TO five_to_six_upgrade");
 	executeQueryClearResult(connection2, "BEGIN;");
 	/*
 	 * (1, 'Jane') and (2, 'Jane') are also being inserted on connection1 in a
 	 * transaction so we expect this will create additional segment files.
 	 */
-	executeQueryClearResult(connection2, "INSERT INTO users VALUES (1, 'Jane')");
-	executeQueryClearResult(connection2, "INSERT INTO users VALUES (2, 'Jane')");
-	executeQueryClearResult(connection2, "INSERT INTO users VALUES (4, 'Andy')");
+	executeQueryClearResult(connection2, "INSERT INTO users_ao VALUES (1, 'Jane')");
+	executeQueryClearResult(connection2, "INSERT INTO users_ao VALUES (2, 'Jane')");
+	executeQueryClearResult(connection2, "INSERT INTO users_ao VALUES (4, 'Andy')");
 
 	executeQueryClearResult(connection1, "END");
 	executeQueryClearResult(connection2, "END");
@@ -139,59 +169,107 @@ createPartitionedTableWithDataOnMultipleSegfilesInFiveCluster(char *options)
 	 * Ensure that we can correctly upgrade tables with dropped or deleted
 	 * tuples.
 	 */
-	executeQueryClearResult(connection2, "UPDATE users SET name='Carolyn' WHERE name='Andy'");
-	executeQueryClearResult(connection2, "INSERT INTO users VALUES (5, 'Bob')");
-	executeQueryClearResult(connection2, "DELETE FROM users WHERE id=5");
+	executeQueryClearResult(connection2, "UPDATE users_ao SET name='Carolyn' WHERE name='Andy'");
+	executeQueryClearResult(connection2, "INSERT INTO users_ao VALUES (5, 'Bob')");
+	executeQueryClearResult(connection2, "DELETE FROM users_ao WHERE id=5");
 
-	executeQueryClearResult(connection1, "DROP INDEX name_index;");
-	executeQueryClearResult(connection1, "DROP INDEX name_index_1_prt_2;");
-	executeQueryClearResult(connection1, "DROP INDEX name_index_1_prt_other_ids;");
-	executeQueryClearResult(connection1, "DROP INDEX name_index_1_prt_2_2_prt_jane;");
-	executeQueryClearResult(connection1, "DROP INDEX name_index_1_prt_2_2_prt_john;");
-	executeQueryClearResult(connection1, "DROP INDEX name_index_1_prt_2_2_prt_other_names;");
-	executeQueryClearResult(connection1, "DROP INDEX name_index_1_prt_other_ids_2_prt_jane;");
-	executeQueryClearResult(connection1, "DROP INDEX name_index_1_prt_other_ids_2_prt_john;");
-	executeQueryClearResult(connection1, "DROP INDEX name_index_1_prt_other_ids_2_prt_other_names;");
+	executeQueryClearResult(connection1, "DROP INDEX users_ao_index;");
+	executeQueryClearResult(connection1, "DROP INDEX users_ao_index_1_prt_2;");
+	executeQueryClearResult(connection1, "DROP INDEX users_ao_index_1_prt_other_ids;");
+	executeQueryClearResult(connection1, "DROP INDEX users_ao_index_1_prt_2_2_prt_jane;");
+	executeQueryClearResult(connection1, "DROP INDEX users_ao_index_1_prt_2_2_prt_john;");
+	executeQueryClearResult(connection1, "DROP INDEX users_ao_index_1_prt_2_2_prt_other_names;");
+	executeQueryClearResult(connection1, "DROP INDEX users_ao_index_1_prt_other_ids_2_prt_jane;");
+	executeQueryClearResult(connection1, "DROP INDEX users_ao_index_1_prt_other_ids_2_prt_john;");
+	executeQueryClearResult(connection1, "DROP INDEX users_ao_index_1_prt_other_ids_2_prt_other_names;");
 	PQfinish(connection1);
 	PQfinish(connection2);
 }
 
 static void
-createPartitionedAOTableWithDataOnMultipleSegfilesInFiveCluster(void)
+createPartitionedAOCOTableWithDataOnMultipleSegfilesInFiveCluster(void **state)
 {
-	createPartitionedTableWithDataOnMultipleSegfilesInFiveCluster("WITH (appendonly=true)");
+	PGconn	   *connection1 = connectToFive();
+	PGconn	   *connection2 = connectToFive();
+	char buffer[1000];
+
+	sprintf(buffer,
+			"CREATE TABLE users_aoco (id int, name text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (id) "
+			"PARTITION BY RANGE (id) "
+			"    SUBPARTITION BY LIST (name) "
+			"        SUBPARTITION TEMPLATE ( "
+			"         SUBPARTITION jane VALUES ('Jane'), "
+			"          SUBPARTITION john VALUES ('John'), "
+			"           DEFAULT SUBPARTITION other_names ) "
+			"(START (1) END (2) EVERY (1), "
+			"    DEFAULT PARTITION other_ids );");
+	executeQueryClearResult(connection1, buffer);
+	/*
+	 * Table has indexes which will be dropped before upgrade and be re-created
+	 * after upgrade.
+	 */
+	executeQueryClearResult(connection1, "CREATE INDEX users_aoco_index ON users_aoco(name);");
+	executeQueryClearResult(connection1, "BEGIN;");
+	executeQueryClearResult(connection1, "INSERT INTO users_aoco VALUES (1, 'Jane')");
+	executeQueryClearResult(connection1, "INSERT INTO users_aoco VALUES (2, 'Jane')");
+
+	executeQueryClearResult(connection2, "BEGIN;");
+	/*
+	 * (1, 'Jane') and (2, 'Jane') are also being inserted on connection1 in a
+	 * transaction so we expect this will create additional segment files.
+	 */
+	executeQueryClearResult(connection2, "INSERT INTO users_aoco VALUES (1, 'Jane')");
+	executeQueryClearResult(connection2, "INSERT INTO users_aoco VALUES (2, 'Jane')");
+	executeQueryClearResult(connection2, "INSERT INTO users_aoco VALUES (4, 'Andy')");
+
+	executeQueryClearResult(connection1, "END");
+	executeQueryClearResult(connection2, "END");
+
+	/*
+	 * Ensure that we can correctly upgrade tables with dropped or deleted
+	 * tuples.
+	 */
+	executeQueryClearResult(connection2, "UPDATE users_aoco SET name='Carolyn' WHERE name='Andy'");
+	executeQueryClearResult(connection2, "INSERT INTO users_aoco VALUES (5, 'Bob')");
+	executeQueryClearResult(connection2, "DELETE FROM users_aoco WHERE id=5");
+
+	executeQueryClearResult(connection1, "DROP INDEX users_aoco_index;");
+	executeQueryClearResult(connection1, "DROP INDEX users_aoco_index_1_prt_2;");
+	executeQueryClearResult(connection1, "DROP INDEX users_aoco_index_1_prt_other_ids;");
+	executeQueryClearResult(connection1, "DROP INDEX users_aoco_index_1_prt_2_2_prt_jane;");
+	executeQueryClearResult(connection1, "DROP INDEX users_aoco_index_1_prt_2_2_prt_john;");
+	executeQueryClearResult(connection1, "DROP INDEX users_aoco_index_1_prt_2_2_prt_other_names;");
+	executeQueryClearResult(connection1, "DROP INDEX users_aoco_index_1_prt_other_ids_2_prt_jane;");
+	executeQueryClearResult(connection1, "DROP INDEX users_aoco_index_1_prt_other_ids_2_prt_john;");
+	executeQueryClearResult(connection1, "DROP INDEX users_aoco_index_1_prt_other_ids_2_prt_other_names;");
+	PQfinish(connection1);
+	PQfinish(connection2);
 }
 
-static void
-createPartitionedAOCOTableWithDataOnMultipleSegfilesInFiveCluster(void)
+void
+test_a_partitioned_ao_table_with_data_on_multiple_segfiles_can_be_upgraded(void)
 {
-	createPartitionedTableWithDataOnMultipleSegfilesInFiveCluster("WITH (appendonly=true)");
+	unit_test_given(createPartitionedAOTableWithDataOnMultipleSegfilesInFiveCluster, "test_a_partitioned_ao_table_with_data_on_multiple_segfiles_can_be_upgraded");
+	unit_test_then(partitionedAoTableShouldHaveDataOnMultipleSegfilesUpgradedToSixCluster, "test_a_partitioned_ao_table_with_data_on_multiple_segfiles_can_be_upgraded");
 }
 
-void test_a_partitioned_ao_table_with_data_can_be_upgraded(void **state)
+void
+test_a_partitioned_aoco_table_with_data_on_multiple_segfiles_can_be_upgraded(void)
 {
-	given(withinGpdbFiveCluster(createPartitionedAOTableWithDataInFiveCluster));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(partitionedTableShouldHaveDataUpgradedToSixCluster));
+	unit_test_given(createPartitionedAOCOTableWithDataOnMultipleSegfilesInFiveCluster, "test_a_partitioned_aoco_table_with_data_on_multiple_segfiles_can_be_upgraded");
+	unit_test_then(partitionedAocoTableShouldHaveDataOnMultipleSegfilesUpgradedToSixCluster, "test_a_partitioned_aoco_table_with_data_on_multiple_segfiles_can_be_upgraded");
 }
 
-void test_a_partitioned_ao_table_with_data_on_multiple_segfiles_can_be_upgraded(void **state)
+void
+test_a_partitioned_aoco_table_with_data_can_be_upgraded(void)
 {
-	given(withinGpdbFiveCluster(createPartitionedAOTableWithDataOnMultipleSegfilesInFiveCluster));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(partitionedTableShouldHaveDataOnMultipleSegfilesUpgradedToSixCluster));
+	unit_test_given(createPartitionedAOCOTableWithDataInFiveCluster, "test_a_partitioned_aoco_table_with_data_can_be_upgraded");
+	unit_test_then(partitionedAocoTableShouldHaveDataUpgradedToSixCluster, "test_a_partitioned_aoco_table_with_data_can_be_upgraded");
 }
 
-void test_a_partitioned_aoco_table_with_data_can_be_upgraded(void **state)
+void
+test_a_partitioned_ao_table_with_data_can_be_upgraded(void)
 {
-	given(withinGpdbFiveCluster(createPartitionedAOCOTableWithDataInFiveCluster));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(partitionedTableShouldHaveDataUpgradedToSixCluster));
-}
-
-void test_a_partitioned_aoco_table_with_data_on_multiple_segfiles_can_be_upgraded(void **state)
-{
-	given(withinGpdbFiveCluster(createPartitionedAOCOTableWithDataOnMultipleSegfilesInFiveCluster));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(partitionedTableShouldHaveDataOnMultipleSegfilesUpgradedToSixCluster));
+	unit_test_given(createPartitionedAOTableWithDataInFiveCluster, "test_a_partitioned_ao_table_with_data_can_be_upgraded");
+	unit_test_then(partitionedAoTableShouldHaveDataUpgradedToSixCluster, "test_a_partitioned_ao_table_with_data_can_be_upgraded");
 }

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_ao_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_ao_table.h
@@ -1,4 +1,4 @@
-void test_a_partitioned_ao_table_with_data_can_be_upgraded(void **state);
-void test_a_partitioned_ao_table_with_data_on_multiple_segfiles_can_be_upgraded(void **state);
-void test_a_partitioned_aoco_table_with_data_can_be_upgraded(void **state);
-void test_a_partitioned_aoco_table_with_data_on_multiple_segfiles_can_be_upgraded(void **state);
+void test_a_partitioned_ao_table_with_data_on_multiple_segfiles_can_be_upgraded(void);
+void test_a_partitioned_aoco_table_with_data_on_multiple_segfiles_can_be_upgraded(void);
+void test_a_partitioned_aoco_table_with_data_can_be_upgraded(void);
+void test_a_partitioned_ao_table_with_data_can_be_upgraded(void);

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.c
@@ -11,16 +11,15 @@
 #include "utilities/upgrade-helpers.h"
 #include "utilities/query-helpers.h"
 #include "utilities/test-helpers.h"
-
 #include "utilities/bdd-helpers.h"
 
+#include "greenplum_five_to_greenplum_six_upgrade_test_suite.h"
+
 static void
-partitionedHeapTableWithDefaultPartitionSplittedShouldHaveBeenUpgraded()
+partitionedHeapTableWithDefaultPartitionSplittedShouldHaveBeenUpgraded(void **state)
 {
 	PGconn	   *connection = connectToSix();
 	PGresult   *result;
-
-	executeQuery(connection, "set search_path to five_to_six_upgrade;");
 
 	result = executeQuery(connection, "select * from p_split_partition_test;");
 	assert_int_equal(5, PQntuples(result));
@@ -35,12 +34,10 @@ partitionedHeapTableWithDefaultPartitionSplittedShouldHaveBeenUpgraded()
 }
 
 static void
-listPartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded()
+listPartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded(void **state)
 {
 	PGconn	   *connection = connectToSix();
 	PGresult   *result;
-
-	executeQuery(connection, "set search_path to five_to_six_upgrade;");
 
 	result = executeQuery(connection, "select * from p_add_list_partition_test");
 	assert_int_equal(4, PQntuples(result));
@@ -55,12 +52,10 @@ listPartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded()
 }
 
 static void
-rangePartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded()
+rangePartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded(void **state)
 {
 	PGconn	   *connection = connectToSix();
 	PGresult   *result;
-
-	executeQuery(connection, "set search_path to five_to_six_upgrade;");
 
 	result = executeQuery(connection, "select * from p_add_partition_test");
 	assert_int_equal(4, PQntuples(result));
@@ -75,12 +70,10 @@ rangePartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded()
 }
 
 static void
-partitionedHeapTableShouldHaveDataUpgradedToSixCluster()
+partitionedHeapTableShouldHaveDataUpgradedToSixCluster(void **state)
 {
 	PGconn	   *connection = connectToSix();
 	PGresult   *result;
-
-	executeQuery(connection, "set search_path to five_to_six_upgrade;");
 
 	result = executeQuery(connection, "select * from users_1_prt_1 where id=1 and name='Jane';");
 	assert_int_equal(1, PQntuples(result));
@@ -95,18 +88,10 @@ partitionedHeapTableShouldHaveDataUpgradedToSixCluster()
 }
 
 static void
-anAdministratorPerformsAnUpgrade()
-{
-	performUpgrade();
-}
-
-static void
-createPartitionedHeapTableWithDataInFiveCluster(void)
+createPartitionedHeapTableWithDataInFiveCluster(void **state)
 {
 	PGconn	   *connection = connectToFive();
 
-	executeQuery(connection, "create schema five_to_six_upgrade;");
-	executeQuery(connection, "set search_path to five_to_six_upgrade");
 	executeQuery(connection, "create table users (id integer, name text) distributed by (id) partition by range(id) (start(1) end(3) every(1));");
 	executeQuery(connection, "insert into users values (1, 'Jane')");
 	executeQuery(connection, "insert into users values (2, 'John')");
@@ -114,84 +99,74 @@ createPartitionedHeapTableWithDataInFiveCluster(void)
 }
 
 static void
-createRangePartitionedHeapTableAndAddPartitionsWithData(void)
+createRangePartitionedHeapTableAndAddPartitionsWithData(void **state)
 {
 	PGconn	   *connection = connectToFive();
 
-	executeQuery(connection, "create schema five_to_six_upgrade;");
-	executeQuery(connection, "set search_path to five_to_six_upgrade");
-	executeQuery(connection, "create table p_add_partition_test (a int, b int) partition by range(b) (start(1) end(2));");
-	executeQuery(connection, "insert into p_add_partition_test values (1, 1)");
-	executeQuery(connection, "insert into p_add_partition_test values (2, 1)");
+	executeQueryClearResult(connection, "create table p_add_partition_test (a int, b int) partition by range(b) (start(1) end(2));");
+	executeQueryClearResult(connection, "insert into p_add_partition_test values (1, 1)");
+	executeQueryClearResult(connection, "insert into p_add_partition_test values (2, 1)");
 	// add partition with a specific name
-	executeQuery(connection, "alter table p_add_partition_test add partition added_part start(2) end(3);");
-	executeQuery(connection, "insert into p_add_partition_test values (1, 2)");
+	executeQueryClearResult(connection, "alter table p_add_partition_test add partition added_part start(2) end(3);");
+	executeQueryClearResult(connection, "insert into p_add_partition_test values (1, 2)");
 	// add partition with default name
-	executeQuery(connection, "alter table p_add_partition_test add partition start(3) end(4);");
-	executeQuery(connection, "insert into p_add_partition_test values (1, 3)");
+	executeQueryClearResult(connection, "alter table p_add_partition_test add partition start(3) end(4);");
+	executeQueryClearResult(connection, "insert into p_add_partition_test values (1, 3)");
 	PQfinish(connection);
 }
 
 static void
-createListPartitionedHeapTableAndAddPartitionsWithData(void)
+createListPartitionedHeapTableAndAddPartitionsWithData(void **state)
 {
 	PGconn	   *connection = connectToFive();
 
-	executeQuery(connection, "create schema five_to_six_upgrade;");
-	executeQuery(connection, "set search_path to five_to_six_upgrade");
-	executeQuery(connection, "create table p_add_list_partition_test (a int, b int) partition by list(b) (PARTITION one VALUES (1));");
-	executeQuery(connection, "insert into p_add_list_partition_test values (1, 1)");
-	executeQuery(connection, "insert into p_add_list_partition_test values (2, 1)");
+	executeQueryClearResult(connection, "create table p_add_list_partition_test (a int, b int) partition by list(b) (PARTITION one VALUES (1));");
+	executeQueryClearResult(connection, "insert into p_add_list_partition_test values (1, 1)");
+	executeQueryClearResult(connection, "insert into p_add_list_partition_test values (2, 1)");
 	// add partition with a specific name
-	executeQuery(connection, "alter table p_add_list_partition_test add partition added_part values(2);");
-	executeQuery(connection, "insert into p_add_list_partition_test values (1, 2)");
+	executeQueryClearResult(connection, "alter table p_add_list_partition_test add partition added_part values(2);");
+	executeQueryClearResult(connection, "insert into p_add_list_partition_test values (1, 2)");
 	// add partition with default name
-	executeQuery(connection, "alter table p_add_list_partition_test add partition values(3);");
-	executeQuery(connection, "insert into p_add_list_partition_test values (1, 3)");
+	executeQueryClearResult(connection, "alter table p_add_list_partition_test add partition values(3);");
+	executeQueryClearResult(connection, "insert into p_add_list_partition_test values (1, 3)");
 	PQfinish(connection);
 }
 
 static void
-createRangePartitionedHeapTableWithDefaultPartition(void)
+createRangePartitionedHeapTableWithDefaultPartition(void **state)
 {
 	PGconn	   *connection = connectToFive();
 
-	executeQuery(connection, "create schema five_to_six_upgrade;");
-	executeQuery(connection, "set search_path to five_to_six_upgrade");
-	executeQuery(connection, "create table p_split_partition_test (a int, b int) partition by range(b) (start(1) end(2), default partition extra);");
-	executeQuery(connection, "insert into p_split_partition_test select i, i from generate_series(1,5)i;");
-	executeQuery(connection, "alter table p_split_partition_test split default partition start(2) end(5) into (partition splitted, partition extra);");
+	executeQueryClearResult(connection, "create table p_split_partition_test (a int, b int) partition by range(b) (start(1) end(2), default partition extra);");
+	executeQueryClearResult(connection, "insert into p_split_partition_test select i, i from generate_series(1,5)i;");
+	executeQueryClearResult(connection, "alter table p_split_partition_test split default partition start(2) end(5) into (partition splitted, partition extra);");
 	PQfinish(connection);
 }
 
 void
-test_a_partitioned_heap_table_with_data_can_be_upgraded(void **state)
+test_a_partitioned_heap_table_with_data_can_be_upgraded(void)
 {
-	given(withinGpdbFiveCluster(createPartitionedHeapTableWithDataInFiveCluster));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(partitionedHeapTableShouldHaveDataUpgradedToSixCluster));
+	unit_test_given(createPartitionedHeapTableWithDataInFiveCluster, "test_a_partitioned_heap_table_with_data_can_be_upgraded");
+	unit_test_then(partitionedHeapTableShouldHaveDataUpgradedToSixCluster, "test_a_partitioned_heap_table_with_data_can_be_upgraded");
 }
 
 void
-test_a_partition_table_with_newly_added_range_partition_can_be_upgraded(void **state)
+test_a_partition_table_with_newly_added_range_partition_can_be_upgraded(void)
 {
-	given(withinGpdbFiveCluster(createRangePartitionedHeapTableAndAddPartitionsWithData));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(rangePartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded));
+	unit_test_given(createRangePartitionedHeapTableAndAddPartitionsWithData, "test_a_partition_table_with_newly_added_range_partition_can_be_upgraded");
+	unit_test_then(rangePartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded, "test_a_partition_table_with_newly_added_range_partition_can_be_upgraded");
 }
 
 void
-test_a_partition_table_with_newly_added_list_partition_can_be_upgraded(void **state)
+test_a_partition_table_with_newly_added_list_partition_can_be_upgraded(void)
 {
-	given(withinGpdbFiveCluster(createListPartitionedHeapTableAndAddPartitionsWithData));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(listPartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded));
+	unit_test_given(createListPartitionedHeapTableAndAddPartitionsWithData, "test_a_partition_table_with_newly_added_list_partition_can_be_upgraded");
+	unit_test_then(listPartitionedHeapTableWithAddedPartitionsShouldHaveBeenUpgraded, "test_a_partition_table_with_newly_added_list_partition_can_be_upgraded");
 }
 
 void
-test_a_partition_table_with_default_partition_after_split_can_be_upgraded(void **state)
+test_a_partition_table_with_default_partition_after_split_can_be_upgraded(void)
 {
-	given(withinGpdbFiveCluster(createRangePartitionedHeapTableWithDefaultPartition));
-	when(anAdministratorPerformsAnUpgrade);
-	then(withinGpdbSixCluster(partitionedHeapTableWithDefaultPartitionSplittedShouldHaveBeenUpgraded));
+	unit_test_given(createRangePartitionedHeapTableWithDefaultPartition, "test_a_partition_table_with_default_partition_after_split_can_be_upgraded");
+	unit_test_then(partitionedHeapTableWithDefaultPartitionSplittedShouldHaveBeenUpgraded, "test_a_partition_table_with_default_partition_after_split_can_be_upgraded");
 }

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table.h
@@ -1,4 +1,4 @@
-void test_a_partitioned_heap_table_with_data_can_be_upgraded(void **state);
-void test_a_partition_table_with_newly_added_list_partition_can_be_upgraded(void **state);
-void test_a_partition_table_with_newly_added_range_partition_can_be_upgraded(void **state);
-void test_a_partition_table_with_default_partition_after_split_can_be_upgraded(void **state);
+void test_a_partitioned_heap_table_with_data_can_be_upgraded(void);
+void test_a_partition_table_with_newly_added_list_partition_can_be_upgraded(void);
+void test_a_partition_table_with_newly_added_range_partition_can_be_upgraded(void);
+void test_a_partition_table_with_default_partition_after_split_can_be_upgraded(void);

--- a/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table_with_a_dropped_column.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/partitioned_heap_table_with_a_dropped_column.h
@@ -1,1 +1,1 @@
-void test_a_partitioned_heap_table_with_a_dropped_column_can_be_upgraded(void ** state);
+void test_a_partitioned_heap_table_with_a_dropped_column_can_be_upgraded(void);

--- a/contrib/pg_upgrade/test/integration/scenarios/pl_function.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/pl_function.h
@@ -1,2 +1,2 @@
-void test_a_plpgsql_function_can_be_upgraded(void **state);
-void test_a_plpython_function_can_be_upgraded(void **state);
+void test_a_plpgsql_function_can_be_upgraded(void);
+void test_a_plpython_function_can_be_upgraded(void);

--- a/contrib/pg_upgrade/test/integration/scenarios/subpartitioned_heap_table.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/subpartitioned_heap_table.h
@@ -1,1 +1,1 @@
-void test_a_subpartitioned_heap_table_with_data_can_be_upgraded(void **state);
+void test_a_subpartitioned_heap_table_with_data_can_be_upgraded(void);

--- a/contrib/pg_upgrade/test/integration/scenarios/user_defined_types.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/user_defined_types.h
@@ -1,1 +1,1 @@
-void test_an_user_defined_type_extension_can_be_upgraded(void **state);
+void test_an_user_defined_type_extension_can_be_upgraded(void);


### PR DESCRIPTION
Refactor the upgrade integration tests to speed up test time. This
change consolidates all the happy path setups, performs the upgrade,
then validates. Change also moves all the tables into the public schema
and updates all table names to be unique which were previously
conflicting.

There are still a couple issues which we don't like that need to be
addrssed:
  1. Main runs 2 types of tests (happy path and check tests)
  2. Cannot easily run focused test because of 1 where happy path
     requires differnt setups than check tests.
  3. This makes it hard to see summary of test results.

On a workstation this reduced the test time from 19 minutes to less than
2 minutes.

Co-authored-by: Bhuvnesh Chaudhary <bhuvnesh2703@gmail.com>