### PR TITLE
docs - pxf supports writing avro data

### DIFF
--- a/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/gpdb-doc/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -51,7 +51,7 @@
         <a href="/7-0/pxf/access_hdfs.html" format="markdown">Accessing Hadoop with PXF</a>
         <ul>
           <li><a href="/7-0/pxf/hdfs_text.html" format="markdown">Reading and Writing Text Data</a></li>
-          <li><a href="/7-0/pxf/hdfs_avro.html" format="markdown">Reading Avro Data</a></li>
+          <li><a href="/7-0/pxf/hdfs_avro.html" format="markdown">Reading and Writing Avro Data</a></li>
           <li><a href="/7-0/pxf/hdfs_json.html" format="markdown">Reading JSON Data</a></li>
           <li><a href="/7-0/pxf/hdfs_parquet.html" format="markdown">Reading and Writing Parquet Data</a></li>
           <li><a href="/7-0/pxf/hdfs_seqfile.html" format="markdown">Reading and Writing SequenceFile Data</a></li>
@@ -65,7 +65,7 @@
         <ul>
           <li><a href="/7-0/pxf/access_s3.html" format="markdown">About Accessing the S3 Object Store</a></li>
           <li><a href="/7-0/pxf/objstore_text.html" format="markdown">Reading and Writing Text Data</a></li>
-          <li><a href="/7-0/pxf/objstore_avro.html" format="markdown">Reading Avro Data</a></li>
+          <li><a href="/7-0/pxf/objstore_avro.html" format="markdown">Reading and Writing Avro Data</a></li>
           <li><a href="/7-0/pxf/objstore_json.html" format="markdown">Reading JSON Data</a></li>
           <li><a href="/7-0/pxf/objstore_parquet.html" format="markdown">Reading and Writing Parquet Data</a></li>
           <li><a href="/7-0/pxf/objstore_seqfile.html" format="markdown">Reading and Writing SequenceFile Data</a></li>

--- a/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
+++ b/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
@@ -30,6 +30,13 @@ To migrate your `gphdfs` external tables to use the `pxf` external table protoco
 <li>Migrate Greenplum 4 data to Greenplum 6.</li></ol></div>
 
 
+## <a id="limits"></a>Limitations
+
+Keep the following in mind as you plan for the migration:
+
+- PXF does not support reading or writing compressed Avro files on HDFS.
+
+
 ## <a id="prepare"></a>Preparing for the Migration
 
 As you prepare for migrating from `gphdfs` to PXF:

--- a/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
+++ b/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
@@ -30,13 +30,6 @@ To migrate your `gphdfs` external tables to use the `pxf` external table protoco
 <li>Migrate Greenplum 4 data to Greenplum 6.</li></ol></div>
 
 
-
-## <a id="limits"></a>Limitations
-
-Keep the following in mind as you plan for the migration:
-
-- PXF does not support writing to Avro files on HDFS.
-
 ## <a id="prepare"></a>Preparing for the Migration
 
 As you prepare for migrating from `gphdfs` to PXF:

--- a/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
@@ -57,7 +57,7 @@ The following table summarizes external mapping rules for Avro data.
 | string | text |
 | Complex type: Array, Map, Record, or Enum                         | text, with delimiters inserted between collection items, mapped key-value pairs, and record data.                                                                                           |
 | Complex type: Fixed                                               | bytea (supported for read operations only).                                                                                                                                                                                 |
-| Union                                                             | Follows the above conventions for primitive or complex data types, depending on the union; must contain 2 elements, only one of which must be null.                                                                     |
+| Union                                                             | Follows the above conventions for primitive or complex data types, depending on the union; must contain 2 elements, one of which must be null.                                                                     |
 
 
 ### <a id="topic_tr3_dpg_ts__section_m2p_ztg_ts"></a>Avro Schemas and Data
@@ -66,26 +66,26 @@ Avro schemas are defined using JSON, and composed of the same primitive and comp
 
 Fields in an Avro schema file are defined via an array of objects, each of which is specified by a name and a type.
 
