### PR TITLE
6X_STABLE: Only parse enough of each COPY row, to compute which segment to send it to.

### DIFF
--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -144,13 +144,6 @@ HandleSingleRowError(CdbSreh *cdbsreh)
 	cdbsreh->rejectcount++;
 
 	/*
-	 * if reached the segment reject limit don't do anything. (this will get
-	 * checked and handled later on by the caller).
-	 */
-	if (IsRejectLimitReached(cdbsreh))
-		return;
-
-	/*
 	 * If not specified table or file, do nothing.  Otherwise, record the
 	 * error: QD - send the bad data row to a random QE (via roundrobin). QE -
 	 * log the error in the error log file.
@@ -162,8 +155,6 @@ HandleSingleRowError(CdbSreh *cdbsreh)
 
 		ErrorLogWrite(cdbsreh);
 	}
-
-	return;						/* OK */
 }
 
 /*

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -348,6 +348,8 @@ typedef struct
 	uint32		line_len;			/* size of the included input line */
 	uint32		residual_off;		/* offset in the line, where QE should
 									 * process remaining fields */
+	bool		delim_seen_at_end;  /* conveys to QE if QD saw a delim at end
+									 * of its processing */
 	uint16		fld_count;			/* # of fields that were processed in the
 									 * QD. */
 
@@ -5089,7 +5091,8 @@ NextCopyFromX(CopyState cstate, ExprContext *econtext,
 			 * We have received the raw line from the QD, and we just
 			 * need to split it into raw fields.
 			 */
-			if (cstate->line_buf.cursor < cstate->line_buf.len)
+			if (cstate->stopped_processing_at_delim &&
+				cstate->line_buf.cursor <= cstate->line_buf.len)
 			{
 				if (cstate->csv_mode)
 					fldct = CopyReadAttributesCSV(cstate, -1);
@@ -5461,6 +5464,7 @@ retry:
 	cstate->line_buf_valid = true;
 	cstate->line_buf_converted = true;
 	cstate->cur_lineno = frame.lineno;
+	cstate->stopped_processing_at_delim = frame.delim_seen_at_end;
 
 	/*
 	 * Parse any fields from the input line that were not processed in the
@@ -5867,6 +5871,7 @@ SendCopyFromForwardedTuple(CopyState cstate,
 	frame->line_len = cstate->line_buf.len;
 	frame->residual_off = cstate->line_buf.cursor;
 	frame->fld_count = num_sent_fields;
+	frame->delim_seen_at_end = cstate->stopped_processing_at_delim;
 
 	if (toAll)
 		cdbCopySendDataToAll(cdbCopy, msgbuf->data, msgbuf->len);
@@ -6508,7 +6513,10 @@ CopyReadAttributesText(CopyState cstate, int stop_processing_at_field)
 		 * In QD, stop once we have processed the last field we need in the QD.
 		 */
 		if (fieldno == stop_processing_at_field)
+		{
+			cstate->stopped_processing_at_delim = true;
 			break;
+		}
 
 		/* Make sure there is enough space for the next value */
 		if (fieldno >= cstate->max_fields)
@@ -6672,7 +6680,10 @@ CopyReadAttributesText(CopyState cstate, int stop_processing_at_field)
 		fieldno++;
 		/* Done if we hit EOL instead of a delim */
 		if (!found_delim)
+		{
+			cstate->stopped_processing_at_delim = false;
 			break;
+		}
 	}
 
 	/*
@@ -6750,7 +6761,10 @@ CopyReadAttributesCSV(CopyState cstate, int stop_processing_at_field)
 		 * In QD, stop once we have processed the last field we need in the QD.
 		 */
 		if (fieldno == stop_processing_at_field)
+		{
+			cstate->stopped_processing_at_delim = true;
 			break;
+		}
 
 		/* Make sure there is enough space for the next value */
 		if (fieldno >= cstate->max_fields)
@@ -6855,7 +6869,10 @@ endfield:
 		fieldno++;
 		/* Done if we hit EOL instead of a delim */
 		if (!found_delim)
+		{
+			cstate->stopped_processing_at_delim = false;
 			break;
+		}
 	}
 
 	/*

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -169,8 +169,8 @@ static void CopyFromInsertBatch(CopyState cstate, EState *estate,
 					uint64 firstBufferedLineNo);
 static bool CopyReadLine(CopyState cstate);
 static bool CopyReadLineText(CopyState cstate);
-static int	CopyReadAttributesText(CopyState cstate);
-static int	CopyReadAttributesCSV(CopyState cstate);
+static int	CopyReadAttributesText(CopyState cstate, int stop_processing_at_field);
+static int	CopyReadAttributesCSV(CopyState cstate, int stop_processing_at_field);
 static Datum CopyReadBinaryAttribute(CopyState cstate,
 						int column_no, FmgrInfo *flinfo,
 						Oid typioparam, int32 typmod,
@@ -205,17 +205,18 @@ static void SendCopyFromForwardedTuple(CopyState cstate,
 						   Oid tuple_oid,
 						   Datum *values,
 						   bool *nulls);
-static void SendCopyFromForwardedHeader(CopyState cstate, CdbCopy *cdbCopy, bool file_has_oids);
+static void SendCopyFromForwardedHeader(CopyState cstate, CdbCopy *cdbCopy);
 static void SendCopyFromForwardedError(CopyState cstate, CdbCopy *cdbCopy, char *errmsg);
 
 static bool NextCopyFromDispatch(CopyState cstate, ExprContext *econtext,
 								 Datum *values, bool *nulls, Oid *tupleOid);
 static TupleTableSlot *NextCopyFromExecute(CopyState cstate, ExprContext *econtext, EState *estate,
 								Oid *tupleOid);
+static bool NextCopyFromRawFieldsX(CopyState cstate, char ***fields, int *nfields, int stop_processing_at_field);
 static bool NextCopyFromX(CopyState cstate, ExprContext *econtext,
-						  Datum *values, bool *nulls, Oid *tupleOid);
+			  Datum *values, bool *nulls, Oid *tupleOid);
 static void HandleCopyError(CopyState cstate);
-static void HandleQDErrorFrame(CopyState cstate);
+static void HandleQDErrorFrame(CopyState cstate, char *p, int len);
 
 static void CopyInitDataParser(CopyState cstate);
 static void setEncodingConversionProc(CopyState cstate, int encoding, bool iswritable);
@@ -223,6 +224,8 @@ static void CopyEolStrToType(CopyState cstate);
 
 static GpDistributionData *InitDistributionData(CopyState cstate, EState *estate);
 static void FreeDistributionData(GpDistributionData *distData);
+static void InitCopyFromDispatchSplit(CopyState cstate, GpDistributionData *distData, EState *estate);
+static Bitmapset *GetTargetKeyCols(Oid relid, PartitionNode *children, Bitmapset *needed_cols, bool distkeys, EState *estate);
 static GpDistributionData *GetDistributionPolicyForPartition(CopyState cstate,
 								  EState *estate,
 								  GpDistributionData *mainDistData,
@@ -274,44 +277,40 @@ static volatile CopyState glob_cstate = NULL;
 /* GPDB_91_MERGE_FIXME: passing through a global variable like this is ugly */
 static CopyStmt *glob_copystmt = NULL;
 
