### PR TITLE
Fix segfault in pg_upgrade when file contents are null.

### DIFF
--- a/contrib/pg_upgrade/tablespace.c
+++ b/contrib/pg_upgrade/tablespace.c
@@ -81,7 +81,8 @@ verify_old_tablespace_paths(void)
 static void
 get_tablespace_paths(void)
 {
-	if (old_cluster.old_tablespace_file_contents && !is_old_tablespaces_file_empty(old_cluster.old_tablespace_file_contents)) {
+	if (old_cluster.old_tablespace_file_contents &&
+		!is_old_tablespaces_file_empty(old_cluster.old_tablespace_file_contents)) {
 		populate_os_info_with_file_contents(old_cluster.old_tablespace_file_contents);
 		verify_old_tablespace_paths();
 		return;


### PR DESCRIPTION
I ran across this bug with @bhuvnesh2703 & @dgkimura 

After switching around the logic for `is_old_tablespace_file_contents_empty`, the null check inside the function no longer prevents from entering the block to populate based on the file contents.

Updated, with a unit test.