### PR TITLE
Delay fsync on append-optimized tables until next restartpoint

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9334,6 +9334,8 @@ CreateRestartPoint(int flags)
 
 	CheckPointGuts(lastCheckPoint.redo, flags);
 
+	SIMPLE_FAULT_INJECTOR("restartpoint_guts");
+
 	/*
 	 * Remember the prior checkpoint's redo pointer, used later to determine
 	 * the point at which we can truncate the log.

--- a/src/backend/cdb/cdbappendonlyxlog.c
+++ b/src/backend/cdb/cdbappendonlyxlog.c
@@ -19,12 +19,13 @@
 #include <fcntl.h>
 #include <sys/file.h>
 
+#include "access/aomd.h"
+#include "access/xlogutils.h"
+#include "catalog/catalog.h"
 #include "cdb/cdbappendonlyxlog.h"
 #include "storage/fd.h"
-#include "catalog/catalog.h"
 #include "utils/faultinjector.h"
 #include "utils/faultinjector_lists.h"
-#include "access/xlogutils.h"
 
 /*
  * Insert an AO XLOG/AOCO record.
@@ -106,13 +107,9 @@ ao_insert_replay(XLogReaderState *record)
 						path)));
 	}
 
-	if (FileSync(file) != 0)
-	{
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("failed to flush file \"%s\": %m",
-						path)));
-	}
+	register_dirty_segment_ao(xlrec->target.node,
+							  xlrec->target.segment_filenum,
+							  file);
 
 	FileClose(file);
 }

--- a/src/backend/postmaster/checkpointer.c
+++ b/src/backend/postmaster/checkpointer.c
@@ -41,6 +41,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "access/appendonlywriter.h"
+#include "access/htup_details.h"
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
 #include "libpq/pqsignal.h"
@@ -110,6 +112,12 @@ typedef struct
 	RelFileNode rnode;
 	ForkNumber	forknum;
 	BlockNumber segno;			/* see md.c for special values */
+	/*
+	 * Is segno a real ao segno but not specially ones like
+	 * FORGET_RELATION_FSYNC. For example for a real relfile like
+	 * /base/16384/50237.129, it should be true and segno should be 129.
+	 */
+	bool		is_ao_segno;
 	/* might add a real request-type field later; not needed yet */
 } CheckpointerRequest;
 
@@ -1089,6 +1097,9 @@ RequestCheckpoint(int flags)
  * use high values for special flags; that's all internal to md.c, which
  * see for details.)
  *
+ * is_ao_segno means the segno is a real segno (i.e. not FORGET_RELATION_FSYNC,
+ * etc) of ao relation.
+ *
  * To avoid holding the lock for longer than necessary, we normally write
  * to the requests[] queue without checking for duplicates.  The checkpointer
  * will have to eliminate dups internally anyway.  However, if we discover
@@ -1100,13 +1111,28 @@ RequestCheckpoint(int flags)
  * let the backend know by returning false.
  */
 bool
-ForwardFsyncRequest(RelFileNode rnode, ForkNumber forknum, BlockNumber segno)
+ForwardFsyncRequest(RelFileNode rnode, ForkNumber forknum, BlockNumber segno,
+					bool is_ao_segno)
 {
 	CheckpointerRequest *request;
 	bool		too_full;
 
 	if (!IsUnderPostmaster)
 		return false;			/* probably shouldn't even get here */
+
+	/*
+	 * Special values of segno are used to indicate that a fsync request
+	 * needs to be forgotten.  Fsync requests for append-optimized tables
+	 * carry no such special meaning.  The segno must identify a valid
+	 * append-optimized segment file on disk.
+	 */
+	AssertImply(is_ao_segno, segno <= MAX_AOREL_CONCURRENCY * MaxTupleAttributeNumber);
+
+	/*
+	 * Append-optimized tables do not use relation forks currently.
+	 * MAIN_FORKNUM is the only fork applicable.
+	 */
+	AssertImply(is_ao_segno, forknum == MAIN_FORKNUM);
 
 	if (AmCheckpointerProcess())
 		elog(ERROR, "ForwardFsyncRequest must not be called in checkpointer");
@@ -1141,6 +1167,7 @@ ForwardFsyncRequest(RelFileNode rnode, ForkNumber forknum, BlockNumber segno)
 	request->rnode = rnode;
 	request->forknum = forknum;
 	request->segno = segno;
+	request->is_ao_segno = is_ao_segno;
 
 	/* If queue is more than half full, nudge the checkpointer to empty it */
 	too_full = (CheckpointerShmem->num_requests >=
@@ -1323,7 +1350,7 @@ AbsorbFsyncRequests(void)
 	LWLockRelease(CheckpointerCommLock);
 
 	for (request = requests; n > 0; request++, n--)
-		RememberFsyncRequest(request->rnode, request->forknum, request->segno);
+		RememberFsyncRequest(request->rnode, request->forknum, request->segno, request->is_ao_segno);
 
 	END_CRIT_SECTION();
 

--- a/src/backend/postmaster/test/checkpointer_test.c
+++ b/src/backend/postmaster/test/checkpointer_test.c
@@ -40,7 +40,7 @@ test__ForwardFsyncRequest_enqueue(void **state)
 	expect_value(LWLockRelease, lock, CheckpointerCommLock);
 	will_be_called(LWLockRelease);
 	/* basic enqueue */
-	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 1);
+	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 1, false);
 	assert_true(ret);
 	assert_true(CheckpointerShmem->num_requests == 1);
 	/* fill up the queue */
