### PR TITLE
packcore: be more verbose on test failures

### DIFF
--- a/src/test/isolation2/expected/packcore.out
+++ b/src/test/isolation2/expected/packcore.out
@@ -5,18 +5,19 @@ CREATE
 
 DO LANGUAGE plpythonu $$ import os import sys import glob import shutil import subprocess 
 if sys.platform not in ('linux', 'linux2'): # packcore only works on linux return 
+def check_call(cmds): ret = subprocess.Popen(cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE) out = ret.communicate() if ret.returncode != 0: raise SystemError('''\ Command {cmds} returned non-zero exit status {retcode} stdout: {stdout} stderr: {stderr} '''.format(cmds=cmds, retcode=ret.returncode, stdout=out[0], stderr=out[1])) 
 # generate and verify a packcore tarball # # TODO: packcore can list shared libraries with gdb, ldd, or ld-linux.so, # we should verify all of them, but so far there is no cmdline option to # specify it.  although we could rename the commands to fallback to others, # we should not do it, it requires root permission and might corrupt the # developer system.  on concourse, gdb is not installed by default, so the # gdb way is not covered by the pipelines. def test_packcore(cmds): # cleanup old files and dirs shutil.rmtree(tarball, ignore_errors=True) shutil.rmtree(dirname, ignore_errors=True) 
-# generate the tarball, the packcore command should return 0 subprocess.check_call(cmds) assert os.path.isfile(tarball) 
-# extract the tarball subprocess.check_call(['tar', '-zxf', tarball]) assert os.path.isdir(dirname) 
+# generate the tarball, the packcore command should return 0 check_call(cmds) assert os.path.isfile(tarball) 
+# extract the tarball check_call(['tar', '-zxf', tarball]) assert os.path.isdir(dirname) 
 # verify that binary and shared libraries are included assert os.path.exists('{}/postgres'.format(dirname)) assert os.path.exists('{}/lib64/ld-linux-x86-64.so.2'.format(dirname)) 
-if os.path.exists('/usr/bin/gdb'): # load the coredump and run some simple gdb commands os.chdir(dirname) subprocess.check_call(['./runGDB.sh', '--batch', '--nx', '--eval-command=bt', '--eval-command=p main', '--eval-command=p fork', '--eval-command=p MyProcPid']) os.chdir('..') 
+if os.path.exists('/usr/bin/gdb'): # load the coredump and run some simple gdb commands os.chdir(dirname) check_call(['./runGDB.sh', '--batch', '--nx', '--eval-command=bt', '--eval-command=p main', '--eval-command=p fork']) os.chdir('..') 
 # gzip runs much faster with -1 os.putenv('GZIP', '-1') 
 # do not put the packcore results under master data, that will cause # failures in other tests os.chdir('/tmp') 
 gphome = os.getenv('GPHOME') assert gphome 
 postgres = '{}/bin/postgres'.format(gphome) assert os.path.exists(postgres) 
 packcore = '{}/sbin/packcore'.format(gphome) assert os.path.exists(packcore) 
-# 'packcore --help' should return 0 subprocess.check_call([packcore, '--help']) subprocess.check_call([packcore, '-h']) 
-# 'packcore --version' should return 0 subprocess.check_call([packcore, '--version']) 
+# 'packcore --help' should return 0 check_call([packcore, '--help']) check_call([packcore, '-h']) 
+# 'packcore --version' should return 0 check_call([packcore, '--version']) 
 cores = glob.glob('/tmp/core.*') if not cores: # no coredump found, skip the packcore tests return 
 corefile = cores[0] corename = os.path.basename(corefile) tarball = 'packcore-{}.tgz'.format(corename) dirname = 'packcore-{}'.format(corename) 
 # 'packcore core' should work test_packcore([packcore, corefile]) 


### PR DESCRIPTION
The packcore test failed once on the pipeline with below error:

    ERROR:  subprocess.CalledProcessError:
      Command '['tar', '-zxf', 'packcore-core.postgres.tgz']'
      returned non-zero exit status 2
    CONTEXT:  Traceback (most recent call last):
      PL/Python anonymous code block, line 72, in <module>
        corefile])
      PL/Python anonymous code block, line 26, in test_packcore
        subprocess.check_call(['tar', '-zxf', tarball])
      PL/Python anonymous code block, line 540, in check_call
    PL/Python anonymous code block

Unfortunately error details were not included.  So we modified the tests
to dump the stdout & stderr of a failed command, hopefully we could
understand what's really wrong when the error happens in the future.

Also removed one gdb check on the core, we should not assume that we are
testing against a postgres coredump, so do not check any postgres
specific symbol.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
