### PR TITLE
docs - remove --ignore-version option from dump/restore utilities

### DIFF
--- a/gpdb-doc/dita/utility_guide/ref/pg_dump.xml
+++ b/gpdb-doc/dita/utility_guide/ref/pg_dump.xml
@@ -56,8 +56,6 @@
         reordering of all archived items, support parallel restoration, and are compressed by
         default. The <varname>directory</varname> format is the only format that supports parallel
         dumps.</p>
-      <note>The <codeph>--ignore-version</codeph> option is deprecated and will be removed in a
-        future release.</note>
     </section>
     <section id="section4">
       <title>Options</title>
@@ -159,14 +157,6 @@
               produces a valid directory-format archive. However, the tar format does not support
               compression. Also, when using tar format the
               relative order of table data items cannot be changed during restore.</pd>
-          </plentry>
-          <plentry>
-            <pt>-i | --ignore-version</pt>
-            <pd><note>This option is deprecated and will be removed in a future
-              release.</note>Ignore version mismatch between <codeph>pg_dump</codeph> and the
-              database server. <codeph>pg_dump</codeph> can dump from servers running previous
-              releases of Greenplum Database (or PostgreSQL), but very old versions may not be
-              supported anymore. Use this option if you need to override the version check.</pd>
           </plentry>
           <plentry>
             <pt>-j <varname>njobs</varname> | --jobs=<varname>njobs</varname></pt>

--- a/gpdb-doc/dita/utility_guide/ref/pg_dumpall.xml
+++ b/gpdb-doc/dita/utility_guide/ref/pg_dumpall.xml
@@ -41,8 +41,6 @@
             <p><codeph>pg_dumpall</codeph> needs to connect several times to the Greenplum Database master server (once per database). If you use password
                 authentication it is likely to ask for a password each time. It is convenient to
                 have a <codeph>~/.pgpass</codeph> file in such cases.</p>
-            <note>The <codeph>--ignore-version</codeph> option is deprecated and will be removed in
-                a future release.</note>
         </section>
         <section id="section4">
             <title>Options</title>
@@ -72,16 +70,6 @@
                     <plentry>
                         <pt>-g | --globals-only</pt>
                         <pd>Dump only global objects (roles and tablespaces), no databases.</pd>
-                    </plentry>
-                    <plentry>
-                        <pt>-i | --ignore-version</pt>
-                        <pd><note>This option is deprecated and will be removed in a future
-                                release.</note>Ignore version mismatch between <codeph><xref
-                                    href="pg_dump.xml#topic1" type="topic" format="dita"/></codeph>
-                            and the database server. <codeph>pg_dump</codeph> can dump from servers
-                            running previous releases of Greenplum Database (or
-                            PostgreSQL), but very old versions may not be supported anymore. Use
-                            this option if you need to override the version check.</pd>
                     </plentry>
                     <plentry>
                         <pt>-o | --oids</pt>

--- a/gpdb-doc/dita/utility_guide/ref/pg_restore.xml
+++ b/gpdb-doc/dita/utility_guide/ref/pg_restore.xml
@@ -32,8 +32,6 @@
         file. For instance, if the archive was made using the "dump data as <codeph>INSERT</codeph>
         commands" option, <codeph>pg_restore</codeph> will not be able to load the data using
           <codeph>COPY</codeph> statements.</p>
-      <note>The <codeph>--ignore-version</codeph> option is deprecated and will be removed in a
-        future release.</note>
     </section>
     <section id="section4">
       <title>Options</title>
@@ -96,11 +94,6 @@
                   type="topic" format="dita"/></codeph>. It is not necessary to specify the format,
               since <codeph>pg_restore</codeph> will determine the format automatically. Format can
               be <codeph>custom</codeph>, <codeph>directory</codeph>, or <codeph>tar</codeph>.</pd>
-          </plentry>
-          <plentry>
-            <pt>-i | --ignore-version</pt>
-            <pd><note>This option is deprecated and will be removed in a future
-              release.</note>Ignore database version checks.</pd>
           </plentry>
           <plentry>
             <pt>-I <varname>index</varname> | --index=<varname>index</varname></pt>


### PR DESCRIPTION
remove the `--ignore-version` option from the pg_dump, pg_dumpall, and pg_restore utililities.

we identified this option as deprecated in 5.x.  it has been listed in the postgres 8.4 and newer docs as deprecated and ignored.  i've removed the option from the ref pages.