+/*
+ * Testing GUC: When enabled, COPY FROM prints an INFO line to indicate which
+ * fields are processed in the QD, and which in the QE.
+ */
+extern bool Test_copy_qd_qe_split;
 
 /*
  * When doing a COPY FROM through the dispatcher, the QD reads the input from
  * the input file (or stdin or program), and forwards the data to the QE nodes,
- * where they will actually be inserted
+ * where they will actually be inserted.
  *
- * - Ideally, the QD would just pass through each line to the QE as is, and let
- *   the QEs to do all the processing. Because the more processing the QD has
- *   to do, the more likely it is to become a bottleneck.
+ * Ideally, the QD would just pass through each line to the QE as is, and let
+ * the QEs to do all the processing. Because the more processing the QD has
+ * to do, the more likely it is to become a bottleneck.
  *
- * - However, the QD needs to figure out which QE to send each row to. For that,
- *   it needs to at least parse the distribution key. The distribution key might
- *   also be a DEFAULTed column, in which case the DEFAULT value needs to be
- *   evaluated in the QD. In that case, the QD must send the computed value
- *   to the QE - we cannot assume that the QE can re-evaluate the expression and
- *   arrive at the same value, at least not if the DEFAULT expression is volatile.
+ * However, the QD needs to figure out which QE to send each row to. For that,
+ * it needs to at least parse the distribution key. The distribution key might
+ * also be a DEFAULTed column, in which case the DEFAULT value needs to be
+ * evaluated in the QD. In that case, the QD must send the computed value
+ * to the QE - we cannot assume that the QE can re-evaluate the expression and
+ * arrive at the same value, at least not if the DEFAULT expression is volatile.
  *
- * - Therefore, we need a flexible format between the QD and QE, where the QD
- *   processes just enough of each input line to figure out where to send it.
- *   It must send the values it had to parse and evaluate to the QE, as well
- *   as the rest of the original input line, so that the QE can parse the rest
- *   of it.
+ * Therefore, we need a flexible format between the QD and QE, where the QD
+ * processes just enough of each input line to figure out where to send it.
+ * It must send the values it had to parse and evaluate to the QE, as well
+ * as the rest of the original input line, so that the QE can parse the rest
+ * of it.
  *
- * GPDB_91_MERGE_FIXME: that's a nice theory, but the current implementation
- * is a lot more dumb: The QD parses every row fully, and sends all
- * precomputed values to each QE. Therefore, with the current implementation,
- * the QD will easily become a bottleneck, if the input functions are
- * expensive. Before the refactoring during the 9.1 merge, there was no
- * special QD->QE protocol. Instead, the QD reconstructed each line in the
- * same format as the original file had, interjecting any DEFAULT values into
- * it. That was fast when only a few columns needed to be evaluated in the QD,
- * but it was not optimal, but it was pretty complicated, and required some
- * majore surgery to the upstream NextCopyFrom and other functions.
- *
- * The 'copy_from_dispatch_frame' struct is used in the QD->QE stream. For each
- * input line, the QD constructs a 'copy_from_dispatch_frame' struct, and sends
+ * The 'copy_from_dispatch_*' structs are used in the QD->QE stream. For each
+ * input line, the QD constructs a 'copy_from_dispatch_row' struct, and sends
  * it to the QE. Before any rows, a QDtoQESignature is sent first, followed by
- * a 'copy_from_dispatch_header'.
+ * a 'copy_from_dispatch_header'. When QD encounters a recoverable error that
+ * needs to be logged in the error log (LOG ERRORS SEGMENT REJECT LIMIT), it
+ * sends the erroneous raw to a QE, in a 'copy_from_dispatch_error' struct.
  *
  *
  * COPY TO is simpler: The QEs form the output rows in the final form, and the QD
@@ -320,49 +319,81 @@ static CopyStmt *glob_copystmt = NULL;
  */
 static const char QDtoQESignature[] = "PGCOPY-QD-TO-QE\n\377\r\n";
 
+/* Header contains information that applies to all the rows that follow. */
 typedef struct
 {
+	/*
+	 * First field that should be processed in the QE. Any fields before
+	 * this will be included as Datums in the rows that follow.
+	 */
+	int16		first_qe_processed_field;
 	bool		file_has_oids;
 } copy_from_dispatch_header;
 
 typedef struct
 {
 	/*
-	 * target relation OID. Normally, the same as cstate->relid, but for
-	 * a partitioned relation, it indicate the target partition.
+	 * Information about this input line.
+	 *
+	 * 'relid' is the target relation's OID. Normally, the same as
+	 * cstate->relid, but for a partitioned relation, it indicates the target
+	 * partition. Note: this must be the first field, because InvalidOid means
+	 * that this is actually a 'copy_from_dispatch_error' struct.
+	 *
+	 * 'lineno' is the input line number, for error reporting.
 	 */
-	Oid			relid;
-	Oid			loaded_oid;
 	int64		lineno;
-	int16		fld_count;
+	Oid			relid;
+
+	uint32		line_len;			/* size of the included input line */
+	uint32		residual_off;		/* offset in the line, where QE should
+									 * process remaining fields */
+	uint16		fld_count;			/* # of fields that were processed in the
+									 * QD. */
+
+	/* If 'file_has_oids' was true, a tuple OID follows. */
+
+	/* The input line follows. */
 
 	/*
-	 * Default values. For each default value:
+	 * For each field that was parsed in the QD already, the following data follows:
+	 *
+	 * int16	fieldnum;
 	 * <data>
 	 *
-	 * The data is the raw Datum.
+	 * NULL values are not included, any attributes that are not included in
+	 * the message are implicitly NULL.
+	 *
+	 * For pass-by-value datatypes, the <data> is the raw Datum. For
+	 * simplicity, it is always sent as a full-width 8-byte Datum, regardless
+	 * of the datatype's length.
+	 *
+	 * For other fixed width datatypes, <data> is the datatype's value.
+	 *
+	 * For variable-length datatypes, <data> begins with a 4-byte length field,
+	 * followed by the data. Cstrings (typlen = -2) are also sent in this
+	 * format.
 	 */
-
-	/* data follows */
 } copy_from_dispatch_row;
+
+/* Size of the struct, without padding at the end. */
+#define SizeOfCopyFromDispatchRow (offsetof(copy_from_dispatch_row, fld_count) + sizeof(uint16))
 
 typedef struct
 {
-	/*
-	 * target relation OID. Normally, the same as cstate->relid, but for
-	 * a partitioned relation, it indicate the target partition.
-	 */
-	Oid			error_marker;		/* InvalidOid, to distinguish this from row. */
+	int64		error_marker;	/* constant -1, to mark that this is an error
+								 * frame rather than 'copy_from_dispatch_row' */
 	int64		lineno;
-	bool		line_buf_converted;
 	uint32		errmsg_len;
 	uint32		line_len;
+	bool		line_buf_converted;
 
 	/* 'errmsg' follows */
 	/* 'line' follows */
 } copy_from_dispatch_error;
 
-
+/* Size of the struct, without padding at the end. */
+#define SizeOfCopyFromDispatchError (offsetof(copy_from_dispatch_error, line_buf_converted) + sizeof(bool))
 
 
 /*
@@ -3703,6 +3734,41 @@ CopyFrom(CopyState cstate)
 			is_check_distkey = false;
 	}
 
+	/* Determine which fields we need to parse in the QD. */
+	if (cstate->dispatch_mode == COPY_DISPATCH)
+		InitCopyFromDispatchSplit(cstate, distData, estate);
+
+	if (cstate->dispatch_mode == COPY_DISPATCH ||
+		cstate->dispatch_mode == COPY_EXECUTOR)
+	{
+		/*
+		 * Now split the attnumlist into the parts that are parsed in the QD, and
+		 * in QE.
+		 */
+		ListCell   *lc;
+		int			i = 0;
+		List	   *qd_attnumlist = NIL;
+		List	   *qe_attnumlist = NIL;
+		int			first_qe_processed_field;
+
+		first_qe_processed_field = cstate->first_qe_processed_field;
+		if (cstate->file_has_oids)
+			first_qe_processed_field--;
+
+		foreach(lc, cstate->attnumlist)
+		{
+			int			attnum = lfirst_int(lc);
+
+			if (i < first_qe_processed_field)
+				qd_attnumlist = lappend_int(qd_attnumlist, attnum);
+			else
+				qe_attnumlist = lappend_int(qe_attnumlist, attnum);
+			i++;
+		}
+		cstate->qd_attnumlist = qd_attnumlist;
+		cstate->qe_attnumlist = qe_attnumlist;
+	}
+
 	if (cstate->dispatch_mode == COPY_DISPATCH)
 	{
 		/*
@@ -3716,7 +3782,7 @@ CopyFrom(CopyState cstate)
 		 * pre-allocate buffer for constructing a message.
 		 */
 		cstate->dispatch_msgbuf = makeStringInfo();
-		enlargeStringInfo(cstate->dispatch_msgbuf, sizeof(copy_from_dispatch_row));
+		enlargeStringInfo(cstate->dispatch_msgbuf, SizeOfCopyFromDispatchRow);
 
 		/*
 		 * prepare to COPY data into segDBs:
@@ -3760,9 +3826,7 @@ CopyFrom(CopyState cstate)
 			 * dummy file on master for COPY FROM ON SEGMENT
 			 */
 			if (!cstate->on_segment)
-			{
-				SendCopyFromForwardedHeader(cstate, cdbCopy, cstate->file_has_oids);
-			}
+				SendCopyFromForwardedHeader(cstate, cdbCopy);
 		}
 	}
 
