### PR TITLE
Fix normalization of queries with window functions

### DIFF
--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -207,7 +207,7 @@ CQueryMutators::NormalizeGroupByProjList
 		}
 	}
 
-	derived_table_query->targetList = context.m_groupby_tlist;
+	derived_table_query->targetList = context.m_derived_table_tlist;
 	new_query->targetList = target_list_copy;
 
 	ReassignSortClause(new_query, derived_table_query);
@@ -626,7 +626,7 @@ CQueryMutators::FixGroupingCols
 {
 	GPOS_ASSERT(NULL != node);
 
-	ULONG arity = gpdb::ListLength(context->m_groupby_tlist) + 1;
+	ULONG arity = gpdb::ListLength(context->m_derived_table_tlist) + 1;
 
 	// fix any outer references in the grouping column expression
 	Node *expr = (Node *) RunGroupingColMutator(node, context);
@@ -637,7 +637,7 @@ CQueryMutators::FixGroupingCols
 	new_target_entry->ressortgroupref = orginal_target_entry->ressortgroupref;
 	new_target_entry->resjunk = false;
 
-	context->m_groupby_tlist = gpdb::LAppend(context->m_groupby_tlist, new_target_entry);
+	context->m_derived_table_tlist = gpdb::LAppend(context->m_derived_table_tlist, new_target_entry);
 
 	Var *new_var = gpdb::MakeVar
 			(
@@ -870,7 +870,7 @@ CQueryMutators::RunExtractAggregatesMutator
 			var->varlevelsup = 0;
 			TargetEntry *found_tle =
 				gpdb::FindFirstMatchingMemberInTargetList((Node*) var,
-													  context->m_groupby_tlist);
+													  context->m_derived_table_tlist);
 
 			if (NULL == found_tle)
 			{
@@ -962,12 +962,17 @@ CQueryMutators::MakeVarInDerivedTable
 {
 	GPOS_ASSERT(NULL != node);
 	GPOS_ASSERT(NULL != context);
-	GPOS_ASSERT(IsA(node, PercentileExpr) || IsA(node, Aggref) || IsA(node, GroupingFunc));
+	GPOS_ASSERT(IsA(node, PercentileExpr) || IsA(node, Aggref) || IsA(node, GroupingFunc) || IsA(node, Var));
 
 	// Append a new target entry for the node to the derived target list ...
-	const ULONG attno = gpdb::ListLength(context->m_groupby_tlist) + 1;
-	TargetEntry *tle = PteAggregateOrPercentileExpr(context->m_mp, context->m_mda, node, attno);
-	context->m_groupby_tlist = gpdb::LAppend(context->m_groupby_tlist, tle);
+	TargetEntry *tle = NULL;
+	const ULONG attno = gpdb::ListLength(context->m_derived_table_tlist) + 1;
+	if (IsA(node, Aggref) || IsA(node, GroupingFunc) || IsA(node, PercentileExpr))
+	    tle = PteAggregateOrPercentileExpr(context->m_mp, context->m_mda, node, attno);
+	else if (IsA(node, Var))
+		tle = gpdb::MakeTargetEntry((Expr*) node, (AttrNumber) attno, NULL, false);
+
+	context->m_derived_table_tlist = gpdb::LAppend(context->m_derived_table_tlist, tle);
 
 	// ... and return a Var referring to it in its stead
 	// NB: Since the new tle is appended at the top query level, Var::varlevelsup
@@ -996,7 +1001,7 @@ CQueryMutators::FindNodeInGroupByTargetList
 	GPOS_ASSERT(NULL != context);
 	
 	TargetEntry *found_tle =
-		gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_tlist);
+		gpdb::FindFirstMatchingMemberInTargetList(node, context->m_derived_table_tlist);
 
 	if (NULL != found_tle)
 	{
@@ -1040,6 +1045,27 @@ CQueryMutators::FlatCopyAggref
     new_aggref->aggstar = old_aggref->aggstar;
 
 	return new_aggref;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CQueryMutators::FlatCopyAggref
+//
+//	@doc:
+//		Make a copy of the aggref (minus the arguments)
+//---------------------------------------------------------------------------
+WindowRef *
+CQueryMutators::FlatCopyWindowRef
+(
+ WindowRef *old_windowref
+ )
+{
+	WindowRef *new_windowref = MakeNode(WindowRef);
+
+	*new_windowref = *old_windowref;
+	new_windowref->args = NIL;
+
+	return new_windowref;
 }
 
 
@@ -1545,7 +1571,7 @@ CQueryMutators::PqueryFixWindowFrameEdgeBoundary
 //			SELECT row_number() over() + rank() over(partition by a+b order by a-b) from foo
 //
 // 		NEW QUERY:
-//			SELECT rn+rk from (SELECT row_number() over() as rn rank() over(partition by a+b order by a-b) as rk FROM foo) foo_new
+//			SELECT rn+rk from (SELECT row_number() over() as rn, rank() over(partition by a+b order by a-b) as rk FROM foo) foo_new
 //---------------------------------------------------------------------------
 Query *
 CQueryMutators::NormalizeWindowProjList
@@ -1581,12 +1607,16 @@ CQueryMutators::NormalizeWindowProjList
 		if (CTranslatorUtils::IsWindowSpec(target_entry, query->windowClause))
 		{
 			// insert the target list entry used in the window specification as is
-			TargetEntry *new_target_entry = (TargetEntry *) gpdb::CopyObject(target_entry);
-			new_target_entry->resno = gpdb::ListLength(context.m_groupby_tlist) + 1;
-			context.m_groupby_tlist = gpdb::LAppend(context.m_groupby_tlist, new_target_entry);
-
 			if (!target_entry->resjunk || CTranslatorUtils::IsSortingColumn(target_entry, query->sortClause))
 			{
+				TargetEntry *new_target_entry = (TargetEntry *) gpdb::CopyObject(target_entry);
+				{
+					SContextIncLevelsupMutator context(0, false);
+					new_target_entry->expr = (Expr *) RunIncrLevelsUpMutator((Node *)new_target_entry->expr, &context);
+				}
+				new_target_entry->resno = gpdb::ListLength(context.m_derived_table_tlist) + 1;
+				context.m_derived_table_tlist = gpdb::LAppend(context.m_derived_table_tlist, new_target_entry);
+
 				// if the target list entry used in the window specification is present
 				// in the query output then add it to the target list of the new top level query
 				Var *new_var = gpdb::MakeVar
@@ -1607,6 +1637,19 @@ CQueryMutators::NormalizeWindowProjList
 
 				new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry_copy);
 			}
+			else
+			{
+				// This target entry is not required to be output, so we just insert it into the
+				// derived table. Since we are moving it down by a level, we need to fix the
+				// varlevelsup of outer refs.
+				TargetEntry *new_target_entry = (TargetEntry *) gpdb::CopyObject(target_entry);
+				{
+					SContextIncLevelsupMutator context(0, false);
+					new_target_entry->expr = (Expr *) RunIncrLevelsUpMutator((Node *)new_target_entry->expr, &context);
+				}
+				new_target_entry->resno = gpdb::ListLength(context.m_derived_table_tlist) + 1;
+				context.m_derived_table_tlist = gpdb::LAppend(context.m_derived_table_tlist, new_target_entry);
+			}
 		}
 		else
 		{
@@ -1617,7 +1660,7 @@ CQueryMutators::NormalizeWindowProjList
 			new_query->targetList = gpdb::LAppend(new_query->targetList, new_target_entry);
 		}
 	}
-	derived_table_query->targetList = context.m_groupby_tlist;
+	derived_table_query->targetList = context.m_derived_table_tlist;
 
 	GPOS_ASSERT(gpdb::ListLength(new_query->targetList) <= gpdb::ListLength(query->targetList));
 
@@ -1647,89 +1690,148 @@ CQueryMutators::RunWindowProjListMutator
 		return NULL;
 	}
 
