### PR TITLE
Fix race condition in deadlock_under_entry_db_singleton

### DIFF
--- a/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
+++ b/src/test/isolation2/expected/deadlock_under_entry_db_singleton.out
@@ -45,6 +45,7 @@ select gp_inject_fault_infinite('transaction_start_under_entry_db_singleton', 's
 --------------------------
  Success:                 
 (1 row)
+2&: select gp_wait_until_triggered_fault('transaction_start_under_entry_db_singleton', 1, 1);  <waiting ...>
 
 -- The QD should already hold RowExclusiveLock and ExclusiveLock on
 -- deadlock_entry_db_singleton_table and the QE ENTRY_DB_SINGLETON
@@ -52,11 +53,10 @@ select gp_inject_fault_infinite('transaction_start_under_entry_db_singleton', 's
 1&:UPDATE deadlock_entry_db_singleton_table set d = d + 1 FROM (select 1 from deadlock_entry_db_singleton_table, function_volatile(5)) t;  <waiting ...>
 
 -- verify the fault hit
-select gp_inject_fault('transaction_start_under_entry_db_singleton', 'status', 1);
- gp_inject_fault                                                                                                                                                                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Success: fault name:'transaction_start_under_entry_db_singleton' fault type:'suspend' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1' 
- 
+2<:  <... completed>
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
 -- This session will wait for ExclusiveLock on

--- a/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
+++ b/src/test/isolation2/sql/deadlock_under_entry_db_singleton.sql
@@ -39,6 +39,7 @@ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
 -- inject fault on QD
 select gp_inject_fault('transaction_start_under_entry_db_singleton', 'reset', 1);
 select gp_inject_fault_infinite('transaction_start_under_entry_db_singleton', 'suspend', 1);
+2&: select gp_wait_until_triggered_fault('transaction_start_under_entry_db_singleton', 1, 1);
 
 -- The QD should already hold RowExclusiveLock and ExclusiveLock on
 -- deadlock_entry_db_singleton_table and the QE ENTRY_DB_SINGLETON
@@ -46,7 +47,7 @@ select gp_inject_fault_infinite('transaction_start_under_entry_db_singleton', 's
 1&:UPDATE deadlock_entry_db_singleton_table set d = d + 1 FROM (select 1 from deadlock_entry_db_singleton_table, function_volatile(5)) t;
 
 -- verify the fault hit
-select gp_inject_fault('transaction_start_under_entry_db_singleton', 'status', 1);
+2<:
 
 -- This session will wait for ExclusiveLock on
 -- deadlock_entry_db_singleton_table.


### PR DESCRIPTION
Issue is immediately after backgrounded sql statement we check whether
the fault was hit. However, there is a scenario where if that statement
takes time to finish then the subsequent check to verify fault was hit
is executed too soon. Fix to use gp_wait_until_triggered_fault. This was
found in CI and is locally reproduced with following diff:

    ```
    @@ -2242,6 +2242,7 @@ StartTransaction(void)

            if (DistributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON)
            {
    +               sleep(5);
                    SIMPLE_FAULT_INJECTOR("transaction_start_under_entry_db_singleton");
            }
    ```

Failed CI run: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/6X_STABLE/jobs/icw_gporca_centos7/builds/656