### PR TITLE
Delay fsync request to checkpoint/restartpoint for ao/co table.

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -533,7 +533,7 @@ CloseWritableFileSeg(AppendOnlyInsertDesc aoInsertDesc)
 	int64		fileLen;
 	int64		fileLen_uncompressed;
 
-	AppendOnlyStorageWrite_TransactionFlushAndCloseFile(&aoInsertDesc->storageWrite,
+	AppendOnlyStorageWrite_TransactionCloseFile(&aoInsertDesc->storageWrite,
 														&fileLen,
 														&fileLen_uncompressed);
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9346,6 +9346,8 @@ CreateRestartPoint(int flags)
 
 	CheckPointGuts(lastCheckPoint.redo, flags);
 
+	SIMPLE_FAULT_INJECTOR("restartpoint_guts");
+
 	/*
 	 * Remember the prior checkpoint's redo pointer, used later to determine
 	 * the point at which we can truncate the log.

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -492,8 +492,8 @@ AppendOnlyStorageWrite_CloseFile(
 							   storageWrite->needsWAL);
 
 	if (!RelFileNodeBackendIsTemp(storageWrite->relFileNode) &&
-		!ForwardFsyncRequest(storageWrite->relFileNode.node, MAIN_FORKNUM,
-							storageWrite->segmentFileNum, true))
+		!register_dirty_segment_ao(storageWrite->relFileNode.node, MAIN_FORKNUM,
+							storageWrite->segmentFileNum))
 	{
 		/*
 		 * We must take care of fsynching to disk ourselves since the fd API won't

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -491,7 +491,9 @@ AppendOnlyStorageWrite_CloseFile(
 							   fileLen_uncompressed,
 							   storageWrite->needsWAL);
 
-	if (!ForwardFsyncRequest(storageWrite->relFileNode.node, MAIN_FORKNUM, storageWrite->segmentFileNum, true))
+	if (!RelFileNodeBackendIsTemp(storageWrite->relFileNode) &&
+		!ForwardFsyncRequest(storageWrite->relFileNode.node, MAIN_FORKNUM,
+							storageWrite->segmentFileNum, true))
 	{
 		/*
 		 * We must take care of fsynching to disk ourselves since the fd API won't

--- a/src/backend/cdb/cdbappendonlyxlog.c
+++ b/src/backend/cdb/cdbappendonlyxlog.c
@@ -107,6 +107,7 @@ ao_insert_replay(XLogReaderState *record)
 						path)));
 	}
 
+	/* Temp table should not have xlog so there is no need to check that. */
 	if (!ForwardFsyncRequest(xlrec->target.node, MAIN_FORKNUM, xlrec->target.segment_filenum, true))
 	{
 		if (FileSync(file) != 0)

--- a/src/backend/cdb/cdbappendonlyxlog.c
+++ b/src/backend/cdb/cdbappendonlyxlog.c
@@ -107,8 +107,7 @@ ao_insert_replay(XLogReaderState *record)
 						path)));
 	}
 
-	/* Temp table should not have xlog so there is no need to check that. */
-	if (!ForwardFsyncRequest(xlrec->target.node, MAIN_FORKNUM, xlrec->target.segment_filenum, true))
+	if (!register_dirty_segment_ao(xlrec->target.node, MAIN_FORKNUM, xlrec->target.segment_filenum))
 	{
 		if (FileSync(file) != 0)
 			ereport(ERROR,

--- a/src/backend/postmaster/checkpointer.c
+++ b/src/backend/postmaster/checkpointer.c
@@ -110,8 +110,13 @@ typedef struct
 	RelFileNode rnode;
 	ForkNumber	forknum;
 	BlockNumber segno;			/* see md.c for special values */
+	/*
+	 * Is segno a real ao segno but not specially ones like
+	 * FORGET_RELATION_FSYNC. For example for a real relfile like
+	 * /base/16384/50237.129, it should be true and segno should be 129.
+	 */
+	bool		is_ao_segno;
 	/* might add a real request-type field later; not needed yet */
-	bool		is_ao_segno;	/* Is segno a real (i.e. >= 1) ao segno */
 } CheckpointerRequest;
 
 typedef struct

--- a/src/backend/postmaster/test/checkpointer_test.c
+++ b/src/backend/postmaster/test/checkpointer_test.c
@@ -40,7 +40,7 @@ test__ForwardFsyncRequest_enqueue(void **state)
 	expect_value(LWLockRelease, lock, CheckpointerCommLock);
 	will_be_called(LWLockRelease);
 	/* basic enqueue */
-	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 1);
+	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 1, false);
 	assert_true(ret);
 	assert_true(CheckpointerShmem->num_requests == 1);
 	/* fill up the queue */
