### PR TITLE
6X: COPY: remove redundant delimiter checking

### DIFF
--- a/contrib/file_fdw/output/file_fdw.source
+++ b/contrib/file_fdw/output/file_fdw.source
@@ -50,7 +50,7 @@ ERROR:  COPY delimiter must not appear in the NULL specification
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', delimiter '-', quote '-');    -- ERROR
 ERROR:  delimiter and quote must be different
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', delimiter '---');     -- ERROR
-ERROR:  COPY delimiter must be a single one-byte character
+ERROR:  delimiter must be a single one-byte character, or 'off'
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', quote '---');         -- ERROR
 ERROR:  quote must be a single one-byte character
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', escape '---');        -- ERROR

--- a/contrib/file_fdw/output/file_fdw.source
+++ b/contrib/file_fdw/output/file_fdw.source
@@ -36,33 +36,33 @@ CREATE USER MAPPING FOR no_priv_user SERVER file_server;
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'xml');  -- ERROR
 ERROR:  COPY format "xml" not recognized
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'text', quote ':');          -- ERROR
-ERROR:  quote available only in CSV mode
+ERROR:  COPY quote available only in CSV mode
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'binary', header 'true');    -- ERROR
-ERROR:  cannot specify HEADER in BINARY mode
+ERROR:  COPY cannot specify HEADER in BINARY mode
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'binary', quote ':');        -- ERROR
-ERROR:  quote available only in CSV mode
+ERROR:  COPY quote available only in CSV mode
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'text', delimiter 'a');      -- ERROR
-ERROR:  delimiter cannot be "a"
+ERROR:  COPY delimiter cannot be "a"
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', quote '-', null '=-=');   -- ERROR
 ERROR:  CSV quote character must not appear in the NULL specification
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', delimiter '-', null '=-=');    -- ERROR
 ERROR:  COPY delimiter must not appear in the NULL specification
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', delimiter '-', quote '-');    -- ERROR
-ERROR:  delimiter and quote must be different
+ERROR:  COPY delimiter and quote must be different
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', delimiter '---');     -- ERROR
-ERROR:  delimiter must be a single one-byte character, or 'off'
+ERROR:  COPY delimiter must be a single one-byte character, or 'off'
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', quote '---');         -- ERROR
-ERROR:  quote must be a single one-byte character
+ERROR:  COPY quote must be a single one-byte character
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', escape '---');        -- ERROR
-ERROR:  escape in CSV format must be a single character
+ERROR:  COPY escape in CSV format must be a single character
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'text', delimiter '\');       -- ERROR
-ERROR:  delimiter cannot be "\"
+ERROR:  COPY delimiter cannot be "\"
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'text', delimiter '.');       -- ERROR
-ERROR:  delimiter cannot be "."
+ERROR:  COPY delimiter cannot be "."
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'text', delimiter '1');       -- ERROR
-ERROR:  delimiter cannot be "1"
+ERROR:  COPY delimiter cannot be "1"
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'text', delimiter 'a');       -- ERROR
-ERROR:  delimiter cannot be "a"
+ERROR:  COPY delimiter cannot be "a"
 CREATE FOREIGN TABLE tbl () SERVER file_server OPTIONS (format 'csv', delimiter '
 ');       -- ERROR
 ERROR:  COPY delimiter cannot be newline or carriage return
@@ -96,7 +96,7 @@ CREATE FOREIGN TABLE text_csv (
 ) SERVER file_server
 OPTIONS (format 'text', filename '@abs_srcdir@/data/text.csv', null 'NULL');
 SELECT * FROM text_csv; -- ERROR
-ERROR:  force not null available only in CSV mode
+ERROR:  COPY force not null available only in CSV mode
 ALTER FOREIGN TABLE text_csv OPTIONS (SET format 'csv');
 \pset null _null_
 SELECT * FROM text_csv;

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1460,12 +1460,6 @@ ProcessCopyOptions(CopyState cstate,
 	if (!cstate->csv_mode && !cstate->escape)
 		cstate->escape = "\\";			/* default escape for text mode */
 
-	/* Only single-byte delimiter strings are supported. */
-	if (strlen(cstate->delim) != 1)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("COPY delimiter must be a single one-byte character")));
-
 	/* Disallow end-of-line characters */
 	if (strchr(cstate->delim, '\r') != NULL ||
 		strchr(cstate->delim, '\n') != NULL)

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1201,6 +1201,7 @@ ProcessCopyOptions(CopyState cstate,
 {
 	bool		format_specified = false;
 	ListCell   *option;
+	bool		delim_off = false;
 
 	/* Support external use for option sanity checking */
 	if (cstate == NULL)
@@ -1257,6 +1258,9 @@ ProcessCopyOptions(CopyState cstate,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("conflicting or redundant options")));
 			cstate->delim = defGetString(defel);
+
+			if (cstate->delim && pg_strcasecmp(cstate->delim, "off") == 0)
+				delim_off = true;
 		}
 		else if (strcmp(defel->defname, "null") == 0)
 		{
@@ -1420,11 +1424,6 @@ ProcessCopyOptions(CopyState cstate,
 					 errmsg("option \"%s\" not recognized", defel->defname)));
 	}
 