@@ -4431,10 +4495,12 @@ BeginCopyFrom(Relation rel,
 	/*
 	 * Determine the mode
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH && !cstate->on_segment &&
-		cstate->rel && cstate->rel->rd_cdbpolicy)
+	if (cstate->on_segment || data_source_cb)
+		cstate->dispatch_mode = COPY_DIRECT;
+	else if (Gp_role == GP_ROLE_DISPATCH &&
+			 cstate->rel && cstate->rel->rd_cdbpolicy)
 		cstate->dispatch_mode = COPY_DISPATCH;
-	else if (Gp_role == GP_ROLE_EXECUTE && !cstate->on_segment)
+	else if (Gp_role == GP_ROLE_EXECUTE)
 		cstate->dispatch_mode = COPY_EXECUTOR;
 	else
 		cstate->dispatch_mode = COPY_DIRECT;
@@ -4677,6 +4743,7 @@ BeginCopyFrom(Relation rel,
 					errmsg("invalid QD->QD COPY communication header")));
 
 		cstate->file_has_oids = header_frame.file_has_oids;
+		cstate->first_qe_processed_field = header_frame.first_qe_processed_field;
 	}
 	else if (!cstate->binary)
 	{
@@ -4758,6 +4825,13 @@ BeginCopyFrom(Relation rel,
 bool
 NextCopyFromRawFields(CopyState cstate, char ***fields, int *nfields)
 {
+	return NextCopyFromRawFieldsX(cstate, fields, nfields, -1);
+}
+
+static bool
+NextCopyFromRawFieldsX(CopyState cstate, char ***fields, int *nfields,
+					   int stop_processing_at_field)
+{
 	int			fldct;
 	bool		done;
 
@@ -4787,9 +4861,9 @@ NextCopyFromRawFields(CopyState cstate, char ***fields, int *nfields)
 
 	/* Parse the line into de-escaped field values */
 	if (cstate->csv_mode)
-		fldct = CopyReadAttributesCSV(cstate);
+		fldct = CopyReadAttributesCSV(cstate, stop_processing_at_field);
 	else
-		fldct = CopyReadAttributesText(cstate);
+		fldct = CopyReadAttributesText(cstate, stop_processing_at_field);
 
 	*fields = cstate->raw_fields;
 	*nfields = fldct;
@@ -4876,7 +4950,7 @@ HandleCopyError(CopyState cstate)
 		 * ErrorIfRejectLimit() below will use this information in the error message,
 		 * if the error count is reached.
 		 */
-		cdbsreh->rawdata = cstate->line_buf.data + cstate->line_buf.cursor;
+		cdbsreh->rawdata = cstate->line_buf.data;
 
 		cdbsreh->is_server_enc = cstate->line_buf_converted;
 		cdbsreh->linenumber = cstate->cur_lineno;
@@ -4899,7 +4973,7 @@ HandleCopyError(CopyState cstate)
 
 				SendCopyFromForwardedError(cstate, cstate->cdbCopy, errormsg);
 			}
