### PR TITLE
5X: Correctly update dirty tables in analyzedb after RENAME

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -672,8 +672,8 @@ class AnalyzeDb(Operation):
                 fp.write("\nanalyzedb finished successfully.\n")
 
     def _get_dirty_lastop_tables(self, curr_last_op, prev_last_op):
-        old_pgstatoperations_dict = get_pgstatlastoperations_dict(prev_last_op)
-        dirty_tables = compare_metadata(old_pgstatoperations_dict, curr_last_op)
+        old_pgstatlastoperation_dict = get_pgstatlastoperation_dict(prev_last_op)
+        dirty_tables = compare_metadata(old_pgstatlastoperation_dict, curr_last_op)
         return dirty_tables
 
     def _get_dirty_ao_state_tables(self, curr_ao_state, prev_ao_state):
@@ -931,17 +931,17 @@ def get_prev_ao_state(timestamp, master_datadir, analyze_dir, dbname):
 
 def get_prev_last_op(timestamp, master_datadir, analyze_dir, dbname):
     logger.debug("getting previous last operation...")
-    old_pgstatoperations_file = generate_statefile_name('lastop', master_datadir, analyze_dir, dbname, timestamp)
-    if not os.path.isfile(old_pgstatoperations_file):
-        old_pgstatoperations = []
+    old_pgstatlastoperation_file = generate_statefile_name('lastop', master_datadir, analyze_dir, dbname, timestamp)
+    if not os.path.isfile(old_pgstatlastoperation_file):
+        old_pgstatlastoperation = []
     else:
-        old_pgstatoperations = get_lines_from_file(old_pgstatoperations_file)
+        old_pgstatlastoperation = get_lines_from_file(old_pgstatlastoperation_file)
     # Parse the lines into tuples like:
     # [('public', 'ao_tab', 67468, 'ALTER', 'ADD COLUMN', '2014-10-15 14:49:27.658777-07'), ...]
     # Each line is a comma-separated string. XXX: This file format cannot deal with names
     # with commas.
     ret = []
-    for l in old_pgstatoperations:
+    for l in old_pgstatlastoperation:
         r = l.split(',')
         tup = (r[0], r[1], r[2], r[3], r[4], r[5])
         ret.append(tup)
@@ -1012,19 +1012,19 @@ def construct_entries_from_dict_colstate(prev_col_dict):
     return ret
 
 
-def compare_metadata(old_pgstatoperations, cur_pgstatoperations):
+def compare_metadata(old_pgstatlastoperation, cur_pgstatlastoperation):
     diffs = set()
-    for operation in cur_pgstatoperations:
+    for operation in cur_pgstatlastoperation:
         # operation[0] and [1] give the schema and table name respectively
         # operation[3] gives the staactionname
         # all three are required to create a unique key for a specific operation
-        if (operation[0], operation[1], operation[3]) not in old_pgstatoperations \
-                or old_pgstatoperations[(operation[0], operation[1], operation[3])] != operation:
+        if (operation[0], operation[1], operation[3]) not in old_pgstatlastoperation \
+                or old_pgstatlastoperation[(operation[0], operation[1], operation[3])] != operation:
             diffs.add((operation[0], operation[1]))
     return diffs
 
 
-def get_pgstatlastoperations_dict(last_operations):
+def get_pgstatlastoperation_dict(last_operations):
     last_operations_dict = {}
     for operation in last_operations:
         last_operations_dict[(operation[0], operation[1], operation[3])] = operation

--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -1015,8 +1015,11 @@ def construct_entries_from_dict_colstate(prev_col_dict):
 def compare_metadata(old_pgstatoperations, cur_pgstatoperations):
     diffs = set()
     for operation in cur_pgstatoperations:
-        if (operation[2], operation[3]) not in old_pgstatoperations \
-                or old_pgstatoperations[(operation[2], operation[3])] != operation:
+        # operation[0] and [1] give the schema and table name respectively
+        # operation[3] gives the staactionname
+        # all three are required to create a unique key for a specific operation
+        if (operation[0], operation[1], operation[3]) not in old_pgstatoperations \
+                or old_pgstatoperations[(operation[0], operation[1], operation[3])] != operation:
             diffs.add((operation[0], operation[1]))
     return diffs
 
@@ -1024,7 +1027,7 @@ def compare_metadata(old_pgstatoperations, cur_pgstatoperations):
 def get_pgstatlastoperations_dict(last_operations):
     last_operations_dict = {}
     for operation in last_operations:
-        last_operations_dict[(str(operation[2]), operation[3])] = operation
+        last_operations_dict[(operation[0], operation[1], operation[3])] = operation
     return last_operations_dict
 
 

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1774,3 +1774,18 @@ Feature: Incrementally analyze the database
           |  stadistinct  |
           |  -0.75         |
         And the user runs "psql -d incr_analyze -c 'drop table foo'"
+
+    Scenario: analyzedb correctly identifies dirty tables after a rename
+        Given no state files exist for database "incr_analyze"
+        And the user runs "psql -d incr_analyze -c 'create table foo (a int, b int) with (appendonly=true)'"
+        And the user runs "psql -d incr_analyze -c 'truncate table foo'"
+        And the user runs "analyzedb -a -d incr_analyze -t public.foo"
+        Then analyzedb should print "-public.foo" to stdout
+        And the user runs "psql -d incr_analyze -c 'alter table foo rename to jazz'"
+        And the user runs "psql -d incr_analyze -c 'truncate table jazz'"
+        And the user runs "analyzedb -a -d incr_analyze -t public.jazz"
+        Then analyzedb should print "-public.jazz" to stdout
+        And "public.jazz" should appear in the latest state files
+        When the user runs "analyzedb -a -d incr_analyze -t public.jazz"
+        Then analyzedb should print "There are no tables or partitions to be analyzed" to stdout
+        And the user runs "psql -d incr_analyze -c 'drop table jazz'"


### PR DESCRIPTION
Analyzedb is intended to skip AO tables that have not been modified
since the last time analyzedb was run.

Previously, analyzedb would unnecessarily analyze an AO table that had
been renamed even if there had been no changes. This occurs because
analyzedb previously used OIDs as part of the key to determine whether
or not the table should be reanalyzed. However, renamed tables have the
same OID as their old couterpart and would cause analyzedb to wrongly
select the table as one that needs to be analyzed. This occurs because
the history file would have entries for both the old and new name of the
table.

Now, when an AO table name or schema gets altered, analyzedb looks at
both the schema and the table name before determining if the table needs
to be analyzed.

Co-Authored-By: Ashuka Xue <axue@pivotal.io>
Co-Authored-By: Chris Hajas <chajas@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
