### PR TITLE
Group clear distributed transaction id

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1913,8 +1913,13 @@ RecordTransactionAbort(bool isSubXact)
 	 * we had already decided that we are going to commit this transaction and
 	 * wrote a commit record for it, there's no turning back. The Distributed
 	 * Transaction Manager will take care of completing the transaction for us.
+	 *
+	 * If the distributed transaction has started rolling back, it means we already
+	 * wrote the abort record, skip it. 
 	 */
-	if (isQEReader || getCurrentDtxState() == DTX_STATE_NOTIFYING_COMMIT_PREPARED)
+	if (isQEReader ||
+		getCurrentDtxState() == DTX_STATE_NOTIFYING_COMMIT_PREPARED ||
+		CurrentDtxIsRollingback())
 		xid = InvalidTransactionId;
 	else
 		xid = GetCurrentTransactionIdIfAny();

--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -75,7 +75,7 @@ doNotifyCommittedInDoubt(char *gid)
 	/* UNDONE: Pass real gxid instead of InvalidDistributedTransactionId. */
 	succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_RECOVERY_COMMIT_PREPARED,
 											 gid,
-											 NULL, /* raiseError */ false,
+											 /* raiseError */ false,
 											 cdbcomponent_getCdbComponentsList(), NULL, 0);
 	if (!succeeded)
 		elog(FATAL, "Crash recovery broadcast of the distributed transaction "
@@ -95,7 +95,7 @@ doAbortInDoubt(char *gid)
 	/* UNDONE: Pass real gxid instead of InvalidDistributedTransactionId. */
 	succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_RECOVERY_ABORT_PREPARED,
 											 gid,
-											 NULL, /* raiseError */ false,
+											 /* raiseError */ false,
 											 cdbcomponent_getCdbComponentsList(), NULL, 0);
 	if (!succeeded)
 		elog(FATAL, "Crash recovery retry of the distributed transaction "

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -403,7 +403,7 @@ doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType)
 	dtxFormGID(gid, getDistributedTransactionTimestamp(), getDistributedTransactionId());
 	succeeded = doDispatchDtxProtocolCommand(cmdType,
 											 gid,
-											 NULL, /* raiseError */ true,
+											 /* raiseError */ true,
 											 cdbcomponent_getCdbComponentsList(),
 											 serializedDtxContextInfo, serializedDtxContextInfoLen);
 
