### PR TITLE
Fix tracking total number of bytes for varlen types in tuplesort_mk.c.

### DIFF
--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -1231,7 +1231,11 @@ tuplesort_putdatum_mk(Tuplesortstate_mk *state, Datum val, bool isNull)
 	{
 		mke_set_not_null(&e);
 		e.d = datumCopy(val, false, state->datumTypeLen);
-		state->totalTupleBytes += state->datumTypeLen;
+
+		if (state->datumTypeLen > 0)
+			state->totalTupleBytes += state->datumTypeLen;
+		else
+			state->totalTupleBytes += datumGetSize(val, state->datumTypeByVal, state->datumTypeLen);
 	}
 
 	puttuple_common(state, &e);


### PR DESCRIPTION
When the datatype is a varlen, datumTypeLen is -1. Adding that to
totalTupleBytes, which is a uint64, cause totalTupleBytes to underflow to
a very large number. To get the correct size for a varlen datum, we must
call datumGetSize().

Per report from Denis Smirnov. The consequence of bogus totalTupleBytes
was that grow_unsorted_array() never enlarged the array, and it generated
tiny 1024-element runs. If there was enough data, you hit the 16k limit on
the number of runs.

Here's a simplified repro:

create table foo (distkey int2, t text) distributed by (distkey);
insert into foo select 1, g || 'fooooooooooooooooooooooo' from
  generate_series(30000000, 10000000, -1 ) g;
set work_mem='4MB';
set enable_hashagg=off;
select count(distinct t) from foo;

With assertions enabled, this resulted in:

FATAL:  Unexpected internal error (tuplesort_mk_details.h:118)
DETAIL:  FailedAssertion("!(run >= 0 && run <= 0x3FFF)", File: "../../../../src/include/utils/tuplesort_mk_details.h", Line: 118)

Without assertions, it resulted in a run-time error instead:
ERROR: insufficient memory reserved for statement (tuplesort_mk_details.h:123)

This patch fixes the immediate bug, but this whole are seems quite fishy
to me. Firstly, even if totalTupleBytes is counted correctly, it doesn't
seem that hard to hit the limit of 16k initial runs. All you need is
fairly large tuples, and a tiny work_mem / statement_mem. Secondly, the
other tuplesort_put*_mk() functions are not updating totalTupleBytes at
all, leaving it as zero. That leads to a opposite problem:
grow_unsorted_array() will merrily enlarge the array, even though we
wouldn't really have the memory for it. I think we haven't noticed,
because in practice there usually is enough spare memory sloshing around
that you don't actually run out of memory because of that. But it sure
seems wrong.

I'm not including that test case in the regression suite, because it takes
quite a long time to run. That's not nice, but it seems unlikely for this
exact same bug to reappear in the future, and there still are all those
other problems in this area, so it doesn't seem worthwhile.

Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/Her9uyZo8GA/imlkYr8vBwAJ
