### PR TITLE
docs - add warning not to move location of transaction files w/ gpfil…

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
@@ -45,9 +45,10 @@ primary location 1&gt; <i>/gpfs1/seg1
 </i>mirror location 2&gt; <i>/gpfs2/mir2
 </i>master location&gt; <i>/gpfs1/master
 </i></codeblock></li>
-          <li id="im179011">gpfilespace creates a configuration file. Examine the file to verify
-            that the gpfilespace configuration is correct. </li>
-          <li id="im179508">Run gpfilespace again to create the filespace based on the configuration file:<p>
+          <li id="im179011"><codeph>gpfilespace</codeph> creates a configuration file. Examine the
+            file to verify that the <codeph>gpfilespace</codeph> configuration is correct. </li>
+          <li id="im179508">Run <codeph>gpfilespace</codeph> again to create the filespace based on
+            the configuration file:<p>
               <codeblock>$ gpfilespace -c gpfilespace_config</codeblock>
             </p></li>
         </ol>
@@ -59,9 +60,12 @@ primary location 1&gt; <i>/gpfs1/seg1
     <body>
       <p>You can move temporary or transaction files to a specific filespace to improve database
         performance when running queries, creating backups, and to store data more sequentially. </p>
+      <note type="warning">Do not move transaction files to a non-default location. Moving
+        transaction files might cause data loss.</note>
       <p>The dedicated filespace for temporary and transaction files is tracked in two separate flat
-        files called gp_temporary_files_filespace and gp_transaction_files_filespace. These are
-        located in the pg_system directory on each primary and mirror segment, and on master and
+        files called <codeph>gp_temporary_files_filespace</codeph> and
+          <codeph>gp_transaction_files_filespace</codeph>. These are located in the
+          <codeph>pg_system</codeph> directory on each primary and mirror segment, and on master and
         standby. You must be a superuser to move temporary or transaction files. Only the
           <codeph>gpfilespace</codeph> utility can write to this file.</p>
     </body>
@@ -86,30 +90,14 @@ primary location 1&gt; <i>/gpfs1/seg1
             <li id="im198894">Check that the filespace exists and is different from the filespace
               used to store all other user data.</li>
             <li id="im198895">Issue smart shutdown to bring the Greenplum Database offline.<p>If any
-                connections are still in progess,the gpfilespace --movetempfiles utility will
-                fail.</p></li>
+                connections are still in progess, the <codeph>gpfilespace --movetempfiles</codeph>
+                utility will fail.</p></li>
             <li id="im198897">Bring Greenplum Database online with no active session and run the
               following command:<p>
                 <codeblock>gpfilespace --movetempfilespace filespace_name</codeblock>
               </p><p>The location of the temporary files is stored in the segment configuration
                 shared memory (PMModuleState) and used whenever temporary files are created, opened,
                 or dropped.</p></li>
-          </ol>
-        </section>
-        <section>
-          <title>To move transaction files using gpfilespace</title>
-          <ol id="ol_vll_hvy_sp">
-            <li id="im198901">Check that the filespace exists and is different from the filespace
-              used to store all other user data.</li>
-            <li id="im198902">Issue smart shutdown to bring the Greenplum Database offline.<p>If any
-                connections are still in progess, the <codeph>gpfilespace --movetransfiles</codeph>
-                utility will fail.</p></li>
-            <li id="im198904">Bring Greenplum Database online with no active session and run the
-              following command:<p>
-                <codeblock>gpfilespace --movetransfilespace filespace_name</codeblock>
-              </p><p>The location of the transaction files is stored in the segment configuration
-                shared memory (PMModuleState) and used whenever transaction files are created,
-                opened, or dropped.</p></li>
           </ol>
         </section>
       </body>
@@ -125,7 +113,7 @@ primary location 1&gt; <i>/gpfs1/seg1
 </codeblock>
       </p>
       <p>Database superusers define tablespaces and grant access to database users with the
-          <codeph>GRANT</codeph><codeph>CREATE </codeph><ph>command</ph>. For example:</p>
+          <codeph>GRANT CREATE</codeph> command. For example:</p>
       <p>
         <codeblock>=# GRANT CREATE ON TABLESPACE fastspace TO admin;
 </codeblock>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpfilespace.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpfilespace.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="kv137980">gpfilespace</title><body><p>Creates a filespace using a configuration file that defines per-segment
