### PR TITLE
Fix the building script of Windows

### DIFF
--- a/src/bin/gpfdist/CMakeLists.txt
+++ b/src/bin/gpfdist/CMakeLists.txt
@@ -3,11 +3,8 @@ project(gpfdist)
 
 set(GPDB_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../)
 
-add_definitions("/D FRONTEND")
-
 set (CPPFLAGS "/MP /wd4996 /wd4018 /wd4090 /wd4102 /wd4244 /wd4267 /wd4273 /wd4715")
 add_definitions("${CPPFLAGS}")
-
 
 set(HEADER_DIRS
     ${GPDB_SRC_DIR}/src/include
@@ -32,6 +29,8 @@ add_executable(gpfdist gpfdist.c gpfdist_helper.c
     ${GPDB_SRC_DIR}/src/backend/utils/misc/fstream/gfile.c
     ${GPDB_SRC_DIR}/src/backend/utils/misc/fstream/fstream.c
     ${GPDB_SRC_DIR}/src/port/glob.c)
+
+SET_SOURCE_FILES_PROPERTIES(gpfdist.c ${GPDB_SRC_DIR}/src/backend/utils/misc/fstream/gfile.c PROPERTIES COMPILE_DEFINITIONS "FRONTEND")
 
 include(FindOpenSSL)
 if (OPENSSL_FOUND)

--- a/src/tools/msvc/Mkvcbuild.pm
+++ b/src/tools/msvc/Mkvcbuild.pm
@@ -135,13 +135,13 @@ sub mkvcbuild
 	$libpgcommon->AddDefine('FRONTEND');
 	$libpgcommon->AddFiles('src/common', @pgcommonfrontendfiles);
 
-	if (!$buildclient)
-	{
 	$libpgfeutils = $solution->AddProject('libpgfeutils', 'lib', 'misc');
 	$libpgfeutils->AddDefine('FRONTEND');
 	$libpgfeutils->AddIncludeDir('src/interfaces/libpq');
 	$libpgfeutils->AddFiles('src/fe_utils', @pgfeutilsfiles);
 
+	if (!$buildclient)
+	{
 	$postgres = $solution->AddProject('postgres', 'exe', '', 'src/backend');
 	$postgres->AddIncludeDir('src/backend');
 	$postgres->AddDir('src/backend/port/win32');


### PR DESCRIPTION
libpgfeutils is a library needed by frontends like psql.exe, generate it
while building the client.

Co-authored-by: Peifeng Qiu <pqiu@pivotal.io>