### PR TITLE
Live check should not display error message for old cluster that is still up.

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -266,7 +266,7 @@ issue_warnings_and_set_wal_level(char *sequence_script_file_name)
 		if (sequence_script_file_name)
 		{
 			prep_status("Adjusting sequences");
-			exec_prog(UTILITY_LOG_FILE, NULL, true,
+			exec_prog(UTILITY_LOG_FILE, NULL, true, true,
 					  "PGOPTIONS='-c gp_session_role=utility' "
 					  "\"%s/psql\" " EXEC_PSQL_ARGS " %s -f \"%s\"",
 					  new_cluster.bindir, cluster_conn_opts(&new_cluster),

--- a/contrib/pg_upgrade/dump.c
+++ b/contrib/pg_upgrade/dump.c
@@ -22,7 +22,7 @@ generate_old_dump(void)
 	prep_status("Creating dump of global objects");
 
 	/* run new pg_dumpall binary for globals */
-	exec_prog(UTILITY_LOG_FILE, NULL, true,
+	exec_prog(UTILITY_LOG_FILE, NULL, true, true,
 			  "PGOPTIONS='-c gp_session_role=utility' "
 			  "\"%s/pg_dumpall\" %s --schema-only --globals-only "
 			  "--quote-all-identifiers --binary-upgrade %s -f %s",

--- a/contrib/pg_upgrade/exec.c
+++ b/contrib/pg_upgrade/exec.c
@@ -32,16 +32,14 @@ static int	win32_check_directory_write_permissions(void);
  * and attempts to execute that command.  If the command executes
  * successfully, exec_prog() returns true.
  *
- * If the command fails, an error message is saved to the specified log_file.
- * If throw_error is true, this raises a PG_FATAL error and pg_upgrade
- * terminates; otherwise it is just reported as PG_REPORT and exec_prog()
- * returns false.
+ * If the command fails, an error message is optionally written to the specified
+ * log_file, and the program optionally exits.
  *
  * The code requires it be called first from the primary thread on Windows.
  */
 bool
 exec_prog(const char *log_file, const char *opt_log_file,
-		  bool throw_error, const char *fmt,...)
+		  bool report_error, bool exit_on_error, const char *fmt,...)
 {
 	int			result = 0;
 	int			written;
@@ -134,7 +132,7 @@ exec_prog(const char *log_file, const char *opt_log_file,
 #endif
 		result = system(cmd);
 
-	if (result != 0)
+	if (result != 0 && report_error)
 	{
 		/* we might be in on a progress status line, so go to the next line */
 		report_status(PG_REPORT, "\n*failure*");
@@ -142,12 +140,12 @@ exec_prog(const char *log_file, const char *opt_log_file,
 
 		pg_log(PG_VERBOSE, "There were problems executing \"%s\"\n", cmd);
 		if (opt_log_file)
-			pg_log(throw_error ? PG_FATAL : PG_REPORT,
+			pg_log(exit_on_error ? PG_FATAL : PG_REPORT,
 				   "Consult the last few lines of \"%s\" or \"%s\" for\n"
 				   "the probable cause of the failure.\n",
 				   log_file, opt_log_file);
 		else
-			pg_log(throw_error ? PG_FATAL : PG_REPORT,
+			pg_log(exit_on_error ? PG_FATAL : PG_REPORT,
 				   "Consult the last few lines of \"%s\" for\n"
 				   "the probable cause of the failure.\n",
 				   log_file);

--- a/contrib/pg_upgrade/parallel.c
+++ b/contrib/pg_upgrade/parallel.c
@@ -81,8 +81,8 @@ parallel_exec_prog(const char *log_file, const char *opt_log_file,
 	va_end(args);
 
 	if (user_opts.jobs <= 1)
-		/* throw_error must be true to allow jobs */
-		exec_prog(log_file, opt_log_file, true, "%s", cmd);
+		/* exit_on_error must be true to allow jobs */
+		exec_prog(log_file, opt_log_file, true, true, "%s", cmd);
 	else
 	{
 		/* parallel */
@@ -125,7 +125,7 @@ parallel_exec_prog(const char *log_file, const char *opt_log_file,
 		child = fork();
 		if (child == 0)
 			/* use _exit to skip atexit() functions */
-			_exit(!exec_prog(log_file, opt_log_file, true, "%s", cmd));
+			_exit(!exec_prog(log_file, opt_log_file, true, true, "%s", cmd));
 		else if (child < 0)
 			/* fork failed */
 			pg_fatal("could not create worker process: %s\n", strerror(errno));
@@ -163,7 +163,7 @@ win32_exec_prog(exec_thread_arg *args)
 {
 	int			ret;
 
-	ret = !exec_prog(args->log_file, args->opt_log_file, true, "%s", args->cmd);
+	ret = !exec_prog(args->log_file, args->opt_log_file, true, true, "%s", args->cmd);
 
 	/* terminates thread */
 	return ret;
@@ -190,7 +190,6 @@ parallel_transfer_all_new_dbs(DbInfoArr *old_db_arr, DbInfoArr *new_db_arr,
 #endif
 
 	if (user_opts.jobs <= 1)
-		/* throw_error must be true to allow jobs */
 		transfer_all_new_dbs(old_db_arr, new_db_arr, old_pgdata, new_pgdata, NULL);
 	else
 	{

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -476,7 +476,8 @@ prepare_new_cluster(void)
 	 * counter later.
 	 */
 	prep_status("Freezing all rows on the new cluster");
-	exec_prog(UTILITY_LOG_FILE, NULL, true, true
+	exec_prog(UTILITY_LOG_FILE, NULL, true, true,
+			  "PGOPTIONS='-c gp_session_role=utility' "
 			  "\"%s/vacuumdb\" %s --all --freeze %s",
 			  new_cluster.bindir, cluster_conn_opts(&new_cluster),
 			  log_opts.verbose ? "--verbose" : "");
@@ -514,6 +515,7 @@ prepare_new_databases(void)
 	 * the template0 template.
 	 */
 	exec_prog(UTILITY_LOG_FILE, NULL, true, true,
+			  "PGOPTIONS='-c gp_session_role=utility' "
 			  "\"%s/psql\" " EXEC_PSQL_ARGS " %s -f \"%s\"",
 			  new_cluster.bindir, cluster_conn_opts(&new_cluster),
 			  GLOBALS_DUMP_FILE);
@@ -1045,7 +1047,7 @@ reset_system_identifier(void)
 	sysidentifier |= ((uint64) tv.tv_usec) << 12;
 	sysidentifier |= getpid() & 0xFFF;
 
-	exec_prog(UTILITY_LOG_FILE, NULL, true,
+	exec_prog(UTILITY_LOG_FILE, NULL, true, true,
 			  "\"%s/pg_resetxlog\" --binary-upgrade --system-identifier " UINT64_FORMAT " \"%s\"",
 			  new_cluster.bindir, sysidentifier, new_cluster.pgdata);
 

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -504,10 +504,10 @@ void		generate_old_dump(void);
 /* exec.c */
 
 #define EXEC_PSQL_ARGS "--echo-queries --set ON_ERROR_STOP=on --no-psqlrc --dbname=template1"
-bool
-exec_prog(const char *log_file, const char *opt_log_file,
-		  bool throw_error, const char *fmt,...)
-__attribute__((format(PG_PRINTF_ATTRIBUTE, 4, 5)));
+
+bool exec_prog(const char *log_file, const char *opt_log_file,
+		  bool report_error, bool exit_on_error, const char *fmt,...)
+		  __attribute__((format(PG_PRINTF_ATTRIBUTE, 5, 6)));
 void		verify_directories(void);
 bool		pid_lock_file_exists(const char *datadir);
 
@@ -605,8 +605,8 @@ __attribute__((format(PG_PRINTF_ATTRIBUTE, 2, 3)));
 
 char	   *cluster_conn_opts(ClusterInfo *cluster);
 
-bool		start_postmaster(ClusterInfo *cluster, bool throw_error);
-void		stop_postmaster(bool fast);
+bool		start_postmaster(ClusterInfo *cluster, bool report_and_exit_on_error);
+void		stop_postmaster(bool in_atexit);
 uint32		get_major_server_version(ClusterInfo *cluster);
 void		check_pghost_envvar(void);
 

--- a/contrib/pg_upgrade/test/integration/.gitignore
+++ b/contrib/pg_upgrade/test/integration/.gitignore
@@ -24,3 +24,4 @@
 /pg_upgrade_regress
 /scripts/upgrade-cluster
 /sql_isolation_testcase.py
+/*.t

--- a/contrib/pg_upgrade/test/integration/Makefile
+++ b/contrib/pg_upgrade/test/integration/Makefile
@@ -94,15 +94,7 @@ scripts/pg-upgrade-copy-from-master: scripts/pg-upgrade-copy-from-master.o \
 #
 ## Libraries
 #
-bdd-library/bdd.o: override CPPFLAGS += -I .
-
-utilities_CPPFLAGS = -I$(pg_upgrade_directory) \
-					 -I$(libpq_srcdir) \
-					 -I .
-
-$(utilities_objs) \
-	$(scenario_objs) \
-	greenplum_five_to_greenplum_six_upgrade_test_suite.o: override CPPFLAGS += $(utilities_CPPFLAGS)
+override CPPFLAGS += -I . -I $(pg_upgrade_directory) -I$(libpq_srcdir)
 
 #
 ## Tests

--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -7,6 +7,7 @@
 
 #include "scenarios/data_checksum_mismatch.h"
 #include "scenarios/filespaces_to_tablespaces.h"
+#include "scenarios/live_check.h"
 
 #include "scenarios/data_checksum_mismatch.h"
 
@@ -62,6 +63,7 @@ main(int argc, char *argv[])
 	cmockery_parse_arguments(argc, argv);
 
 	const		UnitTest tests[] = {
+		unit_test_setup_teardown(test_a_live_check_with_the_old_server_still_up_does_not_throw_error_message, setup, teardown),
 		unit_test_setup_teardown(test_a_filespace_can_be_upgraded_into_new_tablespaces, setup, teardown),
 		unit_test_setup_teardown(test_clusters_with_different_checksum_version_cannot_be_upgraded, setup, teardown),
 	};

--- a/contrib/pg_upgrade/test/integration/scenarios/live_check.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/live_check.c
@@ -1,0 +1,53 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include "bdd-library/bdd.h"
+
+#include "cmockery.h"
+
+#include "live_check.h"
+#include "utilities/gpdb5-cluster.h"
+#include "utilities/test-upgrade-helpers.h"
+
+static void
+assert_string_does_not_contain(char *unexpected_fragment, char *actual)
+{
+	char *found = strstr(actual, unexpected_fragment);
+	
+	if (found != NULL)
+		fail_msg("expected to not find \"%s\" in \"%s\", but did find \"%s\".\n\n", 
+			unexpected_fragment, 
+			actual, 
+			unexpected_fragment);
+	else
+		assert_true(found == NULL);
+}
+
+static void 
+theGpdbFiveServerIsStillRunning(void)
+{
+	startGpdbFiveCluster();
+}
+
+static void
+theAdministratorRunsChecks(void)
+{
+	performUpgradeCheck();
+}
+
+static void
+noWarningMessagesShouldBeOutputThatTheServerIsStillRunning(void)
+{
+	assert_string_does_not_contain("*failure*", upgradeCheckOutput());
+	assert_int_equal(upgradeCheckStatus(), 0);
+
+}
+
+void
+test_a_live_check_with_the_old_server_still_up_does_not_throw_error_message(void **state)
+{
+	given(theGpdbFiveServerIsStillRunning);
+	when(theAdministratorRunsChecks);
+	then(noWarningMessagesShouldBeOutputThatTheServerIsStillRunning);
+}

--- a/contrib/pg_upgrade/test/integration/scenarios/live_check.h
+++ b/contrib/pg_upgrade/test/integration/scenarios/live_check.h
@@ -1,0 +1,2 @@
+void 
+test_a_live_check_with_the_old_server_still_up_does_not_throw_error_message(void **state);

--- a/contrib/pg_upgrade/test/integration/utilities/cluster-upgrade.c
+++ b/contrib/pg_upgrade/test/integration/utilities/cluster-upgrade.c
@@ -9,6 +9,7 @@ struct PgUpgradeOptionsData
 {
 	int old_gp_dbid;
 	int new_gp_dbid;
+	int old_master_port;
 	char *old_segment_path;
 	char *new_segment_path;
 	char *old_bin_dir;
@@ -27,7 +28,8 @@ make_pg_upgrade_options(
 	bool is_dispatcher,
 	char *old_tablespace_mapping_file_path,
 	char *old_bin_dir,
-	char *new_bin_dir)
+	char *new_bin_dir,
+	int old_master_port)
 {
 	char *mode = "segment";
 
@@ -44,6 +46,7 @@ make_pg_upgrade_options(
 	options->mode = mode;
 	options->old_tablespace_mapping_file_path = old_tablespace_mapping_file_path;
 	options->has_tablespaces = old_tablespace_mapping_file_path != NULL;
+	options->old_master_port = old_master_port;
 	return options;
 }
 
@@ -64,6 +67,7 @@ base_upgrade_executable_string(PgUpgradeOptions *options)
 		"--new-datadir=%s "
 		"--old-gp-dbid=%d "
 		"--new-gp-dbid=%d "
+		"--old-port=%d "
 		"--mode=%s "
 		"%s ",
 		options->new_bin_dir,
@@ -73,6 +77,7 @@ base_upgrade_executable_string(PgUpgradeOptions *options)
 		options->new_segment_path,
 		options->old_gp_dbid,
 		options->new_gp_dbid,
+		options->old_master_port,
 		options->mode,
 		tablespace_mapping_option);
 }

--- a/contrib/pg_upgrade/test/integration/utilities/cluster-upgrade.h
+++ b/contrib/pg_upgrade/test/integration/utilities/cluster-upgrade.h
@@ -8,7 +8,8 @@ PgUpgradeOptions *make_pg_upgrade_options(
 	bool is_dispatcher,
 	char *old_tablespace_mapping_file_path,
 	char *old_bin_dir,
-	char *new_bin_dir);
+	char *new_bin_dir,
+	int old_master_port);
 
 void perform_upgrade(PgUpgradeOptions *options);
 

--- a/contrib/pg_upgrade/test/integration/utilities/test-upgrade-helpers.c
+++ b/contrib/pg_upgrade/test/integration/utilities/test-upgrade-helpers.c
@@ -11,6 +11,7 @@
 /*
  * implements:
  */
+#include "gpdb5-cluster.h"
 #include "test-upgrade-helpers.h"
 #include "cluster-upgrade.h"
 #include "pg-upgrade-copy.h"
@@ -89,7 +90,8 @@ performUpgradeWithTablespaces(char *mappingFilePath)
 			true,
 			NULL,
 			old_bin_dir,
-			new_bin_dir));
+			new_bin_dir,
+			GPDB_FIVE_PORT));
 
 	for (int i = 0; i < number_of_segments; i++)
 	{
@@ -103,7 +105,8 @@ performUpgradeWithTablespaces(char *mappingFilePath)
 			false,
 			mappingFilePath,
 			old_bin_dir,
-			new_bin_dir);
+			new_bin_dir,
+			GPDB_FIVE_PORT);
 
 		PgUpgradeCopyOptions *segment_copy_options = make_copy_options(
 			master_host_username,
@@ -166,7 +169,8 @@ performUpgradeCheck(void)
 		true,
 		NULL,
 		"./gpdb5/bin",
-		"./gpdb6/bin"
+		"./gpdb6/bin",
+		GPDB_FIVE_PORT
 		);
 
 	output_file = perform_upgrade_check(options);


### PR DESCRIPTION
I backported a commit from upstream at @danielgustafsson 's suggestion. On top of that I've:

* modified additional places where Greenplum has added exec_prog calls in pg_upgrade.
* added integration tests checking that `*failure*` messages do not appear.


Original story:
```
IF the source cluster is up but the target cluster is down
WHEN I run pg_upgrade --check
THEN I get no error output associated with the source cluster being up
```