@@ -51,7 +51,7 @@ test__ForwardFsyncRequest_enqueue(void **state)
 		will_return(LWLockAcquire, true);
 		expect_value(LWLockRelease, lock, CheckpointerCommLock);
 		will_be_called(LWLockRelease);
-		ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, i);
+		ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, i, false);
 		assert_true(ret);
 	}
 	expect_value(LWLockAcquire, lock, CheckpointerCommLock);
@@ -68,7 +68,7 @@ test__ForwardFsyncRequest_enqueue(void **state)
 	 * duplicates are in the queue.  So the queue should remain
 	 * full.
 	 */
-	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 0);
+	ret = ForwardFsyncRequest(dummy, MAIN_FORKNUM, 0, false);
 	assert_false(ret);
 	assert_true(CheckpointerShmem->num_requests == CheckpointerShmem->max_requests);
 	free(CheckpointerShmem);

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -28,6 +28,8 @@
 #include <sys/stat.h>
 
 #include "access/aomd.h"
+#include "access/appendonlywriter.h"
+#include "access/htup_details.h"
 #include "catalog/catalog.h"
 #include "miscadmin.h"
 #include "access/xlogutils.h"
@@ -57,6 +59,13 @@
  * Note that CompactCheckpointerRequestQueue assumes that it's OK to remove an
  * fsync request from the queue if an identical, subsequent request is found.
  * See comments there before making changes here.
+ */
+/*
+ * GPDB:
+ * For AO/CO tables, the max segno should be
+ * MAX_AOREL_CONCURRENCY (128) * MaxTupleAttributeNumber (1664),
+ * which will not cause overflow and thus will not cause confusion with the
+ * below special segnos.
  */
 #define FORGET_RELATION_FSYNC	(InvalidBlockNumber)
 #define FORGET_DATABASE_FSYNC	(InvalidBlockNumber-1)
@@ -155,6 +164,7 @@ typedef struct
 	Bitmapset  *requests[MAX_FORKNUM + 1];
 	/* canceled[f] is true if we canceled fsyncs for fork "recently" */
 	bool		canceled[MAX_FORKNUM + 1];
+	bool		is_ao_segnos;	/* if the requests are for real ao/co segnos. */
 } PendingOperationEntry;
 
 typedef struct
@@ -203,7 +213,7 @@ static char *_mdfd_segpath(SMgrRelation reln, ForkNumber forknum,
 static MdfdVec *_mdfd_openseg(SMgrRelation reln, ForkNumber forkno,
 			  BlockNumber segno, int oflags);
 static MdfdVec *_mdfd_getseg(SMgrRelation reln, ForkNumber forkno,
-			 BlockNumber blkno, bool skipFsync, int behavior);
+			 BlockNumber blkno, bool skipFsync, bool is_appendoptimized, int behavior);
 static BlockNumber _mdnblocks(SMgrRelation reln, ForkNumber forknum,
 		   MdfdVec *seg);
 
@@ -447,9 +457,12 @@ mdunlink(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo, char relstor
 	 * requests for a temp relation, though.  We can send just one request
 	 * even when deleting multiple forks, since the fsync queuing code accepts
 	 * the "InvalidForkNumber = all forks" convention.
+	 *
+	 * On the mirror, AO fsync requests are always forwarded.
 	 */
 	if (!RelFileNodeBackendIsTemp(rnode) &&
-		!relstorage_is_ao(relstorage))
+		(IsStandbyMode() ||
+		 !relstorage_is_ao(relstorage)))
 		ForgetRelationFsyncRequests(rnode.node, forkNum);
 
 	/* Now do the per-fork work */
