### PR TITLE
Fix compilation errors: implicit fall through.

### DIFF
--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
@@ -1995,6 +1995,7 @@ pgquery_getresult(pgqueryobject * self, PyObject * args)
 						}
 						cashbuf[k] = 0;
 						s = cashbuf;
+						/* FALLTHROUGH */
 
 					case 4:
 						if (decimal)
@@ -2119,6 +2120,7 @@ pgquery_dictresult(pgqueryobject * self, PyObject * args)
 						}
 						cashbuf[k] = 0;
 						s = cashbuf;
+						/* FALLTHROUGH */
 
 					case 4:
 						if (decimal)

--- a/gpcontrib/gp_sparse_vector/operators.c
+++ b/gpcontrib/gp_sparse_vector/operators.c
@@ -411,6 +411,7 @@ svec_count(PG_FUNCTION_ARGS)
 			 * beginning of the accumulation of the correct dimension.
 			 */
 			left = makeSparseDataFromDouble(0.,right->total_value_count);
+			/* FALLTHROUGH */
 
 		case 0: 		//neither arg is scalar
 		case 2:			//right arg is scalar


### PR DESCRIPTION
We have added explicit fall through to fix compilation errors caused by -Wimpicit-fallthrough GCC >= 7 option.
Switch flow was also checked.