### PR TITLE
pg_upgrade should fail when not providing an old-tablespaces-file.

### DIFF
--- a/contrib/pg_upgrade/Makefile
+++ b/contrib/pg_upgrade/Makefile
@@ -14,7 +14,8 @@ OBJS = check.o controldata.o dump.o exec.o file.o function.o info.o \
 OBJS += aotable.o gpdb4_heap_convert.o version_gp.o \
         check_gp.o file_gp.o reporting.o aomd_filehandler.o \
         old_tablespace_file_contents.o old_tablespace_file_parser.o \
-        tablespace_gp.o old_tablespace_file_parser_observer.o
+        tablespace_gp.o old_tablespace_file_parser_observer.o \
+        info_gp.o
 
 PG_CPPFLAGS  = -DFRONTEND -DDLSUFFIX=\"$(DLSUFFIX)\" -I$(srcdir) -I$(libpq_srcdir)
 PG_LIBS = $(libpq_pgport)

--- a/contrib/pg_upgrade/info_gp.c
+++ b/contrib/pg_upgrade/info_gp.c
@@ -1,0 +1,61 @@
+/*-------------------------------------------------------------------------
+ *
+ * info_gp.c
+ *
+ * Copyright (c) 2019-Present Pivotal Software, Inc.
+ */
+
+#include "info_gp.h"
+
+#define EMPTY_TABLESPACE_PATH NULL
+
+static GetTablespacePathResponse
+make_response(GetTablespacePathResponseCodes code, char *path)
+{
+	GetTablespacePathResponse response;
+	response.code = code;
+	response.tablespace_path = path;
+	return response;
+}
+
+static GetTablespacePathResponse
+missing_file(void)
+{
+	return make_response(
+		GetTablespacePathResponse_MISSING_FILE,
+		EMPTY_TABLESPACE_PATH);
+}
+
+static GetTablespacePathResponse
+not_found_in_file(void)
+{
+	return make_response(
+		GetTablespacePathResponse_NOT_FOUND_IN_FILE,
+		EMPTY_TABLESPACE_PATH);
+}
+
+static GetTablespacePathResponse
+found_in_file(char *tablespace_path, Oid tablespace_oid)
+{
+	return make_response(
+		GetTablespacePathResponse_FOUND,
+		psprintf("%s/%u",
+			tablespace_path,
+			tablespace_oid));
+}
+
+GetTablespacePathResponse
+gp_get_tablespace_path(OldTablespaceFileContents *oldTablespaceFileContents, Oid tablespace_oid)
+{
+	if (oldTablespaceFileContents == NULL)
+		return missing_file();
+
+	char* tablespace_path = old_tablespace_file_get_tablespace_path_for_oid(
+		oldTablespaceFileContents,
+		tablespace_oid);
+
+	if (tablespace_path == NULL)
+		return not_found_in_file();
+
+	return found_in_file(tablespace_path, tablespace_oid);
+}

--- a/contrib/pg_upgrade/info_gp.h
+++ b/contrib/pg_upgrade/info_gp.h
@@ -1,0 +1,34 @@
+/*-------------------------------------------------------------------------
+ *
+ * info_gp.h
+ *
+ * Greenplum specific logic for determining tablespace paths
+ * for a given tablespace_oid.
+ *
+ * Copyright (c) 2019-Present Pivotal Software, Inc.
+ */
+
+
+#ifndef PG_UPGRADE_INFO_GP_H
+#define PG_UPGRADE_INFO_GP_H
+
+#include "old_tablespace_file_contents.h"
+
+typedef enum GetTablespacePathResponseCodes {
+	GetTablespacePathResponse_MISSING_FILE,
+	GetTablespacePathResponse_FOUND,
+	GetTablespacePathResponse_NOT_FOUND_IN_FILE,
+} GetTablespacePathResponseCodes;
+
+typedef struct GetTablespacePathResponse {
+	GetTablespacePathResponseCodes code;
+	char *tablespace_path;
+} GetTablespacePathResponse;
+
+/*
+ * Return the Tablespace OID specific tablespace path to an GDPB 5 tablespace
+ */
+GetTablespacePathResponse
+gp_get_tablespace_path(OldTablespaceFileContents *contents, Oid tablespace_oid);
+
+#endif /* PG_UPGRADE_INFO_GP_H */

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -593,6 +593,7 @@ void		init_tablespaces(void);
 void populate_old_cluster_with_old_tablespaces(ClusterInfo *oldCluster, const char *file_path);
 void generate_old_tablespaces_file(ClusterInfo *oldCluster);
 void populate_gpdb6_cluster_tablespace_suffix(ClusterInfo *cluster);
