### PR TITLE
Fix test cases in pg_upgrade

### DIFF
--- a/contrib/pg_upgrade/test/integration/input/unsupported_dist_coltypes.source
+++ b/contrib/pg_upgrade/test/integration/input/unsupported_dist_coltypes.source
@@ -13,7 +13,10 @@ INSERT INTO unsupported_dist_col_money VALUES ('34.23');
 
 ! ./gpdb6/bin/pg_upgrade --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
 
-! /bin/cat tables_using_abstime_reltime_tinterval.txt;
+CREATE TABLE problematic_tables_info (colinfo text);
+! /bin/cat tables_using_abstime_reltime_tinterval.txt | tail -n +2 | tr -d ' ' > @upgrade_test_path@/temp_tables_using_abstime_reltime_tinterval.txt ;
+COPY problematic_tables_info FROM '@upgrade_test_path@/temp_tables_using_abstime_reltime_tinterval.txt';
+SELECT * FROM problematic_tables_info;
 
 -- before upgrade, change the distribution policy to random distribution
 ALTER TABLE unsupported_dist_col_abstime SET DISTRIBUTED RANDOMLY;

--- a/contrib/pg_upgrade/test/integration/output/unsupported_dist_coltypes.source
+++ b/contrib/pg_upgrade/test/integration/output/unsupported_dist_coltypes.source
@@ -34,13 +34,20 @@ and restart the upgrade.  A list of the problem columns is in the file:
 Failure, exiting
 
 
-! /bin/cat tables_using_abstime_reltime_tinterval.txt;
-Database: upgradetest
-  public.unsupported_dist_col_abstime.a
-  public.unsupported_dist_col_reltime.a
-  public.unsupported_dist_col_tinterval.a
-  public.unsupported_dist_col_money.a
+CREATE TABLE problematic_tables_info (colinfo text);
+CREATE
+! /bin/cat tables_using_abstime_reltime_tinterval.txt | tail -n +2 | tr -d ' ' > @upgrade_test_path@/temp_tables_using_abstime_reltime_tinterval.txt ;
 
+COPY problematic_tables_info FROM '@upgrade_test_path@/temp_tables_using_abstime_reltime_tinterval.txt';
+COPY 4
+SELECT * FROM problematic_tables_info;
+ colinfo                                 
+-----------------------------------------
+ public.unsupported_dist_col_tinterval.a 
+ public.unsupported_dist_col_abstime.a   
+ public.unsupported_dist_col_reltime.a   
+ public.unsupported_dist_col_money.a     
+(4 rows)
 
 -- before upgrade, change the distribution policy to random distribution
 ALTER TABLE unsupported_dist_col_abstime SET DISTRIBUTED RANDOMLY;

--- a/contrib/pg_upgrade/test/integration/tablespace_gp_test.c
+++ b/contrib/pg_upgrade/test/integration/tablespace_gp_test.c
@@ -47,6 +47,7 @@ test_populates_old_tablespace_file_contents_to_have_zero_records_for_gpdb6_clust
 	cluster.port = GPDB_SIX_PORT;
 	cluster.major_version = 90400; /* a GPDB 6 cluster */
 	os_info.user = getenv("USER");
+	cluster.sockdir = NULL;
 
 	cluster.old_tablespace_file_contents = NULL;
 
@@ -87,6 +88,7 @@ test_filespaces_on_a_gpdb_five_cluster_are_loaded_as_old_tablespace_file_content
 	cluster.major_version = 10000; /* less than gpdb 6 */
 	cluster.gp_dbid = 2;
 	os_info.user = getenv("USER");
+	cluster.sockdir = NULL;
 
 	cluster.old_tablespace_file_contents = NULL;
 


### PR DESCRIPTION
This PR has 2 commits
1. 51bd0c0 - Initializes the value of sockdir to NULL
2. 2f98466 - Loads the data to a table so that pg_regress suite can handle difference in the ordering of resulting rows.