### PR TITLE
6X: Add ubuntu support for packcore utility

### DIFF
--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -238,8 +238,8 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
 def packCoreFile(coreFile, binary):
     packDir = './packcore-' + os.path.basename(coreFile)
     oldDir = os.getcwd()
+    os.mkdir(packDir)
     try:
-        os.mkdir(packDir)
         os.chdir(packDir)
         shutil.copy(coreFile, '.')
         _getPlatformInfo()

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -18,7 +18,8 @@ def _getPlatformInfo():
         for file in glob.glob('/etc/*release'):
             shutil.copy(file, '.')
     else:
-        Popen('/usr/bin/lsb_release -a > ./lsb_release.out', shell=True)
+        Popen('/usr/bin/lsb_release -a > ./lsb_release.out',
+              shell=True, stderr=PIPE)
 
     if os.path.exists('/etc/gpdb-appliance-version'):
         shutil.copy('/etc/gpdb-appliance-version', '.')

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -84,7 +84,14 @@ def _getLibraryListWithLDD(binary):
         '/libx32/libnss_files.so.2',
     ]
 
-    ldd_output = Popen('ldd `which postgres`', shell=True, stdout=PIPE)
+    ldd = which('ldd')
+    if ldd:
+        args = [ldd]
+    else:
+        # simulate ldd with ld-linux.so
+        args = ['/lib64/ld-linux-x86-64.so.2', '--list']
+
+    ldd_output = Popen(args + [binary], stdout=PIPE)
     for line in ldd_output.stdout:
         match = re.search(r'(\S+) \(0x', line)
         if match and match.group(1):

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -237,6 +237,7 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
 
 def packCoreFile(coreFile, binary):
     packDir = './packcore-' + os.path.basename(coreFile)
+    packTarball = packDir + '.tgz'
     oldDir = os.getcwd()
     os.mkdir(packDir)
     try:
@@ -258,8 +259,11 @@ def packCoreFile(coreFile, binary):
 
         _generateGDBScript(os.path.basename(binary), os.path.basename(coreFile))
         os.chdir(oldDir)
-        cmd = Popen('tar zcf packcore-' + os.path.basename(coreFile) + '.tgz ' + packDir, shell=True)
+        cmd = Popen(['tar', 'zcf', packTarball, packDir])
         cmd.wait()
+    except Exception as e:
+        Popen(['rm', '-rf', packTarball])
+        raise e
     finally:
         os.chdir(oldDir)
         Popen('rm -rf ' + packDir, shell=True)

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -67,8 +67,23 @@ def _getLibraryListWithLDD(binary):
     # We manually seed this with a few libraries that are missed
     # This may not be needed for all proces, but will round out the
     # postgres binary debugging
-    # TODO: Look a ways to distinguise a 32 vs. 64 bit executable
-    libraries = ['/lib64/libgcc_s.so.1', '/lib64/libnss_files.so.2', '/lib/libgcc_s.so.1', '/lib/libnss_files.so.2']
+    # TODO: Look at ways to distinguish a 32 vs. 64 bit executable
+    libraries = [
+        # on centos
+        '/lib64/libgcc_s.so.1',
+        '/lib64/libnss_files.so.2',
+        '/lib/libgcc_s.so.1',
+        '/lib/libnss_files.so.2',
+
+        # on ubuntu
+        '/lib/x86_64-linux-gnu/libgcc_s.so.1',
+        '/lib/x86_64-linux-gnu/libnss_files.so.2',
+        '/usr/lib32/libgcc_s.so.1',
+        '/lib32/libnss_files.so.2',
+        '/usr/libx32/libgcc_s.so.1',
+        '/libx32/libnss_files.so.2',
+    ]
+
     ldd_output = Popen('ldd `which postgres`', shell=True, stdout=PIPE)
     for line in ldd_output.stdout:
         match = re.search(r'(\S+) \(0x', line)

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -110,13 +110,37 @@ def _getLibraryListWithGDB(coreFile, binary):
     for key in ('PYTHONHOME', 'PYTHONPATH', 'LD_LIBRARY_PATH'):
         if key in environ:
             del environ[key]