-	// do not traverse into sub queries as they will be inserted are inserted into
-	// top-level query as is
-	if (IsA(node, SubLink))
+	const ULONG resno = gpdb::ListLength(context->m_derived_table_tlist) + 1;
+
+	if (0 == context->m_current_query_level)
 	{
-		return (Node *) gpdb::CopyObject(node);
-	}
+		if (IsA(node, WindowRef))
+		{
+			// insert window operator into the derived table
+			// and refer to it in the top-level query's target list
+			WindowRef *window_ref = FlatCopyWindowRef((WindowRef *)node);
 
-	const ULONG resno = gpdb::ListLength(context->m_groupby_tlist) + 1;
+			// get the function name and add it to the target list
+			CMDIdGPDB *mdid_func = GPOS_NEW(context->m_mp) CMDIdGPDB(window_ref->winfnoid);
+			const CWStringConst *str = CMDAccessorUtils::PstrWindowFuncName(context->m_mda, mdid_func);
+			mdid_func->Release();
 
-	if (IsA(node, WindowRef))
-	{
-		// insert window operator into the derived table
-        // and refer to it in the top-level query's target list
-		WindowRef *window_ref = (WindowRef*) gpdb::CopyObject(node);
+			ListCell *lc = NULL;
+			List *new_args = NIL;
 
-		// get the function name and add it to the target list
-		CMDIdGPDB *mdid_func = GPOS_NEW(context->m_mp) CMDIdGPDB(window_ref->winfnoid);
-		const CWStringConst *str = CMDAccessorUtils::PstrWindowFuncName(context->m_mda, mdid_func);
-        mdid_func->Release();
+			BOOL is_arg = context->m_is_mutating_window_arg;
+			context->m_is_mutating_window_arg = true;
 
-		TargetEntry *target_entry = gpdb::MakeTargetEntry
-								(
-								(Expr*) gpdb::CopyObject(node),
-								(AttrNumber) resno,
-								CTranslatorUtils::CreateMultiByteCharStringFromWCString(str->GetBuffer()),
-								false /* resjunk */
-								);
-		context->m_groupby_tlist = gpdb::LAppend(context->m_groupby_tlist, target_entry);
+			ForEach (lc, ((WindowRef *)node)->args)
+			{
+				Node *arg = (Node*) lfirst(lc);
+				GPOS_ASSERT(NULL != arg);
+				// traverse each argument and fix levels up when needed
+				new_args = gpdb::LAppend
+				(
+				 new_args,
+				 gpdb::MutateQueryOrExpressionTree
+				 (
+				  arg,
+				  (MutatorWalkerFn) RunWindowProjListMutator,
+				  (void *) context,
+				  0 // mutate into cte-lists
+				  )
+				 );
+			}
+			context->m_is_mutating_window_arg = is_arg;
+			window_ref->args = new_args;
 
-		// return a variable referring to the new derived table's corresponding target list entry
-		Var *new_var = gpdb::MakeVar
-								(
-								1,
-								(AttrNumber) resno,
-								gpdb::ExprType(node),
-								gpdb::ExprTypeMod(node),
-								0 // query levelsup
-								);
+			TargetEntry *target_entry = gpdb::MakeTargetEntry
+									(
+									(Expr*) gpdb::CopyObject(window_ref),
+									(AttrNumber) resno,
+									CTranslatorUtils::CreateMultiByteCharStringFromWCString(str->GetBuffer()),
+									false /* resjunk */
+									);
+			context->m_derived_table_tlist = gpdb::LAppend(context->m_derived_table_tlist, target_entry);
 
-		return (Node*) new_var;
+			// return a variable referring to the new derived table's corresponding target list entry
+			Var *new_var = gpdb::MakeVar
+									(
+									1,
+									(AttrNumber) resno,
+									gpdb::ExprType(node),
+									gpdb::ExprTypeMod(node),
+									0 // query levelsup
+									);
+
+			return (Node*) new_var;
+		}
 	}
 
 	if (IsA(node, Var))
 	{
-		Var *new_var = NULL;
+		Var *var = (Var *) gpdb::CopyObject(node);
 
-		TargetEntry *found_target_entry = gpdb::FindFirstMatchingMemberInTargetList(node, context->m_groupby_tlist);
-		if (NULL == found_target_entry)
+		// Handle other top-level outer references in the project element.
+		// There are three cases:
+		// var->varlevelsup < context->m_current_query_level: The outer reference
+		// is within the subquery, no need to make any change.
+		// var->varlevelsup == context->m_current_query_level: The outer reference is to
+		// the scope of the query being transformed. This needs a modification, see below.
+		// var->varlevelsup > context->m_current_query_level: The outer reference is referencing
+		// a value above our current scope. The new place for the var is the same difference
+		// from those outer refs, therefore we also don't have to change anything.
+		if (var->varlevelsup == context->m_current_query_level && !context->m_is_mutating_window_arg)
 		{
-			// insert target entry into the target list of the derived table
-			CWStringConst str_unnamed_col(GPOS_WSZ_LIT("?column?"));
-			TargetEntry *target_entry = gpdb::MakeTargetEntry
-									(
-									(Expr*) gpdb::CopyObject(node),
-									(AttrNumber) resno,
-									CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_unnamed_col.GetBuffer()),
-									false /* resjunk */
-									);
-			context->m_groupby_tlist = gpdb::LAppend(context->m_groupby_tlist, target_entry);
 
-			new_var = gpdb::MakeVar
-								(
-								1,
-								(AttrNumber) resno,
-								gpdb::ExprType(node),
-								gpdb::ExprTypeMod(node),
-								0 // query levelsup
-								);
+			// For other top-level references, correct their varno & varattno, since
+			// they now must refer to the target list of the derived query - whose
+			// target list may be different from the original query.
+
+			// Set varlevelsup to 0 temporarily while searching in the target list
+			var->varlevelsup = 0;
+			TargetEntry *found_tle =
+			gpdb::FindFirstMatchingMemberInTargetList((Node*) var,
+													  context->m_derived_table_tlist);
+
+			if (NULL == found_tle)
+			{
+				Node *var_copy = (Node*) gpdb::CopyObject(var);
+				return (Node *) MakeVarInDerivedTable(var_copy, context);
+			}
+
+			var->varno = 1;  // derived query is the only table in FROM expression
+			var->varattno = found_tle->resno;
+			var->varlevelsup = context->m_current_query_level;  // reset varlevels up
+			found_tle->resjunk = false;
+
+			return (Node*) var;
 		}
