### PR TITLE
udp interconnect tx/rx executor code should break and exit if postmas…

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3822,8 +3822,8 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 			checkQDConnectionAlive();
 
 			if (!PostmasterIsAlive())
-				ereport(ERROR,
-						(errcode(ERRCODE_INTERNAL_ERROR),
+				ereport(FATAL,
+						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 						 errmsg("interconnect failed to recv chunks"),
 						 errdetail("Postmaster is not alive.")));
 		}
@@ -5324,8 +5324,8 @@ checkExceptions(ChunkTransportState *transportStates,
 		checkQDConnectionAlive();
 
 		if (!PostmasterIsAlive())
-			ereport(ERROR,
-					(errcode(ERRCODE_INTERNAL_ERROR),
+			ereport(FATAL,
+					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 					 errmsg("interconnect failed to send chunks"),
 					 errdetail("Postmaster is not alive.")));
 	}


### PR DESCRIPTION
…ter is dead.

There is no reason to still keep those sessions. We use error code
ERRCODE_GP_INTERCONNECTION_ERROR to avoid unnecessary linger (see guc
gp_debug_linger), and we do not use proc_exit() here since we want QD to know
the error detail.