-	bool	delim_off = false;
-
-	if (cstate->delim && pg_strcasecmp(cstate->delim, "off") == 0)
-		delim_off = true;
-
 	/*
 	 * Check for incompatible options (must do these two before inserting
 	 * defaults)
@@ -1432,12 +1431,12 @@ ProcessCopyOptions(CopyState cstate,
 	if (cstate->binary && cstate->delim)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("cannot specify DELIMITER in BINARY mode")));
+				 errmsg("COPY cannot specify DELIMITER in BINARY mode")));
 
 	if (cstate->binary && cstate->null_print)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("cannot specify NULL in BINARY mode")));
+				 errmsg("COPY cannot specify NULL in BINARY mode")));
 
 	cstate->eol_type = EOL_UNKNOWN;
 
@@ -1460,13 +1459,6 @@ ProcessCopyOptions(CopyState cstate,
 	if (!cstate->csv_mode && !cstate->escape)
 		cstate->escape = "\\";			/* default escape for text mode */
 
-	/* Disallow end-of-line characters */
-	if (strchr(cstate->delim, '\r') != NULL ||
-		strchr(cstate->delim, '\n') != NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("COPY delimiter cannot be newline or carriage return")));
-
 	if (strchr(cstate->null_print, '\r') != NULL ||
 		strchr(cstate->null_print, '\n') != NULL)
 		ereport(ERROR,
@@ -1488,7 +1480,7 @@ ProcessCopyOptions(CopyState cstate,
 			   cstate->delim[0]) != NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("delimiter cannot be \"%s\"", cstate->delim)));
+				 errmsg("COPY delimiter cannot be \"%s\"", cstate->delim)));
 
 	/* Check header */
 	/*
@@ -1498,64 +1490,64 @@ ProcessCopyOptions(CopyState cstate,
 	if (cstate->binary && cstate->header_line)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("cannot specify HEADER in BINARY mode")));
+				 errmsg("COPY cannot specify HEADER in BINARY mode")));
 
 	/* Check quote */
 	if (!cstate->csv_mode && cstate->quote != NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("quote available only in CSV mode")));
+				 errmsg("COPY quote available only in CSV mode")));
 
 	if (cstate->csv_mode && strlen(cstate->quote) != 1)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("quote must be a single one-byte character")));
+				 errmsg("COPY quote must be a single one-byte character")));
 
-	if (cstate->csv_mode && cstate->delim[0] == cstate->quote[0])
+	if (cstate->csv_mode && cstate->delim[0] == cstate->quote[0] && !delim_off)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("delimiter and quote must be different")));
+				 errmsg("COPY delimiter and quote must be different")));
 
 	/* Check escape */
 	if (cstate->csv_mode && cstate->escape != NULL && strlen(cstate->escape) != 1)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("escape in CSV format must be a single character")));
+				 errmsg("COPY escape in CSV format must be a single character")));
 
 	if (!cstate->csv_mode && cstate->escape != NULL &&
 		(strchr(cstate->escape, '\r') != NULL ||
 		strchr(cstate->escape, '\n') != NULL))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("escape representation in text format cannot use newline or carriage return")));
