### PR TITLE
Allow quoted identifiers in gp_dist_random() input

### DIFF
--- a/src/test/regress/expected/gpdist.out
+++ b/src/test/regress/expected/gpdist.out
@@ -734,3 +734,31 @@ select * from xidtab group by x;
  5
 (5 rows)
 
+-- Simple sanity tests for gp_dist_random()
+CREATE TEMP TABLE gp_dist_random_table (a int);
+INSERT INTO gp_dist_random_table SELECT generate_series(1,5);
+SELECT * FROM gp_dist_random('gp_dist_random_table');
+ a 
+---
+ 5
+ 2
+ 3
+ 4
+ 1
+(5 rows)
+
+CREATE SCHEMA "gp.dist.random.schema";
+CREATE TABLE "gp.dist.random.schema".gp_dist_random_table_with_schema
+    AS SELECT * FROM gp_dist_random('"gp_dist_random_table"');
+SELECT * FROM gp_dist_random('"gp.dist.random.schema".gp_dist_random_table_with_schema');
+ a 
+---
+ 5
+ 2
+ 3
+ 4
+ 1
+(5 rows)
+
+DROP SCHEMA "gp.dist.random.schema" CASCADE;
+NOTICE:  drop cascades to table "gp.dist.random.schema".gp_dist_random_table_with_schema

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -744,3 +744,31 @@ select * from xidtab group by x;
  3
 (5 rows)
 
+-- Simple sanity tests for gp_dist_random()
+CREATE TEMP TABLE gp_dist_random_table (a int);
+INSERT INTO gp_dist_random_table SELECT generate_series(1,5);
+SELECT * FROM gp_dist_random('gp_dist_random_table');
+ a 
+---
+ 5
+ 2
+ 3
+ 4
+ 1
+(5 rows)
+
+CREATE SCHEMA "gp.dist.random.schema";
+CREATE TABLE "gp.dist.random.schema".gp_dist_random_table_with_schema
+    AS SELECT * FROM gp_dist_random('"gp_dist_random_table"');
+SELECT * FROM gp_dist_random('"gp.dist.random.schema".gp_dist_random_table_with_schema');
+ a 
+---
+ 5
+ 2
+ 3
+ 4
+ 1
+(5 rows)
+
+DROP SCHEMA "gp.dist.random.schema" CASCADE;
+NOTICE:  drop cascades to table "gp.dist.random.schema".gp_dist_random_table_with_schema

--- a/src/test/regress/sql/gpdist.sql
+++ b/src/test/regress/sql/gpdist.sql
@@ -521,3 +521,13 @@ create table xidtab (x xid) distributed by (x);
 insert into xidtab select g::text::xid from generate_series(1,5) g;
 select * from xidtab a, xidtab b, xidtab c where a.x=b.x and b.x = c.x;
 select * from xidtab group by x;
+
+-- Simple sanity tests for gp_dist_random()
+CREATE TEMP TABLE gp_dist_random_table (a int);
+INSERT INTO gp_dist_random_table SELECT generate_series(1,5);
+SELECT * FROM gp_dist_random('gp_dist_random_table');
+CREATE SCHEMA "gp.dist.random.schema";
+CREATE TABLE "gp.dist.random.schema".gp_dist_random_table_with_schema
+    AS SELECT * FROM gp_dist_random('"gp_dist_random_table"');
+SELECT * FROM gp_dist_random('"gp.dist.random.schema".gp_dist_random_table_with_schema');
+DROP SCHEMA "gp.dist.random.schema" CASCADE;


### PR DESCRIPTION
The gp_dist_random pseudo function is special in that it takes in a
string literal which happens to be a relation name. The parsing logic
used on the string literal simply splits on the first dot and treats
the two tokens as schema and table. That works for common cases but
other cases such as those involving special characters can have issues
(e.g. a schema with a dot in its name would not split as expected). To
cover all cases, allow the schema and table to be quote identifiers so
that we can use regular Postgres parsing logic when constructing the
RangeVar.