-    cmd = Popen(gdb + ' --eval-command="quit" ' + binary + ' -c ' + coreFile, shell=True, stdout=PIPE, stderr=PIPE)
+
+    cmd = Popen([gdb,
+                 '--batch',     # exit after processing options
+                 '--nx',        # do not read any .gdbinit files
+                 '--eval-command=info sharedlibrary',
+                                # list shared libraries explicitly
+                 '-c', coreFile,
+                 binary],
+                stdout=PIPE, stderr=PIPE)
     result = cmd.communicate()[0]
 
+    # gdb output looks like below:
+    #
+    #     ...
+    #     (gdb) info sharedlibrary
+    #     From        To          Syms Read  Shared Object Library
+    #     0x00001000  0x00001234  Yes (*)    /path/to/liba.so.1.0
+    #     0x00002000  0x00002234  Yes (*)    /path/to/libb.so.1.0
+    #     0x00003000  0x00003234  Yes        /path/to/libc.so.1.0
+    #     (*): Shared library is missing debugging information.
+    #
+    # to get the list we first search for the header line, then collect all the
+    # path strings in following lines.
+    header = False
     for line in result.splitlines():
-        if line.find('Reading symbols') is 0:
-            end = line.find('...')
-            libraries.append(line[21:end])
+        if header:
+            begin = line.find(os.path.sep)
+            if begin >= 0:
+                libraries.append(line[begin:])
+        elif 'Shared Object Library' in line:
+            header = True
 
     return libraries
 

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -38,11 +38,28 @@ def _isCore(fileCmdOutput):
 
 
 def _findBinary(fileCmdOutput):
-    start = string.find(fileCmdOutput, "'") + 1
+    # execfn: '/path/to/postgres'
+    field = string.find(fileCmdOutput, 'execfn')
+    # if 'execfn' field is not found, search for 'from' field instead
+    if field < 0:
+        # from: /path/to/postgres
+        # from: postgres: 5432, ...
+        field = string.find(fileCmdOutput, 'from')
+    # if 'from' field is still missing, search for any single-quoted string
+    if field < 0:
+        field = 0
+    start = string.find(fileCmdOutput, "'", field) + 1
     end = string.find(fileCmdOutput, "'", start)
-    cmd = fileCmdOutput[start:end].split()[0].translate(None, string.punctuation)
+    if start <= 0 or end < 0:
+        return None
+    cmd = fileCmdOutput[start:end]
+    # special characters can be correctly handled in abs format, no need to
+    # remove them
     if os.path.isabs(cmd):
         return cmd
+    # otherwise try to search with the process name, punctuations like ':'
+    # should be removed
+    cmd = cmd.split()[0].translate(None, string.punctuation)
     return which(cmd)
 
 

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -157,11 +157,17 @@ def _copyFilePath(src, dst):
 
 def _generateGDBScript(b, c):
     with open('runGDB.sh', 'w') as f1:
-        print >>f1, '#!/bin/bash'
-        print >>f1, 'unset PYTHONHOME'
-        print >>f1, 'unset PYTHONPATH'
-        print >>f1, 'curDIR=`pwd`'
-        print >>f1, '/usr/bin/gdb --eval-command="set sysroot $curDIR" --eval-command="core %s" %s' % (c, b)
+        print >>f1, '''\
+#!/bin/bash
+unset PYTHONHOME
+unset PYTHONPATH
+curDIR=`pwd`
+/usr/bin/gdb \\
+    --eval-command="set sysroot $curDIR" \\
+    --eval-command="core {core}" \\
+    {binary} \\
+    "$@"
+'''.format(core=c, binary=b)
     os.chmod('runGDB.sh', 0755)
 
 

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # Copyright Pivotal 2014
 
 

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -27,7 +27,7 @@ def _getPlatformInfo():
 
 
 def _getFileInfo(coreFile):
-    cmd = Popen('/usr/bin/file ' + coreFile, shell=True, stdout=PIPE)
+    cmd = Popen(['/usr/bin/file', coreFile], stdout=PIPE)
     return cmd.communicate()[0]
 
 
@@ -266,7 +266,7 @@ def packCoreFile(coreFile, binary):
         raise e
     finally:
         os.chdir(oldDir)
-        Popen('rm -rf ' + packDir, shell=True)
+        Popen(['rm', '-rf', packDir])
 
 
 def parseArgs():