@@ -579,7 +592,7 @@ mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 						relpath(reln->smgr_rnode, forknum),
 						InvalidBlockNumber)));
 
-	v = _mdfd_getseg(reln, forknum, blocknum, skipFsync, EXTENSION_CREATE);
+	v = _mdfd_getseg(reln, forknum, blocknum, skipFsync, false, EXTENSION_CREATE);
 
 	seekpos = (off_t) BLCKSZ *(blocknum % ((BlockNumber) RELSEG_SIZE));
 
@@ -721,7 +734,7 @@ mdprefetch(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum)
 	off_t		seekpos;
 	MdfdVec    *v;
 
-	v = _mdfd_getseg(reln, forknum, blocknum, false, EXTENSION_FAIL);
+	v = _mdfd_getseg(reln, forknum, blocknum, false, false, EXTENSION_FAIL);
 
 	seekpos = (off_t) BLCKSZ *(blocknum % ((BlockNumber) RELSEG_SIZE));
 
@@ -753,7 +766,7 @@ mdwriteback(SMgrRelation reln, ForkNumber forknum,
 		int			segnum_start,
 					segnum_end;
 
-		v = _mdfd_getseg(reln, forknum, blocknum, true /* not used */ ,
+		v = _mdfd_getseg(reln, forknum, blocknum, true /* not used */ , false,
 						 EXTENSION_RETURN_NULL);
 
 		/*
@@ -800,7 +813,7 @@ mdread(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 										reln->smgr_rnode.node.relNode,
 										reln->smgr_rnode.backend);
 
-	v = _mdfd_getseg(reln, forknum, blocknum, false,
+	v = _mdfd_getseg(reln, forknum, blocknum, false, false,
 					 EXTENSION_FAIL | EXTENSION_CREATE_RECOVERY);
 
 	seekpos = (off_t) BLCKSZ *(blocknum % ((BlockNumber) RELSEG_SIZE));
@@ -876,7 +889,7 @@ mdwrite(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 										 reln->smgr_rnode.node.relNode,
 										 reln->smgr_rnode.backend);
 
-	v = _mdfd_getseg(reln, forknum, blocknum, skipFsync,
+	v = _mdfd_getseg(reln, forknum, blocknum, skipFsync, false,
 					 EXTENSION_FAIL | EXTENSION_CREATE_RECOVERY);
 
 	seekpos = (off_t) BLCKSZ *(blocknum % ((BlockNumber) RELSEG_SIZE));
@@ -1228,17 +1241,34 @@ mdsync(void)
 				int			failures;
 
 #ifdef FAULT_INJECTOR
-		if (SIMPLE_FAULT_INJECTOR("fsync_counter") == FaultInjectorTypeSkip)
+		if (SIMPLE_FAULT_INJECTOR("fsync_counter") == FaultInjectorTypeSkip ||
+			(entry->is_ao_segnos &&
+			 SIMPLE_FAULT_INJECTOR("ao_fsync_counter") == FaultInjectorTypeSkip))
 		{
 			if (MyAuxProcType == CheckpointerProcess)
-				elog(LOG, "checkpoint performing fsync for %d/%d/%d",
-					 entry->rnode.spcNode, entry->rnode.dbNode,
-					 entry->rnode.relNode);
+			{
+				if (segno == 0)
+					elog(LOG, "checkpoint performing fsync for %d/%d/%d",
+						 entry->rnode.spcNode, entry->rnode.dbNode,
+						 entry->rnode.relNode);
+				else
+					elog(LOG, "checkpoint performing fsync for %d/%d/%d.%d",
+						 entry->rnode.spcNode, entry->rnode.dbNode,
+						 entry->rnode.relNode, segno);
+			}
 			else
-				elog(ERROR, "non checkpoint process trying to fsync "
-					 "%d/%d/%d when fsync_counter fault is set",
-					 entry->rnode.spcNode, entry->rnode.dbNode,
-					 entry->rnode.relNode);
+			{
+				if (segno == 0)
+					elog(ERROR, "non checkpoint process trying to fsync "
+						 "%d/%d/%d when fsync_counter fault is set",
+						 entry->rnode.spcNode, entry->rnode.dbNode,
+						 entry->rnode.relNode);
+				else
+					elog(ERROR, "non checkpoint process trying to fsync "
+						 "%d/%d/%d.%d when fsync_counter fault is set",
+						 entry->rnode.spcNode, entry->rnode.dbNode,
+						 entry->rnode.relNode, segno);
+			}
 		}
 #endif
 				/*
@@ -1300,7 +1330,7 @@ mdsync(void)
 					/* Attempt to open and fsync the target segment */
 					seg = _mdfd_getseg(reln, forknum,
 							 (BlockNumber) segno * (BlockNumber) RELSEG_SIZE,
-									   false,
+									   false, entry->is_ao_segnos,
 									   EXTENSION_RETURN_NULL
 									   | EXTENSION_DONT_CHECK_SIZE);
 
@@ -1348,13 +1378,13 @@ mdsync(void)
 						failures > 0)
 						ereport(ERROR,
 								(errcode_for_file_access(),
-								 errmsg("could not fsync file \"%s\": %m",
-										path)));
+								 errmsg("could not fsync file \"%s\" (is_ao: %d): %m",
+										path, entry->is_ao_segnos)));
 					else
 						ereport(DEBUG1,
 								(errcode_for_file_access(),
-						errmsg("could not fsync file \"%s\" but retrying: %m",
-							   path)));
+						errmsg("could not fsync file \"%s\" (is_ao: %d) but retrying: %m",
+							   path, entry->is_ao_segnos)));
 					pfree(path);
 
 					/*
@@ -1508,11 +1538,11 @@ register_dirty_segment(SMgrRelation reln, ForkNumber forknum, MdfdVec *seg)
 	if (pendingOpsTable)
 	{
 		/* push it into local pending-ops table */
