### PR TITLE
Remove some duplicate code

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6282,18 +6282,6 @@ StartupXLOG(void)
 		SyncDataDirectory();
 
 	/*
-	 * If we previously crashed, there might be data which we had written,
-	 * intending to fsync it, but which we had not actually fsync'd yet.
-	 * Therefore, a power failure in the near future might cause earlier
-	 * unflushed writes to be lost, even though more recent data written to
-	 * disk from here on would be persisted.  To avoid that, fsync the entire
-	 * data directory.
-	 */
-	if (ControlFile->state != DB_SHUTDOWNED &&
-		ControlFile->state != DB_SHUTDOWNED_IN_RECOVERY)
-		SyncDataDirectory();
-
-	/*
 	 * Initialize on the assumption we want to recover to the latest timeline
 	 * that's active according to pg_control.
 	 */

--- a/src/include/access/xlogutils.h
+++ b/src/include/access/xlogutils.h
@@ -53,8 +53,6 @@ extern int read_local_xlog_page(XLogReaderState *state,
 					 TimeLineID *pageTLI);
 
 extern void XLogAOSegmentFile(RelFileNode rnode, uint32 segmentFileNum);
-extern int read_local_xlog_page(XLogReaderState *state, XLogRecPtr targetPagePtr,
-	int reqLen, XLogRecPtr targetRecPtr, char *cur_page, TimeLineID *pageTLI);
 
 extern void XLogReadDetermineTimeline(XLogReaderState *state,
 					XLogRecPtr wantPage, uint32 wantLength);


### PR DESCRIPTION
An `if` block and its comment are duplicate,
the same as the declaration of `read_local_xlog_page`
