### PR TITLE
5X: Use doubly-linked block lists in aset.c to reduce large-chunk overhead.

### DIFF
--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -233,6 +233,14 @@ AddInvalidationMessage(InvalidationChunk **listHdr,
 		/* Need another chunk; double size of last chunk */
 		int			chunksize = 2 * chunk->maxitems;
 
+		/*
+		 * Keep in mind: the max allowed alloc size is about 1GB, for
+		 * simplification we set the upper limit to half of that.
+		 */
+#define MAXCHUNKSIZE (MaxAllocSize / 2 / sizeof(SharedInvalidationMessage))
+		if (chunksize > MAXCHUNKSIZE)
+			chunksize >>= 1;
+
 		chunk = (InvalidationChunk *)
 			MemoryContextAlloc(CurTransactionContext,
 							   sizeof(InvalidationChunk) +

--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -1362,7 +1362,7 @@ AllocSetFreeImpl(MemoryContext context, void *pointer, bool isHeader)
 		 * just past the chunk.
 		 */
 		if (block->aset != set ||
-			block->freeptr != block->endptr ||
+			block->freeptr != UserPtr_GetEndPtr(block) ||
 			block->freeptr != ((char *) block) +
 			(chunk->size + ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ))
             MemoryContextError(ERRCODE_INTERNAL_ERROR,
@@ -1519,7 +1519,7 @@ AllocSetRealloc(MemoryContext context, void *pointer, Size size)
 		 * just past the chunk.
 		 */
 		if (block->aset != set ||
-			block->freeptr != block->endptr ||
+			block->freeptr != UserPtr_GetEndPtr(block) ||
 			block->freeptr != ((char *) block) +
 			(chunk->size + ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ))
             MemoryContextError(ERRCODE_INTERNAL_ERROR,
@@ -1749,7 +1749,7 @@ AllocSetCheck(MemoryContext context)
 		if (block->aset != set ||
 			block->prev != prevblock ||
 			block->freeptr < bpoz ||
-			block->freeptr > block->endptr)
+			block->freeptr > UserPtr_GetEndPtr(block))
 			elog(WARNING, "problem in alloc set %s: corrupt header in block %p",
 				 name, block);
 

--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -123,7 +123,8 @@ typedef void *AllocPointer;
 typedef struct AllocBlockData
 {
 	AllocSet	aset;			/* aset that owns this block */
-	AllocBlock	next;			/* next block in aset's blocks list */
+	AllocBlock	prev;			/* prev block in aset's blocks list, if any */
+	AllocBlock	next;			/* next block in aset's blocks list, if any */
 	char	   *freeptr;		/* start of free space in this block */
 } AllocBlockData;
 
@@ -752,7 +753,10 @@ AllocSetContextCreate(MemoryContext parent,
                                (unsigned long)blksize);
 		block->aset = context;
 		block->freeptr = ((char *) block) + ALLOC_BLOCKHDRSZ;
+		block->prev = NULL;
 		block->next = context->blocks;
+		if (block->next)
+			block->next->prev = block;
 		context->blocks = block;
 		/* Mark block as not to be released at reset time */
 		context->keeper = block;
@@ -904,6 +908,7 @@ AllocSetReset(MemoryContext context)
 			memset(datastart, 0x7F, block->freeptr - datastart);
 #endif
 			block->freeptr = datastart;
+			block->prev = NULL;
 			block->next = NULL;
 		}
 		else
@@ -1045,16 +1050,20 @@ AllocSetAllocImpl(MemoryContext context, Size size, bool isHeader)
 #endif
 
 		/*
-		 * Stick the new block underneath the active allocation block, so that
-		 * we don't lose the use of the space remaining therein.
+		 * Stick the new block underneath the active allocation block, if any,
+		 * so that we don't lose the use of the space remaining therein.
 		 */
 		if (set->blocks != NULL)
 		{
+			block->prev = set->blocks;
 			block->next = set->blocks->next;
+			if (block->next)
+				block->next->prev = block;
 			set->blocks->next = block;
 		}
 		else
 		{
+			block->prev = NULL;
 			block->next = NULL;
 			set->blocks = block;
 		}
@@ -1231,7 +1240,10 @@ AllocSetAllocImpl(MemoryContext context, Size size, bool isHeader)
 		if (set->keeper == NULL && blksize == set->initBlockSize)
 			set->keeper = block;
 
+		block->prev = NULL;
 		block->next = set->blocks;
+		if (block->next)
+			block->next->prev = block;
 		set->blocks = block;
         MemoryContextNoteAlloc(&set->header, blksize);              /*CDB*/
 	}
@@ -1338,33 +1350,32 @@ AllocSetFreeImpl(MemoryContext context, void *pointer, bool isHeader)
 	{
 		/*
 		 * Big chunks are certain to have been allocated as single-chunk
-		 * blocks.	Find the containing block and return it to malloc().
+		 * blocks.  Just unlink that block and return it to malloc().
 		 */
-		AllocBlock	block = set->blocks;
-		AllocBlock	prevblock = NULL;
+		AllocBlock	block = (AllocBlock) (((char *) chunk) - ALLOC_BLOCKHDRSZ);
 
 		size_t freesz;
 
-		while (block != NULL)
-		{
-			if (chunk == (AllocChunk) (((char *) block) + ALLOC_BLOCKHDRSZ))
-				break;
-			prevblock = block;
-			block = block->next;
-		}
-		if (block == NULL)
+		/*
+		 * Try to verify that we have a sane block pointer: it should
+		 * reference the correct aset, and freeptr and endptr should point
+		 * just past the chunk.
+		 */
+		if (block->aset != set ||
+			block->freeptr != block->endptr ||
+			block->freeptr != ((char *) block) +
+			(chunk->size + ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ))
             MemoryContextError(ERRCODE_INTERNAL_ERROR,
                                &set->header, CDB_MCXT_WHERE(&set->header),
                                "could not find block containing chunk %p", chunk);
-		/* let's just make sure chunk is the only one in the block */
-		Assert(block->freeptr == ((char *) block) +
-			   (chunk->size + ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ));
 
 		/* OK, remove block from aset's list and free it */
-		if (prevblock == NULL)
-			set->blocks = block->next;
+		if (block->prev)
+			block->prev->next = block->next;
 		else
-			prevblock->next = block->next;
+			set->blocks = block->next;
+		if (block->next)
+			block->next->prev = block->prev;
 
 		freesz = UserPtr_GetUserPtrSize(block);
 		MemoryContextNoteFree(&set->header, freesz);
@@ -1493,30 +1504,27 @@ AllocSetRealloc(MemoryContext context, void *pointer, Size size)
 	if (oldsize > set->allocChunkLimit)
 	{
 		/*
-		 * The chunk must have been allocated as a single-chunk block.	Find
-		 * the containing block and use realloc() to make it bigger with
-		 * minimum space wastage.
+		 * The chunk must have been allocated as a single-chunk block.  Use
+		 * realloc() to make the containing block bigger with minimum space
+		 * wastage.
 		 */
-		AllocBlock	block = set->blocks;
-		AllocBlock	prevblock = NULL;
+		AllocBlock	block = (AllocBlock) (((char *) chunk) - ALLOC_BLOCKHDRSZ);
 		Size		chksize;
 		Size		blksize;
         Size        oldblksize;
 
-		while (block != NULL)
-		{
-			if (chunk == (AllocChunk) (((char *) block) + ALLOC_BLOCKHDRSZ))
-				break;
-			prevblock = block;
-			block = block->next;
-		}
-		if (block == NULL)
+		/*
+		 * Try to verify that we have a sane block pointer: it should
+		 * reference the correct aset, and freeptr and endptr should point
+		 * just past the chunk.
+		 */
+		if (block->aset != set ||
+			block->freeptr != block->endptr ||
+			block->freeptr != ((char *) block) +
+			(chunk->size + ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ))
             MemoryContextError(ERRCODE_INTERNAL_ERROR,
                                &set->header, CDB_MCXT_WHERE(&set->header),
                                "could not find block containing chunk %p", chunk);
-		/* let's just make sure chunk is the only one in the block */
-		Assert(block->freeptr == ((char *) block) +
-			   (chunk->size + ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ));
 
 		/* isHeader is set to false as we should never require realloc for shared header */
 		AllocFreeInfo(set, chunk, false);
@@ -1539,10 +1547,12 @@ AllocSetRealloc(MemoryContext context, void *pointer, Size size)
 
 		/* Update pointers since block has likely been moved */
 		chunk = (AllocChunk) (((char *) block) + ALLOC_BLOCKHDRSZ);
-		if (prevblock == NULL)
-			set->blocks = block;
+		if (block->prev)
+			block->prev->next = block;
 		else
-			prevblock->next = block;
+			set->blocks = block;
+		if (block->next)
+			block->next->prev = block;
 		chunk->size = chksize;
 
 #ifdef MEMORY_CONTEXT_CHECKING
@@ -1708,9 +1718,12 @@ AllocSetCheck(MemoryContext context)
 {
 	AllocSet	set = (AllocSet) context;
 	char	   *name = set->header.name;
+	AllocBlock	prevblock;
 	AllocBlock	block;
 
-	for (block = set->blocks; block != NULL; block = block->next)
+	for (prevblock = NULL, block = set->blocks;
+		 block != NULL;
+		 prevblock = block, block = block->next)
 	{
 		char	   *bpoz = ((char *) block) + ALLOC_BLOCKHDRSZ;
 		Size		blk_used = block->freeptr - bpoz;
@@ -1729,6 +1742,16 @@ AllocSetCheck(MemoryContext context)
 					 name, block, CDB_MCXT_WHERE(&set->header));
 			}
 		}
+
+		/*
+		 * Check block header fields
+		 */
+		if (block->aset != set ||
+			block->prev != prevblock ||
+			block->freeptr < bpoz ||
+			block->freeptr > block->endptr)
+			elog(WARNING, "problem in alloc set %s: corrupt header in block %p",
+				 name, block);
 
 		/*
 		 * Chunk walker


### PR DESCRIPTION
When loading data to a AOCO table with 300 columns and 1000 partitions we noticed that `pfree()` consumed most of the cpu, so we backported below patch from upstream:

> From ff97741bc810390db6dd4da0f31ee1e93c8d3abb Mon Sep 17 00:00:00 2001
> From: Tom Lane <tgl@sss.pgh.pa.us>
> Date: Wed, 8 Mar 2017 12:21:12 -0500
> Subject: [PATCH] Use doubly-linked block lists in aset.c to reduce large-chunk
>  overhead.
> 
> Large chunks (those too large for any palloc freelist) are managed as
> separate blocks.  Formerly, realloc'ing or pfree'ing such a chunk required
> O(N) time in a context with N blocks, since we had to traipse down the
> singly-linked block list to locate the block's predecessor before we could
> fix the list links.  This can result in O(N^2) runtime in situations where
> large numbers of such chunks are manipulated within one context.  Cases
> like that were not foreseen in the original design of aset.c, and indeed
> didn't arise until fairly recently.  But such problems can now occur in
> reorderbuffer.c and in hash joining, both of which make repeated large
> requests without scaling up their request size as they do so, and which
> will free their requests in not-necessarily-LIFO order.
> 
> To fix, change the block list from singly-linked to doubly-linked.
> This adds another 4 or 8 bytes to ALLOC_BLOCKHDRSZ, but that doesn't
> seem like unacceptable overhead, since aset.c's blocks are normally
> 8K or more, and never less than 1K in current practice.
> 
> In passing, get rid of some redundant AllocChunkGetPointer() calls in
> AllocSetRealloc (the compiler might be smart enough to optimize these
> away anyway, but no need to assume that) and improve AllocSetCheck's
> checking of block header fields.
> 
> Back-patch to 9.4 where reorderbuffer.c appeared.  We could take this
> further back, but currently there's no evidence that it would be useful.
> 
> Discussion: https://postgr.es/m/CAMkU=1x1hvue1XYrZoWk_omG0Ja5nBvTdvgrOeVkkeqs71CV8g@mail.gmail.com

----

We also included a fix for an `invalid alloc size` error during cache invalidation.
In AddInvalidationMessage() a new chunk always has double size of last
chunk, but once the size exceeds 1GB, the max allowed alloc size, an
error like "invalid memory alloc request size 1,342,177,300" will be
thrown. Fixed by limiting the chunk size.

----

FYI, here is the perf data for the `pfree()` slowness issue:

```
Samples: 18K of event 'cpu-clock:uhH', Event count (approx.): 4699250000
  Children      Self  Command   Shared Object       Symbol                                          ▒
-   99.84%     0.01%  postgres  postgres            [.] aocs_insert_finish                          ▒
   - 99.83% aocs_insert_finish                                                                      ◆
      - 99.68% close_ds_write (inlined)                                                             ▒
         - destroy_datumstreamwrite                                                                 ▒
            - 99.66% DatumStreamBlockWrite_Finish                                                   ▒
               - 99.63% AllocSetFree                                                                ▒
                    AllocSetFreeImpl (inlined)                                                      ▒
+   99.83%     0.00%  postgres  postgres            [.] CopyFrom                                    ▒
+   99.82%     0.00%  postgres  postgres            [.] DoCopyInternal                              ▒
+   99.80%     0.00%  postgres  postgres            [.] DoCopy                                      ▒
+   99.76%     0.00%  postgres  postgres            [.] PostgresMain                                ▒
+   99.76%     0.00%  postgres  postgres            [.] exec_mpp_query                              ▒
+   99.76%     0.00%  postgres  postgres            [.] PortalRun                                   ▒
+   99.76%     0.00%  postgres  postgres            [.] ProcessUtility                              ▒
+   99.76%     0.00%  postgres  postgres            [.] PortalRunMulti (inlined)                    ▒
+   99.76%     0.00%  postgres  postgres            [.] PortalRunUtility (inlined)                  ▒
+   99.75%     0.00%  postgres  postgres            [.] ServerLoop                                  ▒
+   99.75%     0.00%  postgres  postgres            [.] BackendStartup (inlined)                    ▒
+   99.75%     0.00%  postgres  postgres            [.] BackendRun (inlined)                        ▒
+   99.71%     0.00%  postgres  postgres            [.] _start                                      ▒
+   99.71%     0.00%  postgres  libc-2.27.so        [.] __libc_start_main                           ▒
+   99.71%     0.00%  postgres  postgres            [.] main                                        ▒
+   99.71%     0.00%  postgres  postgres            [.] PostmasterMain                              ▒
+   99.68%     0.00%  postgres  postgres            [.] close_ds_write (inlined)                    ▒
+   99.68%     0.00%  postgres  postgres            [.] destroy_datumstreamwrite                    ▒
+   99.66%     0.01%  postgres  postgres            [.] DatumStreamBlockWrite_Finish                ▒
+   99.63%    99.60%  postgres  postgres            [.] AllocSetFree                                ▒
+   99.63%     0.00%  postgres  postgres            [.] AllocSetFreeImpl (inlined)                  ▒
     0.29%     0.00%  postgres  [unknown]           [.] 0xffffffffffffffff                          ▒
     0.13%     0.01%  postgres  postgres            [.] MirroredAppendOnly_FlushAndClose            ▒
     0.13%     0.00%  postgres  postgres            [.] AppendOnlyStorageWrite_TransactionFlushAndCl▒
     0.12%     0.00%  postgres  postgres            [.] datumstreamwrite_close_file                 ▒
     0.11%     0.00%  postgres  postgres            [.] AppendOnlyStorageWrite_FlushAndCloseFile (in▒
     0.09%     0.01%  postgres  postgres            [.] FileRepPrimary_IsOperationCompleted         ▒
     0.08%     0.01%  postgres  postgres            [.] FileRepAckPrimary_IsOperationCompleted      ▒
     0.07%     0.00%  postgres  postgres            [.] BufferedAppendCompleteFile                  ▒
     0.07%     0.00%  postgres  postgres            [.] BufferedAppendWrite (inlined)               ▒
     0.07%     0.00%  postgres  postgres            [.] MirroredAppendOnly_Append                   ▒
     0.05%     0.00%  postgres  libc-2.27.so        [.] _IO_vfprintf_internal (inlined)             ▒
     0.05%     0.00%  postgres  postgres            [.] FileRepPrimary_MirrorFlushAndClose          ▒
     0.05%     0.00%  postgres  libc-2.27.so        [.] __GI___snprintf (inlined)                   ▒
     0.04%     0.02%  postgres  postgres            [.] FileWrite                                   ▒
     0.04%     0.01%  postgres  postgres            [.] FileRepPrimary_ConstructAndInsertMessage    ▒
```

## Background
The patches were first merged on 4X for a hotfix release.  Now we are porting them to 5X.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