-		RememberFsyncRequest(reln->smgr_rnode.node, forknum, seg->mdfd_segno);
+		RememberFsyncRequest(reln->smgr_rnode.node, forknum, seg->mdfd_segno, false);
 	}
 	else
 	{
-		if (ForwardFsyncRequest(reln->smgr_rnode.node, forknum, seg->mdfd_segno))
+		if (ForwardFsyncRequest(reln->smgr_rnode.node, forknum, seg->mdfd_segno, false))
 			return;				/* passed it off successfully */
 
 		ereport(DEBUG1,
@@ -1523,6 +1553,38 @@ register_dirty_segment(SMgrRelation reln, ForkNumber forknum, MdfdVec *seg)
 					(errcode_for_file_access(),
 					 errmsg("could not fsync file \"%s\": %m",
 							FilePathName(seg->mdfd_vfd))));
+	}
+}
+
+/*
+ * register_dirty_segment_ao()
+ *
+ * Similar to register_dirty_segment() but it is for append optimized tables.
+ * The API definition is different because (1) relation forks are not used for
+ * AO tables, it's always MAIN_FORKNUM and (2) there is no MdfdVec equivalent
+ * for AO segment files.
+ */
+void
+register_dirty_segment_ao(RelFileNode rnode, int segno, File vfd)
+{
+	if (pendingOpsTable)
+	{
+		/* push it into local pending-ops table */
+		RememberFsyncRequest(rnode, MAIN_FORKNUM, segno, true);
+	}
+	else
+	{
+		if(ForwardFsyncRequest(rnode, MAIN_FORKNUM, segno, true))
+			return;
+
+		ereport(DEBUG1,
+				(errmsg("could not forward AO fsync request because request queue is full")));
+
+		if (FileSync(vfd) < 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not fsync AO file \"%s\": %m",
+							FilePathName(vfd))));
 	}
 }
 
@@ -1545,7 +1607,8 @@ register_unlink(RelFileNodeBackend rnode)
 	{
 		/* push it into local pending-ops table */
 		RememberFsyncRequest(rnode.node, MAIN_FORKNUM,
-							 UNLINK_RELATION_REQUEST);
+							 UNLINK_RELATION_REQUEST,
+							 false);
 	}
 	else
 	{
@@ -1558,7 +1621,7 @@ register_unlink(RelFileNodeBackend rnode)
 		 */
 		Assert(IsUnderPostmaster);
 		while (!ForwardFsyncRequest(rnode.node, MAIN_FORKNUM,
-									UNLINK_RELATION_REQUEST))
+									UNLINK_RELATION_REQUEST, false))
 			pg_usleep(10000L);	/* 10 msec seems a good number */
 	}
 }
