### PR TITLE
Fix batching in analyzedb when gathering partition root statistics

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -449,31 +449,42 @@ class AnalyzeDb(Operation):
 
         return 0
 
+    # We run 'analyze <table>' and 'analyze rootpartition <root>' commands in
+    # separate batches, as 'analyze rootpartition' commands will go through
+    # different codepaths depending on whether all leaf partitions have been
+    # analyzed. If all leaves have been analyzed, 'analyze rootpartition'
+    # simply merges the HLL statistics. If any leaves have not been analyzed, a
+    # sample is taken, which can take longer. Thus we run all 'analyze'
+    # statements before 'analyze rootpartition' statments
     def run_analyze(self, logger, ordered_candidates, candidates, input_col_dict, root_partition_col_dict):
         logger.info("Starting analyze with %d workers..." % self.parallel_level)
-        pool = AnalyzeWorkerPool(numWorkers=self.parallel_level)
+        non_root_pool = AnalyzeWorkerPool(numWorkers=self.parallel_level)
+        root_pool = AnalyzeWorkerPool(numWorkers=self.parallel_level)
 
         for can in ordered_candidates:
             can_schema, can_table = can[0], can[1]
             if can in candidates:
                 target = self._get_tablename_with_cols(can_schema, can_table, input_col_dict)
                 cmd = create_psql_command(self.dbname, self.analyze_gucs + ANALYZE_SQL % target)
+                non_root_pool.addCommand(cmd)
 
             else:  # can in root_partition_col_dict
                 target = self._get_tablename_with_cols(can_schema, can_table, root_partition_col_dict)
                 cmd = create_psql_command(self.dbname, ANALYZE_ROOT_SQL % target)
+                root_pool.addCommand(cmd)
 
             # Also stash the name of the target table in the object, so that it can be extracted
             # from it later.
             cmd.target_schema = can_schema
             cmd.target_table = can_table
-            pool.addCommand(cmd)
 
         wait_count = len(ordered_candidates)
+        num_roots = root_pool.assigned
         start_time = time.time()
+        non_root_pool.run()
         try:
-            while wait_count > 0:
-                done_cmd = pool.completed_queue.get()
+            while wait_count > num_roots:
+                done_cmd = non_root_pool.completed_queue.get()
                 if done_cmd.was_successful():
                     subject = (done_cmd.target_schema, done_cmd.target_table)
                     self.success_list.append(subject)
@@ -482,11 +493,26 @@ class AnalyzeDb(Operation):
                                 (len(self.success_list), len(ordered_candidates)))
                 wait_count -= 1
 
-            pool.join()
-            pool.haltWork()
+            non_root_pool.join()
+            non_root_pool.haltWork()
+            root_pool.run()
+            while wait_count > 0:
+                done_cmd = root_pool.completed_queue.get()
+                if done_cmd.was_successful():
+                    subject = (done_cmd.target_schema, done_cmd.target_table)
+                    self.success_list.append(subject)
+                if wait_count % 10 == 0:
+                    logger.info("progress status: completed %d out of %d tables or partitions" %
+                                (len(self.success_list), len(ordered_candidates)))
+                wait_count -= 1
+
+            root_pool.join()
+            root_pool.haltWork()
         except:
-            pool.haltWork()
-            pool.joinWorkers()
+            non_root_pool.haltWork()
+            non_root_pool.joinWorkers()
+            root_pool.haltWork()
+            root_pool.joinWorkers()
             raise
 
         finally:
@@ -1300,9 +1326,11 @@ class AnalyzeWorkerPool(WorkerPool):
             # use AnalyzeWorker instead of Worker
             w = AnalyzeWorker("worker%d" % i, self)
             self.workers.append(w)
-            w.start()
         self.numWorkers = numWorkers
 
+    def run(self):
+        for w in self.workers:
+            w.start()
 
 class AnalyzeWorker(Worker):
     """

--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -478,41 +478,28 @@ class AnalyzeDb(Operation):
             cmd.target_schema = can_schema
             cmd.target_table = can_table
 
-        wait_count = len(ordered_candidates)
+        wait_count = num_tables = len(ordered_candidates)
         num_roots = root_pool.assigned
         start_time = time.time()
         non_root_pool.run()
         try:
             while wait_count > num_roots:
-                done_cmd = non_root_pool.completed_queue.get()
-                if done_cmd.was_successful():
-                    subject = (done_cmd.target_schema, done_cmd.target_table)
-                    self.success_list.append(subject)
-                if wait_count % 10 == 0:
-                    logger.info("progress status: completed %d out of %d tables or partitions" %
-                                (len(self.success_list), len(ordered_candidates)))
+                self.run_analyze_statements(non_root_pool, wait_count, num_tables)
                 wait_count -= 1
-
             non_root_pool.join()
             non_root_pool.haltWork()
             root_pool.run()
             while wait_count > 0:
-                done_cmd = root_pool.completed_queue.get()
-                if done_cmd.was_successful():
-                    subject = (done_cmd.target_schema, done_cmd.target_table)
-                    self.success_list.append(subject)
-                if wait_count % 10 == 0:
-                    logger.info("progress status: completed %d out of %d tables or partitions" %
-                                (len(self.success_list), len(ordered_candidates)))
+                self.run_analyze_statements(root_pool, wait_count, num_tables)
                 wait_count -= 1
-
             root_pool.join()
             root_pool.haltWork()
         except:
             non_root_pool.haltWork()
             non_root_pool.joinWorkers()
-            root_pool.haltWork()
-            root_pool.joinWorkers()
+            if non_root_pool.completed_queue.qsize() == 0:
+                root_pool.haltWork()
+                root_pool.joinWorkers()
             raise
 
         finally:
@@ -520,6 +507,15 @@ class AnalyzeDb(Operation):
             logger.info(
                         "Total elapsed time: %d seconds. Analyzed %d out of %d table(s) or partition(s) successfully."
                         % (int(end_time - start_time), len(self.success_list), len(ordered_candidates)))
+
+    def run_analyze_statements(self, pool, wait_count, total_to_analyze):
+        done_cmd = pool.completed_queue.get()
+        if done_cmd.was_successful():
+            subject = (done_cmd.target_schema, done_cmd.target_table)
+            self.success_list.append(subject)
+        if wait_count % 10 == 0:
+            logger.info("progress status: completed %d out of %d tables or partitions" %
+                        (len(self.success_list), total_to_analyze))
 
     def read_last_analyzedb_output(self):
         last_analyze_timestamp = get_lastest_analyze_timestamp(self.master_datadir, self.analyze_dir, self.dbname)


### PR DESCRIPTION
analyzedb dispatches 2 types of commands, 'analyze \<table>' and 'analyze
rootpartition \<root>'. 'analyze rootpartition' can go through a couple of
different codepaths:

1) If all leaves have been analyzed, it will merge the hll statistics
into the root. Even if a leaf has out of date statistics, it will still
be merged into the root.

2) If any leaf has not yet been analyzed, it will not merge statistics,
but rather re-sample the rows from all the leaves using a different
codepath, which will be slower than simply merging statistics.

analyzedb runs these 2 commands in batches: both 'analyze' and 'analyze
rootpartition' can be in the same batch. This can cause inaccurate root
statistics, which are then used in ORCA.

Now, we run these commands in separate batches. First, all 'analyze'
commands are batched and executed. Once all these have finished, the 'analyze
rootpartition' commands are batched and executed.

Authored-by: Chris Hajas <chajas@pivotal.io>