@@ -449,9 +449,6 @@ doPrepareTransaction(void)
 
 	if (!succeeded)
 	{
-		elog(DTM_DEBUG5, "doPrepareTransaction error finds badPrimaryGangs = %s",
-			 (MyTmGxactLocal->badPrepareGangs ? "true" : "false"));
-
 		ereport(ERROR,
 				(errmsg("The distributed transaction 'Prepare' broadcast failed to one or more segments"),
 				TM_ERRDETAIL));
@@ -685,86 +682,93 @@ doNotifyingAbort(void)
 
 	elog(DTM_DEBUG5, "doNotifyingAborted entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
 
-	Assert(MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED ||
-			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
-			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_PREPARED);
-
-	if (MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED)
+	switch (MyTmGxactLocal->state)
 	{
-		/*
-		 * In some cases, dtmPreCommand said two phase commit is needed, but some errors
-		 * occur before the command is actually dispatched, no need to dispatch DTX for
-		 * such cases.
-		 */ 
-		succeeded = currentDtxDispatchProtocolCommand(DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED, false);
-		if (!succeeded)
-		{
-			ereport(WARNING,
-					(errmsg("The distributed transaction 'Abort' broadcast failed to one or more segments"),
-					 TM_ERRDETAIL));
+		case DTX_STATE_NOTIFYING_ABORT_NO_PREPARED:
+			{
+				/*
+				 * In some cases, dtmPreCommand said two phase commit is needed, but some errors
+				 * occur before the command is actually dispatched, no need to dispatch DTX for
+				 * such cases.
+				 */ 
+				succeeded = currentDtxDispatchProtocolCommand(DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED, false);
+				if (!succeeded)
+				{
+					ereport(WARNING,
+							(errmsg("The distributed transaction 'Abort' broadcast failed to one or more segments"),
+							 TM_ERRDETAIL));
 
-			/*
-			 * Reset the dispatch logic and disconnect from any segment
-			 * that didn't respond to our abort.
-			 */
-			elog(NOTICE, "Releasing segworker groups to finish aborting the transaction.");
-			ResetAllGangs();
-		}
-		else
-		{
-			ereport(DTM_DEBUG5,
-					(errmsg("The distributed transaction 'Abort' broadcast succeeded to all the segments"),
-					 TM_ERRDETAIL));
-		}
-	}
-	else
-	{
-		DtxProtocolCommand dtxProtocolCommand;
-		char	   *abortString;
+					/*
+					 * Reset the dispatch logic and disconnect from any segment
+					 * that didn't respond to our abort.
+					 */
+					elog(NOTICE, "Releasing segworker groups to finish aborting the transaction.");
+					ResetAllGangs();
+				}
+				else
+				{
+					ereport(DTM_DEBUG5,
+							(errmsg("The distributed transaction 'Abort' broadcast succeeded to all the segments"),
+							 TM_ERRDETAIL));
+				}
 
-		Assert(MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
-				MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_PREPARED);
+				break;
+			}
 
-		if (MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED)
-		{
-			dtxProtocolCommand = DTX_PROTOCOL_COMMAND_ABORT_SOME_PREPARED;
-			abortString = "Abort [Prepared]";
-		}
-		else
-		{
-			dtxProtocolCommand = DTX_PROTOCOL_COMMAND_ABORT_PREPARED;
-			abortString = "Abort Prepared";
-		}
+		case DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED:
+		case DTX_STATE_NOTIFYING_ABORT_PREPARED:
+			{
+				DtxProtocolCommand dtxProtocolCommand;
+				char	   *abortString;
 
-		savedInterruptHoldoffCount = InterruptHoldoffCount;
+				if (MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED)
+				{
+					dtxProtocolCommand = DTX_PROTOCOL_COMMAND_ABORT_SOME_PREPARED;
+					abortString = "Abort [Prepared]";
+				}
+				else
+				{
+					dtxProtocolCommand = DTX_PROTOCOL_COMMAND_ABORT_PREPARED;
+					abortString = "Abort Prepared";
+				}
 
-		PG_TRY();
-		{
-			succeeded = currentDtxDispatchProtocolCommand(dtxProtocolCommand, true);
-		}
-		PG_CATCH();
-		{
-			/*
-			 * restore the previous value, which is reset to 0 in errfinish.
-			 */
-			MemoryContextSwitchTo(oldcontext);
-			InterruptHoldoffCount = savedInterruptHoldoffCount;
-			succeeded = false;
-			FlushErrorState();
-		}
-		PG_END_TRY();
+				savedInterruptHoldoffCount = InterruptHoldoffCount;
 
-		if (!succeeded)
-		{
-			ereport(WARNING,
-					(errmsg("the distributed transaction broadcast failed "
-							"to one or more segments"),
-					TM_ERRDETAIL));
+				PG_TRY();
+				{
+					succeeded = currentDtxDispatchProtocolCommand(dtxProtocolCommand, true);
+				}
+				PG_CATCH();
+				{
+					/*
+					 * restore the previous value, which is reset to 0 in errfinish.
+					 */
+					MemoryContextSwitchTo(oldcontext);
+					InterruptHoldoffCount = savedInterruptHoldoffCount;
+					succeeded = false;
+					FlushErrorState();
+				}
+				PG_END_TRY();
 
-			setCurrentDtxState(DTX_STATE_RETRY_ABORT_PREPARED);
-			setDistributedTransactionContext(DTX_CONTEXT_QD_RETRY_PHASE_2);
+				if (succeeded)
+					break;
+
+				ereport(WARNING,
+						(errmsg("the distributed transaction broadcast failed "
+								"to one or more segments"),
+						 TM_ERRDETAIL));
+
+				setCurrentDtxState(DTX_STATE_RETRY_ABORT_PREPARED);
+				setDistributedTransactionContext(DTX_CONTEXT_QD_RETRY_PHASE_2);
+			}
+			/* FALL THRU */
+
+		case DTX_STATE_RETRY_ABORT_PREPARED:
 			retryAbortPrepared();
-		}
+			break;
+
+		default:
+			elog(PANIC, "Unexpected Dtx state: %s", DtxStateToString(MyTmGxactLocal->state));
 	}
 
 	SIMPLE_FAULT_INJECTOR("dtm_broadcast_abort_prepared");
@@ -859,19 +863,17 @@ rollbackDtxTransaction(void)
 			break;
 
 		case DTX_STATE_PREPARING:
-			if (MyTmGxactLocal->badPrepareGangs)
-			{
+			/*
+			 * The writer gang is detected broken during preparing, then it has been destroyed
+			 * in AtAbort_DispatcherState(). In this way, we will create a new writer gang to
+			 * do the rollback. As this new writer gang is in DTX_CONTEXT_LOCAL_ONLY context,
+			 * we need to dispatch DTX_STATE_RETRY_ABORT_PREPARED command instead of
+			 * DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED.
+			 */
+			if (currentGxactWriterGangLost())
 				setCurrentDtxState(DTX_STATE_RETRY_ABORT_PREPARED);
-
-				/*
-				 * DisconnectAndDestroyAllGangs and ResetSession happens
-				 * inside retryAbortPrepared.
-				 */
-				retryAbortPrepared();
-				clearAndResetGxact();
-				return;
-			}
-			setCurrentDtxState(DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED);
+			else
+				setCurrentDtxState(DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED);
 			break;
 
 		case DTX_STATE_PREPARED:
@@ -916,6 +918,7 @@ rollbackDtxTransaction(void)
 
 	Assert(MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED ||
 			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
+			MyTmGxactLocal->state == DTX_STATE_RETRY_ABORT_PREPARED ||
 			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_PREPARED);
 
 	/*
@@ -931,6 +934,7 @@ rollbackDtxTransaction(void)
 		 * prepared transactions...
 		 */
 		if (MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
+			MyTmGxactLocal->state == DTX_STATE_RETRY_ABORT_PREPARED ||
 			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_PREPARED)
 		{
 			ereport(FATAL,
@@ -1110,17 +1114,16 @@ bool
 currentDtxDispatchProtocolCommand(DtxProtocolCommand dtxProtocolCommand, bool raiseError)
 {
 	char gid[TMGIDSIZE];
-	bool *badgang = (MyTmGxactLocal->state == DTX_STATE_PREPARING) ? &MyTmGxactLocal->badPrepareGangs : NULL;
 
 	dtxFormGID(gid, getDistributedTransactionTimestamp(), getDistributedTransactionId());
-	return doDispatchDtxProtocolCommand(dtxProtocolCommand, gid, badgang, raiseError,
+	return doDispatchDtxProtocolCommand(dtxProtocolCommand, gid, raiseError,
 										MyTmGxactLocal->twophaseSegments, NULL, 0);
 }
 
 bool
 doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 							 char *gid,
-							 bool *badGangs, bool raiseError,
+							 bool raiseError,
 							 List *twophaseSegments,
 							 char *serializedDtxContextInfo,
 							 int serializedDtxContextInfoLen)
@@ -1152,7 +1155,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	results = CdbDispatchDtxProtocolCommand(dtxProtocolCommand,
 											dtxProtocolCommandStr,
 											gid,
-											&qeError, &resultCount, badGangs, twophaseSegments,
+											&qeError, &resultCount, twophaseSegments,
 											serializedDtxContextInfo, serializedDtxContextInfoLen);
 
 	if (qeError)
@@ -1298,7 +1301,6 @@ resetGxact(void)
 	MyTmGxact->sessionId = 0;
 
 	MyTmGxactLocal->explicitBeginRemembered = false;
-	MyTmGxactLocal->badPrepareGangs = false;
 	MyTmGxactLocal->writerGangLost = false;
 	MyTmGxactLocal->twophaseSegmentsMap = NULL;
 	MyTmGxactLocal->twophaseSegments = NIL;

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -580,15 +580,9 @@ doNotifyingCommitPrepared(void)
 		 * or any failed segment instances must be marked INVALID.
 		 */
 		elog(NOTICE, "Releasing segworker group to retry broadcast.");
-		DisconnectAndDestroyAllGangs(true);
+		ResetAllGangs();
 
-		/*
-		 * This call will at a minimum change the session id so we will not
-		 * have SharedSnapshotAdd colissions.
-		 */
-		CheckForResetSession();
 		savedInterruptHoldoffCount = InterruptHoldoffCount;
-
 		PG_TRY();
 		{
 			succeeded = currentDtxDispatchProtocolCommand(DTX_PROTOCOL_COMMAND_RETRY_COMMIT_PREPARED, true);
@@ -644,16 +638,10 @@ retryAbortPrepared(void)
 			 */
 			pg_usleep(DTX_PHASE2_SLEEP_TIME_BETWEEN_RETRIES_MSECS * 1000);
 		}
-		DisconnectAndDestroyAllGangs(true);
 
-		/*
-		 * This call will at a minimum change the session id so we will not
-		 * have SharedSnapshotAdd colissions.
-		 */
-		CheckForResetSession();
+		ResetAllGangs();
 
 		savedInterruptHoldoffCount = InterruptHoldoffCount;
-
 		PG_TRY();
 		{
 			MyTmGxactLocal->twophaseSegments = cdbcomponent_getCdbComponentsList();
@@ -708,41 +696,25 @@ doNotifyingAbort(void)
 		 * occur before the command is actually dispatched, no need to dispatch DTX for
 		 * such cases.
 		 */ 
-		if (!MyTmGxactLocal->writerGangLost && MyTmGxactLocal->twophaseSegments)
+		succeeded = currentDtxDispatchProtocolCommand(DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED, false);
+		if (!succeeded)
 		{
-			succeeded = currentDtxDispatchProtocolCommand(DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED, false);
+			ereport(WARNING,
+					(errmsg("The distributed transaction 'Abort' broadcast failed to one or more segments"),
+					 TM_ERRDETAIL));
 
-			if (!succeeded)
-			{
-				ereport(WARNING,
-						(errmsg("The distributed transaction 'Abort' broadcast failed to one or more segments"),
-						TM_ERRDETAIL));
-
-				/*
-				 * Reset the dispatch logic and disconnect from any segment
-				 * that didn't respond to our abort.
-				 */
-				elog(NOTICE, "Releasing segworker groups to finish aborting the transaction.");
-				DisconnectAndDestroyAllGangs(true);
-
-				/*
-				 * This call will at a minimum change the session id so we
-				 * will not have SharedSnapshotAdd colissions.
-				 */
-				CheckForResetSession();
-			}
-			else
-			{
-				ereport(DTM_DEBUG5,
-						(errmsg("The distributed transaction 'Abort' broadcast succeeded to all the segments"),
-						TM_ERRDETAIL));
-			}
+			/*
+			 * Reset the dispatch logic and disconnect from any segment
+			 * that didn't respond to our abort.
+			 */
+			elog(NOTICE, "Releasing segworker groups to finish aborting the transaction.");
+			ResetAllGangs();
 		}
 		else
 		{
 			ereport(DTM_DEBUG5,
-					(errmsg("The distributed transaction 'Abort' broadcast was omitted (segworker group already dead)"),
-					TM_ERRDETAIL));
+					(errmsg("The distributed transaction 'Abort' broadcast succeeded to all the segments"),
+					 TM_ERRDETAIL));
 		}
 	}
 	else
@@ -796,11 +768,7 @@ doNotifyingAbort(void)
 	}
 
 	SIMPLE_FAULT_INJECTOR("dtm_broadcast_abort_prepared");
-
-	Assert(MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED ||
-			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
-			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_PREPARED ||
-			MyTmGxactLocal->state == DTX_STATE_RETRY_ABORT_PREPARED);
+	Assert(CurrentDtxIsRollingback());
 }
 
 /*
@@ -878,6 +846,15 @@ rollbackDtxTransaction(void)
 	switch (MyTmGxactLocal->state)
 	{
 		case DTX_STATE_ACTIVE_DISTRIBUTED:
+		case DTX_STATE_ONE_PHASE_COMMIT:
+		case DTX_STATE_PERFORMING_ONE_PHASE_COMMIT:
+			if (!MyTmGxactLocal->twophaseSegments || currentGxactWriterGangLost())
+			{
+				ereport(DTM_DEBUG5,
+						(errmsg("The distributed transaction 'Abort' broadcast was omitted (segworker group already dead)"),
+						 TM_ERRDETAIL));
+				return;
+			}
 			setCurrentDtxState(DTX_STATE_NOTIFYING_ABORT_NO_PREPARED);
 			break;
 
@@ -901,27 +878,15 @@ rollbackDtxTransaction(void)
 			setCurrentDtxState(DTX_STATE_NOTIFYING_ABORT_PREPARED);
 			break;
 
-		case DTX_STATE_ONE_PHASE_COMMIT:
-		case DTX_STATE_PERFORMING_ONE_PHASE_COMMIT:
-			setCurrentDtxState(DTX_STATE_NOTIFYING_ABORT_NO_PREPARED);
-			break;
 
 		case DTX_STATE_NOTIFYING_ABORT_NO_PREPARED:
-
 			/*
 			 * By deallocating the gang, we will force a new gang to connect
 			 * to all the segment instances.  And, we will abort the
 			 * transactions in the segments.
 			 */
 			elog(NOTICE, "Releasing segworker groups to finish aborting the transaction.");
-			DisconnectAndDestroyAllGangs(true);
-
-			/*
-			 * This call will at a minimum change the session id so we will
-			 * not have SharedSnapshotAdd colissions.
-			 */
-			CheckForResetSession();
-
+			ResetAllGangs();
 			return;
 
 		case DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED:
@@ -980,14 +945,7 @@ rollbackDtxTransaction(void)
 		 * all the segment instances.  And, we will abort the transactions in
 		 * the segments.
 		 */
-		DisconnectAndDestroyAllGangs(true);
-
-		/*
-		 * This call will at a minimum change the session id so we will not
-		 * have SharedSnapshotAdd colissions.
-		 */
-		CheckForResetSession();
-
+		ResetAllGangs();
 		return;
 	}
 
