### PR TITLE
Provide another solution of utility connection for psql (--utility-mode option).

### DIFF
--- a/src/bin/psql/help.c
+++ b/src/bin/psql/help.c
@@ -137,6 +137,7 @@ usage(unsigned short int pager)
 	env = getenv("PGUSER");
 	if (!env)
 		env = user;
+	fprintf(output, _("      --utility-mode       utility mode connection (Use by care else may cause data inconsistency).\n"));
 	fprintf(output, _("  -U, --username=USERNAME  database user name (default: \"%s\")\n"), env);
 	fprintf(output, _("  -w, --no-password        never prompt for password\n"));
 	fprintf(output, _("  -W, --password           force password prompt (should happen automatically)\n"));


### PR DESCRIPTION
We have had the below solution for that but that is not convinent given the
command line is long sometimes.

PGOPTIONS='-c gp_session_role=utility' psql

This patch provides another way of setting the psql connection in the utility
mode. It does not modify the existing code that uses the previous way to set
psql utility connection.

The code path of this patch to set gp session role is a bit different than the
previous solution.  It sets the gp session role a bit earlier than the previous
solution.