### PR TITLE
Fix normalization of queries with window functions

### DIFF
--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -69,7 +69,7 @@ namespace gpdxl
 				Query *m_query;
 
 				// the new target list of the group by (derived) query
-				List *m_groupby_tlist;
+				List *m_derived_table_tlist;
 
 				// the current query level
 				ULONG m_current_query_level;
@@ -80,22 +80,26 @@ namespace gpdxl
 				// indicate whether we are mutating the argument of an aggregate
 				BOOL m_is_mutating_agg_arg;
 
+				// indicate whether we are mutating the argument of a window function
+				BOOL m_is_mutating_window_arg;
+
 				// ctor
 				SContextGrpbyPlMutator
 					(
 					CMemoryPool *mp,
 					CMDAccessor *mda,
 					Query *query,
-					List *groupby_tlist
+					List *derived_table_tlist
 					)
 						:
 					m_mp(mp),
 					m_mda(mda),
 					m_query(query),
-					m_groupby_tlist(groupby_tlist),
+					m_derived_table_tlist(derived_table_tlist),
 					m_current_query_level(0),
 					m_agg_levels_up(gpos::ulong_max),
-					m_is_mutating_agg_arg(false)
+					m_is_mutating_agg_arg(false),
+					m_is_mutating_window_arg(false)
 				{
 				}
 
@@ -201,6 +205,10 @@ namespace gpdxl
 			// make a copy of the aggref (minus the arguments)
 			static
 			Aggref *FlatCopyAggref(Aggref *aggref);
+
+			// make a copy of the window function (minus the arguments)
+			static
+			WindowFunc *FlatCopyWindowFunc (WindowFunc *old_windowfunc);
 
 			// create a new entry in the derived table and return its corresponding var
 			static

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -6530,6 +6530,122 @@ select lead(c,c+d,1000) over(order by c,d) from orca.s order by 1;
  1000
 (30 rows)
 