@@ -51,7 +51,7 @@ test__ForwardFsyncRequest_enqueue(void **state)
 		will_return(LWLockAcquire, true);
 		expect_value(LWLockRelease, lock, CheckpointerCommLock);
 		will_be_called(LWLockRelease);
-		ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, i);
+		ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, i, false);
 		assert_true(ret);
 	}
 	expect_value(LWLockAcquire, lock, CheckpointerCommLock);
@@ -68,7 +68,7 @@ test__ForwardFsyncRequest_enqueue(void **state)
 	 * duplicates are in the queue.  So the queue should remain
 	 * full.
 	 */
-	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 0);
+	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 0, false);
 	assert_false(ret);
 	assert_true(CheckpointerShmem->num_requests == CheckpointerShmem->max_requests);
 	free(CheckpointerShmem);

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -841,7 +841,7 @@ datumstreamread_open_file(DatumStreamRead * ds, char *fn, int64 eof, int64 eofUn
 void
 datumstreamwrite_close_file(DatumStreamWrite * ds)
 {
-	AppendOnlyStorageWrite_TransactionFlushAndCloseFile(
+	AppendOnlyStorageWrite_TransactionCloseFile(
 														&ds->ao_write,
 														&ds->eof,
 														&ds->eofUncompress);

--- a/src/backend/utils/time/tqual.c
+++ b/src/backend/utils/time/tqual.c
@@ -71,6 +71,7 @@
 #include "storage/procarray.h"
 #include "utils/builtins.h"
 #include "utils/combocid.h"
+#include "utils/faultinjector.h"
 #include "utils/snapmgr.h"
 #include "utils/tqual.h"
 
@@ -176,6 +177,15 @@ SetHintBits(HeapTupleHeader tuple, Buffer buffer, Relation rel,
 			uint16 infomask, TransactionId xid)
 {
 	bool		isXmin;
+
+#ifdef FAULT_INJECTOR
+	if (FaultInjector_InjectFaultIfSet(
+									   "set_hint_bits",
+									   DDLNotSpecified,
+									   "" /* databaseName */,
+									   "" /* tableName */) == FaultInjectorTypeSkip)
+		return;
+#endif
 
 	if (TransactionIdIsValid(xid))
 	{

--- a/src/include/cdb/cdbappendonlystoragewrite.h
+++ b/src/include/cdb/cdbappendonlystoragewrite.h
@@ -197,10 +197,10 @@ extern void AppendOnlyStorageWrite_OpenFile(AppendOnlyStorageWrite *storageWrite
 								int64 fileLen_uncompressed,
 								RelFileNodeBackend *relFileNode,
 								int32 segmentFileNum);
-extern void AppendOnlyStorageWrite_FlushAndCloseFile(AppendOnlyStorageWrite *storageWrite,
+extern void AppendOnlyStorageWrite_CloseFile(AppendOnlyStorageWrite *storageWrite,
 											 int64 *newLogicalEof,
 											 int64 *fileLen_uncompressed);
-extern void AppendOnlyStorageWrite_TransactionFlushAndCloseFile(AppendOnlyStorageWrite *storageWrite,
+extern void AppendOnlyStorageWrite_TransactionCloseFile(AppendOnlyStorageWrite *storageWrite,
 													int64 *newLogicalEof,
 												int64 *fileLen_uncompressed);
 

--- a/src/include/postmaster/bgwriter.h
+++ b/src/include/postmaster/bgwriter.h
@@ -32,7 +32,7 @@ extern void RequestCheckpoint(int flags);
 extern void CheckpointWriteDelay(int flags, double progress);
 
 extern bool ForwardFsyncRequest(RelFileNode rnode, ForkNumber forknum,
-					BlockNumber segno);
+					BlockNumber segno, bool is_ao);
 extern void AbsorbFsyncRequests(void);
 
 extern Size CheckpointerShmemSize(void);

--- a/src/include/postmaster/bgwriter.h
+++ b/src/include/postmaster/bgwriter.h
@@ -32,7 +32,7 @@ extern void RequestCheckpoint(int flags);
 extern void CheckpointWriteDelay(int flags, double progress);
 
 extern bool ForwardFsyncRequest(RelFileNode rnode, ForkNumber forknum,
-					BlockNumber segno, bool is_ao);
+					BlockNumber segno, bool is_ao_segno);
 extern void AbsorbFsyncRequests(void);
 
 extern Size CheckpointerShmemSize(void);

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -138,6 +138,9 @@ extern void mdpreckpt(void);
 extern void mdsync(void);
 extern void mdpostckpt(void);
 
+extern bool register_dirty_segment_ao(RelFileNode rnode, ForkNumber forknum,
+					int segno);
+
 extern void SetForwardFsyncRequests(void);
 extern void RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum,
 					 BlockNumber segno, bool is_ao_segno);

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -140,7 +140,7 @@ extern void mdpostckpt(void);
 
 extern void SetForwardFsyncRequests(void);
 extern void RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum,
-					 BlockNumber segno);
+					 BlockNumber segno, bool is_ao);
 extern void ForgetRelationFsyncRequests(RelFileNode rnode, ForkNumber forknum);
 extern void ForgetDatabaseFsyncRequests(Oid dbid);
 extern void DropRelationFiles(RelFileNodePendingDelete *delrels, int ndelrels, bool isRedo);

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -140,7 +140,7 @@ extern void mdpostckpt(void);
 
 extern void SetForwardFsyncRequests(void);
 extern void RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum,
-					 BlockNumber segno, bool is_ao);
+					 BlockNumber segno, bool is_ao_segno);
 extern void ForgetRelationFsyncRequests(RelFileNode rnode, ForkNumber forknum);
 extern void ForgetDatabaseFsyncRequests(Oid dbid);
 extern void DropRelationFiles(RelFileNodePendingDelete *delrels, int ndelrels, bool isRedo);