-file system locations. Filespaces describe the physical file system resources
-to be used by a tablespace.</p><section id="section2"><title>Synopsis</title><codeblock><b>gpfilespace</b> [<varname>connection_option</varname> ...] [<b>-l</b> <varname>logfile_directory</varname>] 
+<topic id="topic1">
+  <title id="kv137980">gpfilespace</title>
+  <body>
+    <p>Creates a filespace using a configuration file that defines per-segment file system
+      locations. Filespaces describe the physical file system resources to be used by a
+      tablespace.</p>
+    <note><codeph>gpfilespace</codeph> is deprecated and will be removed in the Greenplum Database 6
+      release.</note>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock><b>gpfilespace</b> [<varname>connection_option</varname> ...] [<b>-l</b> <varname>logfile_directory</varname>] 
               [<b>-o</b> <varname>output_file_name</varname>]
 
 <b>gpfilespace</b> [<varname>connection_option</varname> ...] [<b>-l</b> <varname>logfile_directory</varname>] 
@@ -19,68 +27,134 @@ to be used by a tablespace.</p><section id="section2"><title>Synopsis</title><co
 
 <b>gpfilespace -v</b> 
 
-<b>gpfilespace -?</b></codeblock></section><section id="section3"><title>Description</title><p>A tablespace requires a file system location to store its database files. In Greenplum Database, the master and each segment (primary and mirror) needs its own
-        distinct storage location. This collection of file system locations for all components in a
-          Greenplum system is referred to as a
-          <varname>filespace</varname>. Once a filespace is defined, it can be used by one or more
-        tablespaces.</p><p>When used with the <codeph>-o</codeph> option, the <codeph>gpfilespace</codeph> utility looks up
-        your system configuration information in the Greenplum Database catalog tables
-        and prompts you for the appropriate file system locations needed to create the filespace. It
+<b>gpfilespace -?</b></codeblock>
+    </section>
+    <section id="section3">
+      <title>Description</title>
+      <p>A tablespace requires a file system location to store its database files. In Greenplum
+        Database, the master and each segment (primary and mirror) needs its own distinct storage
+        location. This collection of file system locations for all components in a Greenplum system
+        is referred to as a <varname>filespace</varname>. Once a filespace is defined, it can be
+        used by one or more tablespaces.</p>
+      <p>When used with the <codeph>-o</codeph> option, the <codeph>gpfilespace</codeph> utility
+        looks up your system configuration information in the Greenplum Database catalog tables and
+        prompts you for the appropriate file system locations needed to create the filespace. It
         then outputs a configuration file that can be used to create a filespace. If a file name is
         not specified, a <codeph>gpfilespace_config_</codeph><varname>#</varname> file will be
-        created in the current directory by default. </p><p>Once you have a configuration file, you can run <codeph>gpfilespace</codeph> with the
-          <codeph>-c</codeph> option to create the filespace in Greenplum Database.</p><p outputclass="">You will need to create a filespace before you can use the
-          <codeph>gpfilespace --movetempfilespace</codeph> or <codeph>--movetransfilespace</codeph>
-        option to move your temporary or transaction files to the new location.</p><p>Use either <codeph>gpfilespace --showtempfilespace</codeph> or
+        created in the current directory by default. </p>
+      <p>Once you have a configuration file, you can run <codeph>gpfilespace</codeph> with the
+          <codeph>-c</codeph> option to create the filespace in Greenplum Database.</p>
+      <p outputclass="">You will need to create a filespace before you can use the
+          <codeph>gpfilespace --movetempfilespace</codeph> option to move your temporary files to
+        the new location.</p>
+      <p>Use either <codeph>gpfilespace --showtempfilespace</codeph> or
           <codeph>--showtransfilespace</codeph> options to show the name of the filespace currently
-        associated with temporary or transaction files. </p><note type="note">If segments are down due to a power or nic failure, you may see inconsistencies
-        during filespace creation. You may not be able to bring up the Greenplum Database.</note></section><section id="section4"><title>Options</title><parml><plentry><pt>-c | --config <varname>fs_config_file</varname></pt><pd>A configuration file containing:<ul id="ul_xrn_qr2_44"><li id="kv139272">An initial line denoting the new filespace name. For
-                    example:<p>filespace:<varname>myfs</varname></p></li><li id="kv139279">One line each for the master, the primary segments, and the mirror
+        associated with temporary or transaction files. </p>
+      <note type="note">If segments are down due to a power or NIC failure, you may see
+        inconsistencies during filespace creation. You may not be able to bring up the Greenplum
+        Database.</note>
+    </section>
+    <section id="section4">
+      <title>Options</title>
+      <parml>
+        <plentry>
+          <pt>-c | --config <varname>fs_config_file</varname></pt>
+          <pd>A configuration file containing:<ul id="ul_xrn_qr2_44">
+              <li id="kv139272">An initial line denoting the new filespace name. For
+                    example:<p>filespace:<varname>myfs</varname></p></li>
+              <li id="kv139279">One line each for the master, the primary segments, and the mirror
                 segments. A line describes a file system location that a particular segment database
                 instance should use as its data directory location to store database files
                 associated with a tablespace. Each line is in the format