@@ -2286,4 +2244,13 @@ addToGxactTwophaseSegments(Gang *gang)
 			lappend_int(MyTmGxactLocal->twophaseSegments, segindex);
 	}
 	MemoryContextSwitchTo(oldContext);
+}
+
+bool
+CurrentDtxIsRollingback(void)
+{
+	return (MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED ||
+			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
+			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_PREPARED ||
+			MyTmGxactLocal->state == DTX_STATE_RETRY_ABORT_PREPARED);
 }

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -522,10 +522,7 @@ AtAbort_DispatcherState(void)
 	 * reset session and drop temp files
 	 */
 	if (currentGxactWriterGangLost())
-	{
-		DisconnectAndDestroyAllGangs(true);
-		CheckForResetSession();
-	}
+		ResetAllGangs();
 }
 
 void

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -70,7 +70,6 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 							  char *gid,
 							  ErrorData **qeError,
 							  int *numresults,
-							  bool *badGangs,
 							  List *twophaseSegments,
 							  char *serializedDtxContextInfo,
 							  int serializedDtxContextInfoLen)
@@ -120,14 +119,6 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 
 	if (!pr)
 	{
-		if (!GangOK(primaryGang) && badGangs != NULL)
-		{
-			*badGangs = true;
-			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "CdbDispatchDtxProtocolCommand: Bad gang from dispatch of %s for gid = %s",
-				 dtxProtocolCommandLoggingStr, gid);
-		}
-
 		cdbdisp_destroyDispatcherState(ds);
 		return NULL;
 	}

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -861,3 +861,10 @@ RecycleGang(Gang *gp, bool forceDestroy)
 		cdbcomponent_recycleIdleQE(segdbDesc, forceDestroy);
 	}
 }
