### PR TITLE
Backport 6.X: Update old reference to gpinit mirror mode option

### DIFF
--- a/gpMgmt/doc/gpinitsystem_help
+++ b/gpMgmt/doc/gpinitsystem_help
@@ -407,11 +407,10 @@ MIRROR_DATA_DIRECTORY
 EXAMPLES
 *****************************************************
 
-Initialize a Greenplum Database array by supplying a configuration file 
-and a segment host address file, and set up a spread mirroring (-S) 
-configuration:
+Initialize a Greenplum Database array by supplying a configuration file
+and a segment host address file, and set up a spread mirroring configuration:
 
- $ gpinitsystem -c gpinitsystem_config -h hostfile_gpinitsystem -S
+ $ gpinitsystem -c gpinitsystem_config -h hostfile_gpinitsystem --mirror-mode=spread
 
 
 Initialize a Greenplum Database array and set the superuser remote password:


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/9019

The example text included the old -S syntax for specifying the mirror
mode.

This was updated in this commit:
a398b43 but the --help text of
gpinitsystem was missed.

Co-authored-by: Ivan Novick inovick@pivotal.io
Co-authored-by: Kris Macoskey kmacoskey@pivotal.io