--- a/src/test/isolation2/expected/packcore.out
+++ b/src/test/isolation2/expected/packcore.out
@@ -5,18 +5,19 @@ CREATE
 
 DO LANGUAGE plpythonu $$ import os import sys import glob import shutil import subprocess 
 if sys.platform not in ('linux', 'linux2'): # packcore only works on linux return 
+def check_call(cmds): ret = subprocess.Popen(cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE) out = ret.communicate() if ret.returncode != 0: raise SystemError('''\ Command {cmds} returned non-zero exit status {retcode} stdout: {stdout} stderr: {stderr} '''.format(cmds=cmds, retcode=ret.returncode, stdout=out[0], stderr=out[1])) 
 # generate and verify a packcore tarball # # TODO: packcore can list shared libraries with gdb, ldd, or ld-linux.so, # we should verify all of them, but so far there is no cmdline option to # specify it.  although we could rename the commands to fallback to others, # we should not do it, it requires root permission and might corrupt the # developer system.  on concourse, gdb is not installed by default, so the # gdb way is not covered by the pipelines. def test_packcore(cmds): # cleanup old files and dirs shutil.rmtree(tarball, ignore_errors=True) shutil.rmtree(dirname, ignore_errors=True) 
-# generate the tarball, the packcore command should return 0 subprocess.check_call(cmds) assert os.path.isfile(tarball) 
-# extract the tarball subprocess.check_call(['tar', '-zxf', tarball]) assert os.path.isdir(dirname) 
+# generate the tarball, the packcore command should return 0 check_call(cmds) assert os.path.isfile(tarball) 
+# extract the tarball check_call(['tar', '-zxf', tarball]) assert os.path.isdir(dirname) 
 # verify that binary and shared libraries are included assert os.path.exists('{}/postgres'.format(dirname)) assert os.path.exists('{}/lib64/ld-linux-x86-64.so.2'.format(dirname)) 
-if os.path.exists('/usr/bin/gdb'): # load the coredump and run some simple gdb commands os.chdir(dirname) subprocess.check_call(['./runGDB.sh', '--batch', '--nx', '--eval-command=bt', '--eval-command=p main', '--eval-command=p fork', '--eval-command=p MyProcPid']) os.chdir('..') 
+if os.path.exists('/usr/bin/gdb'): # load the coredump and run some simple gdb commands os.chdir(dirname) check_call(['./runGDB.sh', '--batch', '--nx', '--eval-command=bt', '--eval-command=p main', '--eval-command=p fork']) os.chdir('..') 
 # gzip runs much faster with -1 os.putenv('GZIP', '-1') 
 # do not put the packcore results under master data, that will cause # failures in other tests os.chdir('/tmp') 
 gphome = os.getenv('GPHOME') assert gphome 
 postgres = '{}/bin/postgres'.format(gphome) assert os.path.exists(postgres) 
 packcore = '{}/sbin/packcore'.format(gphome) assert os.path.exists(packcore) 
-# 'packcore --help' should return 0 subprocess.check_call([packcore, '--help']) subprocess.check_call([packcore, '-h']) 
-# 'packcore --version' should return 0 subprocess.check_call([packcore, '--version']) 
+# 'packcore --help' should return 0 check_call([packcore, '--help']) check_call([packcore, '-h']) 
+# 'packcore --version' should return 0 check_call([packcore, '--version']) 
 cores = glob.glob('/tmp/core.*') if not cores: # no coredump found, skip the packcore tests return 
 corefile = cores[0] corename = os.path.basename(corefile) tarball = 'packcore-{}.tgz'.format(corename) dirname = 'packcore-{}'.format(corename) 
 # 'packcore core' should work test_packcore([packcore, corefile]) 

--- a/src/test/isolation2/expected/packcore.out
+++ b/src/test/isolation2/expected/packcore.out
@@ -11,6 +11,7 @@ if sys.platform not in ('linux', 'linux2'): # packcore only works on linux retur
 # verify that binary and shared libraries are included assert os.path.exists('{}/postgres'.format(dirname)) assert os.path.exists('{}/lib64/ld-linux-x86-64.so.2'.format(dirname)) 
 if os.path.exists('/usr/bin/gdb'): # load the coredump and run some simple gdb commands os.chdir(dirname) subprocess.check_call(['./runGDB.sh', '--batch', '--nx', '--eval-command=bt', '--eval-command=p main', '--eval-command=p fork', '--eval-command=p MyProcPid']) os.chdir('..') 
 # gzip runs much faster with -1 os.putenv('GZIP', '-1') 
