### PR TITLE
[6X Backport] Flush error state before rethrowing error in dispatcher code. (#9027)

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -695,7 +695,10 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 	{
 		/* errors reported by the segments */
 		if (first_error)
+		{
+			FlushErrorState();
 			ReThrowError(first_error);
+		}
 
 		/* errors that occurred in the COPY itself */
 		if (io_errors)

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1315,7 +1315,10 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 					 errdetail("QE reported error: %s", qeError->message)));
 		}
 		else
+		{
+			FlushErrorState();
 			ReThrowError(qeError);
+		}
 		return false;
 	}
 

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -316,7 +316,11 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 	cdbdisp_markNamedPortalGangsDestroyed();
 
 	if (qeError)
+	{
+
+		FlushErrorState();
 		ReThrowError(qeError);
+	}
 
 	cdbdisp_destroyDispatcherState(ds);
 }
@@ -448,7 +452,10 @@ cdbdisp_dispatchCommandInternal(DispatchCommandQueryParms *pQueryParms,
 	pr = cdbdisp_getDispatchResults(ds, &qeError);
 
 	if (qeError)
+	{
+		FlushErrorState();
 		ReThrowError(qeError);
+	}
 
 	cdbdisp_returnResults(pr, cdb_pgresults);
 
@@ -1189,7 +1196,10 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		cdbdisp_getDispatchResults(ds, &qeError);
 
 		if (qeError)
+		{
+			FlushErrorState();
 			ReThrowError(qeError);
+		}
 
 		/*
 		 * Wasn't an error, must have been an interrupt.
@@ -1449,7 +1459,10 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	cdbdisp_checkDispatchResult(ds, DISPATCH_WAIT_NONE);
 
 	if (!cdbdisp_getDispatchResults(ds, &error))
+	{
+		FlushErrorState();
 		ReThrowError(error);
+	}
 
 	/*
 	 * Notice: Do not call cdbdisp_finishCommand to destroy dispatcher state,

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2076,6 +2076,7 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		if (qeError)
 		{
 			estate->dispatcherState = NULL;
+			FlushErrorState();
 			ReThrowError(qeError);
 		}
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -627,10 +627,6 @@ errfinish(int dummy __attribute__((unused)),...)
 	if (elevel == ERROR)
 	{
 		/*
-		 * GP: While doing local error try/catch, do not reset all these
-		 * important variables!
-		 */
-		/*
 		 * We do some minimal cleanup before longjmp'ing so that handlers can
 		 * execute in a reasonably sane state.
 		 *
@@ -794,11 +790,18 @@ errfinish_and_return(int dummy __attribute__((unused)),...)
 	ErrorData  *edata = &errordata[errordata_stack_depth];
 	ErrorData  *edata_copy;
 	ErrorContextCallback *econtext;
+	MemoryContext oldcontext;
 	int			saved_errno;            /*CDB*/
 
 	recursion_depth++;
 	CHECK_STACK_DEPTH();
 	saved_errno = edata->saved_errno;   /*CDB*/
+
+	/*
+	 * Do processing in ErrorContext, which we hope has enough reserved space
+	 * to report an error.
+	 */
+	oldcontext = MemoryContextSwitchTo(ErrorContext);
 
 	/*
 	 * Call any context callback functions.  Errors occurring in callback
@@ -809,6 +812,8 @@ errfinish_and_return(int dummy __attribute__((unused)),...)
 		 econtext != NULL;
 		 econtext = econtext->previous)
 		(*econtext->callback) (econtext->arg);
+
+	MemoryContextSwitchTo(oldcontext);
 
 	edata_copy = CopyErrorData();
 
@@ -823,6 +828,16 @@ errfinish_and_return(int dummy __attribute__((unused)),...)
 		pfree(edata->hint);
 	if (edata->context)
 		pfree(edata->context);
+	if (edata->schema_name)
+		pfree(edata->schema_name);
+	if (edata->table_name)
+		pfree(edata->table_name);
+	if (edata->column_name)
+		pfree(edata->column_name);
+	if (edata->datatype_name)
+		pfree(edata->datatype_name);
+	if (edata->constraint_name)
+		pfree(edata->constraint_name);
 	if (edata->internalquery)
 		pfree(edata->internalquery);
 

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -190,10 +190,6 @@ void elog_internalerror(const char *filename, int lineno, const char *funcname)
 #define ereport(elevel, rest)	\
 	ereport_domain(elevel, TEXTDOMAIN, rest)
 
-#define ereport_and_return(elevel, rest)	\
-	(errstart((elevel), __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN), \
-		errfinish_and_return rest )
-
 #define TEXTDOMAIN NULL
 
 /*

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -7,8 +7,8 @@
 -- m/(PANIC):.*unable to complete*/
 -- s/gid \=\s*\d+-\d+/gid \= DUMMY/gm
 --
--- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
+-- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/
+-- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
 --
 -- end_matchsubs
 

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -7,8 +7,8 @@
 -- m/(PANIC):.*unable to complete*/
 -- s/gid \=\s*\d+-\d+/gid \= DUMMY/gm
 --
--- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/
--- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
+-- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
+-- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
 --
 -- end_matchsubs
 
@@ -234,7 +234,7 @@ server started
  
 (1 row)
 12<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=16146: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=25361: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -7,8 +7,8 @@ create extension if not exists gp_inject_fault;
 CREATE
 
 -- start_matchsubs
--- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/
--- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
+-- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
+-- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
 -- end_matchsubs
 
 -- to make test deterministic and fast
@@ -141,7 +141,7 @@ END
 -- session 2: in transaction, gxid is dispatched to writer gang, cann't
 --            update cdb_component_dbs, following query should fail
 2:END;
-ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=30365: server closed the connection unexpectedly
+ERROR:  Error on receive from seg1 127.0.0.1:7003 pid=2406: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -152,7 +152,7 @@ DETAIL:
 ----+----
 (0 rows)
 3:END;
-ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=30374: server closed the connection unexpectedly
+ERROR:  Error on receive from seg1 127.0.0.1:7003 pid=2417: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -160,7 +160,7 @@ DETAIL:
 --            cdb_component_dbs, following query should fail and session
 --            is reset
 4:select * from tmp4;
-ERROR:  Error on receive from seg0 slice1 127.0.0.1:25432 pid=30391: server closed the connection unexpectedly
+ERROR:  Error on receive from seg1 slice1 127.0.0.1:7003 pid=2432: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -171,7 +171,7 @@ LINE 1: select * from tmp4;
 -- session 5: has a subtransaction, cann't update cdb_component_dbs,
 --            following query should fail
 5:select * from tmp51;
-ERROR:  Error on receive from seg0 slice1 127.0.0.1:25432 pid=30399: server closed the connection unexpectedly
+ERROR:  Error on receive from seg1 slice1 127.0.0.1:7003 pid=2441: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
@@ -88,7 +88,7 @@ SET
  t                         
 (1 row)
 1<:  <... completed>
-ERROR:  FTS detected connection lost during dispatch to seg0 127.0.0.1:25432 pid=74795:
+ERROR:  FTS detected connection lost during dispatch to seg0 127.0.0.1:7002 pid=5106: (cdbdispatchresult.c:476)
 
 1:SELECT gp_inject_fault('start_prepare', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_inject_fault 

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -2,8 +2,8 @@
 --
 -- # create a match/subs expression
 --
--- m/ERROR:.*server closed the connection unexpectedly/
--- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
+-- m/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
+-- s/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/gm
 -- end_matchsubs
 include: helpers/server_helpers.sql;
 CREATE
@@ -121,12 +121,12 @@ END
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21988)
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21999: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29474: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21994: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29462: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -627,7 +627,7 @@ server started
  
 (1 row)
 4<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.1.1:25432 pid=28337: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29553: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -2,8 +2,8 @@
 --
 -- # create a match/subs expression
 --
--- m/ERROR:.*server closed the connection unexpectedly/
--- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
+-- m/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
+-- s/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/gm
 -- end_matchsubs
 3:CREATE extension if NOT EXISTS gp_inject_fault;
 CREATE
@@ -102,12 +102,12 @@ UPDATE 10
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21369)
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21379: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24819: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:25432 pid=21384: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24830: server closed the connection unexpectedly (cdbdispatchresult.c:476)
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -22,14 +22,13 @@ s/seg\d+ [0-9.]+:\d+ pid=\d+/SEG IP:PORT pid=PID/
 m/^ERROR:  deadlock detected  (seg\d+ [0-9.]+:\d+ pid=\d+)/
 s/seg\d+ [0-9.]+:\d+ pid=\d+/SEG IP:PORT pid=PID/
 