-		else
+
+		if (context->m_is_mutating_window_arg)
 		{
-			found_target_entry->resjunk = false; // ensure that the derived target list is not resjunked
-			new_var = gpdb::MakeVar
-								(
-								1,
-								found_target_entry->resno,
-								gpdb::ExprType(node),
-								gpdb::ExprTypeMod(node),
-								0 // query levelsup
-								);
+			return (Node *) IncrLevelsUpIfOuterRef((Var*) node);
 		}
 
-		return (Node*) new_var;
+		return (Node *) var;
+	}
+
+	if (IsA(node, SubLink))
+	{
+		SubLink *old_sublink = (SubLink *) node;
+
+		SubLink *new_sublink = MakeNode(SubLink);
+		new_sublink->subLinkType = old_sublink->subLinkType;
+		new_sublink->location = old_sublink->location;
+		new_sublink->operName = (List *) gpdb::CopyObject(old_sublink->operName);
+
+		new_sublink->testexpr =	gpdb::MutateQueryOrExpressionTree
+		(
+		 old_sublink->testexpr,
+		 (MutatorWalkerFn) RunWindowProjListMutator,
+		 (void *) context,
+		 0 // mutate into cte-lists
+		 );
+		context->m_current_query_level++;
+
+		GPOS_ASSERT(IsA(old_sublink->subselect, Query));
+
+		new_sublink->subselect = gpdb::MutateQueryOrExpressionTree
+		(
+		 old_sublink->subselect,
+		 (MutatorWalkerFn) RunWindowProjListMutator,
+		 (void *) context,
+		 0 // mutate into cte-lists
+		 );
+		context->m_current_query_level--;
+
+		return (Node *) new_sublink;
 	}
 
 	return gpdb::MutateExpressionTree(node, (MutatorWalkerFn) CQueryMutators::RunWindowProjListMutator, context);

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -70,7 +70,7 @@ namespace gpdxl
 				Query *m_query;
 
 				// the new target list of the group by (derived) query
