### PR TITLE
Add logic to pg_get_viewdef() to handle gp_dist_random

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -9411,10 +9411,18 @@ get_from_clause_item(Node *jtnode, Query *query, deparse_context *context)
 		{
 			case RTE_RELATION:
 				/* Normal relation RTE */
-				appendStringInfo(buf, "%s%s",
-								 only_marker(rte),
-								 generate_relation_name(rte->relid,
-														context->namespaces));
+				if (rte->forceDistRandom)
+				{
+					char * relname = generate_relation_name(rte->relid,
+															context->namespaces);
+					appendStringInfo(buf, "gp_dist_random(%s)",
+									 quote_literal_cstr(relname));
+				}
+				else
+					appendStringInfo(buf, "%s%s",
+									 only_marker(rte),
+									 generate_relation_name(rte->relid,
+															context->namespaces));
 				break;
 			case RTE_SUBQUERY:
 				/* Subquery RTE */

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -104,3 +104,26 @@ drop view v_sourcetable2;
 CREATE TEMP TABLE gp_create_view_t1 (f1 smallint, f2 text) DISTRIBUTED RANDOMLY;
 CREATE TEMP VIEW window_and_agg_v1 AS SELECT count(*) OVER (PARTITION BY f1), max(f2) FROM gp_create_view_t1 GROUP BY f1;
 reset optimizer;
+-- Check that views with gp_dist_random in them will be reconstructed back properly.
+CREATE TEMP VIEW view_with_gp_dist_random AS SELECT 1 FROM gp_dist_random('pg_class');
+SELECT pg_get_viewdef('view_with_gp_dist_random');
+           pg_get_viewdef            
+-------------------------------------
+  SELECT 1                          +
+    FROM gp_dist_random('pg_class');
+(1 row)
+
+CREATE SCHEMA "schema_view\'.gp_dist_random";
+CREATE TABLE "schema_view\'.gp_dist_random"."foo\'.bar" (a int);
+CREATE TEMP VIEW view_with_gp_dist_random_special_chars AS SELECT * FROM gp_dist_random(E'"schema_view\\''.gp_dist_random"."foo\\''.bar"');
+SELECT pg_get_viewdef('view_with_gp_dist_random_special_chars');
+                               pg_get_viewdef                               
+----------------------------------------------------------------------------
+  SELECT "foo\'.bar".a                                                     +
+    FROM gp_dist_random(E'"schema_view\\''.gp_dist_random"."foo\\''.bar"');
+(1 row)
+
+DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
+DETAIL:  drop cascades to table "schema_view\'.gp_dist_random"."foo\'.bar"
+NOTICE:  drop cascades to 2 other objects
+drop cascades to view view_with_gp_dist_random_special_chars

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -65,3 +65,12 @@ CREATE TEMP TABLE gp_create_view_t1 (f1 smallint, f2 text) DISTRIBUTED RANDOMLY;
 CREATE TEMP VIEW window_and_agg_v1 AS SELECT count(*) OVER (PARTITION BY f1), max(f2) FROM gp_create_view_t1 GROUP BY f1;
 
 reset optimizer;
+
+-- Check that views with gp_dist_random in them will be reconstructed back properly.
+CREATE TEMP VIEW view_with_gp_dist_random AS SELECT 1 FROM gp_dist_random('pg_class');
+SELECT pg_get_viewdef('view_with_gp_dist_random');
+CREATE SCHEMA "schema_view\'.gp_dist_random";
+CREATE TABLE "schema_view\'.gp_dist_random"."foo\'.bar" (a int);
+CREATE TEMP VIEW view_with_gp_dist_random_special_chars AS SELECT * FROM gp_dist_random(E'"schema_view\\''.gp_dist_random"."foo\\''.bar"');
+SELECT pg_get_viewdef('view_with_gp_dist_random_special_chars');
+DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;


### PR DESCRIPTION
Currently, if a view is created with gp_dist_random surrounding the
target table, the interpreted view definition does not contain
gp_dist_random.

Before proposed fix (view is from new test introduced in this commit):
```
postgres=# SELECT pg_get_viewdef('view_with_gp_dist_random');
     pg_get_viewdef
------------------------
  SELECT 1             +
    FROM ONLY pg_class;
(1 row)
```

However, the gp_dist_random is there in the stored query parse tree as
a boolean forceDistRandom in the RangeTableEntry. We need to check for
this to properly reconstruct the SQL from the stored query parse tree.

After proposed fix:
```
postgres=# SELECT pg_get_viewdef('view_with_gp_dist_random');
           pg_get_viewdef
-------------------------------------
  SELECT 1                          +
    FROM gp_dist_random('pg_class');
(1 row)
```

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>