### PR TITLE
Fix pushdown of joins and aggregates to foreign servers.

### DIFF
--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -169,9 +169,15 @@ ExecInitForeignScan(ForeignScan *node, EState *estate, int eflags)
 
 	/*
 	 * tuple table initialization
+	 *
+	 * In GPDB, cannot use ExecInitScanTupleSlot() on foreign scans of join
+	 * relations.
 	 */
 	ExecInitResultTupleSlot(estate, &scanstate->ss.ps);
-	ExecInitScanTupleSlot(estate, &scanstate->ss);
+	if (scanrelid > 0)
+		ExecInitScanTupleSlot(estate, &scanstate->ss);
+	else
+		scanstate->ss.ss_ScanTupleSlot = ExecAllocTableSlot(&estate->es_tupleTable);
 
 	/*
 	 * open the base relation, if any, and acquire an appropriate lock on it;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2458,6 +2458,7 @@ grouping_planner(PlannerInfo *root, bool inheritance_update,
 	final_rel->userid = current_rel->userid;
 	final_rel->useridiscurrent = current_rel->useridiscurrent;
 	final_rel->fdwroutine = current_rel->fdwroutine;
+	final_rel->exec_location = current_rel->exec_location;
 
 	if (root->is_split_update)
 	{
@@ -3913,6 +3914,7 @@ create_grouping_paths(PlannerInfo *root,
 	grouped_rel->userid = input_rel->userid;
 	grouped_rel->useridiscurrent = input_rel->useridiscurrent;
 	grouped_rel->fdwroutine = input_rel->fdwroutine;
+	grouped_rel->exec_location = input_rel->exec_location;
 
 	/*
 	 * Check for degenerate grouping.
@@ -4703,6 +4705,7 @@ create_window_paths(PlannerInfo *root,
 	window_rel->userid = input_rel->userid;
 	window_rel->useridiscurrent = input_rel->useridiscurrent;
 	window_rel->fdwroutine = input_rel->fdwroutine;
+	window_rel->exec_location = input_rel->exec_location;
 
 	/*
 	 * Consider computing window functions starting from the existing
@@ -5011,6 +5014,7 @@ create_distinct_paths(PlannerInfo *root,
 	distinct_rel->userid = input_rel->userid;
 	distinct_rel->useridiscurrent = input_rel->useridiscurrent;
 	distinct_rel->fdwroutine = input_rel->fdwroutine;
+	distinct_rel->exec_location = input_rel->exec_location;
 
 	/* Estimate number of distinct rows there will be */
 	if (parse->groupClause || parse->groupingSets || parse->hasAggs ||
@@ -5358,6 +5362,7 @@ create_ordered_paths(PlannerInfo *root,
 	ordered_rel->userid = input_rel->userid;
 	ordered_rel->useridiscurrent = input_rel->useridiscurrent;
 	ordered_rel->fdwroutine = input_rel->fdwroutine;
+	ordered_rel->exec_location = input_rel->exec_location;
 
 	foreach(lc, input_rel->pathlist)
 	{

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3145,7 +3145,7 @@ create_foreignscan_path(PlannerInfo *root, RelOptInfo *rel,
 	pathnode->path.total_cost = total_cost;
 	pathnode->path.pathkeys = pathkeys;
 
-	switch (rel->ftEntry->exec_location)
+	switch (rel->exec_location)
 	{
 		case FTEXECLOCATION_ANY:
 			CdbPathLocus_MakeGeneral(&(pathnode->path.locus));
@@ -3157,7 +3157,7 @@ create_foreignscan_path(PlannerInfo *root, RelOptInfo *rel,
 			CdbPathLocus_MakeEntry(&(pathnode->path.locus));
 			break;
 		default:
-			elog(ERROR, "unrecognized exec_location '%c'", rel->ftEntry->exec_location);
+			elog(ERROR, "unrecognized exec_location '%c'", rel->exec_location);
 	}
 
 	pathnode->fdw_outerpath = fdw_outerpath;

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -147,10 +147,6 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 	if (rel->relstorage == RELSTORAGE_EXTERNAL)
 		get_external_relation_info(relation, rel);
 
-	/* If it's an foreign table, get info from catalog */
-	if (rel->relstorage == RELSTORAGE_FOREIGN)
-		rel->ftEntry = GetForeignTable(RelationGetRelid(relation));
-
 	/*
 	 * Estimate relation size --- unless it's an inheritance parent, in which
 	 * case the size will be computed later in set_append_rel_pathlist, and we
@@ -434,11 +430,13 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 	{
 		rel->serverid = GetForeignServerIdByRelId(RelationGetRelid(relation));
 		rel->fdwroutine = GetFdwRoutineForRelation(relation, true);
+		rel->exec_location = GetForeignTable(RelationGetRelid(relation))->exec_location;
 	}
 	else
 	{
 		rel->serverid = InvalidOid;
 		rel->fdwroutine = NULL;
+		rel->exec_location = FTEXECLOCATION_NOT_DEFINED;
 	}
 
 	/* Collect info about relation's foreign keys, if relevant */

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -674,6 +674,7 @@ typedef struct RelOptInfo
 	Oid			serverid;		/* identifies server for the table or join */
 	Oid			userid;			/* identifies user to check access as */
 	bool		useridiscurrent;	/* join is only valid for current user */
+	char		exec_location;  /* execute on MASTER, ANY or ALL SEGMENTS, Greenplum MPP specific */
 	/* use "struct FdwRoutine" to avoid including fdwapi.h here */
 	struct FdwRoutine *fdwroutine;
 	void	   *fdw_private;
@@ -697,9 +698,6 @@ typedef struct RelOptInfo
 	 */
 	List	   *upperrestrictinfo;		/* RestrictInfo structures (if base
 										 * rel) */
-
-	/* used by foreign scan */
-	ForeignTable		*ftEntry;
 } RelOptInfo;
 
 /*


### PR DESCRIPTION
The planner code assumed that a foreign path is only created for a
base relation. But that is not a valid assumption, a FDW may push down
joins and aggregates, too, which will be represented by the join or
upper rels in the planner. The code in create_foreign_path() tried
to look up the EXECUTE ON attribute from the RelOptInfo->ftEntry field,
but that was only set for base relations, which caused a crash when
pushing down a join or an aggregate.

To fix, propagate the 'exec_location' field to join and upper rels, just
like the fdwroutine and serverid fields are propagated. Unfortunately this
creates a rather large diff, those fields are set in many places. That has
the potential for bugs-of-omission, as we merge with upstream, but I don't
see a better way. If such a bug happens, though, I believe the consequence
is just a graceful error from the planner, or a missed push-down, so I
think we can live with it.

Fixes github issue https://github.com/greenplum-db/gpdb/issues/9209
