### PR TITLE
Remove unused rtables/subplans output params from CContextDXLToPlStmt.

### DIFF
--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -43,9 +43,7 @@ CContextDXLToPlStmt::CContextDXLToPlStmt
 	CIdGenerator *plan_id_counter,
 	CIdGenerator *motion_id_counter,
 	CIdGenerator *param_id_counter,
-	DistributionHashOpsKind distribution_hashops,
-	List **rtable_entries_list,
-	List **subplan_entries_list
+	DistributionHashOpsKind distribution_hashops
 	)
 	:
 	m_mp(mp),
@@ -53,10 +51,10 @@ CContextDXLToPlStmt::CContextDXLToPlStmt
 	m_motion_id_counter(motion_id_counter),
 	m_param_id_counter(param_id_counter),
 	m_distribution_hashops(distribution_hashops),
-	m_rtable_entries_list(rtable_entries_list),
+	m_rtable_entries_list(NULL),
 	m_partitioned_tables_list(NULL),
 	m_num_partition_selectors_array(NULL),
-	m_subplan_entries_list(subplan_entries_list),
+	m_subplan_entries_list(NULL),
 	m_result_relation_index(0),
 	m_into_clause(NULL),
 	m_distribution_policy(NULL)
@@ -210,34 +208,6 @@ CContextDXLToPlStmt::GetCTEConsumerList
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CContextDXLToPlStmt::GetRTableEntriesList
-//
-//	@doc:
-//		Return the list of RangeTableEntries
-//
-//---------------------------------------------------------------------------
-List *
-CContextDXLToPlStmt::GetRTableEntriesList()
-{
-	return (*(m_rtable_entries_list));
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CContextDXLToPlStmt::GetSubplanEntriesList
-//
-//	@doc:
-//		Return the list of subplans generated so far
-//
-//---------------------------------------------------------------------------
-List *
-CContextDXLToPlStmt::GetSubplanEntriesList()
-{
-	return (*(m_subplan_entries_list));
-}
-
-//---------------------------------------------------------------------------
-//	@function:
 //		CContextDXLToPlStmt::AddRTE
 //
 //	@doc:
@@ -251,7 +221,7 @@ CContextDXLToPlStmt::AddRTE
 	BOOL is_result_relation
 	)
 {
-	(* (m_rtable_entries_list)) = gpdb::LAppend((*(m_rtable_entries_list)), rte);
+	m_rtable_entries_list = gpdb::LAppend(m_rtable_entries_list, rte);
 
 	rte->inFromCl = true;
 
@@ -259,7 +229,7 @@ CContextDXLToPlStmt::AddRTE
 	{
 		GPOS_ASSERT(0 == m_result_relation_index && "Only one result relation supported");
 		rte->inFromCl = false;
-		m_result_relation_index = gpdb::ListLength(*(m_rtable_entries_list));
+		m_result_relation_index = gpdb::ListLength(m_rtable_entries_list);
 	}
 }
 
@@ -342,7 +312,7 @@ CContextDXLToPlStmt::GetNumPartitionSelectorsList() const
 void
 CContextDXLToPlStmt::AddSubplan(Plan *plan)
 {
-	(* (m_subplan_entries_list)) = gpdb::LAppend((*(m_subplan_entries_list)), plan);
+	m_subplan_entries_list = gpdb::LAppend(m_subplan_entries_list, plan);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -329,18 +329,13 @@ COptTasks::ConvertToPlanStmtFromDXL
 	CIdGenerator motion_id_generator(1 /* ulStartId */);
 	CIdGenerator param_id_generator(0 /* ulStartId */);
 
-	List *table_list = NULL;
-	List *subplans_list = NULL;
-
 	CContextDXLToPlStmt dxl_to_plan_stmt_ctxt
 							(
 							mp,
 							&plan_id_generator,
 							&motion_id_generator,
 							&param_id_generator,
-							distribution_hashops,
-							&table_list,
-							&subplans_list
+							distribution_hashops
 							);
 	
 	// translate DXL -> PlannedStmt

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -110,7 +110,7 @@ namespace gpdxl
 			DistributionHashOpsKind m_distribution_hashops;
 
 			// list of all rtable entries
-			List **m_rtable_entries_list;
+			List *m_rtable_entries_list;
 
 			// list of oids of partitioned tables
 			List *m_partitioned_tables_list;
@@ -119,7 +119,7 @@ namespace gpdxl
 			ULongPtrArray *m_num_partition_selectors_array;
 
 			// list of all subplan entries
-			List **m_subplan_entries_list;
+			List *m_subplan_entries_list;
 
 			// index of the target relation in the rtable or 0 if not a DML statement
 			ULONG m_result_relation_index;
@@ -141,9 +141,7 @@ namespace gpdxl
 						CIdGenerator *plan_id_counter,
 						CIdGenerator *motion_id_counter,
 						CIdGenerator *param_id_counter,
-						DistributionHashOpsKind distribution_hashops,
-						List **rtable_entries_list,
-						List **subplan_entries_list
+						DistributionHashOpsKind distribution_hashops
 						)
 						;
 
@@ -172,7 +170,10 @@ namespace gpdxl
 			List *GetCTEConsumerList(ULONG cte_id) const;
 
 			// return list of range table entries
-			List *GetRTableEntriesList();
+			List *GetRTableEntriesList() const
+			{
+				return m_rtable_entries_list;
+			}
 
 			// return list of partitioned table indexes
 			List *GetPartitionedTablesList() const
@@ -183,7 +184,10 @@ namespace gpdxl
 			// return list containing number of partition selectors for every scan id
 			List *GetNumPartitionSelectorsList() const;
 
-			List *GetSubplanEntriesList();
+			List *GetSubplanEntriesList() const
+			{
+				return m_subplan_entries_list;
+			}
 
 			// index of result relation in the rtable
 			ULONG GetResultRelationIndex() const


### PR DESCRIPTION
CContextDXLToPlStmt class was set up so that the caller could provide
pointers to RTE and subplan Lists. But there is only one caller, and it
doesn't make use of that. Simplify.