--- a/src/test/isolation2/expected/fsync_ao.out
+++ b/src/test/isolation2/expected/fsync_ao.out
@@ -1,0 +1,234 @@
+-- This test validates that AO tables are sync'ed by checkpoint.
+-- It simulates the following scenario.
+--
+--   * Start with a clean slate - ensure that all files are flushed by checkpointer.
+--   * Write two tables (one is ao and another is aoco).
+--   * Resume checkpointer and let it fsync the two dirty AO relations and their auxiliary tables.
+--   * Verify that 6 files (gp_fastsequence, ao data files, aoseg files) were fsync'ed by checkpointer.
+--   * Verify that those files were also fsync-ed by restartpoint on mirror.
+
+-- Set the GUC to perform replay of checkpoint records immediately.  It speeds up the test.
+-- Set fsync on since we need to test the fsync code logic.
+
+-- start_ignore
+! gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
+20191121:17:04:15:089644 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation'
+
+! gpconfig -c fsync -v on --skipvalidation;
+20191121:17:04:16:089780 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c fsync -v on --skipvalidation'
+
+! gpstop -u;
+20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
+20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
+20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
+20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
+20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5193.g47b7daada9 build dev'
+20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+
+create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+CREATE
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+CREATE
+insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+
+-- Reset all faults.
+--
+-- NOTICE: important.
+--
+-- we use gp_inject_fault_infinite here instead of
+-- gp_inject_fault so cache of pg_proc that contains
+-- gp_inject_fault_infinite is loaded before checkpoint and
+-- the following gp_inject_fault_infinite don't dirty the
+-- buffer again. TODO: gp_inject_fault_infinite vs gp_inject_fault
+select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration where content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+(2 rows)
+
+-- Skip hint bits setting on primaries so that no fsync request due to hint
+-- bits happen in the below tests.
+select gp_inject_fault_infinite('set_hint_bits', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Fault to check that mirror has flushed pending fsync requests.
+select gp_inject_fault_infinite('restartpoint_guts', 'skip', dbid) from gp_segment_configuration where role = 'm' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Start with a clean slate.
+checkpoint;
+CHECKPOINT
+
+-- Wait until restartpoint flush happens.
+select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- We have just created a checkpoint.  The next checkpoint will be triggered
+-- only after 5 minutes or after CheckPointSegments wal segments.  Neither of
+-- that can happen until this test calls explicit checkpoint.
+
+-- Write ao and co data files including aoseg & gp_fastsequence.
+-- These should be fsync-ed by checkpoint & restartpoint.
+insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+
+-- Inject fault to count relfiles fsync'ed by checkpointer on primary as well
+-- as mirror.
+select gp_inject_fault_infinite('fsync_counter', 'skip', dbid) from gp_segment_configuration where content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+(2 rows)
+
+checkpoint;
+CHECKPOINT
+
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Validate that the number of files fsync'ed by checkpointer.
+-- `num times hit` is corresponding to the number of files synced by
+-- `fsync_counter` fault type.
+select gp_inject_fault('fsync_counter', 'status', dbid) from gp_segment_configuration where content=0;
+ gp_inject_fault                                                                                                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'6' 
+ 
+ Success: fault name:'fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'6' 
+ 
+(2 rows)
+
+-- Checkpoint after drop table should be successful. It validates that the drop
+-- removed the fsync requests enqued by the previous insert from
+-- pendingOpsTable.
+insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+drop table fsync_co;
+DROP
+checkpoint;
+CHECKPOINT
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Test vacuum compaction with more than one segment file per table.  Perform
+-- concurrent inserts before vacuum to get multiple segment files.  Validation
+-- criterion is the checkpoint command succeeds on primary and the
+-- restartpoint_guts fault point is reached on the mirror.
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+CREATE
+1: begin;
+BEGIN
+1: insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+1: insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+1: end;
+END
+-- expect two segment files for each table (ao table) or each column (co table).
+select segno, state from gp_toolkit.__gp_aoseg('fsync_ao');
+ segno | state 
+-------+-------
+ 1     | 1     
+ 2     | 1     
+(2 rows)
+select segno, column_num, physical_segno, state from gp_toolkit.__gp_aocsseg('fsync_co');
+ segno | column_num | physical_segno | state 
+-------+------------+----------------+-------
+ 1     | 0          | 1              | 1     
+ 1     | 1          | 129            | 1     
+ 2     | 0          | 2              | 1     
+ 2     | 1          | 130            | 1     
+(4 rows)
+vacuum fsync_ao;
+VACUUM
+vacuum fsync_co;
+VACUUM
+checkpoint;
+CHECKPOINT
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Checkpoint after drop database should be successful. It validates that the drop
+-- removed the fsync requests enqued by the previous insert from
+-- pendingOpsTable.
+create database fsync_ao_db;
+CREATE
+2:@db_name fsync_ao_db: create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+CREATE
+2:@db_name fsync_ao_db: create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+CREATE
+2:@db_name fsync_ao_db: insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+2:@db_name fsync_ao_db: insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+2q: ... <quitting>
+drop database fsync_ao_db;
+DROP
+checkpoint;
+CHECKPOINT
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 5, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Reset all faults.
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+(2 rows)
+
+
+-- start_ignore
+! gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
+20191121:17:04:19:089989 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r create_restartpoint_on_ckpt_record_replay --skipvalidation'
+
+! gpconfig -r fsync --skipvalidation;
+20191121:17:04:19:090125 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
+
+! gpstop -u;
+20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
+20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
+20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
+20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
+20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5193.g47b7daada9 build dev'
+20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore

--- a/src/test/isolation2/expected/fsync_ao.out
+++ b/src/test/isolation2/expected/fsync_ao.out
@@ -1,6 +1,7 @@
 -- This test validates that AO tables are sync'ed by checkpoint.
 -- It simulates the following scenario.
 --
+--   * Quickly test temp table should work fine with the fsync mechanism on ao/co (ignored).
 --   * Start with a clean slate - ensure that all files are flushed by checkpointer.
 --   * Write two tables (one is ao and another is aoco).
 --   * Resume checkpointer and let it fsync the two dirty AO relations and their auxiliary tables.
@@ -17,36 +18,56 @@
 -- Set fsync on since we need to test the fsync code logic.
 !\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
 -- start_ignore
-20191122:22:33:57:007304 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation'
+20191125:15:13:39:014921 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation'
 
 -- end_ignore
 (exited with code 0)
 !\retcode gpconfig -c fsync -v on --skipvalidation;
 -- start_ignore
-20191122:22:33:58:007440 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c fsync -v on --skipvalidation'
+20191125:15:13:39:015057 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c fsync -v on --skipvalidation'
 
 -- end_ignore
 (exited with code 0)
 !\retcode gpstop -u;
 -- start_ignore
-20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
-20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
-20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
-20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
-20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5193.g47b7daada9 build dev'
-20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+20191125:15:13:39:015193 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
+20191125:15:13:39:015193 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
+20191125:15:13:39:015193 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
+20191125:15:13:39:015193 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
+20191125:15:13:40:015193 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5194.gdf0771325b build dev'
+20191125:15:13:40:015193 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
 
 -- end_ignore
 (exited with code 0)
+
+-- Quicly test that temp table should work fine with the fsync mechanism on ao/co.
+create temp table t_fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+CREATE
+create temp table t_fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+CREATE
+insert into t_fsync_ao select i, i from generate_series(1,10)i;
+INSERT 10
+insert into t_fsync_co select i, i from generate_series(1,10)i;
+INSERT 10
+checkpoint;
+CHECKPOINT
+drop table t_fsync_ao;
+DROP
+drop table t_fsync_co;
+DROP
+checkpoint;
+CHECKPOINT
+
+-- Below are all tests for normal tables.
 
 create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
 CREATE
 create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
 CREATE
-insert into fsync_ao select i, i from generate_series(1,20)i;
-INSERT 20
-insert into fsync_co select i, i from generate_series(1,20)i;
-INSERT 20
+insert into fsync_ao select i, i from generate_series(1,10)i;
+INSERT 10
+insert into fsync_co select i, i from generate_series(1,10)i;
+INSERT 10
 
 -- Reset all faults.
 -- Note: we use gp_inject_fault_infinite here instead of
@@ -93,10 +114,10 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid) from gp_segme
 
 -- Write ao and co data files including aoseg & gp_fastsequence.
 -- These should be fsync-ed by checkpoint & restartpoint.