+# do not put the packcore results under master data, that will cause # failures in other tests os.chdir('/tmp') 
 gphome = os.getenv('GPHOME') assert gphome 
 postgres = '{}/bin/postgres'.format(gphome) assert os.path.exists(postgres) 
 packcore = '{}/sbin/packcore'.format(gphome) assert os.path.exists(packcore) 

--- a/src/test/isolation2/expected/packcore.out
+++ b/src/test/isolation2/expected/packcore.out
@@ -1,0 +1,24 @@
+-- start_ignore
+CREATE LANGUAGE plpythonu;
+CREATE
+-- end_ignore
+
+DO LANGUAGE plpythonu $$ import os import sys import glob import shutil import subprocess 
+if sys.platform not in ('linux', 'linux2'): # packcore only works on linux return 
+# generate and verify a packcore tarball # # TODO: packcore can list shared libraries with gdb, ldd, or ld-linux.so, # we should verify all of them, but so far there is no cmdline option to # specify it.  although we could rename the commands to fallback to others, # we should not do it, it requires root permission and might corrupt the # developer system.  on concourse, gdb is not installed by default, so the # gdb way is not covered by the pipelines. def test_packcore(cmds): # cleanup old files and dirs shutil.rmtree(tarball, ignore_errors=True) shutil.rmtree(dirname, ignore_errors=True) 
+# generate the tarball, the packcore command should return 0 subprocess.check_call(cmds) assert os.path.isfile(tarball) 
+# extract the tarball subprocess.check_call(['tar', '-zxf', tarball]) assert os.path.isdir(dirname) 
+# verify that binary and shared libraries are included assert os.path.exists('{}/postgres'.format(dirname)) assert os.path.exists('{}/lib64/ld-linux-x86-64.so.2'.format(dirname)) 
+if os.path.exists('/usr/bin/gdb'): # load the coredump and run some simple gdb commands os.chdir(dirname) subprocess.check_call(['./runGDB.sh', '--batch', '--nx', '--eval-command=bt', '--eval-command=p main', '--eval-command=p fork', '--eval-command=p MyProcPid']) os.chdir('..') 
+# gzip runs much faster with -1 os.putenv('GZIP', '-1') 
+gphome = os.getenv('GPHOME') assert gphome 
+postgres = '{}/bin/postgres'.format(gphome) assert os.path.exists(postgres) 
+packcore = '{}/sbin/packcore'.format(gphome) assert os.path.exists(packcore) 
+# 'packcore --help' should return 0 subprocess.check_call([packcore, '--help']) subprocess.check_call([packcore, '-h']) 
+# 'packcore --version' should return 0 subprocess.check_call([packcore, '--version']) 
+cores = glob.glob('/tmp/core.*') if not cores: # no coredump found, skip the packcore tests return 
+corefile = cores[0] corename = os.path.basename(corefile) tarball = 'packcore-{}.tgz'.format(corename) dirname = 'packcore-{}'.format(corename) 
+# 'packcore core' should work test_packcore([packcore, corefile]) 
+# 'packcore -b postgres core' should work test_packcore([packcore, '--binary={}'.format(postgres), corefile]) test_packcore([packcore, '--binary', postgres, corefile]) test_packcore([packcore, '-b', postgres, corefile]) $$;
+DO
+-- vi: sw=4 et :

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -20,6 +20,10 @@ test: unlogged_heap_tables
 test: unlogged_appendonly_tables
 test: udf_exception_blocks_panic_scenarios
 
+# Tests for packcore, will use the coredumps generated in crash_recovery_dtm,
+# so must be scheduled after that one.
+test: packcore
+
 # Tests on global deadlock detector
 test: select_for_update
 test: gdd/prepare

--- a/src/test/isolation2/sql/packcore.sql
+++ b/src/test/isolation2/sql/packcore.sql
@@ -53,6 +53,10 @@ DO LANGUAGE plpythonu $$
     # gzip runs much faster with -1
     os.putenv('GZIP', '-1')
 
