### PR TITLE
Make pipeline task ictcp ORCA enabled.

### DIFF
--- a/concourse/pipelines/gpdb_master-generated.yml
+++ b/concourse/pipelines/gpdb_master-generated.yml
@@ -39,7 +39,7 @@ groups:
   ## --------------------------------------------------------------------
   - icw_gporca_centos6
   - icw_planner_centos6
-  - icw_planner_ictcp_centos6
+  - icw_gporca_ictcp_centos6
   - gpexpand
   - pg_upgrade
   - icw_gporca_centos7
@@ -120,7 +120,7 @@ groups:
   jobs:
   - icw_gporca_centos6
   - icw_planner_centos6
-  - icw_planner_ictcp_centos6
+  - icw_gporca_ictcp_centos6
   - compile_gpdb_centos6
   - pg_upgrade
   - icw_gporca_centos7
@@ -967,7 +967,7 @@ jobs:
     params:
       file: sqldump/dump.sql.xz
 
-- name: icw_planner_ictcp_centos6
+- name: icw_gporca_ictcp_centos6
   plan:
   - aggregate:
     - get: gpdb_src
@@ -1063,7 +1063,7 @@ jobs:
       passed:
       - icw_gporca_centos6
       - icw_planner_centos6
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
     - get: icw_gporca_centos6_dump
       passed:
@@ -1072,7 +1072,7 @@ jobs:
       passed:
       - icw_gporca_centos6
       - icw_planner_centos6
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - icw_gporca_centos7
       trigger: true
@@ -3197,7 +3197,7 @@ jobs:
       - icw_planner_centos7
       - icw_gporca_ubuntu18.04
       - icw_planner_ubuntu18.04
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - resource_group_centos6
       - resource_group_centos7
@@ -3249,7 +3249,7 @@ jobs:
       - compile_gpdb_centos6
       - icw_planner_centos6
       - icw_gporca_centos6
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - resource_group_centos6
       - gpmovemirrors

--- a/concourse/pipelines/gpdb_pg_merge.yml
+++ b/concourse/pipelines/gpdb_pg_merge.yml
@@ -40,7 +40,7 @@ groups:
   - icw_gporca_centos6
   - icw_gporca_centos6_gpos_memory
   - icw_planner_centos6
-  - icw_planner_ictcp_centos6
+  - icw_gporca_ictcp_centos6
   - gpexpand
   - pg_upgrade
   - icw_gporca_centos7
@@ -119,7 +119,7 @@ groups:
   - icw_gporca_centos6
   - icw_gporca_centos6_gpos_memory
   - icw_planner_centos6
-  - icw_planner_ictcp_centos6
+  - icw_gporca_ictcp_centos6
   - compile_gpdb_centos6
   - pg_upgrade
   - icw_gporca_centos7
@@ -1004,7 +1004,7 @@ jobs:
       TEST_OS: centos
       CONFIGURE_FLAGS: {{configure_flags}}
 
-- name: icw_planner_ictcp_centos6
+- name: icw_gporca_ictcp_centos6
   plan:
   - in_parallel:
     - get: gpdb_src
@@ -1109,7 +1109,7 @@ jobs:
       - icw_gporca_centos6
       - icw_gporca_centos6_gpos_memory
       - icw_planner_centos6
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
     - get: icw_gporca_centos6_dump
       passed:
@@ -1119,7 +1119,7 @@ jobs:
       - icw_gporca_centos6
       - icw_gporca_centos6_gpos_memory
       - icw_planner_centos6
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - icw_gporca_centos7
       trigger: true
@@ -3105,7 +3105,7 @@ jobs:
       - icw_planner_centos7
       - icw_gporca_ubuntu18.04
       - icw_planner_ubuntu18.04
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - resource_group_centos6
       - resource_group_centos7
@@ -3155,7 +3155,7 @@ jobs:
       - compile_gpdb_centos6
       - icw_planner_centos6
       - icw_gporca_centos6
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - resource_group_centos6
       - gpmovemirrors

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -66,7 +66,7 @@ groups:
 {% if "centos6" in os_types %}
   - icw_gporca_centos6
   - icw_planner_centos6
-  - icw_planner_ictcp_centos6
+  - icw_gporca_ictcp_centos6
 {% endif %}
 {% if "centos6" in os_types and "CLI" in test_sections %}
   - gpexpand
@@ -172,7 +172,7 @@ groups:
 {% if "centos6" in os_types %}
   - icw_gporca_centos6
   - icw_planner_centos6
-  - icw_planner_ictcp_centos6
+  - icw_gporca_ictcp_centos6
   - compile_gpdb_centos6
 {% endif %}
 {% if "centos6" in os_types and "CLI" in test_sections %}
@@ -1139,7 +1139,7 @@ jobs:
     params:
       file: sqldump/dump.sql.xz
 
-- name: icw_planner_ictcp_centos6
+- name: icw_gporca_ictcp_centos6
   plan:
   - aggregate:
     - get: gpdb_src
@@ -1153,7 +1153,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb6-centos6-test
     params:
-      MAKE_TEST_COMMAND: -k PGOPTIONS='-c gp_interconnect_type=tcp -c optimizer=off' installcheck-world
+      MAKE_TEST_COMMAND: -k PGOPTIONS='-c gp_interconnect_type=tcp -c optimizer=on' installcheck-world
       TEST_OS: centos
 
 {% endif %}
@@ -1241,7 +1241,7 @@ jobs:
       passed:
       - icw_gporca_centos6
       - icw_planner_centos6
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
 {% if "Extensions" in test_sections %}
       - icw_extensions_gpcloud_centos6
 {% endif %}
@@ -1256,7 +1256,7 @@ jobs:
 {% if "centos6" in os_types %}
       - icw_gporca_centos6
       - icw_planner_centos6
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
 {% if "Extensions" in test_sections %}
       - icw_extensions_gpcloud_centos6
 {% endif %}
@@ -2010,7 +2010,7 @@ jobs:
       - icw_planner_centos7
       - icw_gporca_ubuntu18.04
       - icw_planner_ubuntu18.04
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - resource_group_centos6
       - resource_group_centos7
@@ -2036,7 +2036,7 @@ jobs:
       - compile_gpdb_centos6
       - icw_planner_centos6
       - icw_gporca_centos6
-      - icw_planner_ictcp_centos6
+      - icw_gporca_ictcp_centos6
       - icw_extensions_gpcloud_centos6
       - resource_group_centos6
 {% for test in CLI_BEHAVE_TESTS %}


### PR DESCRIPTION
ORCA is default enabled, so the only task to test ictcp should use orca.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
