### PR TITLE
Remove unsupported version related logic in pg_dump

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -111,10 +111,6 @@ int			postDataSchemaOnly;
 /* subquery used to convert user ID (eg, datdba) to user name */
 static const char *username_subquery;
 
-/* GPDB_96_MERGE_FIXME: is the following still needed? */
-/* obsolete as of 7.3: */
-static Oid	g_last_builtin_oid pg_attribute_unused(); /* value of the last builtin oid */
-
 /* The specified names/patterns should to match at least one entity */
 static int	strict_names = 0;
 
@@ -10049,8 +10045,8 @@ dumpExtension(Archive *fout, ExtensionInfo *extinfo)
 		/*
 		 * We unconditionally create the extension, so we must drop it if it
 		 * exists.  This could happen if the user deleted 'plpgsql' and then
-		 * readded it, causing its oid to be greater than g_last_builtin_oid.
-		 * The g_last_builtin_oid test was kept to avoid repeatedly dropping
+		 * readded it, causing its oid to be greater than FirstNormalObjectId.
+		 * The FirstNormalObjectId test was kept to avoid repeatedly dropping
 		 * and recreating extensions like 'plpgsql'.
 		 */
 		appendPQExpBuffer(q, "DROP EXTENSION IF EXISTS %s;\n", qextname);


### PR DESCRIPTION
In greenplum versions earlier than pg 8.1 are not supported during pg_dump. The
Initial Greenplum code dump already removed all related code, along with the
variable g_last_builtin_oid. During the 9.6 merge the upstream commit
107943f1a9b reinstated the variable.

Remove it again and update documentation to match the code.

Removes a FIXME