-                of:<codeblock><varname>hostname</varname>:<varname>dbid</varname>:/<varname>filesystem_dir</varname>/<varname>seg_datadir_name</varname></codeblock></li></ul></pd></plentry><plentry><pt>-l | --logdir <varname>logfile_directory</varname></pt><pd>The directory to write the log file. Defaults to <codeph>~/gpAdminLogs</codeph>.</pd></plentry><plentry><pt>-o | --output <varname>output_file_name</varname></pt><pd>The directory location and file name to output the generated filespace configuration file. You
-            will be prompted to enter a name for the filespace, a master file system location, the
-            primary segment file system locations, and the mirror segment file system locations. For
-            example, if your configuration has 2 primary and 2 mirror segments per host, you will be
-            prompted for a total of 5 locations (including the master). The file system locations
-            must exist on all hosts in your system prior to running the <codeph>gpfilespace</codeph>
-            utility. The utility will designate segment-specific data directories within the
-            location(s) you specify, so it is possible to use the same location for multiple
-            segments. However, primaries and mirrors cannot use the same location. After the utility
-            creates the configuration file, you can manually edit the file to make any required
-            changes to the filespace layout before creating the filespace in Greenplum Database.</pd></plentry><plentry>
+                of:<codeblock><varname>hostname</varname>:<varname>dbid</varname>:/<varname>filesystem_dir</varname>/<varname>seg_datadir_name</varname></codeblock></li>
+            </ul></pd>
+        </plentry>
+        <plentry>
+          <pt>-l | --logdir <varname>logfile_directory</varname></pt>
+          <pd>The directory to write the log file. Defaults to <codeph>~/gpAdminLogs</codeph>.</pd>
+        </plentry>
+        <plentry>
+          <pt>-o | --output <varname>output_file_name</varname></pt>
+          <pd>The directory location and file name to output the generated filespace configuration
+            file. You will be prompted to enter a name for the filespace, a master file system
+            location, the primary segment file system locations, and the mirror segment file system
+            locations. For example, if your configuration has 2 primary and 2 mirror segments per
+            host, you will be prompted for a total of 5 locations (including the master). The file
+            system locations must exist on all hosts in your system prior to running the
+              <codeph>gpfilespace</codeph> utility. The utility will designate segment-specific data
+            directories within the location(s) you specify, so it is possible to use the same
+            location for multiple segments. However, primaries and mirrors cannot use the same
+            location. After the utility creates the configuration file, you can manually edit the
+            file to make any required changes to the filespace layout before creating the filespace
+            in Greenplum Database.</pd>
+        </plentry>
+        <plentry>
           <pt>--movetempfilespace {<varname>filespace_name</varname> | default}</pt>
           <pd>Moves temporary files to a new filespace or to the default location.</pd>
-        </plentry><plentry>
+        </plentry>
+        <plentry>
           <pt>--movetransfilespace {<varname>filespace_name</varname> | default}</pt>
-          <pd>Moves transaction files to a new filespace or to the default location.</pd>
-        </plentry><plentry>
+          <pd>Moves transaction files to a new filespace or to the default location.
+            <note type="warning">Do not move transaction files to a non-default location. Moving
+              transaction files might cause data loss.</note></pd>
+        </plentry>
+        <plentry>
           <pt>--showtempfilespace</pt>
           <pd>Show the name of the filespace currently associated with temporary files. This option
             checks that all primary and mirror segments, master and master standby are using the
-            same filespace or temporary files. You will receive a warning message and an email if any
-            inconsistencies exist.</pd>
-        </plentry><plentry>
+            same filespace or temporary files. You will receive a warning message and an email if
+            any inconsistencies exist.</pd>
+        </plentry>
+        <plentry>
           <pt>--showtransfilespace</pt>
           <pd>Show the name of the filespace currently associated with transaction files. This
             option checks that all primary and mirror segments, master and master standby are using
             the same filespace or transaction files. You will receive a warning message and an email
             if any inconsistencies exist.</pd>
