### PR TITLE
Fix fts_errors pipeline failure in interconnect tcp mode.

### DIFF
--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -10,8 +10,8 @@
 -- m/^DETAIL:.*gid=.*/
 -- s/gid=\d+-\d+/gid DUMMY/
 --
--- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
+-- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/
+-- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
 --
 -- end_matchsubs
 

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -22,14 +22,13 @@ s/seg\d+ [0-9.]+:\d+ pid=\d+/SEG IP:PORT pid=PID/
 m/^ERROR:  deadlock detected  (seg\d+ [0-9.]+:\d+ pid=\d+)/
 s/seg\d+ [0-9.]+:\d+ pid=\d+/SEG IP:PORT pid=PID/
 
-# (seg0 172.17.0.2:25432)
+# (slice1 172.17.0.2:25432 pid=23848)
+m/(slice\d+ [0-9.]+:\d+ pid=\d+)/
+s/(slice\d+ [0-9.]+:\d+ pid=\d+)//
 
-m/seg\d+ [0-9.]+:\d+/
-s/seg\d+ [0-9.]+:\d+//
-
-# (seg0 slice1 172.17.0.2:25432 pid=23848)
-m/(seg\d+ slice\d+ [0-9.]+:\d+ pid=\d+)/
-s/(seg\d+ slice\d+ [0-9.]+:\d+ pid=\d+)//
+# (172.17.0.2:25432 pid=23848)
+m/([0-9.]+:\d+ pid=\d+)/
+s/([0-9.]+:\d+ pid=\d+)//
 
 # requested 26376 bytes 
 
@@ -41,9 +40,6 @@ s/^DETAIL:  Process \d+ waits for ShareLock on transaction \d+; blocked by proce
 
 m/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./
 s/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./Process PID waits for ShareLock on transaction XID; blocked by process PID./
-
-m/^ERROR:  Error on receive from  pid=\d+: server closed the connection unexpectedly/
-s/^ERROR:  Error on receive from  pid=\d+: server closed the connection unexpectedly/ERROR:  Error on receive from  pid=PID: server closed the connection unexpectedly/
 
 m/available \d+ MB/
 s/available \d+ MB//

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -10,8 +10,8 @@
 -- m/^DETAIL:.*gid=.*/
 -- s/gid=\d+-\d+/gid DUMMY/
 --
--- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
+-- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/
+-- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
 --
 -- end_matchsubs
 


### PR DESCRIPTION
Also fix previous trival wrong behavior in test crash_recovery_dtm which seems
to intend to test error on seg0 but never verified that.