### PR TITLE
Remove redundant Result nodes from ORCA-generated plans.

### DIFF
--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -200,6 +200,17 @@ plan_tree_mutator(Node *node,
 			}
 			break;
 
+		case T_DML:
+			{
+				DML		   *dml = (DML *) node;
+				DML		   *newdml;
+
+				FLATCOPY(newdml, dml, DML);
+				PLANMUTATE(newdml, dml);
+				return (Node *) newdml;
+			}
+			break;
+
 		case T_LockRows:
 			{
 				LockRows   *lockrows = (LockRows *) node;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -8002,6 +8002,7 @@ is_projection_capable_plan(Plan *plan)
 		case T_RecursiveUnion:
 		case T_Motion:
 		case T_ShareInputScan:
+		case T_Sequence:
 			return false;
 		default:
 			break;

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -54,39 +54,37 @@ delete from s;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 explain update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
  Update  (cost=0.00..869.57 rows=34 width=1)
    ->  Result  (cost=0.00..862.80 rows=67 width=26)
          ->  Split  (cost=0.00..862.80 rows=67 width=22)
-               ->  Result  (cost=0.00..862.80 rows=34 width=22)
-                     ->  Hash Semi Join  (cost=0.00..862.80 rows=34 width=18)
-                           Hash Cond: s.a = r.b
-                           ->  Seq Scan on s  (cost=0.00..431.00 rows=34 width=18)
-                           ->  Hash  (cost=431.15..431.15 rows=3334 width=4)
-                                 ->  Result  (cost=0.00..431.15 rows=3334 width=4)
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
-                                             Hash Key: r.b
-                                             ->  Seq Scan on r  (cost=0.00..431.07 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(13 rows)
+               ->  Hash Semi Join  (cost=0.00..862.80 rows=34 width=18)
+                     Hash Cond: (s.a = r.b)
+                     ->  Seq Scan on s  (cost=0.00..431.00 rows=34 width=18)
+                     ->  Hash  (cost=431.15..431.15 rows=3334 width=4)
+                           ->  Result  (cost=0.00..431.15 rows=3334 width=4)
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+                                       Hash Key: r.b
+                                       ->  Seq Scan on r  (cost=0.00..431.07 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(12 rows)
 
 update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
 explain delete from s where exists (select 1 from r where s.a = r.b);
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Delete  (cost=0.00..865.66 rows=34 width=1)
-   ->  Result  (cost=0.00..862.80 rows=34 width=22)
-         ->  Hash Semi Join  (cost=0.00..862.80 rows=34 width=18)
-               Hash Cond: s.a = r.b
-               ->  Seq Scan on s  (cost=0.00..431.00 rows=34 width=18)
-               ->  Hash  (cost=431.15..431.15 rows=3334 width=4)
-                     ->  Result  (cost=0.00..431.15 rows=3334 width=4)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
-                                 Hash Key: r.b
-                                 ->  Seq Scan on r  (cost=0.00..431.07 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(11 rows)
+   ->  Hash Semi Join  (cost=0.00..862.80 rows=34 width=18)
+         Hash Cond: (s.a = r.b)
+         ->  Seq Scan on s  (cost=0.00..431.00 rows=34 width=18)
+         ->  Hash  (cost=431.15..431.15 rows=3334 width=4)
+               ->  Result  (cost=0.00..431.15 rows=3334 width=4)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+                           Hash Key: r.b
+                           ->  Seq Scan on r  (cost=0.00..431.07 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(10 rows)
 
 delete from s where exists (select 1 from r where s.a = r.b);
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -839,18 +839,17 @@ select max(unique2) from tenk1 order by max(unique2);
 
 explain (costs off)
   select max(unique2) from tenk1 order by max(unique2)+1;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Result
    ->  Sort
-         Sort Key: (((max(unique2)) + 1))
-         ->  Result
-               ->  Finalize Aggregate
-                     ->  Gather Motion 3:1  (slice1; segments: 3)
-                           ->  Partial Aggregate
-                                 ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(9 rows)
+         Sort Key: ((max(unique2) + 1))
+         ->  Finalize Aggregate
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Partial Aggregate
+                           ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 select max(unique2) from tenk1 order by max(unique2)+1;
  max  
@@ -1025,19 +1024,18 @@ explain (costs off) select * from t1 group by a,b,c,d;
 
 -- No removal can happen if the complete PK is not present in GROUP BY
 explain (costs off) select a,c from t1 group by a,c,d;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Result
-         ->  GroupAggregate
-               Group Key: a, c, d
-               ->  Sort
-                     Sort Key: a, c, d
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: a, c, d
-                           ->  Seq Scan on t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.78.0
-(10 rows)
+   ->  GroupAggregate
+         Group Key: a, c, d
+         ->  Sort
+               Sort Key: a, c, d
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: a, c, d
+                     ->  Seq Scan on t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 -- Test removal across multiple relations
 explain (costs off) select *

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1574,19 +1574,18 @@ select array_agg(a order by b desc nulls last) from aggordertest;
 create temp table mpp14125 as select repeat('a', a) a, a % 10 b from generate_series(1, 100)a;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 explain select string_agg(a, '') from mpp14125 group by b;
-                                                  QUERY PLAN
---------------------------------------------------------------------------------------------------------------
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.07 rows=10 width=8)
-   ->  Result  (cost=0.00..431.07 rows=4 width=8)
-         ->  GroupAggregate  (cost=0.00..431.07 rows=4 width=8)
-               Group Key: b
-               ->  Sort  (cost=0.00..431.06 rows=34 width=55)
-                     Sort Key: b
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=34 width=55)
-                           Hash Key: b
-                           ->  Seq Scan on mpp14125  (cost=0.00..431.00 rows=34 width=55)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.0
-(10 rows)
+   ->  GroupAggregate  (cost=0.00..431.07 rows=4 width=8)
+         Group Key: b
+         ->  Sort  (cost=0.00..431.06 rows=34 width=55)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=34 width=55)
+                     Hash Key: b
+                     ->  Seq Scan on mpp14125  (cost=0.00..431.00 rows=34 width=55)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 -- end MPP-14125
 -- Test unsupported ORCA feature: agg(set returning function)

--- a/src/test/regress/expected/bfv_catalog_optimizer.out
+++ b/src/test/regress/expected/bfv_catalog_optimizer.out
@@ -257,13 +257,11 @@ reset optimizer_enable_indexscan;
 create table mpp_bfv_2(a int, b text, primary key (a)) distributed by (a);
 -- stop falling back to planner when catalog functions are encountered
 explain select pg_column_size('mpp_bfv_2');
-                   QUERY PLAN                   
-------------------------------------------------
- Result  (cost=0.00..0.00 rows=1 width=4)
-   ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.23.0
-(4 rows)
+                      QUERY PLAN                      
+------------------------------------------------------
+ Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(2 rows)
 
 explain select pg_lock_status();
                    QUERY PLAN                   

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -181,15 +181,14 @@ drop table m;
 create table update_pk_test (a int primary key, b int) distributed by (a);
 insert into update_pk_test values(1,1);
 explain update update_pk_test set b = 5;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Update  (cost=0.00..431.07 rows=1 width=1)
    ->  Result  (cost=0.00..431.00 rows=1 width=26)
          ->  Split  (cost=0.00..431.00 rows=1 width=22)
-               ->  Result  (cost=0.00..431.00 rows=1 width=22)
-                     ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=18)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(6 rows)
+               ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=18)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(5 rows)
 
 update update_pk_test set b = 5;
 select * from update_pk_test order by 1,2;
@@ -199,8 +198,8 @@ select * from update_pk_test order by 1,2;
 (1 row)
 
 explain update update_pk_test set a = 5;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Update  (cost=0.00..431.07 rows=1 width=1)
    ->  Result  (cost=0.00..431.00 rows=1 width=26)
          ->  Sort  (cost=0.00..431.00 rows=1 width=22)
@@ -208,10 +207,9 @@ explain update update_pk_test set a = 5;
                ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=22)
                      Hash Key: update_pk_test.a
                      ->  Split  (cost=0.00..431.00 rows=1 width=22)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=22)
-                                 ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=18)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.39.0
-(10 rows)
+                           ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=18)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 update update_pk_test set a = 5;
 select * from update_pk_test order by 1,2;

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -658,19 +658,17 @@ SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS NOT DISTINCT FR
 -- Test for unexpected NLJ qual
 --
 explain select 1 as mrs_t1 where 1 <= ALL (select x from z);
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Result  (cost=0.00..882688.07 rows=1 width=4)
-   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=0.00..882688.07 rows=1 width=1)
-         Join Filter: true
-         ->  Result  (cost=0.00..0.00 rows=1 width=1)
-         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-                     ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=1)
-                           Filter: 1 > x
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(10 rows)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Nested Loop Left Anti Semi (Not-In) Join  (cost=0.00..882688.07 rows=1 width=1)
+   Join Filter: true
+   ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=1)
+                     Filter: (1 > x)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 --
 -- Test for wrong results in window functions under joins #1
@@ -3180,16 +3178,14 @@ explain select * from nlj1, (select NULL a, b from nlj2) other where nlj1.a is n
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.53 rows=4 width=16)
    ->  Nested Loop  (cost=0.00..1324032.53 rows=2 width=16)
-         Join Filter: (NOT (nlj1.a IS DISTINCT FROM "outer".a))
+         Join Filter: (NOT (nlj1.a IS DISTINCT FROM (NULL::integer)))
          ->  Seq Scan on nlj1  (cost=0.00..431.00 rows=1 width=8)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
                ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                     Hash Key: "outer".a
-                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Seq Scan on nlj2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.2.0
-(11 rows)
+                     Hash Key: (NULL::integer)
+                     ->  Seq Scan on nlj2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 select * from nlj1, (select NULL a, b from nlj2) other where nlj1.a is not distinct from other.a;
  a | b | a | b 

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -485,14 +485,12 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882690.51 rows=1 width=1)
-   ->  Result  (cost=0.00..882690.51 rows=1 width=1)
-         ->  Seq Scan on a  (cost=0.00..882690.51 rows=334 width=1)
+   ->  Seq Scan on a  (cost=0.00..882690.51 rows=334 width=1)
          SubPlan 1
            ->  Result  (cost=0.00..0.00 rows=1 width=6)
                  ->  Result  (cost=0.00..0.00 rows=1 width=6)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.46.3
-(9 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 DROP TABLE A;

--- a/src/test/regress/expected/bitmapops_optimizer.out
+++ b/src/test/regress/expected/bitmapops_optimizer.out
@@ -57,16 +57,15 @@ CREATE INDEX i_bmtest2_b ON bmscantest2 USING BITMAP(b);
 CREATE INDEX i_bmtest2_c ON bmscantest2(c);
 CREATE INDEX i_bmtest2_d ON bmscantest2(d);
 EXPLAIN SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..6.35 rows=1 width=8)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.35 rows=2 width=1)
-         ->  Result  (cost=0.00..6.35 rows=1 width=1)
-               ->  Index Scan using i_bmtest2_c on bmscantest2  (cost=0.00..6.35 rows=1 width=1)
-                     Index Cond: (c = 1)
-                     Filter: ((a = 1) AND (b = 1))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.72.0
-(7 rows)
+         ->  Index Scan using i_bmtest2_c on bmscantest2  (cost=0.00..6.35 rows=1 width=1)
+               Index Cond: (c = 1)
+               Filter: ((a = 1) AND (b = 1))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
  count 

--- a/src/test/regress/expected/create_am_optimizer.out
+++ b/src/test/regress/expected/create_am_optimizer.out
@@ -45,17 +45,17 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM fast_emp4000
     WHERE home_base @ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Result
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: ((home_base[0])[0])
          ->  Sort
                Sort Key: ((home_base[0])[0])
-               ->  Result
-                     ->  Seq Scan on fast_emp4000
-                           Filter: (home_base @ '(2000,1000),(200,200)'::box)
-(9 rows)
+               ->  Seq Scan on fast_emp4000
+                     Filter: (home_base @ '(2000,1000),(200,200)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 SELECT * FROM fast_emp4000
     WHERE home_base @ '(200,200),(2000,1000)'::box

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -411,19 +411,18 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM fast_emp4000
     WHERE home_base @ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
  Result
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: ((home_base[0])[0])
          ->  Sort
                Sort Key: ((home_base[0])[0])
-               ->  Result
-                     ->  Index Scan using grect2ind on fast_emp4000
-                           Index Cond: (home_base @ '(2000,1000),(200,200)'::box)
-                           Filter: (home_base @ '(2000,1000),(200,200)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(10 rows)
+               ->  Index Scan using grect2ind on fast_emp4000
+                     Index Cond: (home_base @ '(2000,1000),(200,200)'::box)
+                     Filter: (home_base @ '(2000,1000),(200,200)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 SELECT * FROM fast_emp4000
     WHERE home_base @ '(200,200),(2000,1000)'::box
@@ -474,19 +473,18 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base IS NULL;
 EXPLAIN (COSTS OFF)
 SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Result
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: ((poly_center(f1))[0])
          ->  Sort
                Sort Key: ((poly_center(f1))[0])
-               ->  Result
-                     ->  Index Scan using gpolygonind on polygon_tbl
-                           Index Cond: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
-                           Filter: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(10 rows)
+               ->  Index Scan using gpolygonind on polygon_tbl
+                     Index Cond: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
+                     Filter: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
@@ -561,16 +559,15 @@ SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
-                     Filter: (f1 <@ '(100,100),(0,0)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+               Filter: (f1 <@ '(100,100),(0,0)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
  count 
@@ -580,16 +577,15 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
-                     Filter: (f1 <@ '(100,100),(0,0)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+               Filter: (f1 <@ '(100,100),(0,0)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
  count 
@@ -599,16 +595,15 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
-                     Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
+               Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
  count 
@@ -618,16 +613,15 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '<(50,50),50>'::circle)
-                     Filter: (f1 <@ '<(50,50),50>'::circle)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '<(50,50),50>'::circle)
+               Filter: (f1 <@ '<(50,50),50>'::circle)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
  count 
@@ -637,16 +631,15 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 << '(0,0)'::point)
-                     Filter: (f1 << '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 << '(0,0)'::point)
+               Filter: (f1 << '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
  count 
@@ -656,16 +649,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 >> '(0,0)'::point)
-                     Filter: (f1 >> '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 >> '(0,0)'::point)
+               Filter: (f1 >> '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
  count 
@@ -675,16 +667,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <^ '(0,0)'::point)
-                     Filter: (f1 <^ '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <^ '(0,0)'::point)
+               Filter: (f1 <^ '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
  count 
@@ -694,16 +685,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 >^ '(0,0)'::point)
-                     Filter: (f1 >^ '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 >^ '(0,0)'::point)
+               Filter: (f1 >^ '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
  count 
@@ -713,16 +703,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
-                        QUERY PLAN                         
------------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 ~= '(-5,-12)'::point)
-                     Filter: (f1 ~= '(-5,-12)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 ~= '(-5,-12)'::point)
+               Filter: (f1 ~= '(-5,-12)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
  count 
@@ -3154,16 +3143,15 @@ SELECT * FROM tenk1
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               ->  Index Scan using tenk1_hundred on tenk1
-                     Index Cond: (hundred = 42)
-                     Filter: ((thousand = 42) OR (thousand = 99))
- Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
-(7 rows)
+         ->  Index Scan using tenk1_hundred on tenk1
+               Index Cond: (hundred = 42)
+               Filter: ((thousand = 42) OR (thousand = 99))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -423,27 +423,26 @@ INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 EXPLAIN SELECT a.* FROM MPP_22019_a a INNER JOIN MPP_22019_b b ON a.i = b.i WHERE a.j NOT IN (SELECT j FROM MPP_22019_a a2 where a2.j = b.j) and a.i = 1;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1765376.88 rows=1 width=8)
    ->  Result  (cost=0.00..1765376.88 rows=1 width=8)
-         ->  Result  (cost=0.00..1765376.88 rows=1 width=8)
-               Filter: (SubPlan 1)
-               ->  Hash Join  (cost=0.00..862.00 rows=1 width=12)
-                     Hash Cond: mpp_22019_a.i = mpp_22019_b.i
-                     ->  Seq Scan on mpp_22019_a  (cost=0.00..431.00 rows=1 width=8)
-                           Filter: i = 1
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-                           ->  Seq Scan on mpp_22019_b  (cost=0.00..431.00 rows=1 width=8)
-                                 Filter: i = 1
-               SubPlan 1
-                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                       Filter: mpp_22019_a_1.j = mpp_22019_b.j
-                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                   ->  Seq Scan on mpp_22019_a mpp_22019_a_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(18 rows)
+         Filter: (SubPlan 1)
+         ->  Hash Join  (cost=0.00..862.00 rows=1 width=12)
+               Hash Cond: (mpp_22019_a.i = mpp_22019_b.i)
+               ->  Seq Scan on mpp_22019_a  (cost=0.00..431.00 rows=1 width=8)
+                     Filter: (i = 1)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on mpp_22019_b  (cost=0.00..431.00 rows=1 width=8)
+                           Filter: (i = 1)
+         SubPlan 1
+           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                 Filter: (mpp_22019_a_1.j = mpp_22019_b.j)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Seq Scan on mpp_22019_a mpp_22019_a_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(17 rows)
 
 SELECT a.* FROM MPP_22019_a a INNER JOIN MPP_22019_b b ON a.i = b.i WHERE a.j NOT IN (SELECT j FROM MPP_22019_a a2 where a2.j = b.j) and a.i = 1;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -267,21 +267,17 @@ select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
 explain select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.01 rows=9 width=31)
-   ->  Hash Semi Join  (cost=0.00..862.01 rows=3 width=31)
-         Hash Cond: pt.ptid = t.tid
-         ->  Dynamic Seq Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=18 width=31)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=9 width=31)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=31)
+         Hash Cond: (pt.ptid = t.tid)
+         ->  Dynamic Seq Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=3 width=31)
          ->  Hash  (cost=100.00..100.00 rows=34 width=4)
                ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                     Filter: pt.ptid = t.tid
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=4)
-                                             Filter: t1 = ('hello'::text || tid::text)
- Settings:  gp_segments_for_planner=2; optimizer=on; optimizer_segments=2
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.5.0
-(14 rows)
+                           ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: (t1 = ('hello'::text || (tid)::text))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(10 rows)
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -1389,23 +1389,22 @@ where i < (select count(*) from smallt where smallt.i = smallt2.i) order by 1,2,
 
 explain select smallt2.* from smallt2
 where i < (select count(*) from smallt where smallt.i = smallt2.i);
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=50 width=15)
    ->  Result  (cost=0.00..862.01 rows=17 width=15)
-         Filter: smallt2.i < COALESCE((count()), 0::bigint)
-         ->  Result  (cost=0.00..862.01 rows=17 width=24)
-               ->  Hash Left Join  (cost=0.00..862.01 rows=17 width=23)
-                     Hash Cond: smallt2.i = smallt.i
-                     ->  Seq Scan on smallt2  (cost=0.00..431.00 rows=17 width=15)
-                     ->  Hash  (cost=431.01..431.01 rows=4 width=12)
-                           ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12)
-                                 Group Key: smallt.i
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4)
-                                       Sort Key: smallt.i
-                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
-(14 rows)
+         Filter: (smallt2.i < COALESCE((count()), '0'::bigint))
+         ->  Hash Left Join  (cost=0.00..862.01 rows=17 width=23)
+               Hash Cond: (smallt2.i = smallt.i)
+               ->  Seq Scan on smallt2  (cost=0.00..431.00 rows=17 width=15)
+               ->  Hash  (cost=431.01..431.01 rows=4 width=12)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12)
+                           Group Key: smallt.i
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                 Sort Key: smallt.i
+                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- Sort in MergeJoin
 -- start_ignore

--- a/src/test/regress/expected/equivclass_optimizer.out
+++ b/src/test/regress/expected/equivclass_optimizer.out
@@ -232,8 +232,8 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
          Join Filter: (((((ec1.ff + 2)) + 1)) = ec1_3.f1)
@@ -244,14 +244,11 @@ explain (costs off)
                      ->  Append
                            ->  Result
                                  ->  Append
-                                       ->  Result
-                                             ->  Seq Scan on ec1
-                                       ->  Result
-                                             ->  Seq Scan on ec1 ec1_1
-                           ->  Result
-                                 ->  Seq Scan on ec1 ec1_2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(17 rows)
+                                       ->  Seq Scan on ec1
+                                       ->  Seq Scan on ec1 ec1_1
+                           ->  Seq Scan on ec1 ec1_2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
 
 explain (costs off)
   select * from ec1,
@@ -262,8 +259,8 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8 and ec1.ff = ec1.f1;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
          Join Filter: (((((ec1.ff + 2)) + 1)) = ec1_3.f1)
@@ -275,14 +272,11 @@ explain (costs off)
                      ->  Append
                            ->  Result
                                  ->  Append
-                                       ->  Result
-                                             ->  Seq Scan on ec1
-                                       ->  Result
-                                             ->  Seq Scan on ec1 ec1_1
-                           ->  Result
-                                 ->  Seq Scan on ec1 ec1_2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(18 rows)
+                                       ->  Seq Scan on ec1
+                                       ->  Seq Scan on ec1 ec1_1
+                           ->  Seq Scan on ec1 ec1_2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 explain (costs off)
   select * from ec1,
@@ -299,8 +293,8 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss2
   where ss1.x = ec1.f1 and ss1.x = ss2.x and ec1.ff = 42::int8;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
          Hash Cond: (((((ec1.ff + 2)) + 1)) = ((((ec1_4.ff + 2)) + 1)))
@@ -314,25 +308,19 @@ explain (costs off)
                            ->  Append
                                  ->  Result
                                        ->  Append
-                                             ->  Result
-                                                   ->  Seq Scan on ec1
-                                             ->  Result
-                                                   ->  Seq Scan on ec1 ec1_1
-                                 ->  Result
-                                       ->  Seq Scan on ec1 ec1_2
+                                             ->  Seq Scan on ec1
+                                             ->  Seq Scan on ec1 ec1_1
+                                 ->  Seq Scan on ec1 ec1_2
          ->  Hash
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Append
                            ->  Result
                                  ->  Append
-                                       ->  Result
-                                             ->  Seq Scan on ec1 ec1_4
-                                       ->  Result
-                                             ->  Seq Scan on ec1 ec1_5
-                           ->  Result
-                                 ->  Seq Scan on ec1 ec1_6
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(31 rows)
+                                       ->  Seq Scan on ec1 ec1_4
+                                       ->  Seq Scan on ec1 ec1_5
+                           ->  Seq Scan on ec1 ec1_6
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(25 rows)
 
 -- let's try that as a mergejoin
 set enable_mergejoin = on;
@@ -352,8 +340,8 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss2
   where ss1.x = ec1.f1 and ss1.x = ss2.x and ec1.ff = 42::int8;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Hash Join
          Hash Cond: (((((ec1.ff + 2)) + 1)) = ((((ec1_4.ff + 2)) + 1)))
@@ -367,25 +355,19 @@ explain (costs off)
                            ->  Append
                                  ->  Result
                                        ->  Append
-                                             ->  Result
-                                                   ->  Seq Scan on ec1
-                                             ->  Result
-                                                   ->  Seq Scan on ec1 ec1_1
-                                 ->  Result
-                                       ->  Seq Scan on ec1 ec1_2
+                                             ->  Seq Scan on ec1
+                                             ->  Seq Scan on ec1 ec1_1
+                                 ->  Seq Scan on ec1 ec1_2
          ->  Hash
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Append
                            ->  Result
                                  ->  Append
-                                       ->  Result
-                                             ->  Seq Scan on ec1 ec1_4
-                                       ->  Result
-                                             ->  Seq Scan on ec1 ec1_5
-                           ->  Result
-                                 ->  Seq Scan on ec1 ec1_6
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(31 rows)
+                                       ->  Seq Scan on ec1 ec1_4
+                                       ->  Seq Scan on ec1 ec1_5
+                           ->  Seq Scan on ec1 ec1_6
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(25 rows)
 
 -- check partially indexed scan
 set enable_nestloop = on;
@@ -400,8 +382,8 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
          Join Filter: (((((ec1.ff + 2)) + 1)) = ec1_3.f1)
@@ -412,14 +394,11 @@ explain (costs off)
                      ->  Append
                            ->  Result
                                  ->  Append
-                                       ->  Result
-                                             ->  Seq Scan on ec1
-                                       ->  Result
-                                             ->  Seq Scan on ec1 ec1_1
-                           ->  Result
-                                 ->  Seq Scan on ec1 ec1_2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(17 rows)
+                                       ->  Seq Scan on ec1
+                                       ->  Seq Scan on ec1 ec1_1
+                           ->  Seq Scan on ec1 ec1_2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
 
 -- let's try that as a mergejoin
 set enable_mergejoin = on;
@@ -433,8 +412,8 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
          Join Filter: (((((ec1.ff + 2)) + 1)) = ec1_3.f1)
@@ -445,12 +424,9 @@ explain (costs off)
                      ->  Append
                            ->  Result
                                  ->  Append
-                                       ->  Result
-                                             ->  Seq Scan on ec1
-                                       ->  Result
-                                             ->  Seq Scan on ec1 ec1_1
-                           ->  Result
-                                 ->  Seq Scan on ec1 ec1_2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(17 rows)
+                                       ->  Seq Scan on ec1
+                                       ->  Seq Scan on ec1 ec1_1
+                           ->  Seq Scan on ec1 ec1_2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
 

--- a/src/test/regress/expected/gist_optimizer.out
+++ b/src/test/regress/expected/gist_optimizer.out
@@ -65,19 +65,18 @@ select p from gist_tbl where p <@ box(point(0,0), point(0.5, 0.5));
 explain (costs off)
 select p from gist_tbl where p <@ box(point(0,0), point(0.5, 0.5))
 order by p <-> point(0.201, 0.201);
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Result
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: ((p <-> '(0.201,0.201)'::point))
          ->  Sort
                Sort Key: ((p <-> '(0.201,0.201)'::point))