-			else 
+			else
 			{
 				/* after all the prep work let cdbsreh do the real work */
 				if (Gp_role == GP_ROLE_DISPATCH)
@@ -4934,7 +5008,7 @@ HandleCopyError(CopyState cstate)
  * relation passed to BeginCopyFrom. This function fills the arrays.
  * Oid of the tuple is returned with 'tupleOid' separately.
  */
-bool
+static bool
 NextCopyFromX(CopyState cstate, ExprContext *econtext,
 			 Datum *values, bool *nulls, Oid *tupleOid)
 {
@@ -4948,14 +5022,46 @@ NextCopyFromX(CopyState cstate, ExprContext *econtext,
 	int			i;
 	int			nfields;
 	bool		isnull;
-	bool		file_has_oids = cstate->file_has_oids;
 	int		   *defmap = cstate->defmap;
 	ExprState **defexprs = cstate->defexprs;
+	List	   *attnumlist;
+	bool		file_has_oids;
+	int			stop_processing_at_field;
+
+	/*
+	 * Figure out what fields we're going to process in this process.
+	 *
+	 * In the QD, set 'stop_processing_at_field' so that we only those
+	 * fields that are needed in the QD.
+	 */
+	switch (cstate->dispatch_mode)
+	{
+		case COPY_DIRECT:
+			stop_processing_at_field = -1;
+			attnumlist = cstate->attnumlist;
+			file_has_oids = cstate->file_has_oids;
+			break;
+
+		case COPY_DISPATCH:
+			stop_processing_at_field = cstate->first_qe_processed_field;
+			attnumlist = cstate->qd_attnumlist;
+			file_has_oids = cstate->file_has_oids;
+			break;
+
+		case COPY_EXECUTOR:
+			stop_processing_at_field = -1;
+			attnumlist = cstate->qe_attnumlist;
+			file_has_oids = false;	/* already handled in QD. */
+			break;
+
+		default:
+			elog(ERROR, "unexpected COPY dispatch mode %d", cstate->dispatch_mode);
+	}
 
 	tupDesc = RelationGetDescr(cstate->rel);
 	attr = tupDesc->attrs;
 	num_phys_attrs = tupDesc->natts;
-	attr_count = list_length(cstate->attnumlist);
+	attr_count = list_length(attnumlist);
 	nfields = file_has_oids ? (attr_count + 1) : attr_count;
 
 	/* Initialize all values for row to NULL */
@@ -4971,8 +5077,29 @@ NextCopyFromX(CopyState cstate, ExprContext *econtext,
 		char	   *string;
 
 		/* read raw fields in the next line */
-		if (!NextCopyFromRawFields(cstate, &field_strings, &fldct))
-			return false;
+		if (cstate->dispatch_mode != COPY_EXECUTOR)
+		{
+			if (!NextCopyFromRawFieldsX(cstate, &field_strings, &fldct,
+										stop_processing_at_field))
+				return false;
+		}
+		else
+		{
+			/*
+			 * We have received the raw line from the QD, and we just
+			 * need to split it into raw fields.
+			 */
+			if (cstate->line_buf.cursor < cstate->line_buf.len)
+			{
+				if (cstate->csv_mode)
+					fldct = CopyReadAttributesCSV(cstate, -1);
+				else
+					fldct = CopyReadAttributesText(cstate, -1);
+			}
+			else
+				fldct = 0;
+			field_strings = cstate->raw_fields;
+		}
 
 		/* check for overflowing fields */
 		if (nfields > 0 && fldct > nfields)
@@ -5027,7 +5154,7 @@ NextCopyFromX(CopyState cstate, ExprContext *econtext,
 		}
 
 		/* Loop to read the user attributes on the line. */
-		foreach(cur, cstate->attnumlist)
+		foreach(cur, attnumlist)
 		{
 			int			attnum = lfirst_int(cur);
 			int			m = attnum - 1;
@@ -5161,7 +5288,7 @@ NextCopyFromX(CopyState cstate, ExprContext *econtext,
 		}
 
 		i = 0;
-		foreach(cur, cstate->attnumlist)
+		foreach(cur, attnumlist)
 		{
 			int			attnum = lfirst_int(cur);
 			int			m = attnum - 1;
@@ -5183,7 +5310,15 @@ NextCopyFromX(CopyState cstate, ExprContext *econtext,
 	 * Now compute and insert any defaults available for the columns not
 	 * provided by the input data.  Anything not processed here or above will
 	 * remain NULL.
+	 *
+	 * GPDB: The defaults are always computed in the QD, and are included
+	 * in the QD->QE stream as pre-computed Datums. Funny indentation, to
+	 * keep the indentation of the code inside the same as in upstream.
+	 * (We could improve this, and compute immutable defaults that don't
+	 * affect which segment the row belongs to, in the QE.)
 	 */
+  if (cstate->dispatch_mode != COPY_EXECUTOR)
+  {
 	for (i = 0; i < num_defaults; i++)
 	{
 		/*
@@ -5196,6 +5331,7 @@ NextCopyFromX(CopyState cstate, ExprContext *econtext,
 		values[defmap[i]] = ExecEvalExpr(defexprs[i], econtext,
 										 &nulls[defmap[i]], NULL);
 	}
+  }
 
 	return true;
 }
@@ -5205,21 +5341,14 @@ NextCopyFromX(CopyState cstate, ExprContext *econtext,
  * Like NextCopyFrom(), but used in the QD, when we want to parse the
  * input line only partially. We only want to parse enough fields needed
  * to determine which target segment to forward the row to.
+ *
+ * (The logic is actually within NextCopyFrom(). This is a separate
+ * function just for symmetry with NextCopyFromExecute()).
  */
 static bool
 NextCopyFromDispatch(CopyState cstate, ExprContext *econtext,
 					 Datum *values, bool *nulls, Oid *tupleOid)
 {
-	/*
-	 * GPDB_91_MERGE_FIXME: The idea here would be to only call the
-	 * input function for the fields we need in the QD. But for now,
-	 * screw performance.
-	 *
-	 * Note: There used to be code in InitDistributionData(), to compute
-	 * the last field number that's needed for to determine which partition
-	 * a row belongs to. If you resurrect this optimization, you'll probably
-	 * need to resurrect that, too.
-	 */
 	return NextCopyFrom(cstate, econtext, values, nulls, tupleOid);
 }
 
@@ -5238,61 +5367,58 @@ NextCopyFromExecute(CopyState cstate, ExprContext *econtext,
 	AttrNumber	num_phys_attrs;
 	copy_from_dispatch_row frame;
 	int			r;
-	Oid			header;
 	ResultRelInfo *resultRelInfo;
+	TupleTableSlot *baseSlot;
 	TupleTableSlot *slot;
+	Datum	   *baseValues;
+	bool	   *baseNulls;
 	Datum	   *values;
 	bool	   *nulls;
-	MemoryContext oldcxt;
+	bool		got_error;
 
+	/*
+	 * The code below reads the 'copy_from_dispatch_row' struct, and only
+	 * then checks if it was actually a 'copy_from_dispatch_error' struct.
+	 * That only works when 'copy_from_dispatch_error' is larger than
+	 *'copy_from_dispatch_row'.
+	 */
+	StaticAssertStmt(SizeOfCopyFromDispatchError >= SizeOfCopyFromDispatchRow,
+					 "copy_from_dispatch_error must be larger than copy_from_dispatch_row");
+
+	/*
+	 * If we encounter an error while parsing the row (or we receive a row from
+	 * the QD that was already marked as an erroneous row), we loop back here
+	 * until we get a good row.
+	 */
 retry:
-	/* sneak peek at the first Oid field to see if it's a row or an error */
-	r = CopyGetData(cstate, &header, sizeof(Oid));
+	got_error = false;
+
+	r = CopyGetData(cstate, (char *) &frame, SizeOfCopyFromDispatchRow);
 	if (r == 0)
 		return NULL;
-	if (r != sizeof(Oid))
+	if (r != SizeOfCopyFromDispatchRow)
 		ereport(ERROR,
 				(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
 				 errmsg("unexpected EOF in COPY data")));
-
-	if (header == InvalidOid)
+	if (frame.lineno == -1)
 	{
-		HandleQDErrorFrame(cstate);
+		HandleQDErrorFrame(cstate, (char *) &frame, SizeOfCopyFromDispatchRow);
 		goto retry;
 	}
 
-	frame.relid = header;
-	r = CopyGetData(cstate, ((char *) &frame) + sizeof(Oid), sizeof(frame) - sizeof(Oid));
-	if (r != sizeof(frame) - sizeof(Oid))
-		ereport(ERROR,
-				(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-				 errmsg("unexpected EOF in COPY data")));
-
-	if (!OidIsValid(frame.relid))
-		elog(ERROR, "invalid target relation id in tuple frame received from QD");
-
-	/*
-	 * Look up the correct partition
-	 */
-	oldcxt = MemoryContextSwitchTo(estate->es_query_cxt);
-
+	/* Prepare for parsing the input line */
 	resultRelInfo = estate->es_result_relation_info;
-	if (frame.relid != RelationGetRelid(resultRelInfo->ri_RelationDesc))
-	{
-		resultRelInfo = targetid_get_partition(frame.relid, estate, true);
-		estate->es_result_relation_info = resultRelInfo;
-	}
-
-	if (!resultRelInfo->ri_resultSlot)
-		resultRelInfo->ri_resultSlot =
-			MakeSingleTupleTableSlot(resultRelInfo->ri_RelationDesc->rd_att);
-	slot = resultRelInfo->ri_resultSlot;
-
+	baseSlot = resultRelInfo->ri_resultSlot;
 	tupDesc = RelationGetDescr(resultRelInfo->ri_RelationDesc);
 	attr = tupDesc->attrs;
 	num_phys_attrs = tupDesc->natts;
 
-	MemoryContextSwitchTo(oldcxt);
+	/* Initialize all values for row to NULL */
+	ExecClearTuple(baseSlot);
+	baseValues = slot_get_values(baseSlot);
+	baseNulls = slot_get_isnull(baseSlot);
+	MemSet(baseValues, 0, num_phys_attrs * sizeof(Datum));
+	MemSet(baseNulls, true, num_phys_attrs * sizeof(bool));
 
 	/* check for overflowing fields */
 	if (frame.fld_count < 0 || frame.fld_count > num_phys_attrs)
@@ -5300,17 +5426,15 @@ retry:
 				(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
 				 errmsg("extra data after last expected column")));
 
-	/* Initialize all values for row to NULL */
-	ExecClearTuple(slot);
-	values = slot_get_values(resultRelInfo->ri_resultSlot);
-	nulls = slot_get_isnull(resultRelInfo->ri_resultSlot);
-	MemSet(values, 0, num_phys_attrs * sizeof(Datum));
-	MemSet(nulls, true, num_phys_attrs * sizeof(bool));
-
-	/* Read the OID field if present */
+	/* Read the OID field, if present */
 	if (file_has_oids)
 	{
-		Oid			loaded_oid = frame.loaded_oid;
+		Oid			loaded_oid;
+
+		if (CopyGetData(cstate, &loaded_oid, sizeof(Oid)) != sizeof(Oid))
+			ereport(ERROR,
+					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+					 errmsg("unexpected EOF in COPY data")));
 
 		if (loaded_oid == InvalidOid)
 		{
@@ -5321,13 +5445,91 @@ retry:
 		}
 		*tupleOid = loaded_oid;
 	}
-	else if (frame.loaded_oid != InvalidOid)
-			ereport(ERROR,
-					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
-					 errmsg("unexpected OID received in COPY data")));
 
+	/*
+	 * Read the input line into 'line_buf'.
+	 */
+	resetStringInfo(&cstate->line_buf);
+	enlargeStringInfo(&cstate->line_buf, frame.line_len);
+	if (CopyGetData(cstate, cstate->line_buf.data, frame.line_len) != frame.line_len)
+		ereport(ERROR,
+				(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+				 errmsg("unexpected EOF in COPY data")));
+	cstate->line_buf.data[frame.line_len] = '\0';
+	cstate->line_buf.len = frame.line_len;
+	cstate->line_buf.cursor = frame.residual_off;
+	cstate->line_buf_valid = true;
+	cstate->line_buf_converted = true;
 	cstate->cur_lineno = frame.lineno;
 
+	/*
+	 * Parse any fields from the input line that were not processed in the
+	 * QD already.
+	 */
+	if (!cstate->cdbsreh)
+	{
+		if (!NextCopyFromX(cstate, econtext, baseValues, baseNulls, NULL))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+					 errmsg("unexpected EOF in COPY data")));
+		}
+	}
+	else
+	{
+		MemoryContext oldcontext = CurrentMemoryContext;
+		bool		result;
+
+		PG_TRY();
+		{
+			result = NextCopyFromX(cstate, econtext,
+								   baseValues, baseNulls, tupleOid);
+
+			if (!result)
+				ereport(ERROR,
+						(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+						 errmsg("unexpected EOF in COPY data")));
+		}
+		PG_CATCH();
+		{
+			HandleCopyError(cstate);
+			got_error = true;
+			MemoryContextSwitchTo(oldcontext);
+		}
+		PG_END_TRY();
+	}
+
+	ExecStoreVirtualTuple(baseSlot);
+
+	/*
+	 * Remap the values to the form expected by the target partition.
+	 */
+	if (frame.relid != RelationGetRelid(resultRelInfo->ri_RelationDesc))
+	{
+		MemoryContext oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
+
+		resultRelInfo = targetid_get_partition(frame.relid, estate, true);
+		estate->es_result_relation_info = resultRelInfo;
+
+		MemoryContextSwitchTo(oldcontext);
+
+		slot = reconstructMatchingTupleSlot(baseSlot, resultRelInfo);
+
+		/* since resultRelInfo has changed, refresh these values */
+		tupDesc = RelationGetDescr(resultRelInfo->ri_RelationDesc);
+		attr = tupDesc->attrs;
+		num_phys_attrs = tupDesc->natts;
+	}
+	else
+		slot = baseSlot;
+
+	/*
+	 * Read any attributes that were processed in the QD already. The attribute
+	 * numbers in the message are already in terms of the target partition, so
+	 * we do this after remapping and switching to the partition slot.
+	 */
+	values = slot_get_values(slot);
+	nulls = slot_get_isnull(slot);
 	for (i = 0; i < frame.fld_count; i++)
 	{
 		int16		attnum;
@@ -5339,8 +5541,10 @@ retry:
 			ereport(ERROR,
 					(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
 					 errmsg("unexpected EOF in COPY data")));
+
 		if (attnum < 1 || attnum > num_phys_attrs)
-			elog(ERROR, "invalid attnum received from QD: %d", attnum);
+			elog(ERROR, "invalid attnum received from QD: %d (num physical attributes: %d)",
+				 attnum, num_phys_attrs);
 		m = attnum - 1;
 
 		cstate->cur_attname = NameStr(attr[m]->attname);
@@ -5411,9 +5615,13 @@ retry:
 		cstate->cur_attname = NULL;
 
 		values[m] = value;
-		/* NULLs are currently not transmitted */
 		nulls[m] = false;
 	}
+
+	if (got_error)
+		goto retry;
+
+	ExecStoreVirtualTuple(slot);
 
 	/*
 	 * Here we should compute defaults for any columns for which we didn't
@@ -5421,13 +5629,17 @@ retry:
 	 * in the QD.
 	 */
 
-	ExecStoreVirtualTuple(slot);
-
 	return slot;
 }
 
+/*
+ * Parse and handle an "error frame" from QD.
+ *
+ * The caller has already read part of the frame; 'p' points to that part,
+ * of length 'len'.
+ */
 static void
-HandleQDErrorFrame(CopyState cstate)
+HandleQDErrorFrame(CopyState cstate, char *p, int len)
 {
 	CdbSreh *cdbsreh = cstate->cdbsreh;
 	MemoryContext oldcontext;
@@ -5436,12 +5648,20 @@ HandleQDErrorFrame(CopyState cstate)
 	char	   *line;
 	int			r;
 
+	Assert(len <= SizeOfCopyFromDispatchError);
+
 	Assert(Gp_role == GP_ROLE_EXECUTE);
 
 	oldcontext = MemoryContextSwitchTo(cdbsreh->badrowcontext);
 
-	r = CopyGetData(cstate, ((char *) &errframe) + sizeof(Oid), sizeof(errframe) - sizeof(Oid));
-	if (r != sizeof(errframe) - sizeof(Oid))
+	/*
+	 * Copy the part of the struct that the caller had already read, and
+	 * read the rest.
+	 */
+	memcpy(&errframe, p, len);
+
+	r = CopyGetData(cstate, ((char *) &errframe) + len, SizeOfCopyFromDispatchError - len);
+	if (r != SizeOfCopyFromDispatchError - len)
 		ereport(ERROR,
 				(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
 				 errmsg("unexpected EOF in COPY data")));
@@ -5465,8 +5685,8 @@ HandleQDErrorFrame(CopyState cstate)
 
 	cdbsreh->linenumber = errframe.lineno;
 	cdbsreh->rawdata = line;
-	cdbsreh->is_server_enc = errframe.line_buf_converted;
 	cdbsreh->errmsg = errormsg;
+	cdbsreh->is_server_enc = errframe.line_buf_converted;
 
 	HandleSingleRowError(cdbsreh);
 
@@ -5534,11 +5754,25 @@ SendCopyFromForwardedTuple(CopyState cstate,
 	num_phys_attrs = tupDesc->natts;
 
 	/*
-	 * Reset the message buffer, and reserve space for the frame header.
+	 * Reset the message buffer, and reserve enough space for the header,
+	 * the OID if any, and the residual line.
 	 */
 	msgbuf = cstate->dispatch_msgbuf;
-	Assert(msgbuf->maxlen >= sizeof(copy_from_dispatch_row));
-	msgbuf->len = sizeof(copy_from_dispatch_row);
+	ENLARGE_MSGBUF(msgbuf, SizeOfCopyFromDispatchRow + sizeof(Oid) + cstate->line_buf.len);
+
+	/* the header goes to the beginning of the struct, but it will be filled in later. */
+	msgbuf->len = SizeOfCopyFromDispatchRow;
+
+	/*
+	 * After the header, the OID from the input row, if any.
+	 */
+	if (cstate->file_has_oids)
+		APPEND_MSGBUF_NOCHECK(msgbuf, &tuple_oid, sizeof(Oid));
+
+	/*
+	 * Next, any residual text that we didn't process in the QD.
+	 */
+	APPEND_MSGBUF_NOCHECK(msgbuf, cstate->line_buf.data, cstate->line_buf.len);
 
 	/*
 	 * Append attributes to the buffer.
@@ -5628,9 +5862,10 @@ SendCopyFromForwardedTuple(CopyState cstate,
 	 * buffer.
 	 */
 	frame = (copy_from_dispatch_row *) msgbuf->data;
-	frame->relid = RelationGetRelid(rel);
-	frame->loaded_oid = tuple_oid;
 	frame->lineno = lineno;
+	frame->relid = RelationGetRelid(rel);
+	frame->line_len = cstate->line_buf.len;
+	frame->residual_off = cstate->line_buf.cursor;
 	frame->fld_count = num_sent_fields;
 
 	if (toAll)
@@ -5640,14 +5875,15 @@ SendCopyFromForwardedTuple(CopyState cstate,
 }
 
 static void
-SendCopyFromForwardedHeader(CopyState cstate, CdbCopy *cdbCopy, bool file_has_oids)
+SendCopyFromForwardedHeader(CopyState cstate, CdbCopy *cdbCopy)
 {
 	copy_from_dispatch_header header_frame;
 
 	cdbCopySendDataToAll(cdbCopy, QDtoQESignature, sizeof(QDtoQESignature));
 
 	memset(&header_frame, 0, sizeof(header_frame));
-	header_frame.file_has_oids = file_has_oids;
+	header_frame.file_has_oids = cstate->file_has_oids;
+	header_frame.first_qe_processed_field = cstate->first_qe_processed_field;
 
 	cdbCopySendDataToAll(cdbCopy, (char *) &header_frame, sizeof(header_frame));
 }
@@ -5662,27 +5898,27 @@ SendCopyFromForwardedError(CopyState cstate, CdbCopy *cdbCopy, char *errormsg)
 
 	msgbuf = cstate->dispatch_msgbuf;
 	resetStringInfo(msgbuf);
-	enlargeStringInfo(msgbuf, sizeof(copy_from_dispatch_error));
+	enlargeStringInfo(msgbuf, SizeOfCopyFromDispatchError);
 	/* allocate space for the header (we'll fill it in last). */
-	msgbuf->len = sizeof(copy_from_dispatch_error);
+	msgbuf->len = SizeOfCopyFromDispatchError;
 
 	appendBinaryStringInfo(msgbuf, errormsg, errormsg_len);
 	appendBinaryStringInfo(msgbuf, cstate->line_buf.data, cstate->line_buf.len);
 
 	errframe = (copy_from_dispatch_error *) msgbuf->data;
 
-	errframe->error_marker = InvalidOid;
+	errframe->error_marker = -1;
 	errframe->lineno = cstate->cur_lineno;
-	errframe->line_buf_converted = cstate->line_buf_converted;
 	errframe->line_len = cstate->line_buf.len;
 	errframe->errmsg_len = errormsg_len;
+	errframe->line_buf_converted = cstate->line_buf_converted;
 
 	/* send the bad data row to a random QE (via roundrobin) */
 	if (cstate->lastsegid == cdbCopy->total_segs)
 		cstate->lastsegid = 0; /* start over from first segid */
 
 	target_seg = (cstate->lastsegid++ % cdbCopy->total_segs);
-	
+
 	cdbCopySendData(cdbCopy, target_seg, msgbuf->data, msgbuf->len);
 }
 
@@ -6219,7 +6455,7 @@ GetDecimalFromHex(char hex)
  * The return value is the number of fields actually read.
  */
 static int
-CopyReadAttributesText(CopyState cstate)
+CopyReadAttributesText(CopyState cstate, int stop_processing_at_field)
 {
 	char		delimc = cstate->delim[0];
 	char		escapec = cstate->escape_off ? delimc : cstate->escape[0];
@@ -6255,7 +6491,7 @@ CopyReadAttributesText(CopyState cstate)
 	output_ptr = cstate->attribute_buf.data;
 
 	/* set pointer variables for loop */
-	cur_ptr = cstate->line_buf.data;
+	cur_ptr = cstate->line_buf.data + cstate->line_buf.cursor;
 	line_end_ptr = cstate->line_buf.data + cstate->line_buf.len;
 
 	/* Outer loop iterates over fields */
@@ -6267,6 +6503,12 @@ CopyReadAttributesText(CopyState cstate)
 		char	   *end_ptr;
 		int			input_len;
 		bool		saw_non_ascii = false;
+
+		/*
+		 * In QD, stop once we have processed the last field we need in the QD.
+		 */
+		if (fieldno == stop_processing_at_field)
+			break;
 
 		/* Make sure there is enough space for the next value */
 		if (fieldno >= cstate->max_fields)
@@ -6433,6 +6675,12 @@ CopyReadAttributesText(CopyState cstate)
 			break;
 	}
 
+	/*
+	 * Make note of the stopping point in 'line_buf.cursor', so that we
+	 * can send the rest to the QE later.
+	 */
+	cstate->line_buf.cursor = cur_ptr - cstate->line_buf.data;
+
 	/* Clean up state of attribute_buf */
 	output_ptr--;
 	Assert(*output_ptr == '\0');
@@ -6448,7 +6696,7 @@ CopyReadAttributesText(CopyState cstate)
  * "standard" (i.e. common) CSV usage.
  */
 static int
-CopyReadAttributesCSV(CopyState cstate)
+CopyReadAttributesCSV(CopyState cstate, int stop_processing_at_field)
 {
 	char		delimc = cstate->delim[0];
 	char		quotec = cstate->quote[0];
@@ -6485,7 +6733,7 @@ CopyReadAttributesCSV(CopyState cstate)
 	output_ptr = cstate->attribute_buf.data;
 
 	/* set pointer variables for loop */
-	cur_ptr = cstate->line_buf.data;
+	cur_ptr = cstate->line_buf.data + cstate->line_buf.cursor;
 	line_end_ptr = cstate->line_buf.data + cstate->line_buf.len;
 
 	/* Outer loop iterates over fields */
@@ -6497,6 +6745,12 @@ CopyReadAttributesCSV(CopyState cstate)
 		char	   *start_ptr;
 		char	   *end_ptr;
 		int			input_len;
+
+		/*
+		 * In QD, stop once we have processed the last field we need in the QD.
+		 */
+		if (fieldno == stop_processing_at_field)
+			break;
 
 		/* Make sure there is enough space for the next value */
 		if (fieldno >= cstate->max_fields)
@@ -6603,6 +6857,12 @@ endfield:
 		if (!found_delim)
 			break;
 	}
+
+	/*
+	 * Make note of the stopping point in 'line_buf.cursor', so that we
+	 * can send the rest to the QE later.
+	 */
+	cstate->line_buf.cursor = cur_ptr - cstate->line_buf.data;
 
 	/* Clean up state of attribute_buf */
 	output_ptr--;
@@ -7286,6 +7546,151 @@ FreeDistributionData(GpDistributionData *distData)
 	}
 }
 
+/*
+ * Compute which fields need to be processed in the QD, and which ones can
+ * be delayed to the QE.
+ */
+static void
+InitCopyFromDispatchSplit(CopyState cstate, GpDistributionData *distData,
+						  EState *estate)
+{
+	int			first_qe_processed_field;
+	Bitmapset  *needed_cols = NULL;
+	ListCell   *lc;
+	int			fieldno;
+
+	/*
+	 * We need all the columns that form the distribution key.
+	 */
+	if (distData->policy)
+	{
+		for (int i = 0; i < distData->policy->nattrs; i++)
+			needed_cols = bms_add_member(needed_cols, distData->policy->attrs[i]);
+	}
+
+	/*
+	 * If the target is partitioned, get the columns needed for partitioning
+	 * keys, and for distribution keys of each partition.
+	 */
+	if (estate->es_result_partitions)
+		needed_cols = GetTargetKeyCols(RelationGetRelid(estate->es_result_relation_info->ri_RelationDesc),
+									   estate->es_result_partitions, needed_cols,
+									   distData->policy == NULL, estate);
+
+	/* Get the max fieldno that contains one of the needed attributes. */
+	first_qe_processed_field = 0;
+	fieldno = 0;
+	foreach(lc, cstate->attnumlist)
+	{
+		AttrNumber attnum = lfirst_int(lc);
+
+		if (bms_is_member(attnum, needed_cols))
+			first_qe_processed_field = fieldno + 1;
+		fieldno++;
+	}
+
+	/* If the file contains OIDs, it's the first field. */
+	if (cstate->file_has_oids)
+		first_qe_processed_field++;
+
+	cstate->first_qe_processed_field = first_qe_processed_field;
+
+	if (Test_copy_qd_qe_split)
+	{
+		if (first_qe_processed_field ==
+			list_length(cstate->attnumlist) + (cstate->file_has_oids ? 1 : 0))
+			elog(INFO, "all fields will be processed in the QD");
+		else
+			elog(INFO, "first field processed in the QE: %d", first_qe_processed_field);
+	}
+}
+
+/*
+ * Recursive helper function for InitCopyFromDispatchSplit(), to get
+ * the columns needed in QD for a partition and its subpartitions.
+ */
+static Bitmapset *
+GetTargetKeyCols(Oid relid, PartitionNode *children, Bitmapset *needed_cols,
+				 bool distkeys, EState *estate)
+{
+	int			i;
+	ListCell   *lc;
+
+	/*
+	 * Partition key columns.
+	 *
+	 * Note: paratts[] stores the attribute numbers, in terms of the root
+	 * partition. That's exactly what we want.
+	 */
+	if (children)
+	{
+		for (i = 0; i < children->part->parnatts; i++)
+			needed_cols = bms_add_member(needed_cols, children->part->paratts[i]);
+	}
+
+	/*
+	 * Distribution key columns
+	 *
+	 * These are in terms of the partition itself! We need to map them to
+	 * the root partition's attribute numbers.
+	 *
+	 * (At the moment, this is more complicated than necessary, because GPDB
+	 * doesn't support partitions that have differing distribution policies,
+	 * except that child partitions can be randomly distributed, even though
+	 * the parent is hash distributed.)
+	 */
+	if (distkeys)
+	{
+		ResultRelInfo *partrr;
+		GpPolicy *partPolicy;
+		AttrMap	   *map;
+
+		partrr = targetid_get_partition(relid, estate, false);
+		map = partrr->ri_partInsertMap;
+		partPolicy = partrr->ri_RelationDesc->rd_cdbpolicy;
+
+		if (partPolicy)
+		{
+			for (i = 0; i < partPolicy->nattrs; i++)
+			{
+				AttrNumber	partAttNum = partPolicy->attrs[i];
+				AttrNumber	parentAttNum;
+
+				/* Map this partition's attribute number to the parent's. */
+				if (map)
+				{
+					for (parentAttNum = 1; parentAttNum <= map->attr_count; parentAttNum++)
+					{
+						if (map->attr_map[parentAttNum] == partAttNum)
+							break;
+					}
+					if (parentAttNum > map->attr_count)
+						elog(ERROR, "could not find mapping partition distribution key column %d in parent relation",
+							 partAttNum);
+				}
+				else
+					parentAttNum = partAttNum;
+
+				needed_cols = bms_add_member(needed_cols, parentAttNum);
+			}
+		}
+	}
+
+	/* Recurse to subpartitions */
+	if (children)
+	{
+		foreach(lc, children->rules)
+		{
+			PartitionRule *pr = (PartitionRule *) lfirst(lc);
+
+			needed_cols = GetTargetKeyCols(pr->parchildrelid, pr->children,
+										   needed_cols, distkeys, estate);
+		}
+	}
+
+	return needed_cols;
+}
+
 /* Get distribution policy for specific part */
 static GpDistributionData *
 GetDistributionPolicyForPartition(CopyState cstate, EState *estate,
@@ -7316,10 +7721,8 @@ GetDistributionPolicyForPartition(CopyState cstate, EState *estate,
 		d = hash_search(mainDistData->hashmap, &(relid), HASH_ENTER, &found);
 		if (!found)
 		{
-			Relation rel;
+			Relation rel = resultRelInfo->ri_RelationDesc;
 			MemoryContext oldcontext;
-
-			rel = heap_open(relid, NoLock);
 
 			/*
 			 * Make sure this all persists the current iteration.
@@ -7330,8 +7733,6 @@ GetDistributionPolicyForPartition(CopyState cstate, EState *estate,
 			d->policy = GpPolicyCopy(rel->rd_cdbpolicy);
 
 			MemoryContextSwitchTo(oldcontext);
-
-			heap_close(rel, NoLock);
 		}
 
 		return d;

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4909,7 +4909,6 @@ HandleCopyError(CopyState cstate)
 				else
 				{
 					HandleSingleRowError(cstate->cdbsreh);
-					//ErrorLogWrite(cstate->cdbsreh);
 				}
 			}
 		}

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -5224,7 +5224,7 @@ NextCopyFromX(CopyState cstate, ExprContext *econtext,
 
 		Assert(fieldno == nfields);
 	}
-	else
+	else if (attr_count)
 	{
 		/* binary */
 		int16		fld_count;
@@ -7571,39 +7571,50 @@ static void
 InitCopyFromDispatchSplit(CopyState cstate, GpDistributionData *distData,
 						  EState *estate)
 {
-	int			first_qe_processed_field;
+	int			first_qe_processed_field = 0;
 	Bitmapset  *needed_cols = NULL;
 	ListCell   *lc;
-	int			fieldno;
 
-	/*
-	 * We need all the columns that form the distribution key.
-	 */
-	if (distData->policy)
+	if (cstate->binary)
 	{
-		for (int i = 0; i < distData->policy->nattrs; i++)
-			needed_cols = bms_add_member(needed_cols, distData->policy->attrs[i]);
+		foreach(lc, cstate->attnumlist)
+		{
+			AttrNumber attnum = lfirst_int(lc);
+			needed_cols = bms_add_member(needed_cols, attnum);
+			first_qe_processed_field++;
+		}
 	}
-
-	/*
-	 * If the target is partitioned, get the columns needed for partitioning
-	 * keys, and for distribution keys of each partition.
-	 */
-	if (estate->es_result_partitions)
-		needed_cols = GetTargetKeyCols(RelationGetRelid(estate->es_result_relation_info->ri_RelationDesc),
-									   estate->es_result_partitions, needed_cols,
-									   distData->policy == NULL, estate);
-
-	/* Get the max fieldno that contains one of the needed attributes. */
-	first_qe_processed_field = 0;
-	fieldno = 0;
-	foreach(lc, cstate->attnumlist)
+	else
 	{
-		AttrNumber attnum = lfirst_int(lc);
+		int			fieldno;
+		/*
+		 * We need all the columns that form the distribution key.
+		 */
+		if (distData->policy)
+		{
+			for (int i = 0; i < distData->policy->nattrs; i++)
+				needed_cols = bms_add_member(needed_cols, distData->policy->attrs[i]);
+		}
 
-		if (bms_is_member(attnum, needed_cols))
-			first_qe_processed_field = fieldno + 1;
-		fieldno++;
+		/*
+		 * If the target is partitioned, get the columns needed for partitioning
+		 * keys, and for distribution keys of each partition.
+		 */
+		if (estate->es_result_partitions)
+			needed_cols = GetTargetKeyCols(RelationGetRelid(estate->es_result_relation_info->ri_RelationDesc),
+										   estate->es_result_partitions, needed_cols,
+										   distData->policy == NULL, estate);
+
+		/* Get the max fieldno that contains one of the needed attributes. */
+		fieldno = 0;
+		foreach(lc, cstate->attnumlist)
+		{
+			AttrNumber attnum = lfirst_int(lc);
+
+			if (bms_is_member(attnum, needed_cols))
+				first_qe_processed_field = fieldno + 1;
+			fieldno++;
+		}
 	}
 
 	/* If the file contains OIDs, it's the first field. */

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -125,6 +125,7 @@ bool		Debug_appendonly_print_compaction = false;
 bool		Debug_resource_group = false;
 bool		Debug_bitmap_print_insert = false;
 bool		Test_print_direct_dispatch_info = false;
+bool		Test_copy_qd_qe_split = false;
 bool		gp_permit_relation_node_change = false;
 int			gp_max_local_distributed_cache = 1024;
 bool		gp_appendonly_verify_block_checksums = true;
@@ -1533,6 +1534,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Test_print_direct_dispatch_info,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"test_copy_qd_qe_split", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("For testing purposes, print information about which columns are parsed in QD and which in QE."),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Test_copy_qd_qe_split,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -241,6 +241,7 @@ typedef struct CopyStateData
 	int			first_qe_processed_field;
 	List	   *qd_attnumlist;
 	List	   *qe_attnumlist;
+	bool		stopped_processing_at_delim;
 
 	PartitionNode *partitions; /* partitioning meta data from dispatcher */
 	List		  *ao_segnos;  /* AO table meta data from dispatcher */

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -238,6 +238,9 @@ typedef struct CopyStateData
 
 	/* Greenplum Database specific variables */
 	bool		escape_off;		/* treat backslashes as non-special? */
+	int			first_qe_processed_field;
+	List	   *qd_attnumlist;
+	List	   *qe_attnumlist;
 
 	PartitionNode *partitions; /* partitioning meta data from dispatcher */
 	List		  *ao_segnos;  /* AO table meta data from dispatcher */

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -102,6 +102,7 @@
 		"statement_mem",
 		"statement_timeout",
 		"temp_buffers",
+		"test_copy_qd_qe_split",
 		"TimeZone",
 		"verify_gpfdists_cert",
 		"vmem_process_interrupt",

--- a/src/test/regress/expected/gpcopy_dispatch.out
+++ b/src/test/regress/expected/gpcopy_dispatch.out
@@ -1,0 +1,82 @@
+SET test_copy_qd_qe_split = on;
+-- Distributed randomly. QD doesn't need any of the cols.
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED RANDOMLY;
+COPY disttest FROM stdin;
+INFO:  first field processed in the QE: 0
+CONTEXT:  COPY disttest, line 0
+DROP TABLE disttest;
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED BY (b);
+COPY disttest FROM stdin;
+INFO:  first field processed in the QE: 2
+CONTEXT:  COPY disttest, line 0
+DROP TABLE disttest;
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED BY (c);
+COPY disttest FROM stdin;
+INFO:  all fields will be processed in the QD
+CONTEXT:  COPY disttest, line 0
+DROP TABLE disttest;
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED BY (c, a);
+COPY disttest FROM stdin;
+INFO:  all fields will be processed in the QD
+CONTEXT:  COPY disttest, line 0
+DROP TABLE disttest;
+-- With column list
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED BY (c, b);
+COPY disttest (c, b, a) FROM stdin;
+INFO:  first field processed in the QE: 2
+CONTEXT:  COPY disttest, line 0
+DROP TABLE disttest;
+--
+-- Partitioned scenarios.
+--
+-- Distributed randomly, but QD needs the partitioning key.
+CREATE TABLE partdisttest (a int, b int, c int) DISTRIBUTED RANDOMLY PARTITION BY RANGE (b) (START (1) END (10) EVERY (5));
+NOTICE:  CREATE TABLE will create partition "partdisttest_1_prt_1" for table "partdisttest"
+NOTICE:  CREATE TABLE will create partition "partdisttest_1_prt_2" for table "partdisttest"
+COPY partdisttest FROM stdin;
+INFO:  first field processed in the QE: 2
+CONTEXT:  COPY partdisttest, line 0
+DROP TABLE partdisttest;
+-- With a dropped column
+CREATE TABLE partdisttest (a int, dropped int, b int, c int) DISTRIBUTED RANDOMLY PARTITION BY RANGE (b) (START (1) END (10) EVERY (5));
+ALTER TABLE partdisttest DROP COLUMN dropped;
+COPY partdisttest FROM stdin;
+INFO:  first field processed in the QE: 2
+CONTEXT:  COPY partdisttest, line 0
+DROP TABLE partdisttest;
+-- Hash distributed, with a dropped column
+CREATE TABLE partdisttest (a int, dropped int, b int, c int)
+  DISTRIBUTED BY (b)
+  PARTITION BY RANGE (a) (START (0) END (100) EVERY (50));
+ALTER TABLE partdisttest DROP COLUMN dropped;
+ALTER TABLE partdisttest ADD PARTITION neg start (-10) end (0);
+COPY partdisttest FROM stdin;
+INFO:  first field processed in the QE: 2
+CONTEXT:  COPY partdisttest, line 0
+DROP TABLE partdisttest;
+-- Subpartitions
+CREATE TABLE partdisttest (a int, dropped int, b int, c int, d int)
+  DISTRIBUTED RANDOMLY
+  PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c)
+  (
+    PARTITION b_low start (1)
+    (
+      SUBPARTITION c_low start (1),
+      SUBPARTITION c_hi start (5)
+    ),
+    PARTITION b_hi start (5)
+    (
+      SUBPARTITION c_low start (1),
+      SUBPARTITION c_hi start (5)
+    )
+  );
+ALTER TABLE partdisttest DROP COLUMN dropped;
+COPY partdisttest FROM stdin;
+INFO:  first field processed in the QE: 3
+CONTEXT:  COPY partdisttest, line 0
+ALTER TABLE partdisttest ADD PARTITION b_negative start (-10) end (0) (subpartition c_negative start (-10) end (0));
+COPY partdisttest FROM stdin;
+INFO:  first field processed in the QE: 3
+CONTEXT:  COPY partdisttest, line 0
+DROP TABLE partdisttest;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -37,7 +37,7 @@ test: gp_tablespace
 test: temp_tablespaces
 test: default_tablespace
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views create_table_like_gp matview_ao
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views create_table_like_gp matview_ao gpcopy_dispatch
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -715,7 +715,7 @@ SELECT * from exttab_insert_1 order by i;
 SELECT count(*) from gp_read_error_log('exttab_basic_5');
  count 
 -------
-     4
+     5
 (1 row)
 
 -- CTAS
@@ -772,7 +772,7 @@ LINE 1: SELECT * from exttab_ctas_2 order by i;
 SELECT count(*) from gp_read_error_log('exttab_basic_7');
  count 
 -------
-     4
+     5
 (1 row)
 
 -- Drop external table gets rid off error logs
@@ -856,7 +856,7 @@ CONTEXT:  External table exttab_cte_2, line 7 of file://@hostname@@abs_srcdir@/d
 select count(*) from gp_read_error_log('exttab_cte_2');
  count 
 -------
-     1
+     2
 (1 row)
 
 -- start_ignore
@@ -940,7 +940,7 @@ SET ROLE exttab_superuser;
 SELECT COUNT(*) FROM gp_read_error_log('exttab_permissions_2');
  count 
 -------
-     1
+     2
 (1 row)
 
 SELECT gp_truncate_error_log('*');
@@ -2353,7 +2353,7 @@ CONTEXT:  External table exttab_limit_2, line 7 of file://@hostname@@abs_srcdir@
 SELECT count(*) FROM gp_read_error_log('exttab_limit_2');
  count 
 -------
-     1
+     2
 (1 row)
 
 SELECT gp_truncate_error_log('exttab_limit_1');

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -690,7 +690,8 @@ SELECT relname, filename, bytenum, errmsg FROM gp_read_error_log('segment_reject
           relname          |            filename            | bytenum |                     errmsg                      
 ---------------------------+--------------------------------+---------+-------------------------------------------------
  segment_reject_limit_from | /tmp/segment_reject_limit1.csv |         | invalid input syntax for integer: "a", column b
-(1 row)
+ segment_reject_limit_from | /tmp/segment_reject_limit1.csv |         | invalid input syntax for integer: "b", column b
+(2 rows)
 
 -- not exceed reject limit on segment
 COPY segment_reject_limit_from from '/tmp/segment_reject_limit<SEGID>.csv' on segment log errors segment reject limit 3 rows;

--- a/src/test/regress/output/sreh.source
+++ b/src/test/regress/output/sreh.source
@@ -37,8 +37,8 @@ SELECT * FROM sreh_copy ORDER BY a,b,c;
 --
 COPY sreh_copy FROM '@abs_srcdir@/data/bad_data1.data' DELIMITER '|' SEGMENT REJECT LIMIT 2;
 ERROR:  segment reject limit reached, aborting operation
-DETAIL:  Last error was: invalid input syntax for integer: "", column b
-CONTEXT:  COPY sreh_copy, line 8, column a
+DETAIL:  Last error was: invalid input syntax for integer: "eleven", column a
+CONTEXT:  COPY sreh_copy, line 11, column a: "eleven"
 SELECT * FROM sreh_copy ORDER BY a,b,c;
  a  | b  | c  
 ----+----+----

--- a/src/test/regress/sql/gpcopy_dispatch.sql
+++ b/src/test/regress/sql/gpcopy_dispatch.sql
@@ -1,0 +1,99 @@
+
+SET test_copy_qd_qe_split = on;
+
+-- Distributed randomly. QD doesn't need any of the cols.
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED RANDOMLY;
+COPY disttest FROM stdin;
+1	2	3
+\.
+DROP TABLE disttest;
+
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED BY (b);
+COPY disttest FROM stdin;
+1	2	3
+\.
+DROP TABLE disttest;
+
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED BY (c);
+COPY disttest FROM stdin;
+1	2	3
+\.
+DROP TABLE disttest;
+
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED BY (c, a);
+COPY disttest FROM stdin;
+1	2	3
+\.
+DROP TABLE disttest;
+
+-- With column list
+CREATE TABLE disttest (a int, b int, c int) DISTRIBUTED BY (c, b);
+COPY disttest (c, b, a) FROM stdin;
+3	2	1
+\.
+DROP TABLE disttest;
+
+
+--
+-- Partitioned scenarios.
+--
+
+-- Distributed randomly, but QD needs the partitioning key.
+CREATE TABLE partdisttest (a int, b int, c int) DISTRIBUTED RANDOMLY PARTITION BY RANGE (b) (START (1) END (10) EVERY (5));
+COPY partdisttest FROM stdin;
+1	2	3
+\.
+DROP TABLE partdisttest;
+
+-- With a dropped column
+CREATE TABLE partdisttest (a int, dropped int, b int, c int) DISTRIBUTED RANDOMLY PARTITION BY RANGE (b) (START (1) END (10) EVERY (5));
+ALTER TABLE partdisttest DROP COLUMN dropped;
+COPY partdisttest FROM stdin;
+1	2	3
+\.
+DROP TABLE partdisttest;
+
+-- Hash distributed, with a dropped column
+CREATE TABLE partdisttest (a int, dropped int, b int, c int)
+  DISTRIBUTED BY (b)
+  PARTITION BY RANGE (a) (START (0) END (100) EVERY (50));
+ALTER TABLE partdisttest DROP COLUMN dropped;
+
+ALTER TABLE partdisttest ADD PARTITION neg start (-10) end (0);
+
+COPY partdisttest FROM stdin;
+-1	2	3
+\.
+DROP TABLE partdisttest;
+
+
+
+-- Subpartitions
+CREATE TABLE partdisttest (a int, dropped int, b int, c int, d int)
+  DISTRIBUTED RANDOMLY
+  PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c)
+  (
+    PARTITION b_low start (1)
+    (
+      SUBPARTITION c_low start (1),
+      SUBPARTITION c_hi start (5)
+    ),
+    PARTITION b_hi start (5)
+    (
+      SUBPARTITION c_low start (1),
+      SUBPARTITION c_hi start (5)
+    )
+  );
+ALTER TABLE partdisttest DROP COLUMN dropped;
+COPY partdisttest FROM stdin;
+1	2	3	4
+\.
+
+ALTER TABLE partdisttest ADD PARTITION b_negative start (-10) end (0) (subpartition c_negative start (-10) end (0));
+
+COPY partdisttest FROM stdin;
+100	-1	-1	1
+\.
+
+DROP TABLE partdisttest;


### PR DESCRIPTION
This PR is back-port to 6X_STABLE of code already committed to master via PR https://github.com/greenplum-db/gpdb/pull/9085. Mostly to run PR pipeline and then merge the same, locally ICW passed.

Please let me know if you see any concerns with back-porting this PR to 6X_STABLE. It removes the performance regression in COPY FROM which was introduced during 9.1 merge.