### PR TITLE
Make the macro of FAULT_INJECTOR configurable

### DIFF
--- a/configure
+++ b/configure
@@ -748,6 +748,7 @@ HAVE_CXX11
 enable_gpcloud
 enable_mapreduce
 enable_orca
+enable_faultinjector
 autodepend
 TAS
 GCC
@@ -863,6 +864,7 @@ with_CC
 enable_depend
 enable_cassert
 enable_debugntuplestore
+enable_faultinjector
 enable_orca
 enable_mapreduce
 enable_gpcloud
@@ -1547,6 +1549,7 @@ Optional Features:
   --enable-cassert        enable assertion checks (for debugging)
   --enable-debugntuplestore
                           enable debug_ntuplestore (for debugging)
+  --enable-faultinjector  enable fault injector
   --disable-orca          disable ORCA optimizer
   --enable-mapreduce      enable Greenplum Mapreduce support
   --disable-gpcloud       disable gpcloud support
@@ -6555,6 +6558,38 @@ else
 
 fi
 
+
+
+#
+# Enable fault injector
+#
+
+
+# Check whether --enable-faultinjector was given.
+if test "${enable_faultinjector+set}" = set; then :
+  enableval=$enable_faultinjector;
+  case $enableval in
+    yes)
+
+$as_echo "#define FAULT_INJECTOR 1" >>confdefs.h
+
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --enable-faultinjector option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  enable_faultinjector=no
+
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: checking whether to build with FAULT_INJECTOR... $enable_faultinjector" >&5
+$as_echo "checking whether to build with FAULT_INJECTOR... $enable_faultinjector" >&6; }
 
 
 #

--- a/configure.in
+++ b/configure.in
@@ -803,6 +803,15 @@ PGAC_ARG_BOOL(enable, debugntuplestore, no, [enable debug_ntuplestore (for debug
                          [Define to 1 to build with debug_ntuplestore. (--enable-ntuplestore)])])
 
 #
