### PR TITLE
Add ctid in function scan

### DIFF
--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -133,6 +133,16 @@ FunctionNext_guts(FunctionScanState *node)
 									   ScanDirectionIsForward(direction),
 									   false,
 									   scanslot);
+
+		/*
+		 * CDB: Label each row with a synthetic ctid if needed for subquery dedup.
+		 */
+		if (node->cdb_want_ctid &&
+			!TupIsNull(scanslot))
+		{
+			slot_set_ctid_from_fake(scanslot, &node->cdb_fake_ctid);
+		}
+
 		return scanslot;
 	}
 

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -499,3 +499,16 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 (6 rows)
 
 DROP TABLE A;
+--
+-- Test the ctid in function scan
+--
+create table t1(a int) ;
+insert into t1 select i from generate_series(1, 100000) i;
+analyze t1;
+select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
+ count 
+-------
+     1
+(1 row)
+
+drop table t1;

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -496,3 +496,16 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 (9 rows)
 
 DROP TABLE A;
+--
+-- Test the ctid in function scan
+--
+create table t1(a int) ;
+insert into t1 select i from generate_series(1, 100000) i;
+analyze t1;
+select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
+ count 
+-------
+     1
+(1 row)
+
+drop table t1;

--- a/src/test/regress/sql/bfv_subquery.sql
+++ b/src/test/regress/sql/bfv_subquery.sql
@@ -291,3 +291,13 @@ SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 
 DROP TABLE A;
+
+--
+-- Test the ctid in function scan
+--
+
+create table t1(a int) ;
+insert into t1 select i from generate_series(1, 100000) i;
+analyze t1;
+select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
+drop table t1;


### PR DESCRIPTION
When we convert semi join to inner join, a distinct agg on ctid is added
above the hash join node. But tuples from function scan have no ctid. So
the assert check failed.

Set a synthetic ctid based on a fake ctid by call existed funciton
slot_set_ctid_from_fake.

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