@@ -1585,9 +1648,23 @@ register_unlink(RelFileNodeBackend rnode)
  * heavyweight operation anyhow, so we'll live with it.)
  */
 void
-RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum, BlockNumber segno)
+RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum, BlockNumber segno,
+					 bool is_ao_segno)
 {
 	Assert(pendingOpsTable);
+
+	/*
+	 * FORGET_* requests for append-optimized tables do not need special
+	 * handling.  Drop table and drop database operations do not distinguish
+	 * between a heap and AO FORGET_* request.
+	 */
+	AssertImply(is_ao_segno, segno <= MAX_AOREL_CONCURRENCY * MaxTupleAttributeNumber);
+
+	/*
+	 * Append-optimized tables do not use relation forks currently.
+	 * MAIN_FORKNUM is the only fork applicable.
+	 */
+	AssertImply(is_ao_segno, forknum == MAIN_FORKNUM);
 
 	if (segno == FORGET_RELATION_FSYNC)
 	{
@@ -1711,6 +1788,7 @@ RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum, BlockNumber segno)
 
 		entry->requests[forknum] = bms_add_member(entry->requests[forknum],
 												  (int) segno);
+		entry->is_ao_segnos = is_ao_segno;
 
 		MemoryContextSwitchTo(oldcxt);
 	}
@@ -1728,7 +1806,7 @@ ForgetRelationFsyncRequests(RelFileNode rnode, ForkNumber forknum)
 	if (pendingOpsTable)
 	{
 		/* standalone backend or startup process: fsync state is local */
-		RememberFsyncRequest(rnode, forknum, FORGET_RELATION_FSYNC);
+		RememberFsyncRequest(rnode, forknum, FORGET_RELATION_FSYNC, false);
 	}
 	else if (IsUnderPostmaster)
 	{
@@ -1742,7 +1820,7 @@ ForgetRelationFsyncRequests(RelFileNode rnode, ForkNumber forknum)
 		 * which would be bad, so I'm inclined to assume that the checkpointer
 		 * will always empty the queue soon.
 		 */
-		while (!ForwardFsyncRequest(rnode, forknum, FORGET_RELATION_FSYNC))
+		while (!ForwardFsyncRequest(rnode, forknum, FORGET_RELATION_FSYNC, false))
 			pg_usleep(10000L);	/* 10 msec seems a good number */
 
 		/*
@@ -1767,13 +1845,13 @@ ForgetDatabaseFsyncRequests(Oid dbid)
 	if (pendingOpsTable)
 	{
 		/* standalone backend or startup process: fsync state is local */
-		RememberFsyncRequest(rnode, InvalidForkNumber, FORGET_DATABASE_FSYNC);
+		RememberFsyncRequest(rnode, InvalidForkNumber, FORGET_DATABASE_FSYNC, false);
 	}
 	else if (IsUnderPostmaster)
 	{
 		/* see notes in ForgetRelationFsyncRequests */
 		while (!ForwardFsyncRequest(rnode, InvalidForkNumber,
-									FORGET_DATABASE_FSYNC))
+									FORGET_DATABASE_FSYNC, false))
 			pg_usleep(10000L);	/* 10 msec seems a good number */
 	}
 }
