### PR TITLE
6X_STABLE: Crash caused by null str in make_url

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -949,6 +949,11 @@ make_url(const char *url, char *buf, bool is_ipv6)
 
 	hostip = getDnsAddress(hostname, port, ERROR);
 
+	if (hostip == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("hostname cannot be resolved '%s'", url)));
+
 	/*
 	 * test for the case where the URL originaly contained a domain name
 	 * (so is_ipv6 was set to false) but the DNS resolution in getDnsAddress

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3501,6 +3501,14 @@ select numsegments from gp_distribution_policy where localoid = 'ext_w_expand'::
 
 drop external table ext_w_expand;
 
+
+--
+-- Test host name cannot be resolved
+--
+CREATE READABLE EXTERNAL TABLE ext_invalid_host() LOCATION ('gpfdist://not-exist-host/data.csv') FORMAT 'CSV' ( DELIMITER AS ',');
+
+SELECT * from ext_invalid_host;
+
 -- Test delimiter off
 
 CREATE EXTERNAL TABLE test_delimiter(data text) LOCATION('gpfdist://127.0.0.1/test_delimiter.txt') FORMAT 'text' (DELIMITER 'off');

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4810,6 +4810,15 @@ select numsegments from gp_distribution_policy where localoid = 'ext_w_expand'::
 (1 row)
 
 drop external table ext_w_expand;
+--
+-- Test host name cannot be resolved
+--
+CREATE READABLE EXTERNAL TABLE ext_invalid_host() LOCATION ('gpfdist://not-exist-host/data.csv') FORMAT 'CSV' ( DELIMITER AS ',');
+SELECT * from ext_invalid_host;
+WARNING:  could not translate host name "not-exist-host", port "8080" to address: Name or service not known  (seg0 slice1 127.0.0.1:5434 pid=181826)
+WARNING:  could not translate host name "not-exist-host", port "8080" to address: Name or service not known  (seg1 slice1 127.0.0.1:5435 pid=181824)
+WARNING:  could not translate host name "not-exist-host", port "8080" to address: Name or service not known  (seg2 slice1 127.0.0.1:5436 pid=181825)
+ERROR:  hostname cannot be resolved 'gpfdist://not-exist-host:8080/data.csv'  (seg0 slice1 127.0.0.1:5434 pid=181826)
 -- Test delimiter off
 CREATE EXTERNAL TABLE test_delimiter(data text) LOCATION('gpfdist://127.0.0.1/test_delimiter.txt') FORMAT 'text' (DELIMITER 'off');
 DROP EXTERNAL TABLE test_delimiter;


### PR DESCRIPTION
When the hostname cannot be resolved, getDnsAddress can return NULL
which should be checked before using.

Backport from: 027b3ae7087fac34be48caa27bfb1f793f175a8e

Authored-by: Chen Mulong <muchen@pivotal.io>


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community