### PR TITLE
Fixes #9001: the non-super-user relowner can't vacuum owned relation.

### DIFF
--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -150,6 +150,21 @@ typedef struct VacAttrStats
 #define WIDTH_THRESHOLD  1024
 
 /*
+ * GPDB: Auxiliary relations are those that are vacuumed during the vacuum of a
+ * base relation. For eg, if we are to vacuum the following base table:
+ * heap_t(i int, j text)
+ * The auxiliary relation would be pg_toast.pg_toast_<reltoastrelid_of_heap_t>
+ */
+#define IS_AUX_REL_FOR_VACUUM(vacrel) \
+			( \
+				((vacrel)->schemaname != NULL) && \
+				( \
+					strcmp((vacrel)->schemaname, "pg_toast") == 0 || \
+					strcmp((vacrel)->schemaname, "pg_aoseg") == 0 || \
+					strcmp((vacrel)->schemaname, "pg_aocsseg") == 0 \
+				) \
+			)
+/*
  * VPgClassStats is used to hold the stats information that are stored in
  * pg_class. It is sent from QE to QD in a special libpq message , when a
  * QE runs VACUUM on a table.

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -335,3 +335,32 @@ WARNING:  skipping "s_serial" --- cannot vacuum non-tables, external tables, for
 DROP SEQUENCE s_serial;
 VACUUM gp_toolkit.__gp_log_master_ext;
 WARNING:  skipping "__gp_log_master_ext" --- cannot vacuum non-tables, external tables, foreign tables or special system tables
+-- Vacuum related access control tests (Issue: #9001)
+-- Given a non-super-user role
+CREATE ROLE non_super_user_vacuum;
+-- And a heap table with auxiliary relations under the pg_toast namespace.
+CREATE TABLE vac_acl_heap(i int, j text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- And an AO table with auxiliary relations under the pg_aoseg namespace.
+CREATE TABLE vac_acl_ao(i int, j text) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- And an AOCS table with auxiliary relations under the pg_aocsseg namespace.
+CREATE TABLE vac_acl_aocs(i int, j text) with (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- And all the tables belong to the non-super-user role.
+ALTER TABLE vac_acl_heap OWNER TO non_super_user_vacuum;
+ALTER TABLE vac_acl_ao OWNER TO non_super_user_vacuum;
+ALTER TABLE vac_acl_aocs OWNER TO non_super_user_vacuum;
+-- We can vacuum each table as the non-super-user
+SET ROLE TO non_super_user_vacuum;
+VACUUM vac_acl_heap;
+VACUUM vac_acl_ao;
+VACUUM vac_acl_aocs;
+\c
+DROP TABLE vac_acl_heap;
+DROP TABLE vac_acl_ao;
+DROP TABLE vac_acl_aocs;
+DROP ROLE non_super_user_vacuum;

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -208,3 +208,27 @@ CREATE SEQUENCE s_serial START 100;
 VACUUM (ANALYZE, VERBOSE) s_serial;
 DROP SEQUENCE s_serial;
 VACUUM gp_toolkit.__gp_log_master_ext;
+
+-- Vacuum related access control tests (Issue: #9001)
+-- Given a non-super-user role
+CREATE ROLE non_super_user_vacuum;
+-- And a heap table with auxiliary relations under the pg_toast namespace.
+CREATE TABLE vac_acl_heap(i int, j text);
+-- And an AO table with auxiliary relations under the pg_aoseg namespace.
+CREATE TABLE vac_acl_ao(i int, j text) with (appendonly=true);
+-- And an AOCS table with auxiliary relations under the pg_aocsseg namespace.
+CREATE TABLE vac_acl_aocs(i int, j text) with (appendonly=true, orientation=column);
+-- And all the tables belong to the non-super-user role.
+ALTER TABLE vac_acl_heap OWNER TO non_super_user_vacuum;
+ALTER TABLE vac_acl_ao OWNER TO non_super_user_vacuum;
+ALTER TABLE vac_acl_aocs OWNER TO non_super_user_vacuum;
+-- We can vacuum each table as the non-super-user
+SET ROLE TO non_super_user_vacuum;
+VACUUM vac_acl_heap;
+VACUUM vac_acl_ao;
+VACUUM vac_acl_aocs;
+\c
+DROP TABLE vac_acl_heap;
+DROP TABLE vac_acl_ao;
+DROP TABLE vac_acl_aocs;
+DROP ROLE non_super_user_vacuum;


### PR DESCRIPTION
This fixes #9001

In GP6x+, we dispatch vacuum statements for auxiliary relations such as
pg_toast, pg_aoseg, pg_aocsseg separately during the course of the
vacuum of a base relation. Since we do this, we perform an extra
namespace access check (as a result of `get_rel_oids() ->
RangeVarGetRelid() -> LookupExplicitNamespace()`) which is not applicable
to such auxiliary relations. (Even though the owner of the base relation
being vacuumed may own the auxiliary relations, he/she will not have
access rights to the auxiliary relation's schema).

This patch elevates the access level temporarily to that of the auxiliary
relation's schema's owner while performing `RangeVarGetRelid()` inside
`get_rel_oids()`.

Detailed RCA: https://github.com/greenplum-db/gpdb/issues/9001#issuecomment-551970409