### PR TITLE
Delay fsync ao mirror and primary

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -533,7 +533,7 @@ CloseWritableFileSeg(AppendOnlyInsertDesc aoInsertDesc)
 	int64		fileLen;
 	int64		fileLen_uncompressed;
 
-	AppendOnlyStorageWrite_TransactionFlushAndCloseFile(&aoInsertDesc->storageWrite,
+	AppendOnlyStorageWrite_TransactionCloseFile(&aoInsertDesc->storageWrite,
 														&fileLen,
 														&fileLen_uncompressed);
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9334,6 +9334,8 @@ CreateRestartPoint(int flags)
 
 	CheckPointGuts(lastCheckPoint.redo, flags);
 
+	SIMPLE_FAULT_INJECTOR("restartpoint_guts");
+
 	/*
 	 * Remember the prior checkpoint's redo pointer, used later to determine
 	 * the point at which we can truncate the log.

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -31,6 +31,7 @@
 #include "cdb/cdbappendonlystoragewrite.h"
 #include "cdb/cdbappendonlyxlog.h"
 #include "common/relpath.h"
+#include "postmaster/bgwriter.h"
 #include "storage/gp_compress.h"
 #include "utils/faultinjector.h"
 #include "utils/guc.h"
@@ -459,7 +460,7 @@ AppendOnlyStorageWrite_DoPadOutRemainder(AppendOnlyStorageWrite *storageWrite,
  * The new EOF of the segment file is returend in *newLogicalEof.
  */
 void
-AppendOnlyStorageWrite_FlushAndCloseFile(
+AppendOnlyStorageWrite_CloseFile(
 										 AppendOnlyStorageWrite *storageWrite,
 										 int64 *newLogicalEof,
 										 int64 *fileLen_uncompressed)
@@ -490,17 +491,22 @@ AppendOnlyStorageWrite_FlushAndCloseFile(
 							   fileLen_uncompressed,
 							   storageWrite->needsWAL);
 
-	/*
-	 * We must take care of fsynching to disk ourselves since the fd API won't
-	 * do it for us.
-	 */
+	if (!RelFileNodeBackendIsTemp(storageWrite->relFileNode) &&
+		!register_dirty_segment_ao(storageWrite->relFileNode.node, MAIN_FORKNUM,
+							storageWrite->segmentFileNum))
+	{
+		/*
+		 * We must take care of fsynching to disk ourselves since the fd API won't
+		 * do it for us.
+		 */
 
-	if (FileSync(storageWrite->file) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("Could not flush (fsync) Append-Only segment file '%s' to disk for relation '%s': %m",
-						storageWrite->segmentFileName,
-						storageWrite->relationName)));
+		if (FileSync(storageWrite->file) != 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("Could not flush (fsync) Append-Only segment file '%s' to disk for relation '%s': %m",
+							storageWrite->segmentFileName,
+							storageWrite->relationName)));
+	}
 
 	storageWrite->file = -1;
 	storageWrite->formatVersion = -1;
@@ -510,7 +516,7 @@ AppendOnlyStorageWrite_FlushAndCloseFile(
 }
 
 /*
- * Flush and close the current segment file under a transaction.
+ * Close the current segment file under a transaction.
  *
  * Handles mirror loss end transaction work.
  *
@@ -519,7 +525,7 @@ AppendOnlyStorageWrite_FlushAndCloseFile(
  * The new EOF of the segment file is returned in *newLogicalEof.
  */
 void
-AppendOnlyStorageWrite_TransactionFlushAndCloseFile(AppendOnlyStorageWrite *storageWrite,
+AppendOnlyStorageWrite_TransactionCloseFile(AppendOnlyStorageWrite *storageWrite,
 													int64 *newLogicalEof,
 													int64 *fileLen_uncompressed)
 {
@@ -533,7 +539,7 @@ AppendOnlyStorageWrite_TransactionFlushAndCloseFile(AppendOnlyStorageWrite *stor
 		return;
 	}
 
-	AppendOnlyStorageWrite_FlushAndCloseFile(storageWrite,
+	AppendOnlyStorageWrite_CloseFile(storageWrite,
 											 newLogicalEof,
 											 fileLen_uncompressed);
 }

--- a/src/backend/cdb/cdbappendonlyxlog.c
+++ b/src/backend/cdb/cdbappendonlyxlog.c
@@ -19,12 +19,13 @@
 #include <fcntl.h>
 #include <sys/file.h>
 
-#include "cdb/cdbappendonlyxlog.h"
-#include "storage/fd.h"
+#include "access/xlogutils.h"
 #include "catalog/catalog.h"
+#include "cdb/cdbappendonlyxlog.h"
+#include "postmaster/bgwriter.h"
+#include "storage/fd.h"
 #include "utils/faultinjector.h"
 #include "utils/faultinjector_lists.h"
-#include "access/xlogutils.h"
 
 /*
  * Insert an AO XLOG/AOCO record.
@@ -106,12 +107,13 @@ ao_insert_replay(XLogReaderState *record)
 						path)));
 	}
 
-	if (FileSync(file) != 0)
+	if (!register_dirty_segment_ao(xlrec->target.node, MAIN_FORKNUM, xlrec->target.segment_filenum))
 	{
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("failed to flush file \"%s\": %m",
-						path)));
+		if (FileSync(file) != 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("failed to flush file \"%s\": %m",
+							path)));
 	}
 
 	FileClose(file);

--- a/src/backend/postmaster/test/checkpointer_test.c
+++ b/src/backend/postmaster/test/checkpointer_test.c
@@ -40,7 +40,7 @@ test__ForwardFsyncRequest_enqueue(void **state)
 	expect_value(LWLockRelease, lock, CheckpointerCommLock);
 	will_be_called(LWLockRelease);
 	/* basic enqueue */
-	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 1);
+	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 1, false);
 	assert_true(ret);
 	assert_true(CheckpointerShmem->num_requests == 1);
 	/* fill up the queue */
@@ -51,7 +51,7 @@ test__ForwardFsyncRequest_enqueue(void **state)
 		will_return(LWLockAcquire, true);
 		expect_value(LWLockRelease, lock, CheckpointerCommLock);
 		will_be_called(LWLockRelease);
-		ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, i);
+		ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, i, false);
 		assert_true(ret);
 	}
 	expect_value(LWLockAcquire, lock, CheckpointerCommLock);