+    # do not put the packcore results under master data, that will cause
+    # failures in other tests
+    os.chdir('/tmp')
+
     gphome = os.getenv('GPHOME')
     assert gphome
 

--- a/src/test/isolation2/sql/packcore.sql
+++ b/src/test/isolation2/sql/packcore.sql
@@ -1,0 +1,97 @@
+-- start_ignore
+CREATE LANGUAGE plpythonu;
+-- end_ignore
+
+DO LANGUAGE plpythonu $$
+    import os
+    import sys
+    import glob
+    import shutil
+    import subprocess
+
+    if sys.platform not in ('linux', 'linux2'):
+        # packcore only works on linux
+        return
+
+    # generate and verify a packcore tarball
+    #
+    # TODO: packcore can list shared libraries with gdb, ldd, or ld-linux.so,
+    # we should verify all of them, but so far there is no cmdline option to
+    # specify it.  although we could rename the commands to fallback to others,
+    # we should not do it, it requires root permission and might corrupt the
+    # developer system.  on concourse, gdb is not installed by default, so the
+    # gdb way is not covered by the pipelines.
+    def test_packcore(cmds):
+        # cleanup old files and dirs
+        shutil.rmtree(tarball, ignore_errors=True)
+        shutil.rmtree(dirname, ignore_errors=True)
+
+        # generate the tarball, the packcore command should return 0
+        subprocess.check_call(cmds)
+        assert os.path.isfile(tarball)
+
+        # extract the tarball
+        subprocess.check_call(['tar', '-zxf', tarball])
+        assert os.path.isdir(dirname)
+
+        # verify that binary and shared libraries are included
+        assert os.path.exists('{}/postgres'.format(dirname))
+        assert os.path.exists('{}/lib64/ld-linux-x86-64.so.2'.format(dirname))
+
+        if os.path.exists('/usr/bin/gdb'):
+            # load the coredump and run some simple gdb commands
+            os.chdir(dirname)
+            subprocess.check_call(['./runGDB.sh',
+                                   '--batch',
+                                   '--nx',
+                                   '--eval-command=bt',
+                                   '--eval-command=p main',
+                                   '--eval-command=p fork',
+                                   '--eval-command=p MyProcPid'])
+            os.chdir('..')
+
+    # gzip runs much faster with -1
+    os.putenv('GZIP', '-1')
+
+    gphome = os.getenv('GPHOME')
+    assert gphome
+
+    postgres = '{}/bin/postgres'.format(gphome)
+    assert os.path.exists(postgres)
+
+    packcore = '{}/sbin/packcore'.format(gphome)
+    assert os.path.exists(packcore)
+
+    # 'packcore --help' should return 0
+    subprocess.check_call([packcore, '--help'])
+    subprocess.check_call([packcore, '-h'])
+
+    # 'packcore --version' should return 0
+    subprocess.check_call([packcore, '--version'])
+
+    cores = glob.glob('/tmp/core.*')
+    if not cores:
+        # no coredump found, skip the packcore tests
+        return
+
+    corefile = cores[0]
+    corename = os.path.basename(corefile)
+    tarball = 'packcore-{}.tgz'.format(corename)
+    dirname = 'packcore-{}'.format(corename)
+
+    # 'packcore core' should work
+    test_packcore([packcore,
+                   corefile])
+
+    # 'packcore -b postgres core' should work
+    test_packcore([packcore,
+                   '--binary={}'.format(postgres),
+                   corefile])
+    test_packcore([packcore,
+                   '--binary', postgres,
+                   corefile])
+    test_packcore([packcore,
+                   '-b', postgres,
+                   corefile])
+$$;
+-- vi: sw=4 et :


### PR DESCRIPTION
The packcore utility is a useful tool to collect a coredump and dependent shared libraries, however it only supports centos.  Now we add ubuntu support for it:

- list libraries with gdb explicitly
- list libraries with ld-linux.so when ldd is unavailable
- add missing libraries for ubuntu
- find correct binary path with file command
- use /usr/bin/env in shebang

Please refer to each commit for details.

Fixes https://github.com/greenplum-db/gpdb/issues/9145

This PR back ports https://github.com/greenplum-db/gpdb/pull/9153 to 6X.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
