### PR TITLE
Deduplicate plan_node_id

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -1047,7 +1047,7 @@ static void extract_segments_exec(gpmon_packet_t* pkt)
 	{
 		rec->u.queryseg.sum_cpu_elapsed += pidrec->cpu_elapsed;
 		rec->u.queryseg.sum_measures_rows_out += p->rowsout;
-		if (p->key.hash_key.segid == -1 && p->key.hash_key.nid == 1 && (int64)(p->rowsout) > rec->u.queryseg.final_rowsout)
+		if (p->key.hash_key.segid == -1 && p->key.hash_key.nid == ROOT_PLAN_NODE_ID && (int64)(p->rowsout) > rec->u.queryseg.final_rowsout)
 		{
 			rec->u.queryseg.final_rowsout = p->rowsout;
 		}
@@ -1059,7 +1059,7 @@ static void extract_segments_exec(gpmon_packet_t* pkt)
 		CHECKMEM(rec);
 		gp_smon_to_mmon_set_header(rec, GPMON_PKTTYPE_QUERYSEG);
 		rec->u.queryseg.key = qseg_key;
-		if (p->key.hash_key.segid == -1 && p->key.hash_key.nid == 1)
+		if (p->key.hash_key.segid == -1 && p->key.hash_key.nid == ROOT_PLAN_NODE_ID)
 		{
 			rec->u.queryseg.final_rowsout = p->rowsout;
 		}

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -667,16 +667,6 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 
 	Assert(result->utilityStmt == NULL || IsA(result->utilityStmt, DeclareCursorStmt));
 
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		/*
-		 * Generate a plan node id for each node. Used by gpmon and instrument.
-		 * Note that this needs to be the last step of the planning when the
-		 * structure of the plan is final.
-		 */
-		assign_plannode_id(result);
-	}
-
 	if (gp_log_optimization_time)
 	{
 		INSTR_TIME_SET_CURRENT(endtime);

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -44,7 +44,6 @@ extern Plan *apply_shareinput_dag_to_tree(PlannerInfo *root, Plan *plan);
 extern void collect_shareinput_producers(PlannerInfo *root, Plan *plan);
 extern Plan *replace_shareinput_targetlists(PlannerInfo *root, Plan *plan);
 extern Plan *apply_shareinput_xslice(Plan *plan, PlannerInfo *root);
-extern void assign_plannode_id(PlannedStmt *stmt);
 
 extern List *getExprListFromTargetList(List *tlist, int numCols, AttrNumber *colIdx);
 extern void remove_unused_initplans(Plan *plan, PlannerInfo *root);

--- a/src/include/gpmon/gpmon.h
+++ b/src/include/gpmon/gpmon.h
@@ -30,6 +30,12 @@ typedef struct gpmon_query_seginfo_t gpmon_query_seginfo_t;
 #define GPMON_UNKNOWN "Unknown"
 
 /*
+ * Plan node id assignments in the server start from 0, with the root being
+ * assigned first.
+ */
+#define ROOT_PLAN_NODE_ID 0
+
+/*
 this is enough space for 2 names plus a . between the names plus a null char at the end of the string
 for example SCHEMA.RELATION\0
 */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -193,16 +193,6 @@ static inline void exec_subplan_put_plan(struct PlannedStmt *plannedstmt, SubPla
 typedef struct Plan
 {
 	NodeTag		type;
-
-	/* Plan node id */
-	/* GPDB_96_MERGE_FIXME: we had this in GPDB before 9.6 merge, but
-	 * PostgreSQL 9.6 introduced a new field called 'plan_node_id'.
-	 * Is it the same thing? Can we just remove this commented out copy,
-	 * or do we need to have a new field with different name, for the
-	 * stuff that we used to do with this old 'plan_node_id'?
-	 */
-	//int			plan_node_id;	/* unique across entire final plan tree */
-
 	/*
 	 * estimated execution costs for plan (see costsize.c for more info)
 	 */


### PR DESCRIPTION
This addresses the following GPDB_96_MERGE_FIXME:
```
/* GPDB_96_MERGE_FIXME: we had this in GPDB before 9.6 merge, but
 * PostgreSQL 9.6 introduced a new field called 'plan_node_id'.
 * Is it the same thing? Can we just remove this commented out copy,
 * or do we need to have a new field with different name, for the
 * stuff that we used to do with this old 'plan_node_id'?
```

Historical context:
Historically, GP had a `plan_node_id` node to identify plan nodes for
gpmon and for `InstrumentationSlot` ids which are used for managing
instrumentation data in shmem. An identical field `plan_node_id` inside
the same struct was introduced in Postgres commit "Parallel executor
support" (d1b7c1ffe72) as a means to support parallel execution of
subtrees of the plan tree by workers. The use case in Postgres was
extended in upstream commit 69d3440: where they were used as keys into the
shared memory table-of-contents (toc) for custom and foreign scan
executor nodes.

Problem:
There are two conflicting assignments to a plan node's plan_node_id
right now, which I will refer to as a_GP and a_PG.
a_GP: assign_plannode_id_walker:
```
((Plan *) node)->plan_node_id = ++ctxt->nextPlanId;
```
a_PG: (From 9_6) set_plan_refs::
```
plan->plan_node_id = root->glob->lastPlanNodeId++;
```
a_GP overrides a_PG and can lead to non-unique plan_node_ids
which are meant to be unique both from a GP and a PG perspective. So we
must remove one of them.

Solution:
This commit removes assignment a_GP.

Although plan nodes will be guaranteed to have unique ids, this change
will modify plan node id sequencing and will break any components that
depend on this ordering. Notes:

* a_GP is 1-based whereas a_PG is 0-based.
* a_GP is only done on the final plan's nodes whereas a_PG is done
earlier. So if there was a subquery scan for example with node id = 3,
the node would be removed in the final plan and there would be a hole in
the node ids in the sequence of plan node ids (node ids would look like
0, 1, 2, 4, ...). Archaeology doesn't yield information about why it is
important from gpmon's perspective to assign plan node ids to the final
plan's nodes. Reference (GP):
```
/*
 * Generate a plan node id for each node. Used by gpmon and instrument.
 * Note that this needs to be the last step of the planning when the
 * structure of the plan is final.
 */
```
* a_GP assigns plan node ids for subplans after assigning plan node ids
for the entire tree. Archaeology doesn't yield much about the reason for
this. a_PG does nothing of this sort, it assigns ids to subplans upon
encountering them. Reference (GP):
```
assign_plannode_id_walker((Node *) stmt->planTree, &ctxt);

foreach(lc, stmt->subplans)
{
    Plan       *subplan = lfirst(lc);

    Assert(subplan);

    assign_plannode_id_walker((Node *) subplan, &ctxt);
}
```
