### PR TITLE
Refactor snapshot synchronization between writer gang and reader gang

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2423,7 +2423,6 @@ StartTransaction(void)
 				SharedLocalSnapshotSlot->xid = s->transactionId;
 				SharedLocalSnapshotSlot->startTimestamp = stmtStartTimestamp;
 				SharedLocalSnapshotSlot->QDxid = QEDtxContextInfo.distributedXid;
-				SharedLocalSnapshotSlot->pid = MyProc->pid;
 				SharedLocalSnapshotSlot->writer_proc = MyProc;
 				SharedLocalSnapshotSlot->writer_xact = MyPgXact;
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1686,15 +1686,14 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 				LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
 				elog(DTM_DEBUG5,
 					 "setupQEDtxContext inputs (part 2b):  shared local snapshot xid = %u "
-					 "(xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u/%u, QDcid = %u",
+					 "(xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u/%u",
 					 SharedLocalSnapshotSlot->xid,
 					 SharedLocalSnapshotSlot->snapshot.xmin,
 					 SharedLocalSnapshotSlot->snapshot.xmax,
 					 SharedLocalSnapshotSlot->snapshot.xcnt,
 					 SharedLocalSnapshotSlot->snapshot.curcid,
 					 SharedLocalSnapshotSlot->QDxid,
-					 SharedLocalSnapshotSlot->segmateSync,
-					 SharedLocalSnapshotSlot->QDcid);
+					 SharedLocalSnapshotSlot->segmateSync);
 				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 			}
 		}

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -49,6 +49,7 @@
 #include "utils/faultinjector.h"
 #include "utils/guc.h"
 #include "utils/fmgroids.h"
+#include "utils/session_state.h"
 #include "utils/sharedsnapshot.h"
 #include "utils/snapmgr.h"
 #include "utils/memutils.h"
@@ -1470,24 +1471,27 @@ insertedDistributedCommitted(void)
  * information.
  */
 void
