### PR TITLE
Fix pg_dump with multiple '-t' arguments

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1568,8 +1568,6 @@ expand_table_name_patterns(Archive *fout,
 		 * would be unnecessary given a pg_table_is_visible() variant taking a
 		 * search_path argument.
 		 */
-		if (cell != patterns->head)
-			appendPQExpBufferStr(query, "UNION ALL\n");
 		appendPQExpBuffer(query,
 						  "SELECT c.oid"
 						  "\nFROM pg_catalog.pg_class c"


### PR DESCRIPTION
It's an upstream merge issue, just align with the REL9_6_STABLE here.

Fixes #9059