### PR TITLE
Before exiting these tests, shutdown the clusters.

### DIFF
--- a/contrib/pg_upgrade/test/integration/test.sh
+++ b/contrib/pg_upgrade/test/integration/test.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+shutdown_servers() {
+	./scripts/gpdb5-cluster stop
+	./scripts/gpdb6-cluster stop
+}
+
+trap shutdown_servers EXIT
+
 main() {
 	local old_port=50000
 	local new_port=60000


### PR DESCRIPTION
This aids local development by shutting down the clusters even in the event of a test failure.
