### PR TITLE
5X PR pipeline: Fetch tags and submodules and add on_failure hook

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -57,7 +57,6 @@ jobs:
             trigger: true
           - get: binary_swap_gpdb
             resource: binary_swap_gpdb_centos6
-            trigger: true
           - get: centos-gpdb-dev-6
           - get: gpaddon_src
           - get: gpdb_5x_upstream

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -79,36 +79,56 @@ jobs:
           TASK_OS: centos
           TASK_OS_VERSION: 6
 
-      - task: compile_gpdb
-        input_mapping:
-          gpdb_src: gpdb_pr
-        file: gpdb_pr/concourse/tasks/compile_gpdb.yml
-        image: centos-gpdb-dev-6
+      - put: gpdb_pr
         params:
-          CONFIGURE_FLAGS: {{configure_flags}}
-          TARGET_OS: centos
-          TARGET_OS_VERSION: 6
-          BLD_TARGETS: "clients loaders"
-
-      - in_parallel:
-        - put: gpdb_pr
+          path: gpdb_pr
+          status: pending
+      - # "do" the remaining steps with these hooks:
+        on_failure:
+          put: gpdb_pr
           params:
             path: gpdb_pr
-            status: pending
+            status: failure
+        on_success:
+          put: report_pr_success
+          resource: gpdb_pr
+          params:
+            path: gpdb_pr
+            status: success
+        do:
+        # Fetch tags and submodules, because the PR resource doesn't.
+        # gpdb_src is to be used by compile_gpdb and ic_gpdb.
+        - task: init gpdb_src
+          image: centos-gpdb-dev-6
+          config:
+            platform: linux
+            run:
+              path: bash
+              args:
+                - -c
+                - |
+                  git clone gpdb_pr gpdb_src &&
+                  cd gpdb_src &&
+                  git fetch https://github.com/greenplum-db/gpdb.git --tags &&
+                  git submodule update --init --recursive
+            inputs: [{ name: gpdb_pr }]
+            outputs: [{ name: gpdb_src }]
+        - task: compile_gpdb
+          file: gpdb_src/concourse/tasks/compile_gpdb.yml
+          image: centos-gpdb-dev-6
+          params:
+            CONFIGURE_FLAGS: {{configure_flags}}
+            TARGET_OS: centos
+            TARGET_OS_VERSION: 6
+            BLD_TARGETS: "clients loaders"
+
         - task: ic_gpdb
-          file: gpdb_pr/concourse/tasks/ic_gpdb_binary_swap.yml
+          file: gpdb_src/concourse/tasks/ic_gpdb_binary_swap.yml
           image: centos-gpdb-dev-6
           input_mapping:
-            gpdb_src: gpdb_pr
             bin_gpdb: gpdb_artifacts
           params:
             MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
             BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
             TEST_OS: centos
             CONFIGURE_FLAGS: {{configure_flags}}
-
-      - put: report_pr_success
-        resource: gpdb_pr
-        params:
-          path: gpdb_pr
-          status: success


### PR DESCRIPTION
We need to fetch tags and submodules in order for extensions like
pgbouncer to be built. Otherwise, we get the following:

```
/bin/bash: ./autogen.sh: No such file or directory
make[1]: *** [mkpgbouncer] Error 127
make: *** [dist] Error 2
```

Also we added an `on_failure` hook to compile and IC tasks to report PR
failure. Additionally, reporting PR success is now part of a `on_success`
hook.

Co-authored-by: Alexandra Wang <lewang@pivotal.io>