@@ -68,7 +68,7 @@ test__ForwardFsyncRequest_enqueue(void **state)
 	 * duplicates are in the queue.  So the queue should remain
 	 * full.
 	 */
-	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 0);
+	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 0, false);
 	assert_false(ret);
 	assert_true(CheckpointerShmem->num_requests == CheckpointerShmem->max_requests);
 	free(CheckpointerShmem);

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -58,6 +58,13 @@
  * fsync request from the queue if an identical, subsequent request is found.
  * See comments there before making changes here.
  */
+/*
+ * GPDB:
+ * For AO/CO tables, the max segno should be
+ * MAX_AOREL_CONCURRENCY (128) * MaxTupleAttributeNumber (1664),
+ * which will not cause overflow and thus will not cause confusion with the
+ * below special segnos.
+ */
 #define FORGET_RELATION_FSYNC	(InvalidBlockNumber)
 #define FORGET_DATABASE_FSYNC	(InvalidBlockNumber-1)
 #define UNLINK_RELATION_REQUEST (InvalidBlockNumber-2)
@@ -155,6 +162,7 @@ typedef struct
 	Bitmapset  *requests[MAX_FORKNUM + 1];
 	/* canceled[f] is true if we canceled fsyncs for fork "recently" */
 	bool		canceled[MAX_FORKNUM + 1];
+	bool		is_ao_segnos;	/* if the requests are for real ao/co segnos. */
 } PendingOperationEntry;
 
 typedef struct
@@ -203,7 +211,7 @@ static char *_mdfd_segpath(SMgrRelation reln, ForkNumber forknum,
 static MdfdVec *_mdfd_openseg(SMgrRelation reln, ForkNumber forkno,
 			  BlockNumber segno, int oflags);
 static MdfdVec *_mdfd_getseg(SMgrRelation reln, ForkNumber forkno,
-			 BlockNumber blkno, bool skipFsync, int behavior);
+			 BlockNumber blkno, bool skipFsync, bool is_appendoptimized, int behavior);
 static BlockNumber _mdnblocks(SMgrRelation reln, ForkNumber forknum,
 		   MdfdVec *seg);
 
@@ -579,7 +587,7 @@ mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 						relpath(reln->smgr_rnode, forknum),
 						InvalidBlockNumber)));
 
-	v = _mdfd_getseg(reln, forknum, blocknum, skipFsync, EXTENSION_CREATE);
+	v = _mdfd_getseg(reln, forknum, blocknum, skipFsync, false, EXTENSION_CREATE);
 
 	seekpos = (off_t) BLCKSZ *(blocknum % ((BlockNumber) RELSEG_SIZE));
 
@@ -721,7 +729,7 @@ mdprefetch(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum)
 	off_t		seekpos;
 	MdfdVec    *v;
 
-	v = _mdfd_getseg(reln, forknum, blocknum, false, EXTENSION_FAIL);
+	v = _mdfd_getseg(reln, forknum, blocknum, false, false, EXTENSION_FAIL);
 
 	seekpos = (off_t) BLCKSZ *(blocknum % ((BlockNumber) RELSEG_SIZE));
 
@@ -753,7 +761,7 @@ mdwriteback(SMgrRelation reln, ForkNumber forknum,
 		int			segnum_start,
 					segnum_end;
 
-		v = _mdfd_getseg(reln, forknum, blocknum, true /* not used */ ,
+		v = _mdfd_getseg(reln, forknum, blocknum, true /* not used */ , false,
 						 EXTENSION_RETURN_NULL);
 
 		/*
@@ -800,7 +808,7 @@ mdread(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 										reln->smgr_rnode.node.relNode,
 										reln->smgr_rnode.backend);
 
-	v = _mdfd_getseg(reln, forknum, blocknum, false,
+	v = _mdfd_getseg(reln, forknum, blocknum, false, false,
 					 EXTENSION_FAIL | EXTENSION_CREATE_RECOVERY);
 
 	seekpos = (off_t) BLCKSZ *(blocknum % ((BlockNumber) RELSEG_SIZE));
@@ -876,7 +884,7 @@ mdwrite(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 										 reln->smgr_rnode.node.relNode,
 										 reln->smgr_rnode.backend);
 
-	v = _mdfd_getseg(reln, forknum, blocknum, skipFsync,
+	v = _mdfd_getseg(reln, forknum, blocknum, skipFsync, false,
 					 EXTENSION_FAIL | EXTENSION_CREATE_RECOVERY);
 
 	seekpos = (off_t) BLCKSZ *(blocknum % ((BlockNumber) RELSEG_SIZE));
@@ -1228,17 +1236,34 @@ mdsync(void)
 				int			failures;
 
 #ifdef FAULT_INJECTOR
-		if (SIMPLE_FAULT_INJECTOR("fsync_counter") == FaultInjectorTypeSkip)
+		if (SIMPLE_FAULT_INJECTOR("fsync_counter") == FaultInjectorTypeSkip ||
+			(entry->is_ao_segnos &&
+			 SIMPLE_FAULT_INJECTOR("ao_fsync_counter") == FaultInjectorTypeSkip))
 		{
 			if (MyAuxProcType == CheckpointerProcess)
-				elog(LOG, "checkpoint performing fsync for %d/%d/%d",
-					 entry->rnode.spcNode, entry->rnode.dbNode,
-					 entry->rnode.relNode);
+			{
+				if (segno == 0)
+					elog(LOG, "checkpoint performing fsync for %d/%d/%d",
+						 entry->rnode.spcNode, entry->rnode.dbNode,
+						 entry->rnode.relNode);
+				else
+					elog(LOG, "checkpoint performing fsync for %d/%d/%d.%d",
+						 entry->rnode.spcNode, entry->rnode.dbNode,
+						 entry->rnode.relNode, segno);
+			}
 			else
-				elog(ERROR, "non checkpoint process trying to fsync "
-					 "%d/%d/%d when fsync_counter fault is set",
-					 entry->rnode.spcNode, entry->rnode.dbNode,
-					 entry->rnode.relNode);
+			{
+				if (segno == 0)
+					elog(ERROR, "non checkpoint process trying to fsync "
+						 "%d/%d/%d when fsync_counter fault is set",
+						 entry->rnode.spcNode, entry->rnode.dbNode,
+						 entry->rnode.relNode);
+				else
+					elog(ERROR, "non checkpoint process trying to fsync "
+						 "%d/%d/%d.%d when fsync_counter fault is set",
+						 entry->rnode.spcNode, entry->rnode.dbNode,
+						 entry->rnode.relNode, segno);
+			}
 		}
 #endif
 				/*
@@ -1300,7 +1325,7 @@ mdsync(void)
 					/* Attempt to open and fsync the target segment */
 					seg = _mdfd_getseg(reln, forknum,
 							 (BlockNumber) segno * (BlockNumber) RELSEG_SIZE,
-									   false,
+									   false, entry->is_ao_segnos,
 									   EXTENSION_RETURN_NULL
 									   | EXTENSION_DONT_CHECK_SIZE);
 
@@ -1348,13 +1373,13 @@ mdsync(void)
 						failures > 0)
 						ereport(ERROR,
 								(errcode_for_file_access(),
-								 errmsg("could not fsync file \"%s\": %m",
-										path)));
+								 errmsg("could not fsync file \"%s\" (is_ao: %d): %m",
+										path, entry->is_ao_segnos)));
 					else
 						ereport(DEBUG1,
 								(errcode_for_file_access(),
-						errmsg("could not fsync file \"%s\" but retrying: %m",
-							   path)));
+						errmsg("could not fsync file \"%s\" (is_ao: %d) but retrying: %m",
+							   path, entry->is_ao_segnos)));
 					pfree(path);
 
 					/*
@@ -1508,11 +1533,11 @@ register_dirty_segment(SMgrRelation reln, ForkNumber forknum, MdfdVec *seg)
 	if (pendingOpsTable)
 	{
 		/* push it into local pending-ops table */