+bool is_gpdb_version_with_filespaces(ClusterInfo *cluster);
 
 
 
@@ -718,5 +719,3 @@ is_gpdb6(ClusterInfo *cluster)
 {
 	return GET_MAJOR_VERSION(cluster->major_version) == 904;
 }
-
-

--- a/contrib/pg_upgrade/tablespace_gp.c
+++ b/contrib/pg_upgrade/tablespace_gp.c
@@ -23,7 +23,7 @@ get_generated_old_tablespaces_file_path(void)
 	return psprintf("%s/%s", current_working_directory, OLD_TABLESPACES_FILE);
 }
 
-static inline bool
+bool
 is_gpdb_version_with_filespaces(ClusterInfo *cluster)
 {
 	return GET_MAJOR_VERSION(cluster->major_version) < 904;

--- a/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
+++ b/contrib/pg_upgrade/test/integration/greenplum_five_to_greenplum_six_upgrade_test_suite.c
@@ -1,8 +1,5 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
+#include "cmockery_gp.h"
 
-#include "cmockery.h"
 #include "old_tablespace_file_parser_observer.h"
 
 #include "scenarios/data_checksum_mismatch.h"

--- a/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/data_checksum_mismatch.c
@@ -1,8 +1,4 @@
-#include <stdarg.h>
-#include <setjmp.h>
-#include <stdlib.h>
-
-#include "cmockery.h"
+#include "cmockery_gp.h"
 
 #include "data_checksum_mismatch.h"
 #include "utilities/test-upgrade-helpers.h"
@@ -27,7 +23,7 @@ assert_error_in_log(const char *errMsg)
 static void
 checkFailsWithError(const char* errMsg)
 {
-	assert_int_not_equal(0, upgradeCheckStatus());
+	assert_false(upgradeReturnedSuccess());
 	assert_error_in_log(errMsg);
 }
 

--- a/contrib/pg_upgrade/test/integration/scenarios/filespaces_to_tablespaces.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/filespaces_to_tablespaces.c
@@ -1,13 +1,11 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
 #include <string.h>
+#include <stdbool.h>
+#include <sys/stat.h>
+#include <stdlib.h>
 
-#include "cmockery.h"
+#include "cmockery_gp.h"
+
 #include "libpq-fe.h"
-#include "stdbool.h"
-#include "stdlib.h"
-#include "sys/stat.h"
 
 #include "utilities/gpdb5-cluster.h"
 #include "utilities/gpdb6-cluster.h"

--- a/contrib/pg_upgrade/test/integration/scenarios/live_check.c
+++ b/contrib/pg_upgrade/test/integration/scenarios/live_check.c
@@ -1,10 +1,6 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
+#include "cmockery_gp.h"
 
 #include "bdd-library/bdd.h"
-
-#include "cmockery.h"
 
 #include "live_check.h"
 #include "utilities/gpdb5-cluster.h"
@@ -40,8 +36,7 @@ static void
 noWarningMessagesShouldBeOutputThatTheServerIsStillRunning(void)
 {
 	assert_string_does_not_contain("*failure*", upgradeCheckOutput());
-	assert_int_equal(upgradeCheckStatus(), 0);
-
+	assert_true(upgradeReturnedSuccess());
 }
 
 void

--- a/contrib/pg_upgrade/test/integration/utilities/cluster-upgrade.c
+++ b/contrib/pg_upgrade/test/integration/utilities/cluster-upgrade.c
@@ -1,4 +1,7 @@
+#include <stdlib.h>
+
 #include "postgres_fe.h"
+#include "pqexpbuffer.h"
 
 /*
  * implements:
@@ -19,35 +22,43 @@ struct PgUpgradeOptionsData
 	bool has_tablespaces;
 };
 
-PgUpgradeOptions *
-make_pg_upgrade_options(
-	char *old_segment_path,
-	char *new_segment_path,
-	int old_gp_dbid,
-	int new_gp_dbid,
-	bool is_dispatcher,
-	char *old_tablespace_mapping_file_path,
-	char *old_bin_dir,
-	char *new_bin_dir,
-	int old_master_port)
+struct PgUpgradeResponse
 {
-	char *mode = "segment";
+	int exit_code;
+	char *stdout;
+};
 
-	if (is_dispatcher)
-		mode = "dispatcher";
+static void
+log_upgrade_line(char *output)
+{
+	printf("%s", output);
+}
 
-	PgUpgradeOptions *options = palloc0(sizeof(PgUpgradeOptions));
-	options->old_gp_dbid = old_gp_dbid;
-	options->new_gp_dbid = new_gp_dbid;
-	options->old_segment_path = old_segment_path;
-	options->new_segment_path = new_segment_path;
-	options->old_bin_dir = old_bin_dir;
-	options->new_bin_dir = new_bin_dir;
-	options->mode = mode;
-	options->old_tablespace_mapping_file_path = old_tablespace_mapping_file_path;
-	options->has_tablespaces = old_tablespace_mapping_file_path != NULL;
-	options->old_master_port = old_master_port;
-	return options;
+static PgUpgradeResponse *
+perform_upgrade_command(const char *command)
+{
+	PQExpBufferData stdout;
+	PgUpgradeResponse *response;
+	char buffer[2000];
+	char *output;
+
+	response = palloc0(sizeof(PgUpgradeResponse));
+	initPQExpBuffer(&stdout);
+
+#ifndef WIN32
+	log_upgrade_line(psprintf("%s\n", command));
+	FILE *output_file = popen(command, "r");
+	while ((output = fgets(buffer, sizeof(buffer), output_file)) != NULL)
+	{
+		log_upgrade_line(output);
+		appendPQExpBufferStr(&stdout, output);
+	}
+
+	response->exit_code = pclose(output_file);
+	response->stdout = stdout.data;
+#endif
+
+	return response;
 }
 
 static char *
@@ -82,22 +93,61 @@ base_upgrade_executable_string(PgUpgradeOptions *options)
 		tablespace_mapping_option);
 }
 
-void
-perform_upgrade(PgUpgradeOptions *options)
+PgUpgradeOptions *
+make_pg_upgrade_options(
+	char *old_segment_path,
+	char *new_segment_path,
+	int old_gp_dbid,
+	int new_gp_dbid,
+	bool is_dispatcher,
+	char *old_tablespace_mapping_file_path,
+	char *old_bin_dir,
+	char *new_bin_dir,
+	int old_master_port)
 {
-	system(base_upgrade_executable_string(options));
+	char *mode = "segment";
+
+	if (is_dispatcher)
+		mode = "dispatcher";
+
+	PgUpgradeOptions *options = palloc0(sizeof(PgUpgradeOptions));
+	options->old_gp_dbid = old_gp_dbid;
+	options->new_gp_dbid = new_gp_dbid;
+	options->old_segment_path = old_segment_path;
+	options->new_segment_path = new_segment_path;
+	options->old_bin_dir = old_bin_dir;
+	options->new_bin_dir = new_bin_dir;
+	options->mode = mode;
+	options->old_tablespace_mapping_file_path = old_tablespace_mapping_file_path;
+	options->has_tablespaces = old_tablespace_mapping_file_path != NULL;
+	options->old_master_port = old_master_port;
+	return options;
 }
 
-FILE *
+PgUpgradeResponse *
+perform_upgrade(PgUpgradeOptions *options)
+{
+	return perform_upgrade_command(
+		base_upgrade_executable_string(options));
+}
+
+int
+pg_upgrade_exit_status(PgUpgradeResponse *status)
+{
+	return status->exit_code;
+}
+
+char *
+pg_upgrade_output(PgUpgradeResponse *status)
+{
+	return status->stdout;
+}
+
+PgUpgradeResponse *
 perform_upgrade_check(PgUpgradeOptions *options)
 {
-	char *command = psprintf(
+	return perform_upgrade_command(psprintf(
 		"%s "
 		"--check ",
-		base_upgrade_executable_string(options));
-
-#ifndef WIN32
-	return popen(command, "r");
-#endif
-	return NULL; /* else if */
+		base_upgrade_executable_string(options)));
 }