-You can specify an Avro schema on both read and write operations to HDFS. 
+An Avro data file contains the schema and a compact binary representation of the data. Avro data files typically have the `.avro` suffix.
+
+You can specify an Avro schema on both read and write operations to HDFS. You can provide either a binary `*.avro` file or a JSON-format `*.avsc` file for the schema file:
 
 | External Table Type  | Schema Specified? | Description
 |-------|--------------------------|-----------|
-| readable   | yes | PXF uses the specified schema; this overrides a schema in the `.avro` data file. |
-| readable   | no | PXF uses the schema in the `.avro` data file. |
+| readable   | yes | PXF uses the specified schema; this overrides the schema embedded in the Avro data file. |
+| readable   | no | PXF uses the schema embedded in the Avro data file. |
 | writable   | yes | PXF uses the specified schema. |
 | writable   | no | PXF creates the Avro schema based on the external table definition. |
 
-When you provide the Avro schema file to PXF, the file must reside in the same location on each Greenplum Database segment host **or** the file may reside on the Hadoop file system. PXF first searches for an absolute or relative (to the PXF classpath) Avro file path on the Greenplum segment hosts. If PXF cannot find the schema file locally, it searches for the file on HDFS.
+When you provide the Avro schema file to PXF, the file must reside in the same location on each Greenplum Database segment host **or** the file may reside on the Hadoop file system. PXF first searches for an absolute file path on the Greenplum segment hosts. If PXF does not find the schema file there, it searches for the file relative to the PXF classpath. If PXF cannot find the schema file locally, it searches for the file on HDFS.
 
 The `$PXF_CONF/conf` directory is in the PXF classpath. PXF can locate an Avro schema file that you add to this directory on every Greenplum Database segment host.