-		RememberFsyncRequest(reln->smgr_rnode.node, forknum, seg->mdfd_segno);
+		RememberFsyncRequest(reln->smgr_rnode.node, forknum, seg->mdfd_segno, false);
 	}
 	else
 	{
-		if (ForwardFsyncRequest(reln->smgr_rnode.node, forknum, seg->mdfd_segno))
+		if (ForwardFsyncRequest(reln->smgr_rnode.node, forknum, seg->mdfd_segno, false))
 			return;				/* passed it off successfully */
 
 		ereport(DEBUG1,
@@ -1524,6 +1549,25 @@ register_dirty_segment(SMgrRelation reln, ForkNumber forknum, MdfdVec *seg)
 					 errmsg("could not fsync file \"%s\": %m",
 							FilePathName(seg->mdfd_vfd))));
 	}
+}
+
+/*
+ * register_dirty_segment_ao()
+ *
+ * Similar to register_dirty_segment() but it is for the appendoptimized table.
+ * The API definition is a bit different. Specially this function returns a
+ * value.
+ */
+bool
+register_dirty_segment_ao(RelFileNode rnode, ForkNumber forknum, int segno)
+{
+	if (pendingOpsTable)
+	{
+		RememberFsyncRequest(rnode, forknum, segno, true);
+		return true;
+	}
+	else
+		return ForwardFsyncRequest(rnode, forknum, segno, true);
 }
 
 /*
@@ -1545,7 +1589,8 @@ register_unlink(RelFileNodeBackend rnode)
 	{
 		/* push it into local pending-ops table */
 		RememberFsyncRequest(rnode.node, MAIN_FORKNUM,
-							 UNLINK_RELATION_REQUEST);
+							 UNLINK_RELATION_REQUEST,
+							 false);
 	}
 	else
 	{
@@ -1558,7 +1603,7 @@ register_unlink(RelFileNodeBackend rnode)
 		 */
 		Assert(IsUnderPostmaster);
 		while (!ForwardFsyncRequest(rnode.node, MAIN_FORKNUM,
-									UNLINK_RELATION_REQUEST))
+									UNLINK_RELATION_REQUEST, false))
 			pg_usleep(10000L);	/* 10 msec seems a good number */
 	}
 }
@@ -1585,7 +1630,7 @@ register_unlink(RelFileNodeBackend rnode)
  * heavyweight operation anyhow, so we'll live with it.)
  */
 void
-RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum, BlockNumber segno)
+RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum, BlockNumber segno, bool is_ao_segno)
 {
 	Assert(pendingOpsTable);
 
@@ -1711,6 +1756,7 @@ RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum, BlockNumber segno)
 
 		entry->requests[forknum] = bms_add_member(entry->requests[forknum],
 												  (int) segno);
+		entry->is_ao_segnos = is_ao_segno;
 
 		MemoryContextSwitchTo(oldcxt);
 	}
@@ -1728,7 +1774,7 @@ ForgetRelationFsyncRequests(RelFileNode rnode, ForkNumber forknum)
 	if (pendingOpsTable)
 	{
 		/* standalone backend or startup process: fsync state is local */
-		RememberFsyncRequest(rnode, forknum, FORGET_RELATION_FSYNC);
+		RememberFsyncRequest(rnode, forknum, FORGET_RELATION_FSYNC, false);
 	}
 	else if (IsUnderPostmaster)
 	{
@@ -1742,7 +1788,7 @@ ForgetRelationFsyncRequests(RelFileNode rnode, ForkNumber forknum)
 		 * which would be bad, so I'm inclined to assume that the checkpointer
 		 * will always empty the queue soon.
 		 */
-		while (!ForwardFsyncRequest(rnode, forknum, FORGET_RELATION_FSYNC))
+		while (!ForwardFsyncRequest(rnode, forknum, FORGET_RELATION_FSYNC, false))
 			pg_usleep(10000L);	/* 10 msec seems a good number */
 
 		/*
@@ -1767,13 +1813,13 @@ ForgetDatabaseFsyncRequests(Oid dbid)
 	if (pendingOpsTable)
 	{
 		/* standalone backend or startup process: fsync state is local */
-		RememberFsyncRequest(rnode, InvalidForkNumber, FORGET_DATABASE_FSYNC);
+		RememberFsyncRequest(rnode, InvalidForkNumber, FORGET_DATABASE_FSYNC, false);
 	}
 	else if (IsUnderPostmaster)
 	{
 		/* see notes in ForgetRelationFsyncRequests */
 		while (!ForwardFsyncRequest(rnode, InvalidForkNumber,
-									FORGET_DATABASE_FSYNC))
+									FORGET_DATABASE_FSYNC, false))
 			pg_usleep(10000L);	/* 10 msec seems a good number */
 	}
 }