-               ->  Result
-                     ->  Index Scan using gist_tbl_point_index on gist_tbl
-                           Index Cond: (p <@ '(0.5,0.5),(0,0)'::box)
-                           Filter: (p <@ '(0.5,0.5),(0,0)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
-(6 rows)
+               ->  Index Scan using gist_tbl_point_index on gist_tbl
+                     Index Cond: (p <@ '(0.5,0.5),(0,0)'::box)
+                     Filter: (p <@ '(0.5,0.5),(0,0)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 select p from gist_tbl where p <@ box(point(0,0), point(0.5, 0.5))
 order by p <-> point(0.201, 0.201);
@@ -100,19 +99,18 @@ order by p <-> point(0.201, 0.201);
 explain (costs off)
 select p from gist_tbl where p <@ box(point(0,0), point(0.5, 0.5))
 order by point(0.101, 0.101) <-> p;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Result
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: (('(0.101,0.101)'::point <-> p))
          ->  Sort
                Sort Key: (('(0.101,0.101)'::point <-> p))
-               ->  Result
-                     ->  Index Scan using gist_tbl_point_index on gist_tbl
-                           Index Cond: (p <@ '(0.5,0.5),(0,0)'::box)
-                           Filter: (p <@ '(0.5,0.5),(0,0)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
-(6 rows)
+               ->  Index Scan using gist_tbl_point_index on gist_tbl
+                     Index Cond: (p <@ '(0.5,0.5),(0,0)'::box)
+                     Filter: (p <@ '(0.5,0.5),(0,0)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 select p from gist_tbl where p <@ box(point(0,0), point(0.5, 0.5))
 order by point(0.101, 0.101) <-> p;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -52,22 +52,20 @@ select count(distinct d) from dqa_t1 group by i;
 (12 rows)
 
 explain (costs off) select count(distinct d) from dqa_t1 group by i;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Result
-         ->  Finalize HashAggregate
-               Group Key: i
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: i
-                     ->  Result
-                           ->  Partial GroupAggregate
-                                 Group Key: i
-                                 ->  Sort
-                                       Sort Key: i, d
-                                       ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
-(13 rows)
+   ->  Finalize HashAggregate
+         Group Key: i
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: i
+               ->  Partial GroupAggregate
+                     Group Key: i
+                     ->  Sort
+                           Sort Key: i, d
+                           ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 select count(distinct d), sum(distinct d) from dqa_t1 group by i;
  count | sum 
@@ -87,22 +85,20 @@ select count(distinct d), sum(distinct d) from dqa_t1 group by i;
 (12 rows)
 
 explain (costs off) select count(distinct d), sum(distinct d) from dqa_t1 group by i;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Result
-         ->  Finalize HashAggregate
-               Group Key: i
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: i
-                     ->  Result
-                           ->  Partial GroupAggregate
-                                 Group Key: i
-                                 ->  Sort
-                                       Sort Key: i, d
-                                       ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.78.0
-(13 rows)
+   ->  Finalize HashAggregate
+         Group Key: i
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: i
+               ->  Partial GroupAggregate
+                     Group Key: i
+                     ->  Sort
+                           Sort Key: i, d
+                           ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 select count(distinct d), count(distinct dt) from dqa_t1;
  count | count 
@@ -285,23 +281,22 @@ select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d gr
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d group by dqa_t2.dt;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Result
-         ->  GroupAggregate
-               Group Key: dqa_t2.dt
-               ->  Sort
-                     Sort Key: dqa_t2.dt
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: dqa_t2.dt
-                           ->  Hash Join
-                                 Hash Cond: (dqa_t2.d = dqa_t1.d)
-                                 ->  Seq Scan on dqa_t2
-                                 ->  Hash
-                                       ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(14 rows)
+   ->  GroupAggregate
+         Group Key: dqa_t2.dt
+         ->  Sort
+               Sort Key: dqa_t2.dt
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: dqa_t2.dt
+                     ->  Hash Join
+                           Hash Cond: (dqa_t2.d = dqa_t1.d)
+                           ->  Seq Scan on dqa_t2
+                           ->  Hash
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- Distinct keys are not distribution keys
 select count(distinct c) from dqa_t1;
@@ -362,19 +357,18 @@ select count(distinct c) from dqa_t1 group by dt;
 (34 rows)
 
 explain (costs off) select count(distinct c) from dqa_t1 group by dt;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Result
-         ->  GroupAggregate
-               Group Key: dt
-               ->  Sort
-                     Sort Key: dt
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: dt
-                           ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(10 rows)
+   ->  GroupAggregate
+         Group Key: dt
+         ->  Sort
+               Sort Key: dt
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: dt
+                     ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 select count(distinct c) from dqa_t1 group by d;
  count 
@@ -408,14 +402,13 @@ explain (costs off) select count(distinct c) from dqa_t1 group by d;
                       QUERY PLAN                      
 ------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Result
-         ->  GroupAggregate
-               Group Key: d
-               ->  Sort
-                     Sort Key: d
-                     ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.42.0
-(8 rows)
+   ->  GroupAggregate
+         Group Key: d
+         ->  Sort
+               Sort Key: d
+               ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 select count(distinct i), sum(distinct i) from dqa_t1 group by c;
  count | sum 
@@ -433,19 +426,18 @@ select count(distinct i), sum(distinct i) from dqa_t1 group by c;
 (10 rows)
 
 explain (costs off) select count(distinct i), sum(distinct i) from dqa_t1 group by c;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Result
-         ->  GroupAggregate
-               Group Key: c
-               ->  Sort
-                     Sort Key: c
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: c
-                           ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.78.0
-(10 rows)
+   ->  GroupAggregate
+         Group Key: c
+         ->  Sort
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: c
+                     ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 select count(distinct c), count(distinct dt) from dqa_t1;
  count | count 
@@ -621,27 +613,26 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c g
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
-   ->  Result
-         ->  GroupAggregate
-               Group Key: dqa_t2.dt
-               ->  Sort
-                     Sort Key: dqa_t2.dt
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: dqa_t2.dt
-                           ->  Hash Join
-                                 Hash Cond: (dqa_t1.c = dqa_t2.c)
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                       Hash Key: dqa_t1.c
-                                       ->  Seq Scan on dqa_t1
-                                 ->  Hash
-                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                             Hash Key: dqa_t2.c
-                                             ->  Seq Scan on dqa_t2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(18 rows)
+   ->  GroupAggregate
+         Group Key: dqa_t2.dt
+         ->  Sort
+               Sort Key: dqa_t2.dt
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: dqa_t2.dt
+                     ->  Hash Join
+                           Hash Cond: (dqa_t1.c = dqa_t2.c)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: dqa_t1.c
+                                 ->  Seq Scan on dqa_t1
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: dqa_t2.c
+                                       ->  Seq Scan on dqa_t2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(17 rows)
 
 -- MPP-19037
 drop table if exists fact_route_aggregation;
@@ -1229,22 +1220,20 @@ select count(distinct d) from dqa_t1 group by i;
 (12 rows)
 
 explain (costs off) select count(distinct d) from dqa_t1 group by i;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Result
-         ->  Finalize HashAggregate
-               Group Key: i
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: i
-                     ->  Result
-                           ->  Partial GroupAggregate
-                                 Group Key: i
-                                 ->  Sort
-                                       Sort Key: i, d
-                                       ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.78.0
-(13 rows)
+   ->  Finalize HashAggregate
+         Group Key: i
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: i
+               ->  Partial GroupAggregate
+                     Group Key: i
+                     ->  Sort
+                           Sort Key: i, d
+                           ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
  count | count | count 

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -181,16 +181,15 @@ WHERE et like '%Hash Cond:%';
 -- doesn't print it at all.)
 --
 explain (costs off) select count(*) over (partition by g) from generate_series(1, 10) g;
-                     QUERY PLAN                     
-----------------------------------------------------
- Result
-   ->  WindowAgg
-         Partition By: generate_series
-         ->  Sort
-               Sort Key: generate_series
-               ->  Function Scan on generate_series
- Optimizer: Pivotal Optimizer (GPORCA) version 2.70.0
-(7 rows)
+                      QUERY PLAN                      
+------------------------------------------------------
+ WindowAgg
+   Partition By: generate_series
+   ->  Sort
+         Sort Key: generate_series
+         ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 --
 -- Test non-text format with a few queries that contain GPDB-specific node types.
@@ -300,16 +299,6 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
                    <Segments>1</Segments>                              +
                    <Gang-Type>primary writer</Gang-Type>               +
                    <Parallel-Aware>false</Parallel-Aware>              +
-                   <Plans>                                             +
-                     <Plan>                                            +
-                       <Node-Type>Result</Node-Type>                   +
-                       <Parent-Relationship>Outer</Parent-Relationship>+
-                       <Slice>0</Slice>                                +
-                       <Segments>1</Segments>                          +
-                       <Gang-Type>primary writer</Gang-Type>           +
-                       <Parallel-Aware>false</Parallel-Aware>          +
-                     </Plan>                                           +
-                   </Plans>                                            +
                  </Plan>                                               +
                </Plans>                                                +
              </Plan>                                                   +
@@ -318,7 +307,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
        </Plans>                                                        +
      </Plan>                                                           +
      <Settings>                                                        +
-       <Optimizer>Pivotal Optimizer (GPORCA) version 2.70.0</Optimizer>                       +
+       <Optimizer>Pivotal Optimizer (GPORCA) version 3.83.0</Optimizer>+
      </Settings>                                                       +
    </Query>                                                            +
  </explain>

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -2395,27 +2395,25 @@ from orca.bar1 inner join orca.bar2 on (bar1.x2 = bar2.x2) order by bar1.x1;
  Sort  (cost=0.00..1765423.13 rows=7 width=8)
    Sort Key: bar1.x1
    ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1765423.13 rows=20 width=8)
-         ->  Result  (cost=0.00..1765423.13 rows=7 width=8)
-               ->  Hash Join  (cost=0.00..862.00 rows=7 width=12)
-                     Hash Cond: bar1.x2 = bar2.x2
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=8)
-                           Hash Key: bar1.x2
-                           ->  Seq Scan on bar1  (cost=0.00..431.00 rows=7 width=8)
-                     ->  Hash  (cost=431.00..431.00 rows=10 width=4)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
-                                 Hash Key: bar2.x2
-                                 ->  Seq Scan on bar2  (cost=0.00..431.00 rows=10 width=4)
+         ->  Hash Join  (cost=0.00..862.00 rows=7 width=12)
+               Hash Cond: (bar1.x2 = bar2.x2)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=8)
+                     Hash Key: bar1.x2
+                     ->  Seq Scan on bar1  (cost=0.00..431.00 rows=7 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=10 width=4)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
+                           Hash Key: bar2.x2
+                           ->  Seq Scan on bar2  (cost=0.00..431.00 rows=10 width=4)
                SubPlan 1
                  ->  Result  (cost=0.00..431.02 rows=1 width=4)
                        ->  Result  (cost=0.00..431.02 rows=1 width=1)
-                             One-Time Filter: $0 = $1
-                             Filter: $0::double precision = random() AND foo.x2 = $1
+                             One-Time Filter: (bar1.x2 = bar2.x2)
+                             Filter: (((bar1.x2)::double precision = random()) AND (foo.x2 = bar2.x2))
                              ->  Materialize  (cost=0.00..431.00 rows=10 width=4)
                                    ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
                                          ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=4)
- Settings:  optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 3.9.0
-(23 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(21 rows)
 
 select case when bar1.x2 = bar2.x2 then coalesce((select 1 from orca.foo where bar1.x2 = bar2.x2 and bar1.x2 = random() and foo.x2 = bar2.x2),0) else 1 end as col1, bar1.x1
 from orca.bar1 inner join orca.bar2 on (bar1.x2 = bar2.x2) order by bar1.x1; 
@@ -10960,8 +10958,8 @@ set optimizer_force_multistage_agg = off;
 set optimizer_force_three_stage_scalar_dqa = off;
 -- end_ignore
 explain (costs off) select count(*), t2.c from input_tab1 t1 left join input_tab2 t2 on t1.a = t2.c group by t2.c;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Finalize GroupAggregate
          Group Key: input_tab2.c
@@ -10969,18 +10967,17 @@ explain (costs off) select count(*), t2.c from input_tab1 t1 left join input_tab
                Sort Key: input_tab2.c
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
                      Hash Key: input_tab2.c
-                     ->  Result
-                           ->  Partial GroupAggregate
-                                 Group Key: input_tab2.c
-                                 ->  Sort
-                                       Sort Key: input_tab2.c
-                                       ->  Hash Left Join
-                                             Hash Cond: (input_tab1.a = input_tab2.c)
-                                             ->  Seq Scan on input_tab1
-                                             ->  Hash
-                                                   ->  Seq Scan on input_tab2
- Optimizer: Pivotal Optimizer (GPORCA) version 2.70.1
-(18 rows)
+                     ->  Partial GroupAggregate
+                           Group Key: input_tab2.c
+                           ->  Sort
+                                 Sort Key: input_tab2.c
+                                 ->  Hash Left Join
+                                       Hash Cond: (input_tab1.a = input_tab2.c)
+                                       ->  Seq Scan on input_tab1
+                                       ->  Hash
+                                             ->  Seq Scan on input_tab2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(17 rows)
 
 select count(*), t2.c from input_tab1 t1 left join input_tab2 t2 on t1.a = t2.c group by t2.c;
  count | c 
@@ -11018,22 +11015,20 @@ FROM   (SELECT *
         SELECT region,
                code
         FROM   tab_3)a;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=4 width=1)
          ->  Append  (cost=0.00..1293.00 rows=2 width=1)
-               ->  Result  (cost=0.00..862.00 rows=1 width=1)
-                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
-                           Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
-                           ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=7)
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
-                                       ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
-               ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                     ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(13 rows)
+               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
+                     Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
+                     ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=7)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
+                                 ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
+               ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 SELECT Count(*)
 FROM   (SELECT *
@@ -11265,20 +11260,18 @@ INSERT INTO csq_cast_param_inner VALUES
 	(11, '11'),
 	(101, '12');
 EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.56 rows=2 width=4)
-   ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
-         ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
-               Filter: (SubPlan 1)
-               SubPlan 1
-                 ->  Result  (cost=0.00..431.00 rows=2 width=4)
-                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
-                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                   ->  Seq Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.51.3
-(11 rows)
+   ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Result  (cost=0.00..431.00 rows=2 width=4)
+                 ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                             ->  Seq Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
  a 
@@ -11291,20 +11284,18 @@ DROP CAST (myint as int8);
 CREATE FUNCTION myint_numeric(myint) RETURNS numeric AS 'int4_numeric' LANGUAGE INTERNAL STRICT IMMUTABLE;
 CREATE CAST (myint AS numeric) WITH FUNCTION myint_numeric(myint) AS IMPLICIT;
 EXPLAIN SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.56 rows=2 width=4)
-   ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
-         ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
-               Filter: (SubPlan 1)
-               SubPlan 1
-                 ->  Result  (cost=0.00..431.00 rows=2 width=4)
-                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
-                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                   ->  Seq Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.51.3
-(11 rows)
+   ->  Seq Scan on csq_cast_param_outer  (cost=0.00..1324032.56 rows=1 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Result  (cost=0.00..431.00 rows=2 width=4)
+                 ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                             ->  Seq Scan on csq_cast_param_inner  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 SELECT a FROM csq_cast_param_outer WHERE b in (SELECT CASE WHEN a > 1 THEN d ELSE '42' END FROM csq_cast_param_inner);
  a 
@@ -11363,16 +11354,15 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                            ->  Seq Scan on onetimefilter1 onetimefilter1_1  (cost=0.00..431.00 rows=4 width=8)
                            ->  Hash  (cost=431.00..431.00 rows=4 width=4)
                                  ->  Seq Scan on onetimefilter2 onetimefilter2_1  (cost=0.00..431.00 rows=4 width=4)
-         ->  Result  (cost=0.00..1852062875785.47 rows=4 width=12)
-               ->  Hash Join  (cost=0.00..862.00 rows=4 width=12)
-                     Hash Cond: (onetimefilter1.b = onetimefilter2.b)
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=8)
-                           Hash Key: onetimefilter1.b
-                           ->  Seq Scan on onetimefilter1  (cost=0.00..431.00 rows=4 width=8)
-                     ->  Hash  (cost=431.00..431.00 rows=4 width=4)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
-                                 Hash Key: onetimefilter2.b
-                                 ->  Seq Scan on onetimefilter2  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash Join  (cost=0.00..862.00 rows=4 width=12)
+               Hash Cond: (onetimefilter1.b = onetimefilter2.b)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=8)
+                     Hash Key: onetimefilter1.b
+                     ->  Seq Scan on onetimefilter1  (cost=0.00..431.00 rows=4 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                           Hash Key: onetimefilter2.b
+                           ->  Seq Scan on onetimefilter2  (cost=0.00..431.00 rows=4 width=4)
                SubPlan 1
                  ->  Result  (cost=0.00..431.01 rows=1 width=4)
                        ->  Limit  (cost=0.00..431.01 rows=1 width=1)
@@ -11398,9 +11388,8 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                              ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=11 width=4)
                                    ->  Result  (cost=0.00..431.00 rows=4 width=4)
                                          ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=4 width=4)
- Planning time: 65.338 ms
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(46 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(44 rows)
 
 WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
  ?column? | coalesce | b  

--- a/src/test/regress/expected/indexjoin_optimizer.out
+++ b/src/test/regress/expected/indexjoin_optimizer.out
@@ -27,8 +27,8 @@ WHERE tq.sym = tt.symbol AND
       tt.event_ts <  tq.end_ts
 GROUP BY 1
 ORDER BY 1 asc ;
-                                                                              QUERY PLAN                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..878.47 rows=413 width=16)
    Merge Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
    ->  Finalize GroupAggregate  (cost=0.00..878.44 rows=138 width=16)
@@ -37,19 +37,17 @@ ORDER BY 1 asc ;
                Sort Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..878.35 rows=138 width=16)
                      Hash Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-                     ->  Result  (cost=0.00..878.34 rows=138 width=16)
-                           ->  Streaming Partial HashAggregate  (cost=0.00..878.34 rows=138 width=16)
-                                 Group Key: (((my_tt_agg_small.event_ts / 100000) / 5) * 5)
-                                 ->  Result  (cost=0.00..866.40 rows=94594 width=8)
-                                       ->  Hash Join  (cost=0.00..865.64 rows=94594 width=8)
-                                             Hash Cond: ((my_tq_agg_small.sym)::text = (my_tt_agg_small.symbol)::text)
-                                             Join Filter: ((my_tt_agg_small.event_ts >= my_tq_agg_small.ets) AND (my_tt_agg_small.event_ts < my_tq_agg_small.end_ts))
-                                             ->  Seq Scan on my_tq_agg_small  (cost=0.00..431.02 rows=676 width=20)
-                                             ->  Hash  (cost=431.30..431.30 rows=420 width=25)
-                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.30 rows=420 width=25)
-                                                         ->  Seq Scan on my_tt_agg_small  (cost=0.00..431.01 rows=140 width=25)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(20 rows)
+                     ->  Streaming Partial HashAggregate  (cost=0.00..878.34 rows=138 width=16)
+                           Group Key: (((my_tt_agg_small.event_ts / 100000) / 5) * 5)
+                           ->  Hash Join  (cost=0.00..865.64 rows=94594 width=8)
+                                 Hash Cond: ((my_tq_agg_small.sym)::text = (my_tt_agg_small.symbol)::text)
+                                 Join Filter: ((my_tt_agg_small.event_ts >= my_tq_agg_small.ets) AND (my_tt_agg_small.event_ts < my_tq_agg_small.end_ts))
+                                 ->  Seq Scan on my_tq_agg_small  (cost=0.00..431.02 rows=676 width=20)
+                                 ->  Hash  (cost=431.30..431.30 rows=420 width=25)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.30 rows=420 width=25)
+                                             ->  Seq Scan on my_tt_agg_small  (cost=0.00..431.01 rows=140 width=25)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(18 rows)
 
 SELECT (tt.event_ts / 100000) / 5 * 5 as fivemin, COUNT(*)
 FROM my_tt_agg_small tt, my_tq_agg_small tq
@@ -90,8 +88,8 @@ WHERE tq.sym = tt.symbol AND
       tt.event_ts <  tq.end_ts
 GROUP BY 1
 ORDER BY 1 asc ;
-                                                                                                            QUERY PLAN                                                                                                             
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                      QUERY PLAN                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1359.12 rows=413 width=16)
    Merge Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
    ->  Finalize GroupAggregate  (cost=0.00..1359.09 rows=138 width=16)
@@ -100,19 +98,17 @@ ORDER BY 1 asc ;
                Sort Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1358.94 rows=138 width=16)
                      Hash Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-                     ->  Result  (cost=0.00..1358.93 rows=138 width=16)
-                           ->  Streaming Partial HashAggregate  (cost=0.00..1358.93 rows=138 width=16)
-                                 Group Key: (((my_tt_agg_small.event_ts / 100000) / 5) * 5)
-                                 ->  Result  (cost=0.00..1341.01 rows=94594 width=8)
-                                       ->  Nested Loop  (cost=0.00..1339.87 rows=94594 width=8)
-                                             Join Filter: (((my_tq_agg_small.sym)::bpchar = my_tt_agg_small.symbol) AND (my_tt_agg_small.event_ts >= my_tq_agg_small.ets) AND (my_tt_agg_small.event_ts < my_tq_agg_small.end_ts))
-                                             ->  Seq Scan on my_tt_agg_small  (cost=0.00..431.01 rows=140 width=25)
-                                             ->  Materialize  (cost=0.00..431.16 rows=676 width=20)
-                                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=676 width=20)
-                                                         Hash Key: (my_tq_agg_small.sym)::bpchar
-                                                         ->  Seq Scan on my_tq_agg_small  (cost=0.00..431.03 rows=676 width=20)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
-(20 rows)
+                     ->  Streaming Partial HashAggregate  (cost=0.00..1358.93 rows=138 width=16)
+                           Group Key: (((my_tt_agg_small.event_ts / 100000) / 5) * 5)
+                           ->  Nested Loop  (cost=0.00..1339.87 rows=94594 width=8)
+                                 Join Filter: (((my_tq_agg_small.sym)::bpchar = my_tt_agg_small.symbol) AND (my_tt_agg_small.event_ts >= my_tq_agg_small.ets) AND (my_tt_agg_small.event_ts < my_tq_agg_small.end_ts))
+                                 ->  Seq Scan on my_tt_agg_small  (cost=0.00..431.01 rows=140 width=25)
+                                 ->  Materialize  (cost=0.00..431.16 rows=676 width=20)
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=676 width=20)
+                                             Hash Key: my_tq_agg_small.sym
+                                             ->  Seq Scan on my_tq_agg_small  (cost=0.00..431.03 rows=676 width=20)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(18 rows)
 
 reset optimizer_segments;
 reset optimizer_nestloop_factor;

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1568,37 +1568,34 @@ SELECT thousand, tenthous, thousand+tenthous AS x FROM tenk1
 UNION ALL
 SELECT 42, 42, hundred FROM tenk1
 ORDER BY thousand, tenthous;
-                    QUERY PLAN                     
----------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: tenk1.thousand, tenk1.tenthous
-   ->  Sort
-         Sort Key: tenk1.thousand, tenk1.tenthous
-         ->  Append
-               ->  Result
-                     ->  Seq Scan on tenk1
-               ->  Result
-                     ->  Seq Scan on tenk1 tenk1_1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
-
-explain (costs off)
-SELECT thousand, tenthous FROM tenk1
-UNION ALL
-SELECT thousand, random()::integer FROM tenk1
-ORDER BY thousand, tenthous;
-                    QUERY PLAN                     
----------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: tenk1.thousand, tenk1.tenthous
    ->  Sort
          Sort Key: tenk1.thousand, tenk1.tenthous
          ->  Append
                ->  Seq Scan on tenk1
-               ->  Result
-                     ->  Seq Scan on tenk1 tenk1_1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(9 rows)
+               ->  Seq Scan on tenk1 tenk1_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
+
+explain (costs off)
+SELECT thousand, tenthous FROM tenk1
+UNION ALL
+SELECT thousand, random()::integer FROM tenk1
+ORDER BY thousand, tenthous;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: tenk1.thousand, tenk1.tenthous
+   ->  Sort
+         Sort Key: tenk1.thousand, tenk1.tenthous
+         ->  Append
+               ->  Seq Scan on tenk1
+               ->  Seq Scan on tenk1 tenk1_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 -- Check min/max aggregate optimization
 -- GPDB: simple union all pull up is disabled in pull_up_subqueries(), so the
@@ -1630,11 +1627,10 @@ SELECT min(y) FROM
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
-                     ->  Result
-                           ->  Seq Scan on tenk1
+                     ->  Seq Scan on tenk1
                      ->  Seq Scan on tenk1 tenk1_1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 -- XXX planner doesn't recognize that index on unique2 is sufficiently sorted
 explain (costs off)

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -317,14 +317,12 @@ create table bar (c int, d int) distributed randomly;
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
 explain select a from foo where a<1 and a>1 and not exists (select c from bar where c=a);
-                   QUERY PLAN                   
-------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=4)
-   ->  Result  (cost=0.00..0.00 rows=0 width=4)
-         One-Time Filter: false
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.39.2
-(5 rows)
+   One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(3 rows)
 
 select a from foo where a<1 and a>1 and not exists (select c from bar where c=a);
  a 
@@ -822,20 +820,19 @@ set enable_material = 0;
 set enable_seqscan = 0;
 set enable_bitmapscan = 0;
 explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..1885517.36 rows=1 width=1)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1885517.36 rows=1 width=1)
          ->  Limit  (cost=0.00..1885517.36 rows=1 width=1)
-               ->  Result  (cost=0.00..1885517.36 rows=33336667 width=1)
-                     ->  Nested Loop Left Join  (cost=0.00..1885484.02 rows=33336667 width=4)
-                           Join Filter: true
-                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
-                           ->  Materialize  (cost=0.00..431.70 rows=10000 width=1)
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.69 rows=10000 width=1)
-                                       ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
-(11 rows)
+               ->  Nested Loop Left Join  (cost=0.00..1885484.02 rows=33336667 width=4)
+                     Join Filter: true
+                     ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
+                     ->  Materialize  (cost=0.00..431.70 rows=10000 width=1)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.69 rows=10000 width=1)
+                                 ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(10 rows)
 
 select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
  ?column? 

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2212,9 +2212,8 @@ order by 1, 2;
                            ->  Result
                                  Filter: ((123) = 123)
                                  ->  Result
