### PR TITLE
5x: Remove redundant Assert in localXidSatisfiesAnyDistributedSnapshot.

### DIFF
--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -51,7 +51,6 @@ bool
 localXidSatisfiesAnyDistributedSnapshot(TransactionId localXid)
 {
 	DistributedSnapshotCommitted distributedSnapshotCommitted;
-	Assert(TransactionIdIsNormal(localXid));
 
 	/*
 	 * In general expect this function to be called only for normal xid, as

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -1,3 +1,8 @@
+-- Test vacuum a catalog can succeed.
+-- Previously, we have a redundant Assert in the function
+-- localXidSatisfiesAnyDistributedSnapshot that will fail this.
+-- See Github Issue 6793.
+vacuum full pg_proc;
 set optimizer_print_missing_stats = off;
 -- MPP-23647 Create a partitioned appendonly table, let its age
 -- increase during the test.  We will vacuum it at the end of the

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -1,3 +1,9 @@
+-- Test vacuum a catalog can succeed.
+-- Previously, we have a redundant Assert in the function
+-- localXidSatisfiesAnyDistributedSnapshot that will fail this.
+-- See Github Issue 6793.
+vacuum full pg_proc;
+
 set optimizer_print_missing_stats = off;
 -- MPP-23647 Create a partitioned appendonly table, let its age
 -- increase during the test.  We will vacuum it at the end of the


### PR DESCRIPTION
Right below we have an if-statement to check the same thing as
this assert.

------------------------

6X and master does not have such function.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
