### PR TITLE
Remove projection in DQA path

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -212,7 +212,13 @@ add_twostage_group_agg_path(PlannerInfo *root,
 		if (!analyze_dqas(root, path, ctx, &input_target, &dqa_group_clause))
 			return;
 
-		path = (Path *) create_projection_path(root, path->parent, path, input_target);
+        /*
+         * If subpath is projection capable, we do not want to generate
+         * projection plan. The reason is that the projection plan does not
+         * constrain child tlist when it create subplan. Thus, GROUP BY expr
+         * may not find in scan targetlist.
+         */
+        path = apply_projection_to_path(root, path->parent, path, input_target);
 
 		distinct_locus = cdb_choose_grouping_locus(root, path,
 												   input_target,
@@ -532,7 +538,13 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 							   &hash_info))
 		return;	/* don't try to hash */
 
-	path = (Path *) create_projection_path(root, path->parent, path, input_target);
+	/*
+	 * If subpath is projection capable, we do not want to generate
+	 * projection plan. The reason is that the projection plan does not
+	 * constrain child tlist when it create subplan. Thus, GROUP BY expr
+	 * may not find in scan targetlist.
+	 */
+	 path = apply_projection_to_path(root, path->parent, path, input_target);
 
 	distinct_locus = cdb_choose_grouping_locus(root, path,
 											   input_target,

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -108,6 +108,21 @@ select ten, ten, count(distinct two), count(distinct four) from tenk1 group by 1
    7 |   7 |     1 |     2
 (10 rows)
 
+select case when ten < 5 then ten else ten * 2 end, count(distinct two) from tenk1 group by 1;
+ case | count 
+------+-------
+    2 |     1
+    3 |     1
+    4 |     1
+   16 |     1
+   18 |     1
+    0 |     1
+    1 |     1
+   12 |     1
+   10 |     1
+   14 |     1
+(10 rows)
+
 --MPP-20151: distinct is transformed to a group-by
 select distinct two from tenk1 order by two;
  two 

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -35,6 +35,8 @@ SELECT * FROM mpp2687v;
 select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from tenk1 group by 1;
 select ten, ten, count(distinct two), count(distinct four) from tenk1 group by 1,2;
 
+select case when ten < 5 then ten else ten * 2 end, count(distinct two) from tenk1 group by 1;
+
 --MPP-20151: distinct is transformed to a group-by
 select distinct two from tenk1 order by two;
 select distinct two, four from tenk1 order by two, four;


### PR DESCRIPTION
Projection plan always using physical tlist as an input target list.
If a DQA query using a complex expr in `GROUP BY` instead of a single
column, the projection plan can not provide suitable target entry.

So, directly replace input PathTarget maybe is better than give a
projection node under the DQA plan.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