-        </plentry><plentry><pt>-v | --version (show utility version)</pt><pd>Displays the version of this utility.</pd></plentry><plentry><pt>-? | --help (help)</pt><pd>Displays the utility usage and syntax.</pd></plentry></parml><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h host | --host <varname>host</varname></pt><pd>The host name of the machine on which the Greenplum master database
-              server is running. If not specified, reads from the environment variable
-                <codeph>PGHOST</codeph> or defaults to localhost.</pd></plentry><plentry><pt>-p port | --port <varname>port</varname></pt><pd>The TCP port on which the Greenplum master database server is
-              listening for connections. If not specified, reads from the environment variable
-                <codeph>PGPORT</codeph> or defaults to 5432.</pd></plentry><plentry><pt>-U username | --username <varname>superuser_name</varname></pt><pd>The database superuser role name to connect as. If not specified,
-reads from the environment variable <codeph>PGUSER</codeph> or defaults
-to the current system user name. Only database superusers are allowed
-to create filespaces.</pd></plentry><plentry><pt>-W | --password</pt><pd>Force a password prompt.</pd></plentry></parml></sectiondiv></section><section id="section6"><title>Examples</title><p>Create a filespace configuration file. You will be prompted to enter
-a name for the filespace, a master file system location, the primary
-segment file system locations, and the mirror segment file system locations.
-For example, if your configuration has 2 primary and 2 mirror segments
-per host, you will be prompted for a total of 5 locations (including
-the master). The file system locations must exist on all hosts in your
-system prior to running the <codeph>gpfilespace</codeph> utility:</p><codeblock>$ <b>gpfilespace -o .
+        </plentry>
+        <plentry>
+          <pt>-v | --version (show utility version)</pt>
+          <pd>Displays the version of this utility.</pd>
+        </plentry>
+        <plentry>
+          <pt>-? | --help (help)</pt>
+          <pd>Displays the utility usage and syntax.</pd>
+        </plentry>
+      </parml>
+      <sectiondiv id="section5"><b>Connection Options</b><parml>
+          <plentry>
+            <pt>-h host | --host <varname>host</varname></pt>
+            <pd>The host name of the machine on which the Greenplum master database server is
+              running. If not specified, reads from the environment variable <codeph>PGHOST</codeph>
+              or defaults to localhost.</pd>
+          </plentry>
+          <plentry>
+            <pt>-p port | --port <varname>port</varname></pt>
+            <pd>The TCP port on which the Greenplum master database server is listening for
+              connections. If not specified, reads from the environment variable
+                <codeph>PGPORT</codeph> or defaults to 5432.</pd>
+          </plentry>
+          <plentry>
+            <pt>-U username | --username <varname>superuser_name</varname></pt>
+            <pd>The database superuser role name to connect as. If not specified, reads from the
+              environment variable <codeph>PGUSER</codeph> or defaults to the current system user
+              name. Only database superusers are allowed to create filespaces.</pd>
+          </plentry>
+          <plentry>
+            <pt>-W | --password</pt>
+            <pd>Force a password prompt.</pd>
+          </plentry>
+        </parml></sectiondiv>
+    </section>
+    <section id="section6">
+      <title>Examples</title>
+      <p>Create a filespace configuration file. You will be prompted to enter a name for the
+        filespace, a master file system location, the primary segment file system locations, and the
+        mirror segment file system locations. For example, if your configuration has 2 primary and 2
+        mirror segments per host, you will be prompted for a total of 5 locations (including the
+        master). The file system locations must exist on all hosts in your system prior to running
+        the <codeph>gpfilespace</codeph> utility:</p>
+      <codeblock>$ <b>gpfilespace -o .
 </b>Enter a name for this filespace
 &gt; <b>fastdisk</b>
 
@@ -100,10 +174,21 @@ mirror location 1&gt; <b>/gp_mir_filespc</b>
 mirror location 2&gt; <b>/gp_mir_filespc</b>
 
 Enter a file system location for the master:
-master location&gt; <b>/gp_master_filespc</b></codeblock><p>Example filespace configuration file:</p><codeblock>filespace:fastdisk
+master location&gt; <b>/gp_master_filespc</b></codeblock>
+      <p>Example filespace configuration file:</p>
+      <codeblock>filespace:fastdisk
 mdw:1:/gp_master_filespc/gp-1
 sdw1:2:/gp_pri_filespc/gp0
 sdw1:3:/gp_mir_filespc/gp1
 sdw2:4:/gp_mir_filespc/gp0
-sdw2:5:/gp_pri_filespc/gp1</codeblock><p>Execute the configuration file to create the filespace in Greenplum Database:</p><codeblock>$ gpfilespace -c gpfilespace_config_1</codeblock></section><section id="section7"><title>See Also</title><p><codeph>CREATE TABLESPACE</codeph><ph> in the <i>Greenplum Database Reference
-            Guide</i></ph></p></section></body></topic>
+sdw2:5:/gp_pri_filespc/gp1</codeblock>
+      <p>Execute the configuration file to create the filespace in Greenplum Database:</p>
+      <codeblock>$ gpfilespace -c gpfilespace_config_1</codeblock>
+    </section>
+    <section id="section7">
+      <title>See Also</title>
+      <p><codeph>CREATE TABLESPACE</codeph><ph> in the <i>Greenplum Database Reference
+          Guide</i></ph></p>
+    </section>
+  </body>
+</topic>


### PR DESCRIPTION
…espace.

gpfilespace.xml
--add gpfilespace deprecation note.
--In description, removed information about moving transaction files
--In --movetransfilespace option add warning not to move transaction files location

ddl-tablespace.xml
--add warning not to move ttransaction files location
--removed information about moving transaction files

Will be backported to 4.3.x
