### PR TITLE
Reinstate elog(ERROR,..) in pg_get_indexdef_worker()

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -1173,12 +1173,7 @@ pg_get_indexdef_worker(Oid indexrelid, int colno,
 	{
 		if (missing_ok)
 			return NULL;
-
-		/* GPDB_96_MERGE_FIXME: This function got the 'missing_ok' argument in 9.6.
-		 * Should we put the elog() back? */
-		/* Was: elog(ERROR, "cache lookup failed for index %u", indexrelid); */
-		/* See: MPP-10387. */
-		return pstrdup("Not an index");
+		elog(ERROR, "cache lookup failed for index %u", indexrelid);
 	}
 	idxrec = (Form_pg_index) GETSTRUCT(ht_idx);
 


### PR DESCRIPTION
This addresses the following GPDB_96_MERGE_FIXME:
```
/* GPDB_96_MERGE_FIXME: This function got the 'missing_ok' argument in 9.6.
 * Should we put the elog() back? */
/* Was: elog(ERROR, "cache lookup failed for index %u", indexrelid); */
/* See: MPP-10387. */
```

Historical context:
This elog error was taken out of the codebase due to the unfriendliness
of the error message when the user ran a lookup on a missing/invalid
index. For instance the user would observe the following:

```
select * from pg_indexes where tablename='doesnt_exist';
ERROR:  cache lookup failed for index 0
```

OR minimally,

```
select pg_get_indexdef(0);
ERROR:  cache lookup failed for index 0
```
So the error message was replaced by returning : "Not an index".

Solution:
Upstream commit 976b24fb477 resolves this problem with the `missing_ok`
parameter. `pg_get_indexdef_worker()` now returns NULL if `missing_ok`
is true. All its user-facing callers do call it with `missing_ok = true`
and return an empty result set if the call involves a non-existent
index. So we now get:

```
postgres=# select pg_get_indexdef(0);
 pg_get_indexdef
-----------------

(1 row)
```
All non-user facing callers should be met with an elog(ERROR, ..) in
these circumstances. This is what we are doing now.

Note: When we removed the elog and replaced it with a hard-coded return,
we incorrectly suppressed the error for non-user facing callers.
