### PR TITLE
Call TransactionIdDidCommit after XidInMVCCSnapshot only if needed

### DIFF
--- a/src/include/utils/tqual.h
+++ b/src/include/utils/tqual.h
@@ -81,7 +81,8 @@ extern HTSV_Result HeapTupleSatisfiesVacuum(Relation relation, HeapTuple htup,
 extern bool HeapTupleIsSurelyDead(HeapTuple htup,
 					  TransactionId OldestXmin);
 extern bool XidInMVCCSnapshot(TransactionId xid, Snapshot snapshot,
-							  bool distributedSnapshotIgnore, bool *setDistributedSnapshotIgnore);
+							  bool distributedSnapshotIgnore, bool *setDistributedSnapshotIgnore,
+							  bool *xidKnownToHaveCommitted);
 extern bool XidInMVCCSnapshot_Local(TransactionId xid, Snapshot snapshot);
 
 extern void HeapTupleSetHintBits(HeapTupleHeader tuple, Buffer buffer, Relation rel,

--- a/src/include/utils/tqual.h
+++ b/src/include/utils/tqual.h
@@ -80,9 +80,15 @@ extern HTSV_Result HeapTupleSatisfiesVacuum(Relation relation, HeapTuple htup,
 						 TransactionId OldestXmin, Buffer buffer);
 extern bool HeapTupleIsSurelyDead(HeapTuple htup,
 					  TransactionId OldestXmin);
-extern bool XidInMVCCSnapshot(TransactionId xid, Snapshot snapshot,
-							  bool distributedSnapshotIgnore, bool *setDistributedSnapshotIgnore,
-							  bool *xidKnownToHaveCommitted);
+
+typedef enum
+{
+	XID_NOT_IN_SNAPSHOT,
+	XID_IN_SNAPSHOT,
+	XID_SURELY_COMMITTED
+} XidInMVCCSnapshotCheckResult;
+extern XidInMVCCSnapshotCheckResult XidInMVCCSnapshot(TransactionId xid, Snapshot snapshot,
+							  bool distributedSnapshotIgnore, bool *setDistributedSnapshotIgnore);
 extern bool XidInMVCCSnapshot_Local(TransactionId xid, Snapshot snapshot);
 
 extern void HeapTupleSetHintBits(HeapTupleHeader tuple, Buffer buffer, Relation rel,


### PR DESCRIPTION
This addresses the following GPDB_96_MERGE_FIXME:
```
/*
 * GPDB_96_MERGE_FIXME: Many of the callers will call
 * TransactionIdDidCommit() after this, but if we get here, we
 * know that it committed. If we could somehow communicate it
 * to the caller, we could skip the TransactionIdDidCommit()
 * call.
 */
```
`HeapTupleSatisfiesMVCC()` frequently calls `TransactionIdDidCommit()`
right after the check: `XidInMVCCSnapshot()`. This commit tries to
reduce the number of calls necessary.

Motivation:
`HeapTupleSatisfiesMVCC()` is in a hot code path as it is the
`satisfies` callback for `Snapshot`: Also refer:
`HeapTupleSatisfiesVisibility()`. Furthermore,
`TransactionIdDidCommit()` can also be recursive if there are
subcommits.

Solution:
`XidInMVCCSnapshot()` now additionally reports if the passed in xid has
definitely committed: which we can infer from
`DISTRIBUTEDSNAPSHOT_COMMITTED_VISIBLE`, which implies that we have a
distributed committed transaction. We now check this report before
invoking `TransactionIdDidCommit()`.