-                                       ->  Result
- Optimizer: Pivotal Optimizer (GPORCA) version 3.77.0
-(18 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(17 rows)
 
 select * from int8_tbl i1 left join (int8_tbl i2 join
   (select 123 as x) ss on i2.q1 = x) on i1.q2 = i2.q2
@@ -2260,30 +2259,29 @@ select a.f1, b.f1, t.thousand, t.tenthous from
   (select sum(f1)+1 as f1 from int4_tbl i4a) a,
   (select sum(f1) as f1 from int4_tbl i4b) b
 where b.f1 = t.thousand and a.f1 = b.f1 and (a.f1+b.f1+999) = t.tenthous;
-                                                                                                                          QUERY PLAN                                                                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Join
-         Hash Cond: (((tenk1.thousand)::bigint = (sum(int4_tbl_1.f1))) AND ((((sum(int4_tbl.f1)) + 1)) = (sum(int4_tbl_1.f1))) AND ((tenk1.thousand)::bigint = (sum(int4_tbl_1.f1))))
-         Join Filter: ((((((sum(int4_tbl.f1)) + 1)) + (sum(int4_tbl_1.f1))) + 999) = (tenk1.tenthous)::bigint)
+         Hash Cond: (((tenk1.thousand)::bigint = (sum(int4_tbl_1.f1))) AND (((sum(int4_tbl.f1) + 1)) = (sum(int4_tbl_1.f1))) AND ((tenk1.thousand)::bigint = (sum(int4_tbl_1.f1))))
+         Join Filter: (((((sum(int4_tbl.f1) + 1)) + (sum(int4_tbl_1.f1))) + 999) = (tenk1.tenthous)::bigint)
          ->  Nested Loop
                Join Filter: true
                ->  Broadcast Motion 1:3  (slice2)
-                     ->  Result
-                           ->  Finalize Aggregate
-                                 ->  Gather Motion 3:1  (slice1; segments: 3)
-                                       ->  Partial Aggregate
-                                             ->  Seq Scan on int4_tbl
+                     ->  Finalize Aggregate
+                           ->  Gather Motion 3:1  (slice1; segments: 3)
+                                 ->  Partial Aggregate
+                                       ->  Seq Scan on int4_tbl
                ->  Index Scan using tenk1_thous_tenthous on tenk1
-                     Index Cond: (thousand = (((sum(int4_tbl.f1)) + 1)))
+                     Index Cond: (thousand = ((sum(int4_tbl.f1) + 1)))
          ->  Hash
                ->  Broadcast Motion 1:3  (slice4)
                      ->  Finalize Aggregate
                            ->  Gather Motion 3:1  (slice3; segments: 3)
                                  ->  Partial Aggregate
                                        ->  Seq Scan on int4_tbl int4_tbl_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(21 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(20 rows)
 
 select a.f1, b.f1, t.thousand, t.tenthous from
   tenk1 t,
@@ -2565,48 +2563,45 @@ where not exists (
               ) a1 on t3.c2 = a1.c1
   where t1.c1 = t2.c2
 );
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Result
          Filter: (COALESCE((count()), '0'::bigint) = '0'::bigint)
-         ->  Result
-               ->  Hash Left Join
-                     Hash Cond: (tt4x.c1 = tt4x_1.c2)
-                     ->  Seq Scan on tt4x
-                     ->  Hash
-                           ->  Result
-                                 ->  Finalize GroupAggregate
-                                       Group Key: tt4x_1.c2
-                                       ->  Sort
-                                             Sort Key: tt4x_1.c2
-                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                   Hash Key: tt4x_1.c2
-                                                   ->  Result
-                                                         ->  Partial GroupAggregate
-                                                               Group Key: tt4x_1.c2
-                                                               ->  Sort
-                                                                     Sort Key: tt4x_1.c2
+         ->  Hash Left Join
+               Hash Cond: (tt4x.c1 = tt4x_1.c2)
+               ->  Seq Scan on tt4x
+               ->  Hash
+                     ->  Finalize GroupAggregate
+                           Group Key: tt4x_1.c2
+                           ->  Sort
+                                 Sort Key: tt4x_1.c2
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                       Hash Key: tt4x_1.c2
+                                       ->  Partial GroupAggregate
+                                             Group Key: tt4x_1.c2
+                                             ->  Sort
+                                                   Sort Key: tt4x_1.c2
+                                                   ->  Hash Left Join
+                                                         Hash Cond: (tt4x_2.c2 = tt4x_4.c1)
+                                                         ->  Hash Left Join
+                                                               Hash Cond: (tt4x_1.c3 = tt4x_2.c1)
+                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                                                     Hash Key: tt4x_1.c3
+                                                                     ->  Seq Scan on tt4x tt4x_1
+                                                               ->  Hash
+                                                                     ->  Seq Scan on tt4x tt4x_2
+                                                         ->  Hash
+                                                               ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                                                      ->  Hash Left Join
-                                                                           Hash Cond: (tt4x_2.c2 = tt4x_4.c1)
-                                                                           ->  Hash Left Join
-                                                                                 Hash Cond: (tt4x_1.c3 = tt4x_2.c1)
-                                                                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                                                                       Hash Key: tt4x_1.c3
-                                                                                       ->  Seq Scan on tt4x tt4x_1
-                                                                                 ->  Hash
-                                                                                       ->  Seq Scan on tt4x tt4x_2
+                                                                           Hash Cond: (tt4x_3.c2 = tt4x_4.c1)
+                                                                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                                                                 Hash Key: tt4x_3.c2
+                                                                                 ->  Seq Scan on tt4x tt4x_3
                                                                            ->  Hash
-                                                                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                                                       ->  Hash Left Join
-                                                                                             Hash Cond: (tt4x_3.c2 = tt4x_4.c1)
-                                                                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                                                                                   Hash Key: tt4x_3.c2
-                                                                                                   ->  Seq Scan on tt4x tt4x_3
-                                                                                             ->  Hash
-                                                                                                   ->  Seq Scan on tt4x tt4x_4
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(39 rows)
+                                                                                 ->  Seq Scan on tt4x tt4x_4
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(36 rows)
 
 --
 -- regression test for problems of the sort depicted in bug #3494
@@ -2908,33 +2903,28 @@ SELECT qq, unique1
   ( SELECT COALESCE(q2, -1) AS qq FROM int8_tbl b ) AS ss2
   USING (qq)
   INNER JOIN tenk1 c ON qq = unique2;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
-   ->  Result
-         ->  Nested Loop
-               Join Filter: true
-               ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                     ->  Result
-                           ->  Result
-                                 ->  Merge Full Join
-                                       Merge Cond: ((COALESCE(int8_tbl.q1, '0'::bigint)) = (COALESCE(int8_tbl_1.q2, '-1'::bigint)))
-                                       ->  Sort
-                                             Sort Key: (COALESCE(int8_tbl.q1, '0'::bigint))
-                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                                   Hash Key: (COALESCE(int8_tbl.q1, '0'::bigint))
-                                                   ->  Result
-                                                         ->  Seq Scan on int8_tbl
-                                       ->  Sort
-                                             Sort Key: (COALESCE(int8_tbl_1.q2, '-1'::bigint))
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                                   Hash Key: (COALESCE(int8_tbl_1.q2, '-1'::bigint))
-                                                   ->  Result
-                                                         ->  Seq Scan on int8_tbl int8_tbl_1
-               ->  Index Scan using tenk1_unique2 on tenk1
-                     Index Cond: (unique2 = (COALESCE((COALESCE(int8_tbl.q1, '0'::bigint)), (COALESCE(int8_tbl_1.q2, '-1'::bigint)))))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
-(24 rows)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice3; segments: 3)
+               ->  Merge Full Join
+                     Merge Cond: ((COALESCE(int8_tbl.q1, '0'::bigint)) = (COALESCE(int8_tbl_1.q2, '-1'::bigint)))
+                     ->  Sort
+                           Sort Key: (COALESCE(int8_tbl.q1, '0'::bigint))
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: (COALESCE(int8_tbl.q1, '0'::bigint))
+                                 ->  Seq Scan on int8_tbl
+                     ->  Sort
+                           Sort Key: (COALESCE(int8_tbl_1.q2, '-1'::bigint))
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: (COALESCE(int8_tbl_1.q2, '-1'::bigint))
+                                 ->  Seq Scan on int8_tbl int8_tbl_1
+         ->  Index Scan using tenk1_unique2 on tenk1
+               Index Cond: (unique2 = (COALESCE((COALESCE(int8_tbl.q1, '0'::bigint)), (COALESCE(int8_tbl_1.q2, '-1'::bigint)))))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(19 rows)
 
 SELECT qq, unique1
   FROM
@@ -2992,8 +2982,8 @@ from nt3 as nt3
     ) as ss2
     on ss2.id = nt3.nt2_id
 where nt3.id = 1 and ss2.b3;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Hash Join
    Hash Cond: (nt3.nt2_id = nt2.id)
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -3002,17 +2992,16 @@ where nt3.id = 1 and ss2.b3;
    ->  Hash
          ->  Result
                Filter: ((nt2.b1 AND ((NOT (nt1.id IS NULL)))))
-               ->  Result
-                     ->  Hash Left Join
-                           Hash Cond: (nt2.nt1_id = nt1.id)
-                           ->  Gather Motion 3:1  (slice2; segments: 3)
-                                 ->  Seq Scan on nt2
-                           ->  Hash
-                                 ->  Result
-                                       ->  Gather Motion 3:1  (slice3; segments: 3)
-                                             ->  Seq Scan on nt1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(18 rows)
+               ->  Hash Left Join
+                     Hash Cond: (nt2.nt1_id = nt1.id)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)
+                           ->  Seq Scan on nt2
+                     ->  Hash
+                           ->  Result
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                                       ->  Seq Scan on nt1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(17 rows)
 
 select nt3.id
 from nt3 as nt3
@@ -3041,8 +3030,8 @@ select * from
 where
   1 = (select 1 from int8_tbl t3 where ss.y is not null limit 1)
 order by 1,2;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Sort
    Sort Key: int8_tbl.q1, int8_tbl.q2
    ->  Result
@@ -3057,17 +3046,16 @@ order by 1,2;
                                  ->  Seq Scan on int8_tbl int8_tbl_1
          SubPlan 1
            ->  Result
+                 Filter: (1 = (1))
                  ->  Result
-                       Filter: (1 = (1))
-                       ->  Result
-                             ->  Limit
-                                   ->  Result
-                                         One-Time Filter: (NOT ((42) IS NULL))
-                                         ->  Materialize
-                                               ->  Gather Motion 3:1  (slice3; segments: 3)
-                                                     ->  Seq Scan on int8_tbl int8_tbl_2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(24 rows)
+                       ->  Limit
+                             ->  Result
+                                   One-Time Filter: (NOT ((42) IS NULL))
+                                   ->  Materialize
+                                         ->  Gather Motion 3:1  (slice3; segments: 3)
+                                               ->  Seq Scan on int8_tbl int8_tbl_2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(23 rows)
 
 --
 -- test case where a PlaceHolderVar is propagated into a subquery
@@ -3158,9 +3146,7 @@ where q1 = thousand or q2 = thousand;
                ->  Nested Loop
                      Join Filter: true
                      ->  Result
-                           ->  Result
                      ->  Result
-                           ->  Result
                ->  Bitmap Heap Scan on tenk1
                      Recheck Cond: ((thousand = (1)) OR (thousand = (0)))
                      ->  BitmapOr
@@ -3171,8 +3157,8 @@ where q1 = thousand or q2 = thousand;
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on int4_tbl
- Optimizer: Pivotal Optimizer (GPORCA) version 3.82.0
-(22 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(20 rows)
 
 explain (costs off)
 select * from
@@ -3180,8 +3166,8 @@ select * from
   int4(sin(1)) q1,
   int4(sin(0)) q2
 where thousand = (q1 + q2);
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
          Hash Cond: (tenk1.twothousand = int4_tbl.f1)
@@ -3190,16 +3176,14 @@ where thousand = (q1 + q2);
                ->  Nested Loop
                      Join Filter: true
                      ->  Result
-                           ->  Result
                      ->  Result
-                           ->  Result
                ->  Index Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = ((1) + (0)))
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on int4_tbl
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(17 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 --
 -- test ability to generate a suitable plan for a star-schema query
@@ -3250,26 +3234,26 @@ select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
   left join tenk1 t2
   on (subq1.y1 = t2.unique1)
 where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Hash Join
-   Hash Cond: ("outer".d1 = tenk1_1.unique2)
+   Hash Cond: ((11) = tenk1_1.unique2)
    Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
    ->  Gather Motion 3:1  (slice2; segments: 3)
          ->  Hash Join
-               Hash Cond: ("outer".column2 = int4_tbl.f1)
+               Hash Cond: ((0) = int4_tbl.f1)
                ->  Nested Loop
                      Join Filter: true
                      ->  Result
                            ->  Result
-                                 ->  Result
-                                       ->  Hash Left Join
-                                             Hash Cond: ("outer".column1 = "outer".column2)
+                                 Filter: ((11) < 42)
+                                 ->  Hash Left Join
+                                       Hash Cond: ((1) = (1))
+                                       ->  Result
+                                       ->  Hash
                                              ->  Result
-                                             ->  Hash
-                                                   ->  Result
                      ->  Index Scan using tenk1_unique1 on tenk1
-                           Index Cond: (unique1 = "outer".column1)
+                           Index Cond: (unique1 = (3))
                ->  Hash
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)
                            ->  Seq Scan on int4_tbl
@@ -3277,8 +3261,8 @@ where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
          ->  Gather Motion 3:1  (slice3; segments: 3)
                ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
                      Index Cond: ((unique2 < 42) AND (unique2 = 11))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(27 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(26 rows)
 
 --end_ignore
 select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
@@ -3597,18 +3581,17 @@ order by fault;
          Sort Key: ((COALESCE(tenk1.unique1, '-1'::integer) + int8_tbl.q1))
          ->  Result
                Filter: (((COALESCE(tenk1.unique1, '-1'::integer) + int8_tbl.q1)) = 122)
-               ->  Result
-                     ->  Hash Left Join
-                           Hash Cond: (int8_tbl.q2 = (tenk1.unique2)::bigint)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                 Hash Key: int8_tbl.q2
-                                 ->  Seq Scan on int8_tbl
-                           ->  Hash
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                       Hash Key: (tenk1.unique2)::bigint
-                                       ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(17 rows)
+               ->  Hash Left Join
+                     Hash Cond: (int8_tbl.q2 = (tenk1.unique2)::bigint)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: int8_tbl.q2
+                           ->  Seq Scan on int8_tbl
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: (tenk1.unique2)::bigint
+                                 ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
 
 select * from
 (
@@ -3683,21 +3666,20 @@ explain (costs off)
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
   where (case when unique2 is null then f1 else 0 end) = 0;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Result
-         ->  Result
-               Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
-               ->  Hash Left Join
-                     Hash Cond: (int4_tbl.f1 = tenk1.unique2)
-                     ->  Seq Scan on int4_tbl
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                 Hash Key: tenk1.unique2
-                                 ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(12 rows)
+         Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
+         ->  Hash Left Join
+               Hash Cond: (int4_tbl.f1 = tenk1.unique2)
+               ->  Seq Scan on int4_tbl
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: tenk1.unique2
+                           ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
@@ -3714,30 +3696,29 @@ explain (costs off)
 select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
   from tenk1 a left join tenk1 b on b.thousand = a.unique1                        left join tenk1 c on c.unique2 = coalesce(b.twothousand, a.twothousand)
   where a.unique2 < 10 and coalesce(b.twothousand, a.twothousand) = 44;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
-   ->  Result
-         ->  Hash Left Join
-               Hash Cond: (COALESCE(tenk1_1.twothousand, tenk1.twothousand) = tenk1_2.unique2)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: COALESCE(tenk1_1.twothousand, tenk1.twothousand)
-                     ->  Result
-                           Filter: (COALESCE(tenk1_1.twothousand, tenk1.twothousand) = 44)
-                           ->  Hash Left Join
-                                 Hash Cond: (tenk1.unique1 = tenk1_1.thousand)
-                                 ->  Index Scan using tenk1_unique2 on tenk1
-                                       Index Cond: (unique2 < 10)
-                                 ->  Hash
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                             Hash Key: tenk1_1.thousand
-                                             ->  Seq Scan on tenk1 tenk1_1
-               ->  Hash
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: tenk1_2.unique2
-                           ->  Seq Scan on tenk1 tenk1_2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
-(21 rows)
+   ->  Hash Left Join
+         Hash Cond: (COALESCE(tenk1_1.twothousand, tenk1.twothousand) = tenk1_2.unique2)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: COALESCE(tenk1_1.twothousand, tenk1.twothousand)
+               ->  Result
+                     Filter: (COALESCE(tenk1_1.twothousand, tenk1.twothousand) = 44)
+                     ->  Hash Left Join
+                           Hash Cond: (tenk1.unique1 = tenk1_1.thousand)
+                           ->  Index Scan using tenk1_unique2 on tenk1
+                                 Index Cond: (unique2 < 10)
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                       Hash Key: tenk1_1.thousand
+                                       ->  Seq Scan on tenk1 tenk1_1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: tenk1_2.unique2
+                     ->  Seq Scan on tenk1 tenk1_2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(20 rows)
 
 select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
   from tenk1 a left join tenk1 b on b.thousand = a.unique1                        left join tenk1 c on c.unique2 = coalesce(b.twothousand, a.twothousand)
@@ -3778,10 +3759,8 @@ using (join_key);
                ->  Hash Left Join
                      Output: int4_tbl.f1, (666)
                      Hash Cond: (int4_tbl.f1 = tenk1.unique2)
-                     ->  Result
+                     ->  Seq Scan on public.int4_tbl
                            Output: 666, int4_tbl.f1
-                           ->  Seq Scan on public.int4_tbl
-                                 Output: int4_tbl.f1
                      ->  Hash
                            Output: tenk1.unique2
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)
@@ -3789,9 +3768,9 @@ using (join_key);
                                  Hash Key: tenk1.unique2
                                  ->  Seq Scan on public.tenk1
                                        Output: tenk1.unique2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  Settings: optimizer=on
-(27 rows)
+(25 rows)
 
 select foo1.join_key as foo1_id, foo3.join_key AS foo3_id, bug_field from
   (values (0),(1)) foo1(join_key)
@@ -3825,8 +3804,8 @@ select t1.* from
   on (t1.f1 = b1.d1)
   left join int4_tbl i4
   on (i8.q2 = i4.f1);
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice6; segments: 3)
    Output: text_tbl.f1
    ->  Hash Left Join
@@ -3863,19 +3842,17 @@ select t1.* from
                                                          Output: int8_tbl_1.q1, int8_tbl_1.q2
                                                    ->  Hash
                                                          Output: (NULL::integer), int8_tbl_2.q1
-                                                         ->  Result
+                                                         ->  Seq Scan on public.int8_tbl int8_tbl_2
                                                                Output: NULL::integer, int8_tbl_2.q1
-                                                               ->  Seq Scan on public.int8_tbl int8_tbl_2
-                                                                     Output: int8_tbl_2.q1
          ->  Hash
                Output: int4_tbl.f1
                ->  Broadcast Motion 3:3  (slice5; segments: 3)
                      Output: int4_tbl.f1
                      ->  Seq Scan on public.int4_tbl
                            Output: int4_tbl.f1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  Settings: optimizer=on
-(49 rows)
+(46 rows)
 
 select t1.* from
   text_tbl t1
@@ -3904,8 +3881,8 @@ select t1.* from
   on (t1.f1 = b1.d1)
   left join int4_tbl i4
   on (i8.q2 = i4.f1);
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice7; segments: 3)
    Output: text_tbl.f1
    ->  Hash Left Join
@@ -3942,25 +3919,23 @@ select t1.* from
                                                          Output: int8_tbl_1.q1, int8_tbl_1.q2
                                                    ->  Hash
                                                          Output: (NULL::integer), int8_tbl_2.q1
-                                                         ->  Result
+                                                         ->  Nested Loop
                                                                Output: NULL::integer, int8_tbl_2.q1
-                                                               ->  Nested Loop
+                                                               Join Filter: true
+                                                               ->  Seq Scan on public.int8_tbl int8_tbl_2
                                                                      Output: int8_tbl_2.q1
-                                                                     Join Filter: true
-                                                                     ->  Seq Scan on public.int8_tbl int8_tbl_2
-                                                                           Output: int8_tbl_2.q1
-                                                                     ->  Materialize
-                                                                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                                                 ->  Seq Scan on public.int4_tbl
+                                                               ->  Materialize
+                                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                                           ->  Seq Scan on public.int4_tbl
          ->  Hash
                Output: int4_tbl_1.f1
                ->  Broadcast Motion 3:3  (slice6; segments: 3)
                      Output: int4_tbl_1.f1
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  Settings: optimizer=on
-(55 rows)
+(52 rows)
 
 select t1.* from
   text_tbl t1
@@ -3990,8 +3965,8 @@ select t1.* from
   on (t1.f1 = b1.d1)
   left join int4_tbl i4
   on (i8.q2 = i4.f1);
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice8; segments: 3)
    Output: text_tbl.f1
    ->  Hash Left Join
@@ -4028,30 +4003,28 @@ select t1.* from
                                                          Output: int8_tbl_1.q1, int8_tbl_1.q2
                                              ->  Hash
                                                    Output: (NULL::integer), int8_tbl_2.q1
-                                                   ->  Result
+                                                   ->  Hash Join
                                                          Output: NULL::integer, int8_tbl_2.q1
-                                                         ->  Hash Join
+                                                         Hash Cond: (int8_tbl_2.q1 = (int4_tbl.f1)::bigint)
+                                                         ->  Gather Motion 3:1  (slice4; segments: 3)
                                                                Output: int8_tbl_2.q1
-                                                               Hash Cond: (int8_tbl_2.q1 = (int4_tbl.f1)::bigint)
-                                                               ->  Gather Motion 3:1  (slice4; segments: 3)
+                                                               ->  Seq Scan on public.int8_tbl int8_tbl_2
                                                                      Output: int8_tbl_2.q1
-                                                                     ->  Seq Scan on public.int8_tbl int8_tbl_2
-                                                                           Output: int8_tbl_2.q1
-                                                               ->  Hash
+                                                         ->  Hash
+                                                               Output: int4_tbl.f1
+                                                               ->  Gather Motion 3:1  (slice5; segments: 3)
                                                                      Output: int4_tbl.f1
-                                                                     ->  Gather Motion 3:1  (slice5; segments: 3)
+                                                                     ->  Seq Scan on public.int4_tbl
                                                                            Output: int4_tbl.f1
-                                                                           ->  Seq Scan on public.int4_tbl
-                                                                                 Output: int4_tbl.f1
          ->  Hash
                Output: int4_tbl_1.f1
                ->  Broadcast Motion 3:3  (slice7; segments: 3)
                      Output: int4_tbl_1.f1
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  Settings: optimizer=on
-(59 rows)
+(57 rows)
 
 select t1.* from
   text_tbl t1
@@ -4281,7 +4254,6 @@ select * from
  Hash Left Join
    Hash Cond: ((1) = COALESCE((1)))
    ->  Result
-         ->  Result
    ->  Hash
          ->  Gather Motion 3:1  (slice1; segments: 3)
                ->  Merge Full Join
@@ -4293,9 +4265,8 @@ select * from
                            Sort Key: (1)
                            ->  Result
                                  ->  Result