@@ -1899,7 +1977,7 @@ _mdfd_openseg(SMgrRelation reln, ForkNumber forknum, BlockNumber segno,
  */
 static MdfdVec *
 _mdfd_getseg(SMgrRelation reln, ForkNumber forknum, BlockNumber blkno,
-			 bool skipFsync, int behavior)
+			 bool skipFsync, bool is_ao_segno, int behavior)
 {
 	MdfdVec    *v = mdopen(reln, forknum, behavior);
 	BlockNumber targetseg;
@@ -1913,9 +1991,16 @@ _mdfd_getseg(SMgrRelation reln, ForkNumber forknum, BlockNumber blkno,
 		return NULL;			/* if behavior & EXTENSION_RETURN_NULL */
 
 	targetseg = blkno / ((BlockNumber) RELSEG_SIZE);
-	for (nextsegno = 1; nextsegno <= targetseg; nextsegno++)
+	/*
+	 * Append-optimized segment files are not numbered consecutively on disk.
+	 * E.g. it is perfectly valid for .129 file to exist without .2 to .128
+	 * files.  Therefore, we need to run this loop exactly once for AO.
+	 */
+	for (nextsegno = is_ao_segno ? targetseg : 1;
+		 nextsegno <= targetseg;
+		 nextsegno++)
 	{
-		Assert(nextsegno == v->mdfd_segno + 1);
+		Assert(is_ao_segno || (nextsegno == v->mdfd_segno + 1));
 
 		if (v->mdfd_chain == NULL)
 		{

--- a/src/include/access/aomd.h
+++ b/src/include/access/aomd.h
@@ -64,4 +64,6 @@ typedef bool (*ao_extent_callback)(int segno, void *ctx);
 
 extern void ao_foreach_extent_file(ao_extent_callback callback, void *ctx);
 
+extern void register_dirty_segment_ao(RelFileNode rnode, int segno, File vfd);
+
 #endif							/* AOMD_H */

--- a/src/include/postmaster/bgwriter.h
+++ b/src/include/postmaster/bgwriter.h
@@ -32,7 +32,7 @@ extern void RequestCheckpoint(int flags);
 extern void CheckpointWriteDelay(int flags, double progress);
 
 extern bool ForwardFsyncRequest(RelFileNode rnode, ForkNumber forknum,
-					BlockNumber segno);
+					BlockNumber segno, bool is_ao_segno);
 extern void AbsorbFsyncRequests(void);
 
 extern Size CheckpointerShmemSize(void);

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -140,7 +140,7 @@ extern void mdpostckpt(void);
 
 extern void SetForwardFsyncRequests(void);
 extern void RememberFsyncRequest(RelFileNode rnode, ForkNumber forknum,
-					 BlockNumber segno);
+					 BlockNumber segno, bool is_ao_segno);
 extern void ForgetRelationFsyncRequests(RelFileNode rnode, ForkNumber forknum);
 extern void ForgetDatabaseFsyncRequests(Oid dbid);
 extern void DropRelationFiles(RelFileNodePendingDelete *delrels, int ndelrels, bool isRedo);

--- a/src/test/isolation2/expected/fsync_ao.out
+++ b/src/test/isolation2/expected/fsync_ao.out
@@ -1,0 +1,231 @@
+-- Validate that the mirror replay process forwards fsync requests for
+-- append-optimized tables to the checkpointer.  This is done using a
+-- fault point that is reached only in a checkpointer process.  Note
+-- that checkpointer process runs on primary as well as mirror.  We
+-- are concerned with the checkpointer running on mirror in this test.
+--
+-- Starting with a clean slate (no pending fsync requests), the test
+-- performs operations such as insert, vacuum, drop on AO row and
+-- column oriented tables.  It validates that fsync was performed by
+-- checkpointer for expected number of AO files at the end of each
+-- operation.
+
+-- Set the GUC to perform replay of checkpoint records immediately.
+-- It speeds up the test.
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
+-- start_ignore
+20191204:17:12:45:024661 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+-- Set fsync on since we need to test the fsync code logic.
+!\retcode gpconfig -c fsync -v on --skipvalidation;
+-- start_ignore
+20191204:17:12:58:024716 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-c fsync -v on --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Starting gpstop with args: -u
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Gathering information and validating the environment...
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Obtaining Greenplum Master catalog information
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Obtaining Segment details from master...
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5242.gb96afb4d9fa build dev'
+20191204:17:12:58:024772 gpstop:asimmac:apraveen-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+
+create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+CREATE
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+CREATE
+insert into fsync_ao select i, i from generate_series(1,10)i;
+INSERT 10
+insert into fsync_co select i, i from generate_series(1,10)i;
+INSERT 10
+
+-- Fault to check that mirror has flushed pending fsync requests.
+select gp_inject_fault_infinite('restartpoint_guts', 'skip', dbid) from gp_segment_configuration where role = 'm' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Start with a clean slate.
+checkpoint;
+CHECKPOINT
+
+-- Wait until restartpoint flush happens.
+select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- We have just created a checkpoint.  The next automatic checkpoint
+-- will be triggered only after 5 minutes or after CheckPointSegments
+-- wal segments.  Neither of that can happen until this test calls
+-- explicit checkpoint.
+
+-- Write ao and co data files including aoseg & gp_fastsequence.
+-- These should be fsync-ed by checkpoint & restartpoint.
+insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+
+-- Inject fault to count relfiles fsync'ed by checkpointer on mirror.
+select gp_inject_fault_infinite('ao_fsync_counter', 'skip', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+checkpoint;
+CHECKPOINT
+
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Validate that the number of files fsync'ed by checkpointer (on
+-- mirror).  `num times hit` is corresponding to the number of files
+-- synced by `ao_fsync_counter` fault.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'3' 
+ 
+(1 row)
+
+-- Test vacuum compaction with more than one segment file per table.
+-- Perform concurrent inserts before vacuum to get multiple segment
+-- files.  Validation criterion is the next checkpoint succeeds on the
+-- mirror.
+1: begin;
+BEGIN
+1: insert into fsync_ao select i, i from generate_series(1,20)i;
+INSERT 20
+1: insert into fsync_co select i, i from generate_series(1,20)i;
+INSERT 20
+insert into fsync_ao select i, i from generate_series(21,40)i;
+INSERT 20
+insert into fsync_co select i, i from generate_series(21,40)i;
+INSERT 20
+1: end;
+END
+-- Generate some invisible tuples in both the tables so as to trigger
+-- compaction during vacuum.
+delete from fsync_ao where a > 20;
+DELETE 20
+update fsync_co set b = -a;
+UPDATE 70
+-- Expect two segment files for each table (ao table) or each column (co table).
+select segno, state from gp_toolkit.__gp_aoseg('fsync_ao');
+ segno | state 
+-------+-------
+ 1     | 1     
+ 2     | 1     
+(2 rows)
+select segno, column_num, physical_segno, state from gp_toolkit.__gp_aocsseg('fsync_co');
+ segno | column_num | physical_segno | state 
+-------+------------+----------------+-------
+ 1     | 0          | 1              | 1     
+ 1     | 1          | 129            | 1     
+ 2     | 0          | 2              | 1     
+ 2     | 1          | 130            | 1     
+(4 rows)
+vacuum fsync_ao;
+VACUUM
+vacuum fsync_co;
+VACUUM
+checkpoint;
+CHECKPOINT
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Expect the segment files that were updated by vacuum to be fsync'ed.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault                                                                                                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'14' 
+ 
+(1 row)
+
+-- Test that replay of drop table operation removes fsync requests
+-- previously registed with the checkpointer.
+update fsync_co set b = -a;
+UPDATE 70
+drop table fsync_co;
+DROP
+-- Drop but don't commit the transaction.
+begin;
+BEGIN
+update fsync_ao set b = -a;
+UPDATE 50
+drop table fsync_ao;
+DROP
+abort;
+ABORT
+-- Fsync request for the following insert should not be forgotten.
+insert into fsync_ao select * from generate_series(41,60)i;
+INSERT 20
+
+checkpoint;
+CHECKPOINT
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Expect that fsync is only performed for fsync_ao table (1 file) but
+-- not for fsync_co table because it was dropped after being updated.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault                                                                                                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'15' 
+ 
+(1 row)
+
+-- Reset all faults.
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+(2 rows)
+
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
+-- start_ignore
+20191204:17:13:13:024809 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r create_restartpoint_on_ckpt_record_replay --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r fsync --skipvalidation;
+-- start_ignore
+20191204:17:13:27:024868 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Starting gpstop with args: -u
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Gathering information and validating the environment...
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Obtaining Greenplum Master catalog information
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Obtaining Segment details from master...
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5242.gb96afb4d9fa build dev'
+20191204:17:13:27:024927 gpstop:asimmac:apraveen-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -77,6 +77,9 @@ test: ao_upgrade
 # below test utilizes fault injectors so it needs to be in a group by itself
 test: external_table
 
+# This test validates that for AO we delay fsync to checkpointer on mirror.
+test: fsync_ao
+
 # Tests on Append-Optimized tables (row-oriented).
 test: concurrent_index_creation_should_not_deadlock
 test: uao/alter_while_vacuum_row uao/alter_while_vacuum2_row

--- a/src/test/isolation2/sql/fsync_ao.sql
+++ b/src/test/isolation2/sql/fsync_ao.sql
@@ -1,0 +1,117 @@
+-- Validate that the mirror replay process forwards fsync requests for
+-- append-optimized tables to the checkpointer.  This is done using a
+-- fault point that is reached only in a checkpointer process.  Note
+-- that checkpointer process runs on primary as well as mirror.  We
+-- are concerned with the checkpointer running on mirror in this test.
+--
+-- Starting with a clean slate (no pending fsync requests), the test
+-- performs operations such as insert, vacuum, drop on AO row and
+-- column oriented tables.  It validates that fsync was performed by
+-- checkpointer for expected number of AO files at the end of each
+-- operation.
+
+-- Set the GUC to perform replay of checkpoint records immediately.
+-- It speeds up the test.
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
+-- Set fsync on since we need to test the fsync code logic.
+!\retcode gpconfig -c fsync -v on --skipvalidation;
+!\retcode gpstop -u;
+
+create table fsync_ao(a int, b int) with (appendoptimized = true) distributed by (a);
+create table fsync_co(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+insert into fsync_ao select i, i from generate_series(1,10)i;
+insert into fsync_co select i, i from generate_series(1,10)i;
+
+-- Fault to check that mirror has flushed pending fsync requests.
+select gp_inject_fault_infinite('restartpoint_guts', 'skip', dbid)
+	from gp_segment_configuration where role = 'm' and content = 0;
+
+-- Start with a clean slate.
+checkpoint;
+
+-- Wait until restartpoint flush happens.
+select gp_wait_until_triggered_fault('restartpoint_guts', 1, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- We have just created a checkpoint.  The next automatic checkpoint
+-- will be triggered only after 5 minutes or after CheckPointSegments
+-- wal segments.  Neither of that can happen until this test calls
+-- explicit checkpoint.
+
+-- Write ao and co data files including aoseg & gp_fastsequence.
+-- These should be fsync-ed by checkpoint & restartpoint.
+insert into fsync_ao select i, i from generate_series(1,20)i;
+insert into fsync_co select i, i from generate_series(1,20)i;
+
+-- Inject fault to count relfiles fsync'ed by checkpointer on mirror.
+select gp_inject_fault_infinite('ao_fsync_counter', 'skip', dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+checkpoint;
+
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Validate that the number of files fsync'ed by checkpointer (on
+-- mirror).  `num times hit` is corresponding to the number of files
+-- synced by `ao_fsync_counter` fault.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Test vacuum compaction with more than one segment file per table.
+-- Perform concurrent inserts before vacuum to get multiple segment
+-- files.  Validation criterion is the next checkpoint succeeds on the
+-- mirror.
+1: begin;
+1: insert into fsync_ao select i, i from generate_series(1,20)i;
+1: insert into fsync_co select i, i from generate_series(1,20)i;
+insert into fsync_ao select i, i from generate_series(21,40)i;
+insert into fsync_co select i, i from generate_series(21,40)i;
+1: end;
+-- Generate some invisible tuples in both the tables so as to trigger
+-- compaction during vacuum.
+delete from fsync_ao where a > 20;
+update fsync_co set b = -a;
+-- Expect two segment files for each table (ao table) or each column (co table).
+select segno, state from gp_toolkit.__gp_aoseg('fsync_ao');
+select segno, column_num, physical_segno, state from gp_toolkit.__gp_aocsseg('fsync_co');
+vacuum fsync_ao;
+vacuum fsync_co;
+checkpoint;
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Expect the segment files that were updated by vacuum to be fsync'ed.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Test that replay of drop table operation removes fsync requests
+-- previously registed with the checkpointer.
+update fsync_co set b = -a;
+drop table fsync_co;
+-- Drop but don't commit the transaction.
+begin;
+update fsync_ao set b = -a;
+drop table fsync_ao;
+abort;
+-- Fsync request for the following insert should not be forgotten.
+insert into fsync_ao select * from generate_series(41,60)i;
+
+checkpoint;
+-- Wait until restartpoint happens again.
+select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Expect that fsync is only performed for fsync_ao table (1 file) but
+-- not for fsync_co table because it was dropped after being updated.
+select gp_inject_fault('ao_fsync_counter', 'status', dbid)
+	from gp_segment_configuration where content=0 and role='m';
+
+-- Reset all faults.
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = 0;
+
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
+!\retcode gpconfig -r fsync --skipvalidation;
+!\retcode gpstop -u;


### PR DESCRIPTION
This is the final version, originated from PRs #9088, #9172 and the results of experiment: https://github.com/greenplum-db/gpdb/pull/9173#issuecomment-562518247

We have decided to delay fsync for append-optimized tables on mirror due to the clear benefit it offers.  It is, however, not that beneficial to introduce analogous change on primary side.

This PR intends to merge the mirror side fix and a bug fix that caused unnecessary fsync for temp tables.

@paul-guo- and I worked together on this.