### PR TITLE
Elide explicit motion when result relation locus is not changed

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -303,16 +303,14 @@ cdbpathlocus_for_insert(PlannerInfo *root, GpPolicy *policy,
 }
 
 /*
- * cdbpathlocus_from_baserel
+ * cdbpathlocus_from_policy
  *
- * Returns a locus describing the distribution of a base relation.
+ * Returns a locus describing the distribution of a policy
  */
 CdbPathLocus
-cdbpathlocus_from_baserel(struct PlannerInfo *root,
-						  struct RelOptInfo *rel)
+cdbpathlocus_from_policy(struct PlannerInfo *root, Index rti, GpPolicy *policy)
 {
 	CdbPathLocus result;
-	GpPolicy   *policy = rel->cdbpolicy;
 
 	if (Gp_role != GP_ROLE_DISPATCH)
 	{
@@ -326,7 +324,7 @@ cdbpathlocus_from_baserel(struct PlannerInfo *root,
 		if (policy->nattrs > 0)
 		{
 			List	   *distkeys = cdb_build_distribution_keys(root,
-															   rel->relid,
+															   rti,
 															   policy);
 
 			if (distkeys)
@@ -354,6 +352,18 @@ cdbpathlocus_from_baserel(struct PlannerInfo *root,
 		CdbPathLocus_MakeEntry(&result);
 
 	return result;
+}								/* cdbpathlocus_from_baserel */
+
+/*
+ * cdbpathlocus_from_baserel
+ *
+ * Returns a locus describing the distribution of a base relation.
+ */
+CdbPathLocus
+cdbpathlocus_from_baserel(struct PlannerInfo *root,
+						  struct RelOptInfo *rel)
+{
+	return cdbpathlocus_from_policy(root, rel->relid, rel->cdbpolicy);
 }								/* cdbpathlocus_from_baserel */
 
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -4734,7 +4734,7 @@ adjust_modifytable_subpaths(PlannerInfo *root, CmdType operation,
 		}
 		else if (operation == CMD_DELETE)
 		{
-			subpath = create_motion_path_for_delete(root, targetPolicy, subpath);
+			subpath = create_motion_path_for_upddel(root, rti, targetPolicy, subpath);
 		}
 		else if (operation == CMD_UPDATE)
 		{
@@ -4745,7 +4745,7 @@ adjust_modifytable_subpaths(PlannerInfo *root, CmdType operation,
 			if (is_split_update)
 				subpath = create_split_update_path(root, rti, targetPolicy, subpath);
 			else
-				subpath = create_motion_path_for_update(root, targetPolicy, subpath);
+				subpath = create_motion_path_for_upddel(root, rti, targetPolicy, subpath);
 
 			lci = lnext(lci);
 		}

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -42,8 +42,7 @@ extern Path *cdbpath_create_redistribute_motion_path_for_exprs(PlannerInfo *root
 
 extern Path *create_motion_path_for_ctas(PlannerInfo *root, GpPolicy *policy, Path *subpath);
 extern Path *create_motion_path_for_insert(PlannerInfo *root, GpPolicy *targetPolicy, Path *subpath);
-extern Path *create_motion_path_for_delete(PlannerInfo *root, GpPolicy *targetPolicy, Path *subpath);
-extern Path *create_motion_path_for_update(PlannerInfo *root, GpPolicy *targetPolicy, Path *subpath);
+extern Path *create_motion_path_for_upddel(PlannerInfo *root, Index rti, GpPolicy *targetPolicy, Path *subpath);
 extern Path *create_split_update_path(PlannerInfo *root, Index rti, GpPolicy *targetPolicy, Path *subpath);
 
 CdbPathLocus

--- a/src/include/cdb/cdbpathlocus.h
+++ b/src/include/cdb/cdbpathlocus.h
@@ -267,6 +267,8 @@ extern CdbPathLocus cdbpathlocus_for_insert(struct PlannerInfo *root,
 											struct PathTarget *pathtarget);
 
 CdbPathLocus
+cdbpathlocus_from_policy(struct PlannerInfo *root, Index rti, struct GpPolicy *policy);
+CdbPathLocus
 cdbpathlocus_from_baserel(struct PlannerInfo   *root,
                           struct RelOptInfo    *rel);
 CdbPathLocus

--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -1640,6 +1640,93 @@ select * from sales_par where region='asia' and id in (select b from m where a =
 (0 rows)
 
 -- ----------------------------------------------------------------------
+-- Test: Explicit redistributed motion may be removed.
+-- ----------------------------------------------------------------------
+create table tab1(a int, b int) distributed by (a);
+create table tab2(a int, b int) distributed by (a);
+analyze tab1;
+analyze tab2;
+-- colocate, no motion, thus no explicit redistributed motion
+explain (costs off) delete from tab1 using tab2 where tab1.a = tab2.a;
+              QUERY PLAN              
+--------------------------------------
+ Delete on tab1
+   ->  Hash Join
+         Hash Cond: (tab1.a = tab2.a)
+         ->  Seq Scan on tab1
+         ->  Hash
+               ->  Seq Scan on tab2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+-- redistribtued tab2, no motion above result relation, thus no explicit
+-- redistributed motion
+explain (costs off) delete from tab1 using tab2 where tab1.a = tab2.b;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Delete on tab1
+   ->  Hash Join
+         Hash Cond: (tab2.b = tab1.a)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: tab2.b
+               ->  Seq Scan on tab2
+         ->  Hash
+               ->  Seq Scan on tab1
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+-- redistributed motion table, has to add explicit redistributed motion
+explain (costs off) delete from tab1 using tab2 where tab1.b = tab2.b;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Delete on tab1
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
+         ->  Hash Join
+               Hash Cond: (tab1.b = tab2.b)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: tab1.b
+                     ->  Seq Scan on tab1
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: tab2.b
+                           ->  Seq Scan on tab2
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+alter table tab1 set distributed by (b);
+create table tab3 (a int, b int) distributed by (b);
+insert into tab1 values (1, 1);
+insert into tab2 values (1, 1);
+insert into tab3 values (1, 1);
+set allow_system_table_mods=true;
+update pg_class set relpages = 10000 where relname='tab2';
+update pg_class set reltuples = 100000000 where relname='tab2';
+update pg_class set relpages = 100000000 where relname='tab3';
+update pg_class set reltuples = 100000 where relname='tab3';
+-- Planner: there is redistribute motion above tab1, however, we can also
+-- remove the explicit redistribute motion here because the final join
+-- co-locate with the result relation tab1.
+explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.b;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Delete on tab1
+   ->  Hash Join
+         Hash Cond: (tab1.b = tab3.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: tab1.b
+               ->  Hash Join
+                     Hash Cond: (tab2.a = tab1.a)
+                     ->  Seq Scan on tab2
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: tab1.a
+                                 ->  Seq Scan on tab1
+         ->  Hash
+               ->  Seq Scan on tab3
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -1646,6 +1646,92 @@ select * from sales_par where region='asia' and id in (select b from m where a =
 (0 rows)
 
 -- ----------------------------------------------------------------------
+-- Test: Explicit redistributed motion may be removed.
+-- ----------------------------------------------------------------------
+create table tab1(a int, b int) distributed by (a);
+create table tab2(a int, b int) distributed by (a);
+analyze tab1;
+analyze tab2;
+-- colocate, no motion, thus no explicit redistributed motion
+explain (costs off) delete from tab1 using tab2 where tab1.a = tab2.a;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Delete
+   ->  Hash Join
+         Hash Cond: (tab1.a = tab2.a)
+         ->  Seq Scan on tab1
+         ->  Hash
+               ->  Seq Scan on tab2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0
+(7 rows)
+
+-- redistribtued tab2, no motion above result relation, thus no explicit
+-- redistributed motion
+explain (costs off) delete from tab1 using tab2 where tab1.a = tab2.b;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Delete
+   ->  Hash Join
+         Hash Cond: (tab1.a = tab2.b)
+         ->  Seq Scan on tab1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: tab2.b
+                     ->  Seq Scan on tab2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0
+(9 rows)
+
+-- redistributed motion table, has to add explicit redistributed motion
+explain (costs off) delete from tab1 using tab2 where tab1.b = tab2.b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Delete
+   ->  Hash Join
+         Hash Cond: (tab1.b = tab2.b)
+         ->  Seq Scan on tab1
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on tab2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0
+(8 rows)
+
+alter table tab1 set distributed by (b);
+create table tab3 (a int, b int) distributed by (b);
+insert into tab1 values (1, 1);
+insert into tab2 values (1, 1);
+insert into tab3 values (1, 1);
+set allow_system_table_mods=true;
+update pg_class set relpages = 10000 where relname='tab2';
+update pg_class set reltuples = 100000000 where relname='tab2';
+update pg_class set relpages = 100000000 where relname='tab3';
+update pg_class set reltuples = 100000 where relname='tab3';
+-- Planner: there is redistribute motion above tab1, however, we can also
+-- remove the explicit redistribute motion here because the final join
+-- co-locate with the result relation tab1.
+explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.b;
+NOTICE:  One or more columns in the following table(s) do not have statistics: tab2
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Delete
+   ->  Result
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: tab1.b
+               ->  Hash Join
+                     Hash Cond: (tab2.a = tab1.a)
+                     ->  Seq Scan on tab2
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: tab1.a
+                                 ->  Hash Join
+                                       Hash Cond: (tab3.b = tab1.b)
+                                       ->  Seq Scan on tab3
+                                       ->  Hash
+                                             ->  Seq Scan on tab1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0
+(16 rows)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore

--- a/src/test/regress/expected/gangsize.out
+++ b/src/test/regress/expected/gangsize.out
@@ -176,13 +176,11 @@ end;
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to PARTIAL contents: 0 1
 update random_2_0 set a = 1 from hash_3_3_2 where hash_3_3_2.b = random_2_0.c;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 begin;
 update random_2_0 set a = 1 from hash_3_3_2 where hash_3_3_2.b = random_2_0.c;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 end;
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2

--- a/src/test/regress/expected/gangsize_optimizer.out
+++ b/src/test/regress/expected/gangsize_optimizer.out
@@ -174,13 +174,11 @@ end;
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to PARTIAL contents: 0 1
 update random_2_0 set a = 1 from hash_3_3_2 where hash_3_3_2.b = random_2_0.c;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 begin;
 update random_2_0 set a = 1 from hash_3_3_2 where hash_3_3_2.b = random_2_0.c;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 end;
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -1071,18 +1071,17 @@ create table TabDel4(a int not null, b int not null);
 insert into TabDel4 values(1,2);
 commit;
 explain delete from TabDel1 where TabDel1.a not in (select a from TabDel3); -- do not support this because we produce NLASJ
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Delete on tabdel1  (cost=1.09..3.17 rows=2 width=16)
-   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.09..3.17 rows=2 width=10)
-         ->  Hash Left Anti Semi (Not-In) Join  (cost=1.09..3.17 rows=2 width=10)
-               Hash Cond: tabdel1.a = tabdel3.a
-               ->  Seq Scan on tabdel1  (cost=0.00..2.03 rows=1 width=14)
-               ->  Hash  (cost=1.05..1.05 rows=1 width=4)
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
-                           ->  Seq Scan on tabdel3  (cost=0.00..1.01 rows=1 width=4)
- Optimizer status: Postgres query optimizer
-(9 rows)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Delete on tabdel1  (cost=1.09..4.16 rows=2 width=16)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=1.09..4.16 rows=2 width=16)
+         Hash Cond: (tabdel1.a = tabdel3.a)
+         ->  Seq Scan on tabdel1  (cost=0.00..3.03 rows=1 width=14)
+         ->  Hash  (cost=1.05..1.05 rows=1 width=10)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=10)
+                     ->  Seq Scan on tabdel3  (cost=0.00..1.01 rows=1 width=10)
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 explain delete from TabDel2 where TabDel2.a not in (select a from TabDel4); -- support this
                                  QUERY PLAN                                 


### PR DESCRIPTION
Delete or Update statement may add motions above result relation
to determine whether the tuple is to delete or update. For example,

-- t1 distributed by (b), t2 distributed by(a)
delete from t1 using t2 where t1.b = t2.a;
The above sql might add motion above t1 (the result relation) when creating the
t1 join t2 plan.

ExecDelete or ExecUpdate use ctid to find the tuple and ctid only make sense
in its original segment. So greenplum will add explicit redistributed motion to
send back each tuple and then do delete or update.

Previously, the condition to add explicit redistributed motion is that no motions in
the subplan of modify table. This can be improved: 
  - if no motion is added above the result relations, then we could elide this motion.
  - if subpath's locus is equal to result relation's locus and both are hashed locus.

--------------------------

See some discussion: https://github.com/greenplum-db/gpdb/pull/9171

I test the following cases, it seems OK. Will try to run the full pipeline.

One thing more: I find the case `DML_over_joins` is good to add plan cases. But there are many
duplicated-shape cases there. Should we add explain for every statement there? 

```sql
gpadmin=# create table tab1(a int, b int) distributed by (a);
CREATE TABLE
gpadmin=# create table tab2(a int, b int) distributed by (a);
CREATE TABLE
gpadmin=# explain (costs off) delete from tab1 using tab2 where tab1.a = tab2.a;
              QUERY PLAN
--------------------------------------
 Delete on tab1
   ->  Hash Join
         Hash Cond: (tab1.a = tab2.a)
         ->  Seq Scan on tab1
         ->  Hash
               ->  Seq Scan on tab2
 Optimizer: Postgres query optimizer
(7 rows)

gpadmin=# explain (costs off) delete from tab1 using tab2 where tab1.a = tab2.b;
                         QUERY PLAN
------------------------------------------------------------
 Delete on tab1
   ->  Hash Join
         Hash Cond: (tab2.b = tab1.a)
         ->  Redistribute Motion 3:3  (slice1; segments: 3)
               Hash Key: tab2.b
               ->  Seq Scan on tab2
         ->  Hash
               ->  Seq Scan on tab1
 Optimizer: Postgres query optimizer
(9 rows)

gpadmin=# explain (costs off) delete from tab1 using tab2 where tab1.b = tab2.b;
                               QUERY PLAN
------------------------------------------------------------------------
 Delete on tab1
   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
         ->  Hash Join
               Hash Cond: (tab1.b = tab2.b)
               ->  Redistribute Motion 3:3  (slice1; segments: 3)
                     Hash Key: tab1.b
                     ->  Seq Scan on tab1
               ->  Hash
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                           Hash Key: tab2.b
                           ->  Seq Scan on tab2
 Optimizer: Postgres query optimizer
(12 rows)

gpadmin=# explain (costs off) delete from tab1 using tab2 where tab1.b = tab2.a;
                            QUERY PLAN
------------------------------------------------------------------
 Delete on tab1
   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
         ->  Hash Join
               Hash Cond: (tab1.b = tab2.a)
               ->  Redistribute Motion 3:3  (slice1; segments: 3)
                     Hash Key: tab1.b
                     ->  Seq Scan on tab1
               ->  Hash
                     ->  Seq Scan on tab2
 Optimizer: Postgres query optimizer
(10 rows)

==========================================================================

gpadmin=#
gpadmin=# drop table t1;
DROP TABLE
gpadmin=# drop table t2;
DROP TABLE
gpadmin=# drop table t3;
DROP TABLE
gpadmin=# create table t1 (a int, b int) distributed by (b);
CREATE TABLE
gpadmin=# create table t2 (a int, b int) distributed by (a);
CREATE TABLE
gpadmin=# create table t3 (a int, b int) distributed by (b);
CREATE TABLE
gpadmin=#
gpadmin=# insert into t1 values (1, 1);
INSERT 0 1
gpadmin=# insert into t2 values (1, 1);
INSERT 0 1
gpadmin=# insert into t3 values (1, 1);
INSERT 0 1
gpadmin=#
gpadmin=# set allow_system_table_mods=true;
SET
gpadmin=# update pg_class set relpages = 10000 where relname='t2';
UPDATE 1
gpadmin=# update pg_class set reltuples = 100000000 where relname='t2';
UPDATE 1
gpadmin=# update pg_class set relpages = 100000000 where relname='t3';
UPDATE 1
gpadmin=# update pg_class set reltuples = 100000 where relname='t3';
UPDATE 1
gpadmin=# explain (costs off) delete from t1 using t2, t3 where t1.a = t2.a and t1.b = t3.b;
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Delete on t1
   ->  Hash Join
         Hash Cond: (t3.b = t1.b)
         ->  Seq Scan on t3
         ->  Hash
               ->  Redistribute Motion 3:3  (slice2; segments: 3)
                     Hash Key: t1.b
                     ->  Hash Join
                           Hash Cond: (t2.a = t1.a)
                           ->  Seq Scan on t2
                           ->  Hash
                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                       Hash Key: t1.a
                                       ->  Seq Scan on t1
 Optimizer: Postgres query optimizer
(15 rows)

```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