-# (seg0 172.17.0.2:25432)
+# (slice1 172.17.0.2:25432 pid=23848)
+m/(slice\d+ [0-9.]+:\d+ pid=\d+)/
+s/(slice\d+ [0-9.]+:\d+ pid=\d+)//
 
-m/seg\d+ [0-9.]+:\d+/
-s/seg\d+ [0-9.]+:\d+//
-
-# (seg0 slice1 172.17.0.2:25432 pid=23848)
-m/(seg\d+ slice\d+ [0-9.]+:\d+ pid=\d+)/
-s/(seg\d+ slice\d+ [0-9.]+:\d+ pid=\d+)//
+# (172.17.0.2:25432 pid=23848)
+m/([0-9.]+:\d+ pid=\d+)/
+s/([0-9.]+:\d+ pid=\d+)//
 
 # requested 26376 bytes 
 
@@ -41,9 +40,6 @@ s/^DETAIL:  Process \d+ waits for ShareLock on transaction \d+; blocked by proce
 
 m/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./
 s/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./Process PID waits for ShareLock on transaction XID; blocked by process PID./
-
-m/^ERROR:  Error on receive from  pid=\d+: server closed the connection unexpectedly/
-s/^ERROR:  Error on receive from  pid=\d+: server closed the connection unexpectedly/ERROR:  Error on receive from  pid=PID: server closed the connection unexpectedly/
 
 m/available \d+ MB/
 s/available \d+ MB//

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -7,8 +7,8 @@
 -- m/(PANIC):.*unable to complete*/
 -- s/gid \=\s*\d+-\d+/gid \= DUMMY/gm
 --
--- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/
--- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
+-- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
+-- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
 --
 -- end_matchsubs
 

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -7,8 +7,8 @@
 -- m/(PANIC):.*unable to complete*/
 -- s/gid \=\s*\d+-\d+/gid \= DUMMY/gm
 --
--- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
+-- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/
+-- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
 --
 -- end_matchsubs
 

--- a/src/test/isolation2/sql/fts_errors.sql
+++ b/src/test/isolation2/sql/fts_errors.sql
@@ -6,8 +6,8 @@
 create extension if not exists gp_inject_fault;
 
 -- start_matchsubs
--- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/
--- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
+-- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
+-- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
 -- end_matchsubs
 
 -- to make test deterministic and fast

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -2,8 +2,8 @@
 --
 -- # create a match/subs expression
 --
--- m/ERROR:.*server closed the connection unexpectedly/
--- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
+-- m/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
+-- s/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/gm
 -- end_matchsubs
 include: helpers/server_helpers.sql;
 

--- a/src/test/isolation2/sql/uao_crash_compaction_row.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_row.sql
@@ -2,8 +2,8 @@
 --
 -- # create a match/subs expression
 --
--- m/ERROR:.*server closed the connection unexpectedly/
--- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
+-- m/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
+-- s/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/gm
 -- end_matchsubs
 3:CREATE extension if NOT EXISTS gp_inject_fault;
 3:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;


### PR DESCRIPTION
This prevents panic due to "ERRORDATA_STACK_SIZE exceeded" which was found
during testing.  The scenario happens when we test a transaction with multiple
cursors. When a QE postmaster is dead, those cursor gangs could error out in
SendChunkUDPIFC() -> checkExceptions(), causing QD loop in PostgresMain() ->
AbortCurrentTransaction() ->...-> mppExecutorFinishup() -> ReThrowError() ->
PostgresMain() -> AbortTransaction(). Note ReThrowError() would increase errordata_stack_depth by 1 so it could lead to error stack overflow (finally the database would PANIC to prevent real overflow).

Typical stack of one item in the errordata array is as below,

	stacktracearray = {[0] = 0xadb39d <errstart+1086>, [1] = 0xb93362 <cdbdisp_get_PQerror+289>, [2] = 0xb93197 <cdbdisp_dumpDispatchResult+87>,
	[3] = 0xb935f3 <cdbdisp_dumpDispatchResults+226>, [4] = 0xb8ffef <cdbdisp_getDispatchResults+169>, [5] = 0x7545cf <mppExecutorFinishup+235>,
	[6] = 0x736c77 <standard_ExecutorEnd+706>, [7] = 0x7369b2 <ExecutorEnd+54>, [8] = 0x6c4e28 <PortalCleanup+345>, [9] = 0xb2168b <AtAbort_Portals+214>,
	[10] = 0x53b996 <AbortTransaction+356>, [11] = 0x53c467 <AbortCurrentTransaction+214>, [12] = 0x9714d9 <PostgresMain+1728>, [13] = 0x8dfdf4 <ExitPostmaster>,
	[14] = 0x8df485 <BackendStartup+371>, [15] = 0x8db324 <ServerLoop+825>, [16] = 0x8da870 <PostmasterMain+4908>, [17] = 0x7d5467 <startup_hacks>,
	[18] = 0x7f5311c51c05 <__libc_start_main+245>, [19] = 0x48e039 <_start+41>, [20] = 0x0, [21] = 0x0, [22] = 0x0, [23] = 0x0, [24] = 0x0, [25] = 0x0, [26] = 0x0,
	[27] = 0x0, [28] = 0x0, [29] = 0x0},

In icg testing, typically running tests with portals.sql + killing one QE postmaster sometimes triggers this issue.

Fixing this by adding FlushErrorState() before ReThrowError(). Calling
FlushErrorState() before ReThrowError() is usual if the error was
copied in advance (e.g. via CopyErrorData()).

Also tweak error logging code a bit.

- errfinish_and_return() does not pfree some memory although so far no callers
set those variables.

- errfinish_and_return() should put context callback function calls in memory
context ErrorContext.

- Some callers of errstart() does not check return value. This is wrong though
currently our callers in the patch does not seem to suffer from this issue, but
it is a good habit to check.

Reviewed-by: Georgios Kokolatos
Reviewed-by: Asim R P