### PR TITLE
Harden analyze rootpartition to merge stats if relpages is incorrect

### DIFF
--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1092,7 +1092,7 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 		int32		relpages = get_rel_relpages(partRelid);
 
 		/* Partition is analyzed and we detect it is empty */
-		if (relTuples == 0.0 && relpages == 1)
+		if (relTuples == 0.0 && relpages > 0)
 			continue;
 
 		all_parts_empty = false;

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1948,3 +1948,23 @@ SELECT relname, relpages, reltuples FROM pg_class WHERE relname LIKE 'incr_analy
  incr_analyze_test_1_prt_6 |        1 |         0
 (7 rows)
 
+-- Test merging of stats if an empty partition contains relpages > 0
+-- Do not collect samples while merging stats
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int) PARTITION BY RANGE (b) (START (0) END (6) EVERY (3));
+INSERT INTO foo SELECT i,i%3 FROM generate_series(1,10)i;
+ANALYZE foo_1_prt_1;
+ANALYZE foo_1_prt_2;
+SET allow_system_table_mods = on;
+UPDATE pg_class set relpages=3 WHERE relname='foo_1_prt_2';
+RESET allow_system_table_mods;
+analyze verbose rootpartition foo;
+INFO:  analyzing "public.foo" inheritance tree
+-- ensure relpages is correctly set after analyzing
+analyze foo_1_prt_2;
+select reltuples, relpages from pg_class where relname ='foo_1_prt_2';
+ reltuples | relpages 
+-----------+----------
+         0 |        1
+(1 row)
+


### PR DESCRIPTION
`analyze rootpartition` will merge statistics if all leaf partitions
have been analyzed. If a partition is empty (that is, the reltuples is
0), we previously considered it analyzed only if the relpages was 1.

However, we have seen a case where the reltuples is 0 and relpages was
greater than 1 (one such case was resolved in 183947f8). This commit hardens 
analyze in case we encounter such a scenario, as it can make `analyze rootpartition` 
take significantly longer.