-
-An Avro data file contains the schema and a compact binary representation of the data. Avro data files typically have the `.avro` suffix.
 
 See [Writing Avro Data](#topic_avro_writedata) for additional schema considerations when writing Avro data to HDFS.
 
 ## <a id="profile_cet"></a>Creating the External Table
 
-Use the `hdfs:avro` profile to read Avro-format data in HDFS. The following syntax creates a Greenplum Database readable external table that references such a file:
+Use the `hdfs:avro` profile to read or write Avro-format data in HDFS. The following syntax creates a Greenplum Database readable external table that references such a file:
 
 ``` sql
 CREATE [WRITABLE] EXTERNAL TABLE <table_name>
@@ -209,10 +209,10 @@ Perform the following steps to create a sample Avro data file conforming to the 
 
     The sample data uses a comma `,` to separate top level records and a colon `:` to separate map/key values and record field name/values.
 
-3. Convert the text file to Avro format. There are various ways to perform the conversion, both programmatically and via the command line. In this example, we use the [Java Avro tools](http://avro.apache.org/releases.html); the jar `avro-tools-1.8.1.jar` file resides in the current directory:
+3. Convert the text file to Avro format. There are various ways to perform the conversion, both programmatically and via the command line. In this example, we use the [Java Avro tools](http://avro.apache.org/releases.html); the jar `avro-tools-1.9.1.jar` file resides in the current directory:
 
     ``` shell
-    $ java -jar ./avro-tools-1.8.1.jar fromjson --schema-file /tmp/avro_schema.avsc /tmp/pxf_avro.txt > /tmp/pxf_avro.avro
+    $ java -jar ./avro-tools-1.9.1.jar fromjson --schema-file /tmp/avro_schema.avsc /tmp/pxf_avro.txt > /tmp/pxf_avro.avro
     ```
 
     The generated Avro binary data file is written to `/tmp/pxf_avro.avro`. 
@@ -289,7 +289,7 @@ If you do not specify a `SCHEMA` file, PXF generates a schema for the Avro file 
 ["string", "null"]
 ```
 
-PXF returns an error if you provide a schema, the schema does not include a `union` of the field data type with `null`, and PXF encounters a NULL data field.
+PXF returns an error if you provide a schema that does not include a `union` of the field data type with `null`, and PXF encounters a NULL data field.
 
 PXF supports writing only Avro primitive data types. It does not support writing complex types to Avro:
 
@@ -299,7 +299,7 @@ PXF supports writing only Avro primitive data types. It does not support writing
 
 ### <a id="topic_avrowrite_example"></a>Example: Writing Avro Data
 
-In this example, you create an external table that writes to an Avro file on HDFS, letting PXF generate the Avro schema. After you insert some data into the file, you create a readable external data to query the Avro data.
+In this example, you create an external table that writes to an Avro file on HDFS, letting PXF generate the Avro schema. After you insert some data into the file, you create a readable external table to query the Avro data.
 
 The Avro file that you create and read in this example includes the following fields:
 
@@ -325,7 +325,7 @@ Example procedure:
 
     PXF uses the external table definition to generate the Avro schema.
 
-3. Create an external table to read the Avro data you just inserted` table:
+3. Create an external table to read the Avro data that you just inserted into the table:
 
     ``` sql
     postgres=# CREATE EXTERNAL TABLE read_pxfwrite(id int, username text, followers text)

--- a/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
@@ -104,7 +104,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
 | \<custom&#8209;option\>  | \<custom-option\>s are discussed below.|
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
-| DISTRIBUTED BY | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
+| DISTRIBUTED BY | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 <a id="customopts"></a>
 
@@ -115,9 +115,9 @@ The `hdfs:avro` profile supports the following \<custom-option\>s:
 
 | Option Keyword   | Description       
 |---------------|--------------------|                                                                                        
-| COLLECTION_DELIM | The delimiter character(s) to place between entries in a top-level array, map, or record field when PXF maps an Avro complex data type to a text column. The default is the comma `,` character. (Read)|
-| MAPKEY_DELIM | The delimiter character(s) to place between the key and value of a map entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
-| RECORDKEY_DELIM | The delimiter character(s) to place between the field name and value of a record entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
+| COLLECTION_DELIM | The delimiter character(s) placed between entries in a top-level array, map, or record field when PXF maps an Avro complex data type to a text column. The default is the comma `,` character. (Read)|
+| MAPKEY_DELIM | The delimiter character(s) placed between the key and value of a map entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
+| RECORDKEY_DELIM | The delimiter character(s) placed between the field name and value of a record entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
 | SCHEMA | The absolute path to the Avro schema file on the segment host or on HDFS, or the relative path to the schema file on the segment host. (Read and Write)|
 
 
@@ -335,10 +335,10 @@ Example procedure:
 
     Notice that the `followers` column is of type `text`.
 
-4. Read the Avro data by querying the `read_avrowrite` table:
+4. Read the Avro data by querying the `read_pxfwrite` table:
 
     ``` sql
-    postgres=# SELECT * FROM read_avrowrite;
+    postgres=# SELECT * FROM read_pxfwrite;
     ```
 
     ``` pre

--- a/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Reading Avro Data from HDFS
+title: Reading and Writing HDFS Avro Data
 ---
 
 <!--
@@ -22,7 +22,9 @@ under the License.
 -->
 
 
-Use the PXF HDFS Connector to read Avro-format data. This section describes how to use PXF to access Avro data in HDFS, including how to create and query an external table that references an Avro file in the HDFS data store.
+Use the PXF HDFS Connector to read and write Avro-format data. This section describes how to use PXF to read and write Avro data in HDFS, including how to create, query, and insert into an external table that references an Avro file in the HDFS data store.
+
+**Note**: PXF does not support reading or writing compressed Avro files.
 
 ## <a id="prereq"></a>Prerequisites
 
@@ -54,8 +56,8 @@ The following table summarizes external mapping rules for Avro data.
 | long | bigint |
 | string | text |
 | Complex type: Array, Map, Record, or Enum                         | text, with delimiters inserted between collection items, mapped key-value pairs, and record data.                                                                                           |
-| Complex type: Fixed                                               | bytea                                                                                                                                                                                               |
-| Union                                                             | Follows the above conventions for primitive or complex data types, depending on the union; supports Null values.                                                                     |
+| Complex type: Fixed                                               | bytea (supported for read operations only).                                                                                                                                                                                 |
+| Union                                                             | Follows the above conventions for primitive or complex data types, depending on the union; must contain 2 elements, only one of which must be null.                                                                     |
 
 
 ### <a id="topic_tr3_dpg_ts__section_m2p_ztg_ts"></a>Avro Schemas and Data
@@ -64,16 +66,33 @@ Avro schemas are defined using JSON, and composed of the same primitive and comp
 
 Fields in an Avro schema file are defined via an array of objects, each of which is specified by a name and a type.
 
+You can specify an Avro schema on both read and write operations to HDFS. 
+
+| External Table Type  | Schema Specified? | Description
+|-------|--------------------------|-----------|
+| readable   | yes | PXF uses the specified schema; this overrides a schema in the `.avro` data file. |
+| readable   | no | PXF uses the schema in the `.avro` data file. |
+| writable   | yes | PXF uses the specified schema. |
+| writable   | no | PXF creates the Avro schema based on the external table definition. |
+
+When you provide the Avro schema file to PXF, the file must reside in the same location on each Greenplum Database segment host **or** the file may reside on the Hadoop file system. PXF first searches for an absolute or relative (to the PXF classpath) Avro file path on the Greenplum segment hosts. If PXF cannot find the schema file locally, it searches for the file on HDFS.
+
+The `$PXF_CONF/conf` directory is in the PXF classpath. PXF can locate an Avro schema file that you add to this directory on every Greenplum Database segment host.
+
+An Avro data file contains the schema and a compact binary representation of the data. Avro data files typically have the `.avro` suffix.
+
+See [Writing Avro Data](#topic_avro_writedata) for additional schema considerations when writing Avro data to HDFS.
 
 ## <a id="profile_cet"></a>Creating the External Table
 
 Use the `hdfs:avro` profile to read Avro-format data in HDFS. The following syntax creates a Greenplum Database readable external table that references such a file:
 
 ``` sql
-CREATE EXTERNAL TABLE <table_name>
+CREATE [WRITABLE] EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:avro[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
-FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import'|'pxfwritable_export');
+[DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
 ```
 
 The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html) command are described in the table below.
@@ -84,18 +103,22 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | PROFILE    | The `PROFILE` keyword must specify `hdfs:avro`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
 | \<custom&#8209;option\>  | \<custom-option\>s are discussed below.|
-| FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `hdfs:avro` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
+| FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
+| DISTRIBUTED BY | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
 
 <a id="customopts"></a>
-For complex types, the PXF `hdfs:avro` profile inserts default delimiters between collection items and values. You can use non-default delimiter characters by identifying values for specific `hdfs:avro` custom options in the `CREATE EXTERNAL TABLE` command. 
+
+
+For complex types, the PXF `hdfs:avro` profile inserts default delimiters between collection items and values before display. You can use non-default delimiter characters by identifying values for specific `hdfs:avro` custom options in the `CREATE EXTERNAL TABLE` command. 
 
 The `hdfs:avro` profile supports the following \<custom-option\>s:
 
 | Option Keyword   | Description       
 |---------------|--------------------|                                                                                        
-| COLLECTION_DELIM | The delimiter character(s) to place between entries in a top-level array, map, or record field when PXF maps an Avro complex data type to a text column. The default is the comma `,` character. |
-| MAPKEY_DELIM | The delimiter character(s) to place between the key and value of a map entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. |
-| RECORDKEY_DELIM | The delimiter character(s) to place between the field name and value of a record entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. |
+| COLLECTION_DELIM | The delimiter character(s) to place between entries in a top-level array, map, or record field when PXF maps an Avro complex data type to a text column. The default is the comma `,` character. (Read)|
+| MAPKEY_DELIM | The delimiter character(s) to place between the key and value of a map entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
+| RECORDKEY_DELIM | The delimiter character(s) to place between the field name and value of a record entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
+| SCHEMA | The absolute path to the Avro schema file on the segment host or on HDFS, or the relative path to the schema file on the segment host. (Read and Write)|
 
 
 ## <a id="avro_example"></a>Example: Reading Avro Data
@@ -108,6 +131,8 @@ The examples in this section will operate on Avro data with the following field 
 - fmap - map of long
 - relationship - enumerated type
 - address - record comprised of street number (int), street name (string), and city (string)
+
+You create an Avro schema and data file, and then create a readable external table to read the data.
 
 
 ### <a id="topic_tr3_dpg_ts__section_m2p_ztg_ts_99"></a>Create Schema
@@ -198,7 +223,7 @@ Perform the following steps to create a sample Avro data file conforming to the 
     $ hdfs dfs -put /tmp/pxf_avro.avro /data/pxf_examples/
     ```
     
-### <a id="topic_avro_querydata"></a>Query With hdfs:avro Profile
+### <a id="topic_avro_querydata"></a>Reading Avro Data
 
 Perform the following operations to create and query an external table that references the `pxf_avro.avro` file that you added to HDFS in the previous section. When creating the table:
 
@@ -253,4 +278,76 @@ Perform the following operations to create and query an external table that refe
     ----------+---------------------------------------------
      jim      | {number:9,street:deer creek,city:palo alto}
     ```
+
+## <a id="topic_avro_writedata"></a>Writing Avro Data
+
+When you create a writable external table to write data to an Avro file, each table row is an Avro record and each table column is an Avro field.
+
+If you do not specify a `SCHEMA` file, PXF generates a schema for the Avro file based on the Greenplum Database external table definition. PXF assigns the name of the external table column to the Avro field name. Because Avro has a `null` type and Greenplum external tables do not support the `NOT NULL` column qualifier, PXF wraps each data type in an Avro `union` of the mapped type and `null`. For example, for a writable external table column that you define with the Greenplum Database `text` data type, PXF generates the following schema element:
+
+``` pre
+["string", "null"]
+```
+
+PXF returns an error if you provide a schema, the schema does not include a `union` of the field data type with `null`, and PXF encounters a NULL data field.
+
+PXF supports writing only Avro primitive data types. It does not support writing complex types to Avro:
+
+- When you specify a `SCHEMA` file in the `LOCATION`, the schema must include only primitive data types.
+- When PXF generates the schema, it writes any complex type that you specify in the writable external table column definition to the Avro file as a single Avro `string` type. For example, if you write an array of integers, PXF converts the array to a `string`, and you must read this data with a Greenplum `text`-type column.
+
+
+### <a id="topic_avrowrite_example"></a>Example: Writing Avro Data
+
+In this example, you create an external table that writes to an Avro file on HDFS, letting PXF generate the Avro schema. After you insert some data into the file, you create a readable external data to query the Avro data.
+
+The Avro file that you create and read in this example includes the following fields:
+
+- id:  `int`
+- username:  `text`
+- followers:  `text[]`
+
+Example procedure:
+
+1. Create the writable external table:
+
+    ``` sql
+    postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_avrowrite(id int, username text, followers text[])
+                LOCATION ('pxf://data/pxf_examples/pxfwrite.avro?PROFILE=hdfs:avro')
+              FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
+
+2. Insert some data into the `pxf_avrowrite` table:
+
+    ``` sql
+    postgres=# INSERT INTO pxf_avrowrite VALUES (33, 'oliver', ARRAY['alex','frank']);
+    postgres=# INSERT INTO pxf_avrowrite VALUES (77, 'lisa', ARRAY['tom','mary']);
+    ```
+
+    PXF uses the external table definition to generate the Avro schema.
+
+3. Create an external table to read the Avro data you just inserted` table:
+
+    ``` sql
+    postgres=# CREATE EXTERNAL TABLE read_pxfwrite(id int, username text, followers text)
+                LOCATION ('pxf://data/pxf_examples/pxfwrite.avro?PROFILE=hdfs:avro')
+              FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+    ```
+
+    Notice that the `followers` column is of type `text`.
+
+4. Read the Avro data by querying the `read_avrowrite` table:
+
+    ``` sql
+    postgres=# SELECT * FROM read_avrowrite;
+    ```
+
+    ``` pre
+     id | username |  followers   
+    ----+----------+--------------
+     77 | lisa     | {tom,mary}
+     33 | oliver   | {alex,frank}
+    (2 rows)
+    ```
+
+    `followers` is a single string comprised of the `text` array elements that you inserted into the table.
 

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -79,7 +79,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
 | \<custom&#8209;option\>=\<value\>  | \<custom-option\>s are described below.|
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
-| DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
+| DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 <a id="customopts"></a>
 The PXF `hdfs:parquet` profile supports encoding- and compression-related write options. You specify these write options in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:parquet` profile supports the following custom options:

--- a/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
@@ -53,7 +53,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
 | \<custom&#8209;option\>  | \<custom-option\>s are described below.|
 | FORMAT | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
-| DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
+| DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 <a id="customopts"></a>
 SequenceFile format data can optionally employ record or block compression. The PXF `hdfs:SequenceFile` profile supports the following compression codecs:

--- a/gpdb-doc/markdown/pxf/hdfs_text.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_text.html.md.erb
@@ -237,7 +237,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<custom&#8209;option\>  | \<custom-option\>s are described below.|
 | FORMAT | Use `FORMAT` `'TEXT'` to write plain, delimited text to \<path-to-hdfs-dir\>.<br> Use `FORMAT` `'CSV'` to write comma-separated value text to \<path-to-hdfs-dir\>. |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
-| DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
+| DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 Writable external tables that you create using the `hdfs:text` profile can optionally use record or block compression. The PXF `hdfs:text` profile supports the following compression codecs:
 

--- a/gpdb-doc/markdown/pxf/objstore_avro.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_avro.html.md.erb
@@ -39,7 +39,7 @@ When you read or write Avro data in an object store:
 - If the Avro schema file resides in the object store:
 
     - You must include the bucket in the schema file path. This bucket need not specify the same bucket as the Avro data file.
-    - The secrets the you specify in the `SERVER` configuration must provide access to both the data file and schema file buckets.
+    - The secrets that you specify in the `SERVER` configuration must provide access to both the data file and schema file buckets.
 - The schema file path must not include spaces.
 
 ## <a id="avro_cet"></a>Creating the External Table
@@ -93,5 +93,5 @@ Refer to [Example: Reading Avro Data](hdfs_avro.html#avro_example) in the PXF HD
     FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
     ```
 
-You make similar modifications to run the [Example: Writing Avro Data](hdfs_avro.html#topic_avro_writedata).
+You make similar modifications to follow the steps in [Example: Writing Avro Data](hdfs_avro.html#topic_avro_writedata).
 

--- a/gpdb-doc/markdown/pxf/objstore_avro.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_avro.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Reading Avro Data from an Object Store
+title: Reading and Writing Avro Data in an Object Store
 ---
 
 <!--
@@ -21,7 +21,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The PXF object store connectors support reading Avro-format data. This section describes how to use PXF to access Avro data in an object store, including how to create and query an external table that references an Avro file in the store.
+The PXF object store connectors support reading Avro-format data. This section describes how to use PXF to read and write Avro data in an object store, including how to create, query, and insert into an external table that references an Avro file in the store.
 
 **Note**: Accessing Avro-format data from an object store is very similar to accessing Avro-format data in HDFS. This topic identifies object store-specific information required to read Avro data, and links to the [PXF HDFS Avro documentation](hdfs_avro.html) where appropriate for common information.
 
@@ -34,9 +34,17 @@ Ensure that you have met the PXF Object Store [Prerequisites](access_objstore.ht
 
 Refer to [Working with Avro Data](hdfs_avro.html#avro_work) in the PXF HDFS Avro documentation for a description of the Apache Avro data serialization framework.
 
+When you read or write Avro data in an object store:
+
+- If the Avro schema file resides in the object store:
+
+    - You must include the bucket in the schema file path. This bucket need not specify the same bucket as the Avro data file.
+    - The secrets the you specify in the `SERVER` configuration must provide access to both the data file and schema file buckets.
+- The schema file path must not include spaces.
+
 ## <a id="avro_cet"></a>Creating the External Table
 
-Use the `<objstore>:avro` profiles to read Avro-format files from an object store. PXF supports the following `<objstore>` profile prefixes:
+Use the `<objstore>:avro` profiles to read and write Avro-format files in an object store. PXF supports the following `<objstore>` profile prefixes:
 
 | Object Store  | Profile Prefix |
 |-------|-------------------------------------|
@@ -46,13 +54,13 @@ Use the `<objstore>:avro` profiles to read Avro-format files from an object stor
 | Minio    | s3 |
 | S3    | s3 |
 
-The following syntax creates a Greenplum Database readable external table that references an Avro-format file:
+The following syntax creates a Greenplum Database external table that references an Avro-format file:
 
 ``` sql
-CREATE EXTERNAL TABLE <table_name>
+CREATE [WRITABLE] EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:avro&SERVER=<server_name>[&<custom-option>=<value>[...]]')
-FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import'|'pxfwritable_export');
 ```
 
 The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html) command are described in the table below.
@@ -63,7 +71,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | PROFILE=\<objstore\>:avro    | The `PROFILE` keyword must identify the specific object store. For example, `s3:avro`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\> | Avro-specific custom options are described in the [PXF HDFS Avro documentation](hdfs_avro.html#customopts). |
-| FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `<objstore>:avro` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
+| FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read).|
 
 If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 
@@ -84,4 +92,6 @@ Refer to [Example: Reading Avro Data](hdfs_avro.html#avro_example) in the PXF HD
       LOCATION ('pxf://BUCKET/pxf_examples/pxf_avro.avro?PROFILE=s3:avro&SERVER=s3srvcfg&COLLECTION_DELIM=,&MAPKEY_DELIM=:&RECORDKEY_DELIM=:')
     FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
     ```
+
+You make similar modifications to run the [Example: Writing Avro Data](hdfs_avro.html#topic_avro_writedata).
 

--- a/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
@@ -67,7 +67,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\> | Parquet-specific custom write options are described in the [PXF HDFS Parquet documentation](hdfs_parquet.html#customopts). |
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
-| DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
+| DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 If you are accessing an S3 object store:
 

--- a/gpdb-doc/markdown/pxf/objstore_seqfile.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_seqfile.html.md.erb
@@ -62,7 +62,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\> | SequenceFile-specific custom options are described in the [PXF HDFS SequenceFile documentation](hdfs_seqfile.html#customopts). |
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
-| DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
+| DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 

--- a/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
@@ -267,7 +267,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<custom&#8209;option\>=\<value\>  | \<custom-option\>s are described below.|
 | FORMAT | Use `FORMAT` `'TEXT'` to write plain, delimited text to \<path-to-dir\>.<br> Use `FORMAT` `'CSV'` to write comma-separated value text to \<path-to-dir\>. |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
-| DISTRIBUTED BY    | If you plan to load the writable external table with data from an existing Greenplum Database table, consider specifying the same distribution policy or \<column_name\> on the writable external table as that defined for the table from which you plan to load the data. Doing so will avoid extra motion of data between segments on the load operation. |
+| DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 Writable external tables that you create using an `<objstore>:text` profile can optionally use record or block compression. The PXF `<objstore>:text` profiles support the following compression codecs:
 


### PR DESCRIPTION
in this PR:
- change topic titles
- add bulk of avro info to the HDFS avro page
- include object store specific info on that page
- read now supports SCHEMA
- remove avro write limitation from gphdfs page
- add write (pxf generate schema) example

doc review site links:
- hdfs page:  http://docs-lisa-pxfavrowrite.cfapps.io/7-0/pxf/hdfs_avro.html
- objstore page:  http://docs-lisa-pxfavrowrite.cfapps.io/7-0/pxf/objstore_avro.html#avro_work
