### PR TITLE
Set wait_event for resource group

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -3319,12 +3319,13 @@ pgstat_get_wait_event(uint32 wait_event_info)
 			event_name = "BufferPin";
 			break;
 		case WAIT_RESOURCE_GROUP:
-			{
-				/* GPDB_96_MERGE_FIXME: this is broken: eventId is only 16 bits wide */
-				char *groupName = GetResGroupNameForId(eventId);
-
-				event_name = groupName ? groupName : "unknown resource group";
-			}
+			/*
+			 * We don't pass details for resource groups via event id, since
+			 * it's an uint16 and resource group id is an Oid.
+			 *
+			 * Here should be never used, pg_stat_get_activity() will get the
+			 * information from backend entry.
+			 */
 			event_name = "ResourceGroup";
 			break;
 		case WAIT_RESOURCE_QUEUE:

--- a/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/backend/utils/adt/pgstatfuncs.c
@@ -801,8 +801,22 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 
 				raw_wait_event = UINT32_ACCESS_ONCE(proc->wait_event_info);
 				wait_event_type = pgstat_get_wait_event_type(raw_wait_event);
-				wait_event = pgstat_get_wait_event(raw_wait_event);
 
+				/*
+				 * We don't pass details for resource groups via event id,
+				 * since it's an uint16 and resource group id is an Oid.
+				 *
+				 * Get it from the backend entry, waitOnGroup() had set the
+				 * information in it.
+				 */
+				if (wait_event_type && (pg_strcasecmp(wait_event_type, "ResourceGroup") == 0))
+				{
+					wait_event = GetResGroupNameForId(beentry->st_rsgid);
+				}
+				else
+				{
+					wait_event = pgstat_get_wait_event(raw_wait_event);
+				}
 			}
 			else
 			{

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2737,7 +2737,13 @@ waitOnGroup(ResGroupData *group)
 	Assert(!LWLockHeldExclusiveByMe(ResGroupLock));
 	Assert(!selfIsAssigned());
 
-	pgstat_report_wait_start(WAIT_RESOURCE_GROUP, group->groupId);
+	/*
+	 * The eventId is never used, because groupId is an Oid, but
+	 * pgstat_report_wait_start() wants an uint16 eventId.
+	 *
+	 * We set that information by the groupId via the backend entry.
+	 */
+	pgstat_report_wait_start(WAIT_RESOURCE_GROUP, 0);
 	pgstat_report_resgroup(group->groupId);
 
 	/*

--- a/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_concurrency.out
@@ -36,10 +36,10 @@ SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_to
 ---------------------+-------------+--------------+------------+--------------
  rg_concurrency_test | 2           | 1            | 1          | 2            
 (1 row)
-SELECT wait_event from pg_stat_activity where query = 'BEGIN;' and state = 'active' and rsgname = 'rg_concurrency_test' and wait_event='ResourceGroup';
- wait_event    
----------------
- ResourceGroup 
+SELECT wait_event from pg_stat_activity where query = 'BEGIN;' and state = 'active' and rsgname = 'rg_concurrency_test' and wait_event_type='ResourceGroup';
+ wait_event          
+---------------------
+ rg_concurrency_test 
 (1 row)
 2:END;
 END

--- a/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_concurrency.sql
@@ -19,7 +19,7 @@ SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_to
 
 -- new transaction will be blocked when the concurrency limit of the resource group is reached.
 SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
-SELECT wait_event from pg_stat_activity where query = 'BEGIN;' and state = 'active' and rsgname = 'rg_concurrency_test' and wait_event='ResourceGroup';
+SELECT wait_event from pg_stat_activity where query = 'BEGIN;' and state = 'active' and rsgname = 'rg_concurrency_test' and wait_event_type='ResourceGroup';
 2:END;
 3:END;
 4<:


### PR DESCRIPTION
Set the wait_event to group_name if the event is a resource group.

waitOnGroup() does set the eventId, but it's never used, because
pgstat_report_wait_start() wants an uint16 and groupId is an Oid.