### PR TITLE
Add apr-util-devel Build Dependency for Building Gpperfmon

### DIFF
--- a/README.CentOS.bash
+++ b/README.CentOS.bash
@@ -4,6 +4,7 @@
 sudo yum install -y epel-release
 sudo yum install -y \
     apr-devel \
+    apr-util-devel \
     bison \
     bzip2-devel \
     cmake3 \


### PR DESCRIPTION
Hi, Team,

I find that apr-util-devel package is required for building Gpperfmon, but there is no obvious description about it.

Hence I add it to README.CentOS.bash script.

Best Regards.