-insert into fsync_ao select i, i from generate_series(1,20)i;
-INSERT 20
-insert into fsync_co select i, i from generate_series(1,20)i;
-INSERT 20
+insert into fsync_ao select i, i from generate_series(1,10)i;
+INSERT 10
+insert into fsync_co select i, i from generate_series(1,10)i;
+INSERT 10
 
 -- Inject fault to count relfiles fsync'ed by checkpointer on primary as well
 -- as mirror.
@@ -132,8 +153,8 @@ select gp_inject_fault('fsync_counter', 'status', dbid) from gp_segment_configur
 -- Checkpoint after drop table should be successful. It validates that the drop
 -- removed the fsync requests enqued by the previous insert from
 -- pendingOpsTable.
-insert into fsync_co select i, i from generate_series(1,20)i;
-INSERT 20
+insert into fsync_co select i, i from generate_series(1,10)i;
+INSERT 10
 drop table fsync_co;
 DROP
 checkpoint;
@@ -153,14 +174,14 @@ create table fsync_co(a int, b int) with (appendoptimized = true, orientation = 
 CREATE
 1: begin;
 BEGIN
-1: insert into fsync_ao select i, i from generate_series(1,20)i;
-INSERT 20
-1: insert into fsync_co select i, i from generate_series(1,20)i;
-INSERT 20
-insert into fsync_ao select i, i from generate_series(1,20)i;
-INSERT 20
-insert into fsync_co select i, i from generate_series(1,20)i;
-INSERT 20
+1: insert into fsync_ao select i, i from generate_series(1,10)i;
+INSERT 10
+1: insert into fsync_co select i, i from generate_series(1,10)i;
+INSERT 10
+insert into fsync_ao select i, i from generate_series(1,10)i;
+INSERT 10
+insert into fsync_co select i, i from generate_series(1,10)i;
+INSERT 10
 1: end;
 END
 -- expect two segment files for each table (ao table) or each column (co table).
@@ -200,10 +221,10 @@ CREATE
 CREATE
 2:@db_name fsync_ao_db: create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
 CREATE
-2:@db_name fsync_ao_db: insert into fsync_ao select i, i from generate_series(1,20)i;
-INSERT 20
-2:@db_name fsync_ao_db: insert into fsync_co select i, i from generate_series(1,20)i;
-INSERT 20
+2:@db_name fsync_ao_db: insert into fsync_ao select i, i from generate_series(1,10)i;
+INSERT 10
+2:@db_name fsync_ao_db: insert into fsync_co select i, i from generate_series(1,10)i;
+INSERT 10
 2q: ... <quitting>
 drop database fsync_ao_db;
 DROP
@@ -226,24 +247,24 @@ select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where
 
 !\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
 -- start_ignore
-20191122:22:34:01:007650 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r create_restartpoint_on_ckpt_record_replay --skipvalidation'
+20191125:15:13:43:015266 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r create_restartpoint_on_ckpt_record_replay --skipvalidation'
 
 -- end_ignore
 (exited with code 0)
 !\retcode gpconfig -r fsync --skipvalidation;
 -- start_ignore
-20191122:22:34:01:007786 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
+20191125:15:13:43:015402 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
 
 -- end_ignore
 (exited with code 0)
 !\retcode gpstop -u;
 -- start_ignore
-20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
-20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
-20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
-20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
-20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5193.g47b7daada9 build dev'
-20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+20191125:15:13:44:015538 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
+20191125:15:13:44:015538 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
+20191125:15:13:44:015538 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
+20191125:15:13:44:015538 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
+20191125:15:13:44:015538 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5194.gdf0771325b build dev'
+20191125:15:13:44:015538 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
 
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/fsync_ao.out
+++ b/src/test/isolation2/expected/fsync_ao.out
@@ -6,26 +6,38 @@
 --   * Resume checkpointer and let it fsync the two dirty AO relations and their auxiliary tables.
 --   * Verify that 6 files (gp_fastsequence, ao data files, aoseg files) were fsync'ed by checkpointer.
 --   * Verify that those files were also fsync-ed by restartpoint on mirror.
+--   * Insert tuples, drop the tables; then run checkpoint (on all rest tests also).
+--   * Verify that the fsync mechanism works for that (FORGET_RELATION_FSYNC).
+--   * Vacuum on the tables with multiple segment files due to concurrent insert.
+--   * Verify that the fsync mechanism works for that.
+--   * Re-test by creating and dropping database.
+--   * Verify that the fsync mechanism works for that (FORGET_DATABASE_FSYNC).
 
 -- Set the GUC to perform replay of checkpoint records immediately.  It speeds up the test.
 -- Set fsync on since we need to test the fsync code logic.
-
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
 -- start_ignore
-! gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
-20191121:17:04:15:089644 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation'
-
-! gpconfig -c fsync -v on --skipvalidation;
-20191121:17:04:16:089780 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c fsync -v on --skipvalidation'
-
-! gpstop -u;
-20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
-20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
-20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
-20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
-20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5193.g47b7daada9 build dev'
-20191121:17:04:16:089916 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+20191122:22:33:57:007304 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation'
 
 -- end_ignore
+(exited with code 0)
+!\retcode gpconfig -c fsync -v on --skipvalidation;
+-- start_ignore
+20191122:22:33:58:007440 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c fsync -v on --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
+20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
+20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
+20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
+20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5193.g47b7daada9 build dev'
+20191122:22:33:58:007576 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
 
 create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
 CREATE
@@ -37,14 +49,11 @@ insert into fsync_co select i, i from generate_series(1,20)i;
 INSERT 20
 
 -- Reset all faults.
---
--- NOTICE: important.
---
--- we use gp_inject_fault_infinite here instead of
+-- Note: we use gp_inject_fault_infinite here instead of
 -- gp_inject_fault so cache of pg_proc that contains
 -- gp_inject_fault_infinite is loaded before checkpoint and
 -- the following gp_inject_fault_infinite don't dirty the
--- buffer again. TODO: gp_inject_fault_infinite vs gp_inject_fault
+-- buffer again.
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration where content = 0;
  gp_inject_fault_infinite 
 --------------------------
@@ -215,20 +224,26 @@ select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where
  Success:        
 (2 rows)
 
-
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
 -- start_ignore
-! gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
-20191121:17:04:19:089989 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r create_restartpoint_on_ckpt_record_replay --skipvalidation'
-
-! gpconfig -r fsync --skipvalidation;
-20191121:17:04:19:090125 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
-
-! gpstop -u;
-20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
-20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
-20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
-20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
-20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5193.g47b7daada9 build dev'
-20191121:17:04:19:090261 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+20191122:22:34:01:007650 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r create_restartpoint_on_ckpt_record_replay --skipvalidation'
 
 -- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r fsync --skipvalidation;
+-- start_ignore
+20191122:22:34:01:007786 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
+20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
+20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
+20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
+20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5193.g47b7daada9 build dev'
+20191122:22:34:01:007922 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -73,6 +73,9 @@ test: ao_upgrade
 # below test utilizes fault injectors so it needs to be in a group by itself
 test: external_table
 
+# This test validates that for AO we delay fsync to checkpointer.
+test: fsync_ao
+
 # Tests on Append-Optimized tables (row-oriented).
 test: concurrent_index_creation_should_not_deadlock
 test: uao/alter_while_vacuum_row uao/alter_while_vacuum2_row

--- a/src/test/isolation2/sql/fsync_ao.sql
+++ b/src/test/isolation2/sql/fsync_ao.sql
@@ -1,0 +1,133 @@
+-- This test validates that AO tables are sync'ed by checkpoint.
+-- It simulates the following scenario.
+--
+--   * Start with a clean slate - ensure that all files are flushed by checkpointer.
+--   * Write two tables (one is ao and another is aoco).
+--   * Resume checkpointer and let it fsync the two dirty AO relations and their auxiliary tables.
+--   * Verify that 6 files (gp_fastsequence, ao data files, aoseg files) were fsync'ed by checkpointer.
+--   * Verify that those files were also fsync-ed by restartpoint on mirror.
+
+-- Set the GUC to perform replay of checkpoint records immediately.  It speeds up the test.
+-- Set fsync on since we need to test the fsync code logic.
+
+-- start_ignore
+! gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
+! gpconfig -c fsync -v on --skipvalidation;
+! gpstop -u;
+-- end_ignore
+
+create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+insert into fsync_ao select i, i from generate_series(1,20)i;
+insert into fsync_co select i, i from generate_series(1,20)i;
+
+-- Reset all faults.
+-- 
+-- NOTICE: important.
+--
+-- we use gp_inject_fault_infinite here instead of
+-- gp_inject_fault so cache of pg_proc that contains
+-- gp_inject_fault_infinite is loaded before checkpoint and
+-- the following gp_inject_fault_infinite don't dirty the
+-- buffer again. TODO: gp_inject_fault_infinite vs gp_inject_fault
+select gp_inject_fault_infinite('all', 'reset', dbid)
+	from gp_segment_configuration where content = 0;
+
+-- Skip hint bits setting on primaries so that no fsync request due to hint
+-- bits happen in the below tests.
+select gp_inject_fault_infinite('set_hint_bits', 'skip', dbid)
+	from gp_segment_configuration where role = 'p' and content = 0;
+
+-- Fault to check that mirror has flushed pending fsync requests.
+select gp_inject_fault_infinite('restartpoint_guts', 'skip', dbid)
+	from gp_segment_configuration where role = 'm' and content = 0;
+
+-- Start with a clean slate.
+checkpoint;
+
+-- Wait until restartpoint flush happens.
+select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- We have just created a checkpoint.  The next checkpoint will be triggered
+-- only after 5 minutes or after CheckPointSegments wal segments.  Neither of
+-- that can happen until this test calls explicit checkpoint.
+
+-- Write ao and co data files including aoseg & gp_fastsequence.
+-- These should be fsync-ed by checkpoint & restartpoint.
+insert into fsync_ao select i, i from generate_series(1,20)i;
+insert into fsync_co select i, i from generate_series(1,20)i;
+
+-- Inject fault to count relfiles fsync'ed by checkpointer on primary as well
+-- as mirror.
+select gp_inject_fault_infinite('fsync_counter', 'skip', dbid)
+	from gp_segment_configuration where content = 0;
+
+checkpoint;
+
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Validate that the number of files fsync'ed by checkpointer.
+-- `num times hit` is corresponding to the number of files synced by
+-- `fsync_counter` fault type.
+select gp_inject_fault('fsync_counter', 'status', dbid)
+	from gp_segment_configuration where content=0;
+
+-- Checkpoint after drop table should be successful. It validates that the drop
+-- removed the fsync requests enqued by the previous insert from
+-- pendingOpsTable.
+insert into fsync_co select i, i from generate_series(1,20)i;
+drop table fsync_co;
+checkpoint;
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Test vacuum compaction with more than one segment file per table.  Perform
+-- concurrent inserts before vacuum to get multiple segment files.  Validation
+-- criterion is the checkpoint command succeeds on primary and the
+-- restartpoint_guts fault point is reached on the mirror.
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation =
+column) distributed by (a);
+1: begin;
+1: insert into fsync_ao select i, i from generate_series(1,20)i;
+1: insert into fsync_co select i, i from generate_series(1,20)i;
+insert into fsync_ao select i, i from generate_series(1,20)i;
+insert into fsync_co select i, i from generate_series(1,20)i;
+1: end;
+-- expect two segment files for each table (ao table) or each column (co table).
+select segno, state from gp_toolkit.__gp_aoseg('fsync_ao');
+select segno, column_num, physical_segno, state from gp_toolkit.__gp_aocsseg('fsync_co');
+vacuum fsync_ao;
+vacuum fsync_co;
+checkpoint;
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Checkpoint after drop database should be successful. It validates that the drop
+-- removed the fsync requests enqued by the previous insert from
+-- pendingOpsTable.
+create database fsync_ao_db;
+2:@db_name fsync_ao_db: create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+2:@db_name fsync_ao_db: create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+2:@db_name fsync_ao_db: insert into fsync_ao select i, i from generate_series(1,20)i;
+2:@db_name fsync_ao_db: insert into fsync_co select i, i from generate_series(1,20)i;
+2q:
+drop database fsync_ao_db;
+checkpoint;
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 5, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Reset all faults.
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = 0;
+
+
+-- start_ignore
+! gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
+! gpconfig -r fsync --skipvalidation;
+! gpstop -u;
+-- end_ignore

