### PR TITLE
Bump ORCA version to 3.83, allow array comparisons on btree indexes when used with bitmap scans

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.82.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.83.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.82.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.83.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.82.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.83.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.82.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.83.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.82.0@gpdb/stable
+orca/v3.83.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.82.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.83.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1303,6 +1303,7 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 		index_cond_list_dxlnode,
 		physical_idx_scan_dxlop->GetDXLTableDescr(),
 		is_index_only_scan,
+		false, // is_bitmap_index_probe
 		md_index,
 		md_rel,
 		output_context,
@@ -1371,6 +1372,7 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 	CDXLNode *index_cond_list_dxlnode,
 	const CDXLTableDescr *dxl_tbl_descr,
 	BOOL is_index_only_scan,
+	BOOL is_bitmap_index_probe,
 	const IMDIndex *index,
 	const IMDRelation *md_rel,
 	CDXLTranslateContext *output_context,
@@ -1398,7 +1400,9 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 		GPOS_ASSERT((IsA(index_cond_expr, OpExpr) || IsA(index_cond_expr, ScalarArrayOpExpr))
 				&& "expected OpExpr or ScalarArrayOpExpr in index qual");
 
-		if (IsA(index_cond_expr, ScalarArrayOpExpr) && IMDIndex::EmdindBitmap != index->IndexType())
+		if (!is_bitmap_index_probe &&
+			IsA(index_cond_expr, ScalarArrayOpExpr) &&
+			IMDIndex::EmdindBitmap != index->IndexType())
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, GPOS_WSZ_LIT("ScalarArrayOpExpr condition on index scan"));
 		}
@@ -4236,6 +4240,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan
 		index_cond_list_dxlnode,
 		dyn_index_scan_dxlop->GetDXLTableDescr(),
 		false, // is_index_only_scan
+		false, // is_bitmap_index_probe
 		md_index,
 		md_rel,
 		output_context,
@@ -6061,6 +6066,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe
 		index_cond_list_dxlnode,
 		table_descr,
 		false /*is_index_only_scan*/,
+		true  /*is_bitmap_index_probe*/,
 		index,
 		md_rel,
 		output_context,

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -726,6 +726,7 @@ namespace gpdxl
 				CDXLNode *index_cond_list_dxlnode,
 				const CDXLTableDescr *dxl_tbl_descr,
 				BOOL is_index_only_scan,
+				BOOL is_bitmap_index_probe,
 				const IMDIndex *index,
 				const IMDRelation *md_rel,
 				CDXLTranslateContext *output_context,

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10146,48 +10146,92 @@ drop function canSetTag_Func(x int);
 drop table canSetTag_bug_table;
 drop table canSetTag_input_data;
 -- Test B-Tree index scan with in list
-CREATE TABLE btree_test as SELECT * FROM generate_series(1,100) as a distributed randomly;
+CREATE TABLE btree_test as SELECT i a, i b FROM generate_series(1,100) i distributed randomly;
 CREATE INDEX btree_test_index ON btree_test(a);
+set optimizer_enable_tablescan = off;
+-- start_ignore
+select disable_xform('CXformSelect2IndexGet');
+           disable_xform           
+-----------------------------------
+ CXformSelect2IndexGet is disabled
+(1 row)
+
+-- end_ignore
 EXPLAIN SELECT * FROM btree_test WHERE a in (1, 47);
-                                         QUERY PLAN
+                                         QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.25 rows=2 width=4)
-   ->  Seq Scan on btree_test  (cost=0.00..4.25 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.25 rows=2 width=8)
+   ->  Seq Scan on btree_test  (cost=0.00..4.25 rows=1 width=8)
          Filter: a = ANY ('{1,47}'::integer[])
  Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
  Optimizer status: legacy query optimizer
 (5 rows)
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('2', 47);
-                                         QUERY PLAN
+                                         QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.25 rows=2 width=4)
-   ->  Seq Scan on btree_test  (cost=0.00..4.25 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.25 rows=2 width=8)
+   ->  Seq Scan on btree_test  (cost=0.00..4.25 rows=1 width=8)
          Filter: a = ANY ('{2,47}'::integer[])
  Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
  Optimizer status: legacy query optimizer
 (5 rows)
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2');
-                                         QUERY PLAN
+                                         QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.25 rows=2 width=4)
-   ->  Seq Scan on btree_test  (cost=0.00..4.25 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.25 rows=2 width=8)
+   ->  Seq Scan on btree_test  (cost=0.00..4.25 rows=1 width=8)
          Filter: a = ANY ('{1,2}'::integer[])
  Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
  Optimizer status: legacy query optimizer
 (5 rows)
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2', 47);
-                                         QUERY PLAN
+                                         QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.38 rows=3 width=4)
-   ->  Seq Scan on btree_test  (cost=0.00..4.38 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.38 rows=3 width=8)
+   ->  Seq Scan on btree_test  (cost=0.00..4.38 rows=1 width=8)
          Filter: a = ANY ('{1,2,47}'::integer[])
  Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
  Optimizer status: legacy query optimizer
 (5 rows)
 