-				List *m_groupby_tlist;
+				List *m_derived_table_tlist;
 
 				// the current query level
 				ULONG m_current_query_level;
@@ -81,22 +81,26 @@ namespace gpdxl
 				// indicate whether we are mutating the argument of an aggregate
 				BOOL m_is_mutating_agg_arg;
 
+				// indice whether we are mutating the argument of a window function
+				BOOL m_is_mutating_window_arg;
+
 				// ctor
 				SContextGrpbyPlMutator
 					(
 					CMemoryPool *mp,
 					CMDAccessor *mda,
 					Query *query,
-					List *groupby_tlist
+					List *derived_query_tlist
 					)
 						:
 					m_mp(mp),
 					m_mda(mda),
 					m_query(query),
-					m_groupby_tlist(groupby_tlist),
+					m_derived_table_tlist(derived_query_tlist),
 					m_current_query_level(0),
 					m_agg_levels_up(gpos::ulong_max),
-					m_is_mutating_agg_arg(false)
+					m_is_mutating_agg_arg(false),
+					m_is_mutating_window_arg(false)
 				{
 				}
 
@@ -202,6 +206,10 @@ namespace gpdxl
 			// make a copy of the aggref (minus the arguments)
 			static
 			Aggref *FlatCopyAggref(Aggref *aggref);
