### PR TITLE
fix buffer overflow

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -39,12 +39,7 @@
 #include "cdb/cdbexplain.h"
 #include "cdb/cdbvars.h"
 
-#define DEFAULT_BUFFER_INCREMENT_SIZE 1024
-#define BUFFER_INCREMENT_SIZE(write_size) \
-	MAXALIGN(write_size) >= DEFAULT_BUFFER_INCREMENT_SIZE ? \
-		MAXALIGN(write_size) + DEFAULT_BUFFER_INCREMENT_SIZE : \
-		DEFAULT_BUFFER_INCREMENT_SIZE
-
+#define BUFFER_INCREMENT_SIZE 1024
 #define HHA_MSG_LVL DEBUG2
 
 
@@ -1576,7 +1571,7 @@ writeHashEntry(AggState *aggstate, BatchFileInfo *file_info,
 	 * with 1024 whenever the buffer + datum_size exceeds the current buffer size
 	 */
 	static char *aggDataBuffer = NULL;
-	static int aggDataBufferSize = DEFAULT_BUFFER_INCREMENT_SIZE;
+	static int aggDataBufferSize = BUFFER_INCREMENT_SIZE;
 	int32 aggDataOffset = 0;
 	if (aggDataBuffer == NULL)
 		aggDataBuffer = MemoryContextAlloc(TopMemoryContext, aggDataBufferSize);
@@ -1641,7 +1636,8 @@ writeHashEntry(AggState *aggstate, BatchFileInfo *file_info,
 
 		if ((aggDataOffset + MAXALIGN(datum_size)) >= aggDataBufferSize)
 		{
-			aggDataBufferSize += BUFFER_INCREMENT_SIZE(datum_size);
+			aggDataBufferSize += MAXALIGN(datum_size) >= BUFFER_INCREMENT_SIZE ?
+				MAXALIGN(datum_size) + BUFFER_INCREMENT_SIZE : BUFFER_INCREMENT_SIZE;
 			MemoryContext oldAggContext = MemoryContextSwitchTo(TopMemoryContext);
 			aggDataBuffer = repalloc(aggDataBuffer, aggDataBufferSize);
 			MemoryContextSwitchTo(oldAggContext);

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -1636,7 +1636,11 @@ writeHashEntry(AggState *aggstate, BatchFileInfo *file_info,
 
 		if ((aggDataOffset + MAXALIGN(datum_size)) >= aggDataBufferSize)
 		{
-			aggDataBufferSize += BUFFER_INCREMENT_SIZE;
+			if (MAXALIGN(datum_size) > BUFFER_INCREMENT_SIZE) {
+				aggDataBufferSize += MAXALIGN(datum_size);
+			} else {
+				aggDataBufferSize += BUFFER_INCREMENT_SIZE;
+			}
 			MemoryContext oldAggContext = MemoryContextSwitchTo(TopMemoryContext);
 			aggDataBuffer = repalloc(aggDataBuffer, aggDataBufferSize);
 			MemoryContextSwitchTo(oldAggContext);


### PR DESCRIPTION
On write buffer its size incremented by fix BUFFER_INCREMENT_SIZE.
And nobody checks that the data being written can be greater than BUFFER_INCREMENT_SIZE.
I've got "realloc(): invalid next size"
Using valgrind found this bug.
Check query where complicated, used HLL on large tables, unions and groups. 
I don't know how to reproduce this bug on test data.
### Here are some reminders before you submit the pull request
 

- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community