### PR TITLE
Don't set bogus flow on SplitUpdate nodes.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -605,19 +605,12 @@ make_broadcast_motion(Plan *lefttree, int numsegments)
 }
 
 Plan *
-make_explicit_motion(PlannerInfo *root, Plan *lefttree, AttrNumber segidColIdx)
+make_explicit_motion(PlannerInfo *root, Plan *lefttree, AttrNumber segidColIdx, int numsegments)
 {
 	Motion	   *motion;
-	int			numsegments;
 	plan_tree_base_prefix base;
 
 	base.node = (Node *) root;
-
-	/*
-	 * For explicit motion data come back to the source segments,
-	 * so numsegments is also the same with source.
-	 */
-	numsegments = lefttree->flow->numsegments;
 
 	Assert(numsegments > 0);
 	Assert(numsegments != GP_POLICY_INVALID_NUMSEGMENTS());

--- a/src/backend/executor/nodeSplitUpdate.c
+++ b/src/backend/executor/nodeSplitUpdate.c
@@ -235,7 +235,6 @@ ExecInitSplitUpdate(SplitUpdate *node, EState *estate, int eflags)
 	bool    has_oids = false;
 
 	SplitUpdateState *splitupdatestate;
-	int			numsegments;
 
 	splitupdatestate = makeNode(SplitUpdateState);
 	splitupdatestate->ps.plan = (Plan *)node;
@@ -282,26 +281,9 @@ ExecInitSplitUpdate(SplitUpdate *node, EState *estate, int eflags)
 	 */
 	if (node->numHashAttrs > 0)
 	{
-		if (estate->es_plannedstmt->planGen == PLANGEN_PLANNER)
-		{
-			Assert(node->plan.flow);
-			Assert(node->plan.flow->numsegments > 0);
-
-			/*
-			 * For planner generated plan the size of receiver slice can be
-			 * determined from flow.
-			 */
-			numsegments = node->plan.flow->numsegments;
-		}
-		else
-		{
-			/*
-			 * For ORCA generated plan we could distribute to ALL as partially
-			 * distributed tables are not supported by ORCA yet.
-			 */
-			numsegments = getgpsegmentCount();
-		}
-		splitupdatestate->cdbhash = makeCdbHash(numsegments, node->numHashAttrs, node->hashFuncs);
+		splitupdatestate->cdbhash = makeCdbHash(node->numHashSegments,
+												node->numHashAttrs,
+												node->hashFuncs);
 	}
 
 	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1444,6 +1444,7 @@ _copySplitUpdate(const SplitUpdate *from)
 	COPY_NODE_FIELD(insertColIdx);
 	COPY_NODE_FIELD(deleteColIdx);
 
+	COPY_SCALAR_FIELD(numHashSegments);
 	COPY_SCALAR_FIELD(numHashAttrs);
 	COPY_POINTER_FIELD(hashAttnos, from->numHashAttrs * sizeof(AttrNumber));
 	COPY_POINTER_FIELD(hashFuncs, from->numHashAttrs * sizeof(Oid));

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1290,6 +1290,7 @@ _outSplitUpdate(StringInfo str, const SplitUpdate *node)
 	WRITE_NODE_FIELD(insertColIdx);
 	WRITE_NODE_FIELD(deleteColIdx);
 
+	WRITE_INT_FIELD(numHashSegments);
 	WRITE_INT_FIELD(numHashAttrs);
 #ifdef COMPILING_BINARY_FUNCS
 	WRITE_INT_ARRAY(hashAttnos, node->numHashAttrs, AttrNumber);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1647,6 +1647,7 @@ _readSplitUpdate(void)
 	READ_NODE_FIELD(insertColIdx);
 	READ_NODE_FIELD(deleteColIdx);
 
+	READ_INT_FIELD(numHashSegments);
 	READ_INT_FIELD(numHashAttrs);
 	READ_ATTRNUMBER_ARRAY(hashAttnos, local_node->numHashAttrs);
 	READ_OID_ARRAY(hashFuncs, local_node->numHashAttrs);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2630,10 +2630,7 @@ create_splitupdate_plan(PlannerInfo *root, SplitUpdatePath *path)
 	splitupdate->hashAttnos = palloc(cdbpolicy->nattrs * sizeof(AttrNumber));
 	memcpy(splitupdate->hashAttnos, cdbpolicy->attrs, cdbpolicy->nattrs * sizeof(AttrNumber));
 	splitupdate->hashFuncs = hashFuncs;
-	splitupdate->plan.flow = makeFlow(FLOW_PARTITIONED, cdbpolicy->numsegments);
-
-	/* XXX: strewn is good enough */
-	splitupdate->plan.flow->locustype = CdbLocusType_Strewn;
+	splitupdate->numHashSegments = cdbpolicy->numsegments;
 
 	relation_close(resultRel, NoLock);
 
@@ -8112,7 +8109,8 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 		segmentid_tle = find_junk_tle(subplan->targetlist, "gp_segment_id");
 		if (!segmentid_tle)
 			elog(ERROR, "could not find gp_segment_id in subplan's targetlist");
-		motion = (Motion *) make_explicit_motion(root, subplan, segmentid_tle->resno);
+		motion = (Motion *) make_explicit_motion(root, subplan, segmentid_tle->resno,
+												 numsegments);
 	}
 	else if (path->policy)
 	{

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -35,7 +35,8 @@ extern Motion *make_broadcast_motion(Plan *lefttree,
 
 extern Plan *make_explicit_motion(PlannerInfo *root,
 								  Plan *lefttree,
-								  AttrNumber segidColIdx);
+								  AttrNumber segidColIdx,
+								  int numsegments);
 
 void 
 cdbmutate_warn_ctid_without_segid(struct PlannerInfo *root, struct RelOptInfo *rel);

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1335,9 +1335,16 @@ typedef struct SplitUpdate
 	List		*insertColIdx;		/* list of columns to INSERT into the target list */
 	List		*deleteColIdx;		/* list of columns to DELETE into the target list */
 
+	/*
+	 * Fields for calculating the target segment id.
+	 *
+	 * If the targetlist contains a 'gp_segment_id' field, these fields are
+	 * used to compute the target segment id, for INSERT-action rows.
+	 */
 	int			numHashAttrs;
 	AttrNumber *hashAttnos;
 	Oid		   *hashFuncs;			/* corresponding hash functions */
+	int			numHashSegments;	/* # of segs to use in hash computation */
 } SplitUpdate;
 
 /*


### PR DESCRIPTION
The 'numsegments' in a SplitUpdate's flow was used in very a bizarre way.
It didn't indicate the number of segments used to execute the SplitUpdate
node itself, instead, it indicated the number of segments in the target
table. In createplan.c, that number was then propagated up to the Explicit
Redistribute Motion node above it, via the flows. Set the number of target
segments explicitly in the SplitUpdate node, and stop abusing the Flow for
that. The Flow is now left uninitialized on the SplitUpdate node, which
means that it will be propagated from the child in apply_motion(), like
with most plan nodes. And the Motion gets the number of segments from its
path's locus, like most plan nodes.