+				 errmsg("COPY escape representation in text format cannot use newline or carriage return")));
 
 	if (!cstate->csv_mode && cstate->escape != NULL && strlen(cstate->escape) != 1)
 	{
 		if (pg_strcasecmp(cstate->escape, "off") != 0)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("escape must be a single character, or [OFF/off] to disable escapes")));
+					 errmsg("COPY escape must be a single character, or [OFF/off] to disable escapes")));
 	}
 
 	/* Check force_quote */
 	if (!cstate->csv_mode && (cstate->force_quote || cstate->force_quote_all))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("force quote available only in CSV mode")));
-	if ((cstate->force_quote != NIL || cstate->force_quote_all) && is_from)
+				 errmsg("COPY force quote available only in CSV mode")));
+	if ((cstate->force_quote || cstate->force_quote_all) && is_from)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("force quote only available for data unloading, not loading")));
+				 errmsg("COPY force quote only available using COPY TO")));
 
 	/* Check force_notnull */
 	if (!cstate->csv_mode && cstate->force_notnull != NIL)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("force not null available only in CSV mode")));
+				 errmsg("COPY force not null available only in CSV mode")));
 	if (cstate->force_notnull != NIL && !is_from)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("force not null only available for data loading, not unloading")));
+			  errmsg("COPY force not null only available using COPY FROM")));
 
 	/* Check force_null */
 	if (!cstate->csv_mode && cstate->force_null != NIL)
@@ -1567,12 +1559,6 @@ ProcessCopyOptions(CopyState cstate,
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("COPY force null only available using COPY FROM")));
-
-	/* Don't allow the delimiter to appear in the null string. */
-	if (strchr(cstate->null_print, cstate->delim[0]) != NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("COPY delimiter must not appear in the NULL specification")));
 
 	/* Don't allow the CSV quote char to appear in the null string. */
 	if (cstate->csv_mode &&
@@ -1595,7 +1581,7 @@ ProcessCopyOptions(CopyState cstate,
 		if (strlen(cstate->delim) != 1 && !delim_off)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("delimiter must be a single one-byte character, or \'off\'")));
+					 errmsg("COPY delimiter must be a single one-byte character, or \'off\'")));
 	}
 	else
 	{
@@ -1603,7 +1589,7 @@ ProcessCopyOptions(CopyState cstate,
 		if ((strlen(cstate->delim) != 1 || IS_HIGHBIT_SET(cstate->delim[0])) && !delim_off )
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("delimiter must be a single one-byte character, or \'off\'")));
+					 errmsg("COPY delimiter must be a single one-byte character, or \'off\'")));
 	}
 
 	/* Disallow end-of-line characters */
@@ -1611,23 +1597,17 @@ ProcessCopyOptions(CopyState cstate,
 		strchr(cstate->delim, '\n') != NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("delimiter cannot be newline or carriage return")));
-
-	if (strchr(cstate->null_print, '\r') != NULL ||
-		strchr(cstate->null_print, '\n') != NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("null representation cannot use newline or carriage return")));
+				 errmsg("COPY delimiter cannot be newline or carriage return")));
 
 	if (!cstate->csv_mode && strchr(cstate->delim, '\\') != NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("delimiter cannot be backslash")));
+				 errmsg("COPY delimiter cannot be backslash")));
 
 	if (strchr(cstate->null_print, cstate->delim[0]) != NULL && !delim_off)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("delimiter must not appear in the NULL specification")));
+				 errmsg("COPY delimiter must not appear in the NULL specification")));
 
 	if (delim_off)
 	{

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -612,7 +612,7 @@ domain_name			varchar(350)
 )
 location ('gpfdist://@hostname@:7070/exttab1/whois.csv' )
 format 'csv' ( header quote as 'ggg');
-ERROR:  quote must be a single one-byte character
+ERROR:  COPY quote must be a single one-byte character
 select count(*) from bad_whois;
 ERROR:  relation "bad_whois" does not exist
 LINE 1: select count(*) from bad_whois;

--- a/src/bin/gpfdist/regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2.source
@@ -891,7 +891,7 @@ FORMAT 'text'
         FORCE NOT NULL L_COMMENT
 )
 ;