--- a/contrib/pg_upgrade/test/integration/utilities/cluster-upgrade.h
+++ b/contrib/pg_upgrade/test/integration/utilities/cluster-upgrade.h
@@ -1,4 +1,5 @@
 typedef struct PgUpgradeOptionsData PgUpgradeOptions;
+typedef struct PgUpgradeResponse PgUpgradeResponse;
 
 PgUpgradeOptions *make_pg_upgrade_options(
 	char *old_segment_path,
@@ -11,9 +12,11 @@ PgUpgradeOptions *make_pg_upgrade_options(
 	char *new_bin_dir,
 	int old_master_port);
 
-void perform_upgrade(PgUpgradeOptions *options);
+PgUpgradeResponse *perform_upgrade(PgUpgradeOptions *options);
+int pg_upgrade_exit_status(PgUpgradeResponse *status);
+char *pg_upgrade_output(PgUpgradeResponse *status);
 
 /*
  * Returns file handler to standard out of pg_upgrade --check
  */
-FILE *perform_upgrade_check(PgUpgradeOptions *options);
+PgUpgradeResponse *perform_upgrade_check(PgUpgradeOptions *options);

--- a/contrib/pg_upgrade/test/integration/utilities/row-assertions.c
+++ b/contrib/pg_upgrade/test/integration/utilities/row-assertions.c
@@ -1,10 +1,8 @@
-#include "stdbool.h"
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
+#include <stdbool.h>
 #include <stdio.h>
 
-#include "cmockery.h"
+#include "cmockery_gp.h"
+
 #include "row-assertions.h"
 
 bool (*matcher)(void *expected, void*actual);

--- a/contrib/pg_upgrade/test/integration/utilities/test-upgrade-helpers.h
+++ b/contrib/pg_upgrade/test/integration/utilities/test-upgrade-helpers.h
@@ -1,4 +1,3 @@
-
 #ifndef PG_UPGRADE_INTEGRATION_TEST_UPGRADE_HELPERS
 #define PG_UPGRADE_INTEGRATION_TEST_UPGRADE_HELPERS
 
@@ -7,10 +6,10 @@
 void		performUpgrade(void);
 void        performUpgradeWithTablespaces(char *mappingFilePath);
 void		performUpgradeCheck(void);
+
 void		initializePgUpgradeStatus(void);
 void		resetPgUpgradeStatus(void);
-
 char	   *upgradeCheckOutput(void);
-int			upgradeCheckStatus(void);
+bool        upgradeReturnedSuccess(void);
 
 #endif							/* PG_UPGRADE_INTEGRATION_TEST_UPGRADE_HELPERS */

--- a/contrib/pg_upgrade/test/unit/Makefile
+++ b/contrib/pg_upgrade/test/unit/Makefile
@@ -8,13 +8,15 @@ OBJS = tablespace_test.o \
 	old_tablespace_file_parser_test.o \
 	check_gp_test.o \
 	mock_server.o \
-	mock_util.o
+	mock_util.o \
+	info_gp_test.o
 
 TARGETS = tablespace_test \
 	old_tablespace_file_contents_test \
 	old_tablespace_file_parser_test \
 	tablespace_gp_test \
-	check_gp
+	check_gp \
+	info_gp_test
 
 include $(top_srcdir)/src/Makefile.global
 include $(top_srcdir)/src/Makefile.mock
@@ -38,6 +40,9 @@ old_tablespace_file_parser_test.t: old_tablespace_file_parser_test.o $(pg_upgrad
 	$(compile_test)
 
 tablespace_gp_test.t: tablespace_gp_test.o $(pg_upgrade_directory)/tablespace_gp.o $(test_dependencies)
+	$(compile_test)
+
+info_gp_test.t: info_gp_test.o $(pg_upgrade_directory)/info_gp.o $(test_dependencies)
 	$(compile_test)
 
 check_gp.t: mock_util.o \

--- a/contrib/pg_upgrade/test/unit/check_gp_test.c
+++ b/contrib/pg_upgrade/test/unit/check_gp_test.c
@@ -1,8 +1,5 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
+#include "cmockery_gp.h"
 
-#include "cmockery.h"
 #include "check_gp.h"
 #include "pg_upgrade.h"
 

--- a/contrib/pg_upgrade/test/unit/info_gp_test.c
+++ b/contrib/pg_upgrade/test/unit/info_gp_test.c
@@ -1,0 +1,104 @@
+#include "cmockery_gp.h"
+
+#include "old_tablespace_file_contents.h"
+#include "info_gp.h"
+
+char *_stubbed_tablespace_path;
+
+static void stub_old_tablespace_file_get_tablespace_path_for_oid(char *value)
+{
+	_stubbed_tablespace_path = value;
+}
+
+/*
+ * old_tablespace_file_contents fakes
+ */
+bool
+is_old_tablespaces_file_empty(OldTablespaceFileContents *contents)
+{
+	return true;
+}
+
+char *old_tablespace_file_get_tablespace_path_for_oid(OldTablespaceFileContents *contents, Oid oid)
+{
+	return _stubbed_tablespace_path;
+}
+
+static void *
+make_fake_old_tablespace_file_contents(void)
+{
+	return palloc0(sizeof(void*));
+}
+
+static void
+test_it_returns_no_file_status_when_there_is_not_a_file(void **state)
+{
+	Oid tablespace_oid = 0;
+
+	GetTablespacePathResponse response = gp_get_tablespace_path(NULL, tablespace_oid);
+
+	assert_int_equal(response.code, GetTablespacePathResponse_MISSING_FILE);
+	assert_int_equal(response.tablespace_path, NULL);
+}
+
+static void
+test_it_returns_no_contents_in_file_when_there_is_a_file_and_there_are_no_contents(void **state)
+{
+	Oid tablespace_oid = 0;
+
+	GetTablespacePathResponse response = gp_get_tablespace_path(make_fake_old_tablespace_file_contents(), tablespace_oid);
+
+	assert_int_equal(response.code, GetTablespacePathResponse_NOT_FOUND_IN_FILE);
+	assert_int_equal(response.tablespace_path, NULL);
+}
+
+static void
+test_it_returns_tablespace_path_when_tablespace_found_by_oid(void **state)
+{
+	Oid tablespace_oid = 1234;
+
+	stub_old_tablespace_file_get_tablespace_path_for_oid("some_path_to_tablespace");
+
+	GetTablespacePathResponse response = gp_get_tablespace_path(make_fake_old_tablespace_file_contents(), tablespace_oid);
+
+	assert_int_equal(response.code, GetTablespacePathResponse_FOUND);
+	assert_string_equal(response.tablespace_path, "some_path_to_tablespace/1234");
+}
+
+static void
+test_it_returns_tablespace_path_not_found_in_file_when_not_found(void **state)
+{
+	Oid tablespace_oid = 1234;
+
+	stub_old_tablespace_file_get_tablespace_path_for_oid(NULL);
+
+	GetTablespacePathResponse response = gp_get_tablespace_path(make_fake_old_tablespace_file_contents(), tablespace_oid);
+
+	assert_int_equal(response.code, GetTablespacePathResponse_NOT_FOUND_IN_FILE);
+	assert_int_equal(response.tablespace_path, NULL);
+}
+
+static void
+setup(void **state)
+{
+	_stubbed_tablespace_path = NULL;
+}
+
+static void
+teardown(void **state)
+{
+
+}
+
+int
+main(int argc, char *argv[])
+{
+	const UnitTest tests[] = {
+		unit_test_setup_teardown(test_it_returns_no_file_status_when_there_is_not_a_file, setup, teardown),
+		unit_test_setup_teardown(test_it_returns_no_contents_in_file_when_there_is_a_file_and_there_are_no_contents, setup, teardown),
+		unit_test_setup_teardown(test_it_returns_tablespace_path_when_tablespace_found_by_oid, setup, teardown),
+		unit_test_setup_teardown(test_it_returns_tablespace_path_not_found_in_file_when_not_found, setup, teardown),
+	};
+
+	return run_tests(tests);
+}

--- a/contrib/pg_upgrade/test/unit/mock_server.c
+++ b/contrib/pg_upgrade/test/unit/mock_server.c
@@ -1,8 +1,4 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
-
-#include "cmockery.h"
+#include "cmockery_gp.h"
 
 #include "pg_upgrade.h"
 

--- a/contrib/pg_upgrade/test/unit/mock_util.c
+++ b/contrib/pg_upgrade/test/unit/mock_util.c
@@ -1,8 +1,4 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
-
-#include "cmockery.h"
+#include "cmockery_gp.h"
 
 #include "pg_upgrade.h"
 

--- a/contrib/pg_upgrade/test/unit/old_tablespace_file_contents_test.c
+++ b/contrib/pg_upgrade/test/unit/old_tablespace_file_contents_test.c
@@ -1,12 +1,8 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
-#include "cmockery.h"
+#include "cmockery_gp.h"
 
 #include "old_tablespace_file_contents.h"
 

--- a/contrib/pg_upgrade/test/unit/old_tablespace_file_parser_test.c
+++ b/contrib/pg_upgrade/test/unit/old_tablespace_file_parser_test.c
@@ -1,9 +1,4 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
-#include <stdbool.h>
-
-#include "cmockery.h"
+#include "cmockery_gp.h"
 
 #include "old_tablespace_file_parser.h"
 #include "old_tablespace_file_parser_observer.h"

--- a/contrib/pg_upgrade/test/unit/tablespace_gp_test.c
+++ b/contrib/pg_upgrade/test/unit/tablespace_gp_test.c
@@ -1,9 +1,6 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
 #include <stdbool.h>
 
-#include "cmockery.h"
+#include "cmockery_gp.h"
 
 #include "pg_upgrade.h"
 #include "pg_upgrade_dummies.c"

--- a/contrib/pg_upgrade/test/unit/tablespace_test.c
+++ b/contrib/pg_upgrade/test/unit/tablespace_test.c
@@ -1,9 +1,6 @@
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
 #include <stdbool.h>
 
-#include "cmockery.h"
+#include "cmockery_gp.h"
 
 #include "pg_upgrade.h"
 #include "pg_upgrade_dummies.c"

--- a/src/test/unit/cmockery/cmockery_gp.h
+++ b/src/test/unit/cmockery/cmockery_gp.h
@@ -1,0 +1,5 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include "cmockery.h"


### PR DESCRIPTION
There were situations where the old tablespaces file was not given, causing upgrade to fail in a strange way. Similarly, if we had the file, but it didn't have the expected contents, we'd fail strangely. Now we present useful errors to the user.

* Improved some test helper code along the way.
* Added low level unit tests to get confidence on the behavior.
* added cmockery_gp.h - to lessen the boilerplate for a cmockery test.