-verify_shared_snapshot_ready(void)
+verify_shared_snapshot_ready(int cid)
 {
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		CdbDispatchCommand("set gp_write_shared_snapshot=true",
-						   DF_CANCEL_ON_ERROR |
-						   DF_WITH_SNAPSHOT |
-						   DF_NEED_TWO_PHASE,
-						   NULL);
+	Assert (Gp_role == GP_ROLE_DISPATCH);
 
-		dumpSharedLocalSnapshot_forCursor();
+	/*
+	 * A cursor/bind/exec command may trigger multiple dispatchs (e.g.
+	 *    DECLARE s1 CURSOR FOR SELECT * FROM test WHERE a=(SELECT max(b) FROM test))
+	 * and all the dispatchs target to the reader gangs only. Since all the dispatchs
+	 * are read-only and happens in one user command, it's ok to share one same snapshot.
+	 */
+	if (MySessionState->latestCursorCommandId == cid)
+		return;
 
-		/*
-		 * To keep our readers in sync (since they will be dispatched
-		 * separately) we need to rewind the segmate synchronizer.
-		 */
-		DtxContextInfo_RewindSegmateSync();
-	}
+	CdbDispatchCommand("set gp_write_shared_snapshot=true",
+					   DF_CANCEL_ON_ERROR |
+					   DF_WITH_SNAPSHOT |
+					   DF_NEED_TWO_PHASE,
+					   NULL);
+
+	dumpSharedLocalSnapshot_forCursor();
+	MySessionState->latestCursorCommandId = cid;
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -168,10 +168,8 @@ qdSerializeDtxContextInfo(int *size, bool wantSnapshot, bool inCursor,
 	{
 		case DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE:
 		case DTX_CONTEXT_LOCAL_ONLY:
-			DtxContextInfo_CreateOnMaster(&TempQDDtxContextInfo,
+			DtxContextInfo_CreateOnMaster(&TempQDDtxContextInfo, inCursor,
 										  txnOptions, snapshot);
-
-			TempQDDtxContextInfo.cursorContext = inCursor;
 
 			if (DistributedTransactionContext ==
 				DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && snapshot != NULL)

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -227,7 +227,7 @@ CdbDispatchPlan(struct QueryDesc *queryDesc,
 	 */
 	if (queryDesc->extended_query)
 	{
-		verify_shared_snapshot_ready();
+		verify_shared_snapshot_ready(gp_command_count);
 	}
 
 	cdbdisp_dispatchX(queryDesc, planRequiresTxn, cancelOnError);
@@ -1146,6 +1146,10 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 
 		primaryGang = slice->primaryGang;
 		Assert(primaryGang != NULL);
+		AssertImply(queryDesc->extended_query,
+					primaryGang->type == GANGTYPE_PRIMARY_READER ||
+					primaryGang->type == GANGTYPE_SINGLETON_READER ||
+					primaryGang->type == GANGTYPE_ENTRYDB_READER);
 
 		if (Test_print_direct_dispatch_info)
 			elog(INFO, "(slice %d) Dispatch command to %s", slice->sliceIndex,

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -478,22 +478,6 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			queryDesc->ddesc->useChangedAOOpts = true;
 		}
 
-		/*
-		 * If this is an extended query (normally cursor or bind/exec) - before
-		 * starting the portal, we need to make sure that the shared snapshot is
-		 * already set by a writer gang, or the cursor query readers will
-		 * timeout waiting for one that may not exist (in some cases). Therefore
-		 * we insert a small hack here and dispatch a SET query that will do it
-		 * for us. (This is also done in performOpenCursor() for the simple
-		 * query protocol).
-		 *
-		 * MPP-7504/MPP-7448: We also call this down inside the dispatcher after
-		 * the pre-dispatch evaluator has run.
-		 */
-		if (queryDesc->extended_query) {
-			verify_shared_snapshot_ready();
-		}
-
 		/* Set up blank slice table to be filled in during InitPlan. */
 		InitSliceTable(estate, queryDesc->plannedstmt->nMotionNodes, queryDesc->plannedstmt->nInitPlans);
 

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1053,20 +1053,6 @@ PG_TRY();
 		Assert((queryDesc->estate->interconnect_context));
 
 		UpdateMotionExpectedReceivers(queryDesc->estate->motionlayer_context, queryDesc->estate->es_sliceTable);
-
-		/*
-		 * MPP-7504/MPP-7448: the pre-dispatch function evaluator
-		 * may mess up our snapshot-sync mechanism. So we've
-		 * called verify_shared_snapshot() down in the dispatcher.
-		 */
-		if (queryDesc->extended_query)
-		{
-			/*
-			 * We rewind the segmateSync value since the InitPlan can
-			 * share the same value with its parent plan. See MPP-4504.
-			 */
-			DtxContextInfo_RewindSegmateSync();
-		}
 	}
 	ArrayBuildStateAny *astate = NULL;
 

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1648,10 +1648,8 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 	
 	SharedLocalSnapshotSlot->QDcid = dtxContextInfo->curcid;
 	SharedLocalSnapshotSlot->QDxid = dtxContextInfo->distributedXid;
-
-	SharedLocalSnapshotSlot->ready = true;
-
 	SharedLocalSnapshotSlot->segmateSync = dtxContextInfo->segmateSync;
+	SharedLocalSnapshotSlot->ready = true;
 
 	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
 			(errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' setting shared local snapshot xid = %u (xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u, QDcid = %u",
@@ -1792,11 +1790,13 @@ readerFillLocalSnapshot(Snapshot snapshot, DtxContext distributedTransactionCont
 	{
 		LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
 
-		if (QEDtxContextInfo.distributedXid == SharedLocalSnapshotSlot->QDxid &&
-			QEDtxContextInfo.curcid == SharedLocalSnapshotSlot->QDcid &&
-			QEDtxContextInfo.segmateSync == SharedLocalSnapshotSlot->segmateSync &&
+		if (QEDtxContextInfo.segmateSync == SharedLocalSnapshotSlot->segmateSync &&
 			SharedLocalSnapshotSlot->ready)
 		{
+			if (QEDtxContextInfo.distributedXid != SharedLocalSnapshotSlot->QDxid)
+				elog(ERROR, "transaction ID doesn't match between the reader gang "
+							"and the writer gang, expect %d but having %d",
+							QEDtxContextInfo.distributedXid, SharedLocalSnapshotSlot->QDxid);
 			copyLocalSnapshot(snapshot);
 			SetSharedTransactionId_reader(SharedLocalSnapshotSlot->xid, snapshot->curcid, distributedTransactionContext);
 			LWLockRelease(SharedLocalSnapshotSlot->slotLock);

--- a/src/backend/utils/session_state.c
+++ b/src/backend/utils/session_state.c
@@ -99,6 +99,7 @@ SessionState_Acquire(int sessionId)
 		acquired->cleanupCountdown = CLEANUP_COUNTDOWN_BEFORE_RUNAWAY;
 		acquired->activeProcessCount = 0;
 		acquired->idle_start = 0;
+		acquired->latestCursorCommandId = 0;
 		acquired->resGroupSlot = NULL;
 
 #ifdef USE_ASSERT_CHECKING
@@ -172,6 +173,7 @@ SessionState_Release(SessionState *acquired)
 		acquired->cleanupCountdown = CLEANUP_COUNTDOWN_BEFORE_RUNAWAY;
 		acquired->activeProcessCount = 0;
 		acquired->idle_start = 0;
+		acquired->latestCursorCommandId = 0;
 		acquired->resGroupSlot = NULL;
 
 #ifdef USE_ASSERT_CHECKING

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -628,7 +628,7 @@ lookupSharedSnapshot(char *lookerDescription, char *creatorDescription, int id)
 }
 
 static char *
-sharedLocalSnapshot_filename(TransactionId xid, CommandId cid, uint32 segmateSync)
+sharedLocalSnapshot_filename(TransactionId xid, uint32 segmateSync)
 {
 	int pid;
 	static char filename[MAXPGPATH];
@@ -647,8 +647,8 @@ sharedLocalSnapshot_filename(TransactionId xid, CommandId cid, uint32 segmateSyn
 		pid = lockHolderProcPtr->pid;
 	}
 
-	snprintf(filename, sizeof(filename), "sess%u_w%u_qdxid%u_qdcid%u_sync%u",
-			 gp_session_id, pid, xid, cid, segmateSync);
+	snprintf(filename, sizeof(filename), "sess%u_w%u_qdxid%u_sync%u",
+			 gp_session_id, pid, xid, segmateSync);
 	return filename;
 }
 
@@ -671,7 +671,7 @@ dumpSharedLocalSnapshot_forCursor(void)
 	LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
 
 	src = (SharedSnapshotSlot *)SharedLocalSnapshotSlot;
-	fname = sharedLocalSnapshot_filename(src->QDxid, src->QDcid, src->segmateSync);
+	fname = sharedLocalSnapshot_filename(src->QDxid, src->segmateSync);
 
 	/*
 	 * Create our dump-file. Hold the reference to it in
@@ -780,8 +780,7 @@ readSharedLocalSnapshot_forCursor(Snapshot snapshot, DtxContext distributedTrans
 	 * NOTE: this is always run *after* the dump by the writer is
 	 * guaranteed to have completed.
 	 */
-	fname = sharedLocalSnapshot_filename(QEDtxContextInfo.distributedXid,
-		QEDtxContextInfo.curcid, QEDtxContextInfo.segmateSync);
+	fname = sharedLocalSnapshot_filename(QEDtxContextInfo.distributedXid, QEDtxContextInfo.segmateSync);
 
 	f = BufFileOpenNamedTemp(fname,
 							 false /* interXact */);

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -61,11 +61,11 @@ test_write_read_shared_snapshot_for_cursor(void **state)
 	expect_any(LWLockAcquire, mode);
 	will_be_called(LWLockAcquire);
 
-	expect_any_count(FaultInjector_InjectFaultIfSet, faultName, 13);
-	expect_any_count(FaultInjector_InjectFaultIfSet, ddlStatement, 13);
-	expect_any_count(FaultInjector_InjectFaultIfSet, databaseName, 13);
-	expect_any_count(FaultInjector_InjectFaultIfSet, tableName, 13);
-	will_be_called_count(FaultInjector_InjectFaultIfSet, 13);
+	expect_any_count(FaultInjector_InjectFaultIfSet, faultName, 11);
+	expect_any_count(FaultInjector_InjectFaultIfSet, ddlStatement, 11);
+	expect_any_count(FaultInjector_InjectFaultIfSet, databaseName, 11);
+	expect_any_count(FaultInjector_InjectFaultIfSet, tableName, 11);
+	will_be_called_count(FaultInjector_InjectFaultIfSet, 11);
 
 	expect_any(LWLockRelease, lock);
 	will_be_called(LWLockRelease);

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -26,6 +26,7 @@ test_write_read_shared_snapshot_for_cursor(void **state)
 	xipEntryCount = XCNT;
 
 	PGPROC writer_proc;
+	writer_proc.pid = 1000;
 
 	TopTransactionResourceOwner = ResourceOwnerCreate(NULL, "unittest resource owner");
 	CurrentResourceOwner = TopTransactionResourceOwner;
@@ -36,14 +37,11 @@ test_write_read_shared_snapshot_for_cursor(void **state)
 	SharedLocalSnapshotSlot = &slot;
 	slot.slotindex = 1;
 	slot.slotid = 1;
-	slot.pid = 1000;
 	slot.writer_proc = &writer_proc;
 	slot.writer_xact = NULL;
 	slot.xid = 100;
-	slot.cid = 1;
 	slot.startTimestamp = 0;
 	slot.QDxid = 10;
-	slot.QDcid = 1;
 	slot.ready = true;
 	slot.segmateSync = 1;
 	slot.combocidcnt = 0;
@@ -85,7 +83,6 @@ test_write_read_shared_snapshot_for_cursor(void **state)
 
 	QEDtxContextInfo.segmateSync = slot.segmateSync;
 	QEDtxContextInfo.distributedXid = slot.QDxid;
-	QEDtxContextInfo.curcid = slot.QDcid;
 
 	SnapshotData snapshot;
 	snapshot.xip = palloc(XCNT * sizeof(TransactionId));

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -17,7 +17,7 @@
 /* This is a shipped header, do not include other files under "cdb" */
 #include "c.h"     /* DistributedTransactionId */
 
-#define DistributedSnapshot_StaticInit {0,0,0,0,0,0}
+#define DistributedSnapshot_StaticInit {0,0,0,0,0,0,0}
 
 typedef struct DistributedSnapshot
 {

--- a/src/include/cdb/cdbdtxcontextinfo.h
+++ b/src/include/cdb/cdbdtxcontextinfo.h
@@ -23,8 +23,6 @@ typedef struct DtxContextInfo
 	
 	DistributedTransactionId 		distributedXid;
 	
-	CommandId				 		curcid;	/* in my xact, CID < curcid are visible */
-
 	bool							haveDistributedSnapshot;
 	bool							cursorContext;
 	
@@ -34,6 +32,9 @@ typedef struct DtxContextInfo
 
 	uint32							segmateSync;
 	uint32							nestingLevel;
+
+	/* currentCommandId of QD, for debugging only */
+	CommandId				 		curcid;	
 } DtxContextInfo;
 
 extern DtxContextInfo QEDtxContextInfo;	

--- a/src/include/cdb/cdbdtxcontextinfo.h
+++ b/src/include/cdb/cdbdtxcontextinfo.h
@@ -39,7 +39,7 @@ typedef struct DtxContextInfo
 extern DtxContextInfo QEDtxContextInfo;	
 
 extern void DtxContextInfo_Reset(DtxContextInfo *dtxContextInfo);
-extern void DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo,
+extern void DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo, bool inCursor,
 										  int txnOptions, Snapshot snapshot);
 extern int DtxContextInfo_SerializeSize(DtxContextInfo *dtxContextInfo);
 
@@ -49,7 +49,4 @@ extern void DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 									   DtxContextInfo *dtxContextInfo);
 
 extern void DtxContextInfo_Copy(DtxContextInfo *target, DtxContextInfo *source);
-
-extern void DtxContextInfo_RewindSegmateSync(void);
-
 #endif   /* CDBDTXCONTEXTINFO_H */

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -313,7 +313,7 @@ extern bool dispatchDtxCommand(const char *cmd);
 extern void tmShmemInit(void);
 extern int	tmShmemSize(void);
 
-extern void verify_shared_snapshot_ready(void);
+extern void verify_shared_snapshot_ready(int cid);
 
 int			mppTxnOptions(bool needTwoPhase);
 int			mppTxOptions_IsoLevel(int txnOptions);

--- a/src/include/utils/session_state.h
+++ b/src/include/utils/session_state.h
@@ -96,6 +96,9 @@ typedef struct SessionState
 	 */
 	void *resGroupSlot;
 
+	/* gp_command_count of the latest cursor command in this session */
+	int latestCursorCommandId;
+
 #ifdef USE_ASSERT_CHECKING
 	/* If we modify the sessionId in ProcMppSessionId, this field is turned on */
 	bool isModifiedSessionId;

--- a/src/include/utils/sharedsnapshot.h
+++ b/src/include/utils/sharedsnapshot.h
@@ -22,20 +22,19 @@ typedef struct SharedSnapshotSlot
 {
 	int32			slotindex;  /* where in the array this one is. */
 	int32	 		slotid;
-	pid_t	 		pid; /* pid of writer seg */
 	PGPROC			*writer_proc;
 	PGXACT			*writer_xact;
-	TransactionId	xid;
-	CommandId       cid;
-	TimestampTz		startTimestamp;
 	volatile TransactionId   QDxid;
-	volatile CommandId		QDcid;
 	volatile bool			ready;
 	volatile uint32			segmateSync;
 	uint32			combocidcnt;
 	ComboCidKeyData combocids[MaxComboCids];
 	SnapshotData	snapshot;
 	LWLock		   *slotLock;
+
+	/* for debugging only */
+	TransactionId	xid;
+	TimestampTz		startTimestamp;
 } SharedSnapshotSlot;
 
 extern volatile SharedSnapshotSlot *SharedLocalSnapshotSlot;

--- a/src/test/regress/expected/cursor.out
+++ b/src/test/regress/expected/cursor.out
@@ -682,3 +682,49 @@ DROP INDEX if exists ctest_id_idx;
 NOTICE:  index "ctest_id_idx" does not exist, skipping
 DROP TABLE if exists ctest;
 --end_ignore
+--
+-- Simple test for the combination of cursor, initplans and function
+--
+SET optimizer=off;
+CREATE TABLE cursor_initplan(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO cursor_initplan SELECT i, i FROM generate_series(1,10) i;
+CREATE OR REPLACE FUNCTION func_test_cursor() RETURNS void AS
+$BODY$
+DECLARE cur CURSOR FOR SELECT * FROM cursor_initplan WHERE a = 2 or a = 3 FOR UPDATE;
+var1 record;
+var2 record;
+BEGIN
+	OPEN cur;
+
+	FETCH  cur INTO var1;
+	UPDATE cursor_initplan SET b = var1.b + 1 WHERE CURRENT OF cur;
+
+	FETCH  cur INTO var2;
+	UPDATE cursor_initplan SET b = var2.b + 1 WHERE CURRENT OF cur;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+SELECT func_test_cursor();
+ func_test_cursor 
+------------------
+ 
+(1 row)
+
+SELECT * FROM cursor_initplan ORDER BY a;
+ a  | b  
+----+----
+  1 |  1
+  2 |  3
+  3 |  4
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+DROP TABLE cursor_initplan;


### PR DESCRIPTION
We use shared memory 'SharedLocalSnapshotSlot' to synchronize information like
snapshot from writer gang to reader gang, also, we dispatch and execute
extended queries to the reader gangs only. To make extended queries have an
identical snapshot across reader gangs, we invented a GUC
'gp_write_shared_snapshot' to let the writer gang write the snapshot to a file
before dispatch extended queries to the reader gangs.

This patch replaces <dxid, currentCommandId, segmentSync> with a simple counter
to identify a dispatch and get rid of the counter rewind code.

This fixes the intermittent fail case `heap-repeatable-read-vacuum-freeze`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