@@ -1899,7 +1945,7 @@ _mdfd_openseg(SMgrRelation reln, ForkNumber forknum, BlockNumber segno,
  */
 static MdfdVec *
 _mdfd_getseg(SMgrRelation reln, ForkNumber forknum, BlockNumber blkno,
-			 bool skipFsync, int behavior)
+			 bool skipFsync, bool is_appendoptimized, int behavior)
 {
 	MdfdVec    *v = mdopen(reln, forknum, behavior);
 	BlockNumber targetseg;
@@ -1913,9 +1959,10 @@ _mdfd_getseg(SMgrRelation reln, ForkNumber forknum, BlockNumber blkno,
 		return NULL;			/* if behavior & EXTENSION_RETURN_NULL */
 
 	targetseg = blkno / ((BlockNumber) RELSEG_SIZE);
-	for (nextsegno = 1; nextsegno <= targetseg; nextsegno++)
+	/* For ao we just need to select the target seg number. */
+	for (nextsegno = is_appendoptimized ? targetseg : 1; nextsegno <= targetseg; nextsegno++)
 	{
-		Assert(nextsegno == v->mdfd_segno + 1);
+		Assert(is_appendoptimized || (nextsegno == v->mdfd_segno + 1));
 
 		if (v->mdfd_chain == NULL)
 		{

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -841,7 +841,7 @@ datumstreamread_open_file(DatumStreamRead * ds, char *fn, int64 eof, int64 eofUn
 void
 datumstreamwrite_close_file(DatumStreamWrite * ds)
 {
-	AppendOnlyStorageWrite_TransactionFlushAndCloseFile(
+	AppendOnlyStorageWrite_TransactionCloseFile(
 														&ds->ao_write,
 														&ds->eof,
 														&ds->eofUncompress);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -201,6 +201,7 @@ bool		gp_encoding_check_locale_compatibility;
 int			gp_connection_send_timeout;
 
 bool create_restartpoint_on_ckpt_record_replay = false;
+bool forward_ao_fsync_on_primary = false;
 
 /*
  * This variable is a dummy that doesn't do anything, except in some
@@ -2932,6 +2933,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 			NULL
 		},
 		&create_restartpoint_on_ckpt_record_replay,
+		false, NULL, NULL
+	},
+
+	{
+		{"forward_ao_fsync_on_primary", PGC_SIGHUP, DEVELOPER_OPTIONS,
+			gettext_noop("forward fsync operations of appendoptimized tables to checkpointer."),
+			NULL
+		},
+		&forward_ao_fsync_on_primary,
 		false, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbappendonlystoragewrite.h
+++ b/src/include/cdb/cdbappendonlystoragewrite.h
@@ -197,10 +197,10 @@ extern void AppendOnlyStorageWrite_OpenFile(AppendOnlyStorageWrite *storageWrite
 								int64 fileLen_uncompressed,
 								RelFileNodeBackend *relFileNode,
 								int32 segmentFileNum);
-extern void AppendOnlyStorageWrite_FlushAndCloseFile(AppendOnlyStorageWrite *storageWrite,
+extern void AppendOnlyStorageWrite_CloseFile(AppendOnlyStorageWrite *storageWrite,
 											 int64 *newLogicalEof,
 											 int64 *fileLen_uncompressed);
-extern void AppendOnlyStorageWrite_TransactionFlushAndCloseFile(AppendOnlyStorageWrite *storageWrite,
+extern void AppendOnlyStorageWrite_TransactionCloseFile(AppendOnlyStorageWrite *storageWrite,
 													int64 *newLogicalEof,
 												int64 *fileLen_uncompressed);
 

--- a/src/include/postmaster/bgwriter.h
+++ b/src/include/postmaster/bgwriter.h
@@ -32,7 +32,7 @@ extern void RequestCheckpoint(int flags);
 extern void CheckpointWriteDelay(int flags, double progress);
 
 extern bool ForwardFsyncRequest(RelFileNode rnode, ForkNumber forknum,
-					BlockNumber segno);
+					BlockNumber segno, bool is_ao_segno);
 extern void AbsorbFsyncRequests(void);
 
 extern Size CheckpointerShmemSize(void);

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -138,9 +138,12 @@ extern void mdpreckpt(void);
 extern void mdsync(void);
 extern void mdpostckpt(void);
 
+extern bool register_dirty_segment_ao(RelFileNode rnode, ForkNumber forknum,
+					int segno);
+
 extern void SetForwardFsyncRequests(void);
 extern void RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum,
-					 BlockNumber segno);
+					 BlockNumber segno, bool is_ao_segno);
 extern void ForgetRelationFsyncRequests(RelFileNode rnode, ForkNumber forknum);
 extern void ForgetDatabaseFsyncRequests(Oid dbid);
 extern void DropRelationFiles(RelFileNodePendingDelete *delrels, int ndelrels, bool isRedo);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -426,6 +426,7 @@ extern bool gp_encoding_check_locale_compatibility;
 extern int	gp_connection_send_timeout;
 
 extern bool create_restartpoint_on_ckpt_record_replay;
+extern bool forward_ao_fsync_on_primary;
 
 /* ORCA related definitions */
 #define OPTIMIZER_XFORMS_COUNT 400 /* number of transformation rules */

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -43,6 +43,7 @@
 		"cpu_operator_cost",
 		"cpu_tuple_cost",
 		"create_restartpoint_on_ckpt_record_replay",
+		"forward_ao_fsync_on_primary",
 		"cursor_tuple_fraction",
 		"cursor_tuple_fraction",
 		"data_checksums",

--- a/src/test/isolation2/expected/fsync_ao.out
+++ b/src/test/isolation2/expected/fsync_ao.out
@@ -10,36 +10,27 @@
 -- Set fsync on since we need to test the fsync code logic.
 !\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
 -- start_ignore
-20191204:17:12:45:024661 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation'
+20191204:20:22:37:017158 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation'
 
 -- end_ignore
 (exited with code 0)
 !\retcode gpconfig -c fsync -v on --skipvalidation;
 -- start_ignore
-20191204:17:12:58:024716 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-c fsync -v on --skipvalidation'
+20191204:20:22:49:017216 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-c fsync -v on --skipvalidation'
 
 -- end_ignore
 (exited with code 0)
 !\retcode gpstop -u;
 -- start_ignore
-20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Starting gpstop with args: -u
-20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Gathering information and validating the environment...
-20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Obtaining Greenplum Master catalog information
-20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Obtaining Segment details from master...
-20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5242.gb96afb4d9fa build dev'
-20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Signalling all postmaster processes to reload
+20191204:20:22:49:017270 gpstop:asimmac:apraveen-[INFO]:-Starting gpstop with args: -u
+20191204:20:22:49:017270 gpstop:asimmac:apraveen-[INFO]:-Gathering information and validating the environment...
+20191204:20:22:49:017270 gpstop:asimmac:apraveen-[INFO]:-Obtaining Greenplum Master catalog information
+20191204:20:22:49:017270 gpstop:asimmac:apraveen-[INFO]:-Obtaining Segment details from master...
+20191204:20:22:49:017270 gpstop:asimmac:apraveen-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5242.gb96afb4d9fa build dev'
+20191204:20:22:49:017270 gpstop:asimmac:apraveen-[INFO]:-Signalling all postmaster processes to reload
 
 -- end_ignore
 (exited with code 0)
-
-create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
-CREATE
-create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
-CREATE
-insert into fsync_ao select i, i from generate_series(1,10)i;
-INSERT 10
-insert into fsync_co select i, i from generate_series(1,10)i;
-INSERT 10
 
 -- Reset all faults.
 select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = 0;
@@ -60,6 +51,10 @@ select gp_inject_fault_infinite('restartpoint_guts', 'skip', dbid) from gp_segme
 checkpoint;
 CHECKPOINT
 
+-- We have just created a checkpoint.  The next checkpoint will be triggered
+-- only after 5 minutes or after CheckPointSegments wal segments.  Neither of
+-- that can happen until this test calls explicit checkpoint.
+
 -- Wait until restartpoint flush happens.
 select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid) from gp_segment_configuration where content=0 and role='m';
  gp_wait_until_triggered_fault 
@@ -67,23 +62,39 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid) from gp_segme
  Success:                      
 (1 row)
 
--- We have just created a checkpoint.  The next checkpoint will be triggered
--- only after 5 minutes or after CheckPointSegments wal segments.  Neither of
--- that can happen until this test calls explicit checkpoint.
+-- Validate that fsync is performed only on the primary when the GUC
+-- to do so is not set.  Also validate that on the mirror, the
+-- checkpointer process performs fsync for AO, regardless of the GUC.
 
--- Write ao and co data files including aoseg & gp_fastsequence.
--- These should be fsync-ed by checkpoint & restartpoint.
+-- Expect the GUC to be off by default.
+show forward_ao_fsync_on_primary;
+ forward_ao_fsync_on_primary 
+-----------------------------
+ off                         
+(1 row)
+
+create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+CREATE
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+CREATE
+-- Temp table segment files should never be fsync'ed.
+create temp table no_fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+CREATE
 insert into fsync_ao select i, i from generate_series(1,20)i;
 INSERT 20
 insert into fsync_co select i, i from generate_series(1,20)i;
 INSERT 20
+insert into no_fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
 
--- Inject fault to count relfiles fsync'ed by checkpointer on mirror.
-select gp_inject_fault_infinite('ao_fsync_counter', 'skip', dbid) from gp_segment_configuration where content=0 and role='m';
+-- Inject fault to count relfiles fsync'ed by checkpointer on primary
+-- as well as on mirror.
+select gp_inject_fault_infinite('ao_fsync_counter', 'skip', dbid) from gp_segment_configuration where content=0;
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
-(1 row)
+ Success:                 
+(2 rows)
 
 checkpoint;
 CHECKPOINT
@@ -95,15 +106,77 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid) from gp_segme
  Success:                      
 (1 row)
 
--- Validate that the number of files fsync'ed by checkpointer.
--- `num times hit` is corresponding to the number of files synced by
--- `ao_fsync_counter` fault.
+-- Validate that the number of files fsync'ed by checkpointer on
+-- primary.  `num times hit` is corresponding to the number of files
+-- noticed by `ao_fsync_counter` fault.  It should be 0 because by
+-- default, fsync of AO data files should be performed by the backend
+-- processes writing to them on primary.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault                                                                                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+(1 row)
+-- Checkpointer on mirror should perfrom fsync for three AO segment
+-- files.
 select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
  gp_inject_fault                                                                                                                                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'3' 
  
 (1 row)
+
+-- Enable fsync forward GUC so that fsync requests for
+-- append-optimized tables are forwarded to checkpointer on primary.
+!\retcode gpconfig -c forward_ao_fsync_on_primary -v on --skipvalidation;
+-- start_ignore
+20191204:20:23:02:017300 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-c forward_ao_fsync_on_primary -v on --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -au;
+-- start_ignore
+20191204:20:23:03:017354 gpstop:asimmac:apraveen-[INFO]:-Starting gpstop with args: -au
+20191204:20:23:03:017354 gpstop:asimmac:apraveen-[INFO]:-Gathering information and validating the environment...
+20191204:20:23:03:017354 gpstop:asimmac:apraveen-[INFO]:-Obtaining Greenplum Master catalog information
+20191204:20:23:03:017354 gpstop:asimmac:apraveen-[INFO]:-Obtaining Segment details from master...
+20191204:20:23:03:017354 gpstop:asimmac:apraveen-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5242.gb96afb4d9fa build dev'
+20191204:20:23:03:017354 gpstop:asimmac:apraveen-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+
+-- Write ao and co data files including temp ao table.  Only the
+-- non-temp files should be fsync-ed by checkpoint & restartpoint.
+insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+insert into no_fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+
+checkpoint;
+CHECKPOINT
+
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Validate that the number of files fsync'ed by checkpointer.  `num
+-- times hit` is corresponding to the number of files synced by
+-- `ao_fsync_counter` fault.  It should be non-zero on both, primary
+-- and mirror.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0;
+ gp_inject_fault                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'3' 
+ 
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'6' 
+ 
+(2 rows)
 
 -- Test vacuum compaction with more than one segment file per table.  Perform
 -- concurrent inserts before vacuum to get multiple segment files.  Validation
@@ -126,7 +199,7 @@ END
 delete from fsync_ao where a > 20;
 DELETE 20
 update fsync_co set b = -a;
-UPDATE 70
+UPDATE 80
 -- Expect two segment files for each table (ao table) or each column (co table).
 select segno, state from gp_toolkit.__gp_aoseg('fsync_ao');
  segno | state 
@@ -149,18 +222,63 @@ VACUUM
 checkpoint;
 CHECKPOINT
 -- Wait until restartpoint happens again.
-select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid) from gp_segment_configuration where content=0 and role='m';
+select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid) from gp_segment_configuration where content=0 and role='m';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
 
 -- Expect the segment files that were updated by vacuum to be fsync'ed.
-select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
+select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0;
  gp_inject_fault                                                                                                                                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'14' 
  
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'17' 
+ 
+(2 rows)
+
+-- Checkpoint after drop table should be successful. It validates that the drop
+-- removed the fsync requests enqued by the previous insert from
+-- pendingOpsTable.
+insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+drop table fsync_co;
+DROP
+checkpoint;
+CHECKPOINT
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Checkpoint after drop database should be successful. It validates that the drop
+-- removed the fsync requests enqued by the previous insert from
+-- pendingOpsTable.
+create database fsync_ao_db;
+CREATE
+2:@db_name fsync_ao_db: create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+CREATE
+2:@db_name fsync_ao_db: create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+CREATE
+2:@db_name fsync_ao_db: insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+2:@db_name fsync_ao_db: insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+2q: ... <quitting>
+drop database fsync_ao_db;
+DROP
+checkpoint;
+CHECKPOINT
+-- Wait until restartpoint happens again.  Create database creates two
+-- and drop database creates one checkpoint.  So wait until the
+-- restartpoint happens three times on mirror.
+select gp_wait_until_triggered_fault('restartpoint_guts', 7, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
 -- Reset all faults.
@@ -173,24 +291,30 @@ select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where
 
 !\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
 -- start_ignore
-20191204:17:13:13:024809 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r create_restartpoint_on_ckpt_record_replay --skipvalidation'
+20191204:20:23:18:017390 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r create_restartpoint_on_ckpt_record_replay --skipvalidation'
 
 -- end_ignore
 (exited with code 0)
 !\retcode gpconfig -r fsync --skipvalidation;
 -- start_ignore
-20191204:17:13:27:024868 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
+20191204:20:23:30:017445 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r forward_ao_fsync_on_primary --skipvalidation;
+-- start_ignore
+20191204:20:23:42:017499 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r forward_ao_fsync_on_primary --skipvalidation'
 
 -- end_ignore
 (exited with code 0)
 !\retcode gpstop -u;
 -- start_ignore
-20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Starting gpstop with args: -u
-20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Gathering information and validating the environment...
-20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Obtaining Greenplum Master catalog information
-20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Obtaining Segment details from master...
-20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5242.gb96afb4d9fa build dev'
-20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Signalling all postmaster processes to reload
+20191204:20:23:43:017553 gpstop:asimmac:apraveen-[INFO]:-Starting gpstop with args: -u
+20191204:20:23:43:017553 gpstop:asimmac:apraveen-[INFO]:-Gathering information and validating the environment...
+20191204:20:23:43:017553 gpstop:asimmac:apraveen-[INFO]:-Obtaining Greenplum Master catalog information
+20191204:20:23:43:017553 gpstop:asimmac:apraveen-[INFO]:-Obtaining Segment details from master...
+20191204:20:23:43:017553 gpstop:asimmac:apraveen-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5242.gb96afb4d9fa build dev'
+20191204:20:23:43:017553 gpstop:asimmac:apraveen-[INFO]:-Signalling all postmaster processes to reload
 
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/fsync_ao.out
+++ b/src/test/isolation2/expected/fsync_ao.out
@@ -1,0 +1,196 @@
+-- This test validates that AO tables are sync'ed by checkpoint.
+-- It simulates the following scenario.
+--
+--   * Start with a clean slate - ensure that all files are flushed by checkpointer.
+--   * Write two tables (one is ao and another is aoco).
+--   * Verify that those files were also fsync-ed by restartpoint on mirror.
+--   * Checkpoint followed by vacuum on tables with multiple segment files.
+
+-- Set the GUC to perform replay of checkpoint records immediately.  It speeds up the test.
+-- Set fsync on since we need to test the fsync code logic.
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
+-- start_ignore
+20191204:17:12:45:024661 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -c fsync -v on --skipvalidation;
+-- start_ignore
+20191204:17:12:58:024716 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-c fsync -v on --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Starting gpstop with args: -u
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Gathering information and validating the environment...
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Obtaining Greenplum Master catalog information
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Obtaining Segment details from master...
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5242.gb96afb4d9fa build dev'
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+
+create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+CREATE
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+CREATE
+insert into fsync_ao select i, i from generate_series(1,10)i;
+INSERT 10
+insert into fsync_co select i, i from generate_series(1,10)i;
+INSERT 10
+
+-- Reset all faults.
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+(2 rows)
+
+-- Fault to check that mirror has flushed pending fsync requests.
+select gp_inject_fault_infinite('restartpoint_guts', 'skip', dbid) from gp_segment_configuration where role = 'm' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Start with a clean slate.
+checkpoint;
+CHECKPOINT
+
+-- Wait until restartpoint flush happens.
+select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- We have just created a checkpoint.  The next checkpoint will be triggered
+-- only after 5 minutes or after CheckPointSegments wal segments.  Neither of
+-- that can happen until this test calls explicit checkpoint.
+
+-- Write ao and co data files including aoseg & gp_fastsequence.
+-- These should be fsync-ed by checkpoint & restartpoint.
+insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+
+-- Inject fault to count relfiles fsync'ed by checkpointer on mirror.
+select gp_inject_fault_infinite('ao_fsync_counter', 'skip', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+checkpoint;
+CHECKPOINT
+
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Validate that the number of files fsync'ed by checkpointer.
+-- `num times hit` is corresponding to the number of files synced by
+-- `ao_fsync_counter` fault.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'3' 
+ 
+(1 row)
+
+-- Test vacuum compaction with more than one segment file per table.  Perform
+-- concurrent inserts before vacuum to get multiple segment files.  Validation
+-- criterion is the checkpoint command succeeds on primary and the
+-- restartpoint_guts fault point is reached on the mirror.
+1: begin;
+BEGIN
+1: insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+1: insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+insert into fsync_ao select i, i from generate_series(21,40)i;
+INSERT 20
+insert into fsync_co select i, i from generate_series(21,40)i;
+INSERT 20
+1: end;
+END
+-- Generate some invisible tuples in both the tables so as to trigger
+-- compaction during vacuum.
+delete from fsync_ao where a > 20;
+DELETE 20
+update fsync_co set b = -a;
+UPDATE 70
+-- Expect two segment files for each table (ao table) or each column (co table).
+select segno, state from gp_toolkit.__gp_aoseg('fsync_ao');
+ segno | state 
+-------+-------
+ 1     | 1     
+ 2     | 1     
+(2 rows)
+select segno, column_num, physical_segno, state from gp_toolkit.__gp_aocsseg('fsync_co');
+ segno | column_num | physical_segno | state 
+-------+------------+----------------+-------
+ 1     | 0          | 1              | 1     
+ 1     | 1          | 129            | 1     
+ 2     | 0          | 2              | 1     
+ 2     | 1          | 130            | 1     
+(4 rows)
+vacuum fsync_ao;
+VACUUM
+vacuum fsync_co;
+VACUUM
+checkpoint;
+CHECKPOINT
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Expect the segment files that were updated by vacuum to be fsync'ed.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault                                                                                                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'14' 
+ 
+(1 row)
+
+-- Reset all faults.
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+(2 rows)
+
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
+-- start_ignore
+20191204:17:13:13:024809 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r create_restartpoint_on_ckpt_record_replay --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r fsync --skipvalidation;
+-- start_ignore
+20191204:17:13:27:024868 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Starting gpstop with args: -u
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Gathering information and validating the environment...
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Obtaining Greenplum Master catalog information
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Obtaining Segment details from master...
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5242.gb96afb4d9fa build dev'
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -73,6 +73,9 @@ test: ao_upgrade
 # below test utilizes fault injectors so it needs to be in a group by itself
 test: external_table
 
+# This test validates that for AO we delay fsync to checkpointer.
+test: fsync_ao
+
 # Tests on Append-Optimized tables (row-oriented).
 test: concurrent_index_creation_should_not_deadlock
 test: uao/alter_while_vacuum_row uao/alter_while_vacuum2_row

--- a/src/test/isolation2/sql/fsync_ao.sql
+++ b/src/test/isolation2/sql/fsync_ao.sql
@@ -12,11 +12,6 @@
 !\retcode gpconfig -c fsync -v on --skipvalidation;
 !\retcode gpstop -u;
 
-create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
-create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
-insert into fsync_ao select i, i from generate_series(1,10)i;
-insert into fsync_co select i, i from generate_series(1,10)i;
-
 -- Reset all faults.
 select gp_inject_fault('all', 'reset', dbid)
 	from gp_segment_configuration where content = 0;
@@ -28,22 +23,34 @@ select gp_inject_fault_infinite('restartpoint_guts', 'skip', dbid)
 -- Start with a clean slate.
 checkpoint;
 
--- Wait until restartpoint flush happens.
-select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid)
-	from gp_segment_configuration where content=0 and role='m';
-
 -- We have just created a checkpoint.  The next checkpoint will be triggered
 -- only after 5 minutes or after CheckPointSegments wal segments.  Neither of
 -- that can happen until this test calls explicit checkpoint.
 
--- Write ao and co data files including aoseg & gp_fastsequence.
--- These should be fsync-ed by checkpoint & restartpoint.
+-- Wait until restartpoint flush happens.
+select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Validate that fsync is performed only on the primary when the GUC
+-- to do so is not set.  Also validate that on the mirror, the
+-- checkpointer process performs fsync for AO, regardless of the GUC.
+
+-- Expect the GUC to be off by default.
+show forward_ao_fsync_on_primary;
+
+create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+-- Temp table segment files should never be fsync'ed.
+create temp table no_fsync_ao(a int, b int)
+       with (appendoptimized = true) distributed by (a);
 insert into fsync_ao select i, i from generate_series(1,20)i;
 insert into fsync_co select i, i from generate_series(1,20)i;
+insert into no_fsync_ao select i, i from generate_series(1,20)i;
 
--- Inject fault to count relfiles fsync'ed by checkpointer on mirror.
+-- Inject fault to count relfiles fsync'ed by checkpointer on primary
+-- as well as on mirror.
 select gp_inject_fault_infinite('ao_fsync_counter', 'skip', dbid)
-	from gp_segment_configuration where content=0 and role='m';
+	from gp_segment_configuration where content=0;
 
 checkpoint;
 
@@ -51,11 +58,41 @@ checkpoint;
 select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid)
 	from gp_segment_configuration where content=0 and role='m';
 
--- Validate that the number of files fsync'ed by checkpointer.
--- `num times hit` is corresponding to the number of files synced by
--- `ao_fsync_counter` fault.
+-- Validate that the number of files fsync'ed by checkpointer on
+-- primary.  `num times hit` is corresponding to the number of files
+-- noticed by `ao_fsync_counter` fault.  It should be 0 because by
+-- default, fsync of AO data files should be performed by the backend
+-- processes writing to them on primary.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid)
+	from gp_segment_configuration where content=0 and role='p';
+-- Checkpointer on mirror should perfrom fsync for three AO segment
+-- files.
 select gp_inject_fault('ao_fsync_counter', 'status', dbid)
 	from gp_segment_configuration where content=0 and role='m';
+
+-- Enable fsync forward GUC so that fsync requests for
+-- append-optimized tables are forwarded to checkpointer on primary.
+!\retcode gpconfig -c forward_ao_fsync_on_primary -v on --skipvalidation;
+!\retcode gpstop -au;
+
+-- Write ao and co data files including temp ao table.  Only the
+-- non-temp files should be fsync-ed by checkpoint & restartpoint.
+insert into fsync_ao select i, i from generate_series(1,20)i;
+insert into fsync_co select i, i from generate_series(1,20)i;
+insert into no_fsync_ao select i, i from generate_series(1,20)i;
+
+checkpoint;
+
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Validate that the number of files fsync'ed by checkpointer.  `num
+-- times hit` is corresponding to the number of files synced by
+-- `ao_fsync_counter` fault.  It should be non-zero on both, primary
+-- and mirror.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid)
+	from gp_segment_configuration where content=0;
 
 -- Test vacuum compaction with more than one segment file per table.  Perform
 -- concurrent inserts before vacuum to get multiple segment files.  Validation
@@ -78,11 +115,38 @@ vacuum fsync_ao;
 vacuum fsync_co;
 checkpoint;
 -- Wait until restartpoint happens again.
-select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid)
+select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid)
 	from gp_segment_configuration where content=0 and role='m';
 
 -- Expect the segment files that were updated by vacuum to be fsync'ed.
 select gp_inject_fault('ao_fsync_counter', 'status', dbid)
+	from gp_segment_configuration where content=0;
+
+-- Checkpoint after drop table should be successful. It validates that the drop
+-- removed the fsync requests enqued by the previous insert from
+-- pendingOpsTable.
+insert into fsync_co select i, i from generate_series(1,20)i;
+drop table fsync_co;
+checkpoint;
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Checkpoint after drop database should be successful. It validates that the drop
+-- removed the fsync requests enqued by the previous insert from
+-- pendingOpsTable.
+create database fsync_ao_db;
+2:@db_name fsync_ao_db: create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+2:@db_name fsync_ao_db: create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+2:@db_name fsync_ao_db: insert into fsync_ao select i, i from generate_series(1,20)i;
+2:@db_name fsync_ao_db: insert into fsync_co select i, i from generate_series(1,20)i;
+2q:
+drop database fsync_ao_db;
+checkpoint;
+-- Wait until restartpoint happens again.  Create database creates two
+-- and drop database creates one checkpoint.  So wait until the
+-- restartpoint happens three times on mirror.
+select gp_wait_until_triggered_fault('restartpoint_guts', 7, dbid)
 	from gp_segment_configuration where content=0 and role='m';
 
 -- Reset all faults.
@@ -90,4 +154,5 @@ select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where
 
 !\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
 !\retcode gpconfig -r fsync --skipvalidation;
+!\retcode gpconfig -r forward_ao_fsync_on_primary --skipvalidation;
 !\retcode gpstop -u;

--- a/src/test/isolation2/sql/fsync_ao.sql
+++ b/src/test/isolation2/sql/fsync_ao.sql
@@ -1,0 +1,93 @@
+-- This test validates that AO tables are sync'ed by checkpoint.
+-- It simulates the following scenario.
+--
+--   * Start with a clean slate - ensure that all files are flushed by checkpointer.
+--   * Write two tables (one is ao and another is aoco).
+--   * Verify that those files were also fsync-ed by restartpoint on mirror.
+--   * Checkpoint followed by vacuum on tables with multiple segment files.
+
+-- Set the GUC to perform replay of checkpoint records immediately.  It speeds up the test.
+-- Set fsync on since we need to test the fsync code logic.
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
+!\retcode gpconfig -c fsync -v on --skipvalidation;
+!\retcode gpstop -u;
+
+create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+insert into fsync_ao select i, i from generate_series(1,10)i;
+insert into fsync_co select i, i from generate_series(1,10)i;
+
+-- Reset all faults.
+select gp_inject_fault('all', 'reset', dbid)
+	from gp_segment_configuration where content = 0;
+
+-- Fault to check that mirror has flushed pending fsync requests.
+select gp_inject_fault_infinite('restartpoint_guts', 'skip', dbid)
+	from gp_segment_configuration where role = 'm' and content = 0;
+
+-- Start with a clean slate.
+checkpoint;
+
+-- Wait until restartpoint flush happens.
+select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- We have just created a checkpoint.  The next checkpoint will be triggered
+-- only after 5 minutes or after CheckPointSegments wal segments.  Neither of
+-- that can happen until this test calls explicit checkpoint.
+
+-- Write ao and co data files including aoseg & gp_fastsequence.
+-- These should be fsync-ed by checkpoint & restartpoint.
+insert into fsync_ao select i, i from generate_series(1,20)i;
+insert into fsync_co select i, i from generate_series(1,20)i;
+
+-- Inject fault to count relfiles fsync'ed by checkpointer on mirror.
+select gp_inject_fault_infinite('ao_fsync_counter', 'skip', dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+checkpoint;
+
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Validate that the number of files fsync'ed by checkpointer.
+-- `num times hit` is corresponding to the number of files synced by
+-- `ao_fsync_counter` fault.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Test vacuum compaction with more than one segment file per table.  Perform
+-- concurrent inserts before vacuum to get multiple segment files.  Validation
+-- criterion is the checkpoint command succeeds on primary and the
+-- restartpoint_guts fault point is reached on the mirror.
+1: begin;
+1: insert into fsync_ao select i, i from generate_series(1,20)i;
+1: insert into fsync_co select i, i from generate_series(1,20)i;
+insert into fsync_ao select i, i from generate_series(21,40)i;
+insert into fsync_co select i, i from generate_series(21,40)i;
+1: end;
+-- Generate some invisible tuples in both the tables so as to trigger
+-- compaction during vacuum.
+delete from fsync_ao where a > 20;
+update fsync_co set b = -a;
+-- Expect two segment files for each table (ao table) or each column (co table).
+select segno, state from gp_toolkit.__gp_aoseg('fsync_ao');
+select segno, column_num, physical_segno, state from gp_toolkit.__gp_aocsseg('fsync_co');
+vacuum fsync_ao;
+vacuum fsync_co;
+checkpoint;
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Expect the segment files that were updated by vacuum to be fsync'ed.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Reset all faults.
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = 0;
+
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
+!\retcode gpconfig -r fsync --skipvalidation;
+!\retcode gpstop -u;


### PR DESCRIPTION
This is essentially PR #9088 broken down into two commits as suggested by the review comments there.  Notable changes:

1. Separated the commit in which mirror replay process forwards fsync requests to checkpointer.
1. Introduced a new GUC to determine whether a backend process should perform fsync or forward that request to checkpointer, on primary.
1. Made some enhancements to the test case along the way - introduced ao_fsync_counter fault that counts fsync requests for AO data files only.  That eliminates the need to worry about hint bits.

We still don't know whether the primary side change is necessary.  The plan to evaluate the change against specific workloads to start with.