+-- test normalization of window functions
+create table orca_w1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table orca_w2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table orca_w3(a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into orca_w1 select i, i from generate_series(1, 3) i;
+insert into orca_w2 select i, i from generate_series(2, 4) i;
+insert into orca_w3 select i, i from generate_series(3, 5) i;
+-- outer ref in subquery in target list and window func in target list
+select (select b from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w2, orca_w1;
+ one | two 
+-----+-----
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+ 3   |   1
+ 3   |   2
+ 3   |   3
+(9 rows)
+
+-- aggref in subquery with window func in target list
+select orca_w1.a, (select sum(orca_w2.a) from orca_w2 where orca_w1.b = orca_w2.b), count(*), rank() over (order by orca_w1.b) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+ a | sum | count | rank 
+---+-----+-------+------
+ 1 |     |     1 |    1
+ 2 |   2 |     1 |    2
+ 3 |   3 |     1 |    3
+(3 rows)
+
+-- window function inside subquery inside target list with outer ref
+select orca_w1.a, (select rank() over (order by orca_w1.b) from orca_w2 where orca_w1.b = orca_w2.b), count(*) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+ a | rank | count 
+---+------+-------
+ 1 |      |     1
+ 2 |    1 |     1
+ 3 |    1 |     1
+(3 rows)
+
+-- window function with empty partition clause inside subquery inside target list with outer ref
+select (select rank() over() from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2;
+ one | two 
+-----+-----
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+   1 |   1
+   1 |   2
+   1 |   3
+(9 rows)
+
+-- window function in IN clause
+select (select a from orca_w3 where a = orca_w1.a) as one from orca_w1 where orca_w1.a IN (select rank() over(partition by orca_w1.a) + 1 from orca_w1, orca_w2);
+ one 
+-----
+    
+(1 row)
+
+-- window function in subquery inside target list with outer ref in partition clause
+select (select rank() over(partition by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+   1 |   1
+   1 |   2
+   1 |   3
+(9 rows)
+
+-- window function in subquery inside target list with outer ref in order clause
+select (select rank() over(order by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+   1 |   1
+   1 |   2
+   1 |   3
+(9 rows)
+
+-- window function with outer ref in arguments
+select (select sum(orca_w1.a + a) over(order by b) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+ ?column? 
+----------
+         
+        5
+        7
+(3 rows)
+
+-- window function with outer ref in window clause and arguments 
+select (select sum(orca_w1.a + a) over(order by b + orca_w1.a) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+ ?column? 
+----------
+         
+        5
+        7
+(3 rows)
+
 -- cte
 with x as (select a, b from orca.r)
 select rank() over(partition by a, case when b = 0 then a+b end order by b asc) as rank_within_parent from x order by a desc ,case when a+b = 0 then a end ,b;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -6554,6 +6554,122 @@ select lead(c,c+d,1000) over(order by c,d) from orca.s order by 1;
  1000
 (30 rows)
 
+-- test normalization of window functions
+create table orca_w1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table orca_w2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table orca_w3(a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into orca_w1 select i, i from generate_series(1, 3) i;
+insert into orca_w2 select i, i from generate_series(2, 4) i;
+insert into orca_w3 select i, i from generate_series(3, 5) i;
+-- outer ref in subquery in target list and window func in target list
+select (select b from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w2, orca_w1;
+ one | two 
+-----+-----
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+ 3   |   1
+ 3   |   2
+ 3   |   3
+(9 rows)
+
+-- aggref in subquery with window func in target list
+select orca_w1.a, (select sum(orca_w2.a) from orca_w2 where orca_w1.b = orca_w2.b), count(*), rank() over (order by orca_w1.b) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+ a | sum | count | rank 
+---+-----+-------+------
+ 1 |     |     1 |    1
+ 2 |   2 |     1 |    2
+ 3 |   3 |     1 |    3
+(3 rows)
+
+-- window function inside subquery inside target list with outer ref
+select orca_w1.a, (select rank() over (order by orca_w1.b) from orca_w2 where orca_w1.b = orca_w2.b), count(*) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+ a | rank | count 
+---+------+-------
+ 1 |      |     1
+ 2 |    1 |     1
+ 3 |    1 |     1
+(3 rows)
+
+-- window function with empty partition clause inside subquery inside target list with outer ref
+select (select rank() over() from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2;
+ one | two 
+-----+-----
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+   1 |   1
+   1 |   2
+   1 |   3
+(9 rows)
+
+-- window function in IN clause
+select (select a from orca_w3 where a = orca_w1.a) as one from orca_w1 where orca_w1.a IN (select rank() over(partition by orca_w1.a) + 1 from orca_w1, orca_w2);
+ one 
+-----
+    
+(1 row)
+
+-- window function in subquery inside target list with outer ref in partition clause
+select (select rank() over(partition by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+   1 |   1
+   1 |   2
+   1 |   3
+(9 rows)
+
+-- window function in subquery inside target list with outer ref in order clause
+select (select rank() over(order by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+   1 |   1
+   1 |   2
+   1 |   3
+(9 rows)
+
+-- window function with outer ref in arguments
+select (select sum(orca_w1.a + a) over(order by b) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+ ?column? 
+----------
+         
+        5
+        7
+(3 rows)
+
+-- window function with outer ref in window clause and arguments 
+select (select sum(orca_w1.a + a) over(order by b + orca_w1.a) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+ ?column? 
+----------
+         
+        5
+        7
+(3 rows)
+
 -- cte
 with x as (select a, b from orca.r)
 select rank() over(partition by a, case when b = 0 then a+b end order by b asc) as rank_within_parent from x order by a desc ,case when a+b = 0 then a end ,b;


### PR DESCRIPTION
Whenever there are queries involving window functions, ORCA requires the query
to be in a specific form in order to optimize it. Specifically, the query
should only contain window functions and the columns referenced by the window
clause. The algebrizer is responsible for normalizing the query to a specific
form. However the algebrizer did not handle the case when one of the columns
selected was a subquery.

For e.g

select (select b from orca_w3 where a = w1.a) as one,
       row_number() over(partition by w1.a) as two
       from w1, w2;

In this case, the algebrizer would simply pull the subquery to the top level
without fixing the vars for the outer references.This caused the algebrizer to
crash.

This commit fixes the issue by recursing into the subquery and fixing up the
vars.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