+
+void
+ResetAllGangs(void)
+{
+	DisconnectAndDestroyAllGangs(true);
+	CheckForResetSession();
+}

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -817,7 +817,7 @@ gangTypeToString(GangType type)
 bool
 GangOK(Gang *gp)
 {
-	int			i;
+	int i;
 
 	if (gp == NULL)
 		return false;

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -545,6 +545,7 @@ InitProcess(void)
 	MyProc->queryCommandId = -1;
 
 	/* Init gxact */
+	MyTmGxact->gxid = InvalidDistributedTransactionId;
 	resetGxact();
 
 	/*

--- a/src/include/cdb/cdbdisp_dtx.h
+++ b/src/include/cdb/cdbdisp_dtx.h
@@ -36,7 +36,6 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 							  char	*gid,
 							  ErrorData **qeError,
 							  int *resultCount,
-							  bool* badGangs,
 							  List *twophaseSegments,
 							  char *serializedDtxContextInfo,
 							  int serializedDtxContextInfoLen);

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -77,6 +77,7 @@ extern void DisconnectAndDestroyAllGangs(bool resetSession);
 extern void DisconnectAndDestroyUnusedQEs(void);
 
 extern void CheckForResetSession(void);
+extern void ResetAllGangs(void);
 
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -343,6 +343,7 @@ extern void markCurrentGxactWriterGangLost(void);
 extern bool currentGxactWriterGangLost(void);
 
 extern void addToGxactTwophaseSegments(struct Gang* gp);
+extern bool CurrentDtxIsRollingback(void);
 
 extern void DtxRecoveryMain(Datum main_arg);
 extern bool DtxRecoveryStartRule(Datum main_arg);

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -344,8 +344,6 @@ extern bool currentGxactWriterGangLost(void);
 
 extern void addToGxactTwophaseSegments(struct Gang* gp);
 
-extern void ClearTransactionState(TransactionId latestXid);
-
 extern void DtxRecoveryMain(Datum main_arg);
 extern bool DtxRecoveryStartRule(Datum main_arg);
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -230,8 +230,6 @@ typedef struct TMGXACTLOCAL
 	/* Used on QE, indicates the transaction applies one-phase commit protocol */
 	bool						isOnePhaseCommit;
 
-	bool						badPrepareGangs;
-
 	bool						writerGangLost;
 
 	Bitmapset					*twophaseSegmentsMap;
@@ -335,7 +333,7 @@ extern void UtilityModeCloseDtmRedoFile(void);
 extern bool currentDtxDispatchProtocolCommand(DtxProtocolCommand dtxProtocolCommand, bool raiseError);
 extern bool doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType);
 extern bool doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, char *gid,
-							 bool *badGangs, bool raiseError, List *twophaseSegments,
+							 bool raiseError, List *twophaseSegments,
 							 char *serializedDtxContextInfo, int serializedDtxContextInfoLen);
 
 extern void markCurrentGxactWriterGangLost(void);

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -29,8 +29,8 @@ extern Size ProcArrayShmemSize(void);
 extern void CreateSharedProcArray(void);
 extern void ProcArrayAdd(PGPROC *proc);
 extern void ProcArrayRemove(PGPROC *proc, TransactionId latestXid);
-extern void ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid, bool lockHeld);
-extern void ProcArrayEndGxact(void);
+extern void ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid);
+extern void ProcArrayEndGxact(TMGXACT *gxact);
 extern void ProcArrayClearTransaction(PGPROC *proc);
 
 extern void ProcArrayInitRecovery(TransactionId initializedUptoXID);


### PR DESCRIPTION
We have merged the group clear xid feature from upstream 9.6, which is supposed
to reduce the contention on ProcArrayLock. We should also use the technique to
clear distributed transaction id.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