-                                       ->  Result
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(17 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 select * from
   (select 1 as id) as xx
@@ -4328,27 +4299,25 @@ explain (costs off)
 
 explain (costs off)
   select * from tenk1 a full join tenk1 b using(unique2) where unique2 = 42;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Result
-         ->  Result
-               Filter: ((COALESCE(tenk1.unique2, tenk1_1.unique2)) = 42)
-               ->  Result
-                     ->  Merge Full Join
-                           Merge Cond: (tenk1.unique2 = tenk1_1.unique2)
-                           ->  Sort
-                                 Sort Key: tenk1.unique2
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                       Hash Key: tenk1.unique2
-                                       ->  Seq Scan on tenk1
-                           ->  Sort
-                                 Sort Key: tenk1_1.unique2
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                       Hash Key: tenk1_1.unique2
-                                       ->  Seq Scan on tenk1 tenk1_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
-(18 rows)
+         Filter: ((COALESCE(tenk1.unique2, tenk1_1.unique2)) = 42)
+         ->  Merge Full Join
+               Merge Cond: (tenk1.unique2 = tenk1_1.unique2)
+               ->  Sort
+                     Sort Key: tenk1.unique2
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: tenk1.unique2
+                           ->  Seq Scan on tenk1
+               ->  Sort
+                     Sort Key: tenk1_1.unique2
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: tenk1_1.unique2
+                           ->  Seq Scan on tenk1 tenk1_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
 
 --
 -- test that quals attached to an outer join have correct semantics,
@@ -4641,17 +4610,16 @@ explain (costs off)
   select p.*, linked from parent p
     left join (select c.*, true as linked from child c) as ss
     on (p.k = ss.k);
-                QUERY PLAN                 
--------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Left Join
          Hash Cond: (parent.k = child.k)
          ->  Seq Scan on parent
          ->  Hash
-               ->  Result
-                     ->  Seq Scan on child
- Optimizer: Pivotal Optimizer (GPORCA) version 2.54.2
-(8 rows)
+               ->  Seq Scan on child
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 -- check for a 9.0rc1 bug: join removal breaks pseudoconstant qual handling
 select p.* from
@@ -4665,13 +4633,12 @@ explain (costs off)
 select p.* from
   parent p left join child c on (p.k = c.k)
   where p.k = 1 and p.k = 2;
-           QUERY PLAN           
---------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Result
-   ->  Result
-         One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 2.54.2
-(4 rows)
+   One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(3 rows)
 
 select p.* from
   (parent p left join child c on (p.k = c.k)) join parent x on p.k = x.k
@@ -4684,13 +4651,12 @@ explain (costs off)
 select p.* from
   (parent p left join child c on (p.k = c.k)) join parent x on p.k = x.k
   where p.k = 1 and p.k = 2;
-           QUERY PLAN           
---------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Result
-   ->  Result
-         One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 2.54.2
-(4 rows)
+   One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(3 rows)
 
 -- bug 5255: this is not optimizable by join removal
 begin;
@@ -4741,7 +4707,7 @@ select t1.* from
   on t1.f1 = t2.f1
   left join uniquetbl t3
   on t2.d1 = t3.f1;
-                              QUERY PLAN                                
+                               QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop Left Join
@@ -4752,12 +4718,11 @@ select t1.* from
                      Hash Cond: (uniquetbl.f1 = uniquetbl_1.f1)
                      ->  Seq Scan on uniquetbl
                      ->  Hash
-                           ->  Result
-                                 ->  Seq Scan on uniquetbl uniquetbl_1
+                           ->  Seq Scan on uniquetbl uniquetbl_1
          ->  Index Scan using uniquetbl_f1_key on uniquetbl uniquetbl_2
                Index Cond: (f1 = ('***'::text))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.77.0
-(14 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 explain (costs off)
 select t0.*
@@ -4780,23 +4745,22 @@ where ss.stringu2 !~* ss.case1;
                Hash Key: (CASE tenk1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END)
                ->  Result
                      Filter: (tenk1.stringu2 !~* (CASE tenk1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END))
-                     ->  Result
-                           ->  Nested Loop Left Join
-                                 Join Filter: true
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                       Hash Key: (tenk1.string4)::text
-                                       ->  Nested Loop
-                                             Join Filter: true
-                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                                   ->  Seq Scan on int4_tbl
-                                             ->  Index Scan using tenk1_unique2 on tenk1
-                                                   Index Cond: (unique2 = int4_tbl.f1)
-                                 ->  Index Scan using uniquetbl_f1_key on uniquetbl
-                                       Index Cond: (f1 = (tenk1.string4)::text)
+                     ->  Nested Loop Left Join
+                           Join Filter: true
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: (tenk1.string4)::text
+                                 ->  Nested Loop
+                                       Join Filter: true
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                             ->  Seq Scan on int4_tbl
+                                       ->  Index Scan using tenk1_unique2 on tenk1
+                                             Index Cond: (unique2 = int4_tbl.f1)
+                           ->  Index Scan using uniquetbl_f1_key on uniquetbl
+                                 Index Cond: (f1 = (tenk1.string4)::text)
          ->  Hash
                ->  Seq Scan on text_tbl
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(23 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(22 rows)
 
 select t0.*
 from

--- a/src/test/regress/expected/limit_optimizer.out
+++ b/src/test/regress/expected/limit_optimizer.out
@@ -292,38 +292,34 @@ order by s2 desc;
 explain (verbose, costs off)
 select sum(tenthous) as s1, sum(tenthous) + random()*0 as s2
   from tenk1 group by thousand order by thousand limit 3;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Result
-   Output: (sum(tenthous)), ((((sum(tenthous)))::double precision + (random() * '0'::double precision)))
+   Output: (sum(tenthous)), (((sum(tenthous))::double precision + (random() * '0'::double precision)))
    ->  Limit
-         Output: (sum(tenthous)), ((((sum(tenthous)))::double precision + (random() * '0'::double precision))), thousand
+         Output: (sum(tenthous)), (((sum(tenthous))::double precision + (random() * '0'::double precision))), thousand
          ->  Gather Motion 3:1  (slice2; segments: 3)
-               Output: (sum(tenthous)), ((((sum(tenthous)))::double precision + (random() * '0'::double precision))), thousand
+               Output: (sum(tenthous)), (((sum(tenthous))::double precision + (random() * '0'::double precision))), thousand
                Merge Key: thousand
                ->  Limit
-                     Output: (sum(tenthous)), ((((sum(tenthous)))::double precision + (random() * '0'::double precision))), thousand
-                     ->  Result
-                           Output: (sum(tenthous)), (((sum(tenthous)))::double precision + (random() * '0'::double precision)), thousand
-                           ->  Finalize GroupAggregate
-                                 Output: sum(tenthous), sum(tenthous), thousand
-                                 Group Key: tenk1.thousand
-                                 ->  Sort
+                     Output: (sum(tenthous)), (((sum(tenthous))::double precision + (random() * '0'::double precision))), thousand
+                     ->  Finalize GroupAggregate
+                           Output: sum(tenthous), ((sum(tenthous))::double precision + (random() * '0'::double precision)), thousand
+                           Group Key: tenk1.thousand
+                           ->  Sort
+                                 Output: thousand, (PARTIAL sum(tenthous)), (PARTIAL sum(tenthous))
+                                 Sort Key: tenk1.thousand
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                        Output: thousand, (PARTIAL sum(tenthous)), (PARTIAL sum(tenthous))
-                                       Sort Key: tenk1.thousand
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                             Output: thousand, (PARTIAL sum(tenthous)), (PARTIAL sum(tenthous))
-                                             Hash Key: thousand
-                                             ->  Result
-                                                   Output: thousand, (PARTIAL sum(tenthous)), (PARTIAL sum(tenthous))
-                                                   ->  Streaming Partial HashAggregate
-                                                         Output: PARTIAL sum(tenthous), PARTIAL sum(tenthous), thousand
-                                                         Group Key: tenk1.thousand
-                                                         ->  Seq Scan on public.tenk1
-                                                               Output: thousand, tenthous
- Optimizer: Pivotal Optimizer (GPORCA) version 3.79.1
+                                       Hash Key: thousand
+                                       ->  Streaming Partial HashAggregate
+                                             Output: thousand, PARTIAL sum(tenthous), PARTIAL sum(tenthous)
+                                             Group Key: tenk1.thousand
+                                             ->  Seq Scan on public.tenk1
+                                                   Output: thousand, tenthous
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  Settings: optimizer=on
-(29 rows)
+(25 rows)
 
 select sum(tenthous) as s1, sum(tenthous) + random()*0 as s2
   from tenk1 group by thousand order by thousand limit 3;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -19,19 +19,17 @@ SELECT * FROM mvtest_tv ORDER BY type;
 -- create a materialized view with no data, and confirm correct behavior
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Result
-   ->  Result
-         ->  GroupAggregate
-               Group Key: type
-               ->  Sort
-                     Sort Key: type
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: type
-                           ->  Seq Scan on mvtest_t
- Optimizer: Pivotal Optimizer (GPORCA) version 3.77.0
-(10 rows)
+                         QUERY PLAN                         
+------------------------------------------------------------
+ GroupAggregate
+   Group Key: type
+   ->  Sort
+         Sort Key: type
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: type
+               ->  Seq Scan on mvtest_t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'mvtest_tm'::regclass;
@@ -63,23 +61,21 @@ SELECT * FROM mvtest_tm;
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW mvtest_tvm AS SELECT * FROM mvtest_tv ORDER BY type;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Result
-   ->  Result
-         ->  Sort
-               Sort Key: type
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: type
-                                 ->  Sort
-                                       Sort Key: type
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                             Hash Key: type
-                                             ->  Seq Scan on mvtest_t
- Optimizer: Pivotal Optimizer (GPORCA) version 3.71.0
-(14 rows)
+   ->  Sort
+         Sort Key: type
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               ->  GroupAggregate
+                     Group Key: type
+                     ->  Sort
+                           Sort Key: type
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: type
+                                 ->  Seq Scan on mvtest_t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(12 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tvm AS SELECT * FROM mvtest_tv ORDER BY type;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -101,23 +97,22 @@ CREATE VIEW mvtest_tvv AS SELECT sum(totamt) AS grandtot FROM mvtest_tv;
 EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW mvtest_tvvm AS SELECT * FROM mvtest_tvv;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Result
-   ->  Result
-         ->  Redistribute Motion 1:3  (slice3; segments: 1)
-               ->  Finalize Aggregate
-                     ->  Gather Motion 3:1  (slice2; segments: 3)
-                           ->  Partial Aggregate
-                                 ->  GroupAggregate
-                                       Group Key: type
-                                       ->  Sort
-                                             Sort Key: type
-                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                                   Hash Key: type
-                                                   ->  Seq Scan on mvtest_t
- Optimizer: Pivotal Optimizer (GPORCA) version 3.77.0
-(14 rows)
+   ->  Redistribute Motion 1:3  (slice3; segments: 1)
+         ->  Finalize Aggregate
+               ->  Gather Motion 3:1  (slice2; segments: 3)
+                     ->  Partial Aggregate
+                           ->  GroupAggregate
+                                 Group Key: type
+                                 ->  Sort
+                                       Sort Key: type
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                             Hash Key: type
+                                             ->  Seq Scan on mvtest_t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tvvm AS SELECT * FROM mvtest_tvv;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -469,8 +469,8 @@ select * from g1 where (a,b,c) not in
 --
 explain select c1 from t1, t2 where c1 not in 
 	(select c3 from t3 where c3 = c1) and c1 = c2;
-                                                                                                                                                                  QUERY PLAN                                                                                                                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324465.54 rows=6 width=4)
    ->  Hash Join  (cost=0.00..1324465.54 rows=2 width=4)
          Hash Cond: (t1.c1 = t2.c2)
@@ -478,21 +478,17 @@ explain select c1 from t1, t2 where c1 not in
                Filter: (SubPlan 1)
                SubPlan 1
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                             Filter: ((CASE WHEN ((sum((CASE WHEN (t1.c1 = t3.c3) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (t3.c3 IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (t1.c1 = t3.c3) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
-                             ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                         ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                               ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                     Filter: (t3.c3 = t1.c1)
-                                                     ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
-                                                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-                                                                 ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+                       Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 = t3.c3) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t3.c3 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 = t3.c3) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                             ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                   Filter: (t3.c3 = t1.c1)
+                                   ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                               ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(21 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(17 rows)
 
 select c1 from t1, t2 where c1 not in 
 	(select c3 from t3 where c3 = c1) and c1 = c2;
@@ -553,15 +549,14 @@ explain select c1 from t1 where c1 not in
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=8)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
-                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
-                                 Group Key: t2.c2
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: t2.c2
-                                       ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
-                                             Filter: ((c2 > 2) AND (c2 > 3))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.77.0
-(14 rows)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+                           Group Key: t2.c2
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                 Sort Key: t2.c2
+                                 ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                                       Filter: ((c2 > 2) AND (c2 > 3))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 select c1 from t1 where c1 not in 
 	(select sum(c2) as s from t2 where c2 > 2 group by c2 having c2 > 3);
@@ -652,39 +647,38 @@ select c1 from t1 where c1 not in
 explain select (case when c1%2 = 0 
  then (select sum(c2) from t2 where c2 not in (select c3 from t3)) 
  else (select sum(c3) from t3 where c3 not in (select c4 from t4)) end) as foo from t1;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..1809071284.19 rows=10 width=8)
-   ->  Result  (cost=0.00..1809071284.19 rows=4 width=8)
-         ->  Nested Loop Left Join  (cost=0.00..1809071284.19 rows=14 width=20)
+   ->  Nested Loop Left Join  (cost=0.00..1809071284.19 rows=14 width=20)
+         Join Filter: true
+         ->  Nested Loop Left Join  (cost=0.00..1765378.17 rows=7 width=12)
                Join Filter: true
-               ->  Nested Loop Left Join  (cost=0.00..1765378.17 rows=7 width=12)
-                     Join Filter: true
-                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
-                     ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
-                           ->  Broadcast Motion 1:3  (slice6)  (cost=0.00..862.00 rows=3 width=8)
-                                 ->  Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
-                                       ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-                                             ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
-                                                   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
-                                                         Hash Cond: (t2.c2 = t3_1.c3)
-                                                         ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
-                                                         ->  Hash  (cost=431.00..431.00 rows=3 width=4)
-                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-                                                                     ->  Seq Scan on t3 t3_1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
                ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
-                     ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..862.00 rows=3 width=8)
+                     ->  Broadcast Motion 1:3  (slice6)  (cost=0.00..862.00 rows=3 width=8)
                            ->  Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
-                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
                                        ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
                                              ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: (t3.c3 = t4.c4)
-                                                   ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
-                                                   ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                                               ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(30 rows)
+                                                   Hash Cond: (t2.c2 = t3_1.c3)
+                                                   ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                                                   ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                                               ->  Seq Scan on t3 t3_1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
+               ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..862.00 rows=3 width=8)
+                     ->  Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                 ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                                       ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
+                                             Hash Cond: (t3.c3 = t4.c4)
+                                             ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                                         ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(29 rows)
 
 select (case when c1%2 = 0 
  then (select sum(c2) from t2 where c2 not in (select c3 from t3)) 
@@ -707,25 +701,22 @@ select (case when c1%2 = 0
 --q27
 --
 explain select c1 from t1 where not c1 >= some (select c2 from t2);
-                                                                                                                                                             QUERY PLAN                                                                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                     QUERY PLAN                                                                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1324032.88 rows=2 width=4)
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
    SubPlan 1
      ->  Result  (cost=0.00..431.00 rows=1 width=1)
-           ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                 Filter: ((CASE WHEN ((sum((CASE WHEN (t1.c1 >= t2.c2) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (t1.c1 >= t2.c2) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
-                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                             ->  Result  (cost=0.00..431.00 rows=2 width=8)
-                                   ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
-                                         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
-                                               ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(16 rows)
+           Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 >= t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 >= t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                 ->  Result  (cost=0.00..431.00 rows=2 width=8)
+                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
+                                   ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 select c1 from t1 where not c1 >= some (select c2 from t2);
  c1 
@@ -762,25 +753,22 @@ select c2 from t2 where not c2 < all (select c2 from t2);
 --q29
 --
 explain select c3 from t3 where not c3 <> any (select c4 from t4);
-                                                                                                                                                             QUERY PLAN                                                                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                     QUERY PLAN                                                                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1324032.31 rows=1 width=4)
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
          ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
    SubPlan 1
      ->  Result  (cost=0.00..431.00 rows=1 width=1)
-           ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                 Filter: ((CASE WHEN ((sum((CASE WHEN (t3.c3 <> t4.c4) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (t4.c4 IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (t3.c3 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (t3.c3 <> t4.c4) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
-                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                               ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(16 rows)
+           Filter: ((CASE WHEN (sum((CASE WHEN (t3.c3 <> t4.c4) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t4.c4 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t3.c3 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t3.c3 <> t4.c4) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                   ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 select c3 from t3 where not c3 <> any (select c4 from t4);
  c3 
@@ -830,25 +818,22 @@ select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order 
 --q32
 --
 explain select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
-                                                                                                                                                                QUERY PLAN                                                                                                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                        QUERY PLAN                                                                                                                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.79 rows=4 width=4)
    ->  Seq Scan on t1  (cost=0.00..1324032.79 rows=2 width=4)
          Filter: (SubPlan 1)
          SubPlan 1
            ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       Filter: ((CASE WHEN ((sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
-                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                     ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
-                                                           Filter: c2 > (-1) AND c2 <= 1
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(16 rows)
+                 Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                       ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                             ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                         ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                                               Filter: ((c2 > '-1'::integer) AND (c2 <= 1))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
  c1 
@@ -887,29 +872,26 @@ select c1 from t1 where c1 <>all (select c2 from t2);
 --q34
 --
 explain select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
-                                                                                                                                                               QUERY PLAN                                                                                                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                       QUERY PLAN                                                                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1765379.01 rows=4 width=4)
    ->  Seq Scan on t1  (cost=0.00..1765379.01 rows=2 width=4)
          Filter: (SubPlan 1)
          SubPlan 1
            ->  Result  (cost=0.00..862.00 rows=1 width=1)
-                 ->  Result  (cost=0.00..862.00 rows=1 width=1)
-                       Filter: ((CASE WHEN ((sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
-                       ->  Result  (cost=0.00..862.00 rows=1 width=1)
-                             ->  Aggregate  (cost=0.00..862.00 rows=1 width=16)
-                                   ->  Result  (cost=0.00..862.00 rows=2 width=8)
-                                         ->  Materialize  (cost=0.00..862.00 rows=2 width=4)
-                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
-                                                     ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
-                                                           Hash Cond: (t2.c2 = t1n.c1n)
-                                                           ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
-                                                           ->  Hash  (cost=431.00..431.00 rows=7 width=4)
-                                                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                                                       ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(20 rows)
+                 Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                 ->  Aggregate  (cost=0.00..862.00 rows=1 width=16)
+                       ->  Result  (cost=0.00..862.00 rows=2 width=8)
+                             ->  Materialize  (cost=0.00..862.00 rows=2 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+                                         ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
+                                               Hash Cond: (t2.c2 = t1n.c1n)
+                                               ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                                               ->  Hash  (cost=431.00..431.00 rows=7 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                                           ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(17 rows)
 
 select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
  c1 
@@ -967,8 +949,8 @@ select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all (select
 --q36
 --
 explain select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select c3 from t3 where c3 = c1n));
-                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324464.89 rows=8 width=4)
    ->  Hash Semi Join  (cost=0.00..1324464.89 rows=3 width=4)
          Hash Cond: (t1.c1 = t1n.c1n)
@@ -978,19 +960,15 @@ explain select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all
                      Filter: (SubPlan 1)
                      SubPlan 1
                        ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                             ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                   Filter: ((CASE WHEN ((sum((CASE WHEN (t1n.c1n >= t3.c3) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (t3.c3 IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (t1n.c1n IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (t1n.c1n >= t3.c3) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
-                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                               ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                           Filter: (t3.c3 = t1n.c1n)
-                                                           ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
-                                                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-                                                                       ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(21 rows)
+                             Filter: ((CASE WHEN (sum((CASE WHEN (t1n.c1n >= t3.c3) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t3.c3 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1n.c1n IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1n.c1n >= t3.c3) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                         Filter: (t3.c3 = t1n.c1n)
+                                         ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(17 rows)
 
 select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select c3 from t3 where c3 = c1n));
  c1 
@@ -1207,23 +1185,22 @@ create or replace function abseq (absint, absint) returns bool as $$ select isze
 create operator = (PROCEDURE = abseq, leftarg=absint, rightarg=absint);
 explain select c1 from t1 where c1::absint not in
 	(select c1n::absint from t1n);
-                                                                                                                            QUERY PLAN                                                                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                QUERY PLAN                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324035.89 rows=10 width=4)
    ->  Result  (cost=0.00..1324035.89 rows=4 width=4)
          Filter: (NOT CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END)
          ->  HashAggregate  (cost=0.00..1324035.89 rows=4 width=20)
                Group Key: t1.c1, t1.ctid, t1.gp_segment_id
-               ->  Result  (cost=0.00..1324035.88 rows=11 width=19)
-                     ->  Nested Loop Left Join  (cost=0.00..1324035.88 rows=11 width=19)
-                           Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
-                           ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
-                           ->  Result  (cost=0.00..431.00 rows=7 width=5)
-                                 ->  Materialize  (cost=0.00..431.00 rows=7 width=4)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                             ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(14 rows)
+               ->  Nested Loop Left Join  (cost=0.00..1324035.88 rows=11 width=19)
+                     Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
+                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
+                     ->  Result  (cost=0.00..431.00 rows=7 width=5)
+                           ->  Materialize  (cost=0.00..431.00 rows=7 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                       ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 select c1 from t1 where c1::absint not in
 	(select c1n::absint from t1n);

--- a/src/test/regress/expected/olap_plans_optimizer.out
+++ b/src/test/regress/expected/olap_plans_optimizer.out
@@ -77,19 +77,18 @@ select a, b, c, sum(d) from olap_test group by a, b, c;
 explain select a, sum(d) from olap_test group by a;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.55 rows=2 width=12)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.55 rows=3 width=12)
    ->  Finalize GroupAggregate  (cost=0.00..431.55 rows=1 width=12)
          Group Key: a
          ->  Sort  (cost=0.00..431.55 rows=1 width=12)
                Sort Key: a
                ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.55 rows=1 width=12)
                      Hash Key: a
-                     ->  Result  (cost=0.00..431.55 rows=1 width=12)
-                           ->  Streaming Partial HashAggregate  (cost=0.00..431.55 rows=1 width=12)
-                                 Group Key: a
-                                 ->  Seq Scan on olap_test  (cost=0.00..431.08 rows=3334 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.79.1
-(12 rows)
+                     ->  Streaming Partial HashAggregate  (cost=0.00..431.55 rows=1 width=12)
+                           Group Key: a
+                           ->  Seq Scan on olap_test  (cost=0.00..431.08 rows=3334 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 select a, sum(d) from olap_test group by a;
  a |   sum    

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -1606,18 +1606,17 @@ explain select cn,
 sum(qty) over (order by ord,cn rows between 1 preceding and 1 following),
 sum(qty) over (order by ord,cn rows between 1 preceding and 1 following)
 from sale_ord;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Result  (cost=0.00..431.00 rows=6 width=24)
-   ->  WindowAgg  (cost=0.00..431.00 rows=6 width=24)
-         Order By: ord, cn
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=12 width=12)
-               Merge Key: ord, cn
-               ->  Sort  (cost=0.00..431.00 rows=6 width=12)
-                     Sort Key: ord, cn
-                     ->  Seq Scan on sale_ord  (cost=0.00..431.00 rows=6 width=12)
- Settings:  optimizer=on; optimizer_segments=3
-(9 rows)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..431.00 rows=4 width=20)
+   Order By: ord, cn
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=12 width=12)
+         Merge Key: ord, cn
+         ->  Sort  (cost=0.00..431.00 rows=4 width=12)
+               Sort Key: ord, cn
+               ->  Seq Scan on sale_ord  (cost=0.00..431.00 rows=4 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 select cn,
 sum(qty) over (order by ord,cn rows between 1 preceding and 1 following),
@@ -7882,24 +7881,22 @@ select count(*) over (partition by 1 order by cn rows between 1 preceding and 1 
 -- MPP-13710
 create table redundant_sort_check (i int, j int, k int) distributed by (i);
 explain select count(*) over (order by i), count(*) over (partition by i order by j) from redundant_sort_check;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..431.00 rows=1 width=16)
-   ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
-         Partition By: i
-         Order By: j
-         ->  Sort  (cost=0.00..431.00 rows=1 width=16)
-               Sort Key: i, j
-               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
-                     Order By: i
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                           Merge Key: i
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                 Sort Key: i
-                                 ->  Seq Scan on redundant_sort_check  (cost=0.00..431.00 rows=1 width=8)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.675
-(15 rows)
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..431.00 rows=1 width=16)
+   Partition By: i
+   Order By: j
+   ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+         Sort Key: i, j
+         ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
+               Order By: i
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     Merge Key: i
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: i
+                           ->  Seq Scan on redundant_sort_check  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- End of MPP-13710
 -- MPP-13879
@@ -8090,25 +8087,23 @@ select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, bar wher
 (3 rows)
 
 explain select foo.a, sum(b) over (partition by bar.a order by bar.b) from foo, bar where foo.a = bar.a;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=6 width=12)
-   ->  Result  (cost=0.00..862.00 rows=3 width=12)
-         ->  WindowAgg  (cost=0.00..862.00 rows=3 width=12)
-               Partition By: bar.a
-               Order By: bar.b
-               ->  Sort  (cost=0.00..862.00 rows=3 width=12)
-                     Sort Key: bar.a, bar.b
-                     ->  Hash Join  (cost=0.00..862.00 rows=3 width=12)
-                           Hash Cond: bar.a = foo.a
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=8)
-                                 Hash Key: bar.a
-                                 ->  Seq Scan on bar  (cost=0.00..431.00 rows=3 width=8)
-                           ->  Hash  (cost=431.00..431.00 rows=5 width=4)
-                                 ->  Seq Scan on foo  (cost=0.00..431.00 rows=5 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.622
-(16 rows)
+   ->  WindowAgg  (cost=0.00..862.00 rows=2 width=12)
+         Partition By: bar.a
+         Order By: bar.b
+         ->  Sort  (cost=0.00..862.00 rows=2 width=12)
+               Sort Key: bar.a, bar.b
+               ->  Hash Join  (cost=0.00..862.00 rows=2 width=12)
+                     Hash Cond: (bar.a = foo.a)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
+                           Hash Key: bar.a
+                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=2 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
 
 drop table foo, bar;
 -- Test to verify fix for https://github.com/greenplum-db/gpdb/issues/2571
@@ -8147,40 +8142,38 @@ EXPLAIN SELECT count(*) over (PARTITION BY a ORDER BY b, c, d) as count1,
        count(*) over (PARTITION BY a ORDER BY c, b) as count2,
        count(*) over (PARTITION BY a ORDER BY c, b, d) as count3
 FROM foo;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=10 width=48)
-   ->  Result  (cost=0.00..431.01 rows=4 width=48)
-         ->  WindowAgg  (cost=0.00..431.01 rows=4 width=48)
-               Partition By: a
-               Order By: c, b, d
-               ->  Sort  (cost=0.00..431.01 rows=4 width=56)
-                     Sort Key: a, c, b, d
-                     ->  WindowAgg  (cost=0.00..431.00 rows=4 width=56)
-                           Partition By: a
-                           Order By: c, b
-                           ->  Sort  (cost=0.00..431.00 rows=4 width=48)
-                                 Sort Key: a, c, b
-                                 ->  WindowAgg  (cost=0.00..431.00 rows=4 width=48)
-                                       Partition By: a
-                                       Order By: c
-                                       ->  Sort  (cost=0.00..431.00 rows=4 width=40)
-                                             Sort Key: a, c
-                                             ->  WindowAgg  (cost=0.00..431.00 rows=4 width=40)
+   ->  WindowAgg  (cost=0.00..431.01 rows=4 width=48)
+         Partition By: a
+         Order By: c, b, d
+         ->  Sort  (cost=0.00..431.01 rows=4 width=56)
+               Sort Key: a, c, b, d
+               ->  WindowAgg  (cost=0.00..431.00 rows=4 width=56)
+                     Partition By: a
+                     Order By: c, b
+                     ->  Sort  (cost=0.00..431.00 rows=4 width=48)
+                           Sort Key: a, c, b
+                           ->  WindowAgg  (cost=0.00..431.00 rows=4 width=48)
+                                 Partition By: a
+                                 Order By: c
+                                 ->  Sort  (cost=0.00..431.00 rows=4 width=40)
+                                       Sort Key: a, c
+                                       ->  WindowAgg  (cost=0.00..431.00 rows=4 width=40)
+                                             Partition By: a
+                                             Order By: b
+                                             ->  WindowAgg  (cost=0.00..431.00 rows=4 width=32)
                                                    Partition By: a
-                                                   Order By: b
-                                                   ->  WindowAgg  (cost=0.00..431.00 rows=4 width=32)
+                                                   Order By: b, c
+                                                   ->  WindowAgg  (cost=0.00..431.00 rows=4 width=24)
                                                          Partition By: a
-                                                         Order By: b, c
-                                                         ->  WindowAgg  (cost=0.00..431.00 rows=4 width=24)
-                                                               Partition By: a
-                                                               Order By: b, c, d
-                                                               ->  Sort  (cost=0.00..431.00 rows=4 width=16)
-                                                                     Sort Key: a, b, c, d
-                                                                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=16)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.45.0
-(31 rows)
+                                                         Order By: b, c, d
+                                                         ->  Sort  (cost=0.00..431.00 rows=4 width=16)
+                                                               Sort Key: a, b, c, d
+                                                               ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=16)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(29 rows)
 
 drop table foo;
 -- test predicate push down in subqueries for quals containing windowref nodes
@@ -8199,23 +8192,21 @@ insert into window_preds values(6,7,8);
 -- end_ignore
 -- for planner qual k = 1 should not be pushed down in the subquery as it has window refs at top level of subquery. orca is able to push down the predicate to appropriate node
 explain select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Append  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..431.00 rows=1 width=8)
-         Filter: ((row_number() OVER (?)) + 2) = 3
-         ->  Result  (cost=0.00..431.00 rows=1 width=8)
-               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-                           ->  Seq Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+         Filter: (((row_number() OVER (?) + 2)) = 3)
+         ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Seq Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
    ->  Result  (cost=0.00..431.00 rows=1 width=8)
-         Filter: ((row_number() OVER (?)) + 2) = 3
-         ->  Result  (cost=0.00..431.00 rows=1 width=8)
-               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-                           ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(14 rows)
+         Filter: (((row_number() OVER (?) + 2)) = 3)
+         ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(12 rows)
 
 select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
  k 
@@ -8225,27 +8216,25 @@ select k from ( select row_number() over()+2 as k from window_preds union all se
 (2 rows)
 
 explain insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
  Insert  (cost=0.00..862.04 rows=1 width=4)
    ->  Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..862.00 rows=2 width=16)
-         Hash Key: (((row_number() OVER (?)) + 2)::integer)
+         Hash Key: (int4(((row_number() OVER (?) + 2))))
          ->  Result  (cost=0.00..862.00 rows=1 width=16)
                ->  Append  (cost=0.00..862.00 rows=1 width=8)
                      ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                           Filter: ((row_number() OVER (?)) + 2) = 3
-                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-                                             ->  Seq Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
+                           Filter: (((row_number() OVER (?) + 2)) = 3)
+                           ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                       ->  Seq Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
                      ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                           Filter: ((row_number() OVER (?)) + 2) = 3
-                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-                                             ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(18 rows)
+                           Filter: (((row_number() OVER (?) + 2)) = 3)
+                           ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                       ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
 
 insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
 explain SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
@@ -8310,21 +8299,20 @@ explain with CTE as (select i, row_number() over (partition by j) j from window_
 insert into window_preds with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where j = 1;
 -- qual k = 1 should be pushed down
 explain select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Append  (cost=0.00..862.00 rows=1 width=8)
    ->  Result  (cost=0.00..431.00 rows=1 width=8)
-         Filter: (row_number() OVER (?)) = 1
+         Filter: ((row_number() OVER (?)) = 1)
          ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
                ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                      ->  Seq Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
          ->  Result  (cost=0.00..431.00 rows=1 width=8)
-               Filter: "outer".k = 1
-               ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(12 rows)
+               Filter: (('1'::bigint) = 1)
+               ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
  k 
@@ -8355,52 +8343,49 @@ select k from ( select k from (select row_number() over() as k from window_preds
 (23 rows)
 
 explain insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
  Insert  (cost=0.00..862.04 rows=1 width=4)
    ->  Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..862.00 rows=2 width=16)
-         Hash Key: ((row_number() OVER (?))::integer)
+         Hash Key: (int4((row_number() OVER (?))))
          ->  Result  (cost=0.00..862.00 rows=1 width=16)
                ->  Append  (cost=0.00..862.00 rows=1 width=8)
                      ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                           Filter: (row_number() OVER (?)) = 1
+                           Filter: ((row_number() OVER (?)) = 1)
                            ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
                                  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                        ->  Seq Scan on window_preds  (cost=0.00..431.00 rows=1 width=1)
                      ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                            ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                 Filter: "outer".k = 1
-                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(16 rows)
+                                 Filter: (('1'::bigint) = 1)
+                                 ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
 explain with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where i = 1;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=12)
    ->  Result  (cost=0.00..862.00 rows=1 width=12)
-         Filter: window_preds.i = 1
+         Filter: (window_preds.i = 1)
          ->  Append  (cost=0.00..862.00 rows=1 width=12)
-               ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                     ->  WindowAgg  (cost=0.00..431.00 rows=1 width=12)
-                           Partition By: window_preds.j
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                 Sort Key: window_preds.j
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                       Hash Key: window_preds.j
-                                       ->  Seq Scan on window_preds  (cost=0.00..431.00 rows=1 width=8)
-               ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                     ->  WindowAgg  (cost=0.00..431.00 rows=1 width=12)
-                           Partition By: window_preds_1.j
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                 Sort Key: window_preds_1.j
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                       Hash Key: window_preds_1.j
-                                       ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(21 rows)
+               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=12)
+                     Partition By: window_preds.j
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: window_preds.j
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 Hash Key: window_preds.j
+                                 ->  Seq Scan on window_preds  (cost=0.00..431.00 rows=1 width=8)
+               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=12)
+                     Partition By: window_preds_1.j
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: window_preds_1.j
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 Hash Key: window_preds_1.j
+                                 ->  Seq Scan on window_preds window_preds_1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(19 rows)
 
 insert into window_preds with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where i = 1;
 --

--- a/src/test/regress/expected/pg_lsn_optimizer.out
+++ b/src/test/regress/expected/pg_lsn_optimizer.out
@@ -78,20 +78,19 @@ SELECT DISTINCT (i || '/' || j)::pg_lsn f
    Sort Key: (((((generate_series_1.generate_series)::text || '/'::text) || (generate_series_2.generate_series)::text))::pg_lsn)
    ->  HashAggregate
          Group Key: ((((generate_series_1.generate_series)::text || '/'::text) || (generate_series_2.generate_series)::text))::pg_lsn
-         ->  Result
+         ->  Nested Loop
+               Join Filter: true
                ->  Nested Loop
                      Join Filter: true
-                     ->  Nested Loop
-                           Join Filter: true
-                           ->  Result
-                                 Filter: ((generate_series_2.generate_series > 0) AND (generate_series_2.generate_series <= 10))
-                                 ->  Function Scan on generate_series generate_series_2
-                           ->  Result
-                                 Filter: (generate_series_1.generate_series <= 10)
-                                 ->  Function Scan on generate_series generate_series_1
-                     ->  Function Scan on generate_series
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(17 rows)
+                     ->  Result
+                           Filter: ((generate_series_2.generate_series > 0) AND (generate_series_2.generate_series <= 10))
+                           ->  Function Scan on generate_series generate_series_2
+                     ->  Result
+                           Filter: (generate_series_1.generate_series <= 10)
+                           ->  Function Scan on generate_series generate_series_1
+               ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
 
 SELECT DISTINCT (i || '/' || j)::pg_lsn f
   FROM generate_series(1, 10) i,

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -5568,16 +5568,13 @@ select i, a from
 
 explain (verbose, costs off)
 select consumes_rw_array(a), a from returns_rw_array(1) a;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Result
-   Output: consumes_rw_array(('{1,1}'::integer[])), ('{1,1}'::integer[])
-   ->  Result
-         Output: '{1,1}'::integer[]
-         ->  Result
-               Output: true
- Optimizer: Pivotal Optimizer (GPORCA) version 3.77.0
-(7 rows)
+   Output: consumes_rw_array('{1,1}'::integer[]), '{1,1}'::integer[]
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Settings: optimizer=on
+(4 rows)
 
 select consumes_rw_array(a), a from returns_rw_array(1) a;
  consumes_rw_array |   a   
@@ -5590,12 +5587,11 @@ select consumes_rw_array(a), a from
   (values (returns_rw_array(1)), (returns_rw_array(2))) v(a);
                       QUERY PLAN                      
 ------------------------------------------------------
- Result
+ Values Scan on "Values"
    Output: consumes_rw_array(column1), column1
-   ->  Values Scan on "Values"
-         Output: column1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.77.0
-(5 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Settings: optimizer=on
+(4 rows)
 
 select consumes_rw_array(a), a from
   (values (returns_rw_array(1)), (returns_rw_array(2))) v(a);

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -197,8 +197,8 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
 -- Test for ALL_SUBLINK pull-up based on both left-hand and right-hand input
 explain (costs off)
 select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    ->  Nested Loop
          Join Filter: true
@@ -212,19 +212,18 @@ select * from A,B where exists (select * from C where B.i not in (select C.i fro
                        ->  Nested Loop
                              Join Filter: true
                              ->  Result
-                                   Filter: ((CASE WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (c_1.i IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (b.i IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
-                                   ->  Result
-                                         ->  Aggregate
-                                               ->  Result
-                                                     ->  Materialize
-                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                                                 ->  Seq Scan on c c_1
-                                                                       Filter: (i <> 10)
+                                   Filter: ((CASE WHEN (sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (c_1.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (b.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                   ->  Aggregate
+                                         ->  Result
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                           ->  Seq Scan on c c_1
+                                                                 Filter: (i <> 10)
                              ->  Materialize
                                    ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                          ->  Seq Scan on c
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
-(26 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(24 rows)
 
 select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
  i  | j  | i  | j 
@@ -387,8 +386,8 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i i
 
 -- MPP-14222
 explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..1422599917800628.75 rows=4 width=12)
    ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1422599917800628.75 rows=270 width=12)
          Merge Key: a.i, b.i, c.j
@@ -399,36 +398,31 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                      ->  Nested Loop  (cost=0.00..1389257731365.17 rows=10 width=8)
                            Join Filter: true
                            ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1356696141.29 rows=5 width=4)
-                                 ->  Result  (cost=0.00..1356696141.29 rows=2 width=4)
-                                       ->  Seq Scan on a  (cost=0.00..1356696141.29 rows=2 width=4)
-                                             Filter: j = ((SubPlan 2))
-                                             SubPlan 2
-                                               ->  Result  (cost=0.00..1324036.57 rows=1 width=4)
-                                                     Filter: c_1.j = a.j
-                                                     ->  Materialize  (cost=0.00..1324036.57 rows=9 width=4)
-                                                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.57 rows=9 width=4)
-                                                                 ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                       ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                             Filter: (SubPlan 1)
-                                                                             SubPlan 1
-                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                           Filter: (CASE WHEN (sum((CASE WHEN c_1.i = b_1.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN b_1.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN c_1.i IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN c_1.i = b_1.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
-                                                                                           ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                                                                                             ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                                                                                   Filter: c_1.i = b_1.i
-                                                                                                                   ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                               ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
-                                                                                                                                     Filter: i <> 10
+                                 ->  Seq Scan on a  (cost=0.00..1356696141.29 rows=2 width=4)
+                                       Filter: (j = (SubPlan 2))
+                                       SubPlan 2
+                                         ->  Result  (cost=0.00..1324036.57 rows=1 width=4)
+                                               Filter: (c_1.j = a.j)
+                                               ->  Materialize  (cost=0.00..1324036.57 rows=9 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.57 rows=9 width=4)
+                                                           ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                 Filter: (SubPlan 1)
+                                                                 SubPlan 1
+                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                         Filter: ((CASE WHEN (sum((CASE WHEN (c_1.i = b_1.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (b_1.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (c_1.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (c_1.i = b_1.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                     Filter: (c_1.i = b_1.i)
+                                                                                     ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                 ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                       Filter: (i <> 10)
                            ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
                      ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(39 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(34 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
@@ -446,8 +440,8 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 (10 rows)
 
 explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
-                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..1422599917782452.00 rows=4 width=4)
    ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1422599917782452.00 rows=270 width=4)
          Merge Key: a.j
@@ -458,36 +452,32 @@ explain select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j a
                      ->  Nested Loop  (cost=0.00..1389257731347.42 rows=10 width=4)
                            Join Filter: true
                            ->  Seq Scan on a  (cost=0.00..1356696141.27 rows=2 width=4)
-                                 Filter: j = ((SubPlan 2))
+                                 Filter: (j = (SubPlan 2))
                                  SubPlan 2
                                    ->  Result  (cost=0.00..1324036.57 rows=1 width=4)
-                                         Filter: c_1.j = a.j
+                                         Filter: (c_1.j = a.j)
                                          ->  Materialize  (cost=0.00..1324036.57 rows=9 width=4)
                                                ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1324036.57 rows=9 width=4)
-                                                     ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
-                                                           ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                 Filter: (SubPlan 1)
-                                                                 SubPlan 1
-                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                         ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                               Filter: (CASE WHEN (sum((CASE WHEN c_1.i = b_1.i THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN b_1.i IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN c_1.i IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN c_1.i = b_1.i THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
-                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                                                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                                                                       Filter: c_1.i = b_1.i
-                                                                                                       ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                   ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
-                                                                                                                         Filter: i <> 10
+                                                     ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
+                                                           Filter: (SubPlan 1)
+                                                           SubPlan 1
+                                                             ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                   Filter: ((CASE WHEN (sum((CASE WHEN (c_1.i = b_1.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (b_1.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (c_1.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (c_1.i = b_1.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                         ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                               Filter: (c_1.i = b_1.i)
+                                                                               ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                           ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                 Filter: (i <> 10)
                            ->  Materialize  (cost=0.00..431.00 rows=6 width=1)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=1)
                                        ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=1)
                      ->  Materialize  (cost=0.00..431.00 rows=9 width=1)
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=1)
                                  ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(39 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(35 rows)
 
 select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i not in (select B.i from B where C.i = B.i and B.i !=10)) order by A.j limit 10;
  j  
@@ -505,25 +495,24 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
 (10 rows)
 
 explain select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1765379.74 rows=5 width=4)
-   ->  Result  (cost=0.00..1765379.74 rows=2 width=4)
-         ->  Seq Scan on a  (cost=0.00..1765379.74 rows=2 width=4)
-               Filter: (j = (SubPlan 1))
-               SubPlan 1
-                 ->  Result  (cost=0.00..862.00 rows=1 width=4)
-                       Filter: (c.j = a.j)
-                       ->  Materialize  (cost=0.00..862.00 rows=6 width=4)
-                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=6 width=4)
-                                   ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
-                                         Hash Cond: ((c.i = b.i) AND (c.i = b.i))
-                                         ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=8)
-                                         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-                                               ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
-                                                     Filter: (i <> 10)
- Optimizer: PQO version 3.27.0
-(16 rows)
+   ->  Seq Scan on a  (cost=0.00..1765379.74 rows=2 width=4)
+         Filter: (j = (SubPlan 1))
+         SubPlan 1
+           ->  Result  (cost=0.00..862.00 rows=1 width=4)
+                 Filter: (c.j = a.j)
+                 ->  Materialize  (cost=0.00..862.00 rows=6 width=4)
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=6 width=4)
+                             ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
+                                   Hash Cond: ((c.i = b.i) AND (c.i = b.i))
+                                   ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=8)
+                                   ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                                         ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                               Filter: (i <> 10)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 select A.i from A where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10));
  i  
@@ -625,8 +614,8 @@ select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = a
 (4 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..1852039581913.64 rows=4 width=12)
    ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1852039581913.64 rows=10 width=12)
          Merge Key: a.i, b.i, c.j
@@ -638,26 +627,25 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C
                            ->  Nested Loop  (cost=0.00..1808631542.21 rows=10 width=8)
                                  Join Filter: true
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1765379.74 rows=5 width=4)
-                                       ->  Result  (cost=0.00..1765379.74 rows=2 width=4)
-                                             ->  Seq Scan on a  (cost=0.00..1765379.74 rows=2 width=4)
-                                                   Filter: j = ((SubPlan 1))
-                                                   SubPlan 1
-                                                     ->  Result  (cost=0.00..862.00 rows=1 width=4)
-                                                           Filter: c_1.j = a.j
-                                                           ->  Materialize  (cost=0.00..862.00 rows=6 width=4)
-                                                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=6 width=4)
-                                                                       ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
-                                                                             Hash Cond: c_1.i = b_1.i AND c_1.i = b_1.i
-                                                                             ->  Seq Scan on c c_1  (cost=0.00..431.00 rows=3 width=8)
-                                                                             ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-                                                                                   ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
-                                                                                         Filter: i <> 10
+                                       ->  Seq Scan on a  (cost=0.00..1765379.74 rows=2 width=4)
+                                             Filter: (j = (SubPlan 1))
+                                             SubPlan 1
+                                               ->  Result  (cost=0.00..862.00 rows=1 width=4)
+                                                     Filter: (c_1.j = a.j)
+                                                     ->  Materialize  (cost=0.00..862.00 rows=6 width=4)
+                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=6 width=4)
+                                                                 ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
+                                                                       Hash Cond: ((c_1.i = b_1.i) AND (c_1.i = b_1.i))
+                                                                       ->  Seq Scan on c c_1  (cost=0.00..431.00 rows=3 width=8)
+                                                                       ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                                                                             ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
+                                                                                   Filter: (i <> 10)
                                  ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(30 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(29 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i  | i  |  j  
@@ -823,8 +811,8 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
 (4 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..1389709665858.46 rows=4 width=12)
    ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1389709665858.46 rows=10 width=12)
          Merge Key: a.i, b.i, c.j
@@ -844,22 +832,18 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                                                          Sort Key: c_1.j
                                                          ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.57 rows=3 width=4)
                                                                Hash Key: c_1.j
-                                                               ->  Result  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                     ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
-                                                                           Filter: (SubPlan 1)
-                                                                           SubPlan 1
-                                                                             ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                         Filter: ((CASE WHEN ((sum((CASE WHEN (c_1.i <> b_1.i) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (b_1.i IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (c_1.i IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (c_1.i <> b_1.i) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
-                                                                                         ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                                                                                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                                                                                 Filter: (c_1.i = b_1.i)
-                                                                                                                 ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                             ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
-                                                                                                                                   Filter: (i <> 10)
+                                                               ->  Seq Scan on c c_1  (cost=0.00..1324036.57 rows=3 width=4)
+                                                                     Filter: (SubPlan 1)
+                                                                     SubPlan 1
+                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                             Filter: ((CASE WHEN (sum((CASE WHEN (c_1.i <> b_1.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (b_1.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (c_1.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (c_1.i <> b_1.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                         Filter: (c_1.i = b_1.i)
+                                                                                         ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                     ->  Seq Scan on b b_1  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                           Filter: (i <> 10)
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=8)
                                                    ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
                                                          Hash Key: a.j
@@ -868,8 +852,8 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(44 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(40 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
@@ -931,8 +915,8 @@ select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not 
 (0 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..926470287116.12 rows=4 width=12)
    ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..926470287116.12 rows=10 width=12)
          Merge Key: a.i, b.i, c.j
@@ -944,24 +928,20 @@ explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C whe
                            ->  Nested Loop  (cost=0.00..904755277.76 rows=2 width=8)
                                  Join Filter: true
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..882688.08 rows=1 width=4)
-                                       ->  Result  (cost=0.00..882688.08 rows=1 width=4)
-                                             ->  Seq Scan on a  (cost=0.00..882688.08 rows=1 width=4)
-                                                   Filter: (SubPlan 1)
-                                                   SubPlan 1
-                                                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
-                                                           ->  Result  (cost=0.00..0.00 rows=1 width=1)
-                                                                 Filter: (CASE WHEN (sum((CASE WHEN $0 <> "outer".j THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN "outer".j IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 <> "outer".j THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
-                                                                 ->  Result  (cost=0.00..0.00 rows=0 width=1)
-                                                                       ->  Aggregate  (cost=0.00..0.00 rows=0 width=16)
-                                                                             ->  Result  (cost=0.00..0.00 rows=0 width=8)
-                                                                                   ->  Result  (cost=0.00..0.00 rows=0 width=4)
-                                                                                         One-Time Filter: false
+                                       ->  Seq Scan on a  (cost=0.00..882688.08 rows=1 width=4)
+                                             Filter: (SubPlan 1)
+                                             SubPlan 1
+                                               ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                     Filter: ((CASE WHEN (sum((CASE WHEN (a.j <> NULL::integer) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (NULL::integer IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (a.j IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (a.j <> NULL::integer) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                                     ->  Aggregate  (cost=0.00..0.00 rows=0 width=16)
+                                                           ->  Result  (cost=0.00..0.00 rows=0 width=4)
+                                                                 One-Time Filter: false
                                  ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.13
-(28 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(24 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
@@ -1378,8 +1358,8 @@ select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offs
 (9 rows)
 
 explain select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324036.36 rows=9 width=4)
    Merge Key: c.j
    ->  Result  (cost=0.00..1324036.36 rows=3 width=4)
@@ -1388,18 +1368,17 @@ explain select C.j from C where not exists (select rank() over (order by B.i) fr
                ->  Seq Scan on c  (cost=0.00..1324036.36 rows=3 width=4)
                      Filter: (SubPlan 1)
                      SubPlan 1
-                       ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                             ->  WindowAgg  (cost=0.00..431.00 rows=1 width=4)
-                                   Order By: b.i
-                                   ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                         Sort Key: b.i
-                                         ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                               Filter: $0 = b.i
-                                               ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                           ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.44.0
-(19 rows)
+                       ->  WindowAgg  (cost=0.00..431.00 rows=1 width=4)
+                             Order By: b.i
+                             ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                   Sort Key: b.i
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                         Filter: (c.i = b.i)
+                                         ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                     ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(18 rows)
 
 select C.j from C where not exists (select rank() over (order by B.i) from B  where C.i = B.i) order by C.j;
  j  
@@ -3642,50 +3621,47 @@ INSERT INTO qp_tab1 VALUES (1,2);
 INSERT INTO qp_tab2 VALUES (3,4);
 INSERT INTO qp_tab3 VALUES (4,5);
 EXPLAIN SELECT a FROM qp_tab1 f1 LEFT JOIN qp_tab2 on a=c WHERE NOT EXISTS(SELECT 1 FROM qp_tab1 f2 WHERE f1.a = f2.a);
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Hash Left Join  (cost=0.00..1293.00 rows=1 width=4)
-         Hash Cond: qp_tab1.a = qp_tab2.c
+         Hash Cond: (qp_tab1.a = qp_tab2.c)
          ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=4)
-               Hash Cond: qp_tab1.a = qp_tab1_1.a
+               Hash Cond: (qp_tab1.a = qp_tab1_1.a)
                ->  Seq Scan on qp_tab1  (cost=0.00..431.00 rows=1 width=4)
                ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on qp_tab1 qp_tab1_1  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Seq Scan on qp_tab1 qp_tab1_1  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on qp_tab2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(12 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1765377.02 rows=1 width=4)
    ->  GroupAggregate  (cost=0.00..1765377.02 rows=1 width=4)
          Group Key: qp_tab1.a
          ->  Sort  (cost=0.00..1765377.02 rows=1 width=4)
                Sort Key: qp_tab1.a
                ->  Result  (cost=0.00..1765377.02 rows=1 width=4)
-                     Filter: NOT "outer".bool
+                     Filter: (NOT (true))
                      ->  Nested Loop Left Join  (cost=0.00..1765377.02 rows=1 width=5)
                            Join Filter: true
                            ->  Seq Scan on qp_tab1  (cost=0.00..431.00 rows=1 width=4)
                            ->  Assert  (cost=0.00..862.00 rows=1 width=1)
-                                 Assert Cond: (row_number() OVER (?)) = 1
+                                 Assert Cond: ((row_number() OVER (?)) = 1)
                                  ->  Materialize  (cost=0.00..862.00 rows=1 width=9)
                                        ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..862.00 rows=3 width=9)
-                                             ->  Result  (cost=0.00..862.00 rows=1 width=9)
-                                                   ->  WindowAgg  (cost=0.00..862.00 rows=1 width=9)
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=1)
-                                                               ->  Result  (cost=0.00..862.00 rows=1 width=1)
-                                                                     ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
-                                                                           Hash Cond: qp_tab2.c = qp_tab3.e
-                                                                           ->  Seq Scan on qp_tab2  (cost=0.00..431.00 rows=1 width=4)
-                                                                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                                                                 ->  Seq Scan on qp_tab3  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.12
-(24 rows)
+                                             ->  WindowAgg  (cost=0.00..862.00 rows=1 width=9)
+                                                   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=1)
+                                                         ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
+                                                               Hash Cond: (qp_tab2.c = qp_tab3.e)
+                                                               ->  Seq Scan on qp_tab2  (cost=0.00..431.00 rows=1 width=4)
+                                                               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                                                     ->  Seq Scan on qp_tab3  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(22 rows)
 
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
  a 
@@ -3827,13 +3803,12 @@ explain select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882708.48 rows=3 width=12)
-   ->  Result  (cost=0.00..882708.48 rows=1 width=12)
-         ->  Seq Scan on t1  (cost=0.00..882708.48 rows=334 width=12)
+   ->  Seq Scan on t1  (cost=0.00..882708.48 rows=334 width=12)
          SubPlan 1
            ->  Aggregate  (cost=0.00..0.00 rows=1 width=8)
                  ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=1)
- Optimizer: PQO version 3.27.0
-(7 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 select x1.a, (select count(*) from generate_series(1, x1.a)) from t1 x1;
  a | count 
@@ -3848,16 +3823,15 @@ explain select t1.a, (select count(*) c from (select city from supplier limit t1
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324051.59 rows=3 width=12)
-   ->  Result  (cost=0.00..1324051.59 rows=1 width=12)
-         ->  Seq Scan on t1  (cost=0.00..1324051.59 rows=334 width=12)
+   ->  Seq Scan on t1  (cost=0.00..1324051.59 rows=334 width=12)
          SubPlan 1
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Limit  (cost=0.00..431.00 rows=5 width=1)
                        ->  Materialize  (cost=0.00..431.00 rows=5 width=1)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=1)
                                    ->  Seq Scan on supplier  (cost=0.00..431.00 rows=2 width=1)
- Optimizer: PQO version 3.27.0
-(10 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 select t1.a, (select count(*) c from (select city from supplier limit t1.a) x) from t1;
  a | c 
@@ -3872,8 +3846,7 @@ explain select t1.*, (select count(*) as ct from generate_series(1, a), t1) from
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1808684647.64 rows=3 width=16)
-   ->  Result  (cost=0.00..1808684647.64 rows=1 width=16)
-         ->  Seq Scan on t1  (cost=0.00..1808684647.64 rows=334 width=16)
+   ->  Seq Scan on t1  (cost=0.00..1808684647.64 rows=334 width=16)
          SubPlan 1
            ->  Aggregate  (cost=0.00..1765431.58 rows=1 width=8)
                  ->  Nested Loop  (cost=0.00..1765431.58 rows=1000 width=1)
@@ -3882,8 +3855,8 @@ explain select t1.*, (select count(*) as ct from generate_series(1, a), t1) from
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=1)
                                    ->  Seq Scan on t1 t1_1  (cost=0.00..431.00 rows=1 width=1)
                        ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=1)
- Optimizer: PQO version 3.27.0
-(12 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 select t1.*, (select count(*) as ct from generate_series(1, a), t1) from t1;
  a | b | ct 

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -1189,19 +1189,17 @@ insert into qp_misc_jiras.tbl5246_sale values
   ( 4, 40, 700, '1401-6-1', 1, 1),
   ( 4, 40, 800, '1401-6-1', 1, 1);
 explain select cn, count(*) over (order by dt range between '2 day'::interval preceding and 2 preceding) from qp_misc_jiras.tbl5246_sale;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Result  (cost=0.00..431.00 rows=4 width=12)
-   ->  WindowAgg  (cost=0.00..431.00 rows=4 width=12)
-         Order By: dt
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=12 width=8)
-               Merge Key: dt
-               ->  Sort  (cost=0.00..431.00 rows=4 width=8)
-                     Sort Key: dt
-                     ->  Seq Scan on tbl5246_sale  (cost=0.00..431.00 rows=4 width=8)
- Settings:  enable_nestloop=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.50.1
-(10 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..431.00 rows=4 width=12)
+   Order By: dt
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=12 width=8)
+         Merge Key: dt
+         ->  Sort  (cost=0.00..431.00 rows=4 width=8)
+               Sort Key: dt
+               ->  Seq Scan on tbl5246_sale  (cost=0.00..431.00 rows=4 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 drop table qp_misc_jiras.tbl5246_sale;
 create table qp_misc_jiras.tbl4896_customer
@@ -4381,85 +4379,81 @@ reset gp_enable_agg_distinct;
 reset gp_enable_agg_distinct_pruning;
 -- both queries should use hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Result  (cost=0.00..862.00 rows=1 width=8)
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(15 rows)
-
-explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Result  (cost=0.00..862.00 rows=1 width=8)
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+         Group Key: tbl5994_test.j
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                        ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (14 rows)
+
+explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+         Group Key: tbl5994_test.j
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- Try same two queries, with group agg.
 set enable_groupagg=on;
 set enable_hashagg=off;
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Result  (cost=0.00..862.00 rows=1 width=8)
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(15 rows)
-
-explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Result  (cost=0.00..862.00 rows=1 width=8)
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+         Group Key: tbl5994_test.j
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                        ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (14 rows)
+
+explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+         Group Key: tbl5994_test.j
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 reset enable_groupagg;
 reset enable_hashagg;
@@ -4623,23 +4617,20 @@ from (
 	group by 1,2
      ) as t1 
 group by 1, 2;
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.28 rows=1 width=12)
    ->  GroupAggregate  (cost=0.00..1324032.28 rows=1 width=12)
-         Group By: bar_6325_attr, foo_6325.foo_6325_attr
+         Group Key: ((bar_6325.bar_6325_attr)::integer), foo_6325.foo_6325_attr
          ->  Sort  (cost=0.00..1324032.28 rows=1 width=12)
-               Sort Key: bar_6325_attr, foo_6325.foo_6325_attr
-               ->  Result  (cost=0.00..1324032.28 rows=1 width=12)
-                     ->  Result  (cost=0.00..1324032.28 rows=1 width=12)
-                           ->  Nested Loop  (cost=0.00..1324032.28 rows=1 width=16)
-                                 Join Filter: true
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Seq Scan on bar_6325  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Seq Scan on foo_6325  (cost=0.00..431.00 rows=1 width=8)
- Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
-(14 rows)
+               Sort Key: ((bar_6325.bar_6325_attr)::integer), foo_6325.foo_6325_attr
+               ->  Nested Loop  (cost=0.00..1324032.28 rows=1 width=16)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Seq Scan on bar_6325  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on foo_6325  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 -- start_ignore
 drop table qp_misc_jiras.foo_6325;
@@ -4891,20 +4882,18 @@ then 'MO' else 'foo' end
 case when ir_call_type_group_code in ('H', 'VH', 'PCB') then 'Thailland'
 else 'Unidentify' end
 ;
-                                                                                                                                     QUERY PLAN                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-   ->  Result  (cost=0.00..431.00 rows=1 width=8)
-         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
-               Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-               ->  Sort  (cost=0.00..431.00 rows=1 width=16)
-                     Sort Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-                           Hash Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=16)
-                                 ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(11 rows)
+   ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+         Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
+         ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+               Sort Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                     Hash Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
+                     ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
 reset gp_motion_cost_per_row;
@@ -5838,38 +5827,34 @@ set optimizer_metadata_caching to off;
 insert into tbl_z select i from generate_series(1,100) i;
 -- plan with no relsize collection
 explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Result  (cost=0.00..882688.07 rows=1 width=4)
-   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=0.00..882688.07 rows=1 width=1)
-         Join Filter: true
-         ->  Result  (cost=0.00..0.00 rows=1 width=1)
-         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-                     ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=1)
-                           Filter: 1 > x
- Optimizer: Pivotal Optimizer (GPORCA) version 2.65.1
-(9 rows)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Nested Loop Left Anti Semi (Not-In) Join  (cost=0.00..882688.07 rows=1 width=1)
+   Join Filter: true
+   ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=1)
+                     Filter: (1 > x)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 set gp_enable_relsize_collection = on;
 -- plan with relsize collection
 explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
-                                                                                                                                                                              QUERY PLAN                                                                                                                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..882700.51 rows=1 width=4)
-   ->  Nested Loop  (cost=0.00..882700.51 rows=1 width=1)
-         Join Filter: true
-         ->  Result  (cost=0.00..431.01 rows=1 width=1)
-               Filter: (CASE WHEN (pg_catalog.sum((sum((CASE WHEN 1 > x THEN 1 ELSE 0 END))))) IS NULL THEN true WHEN (pg_catalog.sum((sum((CASE WHEN x IS NULL THEN 1 ELSE 0 END))))) > 0::bigint THEN NULL::boolean WHEN 1 IS NULL THEN NULL::boolean WHEN (pg_catalog.sum((sum((CASE WHEN 1 > x THEN 1 ELSE 0 END))))) = 0::bigint THEN true ELSE false END) = true
-               ->  Result  (cost=0.00..431.01 rows=1 width=1)
-                     ->  Finalize Aggregate  (cost=0.00..431.01 rows=1 width=16)
-                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=1 width=16)
-                                 ->  Partial Aggregate  (cost=0.00..431.01 rows=1 width=16)
-                                       ->  Result  (cost=0.00..431.01 rows=321 width=8)
-                                             ->  Seq Scan on tbl_z  (cost=0.00..431.01 rows=321 width=4)
-         ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.65.1
-(13 rows)
+                                                                                                                                                       QUERY PLAN                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=0.00..882700.51 rows=1 width=1)
+   Join Filter: true
+   ->  Result  (cost=0.00..431.01 rows=1 width=1)
+         Filter: ((CASE WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+         ->  Finalize Aggregate  (cost=0.00..431.01 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=1 width=16)
+                     ->  Partial Aggregate  (cost=0.00..431.01 rows=1 width=16)
+                           ->  Seq Scan on tbl_z  (cost=0.00..431.01 rows=321 width=4)
+   ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(10 rows)
 
 drop table if exists tbl_z;
 reset optimizer_metadata_caching;

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -17,17 +17,14 @@ DETAIL:  Feature not supported: INSERT with constraints
 
 set optimizer_enable_dml_constraints=on;
 explain insert into constr_tab values (1,2,3);
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Insert  (cost=0.00..0.03 rows=1 width=12)
    ->  Result  (cost=0.00..0.00 rows=1 width=20)
          ->  Result  (cost=0.00..0.00 rows=1 width=16)
-               ->  Result  (cost=0.00..0.00 rows=1 width=16)
-                     ->  Result  (cost=0.00..0.00 rows=1 width=16)
-                           ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.48.0
-(8 rows)
+               ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(5 rows)
 
 -- The remaining tests require a row in the table.
 INSERT INTO constr_tab VALUES(1,5,3,4);
@@ -56,15 +53,14 @@ DETAIL:  Feature not supported: UPDATE with constraints
 
 set optimizer_enable_dml_constraints=on;
 explain update constr_tab set b = 10;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Update  (cost=0.00..431.09 rows=1 width=1)
    ->  Result  (cost=0.00..431.00 rows=1 width=34)
          ->  Split  (cost=0.00..431.00 rows=1 width=30)
-               ->  Result  (cost=0.00..431.00 rows=1 width=30)
-                     ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=26)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(6 rows)
+               ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=26)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(5 rows)
 
 -- Same, with NOT NULL constraint.
 DROP TABLE IF EXISTS constr_tab;
@@ -117,10 +113,9 @@ explain update constr_tab set a = 10;
          ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=30)
                Hash Key: constr_tab.a
                ->  Split  (cost=0.00..431.00 rows=1 width=30)
-                     ->  Result  (cost=0.00..431.00 rows=1 width=30)
-                           ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=26)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.39.0
-(8 rows)
+                     ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=26)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 -- Test ORCA fallback on "FROM ONLY"
 CREATE TABLE homer (a int, b int, c int)
@@ -256,12 +251,11 @@ explain select count(*) from foo group by a;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.50 rows=100 width=8)
-   ->  Result  (cost=0.00..431.50 rows=34 width=8)
-         ->  HashAggregate  (cost=0.00..431.50 rows=34 width=8)
-               Group Key: a
-               ->  Seq Scan on foo  (cost=0.00..431.07 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.39.0
-(6 rows)
+   ->  HashAggregate  (cost=0.00..431.50 rows=34 width=8)
+         Group Key: a
+         ->  Seq Scan on foo  (cost=0.00..431.07 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(5 rows)
 
 set optimizer_enable_hashagg = off;
 set optimizer_enable_groupagg = on;
@@ -269,14 +263,13 @@ explain select count(*) from foo group by a;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.00 rows=100 width=8)
-   ->  Result  (cost=0.00..431.99 rows=34 width=8)
-         ->  GroupAggregate  (cost=0.00..431.99 rows=34 width=8)
-               Group Key: a
-               ->  Sort  (cost=0.00..431.98 rows=3334 width=4)
-                     Sort Key: a
-                     ->  Seq Scan on foo  (cost=0.00..431.07 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.39.0
-(8 rows)
+   ->  GroupAggregate  (cost=0.00..431.99 rows=34 width=8)
+         Group Key: a
+         ->  Sort  (cost=0.00..431.98 rows=3334 width=4)
+               Sort Key: a
+               ->  Seq Scan on foo  (cost=0.00..431.07 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 set optimizer_enable_hashagg = off;
 set optimizer_enable_groupagg = off;

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1072,18 +1072,17 @@ create table TabDel4(a int not null, b int not null);
 insert into TabDel4 values(1,2);
 commit;
 explain delete from TabDel1 where TabDel1.a not in (select a from TabDel3); -- do not support this because we produce NLASJ
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Delete  (cost=0.00..862.04 rows=1 width=1)
-   ->  Result  (cost=0.00..862.00 rows=1 width=22)
-         ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=18)
-               Hash Cond: tabdel1.a = tabdel3.a
-               ->  Seq Scan on tabdel1  (cost=0.00..431.00 rows=1 width=18)
-               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on tabdel3  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(9 rows)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=18)
+         Hash Cond: (tabdel1.a = tabdel3.a)
+         ->  Seq Scan on tabdel1  (cost=0.00..431.00 rows=1 width=18)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Seq Scan on tabdel3  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 explain delete from TabDel2 where TabDel2.a not in (select a from TabDel4); -- support this
                                                   QUERY PLAN                                                   

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1803,19 +1803,18 @@ order by 1,2;
    ->  Sort
          Sort Key: mergeappend_test.a, mergeappend_test.b
          ->  Append
-               ->  Result
-                     ->  GroupAggregate
-                           Group Key: mergeappend_test.a, mergeappend_test.b
-                           ->  Sort
-                                 Sort Key: mergeappend_test.a, mergeappend_test.b
-                                 ->  Seq Scan on mergeappend_test
+               ->  GroupAggregate
+                     Group Key: mergeappend_test.a, mergeappend_test.b
+                     ->  Sort
+                           Sort Key: mergeappend_test.a, mergeappend_test.b
+                           ->  Seq Scan on mergeappend_test
                ->  Result
                      ->  Redistribute Motion 1:3  (slice2)
                            ->  Aggregate
                                  ->  Gather Motion 3:1  (slice1; segments: 3)
                                        ->  Seq Scan on mergeappend_test mergeappend_test_1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(17 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
 
 -- This used to trip an assertion in MotionStateFinderWalker(), when we were
 -- missing support for MergeAppend in planstate_walk_kids().
@@ -1842,31 +1841,30 @@ select null, null, array_dims(array_agg(x)) FROM mergeappend_test r
 order by 1,2;
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.11 rows=22 width=16) (actual time=1.024..1.029 rows=4 loops=2)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.11 rows=22 width=16) (actual time=3.610..3.617 rows=7 loops=1)
    Merge Key: mergeappend_test.a, mergeappend_test.b
-   ->  Sort  (cost=0.00..862.11 rows=8 width=16) (actual time=0.797..0.800 rows=2 loops=2)
+   ->  Sort  (cost=0.00..862.11 rows=8 width=16) (actual time=2.861..2.875 rows=5 loops=1)
          Sort Key: mergeappend_test.a, mergeappend_test.b
          Sort Method:  quicksort  Memory: 99kB
-         ->  Append  (cost=0.00..862.11 rows=8 width=16) (actual time=0.240..0.783 rows=2 loops=2)
-               ->  Result  (cost=0.00..431.09 rows=7 width=16) (actual time=0.240..0.353 rows=2 loops=2)
-                     ->  GroupAggregate  (cost=0.00..431.09 rows=7 width=16) (actual time=0.237..0.349 rows=2 loops=2)
-                           Group Key: mergeappend_test.a, mergeappend_test.b
-                           ->  Sort  (cost=0.00..431.09 rows=167 width=12) (actual time=0.181..0.228 rows=150 loops=2)
-                                 Sort Key: mergeappend_test.a, mergeappend_test.b
-                                 Sort Method:  quicksort  Memory: 115kB
-                                 ->  Seq Scan on mergeappend_test  (cost=0.00..431.00 rows=167 width=12) (actual time=0.005..0.032 rows=150 loops=2)
-               ->  Result  (cost=0.00..431.01 rows=1 width=16) (actual time=0.692..0.693 rows=0 loops=2)
-                     ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.01 rows=1 width=8) (actual time=0.689..0.690 rows=0 loops=2)
-                           ->  Aggregate  (cost=0.00..431.01 rows=1 width=8) (actual time=0.723..0.723 rows=0 loops=2)
-                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=500 width=4) (actual time=0.140..0.645 rows=250 loops=2)
-                                       ->  Seq Scan on mergeappend_test mergeappend_test_1  (cost=0.00..431.00 rows=167 width=4) (actual time=0.006..0.042 rows=150 loops=2)
- Planning time: 21.621 ms
-   (slice0)    Executor memory: 384K bytes.
+         ->  Append  (cost=0.00..862.11 rows=8 width=16) (actual time=0.924..2.791 rows=5 loops=1)
+               ->  GroupAggregate  (cost=0.00..431.09 rows=7 width=16) (actual time=0.922..1.457 rows=4 loops=1)
+                     Group Key: mergeappend_test.a, mergeappend_test.b
+                     ->  Sort  (cost=0.00..431.09 rows=167 width=12) (actual time=0.662..0.826 rows=301 loops=1)
+                           Sort Key: mergeappend_test.a, mergeappend_test.b
+                           Sort Method:  quicksort  Memory: 115kB
+                           ->  Seq Scan on mergeappend_test  (cost=0.00..431.00 rows=167 width=12) (actual time=0.049..0.146 rows=301 loops=1)
+               ->  Result  (cost=0.00..431.01 rows=1 width=16) (actual time=1.324..1.326 rows=1 loops=1)
+                     ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.01 rows=1 width=8) (actual time=1.307..1.309 rows=1 loops=1)
+                           ->  Aggregate  (cost=0.00..431.01 rows=1 width=8) (actual time=2.641..2.641 rows=1 loops=1)
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=500 width=4) (actual time=1.813..2.298 rows=500 loops=1)
+                                       ->  Seq Scan on mergeappend_test mergeappend_test_1  (cost=0.00..431.00 rows=167 width=4) (actual time=0.052..0.329 rows=301 loops=1)
+ Planning time: 70.602 ms
+   (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 215K bytes (entry db).
-   (slice3)    Executor memory: 229K bytes avg x 3 workers, 244K bytes max (seg0).  Work_mem: 49K bytes max.
+   (slice3)    Executor memory: 213K bytes avg x 3 workers, 232K bytes max (seg0).  Work_mem: 49K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.18.0
- Execution time: 3.142 ms
-(26 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Execution time: 5.553 ms
+(25 rows)
 

--- a/src/test/regress/expected/select_distinct_optimizer.out
+++ b/src/test/regress/expected/select_distinct_optimizer.out
@@ -130,27 +130,27 @@ SELECT DISTINCT p.age FROM person* p ORDER BY age using >;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  Aggregate
    Output: count()
    ->  Gather Motion 3:1  (slice2; segments: 3)
-         ->  Result
-               ->  GroupAggregate
+         ->  GroupAggregate
+               Group Key: tenk1.two, tenk1.four, tenk1.two
+               ->  Sort
                      Output: two, four
-                     Group Key: tenk1.two, tenk1.four, tenk1.two
-                     ->  Sort
+                     Sort Key: tenk1.two, tenk1.four, tenk1.two
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Output: two, four
-                           Sort Key: tenk1.two, tenk1.four, tenk1.two
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: two, four, two
+                           ->  Streaming HashAggregate
                                  Output: two, four
-                                 Hash Key: two, four, two
-                                 ->  Streaming HashAggregate
+                                 Group Key: tenk1.two, tenk1.four, tenk1.two
+                                 ->  Seq Scan on public.tenk1
                                        Output: two, four
-                                       Group Key: tenk1.two, tenk1.four, tenk1.two
-                                       ->  Seq Scan on public.tenk1
-                                             Output: two, four
-(19 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Settings: optimizer=on
+(18 rows)
 
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -43,21 +43,20 @@ alter table tenk1 set (parallel_workers = 4);
 explain (verbose, costs off)
 select parallel_restricted(unique1) from tenk1
   where stringu1 = 'GRAAAA' order by 1;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: (parallel_restricted(unique1))
    Merge Key: (parallel_restricted(unique1))
    ->  Sort
          Output: (parallel_restricted(unique1))
          Sort Key: (parallel_restricted(tenk1.unique1))
-         ->  Result
+         ->  Seq Scan on public.tenk1
                Output: parallel_restricted(unique1)
-               ->  Seq Scan on public.tenk1
-                     Output: unique1
-                     Filter: (tenk1.stringu1 = 'GRAAAA'::name)
- Settings: min_parallel_relation_size=0, parallel_setup_cost=0, parallel_tuple_cost=0
-(13 rows)
+               Filter: (tenk1.stringu1 = 'GRAAAA'::name)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Settings: min_parallel_relation_size=0, optimizer=on, parallel_setup_cost=0, parallel_tuple_cost=0
+(11 rows)
 
 -- test parallel plan when group by expression is in target list.
 explain (costs off)
@@ -71,9 +70,9 @@ explain (costs off)
                Hash Key: (length((stringu1)::text))
                ->  Streaming HashAggregate
                      Group Key: length((stringu1)::text)
-                     ->  Result
-                           ->  Seq Scan on tenk1
-(10 rows)
+                     ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 select length(stringu1) from tenk1 group by length(stringu1);
  length 
@@ -93,29 +92,27 @@ explain (costs off)
                Sort Key: stringu1
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
                      Hash Key: stringu1
-                     ->  Result
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: stringu1
-                                 ->  Seq Scan on tenk1
-(13 rows)
+                     ->  Streaming Partial HashAggregate
+                           Group Key: stringu1
+                           ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(12 rows)
 
 -- test that parallel plan for aggregates is not selected when
 -- target list contains parallel restricted clause.
 explain (costs off)
 	select  sum(parallel_restricted(unique1)) from tenk1
 	group by(parallel_restricted(unique1));
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   ->  Result
-         ->  HashAggregate
-               Group Key: (parallel_restricted(unique1))
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: (parallel_restricted(unique1))
-                     ->  Result
-                           ->  Result
-                                 ->  Seq Scan on tenk1
-(10 rows)
+   ->  HashAggregate
+         Group Key: (parallel_restricted(unique1))
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (parallel_restricted(unique1))
+               ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 set force_parallel_mode=1;
 explain (costs off)
@@ -123,10 +120,10 @@ explain (costs off)
                       QUERY PLAN                      
 ------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
-   ->  Result
-         ->  Index Scan using tenk1_unique1 on tenk1
-               Index Cond: (unique1 = 1)
-(5 rows)
+   ->  Index Scan using tenk1_unique1 on tenk1
+         Index Cond: (unique1 = 1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(4 rows)
 
 do $$begin
   -- Provoke error, possibly in worker.  If this error happens to occur in

--- a/src/test/regress/expected/subselect_gp_indexes_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_indexes_optimizer.out
@@ -74,16 +74,15 @@ explain select (select id1 from (select * from choose_seqscan_t2) foo where id2=
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324216.68 rows=50 width=4)
-   ->  Result  (cost=0.00..1324216.68 rows=17 width=4)
-         ->  Seq Scan on choose_seqscan_t1  (cost=0.00..1324216.68 rows=334 width=4)
+   ->  Seq Scan on choose_seqscan_t1  (cost=0.00..1324216.68 rows=334 width=4)
          SubPlan 1
            ->  Result  (cost=0.00..431.17 rows=1 width=4)
                  Filter: (choose_seqscan_t2.id2 = choose_seqscan_t1.id2)
                  ->  Materialize  (cost=0.00..431.01 rows=50 width=8)
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=50 width=8)
                              ->  Seq Scan on choose_seqscan_t2  (cost=0.00..431.00 rows=17 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
-(10 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 -- then, a sequential scan is chosen because I need a motion to move choose_seqscan_t2
 -- Index Scan can be used on quals that don't depend on the correlation vars, however.
@@ -101,24 +100,22 @@ select t1.id1, (select count(*) from choose_seqscan_t2 t2 where t2.id1 = t1.id1 
 (8 rows)
 
 explain select t1.id1, (select count(*) from choose_seqscan_t2 t2 where t2.id1 = t1.id1 and t2.id2 = 1) from choose_seqscan_t1 t1 where t1.id1 < 10;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..437.00 rows=9 width=12)
-   ->  Result  (cost=0.00..437.00 rows=3 width=12)
-         ->  Result  (cost=0.00..437.00 rows=3 width=12)
-               ->  Hash Left Join  (cost=0.00..437.00 rows=3 width=12)
-                     Hash Cond: (choose_seqscan_t1.id1 = choose_seqscan_t2.id1)
-                     ->  Seq Scan on choose_seqscan_t1  (cost=0.00..431.00 rows=3 width=4)
-                           Filter: (id1 < 10)
-                     ->  Hash  (cost=6.00..6.00 rows=1 width=12)
-                           ->  GroupAggregate  (cost=0.00..6.00 rows=1 width=12)
-                                 Group Key: choose_seqscan_t2.id1
-                                 ->  Sort  (cost=0.00..6.00 rows=1 width=4)
-                                       Sort Key: choose_seqscan_t2.id1
-                                       ->  Index Scan using bidx2 on choose_seqscan_t2  (cost=0.00..6.00 rows=1 width=4)
-                                             Index Cond: (id2 = 1)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.74.0
-(15 rows)
+   ->  Hash Left Join  (cost=0.00..437.00 rows=3 width=12)
+         Hash Cond: (choose_seqscan_t1.id1 = choose_seqscan_t2.id1)
+         ->  Seq Scan on choose_seqscan_t1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: (id1 < 10)
+         ->  Hash  (cost=6.00..6.00 rows=1 width=12)
+               ->  GroupAggregate  (cost=0.00..6.00 rows=1 width=12)
+                     Group Key: choose_seqscan_t2.id1
+                     ->  Sort  (cost=0.00..6.00 rows=1 width=4)
+                           Sort Key: choose_seqscan_t2.id1
+                           ->  Index Scan using bidx2 on choose_seqscan_t2  (cost=0.00..6.00 rows=1 width=4)
+                                 Index Cond: (id2 = 1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- Test using a join within the subplan. It could perhaps use an Nested Loop Join +
 -- Index Scan to do the join, but at the memont, the planner doesn't consider distributing
@@ -137,33 +134,30 @@ select t1.id1, (select count(*) from generate_series(1,5) g, choose_seqscan_t2 t
 (8 rows)
 
 explain select t1.id1, (select count(*) from generate_series(1,5) g, choose_seqscan_t2 t2 where t1.id1 = t2.id1 and t2.id2 = g) from choose_seqscan_t1 t1 where t1.id1 < 10;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.14 rows=9 width=12)
-   ->  Result  (cost=0.00..862.14 rows=3 width=12)
-         ->  Result  (cost=0.00..862.14 rows=3 width=12)
-               ->  Hash Left Join  (cost=0.00..862.14 rows=3 width=12)
-                     Hash Cond: (choose_seqscan_t1.id1 = choose_seqscan_t2.id1)
-                     ->  Seq Scan on choose_seqscan_t1  (cost=0.00..431.00 rows=3 width=4)
-                           Filter: (id1 < 10)
-                     ->  Hash  (cost=431.13..431.13 rows=17 width=12)
-                           ->  Finalize HashAggregate  (cost=0.00..431.13 rows=17 width=12)
+   ->  Hash Left Join  (cost=0.00..862.14 rows=3 width=12)
+         Hash Cond: (choose_seqscan_t1.id1 = choose_seqscan_t2.id1)
+         ->  Seq Scan on choose_seqscan_t1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: (id1 < 10)
+         ->  Hash  (cost=431.13..431.13 rows=17 width=12)
+               ->  Finalize HashAggregate  (cost=0.00..431.13 rows=17 width=12)
+                     Group Key: choose_seqscan_t2.id1
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.13 rows=17 width=12)
+                           Hash Key: choose_seqscan_t2.id1
+                           ->  Streaming Partial HashAggregate  (cost=0.00..431.13 rows=17 width=12)
                                  Group Key: choose_seqscan_t2.id1
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.13 rows=17 width=12)
-                                       Hash Key: choose_seqscan_t2.id1
-                                       ->  Result  (cost=0.00..431.13 rows=17 width=12)
-                                             ->  Streaming Partial HashAggregate  (cost=0.00..431.13 rows=17 width=12)
-                                                   Group Key: choose_seqscan_t2.id1
-                                                   ->  Hash Join  (cost=0.00..431.08 rows=334 width=4)
-                                                         Hash Cond: (generate_series.generate_series = choose_seqscan_t2.id2)
-                                                         ->  Result  (cost=0.00..0.01 rows=334 width=4)
-                                                               ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
-                                                         ->  Hash  (cost=431.00..431.00 rows=17 width=8)
-                                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=17 width=8)
-                                                                     Hash Key: choose_seqscan_t2.id2
-                                                                     ->  Seq Scan on choose_seqscan_t2  (cost=0.00..431.00 rows=17 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.74.0
-(24 rows)
+                                 ->  Hash Join  (cost=0.00..431.08 rows=334 width=4)
+                                       Hash Cond: (generate_series.generate_series = choose_seqscan_t2.id2)
+                                       ->  Result  (cost=0.00..0.01 rows=334 width=4)
+                                             ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
+                                       ->  Hash  (cost=431.00..431.00 rows=17 width=8)
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=17 width=8)
+                                                   Hash Key: choose_seqscan_t2.id2
+                                                   ->  Seq Scan on choose_seqscan_t2  (cost=0.00..431.00 rows=17 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(21 rows)
 
 -- Similar, but use a real table. One possible plan for the subplan here would be to do the join
 -- first, and then filter the join result based on the correlation qual "t1.id1 = t2.id1". But
@@ -187,27 +181,25 @@ select t1.id1, (select count(*) from choose_seqscan_t3 t3, choose_seqscan_t2 t2 
 (8 rows)
 
 explain select t1.id1, (select count(*) from choose_seqscan_t3 t3, choose_seqscan_t2 t2 where t1.id1 = t2.id1 and t3.id1 = t2.id1) from choose_seqscan_t1 t1 where t1.id1 < 10;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1162.02 rows=9 width=12)
-   ->  Result  (cost=0.00..1162.02 rows=3 width=12)
-         ->  Result  (cost=0.00..1162.02 rows=3 width=12)
-               ->  Hash Left Join  (cost=0.00..1162.02 rows=3 width=12)
-                     Hash Cond: (choose_seqscan_t1.id1 = choose_seqscan_t2.id1)
-                     ->  Seq Scan on choose_seqscan_t1  (cost=0.00..431.00 rows=3 width=4)
-                           Filter: (id1 < 10)
-                     ->  Hash  (cost=731.01..731.01 rows=17 width=12)
-                           ->  GroupAggregate  (cost=0.00..731.01 rows=17 width=12)
-                                 Group Key: choose_seqscan_t2.id1
-                                 ->  Nested Loop  (cost=0.00..731.01 rows=17 width=4)
-                                       Join Filter: true
-                                       ->  Sort  (cost=0.00..431.00 rows=17 width=4)
-                                             Sort Key: choose_seqscan_t2.id1
-                                             ->  Seq Scan on choose_seqscan_t2  (cost=0.00..431.00 rows=17 width=4)
-                                       ->  Index Scan using bidx3 on choose_seqscan_t3  (cost=0.00..300.01 rows=1 width=1)
-                                             Index Cond: (id1 = choose_seqscan_t2.id1)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.74.0
-(18 rows)
+   ->  Hash Left Join  (cost=0.00..1162.02 rows=3 width=12)
+         Hash Cond: (choose_seqscan_t1.id1 = choose_seqscan_t2.id1)
+         ->  Seq Scan on choose_seqscan_t1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: (id1 < 10)
+         ->  Hash  (cost=731.01..731.01 rows=17 width=12)
+               ->  GroupAggregate  (cost=0.00..731.01 rows=17 width=12)
+                     Group Key: choose_seqscan_t2.id1
+                     ->  Nested Loop  (cost=0.00..731.01 rows=17 width=4)
+                           Join Filter: true
+                           ->  Sort  (cost=0.00..431.00 rows=17 width=4)
+                                 Sort Key: choose_seqscan_t2.id1
+                                 ->  Seq Scan on choose_seqscan_t2  (cost=0.00..431.00 rows=17 width=4)
+                           ->  Index Scan using bidx3 on choose_seqscan_t3  (cost=0.00..300.01 rows=1 width=1)
+                                 Index Cond: (id1 = choose_seqscan_t2.id1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
 
 -- start_ignore
 drop table if exists choose_seqscan_t1;
@@ -253,16 +245,15 @@ select (select id1 from (select * from choose_indexscan_t2) foo where id2=choose
 (20 rows)
 
 explain select (select id1 from (select * from choose_indexscan_t2) foo where id2=choose_indexscan_t1.id2) from choose_indexscan_t1;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324176.46 rows=20 width=4)
-   ->  Result  (cost=0.00..1324176.46 rows=7 width=4)
-         ->  Seq Scan on choose_indexscan_t1  (cost=0.00..1324176.46 rows=334 width=4)
+   ->  Seq Scan on choose_indexscan_t1  (cost=0.00..1324176.46 rows=334 width=4)
          SubPlan 1
            ->  Seq Scan on choose_indexscan_t2  (cost=0.00..431.13 rows=1 width=4)
                  Filter: (id2 = choose_indexscan_t1.id2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
-(7 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 -- then an indexscan is chosen because it is correct to do this on a replicated table since no motion is required
 -- Test that Motions are added when you mix replicated tables and catalog

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -86,8 +86,8 @@ NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_4" for table "csq_t2"
 insert into csq_t1 select * from csq_t1_base;
 insert into csq_t2 select * from csq_t2_base;
 explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1;
-                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                              QUERY PLAN                                                                                                                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1293.00 rows=1 width=8)
    Filter: (SubPlan 1)
    ->  Sort  (cost=0.00..431.00 rows=1 width=8)
@@ -99,21 +99,18 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
                      ->  Dynamic Seq Scan on csq_t1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
    SubPlan 1
      ->  Result  (cost=0.00..431.00 rows=1 width=1)
-           ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                 Filter: (CASE WHEN (sum((CASE WHEN csq_t1.x <= csq_t2.x THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN csq_t2.x IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN csq_t1.x IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN csq_t1.x <= csq_t2.x THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
-                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                         Filter: csq_t2.y = csq_t1.y
-                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                     ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
-                                                           ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                                                 Partitions selected: 4 (out of 4)
-                                                           ->  Dynamic Seq Scan on csq_t2 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(26 rows)
+           Filter: ((CASE WHEN (sum((CASE WHEN (csq_t1.x <= csq_t2.x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (csq_t2.x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (csq_t1.x IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (csq_t1.x <= csq_t2.x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                       Filter: (csq_t2.y = csq_t1.y)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                   ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
+                                         ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                               Partitions selected: 4 (out of 4)
+                                         ->  Dynamic Seq Scan on csq_t2 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(22 rows)
 
 select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
  x | y 
@@ -195,25 +192,24 @@ select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
 (20 rows)
 
 explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
-                                                                                                                                 QUERY PLAN                                                                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.02 rows=20 width=4)
    ->  Result  (cost=0.00..1293.02 rows=7 width=4)
-         Filter: (CASE WHEN ((count("inner".ColRef_0017)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0017))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
+         Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
          ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=20)
                Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-               ->  Result  (cost=0.00..1293.02 rows=56 width=19)
-                     ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
-                           Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
-                           ->  Sort  (cost=0.00..431.00 rows=7 width=14)
-                                 Sort Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                                 ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
-                           ->  Result  (cost=0.00..431.00 rows=20 width=5)
-                                 ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
-                                             ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(16 rows)
+               ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
+                     Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
+                     ->  Sort  (cost=0.00..431.00 rows=7 width=14)
+                           Sort Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
+                           ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
+                     ->  Result  (cost=0.00..431.00 rows=20 width=5)
+                           ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
+                                       ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
  x 
@@ -367,8 +363,8 @@ select * from csq_d1;
 -- outer plan node is master-only and CSQ has distributed relation
 --
 explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- gather motion
-                                                                                                                                               QUERY PLAN                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1293.00 rows=3 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
          Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_m1.x = csq_d1.x) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_m1.x < '-100'::integer))
@@ -378,22 +374,21 @@ explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; 
                      Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
                      ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
                            Hash Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-                           ->  Result  (cost=0.00..1293.00 rows=1 width=30)
-                                 ->  Partial GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
-                                       Group Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-                                       ->  Result  (cost=0.00..1293.00 rows=2 width=19)
-                                             ->  Sort  (cost=0.00..1293.00 rows=2 width=19)
-                                                   Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-                                                   ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..1293.00 rows=4 width=19)
-                                                         ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
-                                                               Join Filter: ((csq_m1.x = csq_d1.x) IS NOT FALSE)
-                                                               ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=14)
-                                                               ->  Result  (cost=0.00..431.00 rows=1 width=5)
-                                                                     ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                                                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                                                                 ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
-(24 rows)
+                           ->  Partial GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
+                                 Group Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
+                                 ->  Result  (cost=0.00..1293.00 rows=2 width=19)
+                                       ->  Sort  (cost=0.00..1293.00 rows=2 width=19)
+                                             Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
+                                             ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..1293.00 rows=4 width=19)
+                                                   ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
+                                                         Join Filter: ((csq_m1.x = csq_d1.x) IS NOT FALSE)
+                                                         ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=14)
+                                                         ->  Result  (cost=0.00..431.00 rows=1 width=5)
+                                                               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                                                           ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(23 rows)
 
 select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
  x 
@@ -405,25 +400,24 @@ select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
 -- outer plan node is master-only and CSQ has distributed relation
 --
 explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- broadcast motion
-                                                                                                                             QUERY PLAN                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
-         Filter: (CASE WHEN ((count("inner".ColRef_0016)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0016))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < (-100)))
+         Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < '-100'::integer))
          ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-               ->  Result  (cost=0.00..1293.00 rows=2 width=19)
-                     ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
-                           Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=14)
-                                 Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-                                 ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                           ->  Result  (cost=0.00..431.00 rows=3 width=5)
-                                 ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
-                                       ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=9 width=4)
-                                             ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(16 rows)
+               ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
+                     Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+                           Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
+                           ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
+                     ->  Result  (cost=0.00..431.00 rows=3 width=5)
+                           ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=9 width=4)
+                                       ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
  x 
@@ -468,12 +462,11 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a = ((SubPlan 1))
+         Filter: (a = (SubPlan 1))
          SubPlan 1
-           ->  Result  (cost=0.00..0.00 rows=1 width=4)
-                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(7 rows)
+           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
  a 
@@ -487,12 +480,11 @@ explain SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a <> ((SubPlan 1))
+         Filter: (a <> (SubPlan 1))
          SubPlan 1
-           ->  Result  (cost=0.00..0.00 rows=1 width=4)
-                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(7 rows)
+           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
  a 
@@ -508,10 +500,8 @@ explain SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
          Filter: (SubPlan 1)
          SubPlan 1
            ->  Result  (cost=0.00..0.00 rows=1 width=1)
-                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
-                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
  a 
@@ -528,10 +518,8 @@ explain SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
          Filter: (SubPlan 1)
          SubPlan 1
            ->  Result  (cost=0.00..0.00 rows=1 width=1)
-                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
-                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
  a 
@@ -544,13 +532,12 @@ explain SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1)
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a > ((SubPlan 1))
+         Filter: (a > (SubPlan 1))
          SubPlan 1
            ->  Limit  (cost=0.00..0.00 rows=1 width=4)
-                 ->  Result  (cost=0.00..0.00 rows=1 width=4)
-                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(8 rows)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1);
  a 
@@ -563,13 +550,11 @@ explain SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a < ((SubPlan 1))
+         Filter: (a < (SubPlan 1))
          SubPlan 1
-           ->  Result  (cost=0.00..0.00 rows=1 width=4)
-                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(8 rows)
+           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
  a 
@@ -582,13 +567,11 @@ explain SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a <= ((SubPlan 1))
+         Filter: (a <= (SubPlan 1))
          SubPlan 1
-           ->  Result  (cost=0.00..0.00 rows=1 width=4)
-                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(8 rows)
+           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
  a 
@@ -606,13 +589,12 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
          SubPlan 1
            ->  Nested Loop  (cost=0.00..862.00 rows=1 width=4)
                  Join Filter: true
-                 ->  Result  (cost=0.00..0.00 rows=1 width=4)
-                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
                  ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                              ->  Seq Scan on csq_r csq_r_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(12 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
  a 
@@ -639,23 +621,22 @@ insert into csq_pullup values ('def',3, 1, 'abc');
 -- text, text
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: 1 = COALESCE((count()), 0::bigint)
-         ->  Result  (cost=0.00..862.00 rows=1 width=36)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: csq_pullup.t = csq_pullup_1.t
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                 Group Key: csq_pullup_1.t
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: csq_pullup_1.t
-                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(14 rows)
+         Filter: (1 = COALESCE((count()), '0'::bigint))
+         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
+               Hash Cond: (csq_pullup.t = csq_pullup_1.t)
+               ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                           Group Key: csq_pullup_1.t
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                 Sort Key: csq_pullup_1.t
+                                 ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
   t  | n | i |  v  
@@ -669,25 +650,24 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 -- text, varchar
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: (1 = COALESCE((count()), 0::bigint))
-         ->  Result  (cost=0.00..862.00 rows=1 width=36)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: (csq_pullup.t = (csq_pullup_1.v)::text)
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                 Group Key: csq_pullup_1.v
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: csq_pullup_1.v
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                             Hash Key: csq_pullup_1.v
-                                             ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(16 rows)
+         Filter: (1 = COALESCE((count()), '0'::bigint))
+         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
+               Hash Cond: (csq_pullup.t = (csq_pullup_1.v)::text)
+               ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                           Group Key: csq_pullup_1.v
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                 Sort Key: csq_pullup_1.v
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                       Hash Key: csq_pullup_1.v
+                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
   t  | n | i |  v  
@@ -701,27 +681,25 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 -- numeric, numeric
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=1 width=17)
-   Filter: (1 = COALESCE((count()), 0::bigint))
-   ->  Result  (cost=0.00..862.00 rows=1 width=36)
-         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-               Hash Cond: (csq_pullup.n = csq_pullup_1.n)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-               ->  Hash  (cost=431.00..431.00 rows=1 width=13)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=13)
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
-                                       Group Key: csq_pullup_1.n
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=5)
-                                             Sort Key: csq_pullup_1.n
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
-                                                   Hash Key: csq_pullup_1.n
-                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(18 rows)
+   Filter: (1 = COALESCE((count()), '0'::bigint))
+   ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
+         Hash Cond: (csq_pullup.n = csq_pullup_1.n)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=17)
+               ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=13)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
+                           Group Key: csq_pullup_1.n
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=5)
+                                 Sort Key: csq_pullup_1.n
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+                                       Hash Key: csq_pullup_1.n
+                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
   t  | n | i |  v  
@@ -819,25 +797,24 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 
 -- subquery contains a HAVING clause
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Result  (cost=0.00..862.00 rows=1 width=17)
          Filter: (1 = COALESCE((count()), '0'::bigint))
-         ->  Result  (cost=0.00..862.00 rows=1 width=36)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: (csq_pullup.t = csq_pullup_1.t)
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                                 Filter: ((count()) < 10)
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=20)
-                                       Group Key: csq_pullup_1.t
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                             Sort Key: csq_pullup_1.t
-                                             ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
+               Hash Cond: (csq_pullup.t = csq_pullup_1.t)
+               ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=12)
+                           Filter: ((count()) < 10)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=20)
+                                 Group Key: csq_pullup_1.t
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                       Sort Key: csq_pullup_1.t
+                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(16 rows)
+(15 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
   t  | n | i |  v  
@@ -854,18 +831,17 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 -- text, text
 --
 explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.t=t1.t and t1.i = 1);
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=17)
-         Hash Cond: csq_pullup.t = csq_pullup_1.t
+         Hash Cond: (csq_pullup.t = csq_pullup_1.t)
          ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-               ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
-                           Filter: i = 1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(9 rows)
+               ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+                     Filter: (i = 1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.t=t1.t and t1.i = 1);
   t  | n | i |  v  
@@ -878,19 +854,17 @@ select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where 
 -- int, function(int)
 --
 explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.i=t1.i + 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=17)
-         Hash Cond: csq_pullup.i = (csq_pullup_1.i + 1)
+         Hash Cond: (csq_pullup.i = (csq_pullup_1.i + 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+                     ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.i=t1.i + 1);
   t  | n | i |  v  
@@ -1071,25 +1045,22 @@ select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
 (0 rows)
 
 explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
-                   QUERY PLAN                   
-------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=4)
-   ->  Result  (cost=0.00..0.00 rows=0 width=4)
-         One-Time Filter: false
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(5 rows)
+   One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(3 rows)
 
 explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
 union all
 select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
-                QUERY PLAN                
-------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=4)
    One-Time Filter: false
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(4 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(3 rows)
 
 select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
 union all
@@ -1101,14 +1072,12 @@ select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
 explain select * from t1,
 (select * from t1 where a=1 and a=2 and a > (select t2.b from t2)) foo
 where t1.a = foo.a;
-                   QUERY PLAN                   
-------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=8)
-   ->  Result  (cost=0.00..0.00 rows=0 width=8)
-         One-Time Filter: false
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(5 rows)
+   One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(3 rows)
 
 select * from t1,
 (select * from t1 where a=1 and a=2 and a > (select t2.b from t2)) foo
@@ -1123,42 +1092,38 @@ where t1.a = foo.a;
 insert into t1 values (1);
 insert into t2 values (1);
 explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1293.00 rows=1 width=4)
-   ->  Result  (cost=0.00..1293.00 rows=1 width=1)
-         Filter: (SubPlan 1)
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
-         SubPlan 1
-           ->  Limit  (cost=0.00..431.00 rows=1 width=4)
-                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                       Filter: t1.a = 1
-                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                   ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on; optimizer_nestloop_factor=1; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.44.1
-(14 rows)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1293.00 rows=1 width=1)
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+   SubPlan 1
+     ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                 One-Time Filter: (t1.a = 1)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(12 rows)
 
 explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1293.00 rows=1 width=4)
-   ->  Result  (cost=0.00..1293.00 rows=1 width=1)
-         Filter: (SubPlan 1)
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
-         SubPlan 1
-           ->  Limit  (cost=0.00..431.00 rows=1 width=4)
-                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                       Filter: t1.a = 1
-                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                   ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on; optimizer_nestloop_factor=1; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.39.2
-(14 rows)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1293.00 rows=1 width=1)
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+   SubPlan 1
+     ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                 One-Time Filter: (t1.a = 1)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(12 rows)
 
 select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
  ?column? 
@@ -1228,30 +1193,27 @@ explain select row_number() over (order by seq asc) as id, foo.cnt
 from
 (select seq, (select count(*) from t1_mpp_24563 t1 where t1.id = t2.id) cnt from
 	t2_mpp_24563 t2 where value = 7) foo;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=1 width=16)
-   ->  WindowAgg  (cost=0.00..862.00 rows=1 width=16)
-         Order By: t2_mpp_24563.seq
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
-               Merge Key: t2_mpp_24563.seq
-               ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                     ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                           ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                                 ->  Sort  (cost=0.00..862.00 rows=1 width=12)
-                                       Sort Key: t2_mpp_24563.seq
-                                       ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=12)
-                                             Hash Cond: t2_mpp_24563.id = t1_mpp_24563.id
-                                             ->  Seq Scan on t2_mpp_24563  (cost=0.00..431.00 rows=1 width=8)
-                                                   Filter: value = 7
-                                             ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                                                   ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                                         Group Key: t1_mpp_24563.id
-                                                         ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                                               Sort Key: t1_mpp_24563.id
-                                                               ->  Seq Scan on t1_mpp_24563  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(21 rows)
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..862.00 rows=1 width=16)
+   Order By: t2_mpp_24563.seq
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+         Merge Key: t2_mpp_24563.seq
+         ->  Result  (cost=0.00..862.00 rows=1 width=12)
+               ->  Sort  (cost=0.00..862.00 rows=1 width=12)
+                     Sort Key: t2_mpp_24563.seq
+                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=12)
+                           Hash Cond: (t2_mpp_24563.id = t1_mpp_24563.id)
+                           ->  Seq Scan on t2_mpp_24563  (cost=0.00..431.00 rows=1 width=8)
+                                 Filter: (value = 7)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                       Group Key: t1_mpp_24563.id
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                             Sort Key: t1_mpp_24563.id
+                                             ->  Seq Scan on t1_mpp_24563  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(18 rows)
 
 drop table t1_mpp_24563;
 drop table t2_mpp_24563;
@@ -1281,33 +1243,31 @@ CASE
 	ELSE 'Q2'::text END  AS  cc,  1 AS nn
 FROM t_mpp_20470 b;
 explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
-                                                                             QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
  WindowAgg  (cost=0.00..862.00 rows=1 width=16)
    ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=12)
-         ->  Result  (cost=0.00..862.00 rows=1 width=12)
-               ->  Result  (cost=0.00..862.00 rows=1 width=16)
-                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
-                           Hash Cond: ((t_mpp_20470.col_name)::text = (t_mpp_20470_1.col_name)::text)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                 Hash Key: t_mpp_20470.col_name
-                                 ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Partition Selector for t_mpp_20470 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                             Partitions selected: 2 (out of 2)
-                                       ->  Dynamic Seq Scan on t_mpp_20470 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=16)
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                                       Group Key: t_mpp_20470_1.col_name
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                                             Sort Key: t_mpp_20470_1.col_name
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-                                                   Hash Key: t_mpp_20470_1.col_name
-                                                   ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
-                                                         ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                                               Partitions selected: 2 (out of 2)
-                                                         ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(24 rows)
+         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
+               Hash Cond: ((t_mpp_20470.col_name)::text = (t_mpp_20470_1.col_name)::text)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     Hash Key: t_mpp_20470.col_name
+                     ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Partition Selector for t_mpp_20470 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on t_mpp_20470 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=16)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                           Group Key: t_mpp_20470_1.col_name
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                 Sort Key: t_mpp_20470_1.col_name
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                       Hash Key: t_mpp_20470_1.col_name
+                                       ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                                             ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                                   Partitions selected: 2 (out of 2)
+                                             ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(22 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;
@@ -1447,8 +1407,7 @@ explain SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1356273068.35 rows=1 width=4)
    ->  Hash Join  (cost=0.00..1356273068.35 rows=1 width=4)
          Hash Cond: ((((SubPlan 1)) = foo_s.b) AND (((SubPlan 2)) = foo_s.b))
-         ->  Result  (cost=0.00..1356272637.26 rows=334 width=12)
-               ->  Seq Scan on bar_s  (cost=0.00..1324053.98 rows=334 width=16)
+         ->  Seq Scan on bar_s  (cost=0.00..1324053.98 rows=334 width=16)
                SubPlan 1
                  ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                        ->  Result  (cost=0.00..431.00 rows=1 width=4)
@@ -1465,8 +1424,8 @@ explain SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz
                            ->  Partition Selector for foo_s (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                                  Partitions selected: 2 (out of 2)
                            ->  Dynamic Seq Scan on foo_s (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.72.0
-(22 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(21 rows)
 
 SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz_s WHERE bar_s.c = 9) AND foo_s.b = (select bar_s.d::int4);
  c 
@@ -1784,22 +1743,20 @@ EXPLAIN select count(distinct ss.ten) from
 -- we should see 2 subplans in the explain
 --
 EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
  Limit  (cost=0.00..865.44 rows=1 width=1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..865.44 rows=1 width=1)
          ->  Limit  (cost=0.00..865.44 rows=1 width=1)
-               ->  Result  (cost=0.00..865.44 rows=3334 width=1)
-                     ->  Result  (cost=0.00..865.44 rows=3334 width=8)
-                           ->  Hash Left Join  (cost=0.00..865.41 rows=3334 width=8)
-                                 Hash Cond: (tenk2.unique1 = tenk1.unique1)
-                                 ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=4)
-                                 ->  Hash  (cost=431.96..431.96 rows=3334 width=12)
-                                       ->  HashAggregate  (cost=0.00..431.96 rows=3334 width=12)
-                                             Group Key: tenk1.unique1
-                                             ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(13 rows)
+               ->  Hash Left Join  (cost=0.00..865.41 rows=3334 width=8)
+                     Hash Cond: (tenk2.unique1 = tenk1.unique1)
+                     ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=4)
+                     ->  Hash  (cost=431.96..431.96 rows=3334 width=12)
+                           ->  HashAggregate  (cost=0.00..431.96 rows=3334 width=12)
+                                 Group Key: tenk1.unique1
+                                 ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
  exists 
@@ -2038,23 +1995,22 @@ insert into simplify_sub values (2);
 -- limit n
 explain (costs off)
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Result
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on simplify_sub
    SubPlan 1
      ->  Result
-           ->  Result
-                 ->  Limit
-                       ->  Result
-                             Filter: (simplify_sub.i = simplify_sub_1.i)
-                             ->  Materialize
-                                   ->  Gather Motion 3:1  (slice2; segments: 3)
-                                         ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(14 rows)
+           ->  Limit
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
  i 
@@ -2065,23 +2021,22 @@ select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where 
 
 explain (costs off)
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Result
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on simplify_sub
    SubPlan 1
      ->  Result
-           ->  Result
-                 ->  Limit
-                       ->  Result
-                             Filter: (simplify_sub.i = simplify_sub_1.i)
-                             ->  Materialize
-                                   ->  Gather Motion 3:1  (slice2; segments: 3)
-                                         ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(14 rows)
+           ->  Limit
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
  i 
@@ -2098,10 +2053,9 @@ select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where 
          ->  Seq Scan on simplify_sub
          ->  Limit
                ->  Result
-                     ->  Result
-                           One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(9 rows)
+                     One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
  i 
@@ -2130,17 +2084,16 @@ select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 wh
 
 explain (costs off)
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
-                           QUERY PLAN                            
------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Semi Join
          Hash Cond: (simplify_sub.i = simplify_sub_1.i)
          ->  Seq Scan on simplify_sub
          ->  Hash
-               ->  Result
-                     ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(8 rows)
+               ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
  i 
@@ -2151,17 +2104,16 @@ select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where 
 
 explain (costs off)
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
-                           QUERY PLAN                            
------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Anti Join
          Hash Cond: (simplify_sub.i = simplify_sub_1.i)
          ->  Seq Scan on simplify_sub
          ->  Hash
-               ->  Result
-                     ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(8 rows)
+               ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
  i 
@@ -2170,17 +2122,16 @@ select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 wh
 
 explain (costs off)
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
-                           QUERY PLAN                            
------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Semi Join
          Hash Cond: (simplify_sub.i = simplify_sub_1.i)
          ->  Seq Scan on simplify_sub
          ->  Hash
-               ->  Result
-                     ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(8 rows)
+               ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
  i 
@@ -2191,17 +2142,16 @@ select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where 
 
 explain (costs off)
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
-                           QUERY PLAN                            
------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Anti Join
          Hash Cond: (simplify_sub.i = simplify_sub_1.i)
          ->  Seq Scan on simplify_sub
          ->  Hash
-               ->  Result
-                     ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(8 rows)
+               ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
  i 
@@ -2230,10 +2180,9 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
                       QUERY PLAN                      
 ------------------------------------------------------
  Result
-   ->  Result
-         One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(4 rows)
+   One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(3 rows)
 
 select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
  i 
@@ -2261,10 +2210,9 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
                       QUERY PLAN                      
 ------------------------------------------------------
  Result
-   ->  Result
-         One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(4 rows)
+   One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(3 rows)
 
 select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
  i 

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -227,38 +227,36 @@ from int8_tbl group by q1 order by q1;
 explain (costs off)
 select * from int4_tbl o where exists
   (select 1 from int4_tbl i where i.f1=o.f1 limit null);
-                       QUERY PLAN                        
----------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Semi Join
          Hash Cond: (int4_tbl.f1 = int4_tbl_1.f1)
          ->  Seq Scan on int4_tbl
          ->  Hash
-               ->  Result
-                     ->  Seq Scan on int4_tbl int4_tbl_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
-(8 rows)
+               ->  Seq Scan on int4_tbl int4_tbl_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 explain (costs off)
 select * from int4_tbl o where not exists
   (select 1 from int4_tbl i where i.f1=o.f1 limit 1);
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Result
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on int4_tbl
    SubPlan 1
      ->  Result
-           ->  Result
-                 ->  Limit
-                       ->  Result
-                             Filter: (int4_tbl_1.f1 = int4_tbl.f1)
-                             ->  Materialize
-                                   ->  Gather Motion 3:1  (slice2; segments: 3)
-                                         ->  Seq Scan on int4_tbl int4_tbl_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
-(14 rows)
+           ->  Limit
+                 ->  Result
+                       Filter: (int4_tbl_1.f1 = int4_tbl.f1)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on int4_tbl int4_tbl_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 explain (costs off)
 select * from int4_tbl o where exists
@@ -271,10 +269,9 @@ select * from int4_tbl o where exists
          ->  Seq Scan on int4_tbl
          ->  Limit
                ->  Result
-                     ->  Result
-                           One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
-(9 rows)
+                     One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 --
 -- Test cases to catch unpleasant interactions between IN-join processing
@@ -740,24 +737,18 @@ where a.thousand = b.thousand
 explain (verbose, costs off)
   select x, x from
     (select (select current_database()) as x from (values(1),(2)) v(y)) ss;
-                   QUERY PLAN                   
-------------------------------------------------
- Result
+                      QUERY PLAN                      
+------------------------------------------------------
+ Nested Loop Left Join
    Output: ('regression'::name), ('regression'::name)
+   Join Filter: true
+   ->  Values Scan on "Values"
+         Output: column1
    ->  Result
-         Output: ('regression'::name)
-         ->  Nested Loop Left Join
-               Output: ('regression'::name)
-               Join Filter: true
-               ->  Values Scan on "Values"
-                     Output: column1
-               ->  Result
-                     Output: 'regression'::name
-                     ->  Result
-                           Output: true
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
+         Output: 'regression'::name
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  Settings: optimizer=on
-(15 rows)
+(9 rows)
 
 explain (verbose, costs off)
   select x, x from
@@ -777,24 +768,18 @@ explain (verbose, costs off)
 explain (verbose, costs off)
   select x, x from
     (select (select current_database() where y=y) as x from (values(1),(2)) v(y)) ss;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Result
+                      QUERY PLAN                      
+------------------------------------------------------
+ Nested Loop Left Join
    Output: ('regression'::name), ('regression'::name)
+   Join Filter: ("Values".column1 = "Values".column1)
+   ->  Values Scan on "Values"
+         Output: column1
    ->  Result
-         Output: ('regression'::name)
-         ->  Nested Loop Left Join
-               Output: ('regression'::name)
-               Join Filter: ("Values".column1 = "Values".column1)
-               ->  Values Scan on "Values"
-                     Output: column1
-               ->  Result
-                     Output: 'regression'::name
-                     ->  Result
-                           Output: true
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
+         Output: 'regression'::name
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  Settings: optimizer=on
-(15 rows)
+(9 rows)
 
 explain (verbose, costs off)
   select x, x from
@@ -861,8 +846,8 @@ explain (verbose, costs off)
 select * from int4_tbl where
   (case when f1 in (select unique1 from tenk1 a) then f1 else null end) in
   (select ten from tenk1 b);
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Result
    Output: int4_tbl.f1
    Filter: (SubPlan 2)
@@ -873,14 +858,12 @@ select * from int4_tbl where
    SubPlan 1
      ->  Result
            Output: tenk1.unique1
-           ->  Result
-                 Output: true, tenk1.unique1
-                 ->  Materialize
+           ->  Materialize
+                 Output: tenk1.unique1
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
                        Output: tenk1.unique1
-                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                       ->  Seq Scan on public.tenk1
                              Output: tenk1.unique1
-                             ->  Seq Scan on public.tenk1
-                                   Output: tenk1.unique1
    SubPlan 2
      ->  Materialize
            Output: tenk1_1.ten
@@ -888,9 +871,9 @@ select * from int4_tbl where
                  Output: tenk1_1.ten
                  ->  Seq Scan on public.tenk1 tenk1_1
                        Output: tenk1_1.ten
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  Settings: optimizer=on
-(27 rows)
+(25 rows)
 
 select * from int4_tbl where
   (case when f1 in (select unique1 from tenk1 a) then f1 else null end) in

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -484,12 +484,11 @@ explain (costs off)
    ->  Append
          ->  Result
                Filter: (((t1.a || t1.b)) = 'ab'::text)
-               ->  Result
-                     ->  Seq Scan on t1
+               ->  Seq Scan on t1
          ->  Index Scan using t2_pkey on t2
                Index Cond: (ab = 'ab'::text)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(9 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 explain (costs off)
  SELECT * FROM
@@ -497,8 +496,8 @@ explain (costs off)
   UNION
   SELECT * FROM t2) t
  WHERE ab = 'ab';
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  GroupAggregate
          Group Key: ((t1.a || t1.b))
@@ -509,12 +508,11 @@ explain (costs off)
                            Hash Key: ((t1.a || t1.b))
                            ->  Result
                                  Filter: (((t1.a || t1.b)) = 'ab'::text)
-                                 ->  Result
-                                       ->  Seq Scan on t1
+                                 ->  Seq Scan on t1
                      ->  Index Scan using t2_pkey on t2
                            Index Cond: (ab = 'ab'::text)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(15 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
 
 --
 -- Test that ORDER BY for UNION ALL can be pushed down to inheritance
@@ -605,19 +603,17 @@ explain (costs off)
    UNION ALL
    SELECT 2 AS t, * FROM tenk1 b) c
  WHERE t = 2;
-                   QUERY PLAN                   
-------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Append
    ->  Result
-         ->  Result
-               One-Time Filter: false
+         One-Time Filter: false
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Result
                Filter: ((2) = 2)
-               ->  Result
-                     ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+               ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 -- Test that we push quals into UNION sub-selects only when it's safe
 explain (costs off)
@@ -626,18 +622,16 @@ SELECT * FROM
    UNION
    SELECT 2 AS t, 4 AS x) ss
 WHERE x < 4;
-              QUERY PLAN              
---------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Append
    ->  Result
          Filter: ((2) < 4)
          ->  Result
-               ->  Result
    ->  Result
-         ->  Result
-               One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(9 rows)
+         One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 SELECT * FROM
   (SELECT 1 AS t, 2 AS x
@@ -670,10 +664,9 @@ ORDER BY x;
                            ->  Result
                                  ->  Result
                      ->  Result
-                           ->  Result
-                                 One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(15 rows)
+                           One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
 
 SELECT * FROM
   (SELECT 1 AS t, generate_series(1,10) AS x

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -402,8 +402,8 @@ SELECT * FROM base_tbl;
 (6 rows)
 
 EXPLAIN (costs off) UPDATE rw_view1 SET a=6 WHERE a=5;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Update
    ->  Result
          ->  Sort
@@ -411,21 +411,19 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a=6 WHERE a=5;
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
                      Hash Key: base_tbl.a
                      ->  Split
-                           ->  Result
-                                 ->  Index Scan using base_tbl_pkey on base_tbl
-                                       Index Cond: ((a = 5) AND (a > 0))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.39.0
-(11 rows)
+                           ->  Index Scan using base_tbl_pkey on base_tbl
+                                 Index Cond: ((a = 5) AND (a > 0))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(10 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view1 WHERE a=5;
-                       QUERY PLAN                       
---------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Delete
-   ->  Result
-         ->  Index Scan using base_tbl_pkey on base_tbl
-               Index Cond: ((a = 5) AND (a > 0))
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(5 rows)
+   ->  Index Scan using base_tbl_pkey on base_tbl
+         Index Cond: ((a = 5) AND (a > 0))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(4 rows)
 
 DROP TABLE base_tbl CASCADE;
 NOTICE:  drop cascades to view rw_view1
@@ -482,8 +480,8 @@ SELECT * FROM rw_view2;
 (3 rows)
 
 EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Update
    ->  Result
          ->  Sort
@@ -491,21 +489,19 @@ EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
                      Hash Key: base_tbl.a
                      ->  Split
-                           ->  Result
-                                 ->  Index Scan using base_tbl_pkey on base_tbl
-                                       Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.39.0
-(11 rows)
+                           ->  Index Scan using base_tbl_pkey on base_tbl
+                                 Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(10 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE aaa=4;
-                          QUERY PLAN                          
---------------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Delete
-   ->  Result
-         ->  Index Scan using base_tbl_pkey on base_tbl
-               Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(5 rows)
+   ->  Index Scan using base_tbl_pkey on base_tbl
+         Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(4 rows)
 
 DROP TABLE base_tbl CASCADE;
 NOTICE:  drop cascades to 2 other objects
@@ -702,21 +698,20 @@ EXPLAIN (costs off) UPDATE rw_view2 SET a=3 WHERE a=2;
 (13 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE a=2;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Delete
-   ->  Result
-         ->  Hash Join
-               Hash Cond: (base_tbl.a = base_tbl_1.a)
-               ->  Index Scan using base_tbl_pkey on base_tbl
-                     Index Cond: (a = 2)
-               ->  Hash
-                     ->  Result
-                           Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
-                           ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
-                                 Index Cond: (a > 0)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(12 rows)
+   ->  Hash Join
+         Hash Cond: (base_tbl.a = base_tbl_1.a)
+         ->  Index Scan using base_tbl_pkey on base_tbl
+               Index Cond: (a = 2)
+         ->  Hash
+               ->  Result
+                     Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
+                     ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+                           Index Cond: (a > 0)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 DROP TABLE base_tbl CASCADE;
 NOTICE:  drop cascades to 2 other objects
@@ -2091,47 +2086,42 @@ EXPLAIN (costs off) DELETE FROM rw_view1 WHERE id = 1 AND snoop(data);
 DELETE FROM rw_view1 WHERE id = 1 AND snoop(data);
 NOTICE:  snooped value: Row 1
 EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Insert
    ->  Redistribute Motion 1:3  (slice2; segments: 1)
          Hash Key: (2)
-         ->  Result
-               ->  GroupAggregate
-                     Group Key: (true), (true)
-                     ->  Sort
-                           Sort Key: (true), (true)
-                           ->  Result
-                                 Filter: (CASE WHEN (NOT ((true) IS NULL)) THEN true ELSE false END IS NOT TRUE)
-                                 ->  Nested Loop Left Join
-                                       Join Filter: true
-                                       ->  Result
-                                       ->  Materialize
-                                             ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                   ->  Result
-                                                         ->  Result
-                                                               ->  Index Scan using base_tbl_pkey on base_tbl
-                                                                     Index Cond: (id = 2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
+         ->  GroupAggregate
+               Group Key: (true), (true)
+               ->  Sort
+                     Sort Key: (true), (true)
+                     ->  Result
+                           Filter: (CASE WHEN (NOT ((true) IS NULL)) THEN true ELSE false END IS NOT TRUE)
+                           ->  Nested Loop Left Join
+                                 Join Filter: true
+                                 ->  Result
+                                 ->  Materialize
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                                             ->  Index Scan using base_tbl_pkey on base_tbl
+                                                   Index Cond: (id = 2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  
  Update
    ->  Result
          ->  Split
-               ->  Result
-                     ->  Nested Loop Semi Join
-                           Join Filter: true
-                           ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
-                                 Index Cond: (id = 2)
-                           ->  Materialize
-                                 ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                                       ->  Result
-                                             ->  Result
-                                                   ->  Limit
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                               ->  Index Scan using base_tbl_pkey on base_tbl
-                                                                     Index Cond: (id = 2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.11.0
-(38 rows)
+               ->  Nested Loop Semi Join
+                     Join Filter: true
+                     ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+                           Index Cond: (id = 2)
+                     ->  Materialize
+                           ->  Broadcast Motion 1:3  (slice2; segments: 1)
+                                 ->  Result
+                                       ->  Limit
+                                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                   ->  Index Scan using base_tbl_pkey on base_tbl
+                                                         Index Cond: (id = 2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(33 rows)
 
 INSERT INTO rw_view1 VALUES (2, 'New row 2');
 SELECT * FROM base_tbl;

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -123,47 +123,46 @@ EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
                 (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
     ) t1
 WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                       QUERY PLAN                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update
    ->  Result
          ->  Explicit Redistribute Motion 3:3  (slice7; segments: 3)
                ->  Split
-                     ->  Result
+                     ->  Hash Join
+                           Hash Cond: ((keo1_1.user_vie_project_code_pk)::text = (keo2.projects_pk)::text)
                            ->  Hash Join
-                                 Hash Cond: ((keo1_1.user_vie_project_code_pk)::text = (keo2.projects_pk)::text)
-                                 ->  Hash Join
-                                       Hash Cond: ((keo1.user_vie_project_code_pk)::text = (keo1_1.user_vie_project_code_pk)::text)
-                                       ->  Seq Scan on keo1
-                                       ->  Hash
-                                             ->  Broadcast Motion 1:3  (slice5; segments: 1)
-                                                   ->  Hash Join
-                                                         Hash Cond: ((keo1_1.user_vie_fiscal_year_period_sk)::text = (max((keo3.sky_per)::text)))
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                               ->  Seq Scan on keo1 keo1_1
-                                                         ->  Hash
-                                                               ->  Aggregate
-                                                                     ->  Hash Join
-                                                                           Hash Cond: ((keo3.bky_per)::text = (keo4.keo_para_required_period)::text)
-                                                                           ->  Gather Motion 3:1  (slice2; segments: 3)
-                                                                                 ->  Seq Scan on keo3
-                                                                           ->  Hash
-                                                                                 ->  Assert
-                                                                                       Assert Cond: ((row_number() OVER (?)) = 1)
-                                                                                       ->  WindowAgg
-                                                                                             ->  Hash Join
-                                                                                                   Hash Cond: ((keo4.keo_para_budget_date)::text = (min((keo4_1.keo_para_budget_date)::text)))
-                                                                                                   ->  Gather Motion 3:1  (slice3; segments: 3)
-                                                                                                         ->  Seq Scan on keo4
-                                                                                                   ->  Hash
-                                                                                                         ->  Aggregate
-                                                                                                               ->  Gather Motion 3:1  (slice4; segments: 3)
-                                                                                                                     ->  Seq Scan on keo4 keo4_1
+                                 Hash Cond: ((keo1.user_vie_project_code_pk)::text = (keo1_1.user_vie_project_code_pk)::text)
+                                 ->  Seq Scan on keo1
                                  ->  Hash
-                                       ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                                             ->  Seq Scan on keo2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.41.0
-(43 rows)
+                                       ->  Broadcast Motion 1:3  (slice5; segments: 1)
+                                             ->  Hash Join
+                                                   Hash Cond: ((keo1_1.user_vie_fiscal_year_period_sk)::text = (max((keo3.sky_per)::text)))
+                                                   ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                         ->  Seq Scan on keo1 keo1_1
+                                                   ->  Hash
+                                                         ->  Aggregate
+                                                               ->  Hash Join
+                                                                     Hash Cond: ((keo3.bky_per)::text = (keo4.keo_para_required_period)::text)
+                                                                     ->  Gather Motion 3:1  (slice2; segments: 3)
+                                                                           ->  Seq Scan on keo3
+                                                                     ->  Hash
+                                                                           ->  Assert
+                                                                                 Assert Cond: ((row_number() OVER (?)) = 1)
+                                                                                 ->  WindowAgg
+                                                                                       ->  Hash Join
+                                                                                             Hash Cond: ((keo4.keo_para_budget_date)::text = (min((keo4_1.keo_para_budget_date)::text)))
+                                                                                             ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                                                                   ->  Seq Scan on keo4
+                                                                                             ->  Hash
+                                                                                                   ->  Aggregate
+                                                                                                         ->  Gather Motion 3:1  (slice4; segments: 3)
+                                                                                                               ->  Seq Scan on keo4 keo4_1
+                           ->  Hash
+                                 ->  Broadcast Motion 3:3  (slice6; segments: 3)
+                                       ->  Seq Scan on keo2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(37 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b
@@ -184,25 +183,24 @@ SELECT user_vie_act_cntr_marg_cum FROM keo1;
 CREATE TABLE keo5 (x int, y int) DISTRIBUTED BY (x);
 INSERT INTO keo5 VALUES (1,1);
 EXPLAIN (COSTS OFF) DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS (SELECT x FROM keo5 WHERE x < 2));
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Delete
-   ->  Result
-         ->  Hash Semi Join
-               Hash Cond: (keo5.x = keo5_2.x)
-               ->  Seq Scan on keo5
-               ->  Hash
-                     ->  Nested Loop Semi Join
-                           Join Filter: true
-                           ->  Seq Scan on keo5 keo5_2
-                           ->  Materialize
-                                 ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                                       ->  Limit
-                                             ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                   ->  Seq Scan on keo5 keo5_1
-                                                         Filter: (x < 2)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(16 rows)
+   ->  Hash Semi Join
+         Hash Cond: (keo5.x = keo5_2.x)
+         ->  Seq Scan on keo5
+         ->  Hash
+               ->  Nested Loop Semi Join
+                     Join Filter: true
+                     ->  Seq Scan on keo5 keo5_2
+                     ->  Materialize
+                           ->  Broadcast Motion 1:3  (slice2; segments: 1)
+                                 ->  Limit
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                                             ->  Seq Scan on keo5 keo5_1
+                                                   Filter: (x < 2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS (SELECT x FROM keo5 WHERE x < 2));
 SELECT x FROM keo5;
@@ -498,17 +496,16 @@ select * from s;
 -- constraints in the planner.
 create table nosplitupdate (a int) distributed by (a);
 explain update nosplitupdate set a=0 where a=1 and a<1;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Update  (cost=0.00..0.00 rows=0 width=1)
    ->  Result  (cost=0.00..0.00 rows=0 width=22)
          ->  Result  (cost=0.00..0.00 rows=0 width=18)
                ->  Split  (cost=0.00..0.00 rows=0 width=18)
                      ->  Result  (cost=0.00..0.00 rows=0 width=18)
-                           ->  Result  (cost=0.00..0.00 rows=0 width=18)
-                                 One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 3.39.0
-(8 rows)
+                           One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 -- test split-update when split-node's flow is entry
 create table tsplit_entry (c int);

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -428,10 +428,9 @@ EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: tab3.c1, tab3.c2, tab3.c3
                ->  Split
-                     ->  Result
-                           ->  Seq Scan on tab3
- Optimizer: Pivotal Optimizer (GPORCA) version 3.39.0
-(8 rows)
+                     ->  Seq Scan on tab3
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 -- clean up
 drop table tab3;

--- a/src/test/regress/expected/window_optimizer.out
+++ b/src/test/regress/expected/window_optimizer.out
@@ -626,22 +626,19 @@ explain (costs off)
 select first_value(max(x)) over (), y
   from (select unique1 as x, ten+four as y from tenk1) ss
   group by y;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  WindowAgg
    ->  Gather Motion 3:1  (slice2; segments: 3)
-         ->  Result
-               ->  Finalize HashAggregate
-                     Group Key: ((ten + four))
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: ((ten + four))
-                           ->  Result
-                                 ->  Streaming Partial HashAggregate
-                                       Group Key: (ten + four)
-                                       ->  Result
-                                             ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(13 rows)
+         ->  Finalize HashAggregate
+               Group Key: ((ten + four))
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: ((ten + four))
+                     ->  Streaming Partial HashAggregate
+                           Group Key: (ten + four)
+                           ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(10 rows)
 
 -- test non-default frame specifications
 SELECT four, ten,
@@ -1080,23 +1077,23 @@ SELECT * FROM
           min(salary) OVER (PARTITION BY depname, empno order by enroll_date) depminsalary
    FROM empsalary) emp
 WHERE depname = 'sales';
-                                  QUERY PLAN
------------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Result
-         ->  WindowAgg
-               Partition By: depname, empno
-               Order By: enroll_date
-               ->  Sort
-                     Sort Key: depname, empno, enroll_date
-                     ->  WindowAgg
-                           Partition By: depname
-                           Order By: empno
-                           ->  Sort
-                                 Sort Key: depname, empno
-                                 ->  Seq Scan on empsalary
-                                       Filter: ((depname)::text = 'sales'::text)
-(15 rows)
+   ->  WindowAgg
+         Partition By: depname, empno
+         Order By: enroll_date
+         ->  Sort
+               Sort Key: depname, empno, enroll_date
+               ->  WindowAgg
+                     Partition By: depname
+                     Order By: empno
+                     ->  Sort
+                           Sort Key: depname, empno
+                           ->  Seq Scan on empsalary
+                                 Filter: ((depname)::text = 'sales'::text)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
 
 -- Test Sort node reordering
 EXPLAIN (COSTS OFF)
@@ -1104,23 +1101,22 @@ SELECT
   lead(1) OVER (PARTITION BY depname ORDER BY salary, enroll_date),
   lag(1) OVER (PARTITION BY depname ORDER BY salary,enroll_date,empno)
 FROM empsalary;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Result
-         ->  WindowAgg
-               Partition By: depname
-               Order By: salary, enroll_date, empno
-               ->  Sort
-                     Sort Key: depname, salary, enroll_date, empno
-                     ->  WindowAgg
-                           Partition By: depname
-                           Order By: salary, enroll_date
-                           ->  Sort
-                                 Sort Key: depname, salary, enroll_date
-                                 ->  Seq Scan on empsalary
- Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
-(14 rows)
+   ->  WindowAgg
+         Partition By: depname
+         Order By: salary, enroll_date, empno
+         ->  Sort
+               Sort Key: depname, salary, enroll_date, empno
+               ->  WindowAgg
+                     Partition By: depname
+                     Order By: salary, enroll_date
+                     ->  Sort
+                           Sort Key: depname, salary, enroll_date
+                           ->  Seq Scan on empsalary
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- Test pushdown of quals into a subquery containing window functions
 -- pushdown is safe because all PARTITION BY clauses include depname:
@@ -1131,23 +1127,22 @@ SELECT * FROM
           min(salary) OVER (PARTITION BY depname || 'A', depname) depminsalary
    FROM empsalary) emp
 WHERE depname = 'sales';
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Result
-         ->  WindowAgg
-               Partition By: (((depname)::text || 'A'::text)), depname
-               ->  Sort
-                     Sort Key: (((depname)::text || 'A'::text)), depname
-                     ->  WindowAgg
-                           Partition By: depname
-                           ->  Result
-                                 ->  Sort
-                                       Sort Key: depname
-                                       ->  Seq Scan on empsalary
-                                             Filter: ((depname)::text = 'sales'::text)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
-(14 rows)
+   ->  WindowAgg
+         Partition By: (((depname)::text || 'A'::text)), depname
+         ->  Sort
+               Sort Key: (((depname)::text || 'A'::text)), depname
+               ->  WindowAgg
+                     Partition By: depname
+                     ->  Result
+                           ->  Sort
+                                 Sort Key: depname
+                                 ->  Seq Scan on empsalary
+                                       Filter: ((depname)::text = 'sales'::text)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- pushdown is unsafe because there's a PARTITION BY clause without depname:
 EXPLAIN (COSTS OFF)
@@ -1186,23 +1181,22 @@ SELECT * FROM
           min(salary) OVER (PARTITION BY depname || 'A', depname) depminsalary
    FROM empsalary) emp
 WHERE depname = 'sales' OR RANDOM() > 0.5;
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Result
-         ->  WindowAgg
-               Partition By: (((depname)::text || 'A'::text)), depname
-               ->  Sort
-                     Sort Key: (((depname)::text || 'A'::text)), depname
-                     ->  WindowAgg
-                           Partition By: depname
-                           ->  Result
-                                 ->  Sort
-                                       Sort Key: depname
-                                       ->  Seq Scan on empsalary
-                                             Filter: (((depname)::text = 'sales'::text) OR (random() > '0.5'::double precision))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.23.0
-(14 rows)
+   ->  WindowAgg
+         Partition By: (((depname)::text || 'A'::text)), depname
+         ->  Sort
+               Sort Key: (((depname)::text || 'A'::text)), depname
+               ->  WindowAgg
+                     Partition By: depname
+                     ->  Result
+                           ->  Sort
+                                 Sort Key: depname
+                                 ->  Seq Scan on empsalary
+                                       Filter: (((depname)::text = 'sales'::text) OR (random() > '0.5'::double precision))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- cleanup
 DROP TABLE empsalary;


### PR DESCRIPTION
ORCA tends to generate redundant Result nodes, like a Result node on top
of a Result node, or a Result node on top of some other projection-capable
Result node. I'm not sure why; sometimes there are reasons for that, but in
most cases, they seem unnecessary.

If the Result only exists to project, we can easily push the projection
down to the child plan. Add a pass through the plan tree, to look for such
Results and eliminate them.

To make the mutator code work, add handler for DML nodes to
plan_tree_mutator(), and note that Sequence nodes are not capable of
projecting, in is_projection_capable_plan(). Those were existing bugs, but
they apparently didn't cause any harm before, because we never tried to
use those functions on ORCA-generated plans, and those plan nodes are only
generated by ORCA.

The reason I'm tackling this right now is that I started to work on a
patch to remove the DML node that is only used in ORCA-generated plans,
and replace it with PostgreSQL ModifyTable node. But there's one difference
between DML node and ModifyTable: DML projects the input first, and then
inserts/updates with the resulting tuple, whereas ModifyTable requires that
the input tuple is already in the correct format. One simple way to fix
that is to add a Result node under the ModifyTable to do the projection,
but that leads to even more Results. My plan is that once we have this
redundant Result elimination step, the extra Results generated in ORCA
translation would be OK, because they would usually get eliminated away
later. But even without that, having less deep plans is nicer.