--- a/src/test/isolation2/sql/fsync_ao.sql
+++ b/src/test/isolation2/sql/fsync_ao.sql
@@ -1,6 +1,7 @@
 -- This test validates that AO tables are sync'ed by checkpoint.
 -- It simulates the following scenario.
 --
+--   * Quickly test temp table should work fine with the fsync mechanism on ao/co (ignored).
 --   * Start with a clean slate - ensure that all files are flushed by checkpointer.
 --   * Write two tables (one is ao and another is aoco).
 --   * Resume checkpointer and let it fsync the two dirty AO relations and their auxiliary tables.
@@ -19,10 +20,22 @@
 !\retcode gpconfig -c fsync -v on --skipvalidation;
 !\retcode gpstop -u;
 
+-- Quicly test that temp table should work fine with the fsync mechanism on ao/co.
+create temp table t_fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+create temp table t_fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+insert into t_fsync_ao select i, i from generate_series(1,10)i;
+insert into t_fsync_co select i, i from generate_series(1,10)i;
+checkpoint;
+drop table t_fsync_ao;
+drop table t_fsync_co;
+checkpoint;
+
+-- Below are all tests for normal tables.
+
 create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
 create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
-insert into fsync_ao select i, i from generate_series(1,20)i;
-insert into fsync_co select i, i from generate_series(1,20)i;
+insert into fsync_ao select i, i from generate_series(1,10)i;
+insert into fsync_co select i, i from generate_series(1,10)i;
 
 -- Reset all faults.
 -- Note: we use gp_inject_fault_infinite here instead of
