### PR TITLE
Fix various  compilation warnings

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -968,7 +968,7 @@ make_url(const char *url, char *buf, bool is_ipv6)
 
 	p = buf;
 	len = hostname_start - url;
-	strncpy(p, url, len);
+	memcpy(p, url, len);
 	p += len;
 	url += len;
 
@@ -981,7 +981,7 @@ make_url(const char *url, char *buf, bool is_ipv6)
 		*p = '[';
 		p++;
 	}
-	strncpy(p, hostip, len);
+	memcpy(p, hostip, len);
 	p += len;
 	if (domain_resolved_to_ipv6)
 	{

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -778,7 +778,7 @@ set_end_state(Node *stmt)
 		((AlterExtensionStmt*)stmt)->update_ext_state = UPDATE_EXTENSION_END;
 }
 
-static bool
+static bool pg_attribute_unused()
 is_begin_state(const Node *stmt)
 {
 	AssertState(stmt != NULL);

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1918,7 +1918,7 @@ BaseBackup(void)
 			char	   *path = (char *) get_tablespace_mapping(PQgetvalue(res, i, 1));
 			char path_with_subdir[MAXPGPATH];
 
-			sprintf(path_with_subdir, "%s/%d/%s", path, target_gp_dbid, GP_TABLESPACE_VERSION_DIRECTORY);
+			snprintf(path_with_subdir, sizeof(path_with_subdir), "%s/%d/%s", path, target_gp_dbid, GP_TABLESPACE_VERSION_DIRECTORY);
 
 			verify_dir_is_empty_or_create(path_with_subdir);
 		}


### PR DESCRIPTION
Tested with gcc 9.2.1

* extension.c:782 ‘is_begin_state’ defined but not used [-Wunused-function]
  used during assertions, decorate as unused to silence warning
* url_curl.c:978 len argument triggers [-Wstringop-overflow=]
  Although the argument is wrong and we have no way to know if the user supplied
  buffer is big enough,  use the better fitted for the purpose memcpy().
* selfuncs.c:8094 ‘try_fetch_largest_child_stats’ [-Wunused-function]
  the function is commented out in a big fixme block. Hide all the relevant
  definitions to silence the warning.
* pg_basebackup.c:1921: sprintf triggering [-Wformat-overflow=]
  since we know the buffer size, use the snprintf() instead
