### PR TITLE
Remove pointless ExecUpdateTransportState() function.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -766,9 +766,6 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			Assert(motionState);
 
 			Assert(IsA(motionState->ps.plan, Motion));
-
-			ExecUpdateTransportState((PlanState *) motionState,
-									 estate->interconnect_context);
 		}
 		else if (exec_identity == GP_ROOT_SLICE)
 		{
@@ -782,12 +779,6 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 				SetupInterconnect(estate);
 				Assert(estate->interconnect_context);
 				UpdateMotionExpectedReceivers(estate->motionlayer_context, estate->es_sliceTable);
-			}
-
-			if (estate->es_interconnect_is_setup)
-			{
-				ExecUpdateTransportState(queryDesc->planstate,
-										 estate->interconnect_context);
 			}
 		}
 		else if (exec_identity != GP_IGNORE)

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -1292,31 +1292,6 @@ MultiExecProcNode(PlanState *node)
 	return result;
 }
 
-static CdbVisitOpt
-transportUpdateNodeWalker(PlanState *node, void *context)
-{
-	/*
-	 * For motion nodes, we just transfer the context information established
-	 * during SetupInterconnect
-	 */
-	if (IsA(node, MotionState))
-	{
-		node->state->interconnect_context = (ChunkTransportState *) context;
-		/* visit subtree */
-	}
-
-	return CdbVisit_Walk;
-}	/* transportUpdateNodeWalker */
-
-void
-ExecUpdateTransportState(PlanState *node, ChunkTransportState * state)
-{
-	Assert(node);
-	Assert(state);
-	planstate_walk_node(node, transportUpdateNodeWalker, state);
-}	/* ExecUpdateTransportState */
-
-
 /* ----------------------------------------------------------------
  *		ExecEndNode
  *

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1061,8 +1061,6 @@ PG_TRY();
 
 		UpdateMotionExpectedReceivers(queryDesc->estate->motionlayer_context, queryDesc->estate->es_sliceTable);
 
-		ExecUpdateTransportState(planstate, queryDesc->estate->interconnect_context);
-
 		/*
 		 * MPP-7504/MPP-7448: the pre-dispatch function evaluator
 		 * may mess up our snapshot-sync mechanism. So we've

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -303,7 +303,6 @@ extern void ExecEndNode(PlanState *node);
 extern bool ExecShutdownNode(PlanState *node);
 
 extern void ExecSquelchNode(PlanState *node);
-extern void ExecUpdateTransportState(PlanState *node, struct ChunkTransportState *state);
 
 typedef enum
 {


### PR DESCRIPTION
ExecUpdateTransportState() walked through the plan tree, and for each
Motion node, it set MotionState->state->interconnect_context to match
estate->interconnect_context. That has no effect: the 'state' field of
every PlanState is set to point to the same 'estate' when the executor
tree is initialized. Remove it.
