### PR TITLE
5X Backport: Fix dispatch of SET TIME ZONE INTERVAL statement.

### DIFF
--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -82,41 +82,69 @@ WARNING:  "work_mem": setting is deprecated, and may be removed in a future rele
 -- Test if RESET timezone is dispatched to all slices
 --
 CREATE TABLE timezone_table AS SELECT * FROM (VALUES (123,1513123564),(123,1512140765),(123,1512173164),(123,1512396441)) foo(a, b) DISTRIBUTED RANDOMLY;
-SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
- to_timestamp 
---------------
- 12-01-2017
- 12-04-2017
- 12-12-2017
-(3 rows)
+SELECT to_timestamp(b)::timestamp WITH TIME ZONE AS b_ts FROM timezone_table ORDER BY b_ts;
+             b_ts
+------------------------------
+ Fri Dec 01 07:06:05 2017 PST
+ Fri Dec 01 16:06:04 2017 PST
+ Mon Dec 04 06:07:21 2017 PST
+ Tue Dec 12 16:06:04 2017 PST
+(4 rows)
 
 SET timezone= 'America/New_York';
-SHOW timezone;
-     TimeZone     
-------------------
- America/New_York
+-- Check if it is set correctly on QD.
+SELECT to_timestamp(1613123565)::timestamp WITH TIME ZONE;
+         to_timestamp
+------------------------------
+ Fri Feb 12 04:52:45 2021 EST
 (1 row)
 
-SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
- to_timestamp 
---------------
- 12-01-2017
- 12-04-2017
- 12-12-2017
-(3 rows)
+-- Check if it is set correctly on the QEs.
+SELECT to_timestamp(b)::timestamp WITH TIME ZONE AS b_ts FROM timezone_table ORDER BY b_ts;
+             b_ts
+------------------------------
+ Fri Dec 01 10:06:05 2017 EST
+ Fri Dec 01 19:06:04 2017 EST
+ Mon Dec 04 09:07:21 2017 EST
+ Tue Dec 12 19:06:04 2017 EST
+(4 rows)
 
 RESET timezone;
-SHOW timezone;
- TimeZone 
-----------
- PST8PDT
+-- Check if it is reset correctly on QD.
+SELECT to_timestamp(1613123565)::timestamp WITH TIME ZONE;
+         to_timestamp
+------------------------------
+ Fri Feb 12 01:52:45 2021 PST
 (1 row)
 
-SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
- to_timestamp 
---------------
- 12-01-2017
- 12-04-2017
- 12-12-2017
-(3 rows)
+-- Check if it is reset correctly on the QEs.
+SELECT to_timestamp(b)::timestamp WITH TIME ZONE AS b_ts FROM timezone_table ORDER BY b_ts;
+             b_ts
+------------------------------
+ Fri Dec 01 07:06:05 2017 PST
+ Fri Dec 01 16:06:04 2017 PST
+ Mon Dec 04 06:07:21 2017 PST
+ Tue Dec 12 16:06:04 2017 PST
+(4 rows)
+
+--
+-- Test if SET TIME ZONE INTERVAL is dispatched correctly to all segments
+--
+SET TIME ZONE INTERVAL '04:30:06' HOUR TO MINUTE;
+-- Check if it is set correctly on QD.
+SELECT to_timestamp(1613123565)::timestamp WITH TIME ZONE;
+          to_timestamp
+---------------------------------
+ Fri Feb 12 14:22:45 2021 +04:30
+(1 row)
+
+-- Check if it is set correctly on the QEs.
+SELECT to_timestamp(b)::timestamp WITH TIME ZONE AS b_ts FROM timezone_table ORDER BY b_ts;
+              b_ts
+---------------------------------
+ Fri Dec 01 19:36:05 2017 +04:30
+ Sat Dec 02 04:36:04 2017 +04:30
+ Mon Dec 04 18:37:21 2017 +04:30
+ Wed Dec 13 04:36:04 2017 +04:30
+(4 rows)
 

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -79,10 +79,23 @@ reset work_mem;
 --
 CREATE TABLE timezone_table AS SELECT * FROM (VALUES (123,1513123564),(123,1512140765),(123,1512173164),(123,1512396441)) foo(a, b) DISTRIBUTED RANDOMLY;
 
-SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
+SELECT to_timestamp(b)::timestamp WITH TIME ZONE AS b_ts FROM timezone_table ORDER BY b_ts;
 SET timezone= 'America/New_York';
-SHOW timezone;
-SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
+-- Check if it is set correctly on QD.
+SELECT to_timestamp(1613123565)::timestamp WITH TIME ZONE;
+-- Check if it is set correctly on the QEs.
+SELECT to_timestamp(b)::timestamp WITH TIME ZONE AS b_ts FROM timezone_table ORDER BY b_ts;
 RESET timezone;
-SHOW timezone;
-SELECT DISTINCT to_timestamp(b)::date FROM timezone_table;
+-- Check if it is reset correctly on QD.
+SELECT to_timestamp(1613123565)::timestamp WITH TIME ZONE;
+-- Check if it is reset correctly on the QEs.
+SELECT to_timestamp(b)::timestamp WITH TIME ZONE AS b_ts FROM timezone_table ORDER BY b_ts;
+
+--
+-- Test if SET TIME ZONE INTERVAL is dispatched correctly to all segments
+--
+SET TIME ZONE INTERVAL '04:30:06' HOUR TO MINUTE;
+-- Check if it is set correctly on QD.
+SELECT to_timestamp(1613123565)::timestamp WITH TIME ZONE;
+-- Check if it is set correctly on the QEs.
+SELECT to_timestamp(b)::timestamp WITH TIME ZONE AS b_ts FROM timezone_table ORDER BY b_ts;


### PR DESCRIPTION
Backported from: fe3f58a9dbc1da0fb5153a19e255b7969295f8bb

This fixes Issue: #9055

Tl;dr: Instead of dispatching SET TIME ZONE INTERVAL <args> when this
flavor was used, we extracted the arguments following INTERVAL and
dispatched SET timezone TO <args>.

Please refer to issue #9055 for the repro, complete RCA and fix details.

Notes:
1. I added a test for this scenario and I refactored some existing tests
in this area for them to be more explicit in their intent.

2. The backport was not a clean one due to the limited scope of
`quote_literal_cstr` (had to use `quote_literal_internal` instead). This
function was not exposed until upstream commit:
4343c0e546b216ab38a3397a4f0f7476d557b352

Also, the function `GetConfigOptionByName()` returned the wrong GUC
value for timezone (in case the `IntervalStyle` was set to
`postgres_verbose` it was returing `@ 4 hours 30 mins`, for our test
example, which is not a
valid value to pass to the SET command and by extension, not a valid
value for dispatch). This is because the function eventually invokes
`show_timezone` and due to the presence of the `HasCTZSet` branch
(removed in upstream commit: 45f64f1b),
`interval_out` is invoked again. Since the
`IntervalStyle=postgres_verbose` `@ 4 hours 30 mins` was returned.

So used the `GetConfigOption()` instead, which does not invoke the
`show_timezone` hook.