### PR TITLE
Give Explicit Gather Motions new MOTIONTYPE_GATHER_SINGLE value.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -403,7 +403,7 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 		Assert(plan->flow && motion->plan.lefttree->flow);
 
 		/* If top slice marked as singleton, make it a dispatcher singleton. */
-		if (motion->motionType == MOTIONTYPE_GATHER
+		if ((motion->motionType == MOTIONTYPE_GATHER || motion->motionType == MOTIONTYPE_GATHER_SINGLE)
 			&& context->sliceDepth == 0)
 		{
 			plan->flow->segindex = -1;
@@ -440,7 +440,8 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 		if (plan->flow->locustype == CdbLocusType_OuterQuery)
 		{
 			Assert(context->outer_query_flow);
-			Assert(motion->motionType == MOTIONTYPE_GATHER || motion->motionType == MOTIONTYPE_BROADCAST);
+			Assert(motion->motionType == MOTIONTYPE_GATHER ||
+				   motion->motionType == MOTIONTYPE_BROADCAST);
 			Assert(!motion->sendSorted);
 
 			if (context->outer_query_flow->flotype == FLOW_SINGLETON)

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1433,10 +1433,12 @@ ExplainNode(PlanState *planstate, List *ancestors,
 				switch (pMotion->motionType)
 				{
 					case MOTIONTYPE_GATHER:
-						if (plan->lefttree->flow->locustype == CdbLocusType_Replicated)
-							sname = "Explicit Gather Motion";
-						else
-							sname = "Gather Motion";
+						sname = "Gather Motion";
+						scaleFactor = 1;
+						motion_recv = 1;
+						break;
+					case MOTIONTYPE_GATHER_SINGLE:
+						sname = "Explicit Gather Motion";
 						scaleFactor = 1;
 						motion_recv = 1;
 						break;
@@ -1475,7 +1477,8 @@ ExplainNode(PlanState *planstate, List *ancestors,
 						motion_snd = plan->lefttree->flow->numsegments;
 					}
 
-					if (pMotion->motionType == MOTIONTYPE_GATHER)
+					if (pMotion->motionType == MOTIONTYPE_GATHER ||
+						pMotion->motionType == MOTIONTYPE_GATHER_SINGLE)
 					{
 						/* In Gather Motion always display receiver size as 1 */
 						motion_recv = 1;

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -251,13 +251,8 @@ execMotionSender(MotionState *node)
 	bool		done = false;
 	int			numsegments = 0;
 
-	/* need refactor */
-	if (node->isExplictGatherMotion)
-	{
+	if (motion->motionType == MOTIONTYPE_GATHER_SINGLE)
 		numsegments = motion->plan.flow->numsegments;
-	}
-
-
 
 #ifdef MEASURE_MOTION_TIME
 	struct timeval time1;
@@ -267,6 +262,7 @@ execMotionSender(MotionState *node)
 #endif
 
 	AssertState(motion->motionType == MOTIONTYPE_GATHER ||
+				motion->motionType == MOTIONTYPE_GATHER_SINGLE ||
 				motion->motionType == MOTIONTYPE_HASH ||
 				motion->motionType == MOTIONTYPE_BROADCAST ||
 				(motion->motionType == MOTIONTYPE_EXPLICIT && motion->segidColIdx > 0));
@@ -302,12 +298,13 @@ execMotionSender(MotionState *node)
 			doSendEndOfStream(motion, node);
 			done = true;
 		}
-		else if (node->isExplictGatherMotion &&
+		else if (motion->motionType == MOTIONTYPE_GATHER_SINGLE &&
 				 GpIdentity.segindex != (gp_session_id % numsegments))
 		{
 			/*
-			 * For explicit gather motion, receiver get data from the
-			 * singleton segment explictly.
+			 * For explicit gather motion, receiver gets data from one
+			 * segment only. The others execute the subplan normally, but
+			 * throw away the resulting tuples.
 			 */
 		}
 		else
@@ -359,6 +356,7 @@ execMotionUnsortedReceiver(MotionState *node)
 	Motion	   *motion = (Motion *) node->ps.plan;
 
 	AssertState(motion->motionType == MOTIONTYPE_GATHER ||
+				motion->motionType == MOTIONTYPE_GATHER_SINGLE ||
 				motion->motionType == MOTIONTYPE_HASH ||
 				motion->motionType == MOTIONTYPE_BROADCAST ||
 				(motion->motionType == MOTIONTYPE_EXPLICIT && motion->segidColIdx > 0));
@@ -731,7 +729,6 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 	motionstate->stopRequested = false;
 	motionstate->hashExprs = NIL;
 	motionstate->cdbhash = NULL;
-	motionstate->isExplictGatherMotion = false;
 
 	/* Look up the sending gang's slice table entry. */
 	sendSlice = (Slice *) list_nth(sliceTable->slices, node->motionID);
@@ -746,7 +743,8 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 		/* Look up the receiving (parent) gang's slice table entry. */
 		recvSlice = (Slice *) list_nth(sliceTable->slices, sendSlice->parentIndex);
 
-		if (node->motionType == MOTIONTYPE_GATHER)
+		if (node->motionType == MOTIONTYPE_GATHER ||
+			node->motionType == MOTIONTYPE_GATHER_SINGLE)
 		{
 			/* Sending to a single receiving process on the entry db? */
 			/* Is receiving slice a root slice that runs here in the qDisp? */
@@ -785,19 +783,6 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 			motionstate->mstype = MOTIONSTATE_SEND;
 		}
 		/* TODO: If neither sending nor receiving, don't bother to initialize. */
-	}
-
-	/*
-	 * If it's gather motion and subplan's locus is CdbLocusType_Replicated,
-	 * mark isExplictGatherMotion to true
-	 */
-	if (motionstate->mstype == MOTIONSTATE_SEND &&
-		node->motionType == MOTIONTYPE_GATHER &&
-		outerPlan(node) &&
-		outerPlan(node)->flow &&
-		outerPlan(node)->flow->locustype == CdbLocusType_Replicated)
-	{
-		motionstate->isExplictGatherMotion = true;
 	}
 
 	motionstate->tupleheapReady = false;
@@ -1304,7 +1289,8 @@ doSendTuple(Motion *motion, MotionState *node, TupleTableSlot *outerTupleSlot)
 	/* We got a tuple from the child-plan. */
 	node->numTuplesFromChild++;
 
-	if (motion->motionType == MOTIONTYPE_GATHER)
+	if (motion->motionType == MOTIONTYPE_GATHER ||
+		motion->motionType == MOTIONTYPE_GATHER_SINGLE)
 	{
 		/*
 		 * Actually, since we can only send to a single output segment

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1593,6 +1593,7 @@ _readMotion(void)
 	READ_ENUM_FIELD(motionType, MotionType);
 
 	Assert(local_node->motionType == MOTIONTYPE_GATHER ||
+		   local_node->motionType == MOTIONTYPE_GATHER_SINGLE ||
 		   local_node->motionType == MOTIONTYPE_HASH ||
 		   local_node->motionType == MOTIONTYPE_BROADCAST ||
 		   local_node->motionType == MOTIONTYPE_EXPLICIT);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2390,6 +2390,10 @@ create_modifytable_plan(PlannerInfo *root, ModifyTablePath *best_path)
 
 	copy_generic_path_info(&plan->plan, &best_path->path);
 
+	plan->plan.flow = cdbpathtoplan_create_flow(root,
+												best_path->path.locus,
+												&plan->plan);
+
 	/*
 	 * GPDB_96_MERGE_FIXME: is this needed here? I think we set directDispatch later in the
 	 * planning, so that this has no effect here. Try removing and see what happens.
@@ -8202,7 +8206,12 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 
 		/* Unordered Union Receive */
 		else
+		{
 			motion = make_union_motion(subplan, numsegments);
+
+			if (subplan->flow->locustype == CdbLocusType_Replicated)
+				motion->motionType = MOTIONTYPE_GATHER_SINGLE;
+		}
 
 		if (CdbPathLocus_IsOuterQuery(path->path.locus))
 			motion->plan.flow->locustype = CdbLocusType_OuterQuery;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -3061,7 +3061,6 @@ typedef struct MotionState
 	Oid		   *outputFunArray;	/* output functions for each column (debug only) */
 
 	int			numInputSegs;	/* the number of segments on the sending slice */
-	bool		isExplictGatherMotion;
 } MotionState;
 
 /*zx

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1287,6 +1287,7 @@ typedef struct Limit
 typedef enum MotionType
 {
 	MOTIONTYPE_GATHER,		/* Send tuples from N senders to one receiver */
+	MOTIONTYPE_GATHER_SINGLE, /* Execute subplan on N nodes, but only send the tuples from one */
 	MOTIONTYPE_HASH,		/* Use hashing to select a segindex destination */
 	MOTIONTYPE_BROADCAST,	/* Send tuples from one sender to a fixed set of segindexes */
 	MOTIONTYPE_EXPLICIT		/* Send tuples to the segment explicitly specified in their segid column */


### PR DESCRIPTION
An Explicit Gather Motion works differently from a normal Gather motion,
so it seems more clear to have a separate MotionType for it. It felt
wrong that the executor code was looking at the Flow information of the
subplan. I think as a matter of principle, each Plan node should carry
all the information needed to initialize the node, without peeking at
the child node.