@@ -55,8 +68,8 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid)
 
 -- Write ao and co data files including aoseg & gp_fastsequence.
 -- These should be fsync-ed by checkpoint & restartpoint.
-insert into fsync_ao select i, i from generate_series(1,20)i;
-insert into fsync_co select i, i from generate_series(1,20)i;
+insert into fsync_ao select i, i from generate_series(1,10)i;
+insert into fsync_co select i, i from generate_series(1,10)i;
 
 -- Inject fault to count relfiles fsync'ed by checkpointer on primary as well
 -- as mirror.
@@ -78,7 +91,7 @@ select gp_inject_fault('fsync_counter', 'status', dbid)
 -- Checkpoint after drop table should be successful. It validates that the drop
 -- removed the fsync requests enqued by the previous insert from
 -- pendingOpsTable.
-insert into fsync_co select i, i from generate_series(1,20)i;
+insert into fsync_co select i, i from generate_series(1,10)i;
 drop table fsync_co;
 checkpoint;
 -- Wait until restartpoint happens again.
@@ -92,10 +105,10 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid)
 create table fsync_co(a int, b int) with (appendoptimized = true, orientation =
 column) distributed by (a);
 1: begin;
-1: insert into fsync_ao select i, i from generate_series(1,20)i;
-1: insert into fsync_co select i, i from generate_series(1,20)i;
-insert into fsync_ao select i, i from generate_series(1,20)i;
-insert into fsync_co select i, i from generate_series(1,20)i;
+1: insert into fsync_ao select i, i from generate_series(1,10)i;
+1: insert into fsync_co select i, i from generate_series(1,10)i;
+insert into fsync_ao select i, i from generate_series(1,10)i;
+insert into fsync_co select i, i from generate_series(1,10)i;
 1: end;
 -- expect two segment files for each table (ao table) or each column (co table).
 select segno, state from gp_toolkit.__gp_aoseg('fsync_ao');
@@ -113,8 +126,8 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid)
 create database fsync_ao_db;
 2:@db_name fsync_ao_db: create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
 2:@db_name fsync_ao_db: create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
-2:@db_name fsync_ao_db: insert into fsync_ao select i, i from generate_series(1,20)i;
-2:@db_name fsync_ao_db: insert into fsync_co select i, i from generate_series(1,20)i;
+2:@db_name fsync_ao_db: insert into fsync_ao select i, i from generate_series(1,10)i;
+2:@db_name fsync_ao_db: insert into fsync_co select i, i from generate_series(1,10)i;
 2q:
 drop database fsync_ao_db;
 checkpoint;


### PR DESCRIPTION
Without this patch, for every AO insert WAL record that is replayed, an fsync system call is made. As known that fsync is a costly system call which could block the replay process and make the replay process much slower than expected.

This patch changes it so that the fsync requests are defered to checkpointer, just like in case of heap tables.  This is changed on primary as well, such that at the end of an insert to an append-optimized table, the backend process no longer performs fsync.  Instead, it registers a fsync request with the checkpointer.

Co-authored-by: Asim R P <apraveen@pivotal.io>