+
+			// make a copy of the window function (minus the arguments)
+			static
+			WindowRef *FlatCopyWindowRef (WindowRef *old_windowref);
 
 			// create a new entry in the derived table and return its corresponding var
 			static

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -6553,6 +6553,122 @@ select lead(c,c+d,1000) over(order by c,d) from orca.s order by 1;
  1000
 (30 rows)
 
+-- test normalization of window functions
+create table orca_w1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table orca_w2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table orca_w3(a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into orca_w1 select i, i from generate_series(1, 3) i;
+insert into orca_w2 select i, i from generate_series(2, 4) i;
+insert into orca_w3 select i, i from generate_series(3, 5) i;
+-- outer ref in subquery in target list and window func in target list
+select (select b from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w2, orca_w1;
+ one | two 
+-----+-----
+ 3   |   1
+ 3   |   2
+ 3   |   3
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+(9 rows)
+
+-- aggref in subquery with window func in target list
+select orca_w1.a, (select sum(orca_w2.a) from orca_w2 where orca_w1.b = orca_w2.b), count(*), rank() over (order by orca_w1.b) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+ a | ?column? | count | rank 
+---+----------+-------+------
+ 1 |          |     1 |    1
+ 2 |        2 |     1 |    2
+ 3 |        3 |     1 |    3
+(3 rows)
+
+-- window function inside subquery inside target list with outer ref
+select orca_w1.a, (select rank() over (order by orca_w1.b) from orca_w2 where orca_w1.b = orca_w2.b), count(*) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+ a | ?column? | count 
+---+----------+-------
+ 1 |          |     1
+ 2 |        1 |     1
+ 3 |        1 |     1
+(3 rows)
+
+-- window function clause inside subquery inside target list with outer ref
+select (select rank() over(order by a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+     |   1
+   1 |   2
+   1 |   3
+   1 |   1
+(9 rows)
+
+-- window function in IN clause
+select (select a from orca_w3 where a = orca_w1.a) as one from orca_w1 where orca_w1.a IN (select rank() over(order by orca_w1.a) + 1 from orca_w1, orca_w2);
+ one 
+-----
+    
+(1 row)
+
+-- window function in subquery inside target list with outer ref in partition clause
+select (select row_number() over(partition by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+     |   1
+   1 |   2
+   1 |   3
+   1 |   1
+(9 rows)
+
+-- window function in subquery inside target list with outer ref in order clause
+select (select rank() over(order by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+     |   1
+   1 |   2
+   1 |   3
+   1 |   1
+(9 rows)
+
+-- window function with outer ref in arguments
+select (select sum(orca_w1.a + a) over(order by b) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+ ?column? 
+----------
+         
+        5
+        7
+(3 rows)
+
+-- window function with outer ref in window clause and arguments 
+select (select sum(orca_w1.a + a) over(order by b + orca_w1.a) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+ ?column? 
+----------
+         
+        5
+        7
+(3 rows)
+
 -- cte
 with x as (select a, b from orca.r)
 select rank() over(partition by a, case when b = 0 then a+b end order by b asc) as rank_within_parent from x order by a desc ,case when a+b = 0 then a end ,b;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -6533,6 +6533,122 @@ select lead(c,c+d,1000) over(order by c,d) from orca.s order by 1;
  1000
 (30 rows)
 
+-- test normalization of window functions
+create table orca_w1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table orca_w2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table orca_w3(a int, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into orca_w1 select i, i from generate_series(1, 3) i;
+insert into orca_w2 select i, i from generate_series(2, 4) i;
+insert into orca_w3 select i, i from generate_series(3, 5) i;
+-- outer ref in subquery in target list and window func in target list
+select (select b from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w2, orca_w1;
+ one | two 
+-----+-----
+ 3   |   1
+ 3   |   2
+ 3   |   3
+     |   1
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+(9 rows)
+
+-- aggref in subquery with window func in target list
+select orca_w1.a, (select sum(orca_w2.a) from orca_w2 where orca_w1.b = orca_w2.b), count(*), rank() over (order by orca_w1.b) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+ a | ?column? | count | rank 
+---+----------+-------+------
+ 1 |          |     1 |    1
+ 2 |        2 |     1 |    2
+ 3 |        3 |     1 |    3
+(3 rows)
+
+-- window function inside subquery inside target list with outer ref
+select orca_w1.a, (select rank() over (order by orca_w1.b) from orca_w2 where orca_w1.b = orca_w2.b), count(*) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+ a | ?column? | count 
+---+----------+-------
+ 1 |          |     1
+ 2 |        1 |     1
+ 3 |        1 |     1
+(3 rows)
+
+-- window function clause inside subquery inside target list with outer ref
+select (select rank() over(order by a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+     |   1
+   1 |   2
+   1 |   3
+   1 |   1
+(9 rows)
+
+-- window function in IN clause
+select (select a from orca_w3 where a = orca_w1.a) as one from orca_w1 where orca_w1.a IN (select rank() over(order by orca_w1.a) + 1 from orca_w1, orca_w2);
+ one 
+-----
+    
+(1 row)
+
+-- window function in subquery inside target list with outer ref in partition clause
+select (select row_number() over(partition by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+     |   1
+   1 |   2
+   1 |   3
+   1 |   1
+(9 rows)
+
+-- window function in subquery inside target list with outer ref in order clause
+select (select rank() over(order by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+ one | two 
+-----+-----
+     |   2
+     |   3
+     |   1
+     |   2
+     |   3
+     |   1
+   1 |   2
+   1 |   3
+   1 |   1
+(9 rows)
+
+-- window function with outer ref in arguments
+select (select sum(orca_w1.a + a) over(order by b) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+ ?column? 
+----------
+         
+        5
+        7
+(3 rows)
+
+-- window function with outer ref in window clause and arguments 
+select (select sum(orca_w1.a + a) over(order by b + orca_w1.a) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+ ?column? 
+----------
+         
+        5
+        7
+(3 rows)
+
 -- cte
 with x as (select a, b from orca.r)
 select rank() over(partition by a, case when b = 0 then a+b end order by b asc) as rank_within_parent from x order by a desc ,case when a+b = 0 then a end ,b;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -281,6 +281,42 @@ select lead(a) over(order by a) from orca.r order by 1;
 select lag(c,d) over(order by c,d) from orca.s order by 1;
 select lead(c,c+d,1000) over(order by c,d) from orca.s order by 1;
 
+-- test normalization of window functions
+create table orca_w1(a int, b int);
+create table orca_w2(a int, b int);
+create table orca_w3(a int, b text);
+
+insert into orca_w1 select i, i from generate_series(1, 3) i;
+insert into orca_w2 select i, i from generate_series(2, 4) i;
+insert into orca_w3 select i, i from generate_series(3, 5) i;
+
+-- outer ref in subquery in target list and window func in target list
+select (select b from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w2, orca_w1;
+
+-- aggref in subquery with window func in target list
+select orca_w1.a, (select sum(orca_w2.a) from orca_w2 where orca_w1.b = orca_w2.b), count(*), rank() over (order by orca_w1.b) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+
+-- window function inside subquery inside target list with outer ref
+select orca_w1.a, (select rank() over (order by orca_w1.b) from orca_w2 where orca_w1.b = orca_w2.b), count(*) from orca_w1 group by orca_w1.a, orca_w1.b order by orca_w1.a;
+
+-- window function clause inside subquery inside target list with outer ref
+select (select rank() over(order by a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+
+-- window function in IN clause
+select (select a from orca_w3 where a = orca_w1.a) as one from orca_w1 where orca_w1.a IN (select rank() over(order by orca_w1.a) + 1 from orca_w1, orca_w2);
+
+-- window function in subquery inside target list with outer ref in partition clause
+select (select row_number() over(partition by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+
+-- window function in subquery inside target list with outer ref in order clause
+select (select rank() over(order by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
+
+-- window function with outer ref in arguments
+select (select sum(orca_w1.a + a) over(order by b) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+
+-- window function with outer ref in window clause and arguments 
+select (select sum(orca_w1.a + a) over(order by b + orca_w1.a) + 1 from orca_w2 where orca_w1.a = orca_w2.a) from orca_w1 order by orca_w1.a;
+
 -- cte
 with x as (select a, b from orca.r)
 select rank() over(partition by a, case when b = 0 then a+b end order by b asc) as rank_within_parent from x order by a desc ,case when a+b = 0 then a end ,b;


### PR DESCRIPTION
Whenever there are queries involving window functions, ORCA requires the query
to be in a specific form in order to optimize it. Specifically, the query
should only contain window functions and the columns referenced by the window
clause. The algebrizer is responsible for normalizing the query to a specific
form. However the algebrizer did not handle the case when one of the columns
selected was a subquery.

For e.g

select (select b from w3 where a = w1.a) as one,
       row_number() over(partition by w1.a) as two
       from w2, w1;

In this case, the algebrizer would simply pull the subquery to the top level
without fixing the vars for the outer references.This caused the algebrizer to
crash.

This commit fixes the issue by recursing into the subquery and fixing up the
vars.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