+SELECT * FROM btree_test WHERE a in ('1', '2', 47);
+ a  | b  
+----+----
+  1 |  1
+  2 |  2
+ 47 | 47
+(3 rows)
+
+CREATE INDEX btree_test_index_ab ON btree_test using btree(a,b);
+EXPLAIN SELECT * FROM btree_test WHERE a in (1, 2, 47) AND b > 1;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.62 rows=3 width=8)
+   ->  Seq Scan on btree_test  (cost=0.00..4.62 rows=1 width=8)
+         Filter: b > 1 AND (a = ANY ('{1,2,47}'::integer[]))
+ Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+SELECT * FROM btree_test WHERE a in (1, 2, 47) AND b > 1;
+ a  | b  
+----+----
+ 47 | 47
+  2 |  2
+(2 rows)
+
+-- start_ignore
+select enable_xform('CXformSelect2IndexGet');
+           enable_xform           
+----------------------------------
+ CXformSelect2IndexGet is enabled
+(1 row)
+
+-- end_ignore
+reset optimizer_enable_tablescan;
 -- Test Bitmap index scan with in list
 CREATE TABLE bitmap_test as SELECT * FROM generate_series(1,100) as a distributed randomly;
 CREATE INDEX bitmap_index ON bitmap_test USING BITMAP(a);

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10201,48 +10201,102 @@ drop function canSetTag_Func(x int);
 drop table canSetTag_bug_table;
 drop table canSetTag_input_data;
 -- Test B-Tree index scan with in list
-CREATE TABLE btree_test as SELECT * FROM generate_series(1,100) as a distributed randomly;
+CREATE TABLE btree_test as SELECT i a, i b FROM generate_series(1,100) i distributed randomly;
 CREATE INDEX btree_test_index ON btree_test(a);
+set optimizer_enable_tablescan = off;
+-- start_ignore
+select disable_xform('CXformSelect2IndexGet');
+           disable_xform           
+-----------------------------------
+ CXformSelect2IndexGet is disabled
+(1 row)
+
+-- end_ignore
 EXPLAIN SELECT * FROM btree_test WHERE a in (1, 47);
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-   ->  Table Scan on btree_test  (cost=0.00..431.00 rows=1 width=4)
-         Filter: a = ANY ('{1,47}'::integer[])
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..204.38 rows=3 width=8)
+   ->  Bitmap Table Scan on btree_test  (cost=0.00..204.38 rows=1 width=8)
+         Recheck Cond: a = ANY ('{1,47}'::integer[])
+         ->  Bitmap Index Scan on btree_test_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: a = ANY ('{1,47}'::integer[])
  Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
  Optimizer status: PQO version 3.82.0
-(5 rows)
+(7 rows)
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('2', 47);
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-   ->  Table Scan on btree_test  (cost=0.00..431.00 rows=1 width=4)
-         Filter: a = ANY ('{2,47}'::integer[])
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..204.38 rows=3 width=8)
+   ->  Bitmap Table Scan on btree_test  (cost=0.00..204.38 rows=1 width=8)
+         Recheck Cond: a = ANY ('{2,47}'::integer[])
+         ->  Bitmap Index Scan on btree_test_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: a = ANY ('{2,47}'::integer[])
  Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
  Optimizer status: PQO version 3.82.0