-ERROR:  force not null available only in CSV mode
+ERROR:  COPY force not null available only in CSV mode
 SELECT count(*) FROM ext_lineitem;
 ERROR:  relation "ext_lineitem" does not exist
 LINE 1: SELECT count(*) FROM ext_lineitem;

--- a/src/bin/gpfdist/remote_regress/output/exttab1.source
+++ b/src/bin/gpfdist/remote_regress/output/exttab1.source
@@ -614,7 +614,7 @@ domain_name			varchar(350)
 )
 location ('gpfdist://@hostname@:7070/exttab1/whois.csv' )
 format 'csv' ( header quote as 'ggg');
-ERROR:  quote must be a single one-byte character
+ERROR:  COPY quote must be a single one-byte character
 select count(*) from bad_whois;
 ERROR:  relation "bad_whois" does not exist
 LINE 1: select count(*) from bad_whois;

--- a/src/bin/gpfdist/remote_regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/remote_regress/output/gpfdist2.source
@@ -891,7 +891,7 @@ FORMAT 'text'
         FORCE NOT NULL L_COMMENT
 )
 ;
-ERROR:  force not null available only in CSV mode
+ERROR:  COPY force not null available only in CSV mode
 SELECT count(*) FROM ext_lineitem;
 ERROR:  relation "ext_lineitem" does not exist
 LINE 1: SELECT count(*) FROM ext_lineitem;

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3506,3 +3506,7 @@ drop external table ext_w_expand;
 CREATE EXTERNAL TABLE test_delimiter(data text) LOCATION('gpfdist://127.0.0.1/test_delimiter.txt') FORMAT 'text' (DELIMITER 'off');
 
 DROP EXTERNAL TABLE test_delimiter;
+
+-- Test multiple character delimiter
+
+CREATE EXTERNAL TABLE test_delimiter(data text) LOCATION('gpfdist://127.0.0.1/test_delimiter.txt') FORMAT 'csv' (DELIMITER 'ab');

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3500,3 +3500,9 @@ alter external table ext_w_expand expand table;
 select numsegments from gp_distribution_policy where localoid = 'ext_w_expand'::regclass;
 
 drop external table ext_w_expand;
+
+-- Test delimiter off
+
+CREATE EXTERNAL TABLE test_delimiter(data text) LOCATION('gpfdist://127.0.0.1/test_delimiter.txt') FORMAT 'text' (DELIMITER 'off');
+
+DROP EXTERNAL TABLE test_delimiter;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -184,7 +184,7 @@ domain_name			varchar(350)
 )
 location ('gpfdist://@hostname@:7070/exttab1/whois.csv' )
 format 'csv' ( header quote as 'ggg');
-ERROR:  quote must be a single one-byte character
+ERROR:  COPY quote must be a single one-byte character
 select count(*) from bad_whois;
 ERROR:  relation "bad_whois" does not exist
 LINE 1: select count(*) from bad_whois;
@@ -4813,3 +4813,6 @@ drop external table ext_w_expand;
 -- Test delimiter off
 CREATE EXTERNAL TABLE test_delimiter(data text) LOCATION('gpfdist://127.0.0.1/test_delimiter.txt') FORMAT 'text' (DELIMITER 'off');
 DROP EXTERNAL TABLE test_delimiter;
+-- Test multiple character delimiter
+CREATE EXTERNAL TABLE test_delimiter(data text) LOCATION('gpfdist://127.0.0.1/test_delimiter.txt') FORMAT 'csv' (DELIMITER 'ab');
+ERROR:  COPY delimiter must be a single one-byte character, or 'off'

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4810,3 +4810,6 @@ select numsegments from gp_distribution_policy where localoid = 'ext_w_expand'::
 (1 row)
 
 drop external table ext_w_expand;
+-- Test delimiter off
+CREATE EXTERNAL TABLE test_delimiter(data text) LOCATION('gpfdist://127.0.0.1/test_delimiter.txt') FORMAT 'text' (DELIMITER 'off');
+DROP EXTERNAL TABLE test_delimiter;


### PR DESCRIPTION
There is one after and with correct delim_off checking.

And take the chance to tidy the ProcessCopyOptions(), align with
upstream, handle delim_off.

6X version of #9114 