+# Enable fault injector
+#
+PGAC_ARG_BOOL(enable, faultinjector, no, [enable fault injector],
+              [AC_DEFINE([FAULT_INJECTOR], 1,
+                         [Define to 1 to build with fault injector. (--enable-faultinjector)])])
+AC_MSG_RESULT([checking whether to build with FAULT_INJECTOR... $enable_faultinjector])
+AC_SUBST(enable_faultinjector)
+
+#
 # Enable Greenplum ORCA optimizer
 #
 PGAC_ARG_BOOL(enable, orca, yes, [disable ORCA optimizer],

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -208,6 +208,7 @@ enable_rpath	= @enable_rpath@
 enable_debug	= @enable_debug@
 enable_dtrace	= @enable_dtrace@
 enable_coverage	= @enable_coverage@
+enable_faultinjector	= @enable_faultinjector@
 enable_tap_tests	= @enable_tap_tests@
 enable_thread_safety	= @enable_thread_safety@
 enable_largefile	= @enable_largefile@

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -58,6 +58,9 @@
    (--enable-thread-safety) */
 #undef ENABLE_THREAD_SAFETY
 
+/* Define to 1 to build with fault injector. (--enable-faultinjector) */
+#undef FAULT_INJECTOR
+
 /* Define to nothing if C supports flexible array members, and to 1 if it does
    not. That way, with a declaration like `struct s { int n; double
    d[FLEXIBLE_ARRAY_MEMBER]; };', the struct hack can be used with pre-C99

--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -277,11 +277,6 @@
 /* #define WAL_DEBUG */
 
 /*
- * Enable injecting faults.
- */
-#define FAULT_INJECTOR 1
-
-/*
  * Enable tracing of resource consumption during sort operations;
  * see also the trace_sort GUC var.  For 8.1 this is enabled by default.
  */

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -9,7 +9,7 @@
 #ifndef FAULTINJECTOR_H
 #define FAULTINJECTOR_H
 
-#include "pg_config_manual.h"
+#include "pg_config.h"
 
 #define FAULTINJECTOR_MAX_SLOTS	16
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -14,6 +14,9 @@ include $(top_builddir)/src/Makefile.global
 
 SUBDIRS = perl regress isolation
 
-SUBDIRS += fsync walrep heap_checksum isolation2 kerberos modules
+SUBDIRS += walrep isolation2 kerberos modules
+ifeq ($(enable_faultinjector),yes)
+SUBDIRS += fsync heap_checksum
+endif
 
 $(recurse)

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -50,6 +50,7 @@ data:
 .PHONY: scan_flaky_fault_injectors
 scan_flaky_fault_injectors:
 	$(top_builddir)/src/test/regress/scan_flaky_fault_injectors.sh
+	enable_faultinjector=$(enable_faultinjector) $(top_builddir)/src/test/regress/ignore_fault_injectors.sh
 
 pg_isolation2_regress$(X): isolation2_main.o pg_regress.o submake-libpq submake-libpgport
 	$(CC) $(CFLAGS) $(filter %.o,$^) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -61,6 +61,7 @@ regress_gp.o: override LDFLAGS += -L$(top_builddir)/src/interfaces/libpq
 .PHONY: scan_flaky_fault_injectors
 scan_flaky_fault_injectors:
 	$(top_builddir)/src/test/regress/scan_flaky_fault_injectors.sh
+	enable_faultinjector=$(enable_faultinjector) $(top_builddir)/src/test/regress/ignore_fault_injectors.sh
 
 twophase_pqexecparams: twophase_pqexecparams.c
 	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq  -o $@ $< -lpq

--- a/src/test/regress/expected/alter_extension.out
+++ b/src/test/regress/expected/alter_extension.out
@@ -1,7 +1,10 @@
-CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- Creating extension to test alter extension
+-- Assume: pageinspect is shipped by default
+CREATE EXTENSION pageinspect;
 CREATE AGGREGATE example_agg(int4) (
     SFUNC = int4larger,
     STYPE = int4
 );
-ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
-ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+ALTER EXTENSION pageinspect ADD AGGREGATE example_agg(int4);
+ALTER EXTENSION pageinspect DROP AGGREGATE example_agg(int4);
+DROP EXTENSION pageinspect;

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -1,29 +1,23 @@
 --
 -- Test \dx and \dx+, to display extensions.
 --
--- We just use gp_inject_fault as an example of an extension here. We don't
--- inject any faults.
--- start_ignore
-CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
--- end_ignore
-\dx gp_inject*
-                           List of installed extensions
-      Name       | Version | Schema |                 Description                  
------------------+---------+--------+----------------------------------------------
- gp_inject_fault | 1.0     | public | simulate various faults for testing purposes
+-- We just use plpgsql as an example of an extension here.
+\dx plpgsql
+                 List of installed extensions
+  Name   | Version |   Schema   |         Description          
+---------+---------+------------+------------------------------
+ plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
 (1 row)
 
-\dx+ gp_inject*
-                       Objects in extension "gp_inject_fault"
-                                 Object Description                                 
-------------------------------------------------------------------------------------
- function force_mirrors_to_catch_up()
- function gp_inject_fault(text,text,integer)
- function gp_inject_fault(text,text,text,text,text,integer,integer,integer,integer)
- function gp_inject_fault_infinite(text,text,integer)
- function gp_wait_until_triggered_fault(text,integer,integer)
- function insert_noop_xlog_record()
-(6 rows)
+\dx+ plpgsql
+      Objects in extension "plpgsql"
+            Object Description             
+-------------------------------------------
+ function plpgsql_call_handler()
+ function plpgsql_inline_handler(internal)
+ function plpgsql_validator(oid)
+ language plpgsql
+(4 rows)
 
 --
 -- Test extended \du flags

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -41,7 +41,9 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 
-test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format
+test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format
+# below test(s) inject faults so each of them need to be in a separate group
+test: toast
 test: guc_gp
 # namespace_gp test will show diff if concurrent tests use temporary tables.
 # So run it separately.

--- a/src/test/regress/ignore_fault_injectors.sh
+++ b/src/test/regress/ignore_fault_injectors.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# This scripts scan for the tests that inject faults and comment them in the
+# schedule files, so they will not run when gpdb is compiled without fault-injector.
+
+# It's possible now that some tests depend on other tests that use fault-injector.
+# But it's hard to tell which one depends, just let the pipeline complains.
+
+set -e
+[[ "$enable_faultinjector" == "yes" ]] && exit 0
+
+fault_injection_tests=$(mktemp fault_injection_tests.XXX)
+
+# list the tests that inject faults
+grep -ERIli '\s+gp_inject_fault' sql input \
+| sed 's,^[^/]*/\(.*\)\.[^.]*$,\1,' \
+| sort -u \
+> $fault_injection_tests
+
+echo "scanning for flaky fault-injection tests..."
+
+for schedule in *_schedule; do
+	while read item
+	do
+		sed -i "s,^\(test:\s\+$item\s*\)$,#\1," $schedule
+	done < $fault_injection_tests
+
+done
+
+rm -f $fault_injection_tests
+

--- a/src/test/regress/scan_flaky_fault_injectors.sh
+++ b/src/test/regress/scan_flaky_fault_injectors.sh
@@ -12,7 +12,7 @@ parallel_tests=$(mktemp parallel_tests.XXX)
 retcode=0
 
 # list the tests that inject faults
-grep -ERIli '(select|perform)\s+gp_inject_fault' sql input \
+grep -ERIli '\s+gp_inject_fault' sql input \
 | sed 's,^[^/]*/\(.*\)\.[^.]*$,\1,' \
 | sort -u \
 > $fault_injection_tests

--- a/src/test/regress/sql/alter_extension.sql
+++ b/src/test/regress/sql/alter_extension.sql
@@ -1,9 +1,13 @@
-CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- Creating extension to test alter extension
+-- Assume: pageinspect is shipped by default
+CREATE EXTENSION pageinspect;
 
 CREATE AGGREGATE example_agg(int4) (
     SFUNC = int4larger,
     STYPE = int4
 );
 
-ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
-ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+ALTER EXTENSION pageinspect ADD AGGREGATE example_agg(int4);
+ALTER EXTENSION pageinspect DROP AGGREGATE example_agg(int4);
+
+DROP EXTENSION pageinspect;

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -1,14 +1,9 @@
 --
 -- Test \dx and \dx+, to display extensions.
 --
--- We just use gp_inject_fault as an example of an extension here. We don't
--- inject any faults.
--- start_ignore
-CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
--- end_ignore
-
-\dx gp_inject*
-\dx+ gp_inject*
+-- We just use plpgsql as an example of an extension here.
+\dx plpgsql
+\dx+ plpgsql
 
 
 --

--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -8,8 +8,12 @@ USE_MODULE_DB=1
 include $(top_builddir)/src/Makefile.global
 
 REGRESS = setup
-REGRESS += replication_views_mirrored missing_xlog walreceiver generate_ao_xlog generate_aoco_xlog
+REGRESS += replication_views_mirrored walreceiver generate_ao_xlog generate_aoco_xlog
+
+ifeq ($(enable_faultinjector),yes)
+REGRESS += missing_xlog
 REGRESS_OPTS = --load-extension=gp_inject_fault
+endif
 
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk


### PR DESCRIPTION
Definition FAULT_INJECTOR is hardcoded in a header(pg_config_manual.h) file.
Fault injector is useful, but it may introduce some issues in production
stage, like runtime cost, security problems. It's better to enable this
feature in development and disable it in release.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
