### PR TITLE
Elide explicit motion if no motion above result relation

### DIFF
--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -367,6 +367,8 @@ typedef struct PlannerInfo
 	bool		is_split_update;	/* true if UPDATE that modifies
 									 * distribution key columns */
 	bool		is_correlated_subplan; /* true for correlated subqueries nested within subplans */
+
+	Bitmapset  *resultRelations; /* all relids that are result relation of delete|update */
 } PlannerInfo;
 
 /*


### PR DESCRIPTION
Delete or Update statement may add motions above result relation
to determine whether the tuple is to delete or update. For example,

```
-- t1 distributed by (b), t2 distributed by(a)
delete from t1 using t2 where t1.b = t2.a;
```

The above sql might add motion above t1 (the result relation) when creating the
t1 join t2 plan.

ExecDelete or ExecUpdate use ctid to find the tuple and ctid only make sense
in its original segment. So greenplum will add explicit redistributed motion to
send back each tuple and then do delete or update.

Previously, the condition to add explicit redistributed motion is that no motions in
the subplan of modify table. This can be improved: if no motion is added above the
result relations, then we could elide this motion.

------------------------------

I build a dev pipeline to check it. Current test cases have some case on update | delete with motions.

I will try to add more cases if needed (after the full dev pipeline finishes).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
