### PR TITLE
Adds timestamp in milliseconds to the output during pg_upgrade when -…

### DIFF
--- a/contrib/pg_upgrade/option.c
+++ b/contrib/pg_upgrade/option.c
@@ -62,7 +62,7 @@ parseCommandLine(int argc, char *argv[])
 		{"progress", no_argument, NULL, 2},
 		{"add-checksum", no_argument, NULL, 3},
 		{"remove-checksum", no_argument, NULL, 4},
-
+		{"print-timing", no_argument, NULL, 5},
 		{NULL, 0, NULL, 0}
 	};
 	int			option;			/* Command line option */
@@ -73,6 +73,7 @@ parseCommandLine(int argc, char *argv[])
 	time_t		run_time = time(NULL);
 
 	user_opts.transfer_mode = TRANSFER_MODE_COPY;
+	user_opts.print_timing = false;
 
 	os_info.progname = get_progname(argv[0]);
 
@@ -227,6 +228,10 @@ parseCommandLine(int argc, char *argv[])
 
 			case 4:		/* --remove-checksum */
 				user_opts.checksum_mode = CHECKSUM_REMOVE;
+				break;
+
+			case 5:
+				user_opts.print_timing = true;
 				break;
 
 			default:

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -435,6 +435,7 @@ typedef struct
 	bool		progress;
 	segmentMode	segment_mode;
 	checksumMode checksum_mode;
+	bool print_timing;
 
 } UserOpts;
 

--- a/contrib/pg_upgrade/test/integration/utilities/gpdb5-cluster.c
+++ b/contrib/pg_upgrade/test/integration/utilities/gpdb5-cluster.c
@@ -9,7 +9,7 @@ startGpdbFiveCluster(void)
 		   ". $PWD/gpdb5/greenplum_path.sh; "
 		   "export PGPORT=50000; "
 		   "export MASTER_DATA_DIRECTORY=$PWD/gpdb5-data/qddir/demoDataDir-1; "
-		   "$PWD/gpdb5/bin/gpstart -a --skip_standby_check --no_standby"
+		   "time $PWD/gpdb5/bin/gpstart -a --skip_standby_check --no_standby"
 		);
 }
 
@@ -20,7 +20,7 @@ stopGpdbFiveCluster(void)
 		   ". $PWD/gpdb5/greenplum_path.sh; \n"
 		   "export PGPORT=50000; \n"
 		   "export MASTER_DATA_DIRECTORY=$PWD/gpdb5-data/qddir/demoDataDir-1; \n"
-		   "$PWD/gpdb5/bin/gpstop -af"
+		   "time $PWD/gpdb5/bin/gpstop -af"
 		);
 }
 


### PR DESCRIPTION
I've been trying to look into the speed of pg_upgrade and this is what I came up with to get a high level sense of how long things are taking:

```
2019-11-08 09:55:09.796477: Performing Consistency Checks
2019-11-08 09:55:09.796518: -----------------------------
2019-11-08 09:55:09.796541: Checking cluster versions                                   2019-11-08 09:55:09.811953: ok
2019-11-08 09:55:11.052809: Checking database user is a superuser                       2019-11-08 09:55:11.060081: ok
2019-11-08 09:55:11.060108: Checking database connection settings                       2019-11-08 09:55:11.068767: ok
2019-11-08 09:55:11.073361: Checking for prepared transactions                          2019-11-08 09:55:11.078032: ok
2019-11-08 09:55:11.078053: Checking for reg* system OID user data types                2019-11-08 09:55:11.102908: ok
2019-11-08 09:55:11.102947: Checking for contrib/isn with bigint-passing mismatch       2019-11-08 09:55:11.120413: ok
2019-11-08 09:55:11.120456: Checking array types derived from partitions                2019-11-08 09:55:11.196014: ok
2019-11-08 09:55:11.196048: Checking for external tables used in partitioning           2019-11-08 09:55:11.214552: ok
2019-11-08 09:55:11.214587: Checking for non-covering indexes on partitioned AO tables  2019-11-08 09:55:11.234969: ok
2019-11-08 09:55:11.234997: Checking for heterogeneous partitioned tables               2019-11-08 09:55:11.266710: ok
2019-11-08 09:55:11.266738: Checking for indexes on partitioned tables                  2019-11-08 09:55:11.346623: ok
2019-11-08 09:55:11.346646: Checking for orphaned TOAST relations                       2019-11-08 09:55:11.365880: ok
2019-11-08 09:55:11.365907: Checking for gphdfs external tables                         2019-11-08 09:55:11.387478: ok
2019-11-08 09:55:11.387501: Checking for users assigned the gphdfs role                 2019-11-08 09:55:11.394721: ok
2019-11-08 09:55:11.394744: Checking for invalid "name" user columns                    2019-11-08 09:55:11.417148: ok
2019-11-08 09:55:11.417189: Checking for tsquery user columns                           2019-11-08 09:55:11.440979: ok
2019-11-08 09:55:11.441005: Checking for contrib/ltree                                  2019-11-08 09:55:11.456974: ok
2019-11-08 09:55:11.457018: Checking for hash partitioned tables                        2019-11-08 09:55:11.478642: ok
2019-11-08 09:55:11.478673: Creating script to adjust sequences                         2019-11-08 09:55:11.495025: ok
2019-11-08 09:55:11.495060: Checking for abstime, reltime, tinterval user data types    2019-11-08 09:55:11.514975: ok
2019-11-08 09:55:11.515005: Checking for invalid "line" user columns                    2019-11-08 09:55:11.539503: ok
2019-11-08 09:55:11.539536: Checking for large objects                                  2019-11-08 09:55:11.551229: ok
2019-11-08 09:55:12.926960: Checking for presence of required libraries                 2019-11-08 09:55:12.927731: ok
2019-11-08 09:55:12.935824: Checking database user is a superuser                       2019-11-08 09:55:12.946303: ok
2019-11-08 09:55:12.952124: Checking for prepared transactions                          2019-11-08 09:55:12.956902: ok
```