-(5 rows)
+(7 rows)
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2');
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-   ->  Table Scan on btree_test  (cost=0.00..431.00 rows=1 width=4)
-         Filter: a = ANY ('{1,2}'::integer[])
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..204.38 rows=3 width=8)
+   ->  Bitmap Table Scan on btree_test  (cost=0.00..204.38 rows=1 width=8)
+         Recheck Cond: a = ANY ('{1,2}'::integer[])
+         ->  Bitmap Index Scan on btree_test_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: a = ANY ('{1,2}'::integer[])
  Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
  Optimizer status: PQO version 3.82.0
-(5 rows)
+(7 rows)
 
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2', 47);
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
-   ->  Table Scan on btree_test  (cost=0.00..431.00 rows=2 width=4)
-         Filter: a = ANY ('{1,2,47}'::integer[])
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..613.15 rows=4 width=8)
+   ->  Bitmap Table Scan on btree_test  (cost=0.00..613.15 rows=2 width=8)
+         Recheck Cond: a = ANY ('{1,2,47}'::integer[])
+         ->  Bitmap Index Scan on btree_test_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: a = ANY ('{1,2,47}'::integer[])
  Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
  Optimizer status: PQO version 3.82.0
-(5 rows)
+(7 rows)
 
+SELECT * FROM btree_test WHERE a in ('1', '2', 47);
+ a  | b  
+----+----
+  1 |  1
+  2 |  2
+ 47 | 47
+(3 rows)
+
+CREATE INDEX btree_test_index_ab ON btree_test using btree(a,b);
+EXPLAIN SELECT * FROM btree_test WHERE a in (1, 2, 47) AND b > 1;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.06 rows=4 width=8)
+   ->  Bitmap Table Scan on btree_test  (cost=0.00..431.06 rows=2 width=8)
+         Recheck Cond: (a = ANY ('{1,2,47}'::integer[])) AND b > 1
+         ->  Bitmap Index Scan on btree_test_index_ab  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a = ANY ('{1,2,47}'::integer[])) AND b > 1
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 3.82.0
+(7 rows)
+
+SELECT * FROM btree_test WHERE a in (1, 2, 47) AND b > 1;
+ a  | b  
+----+----
+ 47 | 47
+  2 |  2
+(2 rows)
+
+-- start_ignore
+select enable_xform('CXformSelect2IndexGet');
+           enable_xform           
+----------------------------------
+ CXformSelect2IndexGet is enabled
+(1 row)
+
+-- end_ignore
+reset optimizer_enable_tablescan;
 -- Test Bitmap index scan with in list
 CREATE TABLE bitmap_test as SELECT * FROM generate_series(1,100) as a distributed randomly;
 CREATE INDEX bitmap_index ON bitmap_test USING BITMAP(a);

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1405,12 +1405,24 @@ drop table canSetTag_bug_table;
 drop table canSetTag_input_data;
 
 -- Test B-Tree index scan with in list
-CREATE TABLE btree_test as SELECT * FROM generate_series(1,100) as a distributed randomly;
+CREATE TABLE btree_test as SELECT i a, i b FROM generate_series(1,100) i distributed randomly;
 CREATE INDEX btree_test_index ON btree_test(a);
+set optimizer_enable_tablescan = off;
+-- start_ignore
+select disable_xform('CXformSelect2IndexGet');
+-- end_ignore
 EXPLAIN SELECT * FROM btree_test WHERE a in (1, 47);
 EXPLAIN SELECT * FROM btree_test WHERE a in ('2', 47);
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2');
 EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2', 47);
+SELECT * FROM btree_test WHERE a in ('1', '2', 47);
+CREATE INDEX btree_test_index_ab ON btree_test using btree(a,b);
+EXPLAIN SELECT * FROM btree_test WHERE a in (1, 2, 47) AND b > 1;
+SELECT * FROM btree_test WHERE a in (1, 2, 47) AND b > 1;
+-- start_ignore
+select enable_xform('CXformSelect2IndexGet');
+-- end_ignore
+reset optimizer_enable_tablescan;
 
 -- Test Bitmap index scan with in list
 CREATE TABLE bitmap_test as SELECT * FROM generate_series(1,100) as a distributed randomly;


### PR DESCRIPTION
The corresponding ORCA PR is https://github.com/greenplum-db/gporca/pull/554.

Change the check when translating an ORCA query to a plan.
The old check prohibited ArrayCmp on a btree index. The new
check is similar, except that it allows an ArrayCmp on a
btree index when it is done in a bitmap index probe.

Updated ICG result files and added a new test case.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
