### PR TITLE
Pg upgrade table in different tablespace

### DIFF
--- a/contrib/pg_upgrade/info_gp.c
+++ b/contrib/pg_upgrade/info_gp.c
@@ -35,10 +35,18 @@ not_found_in_file(void)
 }
 
 static GetTablespacePathResponse
+system_tablespace(void)
+{
+	return make_response(
+		GetTablespacePathResponse_FOUND_SYSTEM_TABLESPACE,
+		EMPTY_TABLESPACE_PATH);
+}
+
+static GetTablespacePathResponse
 found_in_file(char *tablespace_path, Oid tablespace_oid)
 {
 	return make_response(
-		GetTablespacePathResponse_FOUND,
+		GetTablespacePathResponse_FOUND_USER_DEFINED_TABLESPACE,
 		psprintf("%s/%u",
 			tablespace_path,
 			tablespace_oid));
@@ -50,13 +58,18 @@ gp_get_tablespace_path(OldTablespaceFileContents *oldTablespaceFileContents, Oid
 	if (oldTablespaceFileContents == NULL)
 		return missing_file();
 
-	char* tablespace_path = old_tablespace_file_get_tablespace_path_for_oid(
+	OldTablespaceRecord *record = old_tablespace_file_get_record(
 		oldTablespaceFileContents,
 		tablespace_oid);
 
-	if (tablespace_path == NULL)
+	if (record == NULL)
 		return not_found_in_file();
 
-	return found_in_file(tablespace_path, tablespace_oid);
+	if (!OldTablespaceRecord_GetIsUserDefinedTablespace(record))
+		return system_tablespace();
+
+	return found_in_file(
+		OldTablespaceRecord_GetDirectoryPath(record),
+		tablespace_oid);
 }
 

--- a/contrib/pg_upgrade/info_gp.h
+++ b/contrib/pg_upgrade/info_gp.h
@@ -16,8 +16,9 @@
 
 typedef enum GetTablespacePathResponseCodes {
 	GetTablespacePathResponse_MISSING_FILE,
-	GetTablespacePathResponse_FOUND,
 	GetTablespacePathResponse_NOT_FOUND_IN_FILE,
+	GetTablespacePathResponse_FOUND_USER_DEFINED_TABLESPACE,
+	GetTablespacePathResponse_FOUND_SYSTEM_TABLESPACE,
 } GetTablespacePathResponseCodes;
 
 typedef struct GetTablespacePathResponse {

--- a/contrib/pg_upgrade/old_tablespace_file_contents.h
+++ b/contrib/pg_upgrade/old_tablespace_file_contents.h
@@ -57,6 +57,9 @@ OldTablespaceRecord_GetTablespaceName(OldTablespaceRecord *record);
 char *
 OldTablespaceRecord_GetDirectoryPath(OldTablespaceRecord *record);
 
+bool
+OldTablespaceRecord_GetIsUserDefinedTablespace(OldTablespaceRecord *record);
+
 /*
  * free memory allocated for OldTablespaceFileContents
  */
@@ -67,7 +70,7 @@ bool is_old_tablespaces_file_empty(OldTablespaceFileContents *contents);
 /*
  * Get the file path for a given old tablespace for the given tablespace oid
  */
-char *old_tablespace_file_get_tablespace_path_for_oid(
+OldTablespaceRecord *old_tablespace_file_get_record(
 	OldTablespaceFileContents *contents, Oid oid);
 
 #endif /* OLD_TABLESPACE_FILE_CONTENTS_H */

--- a/contrib/pg_upgrade/old_tablespace_file_parser.c
+++ b/contrib/pg_upgrade/old_tablespace_file_parser.c
@@ -83,7 +83,7 @@ make_document(int number_of_rows)
  *
  * expects file to have the fields without a header:
  *
- * [dbid],[tablespace oid],[tablespace name],[path]
+ * [dbid],[tablespace oid],[tablespace name],[path],[is user defined tablespace (0 or 1)]
  *
  */
 OldTablespaceFileParser_Document *

--- a/contrib/pg_upgrade/test/integration/Makefile
+++ b/contrib/pg_upgrade/test/integration/Makefile
@@ -6,8 +6,9 @@
 subdir = contrib/pg_upgrade/test/integration
 top_builddir = ../../../..
 pg_upgrade_directory=../..
-TARGETS = greenplum_five_to_greenplum_six_upgrade_test_suite \
-	  tablespace_gp_test
+TARGETS = tablespace_gp_test \
+	greenplum_five_to_greenplum_six_upgrade_test_suite
+
 
 include $(top_builddir)/src/Makefile.global
 include $(top_builddir)/src/Makefile.mock

--- a/contrib/pg_upgrade/test/integration/input/gphdfs.source
+++ b/contrib/pg_upgrade/test/integration/input/gphdfs.source
@@ -1,6 +1,6 @@
 CREATE ROLE gphdfsuser WITH CREATEEXTTABLE(protocol='gphdfs', type='readable') CREATEEXTTABLE(protocol='gphdfs', type='writable');
 
-! ./gpdb6/bin/pg_upgrade --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
 
 -- gphdfs has been removed in GPDB 6 and replaced with PXF. In order to upgrade
 -- from 5 to 6 customer must drop the gphdfs privileges.

--- a/contrib/pg_upgrade/test/integration/input/mismatched_aopartition_indexes.source
+++ b/contrib/pg_upgrade/test/integration/input/mismatched_aopartition_indexes.source
@@ -6,7 +6,7 @@ ALTER TABLE mismatched_partition_indexes exchange partition for (rank(1)) with t
 
 INSERT INTO mismatched_partition_indexes VALUES(1, 'apple', 1), (2, 'boss', 2);
 
-! ./gpdb6/bin/pg_upgrade --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
 
 -- before upgrade drop the indexes
 DROP INDEX mismatch_idx_1_prt_2;

--- a/contrib/pg_upgrade/test/integration/input/unsupported_name_col.source
+++ b/contrib/pg_upgrade/test/integration/input/unsupported_name_col.source
@@ -6,7 +6,7 @@ CREATE TABLE table_with_name_column(
 INSERT INTO table_with_name_column VALUES(1, 'abc def');
 
 -- If name data type column not the first column in the table then we must not upgrade as the alignment will not be correct.
-! ./gpdb6/bin/pg_upgrade --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
 
 ALTER TABLE table_with_name_column ALTER COLUMN a_name TYPE varchar;
 INSERT INTO table_with_name_column VALUES(2, 'ghi jkl');

--- a/contrib/pg_upgrade/test/integration/input/unsupported_tsquery_col.source
+++ b/contrib/pg_upgrade/test/integration/input/unsupported_tsquery_col.source
@@ -4,7 +4,7 @@
 CREATE TABLE tsquery_tbl (a text, b tsquery) DISTRIBUTED BY (a);
 INSERT INTO tsquery_tbl SELECT 'a', 'New&York' FROM generate_series(1,4);
 
-! ./gpdb6/bin/pg_upgrade --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
 
 -- before upgrade, alter the tsquery datatype to text
 ALTER TABLE tsquery_tbl ALTER COLUMN b TYPE TEXT;

--- a/contrib/pg_upgrade/test/integration/output/gphdfs.source
+++ b/contrib/pg_upgrade/test/integration/output/gphdfs.source
@@ -1,9 +1,10 @@
 CREATE ROLE gphdfsuser WITH CREATEEXTTABLE(protocol='gphdfs', type='readable') CREATEEXTTABLE(protocol='gphdfs', type='writable');
 CREATE
 
-! ./gpdb6/bin/pg_upgrade --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
 Performing Consistency Checks on Old Live Server
 ------------------------------------------------
+Creating a dump of all tablespace metadata.                 ok
 Checking for users assigned the gphdfs role                 fatal
 
 | Your installation contains roles that have gphdfs privileges.

--- a/contrib/pg_upgrade/test/integration/output/mismatched_aopartition_indexes.source
+++ b/contrib/pg_upgrade/test/integration/output/mismatched_aopartition_indexes.source
@@ -11,9 +11,10 @@ ALTER
 INSERT INTO mismatched_partition_indexes VALUES(1, 'apple', 1), (2, 'boss', 2);
 INSERT 2
 
-! ./gpdb6/bin/pg_upgrade --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
 Performing Consistency Checks on Old Live Server
 ------------------------------------------------
+Creating a dump of all tablespace metadata.                 ok
 Checking for non-covering indexes on partitioned AO tables  fatal
 
 | Your installation contains partitioned append-only tables

--- a/contrib/pg_upgrade/test/integration/output/unsupported_name_col.source
+++ b/contrib/pg_upgrade/test/integration/output/unsupported_name_col.source
@@ -5,9 +5,10 @@ INSERT INTO table_with_name_column VALUES(1, 'abc def');
 INSERT 1
 
 -- If name data type column not the first column in the table then we must not upgrade as the alignment will not be correct.
-! ./gpdb6/bin/pg_upgrade --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
 Performing Consistency Checks on Old Live Server
 ------------------------------------------------
+Creating a dump of all tablespace metadata.                 ok
 Checking for invalid "name" user columns                    fatal
 
 Your installation contains the "name" data type in user tables.  This

--- a/contrib/pg_upgrade/test/integration/output/unsupported_tsquery_col.source
+++ b/contrib/pg_upgrade/test/integration/output/unsupported_tsquery_col.source
@@ -6,9 +6,10 @@ CREATE
 INSERT INTO tsquery_tbl SELECT 'a', 'New&York' FROM generate_series(1,4);
 INSERT 4
 
-! ./gpdb6/bin/pg_upgrade --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
 Performing Consistency Checks on Old Live Server
 ------------------------------------------------
+Creating a dump of all tablespace metadata.                 ok
 Checking for tsquery user columns                           fatal
 
 Your installation contains the "tsquery" data type.    This data type

--- a/contrib/pg_upgrade/test/integration/scripts/upgrade-cluster.c
+++ b/contrib/pg_upgrade/test/integration/scripts/upgrade-cluster.c
@@ -27,5 +27,5 @@ OldTablespaceFileParser_invalid_access_error_for_row(int invalid_row_index)
 int
 main(int argc, char *argv[])
 {
-	performUpgrade();
+	performUpgradeWithTablespaces("./old_tablespaces.txt");
 }

--- a/contrib/pg_upgrade/test/integration/tablespace_gp_test.c
+++ b/contrib/pg_upgrade/test/integration/tablespace_gp_test.c
@@ -79,7 +79,7 @@ test_filespaces_on_a_gpdb_five_cluster_are_loaded_as_old_tablespace_file_content
 	                                    "8: '/tmp/tablespace-gp-test/fsdummy4/' );");
 	PQclear(result5);
 
-	result5 = executeQuery(connection, "CREATE TABLESPACE my_fast_tablespace FILESPACE my_fast_locations;");
+	PQclear(executeQuery(connection, "CREATE TABLESPACE my_fast_tablespace FILESPACE my_fast_locations;"));
 
 	PQfinish(connection);
 	
@@ -98,14 +98,25 @@ test_filespaces_on_a_gpdb_five_cluster_are_loaded_as_old_tablespace_file_content
 
 	assert_int_equal(
 		OldTablespaceFileContents_TotalNumberOfTablespaces(cluster.old_tablespace_file_contents),
-		1);
+		3);
 
 	char **results = OldTablespaceFileContents_GetArrayOfTablespacePaths(
 		cluster.old_tablespace_file_contents);
 
 	assert_string_equal(
-		results[0],
+		results[2],
 		"/tmp/tablespace-gp-test/fsseg0");
+
+	OldTablespaceRecord **records = OldTablespaceFileContents_GetTablespaceRecords(
+		cluster.old_tablespace_file_contents
+		);
+
+	assert_false(
+		OldTablespaceRecord_GetIsUserDefinedTablespace(records[0]));
+	assert_false(
+		OldTablespaceRecord_GetIsUserDefinedTablespace(records[1]));
+	assert_true(
+		OldTablespaceRecord_GetIsUserDefinedTablespace(records[2]));
 }
 
 static void


### PR DESCRIPTION
Push is_user_defined_tablespace into the old tablespace file logic.

This allows us to reuse the logic between different scenarios. A table
with a specified tablespace in a database with a different tablespace
needs to know if the old tablespace record is a default tablespace.