### PR TITLE
Compile server against PR in 5X PR Pipeline

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -20,6 +20,19 @@ resources:
         - gpdb-doc/*
         - README*
 
+  - name: gpdb_5x_upstream
+    type: git
+    source:
+      uri: https://github.com/greenplum-db/gpdb
+      branch: "5X_STABLE"
+
+  - name: gpaddon_src
+    type: git
+    source:
+      branch: {{gpaddon-git-branch}}
+      private_key: {{gpaddon-git-key}}
+      uri: {{gpaddon-git-remote}}
+
   - name: centos-gpdb-dev-6
     type: docker-image
     source:
@@ -35,32 +48,49 @@ resources:
       secret_access_key: {{bucket-secret-access-key}}
       versioned_file: {{binary_swap_gpdb_centos_versioned_file}}
 
-  - name: bin_gpdb_centos6
-    type: s3
-    source:
-      access_key_id: {{bucket-access-key-id}}
-      bucket: {{bucket-name}}
-      region_name: {{aws-region}}
-      secret_access_key: {{bucket-secret-access-key}}
-      versioned_file: {{bin_gpdb_centos_versioned_file}}
-
 jobs:
   - name: compile-and-test-pull-request
     plan:
-      - aggregate:
+      - in_parallel:
           - get: gpdb_pr
             version: every
-            trigger: true
-          - get: bin_gpdb
-            resource: bin_gpdb_centos6
             trigger: true
           - get: binary_swap_gpdb
             resource: binary_swap_gpdb_centos6
             trigger: true
           - get: centos-gpdb-dev-6
-            trigger: true
+          - get: gpaddon_src
+          - get: gpdb_5x_upstream
+      # We use the 5X_STABLE source for running make sync_tools instead for security.
+      # For example, this would prevent a user to submit a PR that maliciously
+      # modifies the sync_tools task to expose the ivy credentials.
+      - task: sync_tools
+        input_mapping:
+          gpdb_src: gpdb_5x_upstream
+        file: gpdb_5x_upstream/concourse/tasks/sync_tools.yml
+        image: centos-gpdb-dev-6
+        params:
+          IVYREPO_HOST: {{ivyrepo_host}}
+          IVYREPO_REALM: {{ivyrepo_realm}}
+          IVYREPO_USER: {{ivyrepo_user}}
+          IVYREPO_PASSWD: {{ivyrepo_passwd}}
+          TARGET_OS: centos
+          TARGET_OS_VERSION: 6
+          TASK_OS: centos
+          TASK_OS_VERSION: 6
 
-      - aggregate:
+      - task: compile_gpdb
+        input_mapping:
+          gpdb_src: gpdb_pr
+        file: gpdb_pr/concourse/tasks/compile_gpdb.yml
+        image: centos-gpdb-dev-6
+        params:
+          CONFIGURE_FLAGS: {{configure_flags}}
+          TARGET_OS: centos
+          TARGET_OS_VERSION: 6
+          BLD_TARGETS: "clients loaders"
+
+      - in_parallel:
         - put: gpdb_pr
           params:
             path: gpdb_pr
@@ -70,6 +100,7 @@ jobs:
           image: centos-gpdb-dev-6
           input_mapping:
             gpdb_src: gpdb_pr
+            bin_gpdb: gpdb_artifacts
           params:
             MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
             BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"


### PR DESCRIPTION
We were using a pre-built gpdb binary instead of building a fresh
version of the server against the PR. Now we compile the PR source
as we should.

Notes:
1. We had to bring in `gpaddon` which is a private repo.
2. We had to run `sync_tools`. To prevent exposing credentials, we
deliberately use the 5X_STABLE source to run sync_tools instead of using
the PR's source.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>

To test these changes:

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/soumyadeep2007_5x_pr
We made a branch containing deliberately broken code (won't compile) that should not compile.
Dummy PR on greenplum-db/gpdb:5X_STABLE: https://github.com/greenplum-db/gpdb/pull/9134
(Build: https://prod.ci.gpdb.pivotal.io/builds/551164)
Dummy PR on soumyadeep2007/gpdb:5X_STABLE: https://github.com/soumyadeep2007/gpdb/pull/1
(Build: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/soumyadeep2007_5x_pr/jobs/compile-and-test-pull-request/builds/3)
We can see that in the second PR listed above that the pipeline actually built the PR source (which was intentionally broken) and it failed fast.
The first PR's pipeline run failed much later as it did not build the PR's source and used a pre-built binary.