### PR TITLE
Extract gid from TwoPhaseFileHeader and use it in xact_desc

### DIFF
--- a/src/backend/access/rmgrdesc/test/xactdesc_test.c
+++ b/src/backend/access/rmgrdesc/test/xactdesc_test.c
@@ -28,9 +28,13 @@ test_xactdescprepareCommit(void **state)
 	tpfh->tablespace_oid_to_delete_on_commit = 42;
 	tpfh->tablespace_oid_to_delete_on_abort = InvalidOid;
 
+	/* Can not use save_state() here, so emulate it */
+	tpfh->gidlen = strlen("4242424242-0000000042") + 1;
+	strcpy((char *)tpfh + sizeof(*tpfh), "4242424242-0000000042");
+
 	xact_desc(buf, record);
 
-	assert_string_equal("at = 2019-07-30 18:26:11.83003+00; tablespace_oid_to_delete_on_commit = 42", buf->data);
+	assert_string_equal("at = 2019-07-30 18:26:11.83003+00; gid = 4242424242-0000000042; tablespace_oid_to_delete_on_commit = 42", buf->data);
 }
 
 static void
@@ -49,9 +53,13 @@ test_xactdescprepareAbort(void **state)
 	tpfh->tablespace_oid_to_delete_on_commit = InvalidOid;
 	tpfh->tablespace_oid_to_delete_on_abort = 42;
 
+	/* Can not use save_state() here, so emulate it */
+	tpfh->gidlen = strlen("4242424242-0000000042") + 1;
+	strcpy((char *)tpfh + sizeof(*tpfh), "4242424242-0000000042");
+
 	xact_desc(buf, record);
 
-	assert_string_equal("at = 2019-07-30 18:26:11.83003+00; tablespace_oid_to_delete_on_abort = 42", buf->data);
+	assert_string_equal("at = 2019-07-30 18:26:11.83003+00; gid = 4242424242-0000000042; tablespace_oid_to_delete_on_abort = 42", buf->data);
 }
 
 static void
@@ -70,9 +78,13 @@ test_xactdescprepareNone(void **state)
 	tpfh->tablespace_oid_to_delete_on_commit = InvalidOid;
 	tpfh->tablespace_oid_to_delete_on_abort = InvalidOid;
 
+	/* Can not use save_state() here, so emulate it */
+	tpfh->gidlen = strlen("4242424242-0000000042") + 1;
+	strcpy((char *)tpfh + sizeof(*tpfh), "4242424242-0000000042");
+
 	xact_desc(buf, record);
 
-	assert_string_equal("at = 2019-07-30 18:26:11.83003+00", buf->data);
+	assert_string_equal("at = 2019-07-30 18:26:11.83003+00; gid = 4242424242-0000000042", buf->data);
 }
 
 int


### PR DESCRIPTION
During the 9.6 cycle TwoPhaseFileHeader changed the way that gid is stored.
Instead of it being an element of the struct, it is now stored directly after
it. Extract it from the record and print it if present.
Re-add it to the tests also.

Removes a FIXME
