### PR TITLE
Multiple Distinct-qualified Aggregation(Multi-DQA) MPP execution method 

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -184,15 +184,15 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 	if (!CdbPathLocus_IsPartitioned(cheapest_path->locus))
 		return;
 
-	memset(&cxt, 0, sizeof(cxt));
-	cxt.target = target;
-	cxt.partial_grouping_target = partial_grouping_target;
-	cxt.dNumGroups = dNumGroups;
-	cxt.agg_costs = agg_costs;
-	cxt.agg_partial_costs = agg_partial_costs;
-	cxt.agg_final_costs = agg_final_costs;
-	cxt.rollup_lists = rollup_lists;
-	cxt.rollup_groupclauses = rollup_groupclauses;
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.target = target;
+	ctx.partial_grouping_target = partial_grouping_target;
+	ctx.dNumGroups = dNumGroups;
+	ctx.agg_costs = agg_costs;
+	ctx.agg_partial_costs = agg_partial_costs;
+	ctx.agg_final_costs = agg_final_costs;
+	ctx.rollup_lists = rollup_lists;
+	ctx.rollup_groupclauses = rollup_groupclauses;
 
 	/*
 	 * Consider 2-phase aggs

--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -348,7 +348,6 @@ add_twostage_group_agg_path(PlannerInfo *root,
 	DQAType     dqa_type;
 	CdbPathLocus group_locus;
 	bool		need_redistribute;
-	int			extra_aggsplitops = 0;
 	List		*motion_pathkeys = NIL;
 	List		*grouping_sets_tlist = NIL;
 	List		*grouping_sets_groupClause = NIL;

--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -25,6 +25,7 @@
 #include "executor/execHHashagg.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
+#include "optimizer/clauses.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/paths.h"
 #include "optimizer/tlist.h"
@@ -33,6 +34,15 @@
 #include "parser/parse_oper.h"
 #include "utils/lsyscache.h"
 
+typedef enum
+{
+	INVALID_DQA = -1,
+	SINGLE_DQA, /* only one unique DQA expr */
+	MULTI_DQAS, /* multiple DQA exprs */
+	SINGLE_DQA_WITHAGG, /* only one unique DQA expr with agg */
+	MULTI_DQAS_WITHAGG/* mixed DQA and normal aggregate */
+} DQAType;
+
 /*
  * For convenience, we collect various inputs and intermediate planning results
  * in this struct, instead of passing a dozen arguments to all subroutines.
@@ -40,6 +50,7 @@
 typedef struct
 {
 	/* Inputs from the caller */
+	DQAType     type;
 	PathTarget *target;
 	PathTarget *partial_grouping_target;
 	double		dNumGroups;
@@ -49,6 +60,22 @@ typedef struct
 	List *rollup_lists;
 	List *rollup_groupclauses;
 } cdb_agg_planning_context;
+
+typedef struct
+{
+	DQAType     type;
+
+	PathTarget  *final_target;          /* finalize agg tlist */
+	PathTarget  *partial_target;        /* partial agg tlist */
+	PathTarget  *tup_split_target;      /* AggExprId + subpath_proj_target */
+	PathTarget  *input_proj_target;     /* input tuple tlist + DQA expr */
+
+	List        *dqa_group_clause;      /* DQA exprs + group by clause for remove duplication */
+
+	int          numDisDQAs;            /* the number of different dqa exprs */
+	Bitmapset  **agg_args_id_bms;       /* each DQA's arg indexes bitmapset */
+
+} cdb_multi_dqas_info;
 
 static Index add_gsetid_tlist(List *tlist);
 
@@ -68,13 +95,40 @@ static void add_twostage_hash_agg_path(PlannerInfo *root,
 static void add_single_dqa_hash_agg_path(PlannerInfo *root,
 										 Path *path,
 										 cdb_agg_planning_context *ctx,
-										 RelOptInfo *output_rel);
+										 RelOptInfo *output_rel,
+										 PathTarget *input_target,
+										 List       *dqa_group_clause);
 
-static bool analyze_dqas(PlannerInfo *root,
-						 Path *path,
-						 cdb_agg_planning_context *ctx,
-						 PathTarget **dqa_input_target_p,
-						 List	   **dqa_group_clause_p);
+static void add_single_mixed_dqa_hash_agg_path(PlannerInfo *root,
+                                               Path *path,
+                                               cdb_agg_planning_context *ctx,
+                                               RelOptInfo *output_rel,
+                                               PathTarget *input_target,
+                                               List       *dqa_group_clause);
+static void
+add_multi_dqas_hash_agg_path(PlannerInfo *root,
+							 Path *path,
+							 cdb_agg_planning_context *ctx,
+							 RelOptInfo *output_rel,
+							 cdb_multi_dqas_info *info);
+
+static void
+fetch_single_dqa_info(PlannerInfo *root,
+					  Path *path,
+					  cdb_agg_planning_context *ctx,
+					  cdb_multi_dqas_info *info);
+
+static void
+fetch_multi_dqas_info(PlannerInfo *root,
+					  Path *path,
+					  cdb_agg_planning_context *ctx,
+					  cdb_multi_dqas_info *info);
+
+static DQAType
+recognize_dqa_type(cdb_agg_planning_context *ctx);
+
+static PathTarget *
+strip_aggdistinct(PathTarget *target);
 
 /*
  * Function: cdb_grouping_planner
@@ -101,7 +155,7 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 	Query	   *parse = root->parse;
 	Path	   *cheapest_path = input_rel->cheapest_total_path;
 	bool		has_ordered_aggs = agg_costs->numPureOrderedAggs > 0;
-	cdb_agg_planning_context cxt;
+	cdb_agg_planning_context ctx;
 
 	/* The caller should've checked these already */
 	Assert(parse->hasAggs || parse->groupClause);
@@ -159,7 +213,7 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 				add_twostage_group_agg_path(root,
 											path,
 											is_sorted,
-											&cxt,
+											&ctx,
 											output_rel);
 			}
 		}
@@ -169,7 +223,7 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 	{
 		add_twostage_hash_agg_path(root,
 								   cheapest_path,
-								   &cxt,
+								   &ctx,
 								   output_rel);
 	}
 
@@ -178,15 +232,51 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 		/*
 		 * Try possible plans for DISTINCT-qualified aggregate.
 		 */
-		add_single_dqa_hash_agg_path(root,
-									 cheapest_path,
-									 &cxt,
-									 output_rel);
+		cdb_multi_dqas_info info = {};
+		DQAType type = recognize_dqa_type(&ctx);
+		switch (type)
+		{
+		case SINGLE_DQA:
+			{
+				fetch_single_dqa_info(root, cheapest_path, &ctx, &info);
+
+				add_single_dqa_hash_agg_path(root,
+											 cheapest_path,
+											 &ctx,
+											 output_rel,
+											 info.input_proj_target,
+											 info.dqa_group_clause);
+			}
+			break;
+		case SINGLE_DQA_WITHAGG:
+			{
+				fetch_single_dqa_info(root, cheapest_path, &ctx, &info);
+
+				add_single_mixed_dqa_hash_agg_path(root,
+				                                   cheapest_path,
+				                                   &ctx,
+				                                   output_rel,
+				                                   info.input_proj_target,
+				                                   info.dqa_group_clause);
+			}
+			break;
+		case MULTI_DQAS:
+			{
+				fetch_multi_dqas_info(root, cheapest_path, &ctx, &info);
+
+				add_multi_dqas_hash_agg_path(root,
+											 cheapest_path,
+											 &ctx,
+											 output_rel,
+											 &info);
+			}
+			break;
+		case MULTI_DQAS_WITHAGG:
+			break;
+		default:
+			break;
+		}
 	}
-	/*
-	 * GPDB_96_MERGE_FIXME: multiple DISTINCT-Qualified Aggregates
-	 * not re-implemented yet
-	 */
 }
 
 /*
@@ -255,6 +345,7 @@ add_twostage_group_agg_path(PlannerInfo *root,
 	Query	   *parse = root->parse;
 	CdbPathLocus singleQE_locus;
 	Path	   *initial_agg_path = NULL;
+	DQAType     dqa_type;
 	CdbPathLocus group_locus;
 	bool		need_redistribute;
 	int			extra_aggsplitops = 0;
@@ -347,26 +438,33 @@ add_twostage_group_agg_path(PlannerInfo *root,
 
 	if (ctx->agg_costs->distinctAggrefs)
 	{
-		PathTarget *input_target;
-		List	   *dqa_group_clause;
+		cdb_multi_dqas_info info = {};
 		CdbPathLocus distinct_locus;
 		bool		distinct_need_redistribute;
 
-		if (!analyze_dqas(root, path, ctx, &input_target, &dqa_group_clause))
+		dqa_type = recognize_dqa_type(ctx);
+
+		if (dqa_type != SINGLE_DQA)
 			return;
 
-		path = (Path *) create_projection_path(root, path->parent, path, input_target);
+		fetch_single_dqa_info(root, path, ctx, &info);
+
+		/*
+		 * If subpath is projection capable, we do not want to generate a
+		 * projection plan. The reason is that the projection plan does not
+		 * constrain a child tlist when it creates subplan. Thus, GROUP BY expr
+		 * may not be found in the scan targetlist.
+		 */
+		path = apply_projection_to_path(root, path->parent, path, info.input_proj_target);
 
 		distinct_locus = cdb_choose_grouping_locus(root, path,
-												   input_target,
-												   dqa_group_clause, NIL, NIL,
+												   info.input_proj_target,
+												   info.dqa_group_clause, NIL, NIL,
 												   &distinct_need_redistribute);
 
 		/* If the input distribution matches the distinct, we can proceed */
 		if (distinct_need_redistribute)
 			return;
-
-		extra_aggsplitops = AGGSPLITOP_DEDUPLICATED;
 	}
 
 	if (!is_sorted)
@@ -585,126 +683,89 @@ strip_aggdistinct(PathTarget *target)
 	return result;
 }
 
-static bool
-analyze_dqas(PlannerInfo *root,
-			 Path *path,
-			 cdb_agg_planning_context *ctx,
-			 PathTarget **dqa_input_target_p,
-			 List	   **dqa_group_clause_p)
+/*
+ * Create Paths for an Aggregate with one DISTINCT-qualified aggregate and
+ * multi normal aggregate.
+ */
+static void add_single_mixed_dqa_hash_agg_path(PlannerInfo *root,
+                                               Path *path,
+                                               cdb_agg_planning_context *ctx,
+                                               RelOptInfo *output_rel,
+                                               PathTarget *input_target,
+                                               List       *dqa_group_clause)
 {
 	Query	   *parse = root->parse;
-	PathTarget *input_target;
-	List	   *dqa_group_clause;
-	ListCell   *lc;
-	Index		sortgroupref;
-	Index		maxRef;
+	CdbPathLocus group_locus;
+	bool		group_need_redistribute;
+	CdbPathLocus distinct_locus;
+	bool		distinct_need_redistribute;
+	HashAggTableSizes hash_info;
 
-	/* Prepare a modifiable copy of the input path target */
-	input_target = copy_pathtarget(path->pathtarget);
-	maxRef = 0;
-	if (input_target->sortgrouprefs)
-	{
-		for (int idx = 0; idx < list_length(input_target->exprs); idx++)
-		{
-			if (input_target->sortgrouprefs[idx] > maxRef)
-				maxRef = input_target->sortgrouprefs[idx];
-		}
-	}
-	else
-		input_target->sortgrouprefs = (Index *) palloc0(list_length(input_target->exprs) * sizeof(Index));
+	if (!gp_enable_agg_distinct)
+		return;
+
+	if (!calcHashAggTableSizes(work_mem * 1024L,
+	                           ctx->dNumGroups,
+	                           path->pathtarget->width,
+	                           false,	/* force */
+	                           &hash_info))
+		return;	/* don't try to hash */
 
 	/*
-	 * Analyze the DISTINCT argument, to see if it's something we can
-	 * support.
+	 * If subpath is projection capable, we do not want to generate a
+	 * projection plan. The reason is that the projection plan does not
+	 * constrain a child tlist when it creates subplan. Thus, GROUP BY expr
+	 * may not be found in the scan targetlist.
 	 */
-	dqa_group_clause = list_copy(parse->groupClause);
-	sortgroupref = 0;
-	foreach (lc, ctx->agg_costs->distinctAggrefs)
+	path = apply_projection_to_path(root, path->parent, path, input_target);
+
+	distinct_locus = cdb_choose_grouping_locus(root, path,
+	                                           input_target,
+	                                           dqa_group_clause, NIL, NIL,
+	                                           &distinct_need_redistribute);
+	group_locus = cdb_choose_grouping_locus(root, path,
+	                                        input_target,
+	                                        parse->groupClause, NIL, NIL,
+	                                        &group_need_redistribute);
+	if (!parse->groupClause)
 	{
-		Aggref	   *aggref = (Aggref *) lfirst(lc);
-		SortGroupClause *arg_sortcl;
-		SortGroupClause *sortcl = NULL;
-		TargetEntry *arg_tle;
-		int			idx;
-		ListCell   *lcc;
+		Path    *dqa_dist_path = path;
+		if (distinct_need_redistribute)
+			dqa_dist_path = cdbpath_create_motion_path(root, path, NIL, false,
+			                                           distinct_locus);
 
-		if (list_length(aggref->aggdistinct) != 1)
-			return false;		/* I don't think the parser can even produce this */
+		path = (Path *) create_agg_path(root,
+		                                output_rel,
+		                                dqa_dist_path,
+		                                ctx->partial_grouping_target,
+		                                AGG_PLAIN,
+		                                AGGSPLIT_INITIAL_SERIAL,
+		                                false, /* streaming */
+		                                parse->groupClause,
+		                                NIL,
+		                                ctx->agg_partial_costs, /* FIXME */
+		                                ctx->dNumGroups * getgpsegmentCount(),
+		                                &hash_info);
 
-		arg_sortcl = (SortGroupClause *) linitial(aggref->aggdistinct);
-		arg_tle = get_sortgroupref_tle(arg_sortcl->tleSortGroupRef, aggref->args);
+		if (group_need_redistribute)
+			path = cdbpath_create_motion_path(root, path, NIL, false,
+			                                  group_locus);
 
-		if (!arg_sortcl->hashable)
-		{
-			/*
-			 * XXX: I'm not sure if the hashable flag is always set correctly
-			 * for DISTINCT args. DISTINCT aggs are never implemented with hashing
-			 * in PostgreSQL.
-			 */
-			return false;
-		}
-
-		/* Now find this expression in the sub-path's target list */
-		idx = 0;
-		foreach(lcc, input_target->exprs)
-		{
-			Expr		*expr = lfirst(lcc);
-
-			if (equal(expr, arg_tle->expr))
-				break;
-			idx++;
-		}
-		if (idx == list_length(input_target->exprs))
-			add_column_to_pathtarget(input_target, arg_tle->expr, ++maxRef);
-		else if (input_target->sortgrouprefs[idx] == 0)
-			input_target->sortgrouprefs[idx] = ++maxRef;
-
-		sortcl = copyObject(arg_sortcl);
-		sortcl->tleSortGroupRef = input_target->sortgrouprefs[idx];
-		sortcl->hashable = true;	/* we verified earlier that it's hashable */
-
-		/*
-		 * There can be only one DISTINCT-qualified aggregate.
-		 */
-		if (sortgroupref == 0)
-			sortgroupref = sortcl->tleSortGroupRef;
-		else if (sortgroupref != sortcl->tleSortGroupRef)
-		{
-			return false;
-		}
-		else
-			continue;
-
-		dqa_group_clause = lappend(dqa_group_clause, sortcl);
+		path = (Path *) create_agg_path(root,
+		                                output_rel,
+		                                path,
+		                                ctx->target,
+		                                AGG_PLAIN,
+		                                AGGSPLIT_FINAL_DESERIAL,
+		                                false, /* streaming */
+		                                parse->groupClause,
+		                                (List *) parse->havingQual,
+		                                ctx->agg_final_costs,
+		                                ctx->dNumGroups,
+		                                &hash_info);
+		add_path(output_rel, path);
 	}
-
-	/* Check that there are no non-DISTINCT aggregates mixed in. */
-	List *varnos = pull_var_clause((Node *) ctx->target->exprs,
-								   PVC_INCLUDE_AGGREGATES |
-								   PVC_INCLUDE_WINDOWFUNCS |
-								   PVC_INCLUDE_PLACEHOLDERS);
-	foreach (lc, varnos)
-	{
-		Node	   *node = lfirst(lc);
-
-		if (IsA(node, Aggref))
-		{
-			Aggref	   *aggref = (Aggref *) node;
-
-			if (!aggref->aggdistinct)
-			{
-				/* mixing DISTINCT and non-DISTINCT aggs not supported */
-				return false;
-			}
-		}
-	}
-
-	/* Ok, we can do this */
-	*dqa_input_target_p = input_target;
-	*dqa_group_clause_p = dqa_group_clause;
-	return true;
 }
-
 /*
  * Create Paths for an Aggregate with one DISTINCT-qualified aggregate.
  */
@@ -712,23 +773,19 @@ static void
 add_single_dqa_hash_agg_path(PlannerInfo *root,
 							 Path *path,
 							 cdb_agg_planning_context *ctx,
-							 RelOptInfo *output_rel)
+							 RelOptInfo *output_rel,
+							 PathTarget *input_target,
+							 List       *dqa_group_clause)
 {
-	List	   *dqa_group_clause;
 	Query	   *parse = root->parse;
 	CdbPathLocus group_locus;
 	bool		group_need_redistribute;
 	CdbPathLocus distinct_locus;
 	bool		distinct_need_redistribute;
-	PathTarget *input_target = NULL;
 	HashAggTableSizes hash_info;
 
 	if (!gp_enable_agg_distinct)
 		return;
-
-	if (!analyze_dqas(root, path, ctx, &input_target, &dqa_group_clause))
-		return;
-
 
 	/*
 	 * GPDB_96_MERGE_FIXME: compute the hash table size once. But we create
@@ -742,7 +799,13 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 							   &hash_info))
 		return;	/* don't try to hash */
 
-	path = (Path *) create_projection_path(root, path->parent, path, input_target);
+	/*
+	 * If subpath is projection capable, we do not want to generate a
+	 * projection plan. The reason is that the projection plan does not
+	 * constrain a child tlist when it creates subplan. Thus, GROUP BY expr
+	 * may not be found in the scan targetlist.
+	 */
+	path = apply_projection_to_path(root, path->parent, path, input_target);
 
 	distinct_locus = cdb_choose_grouping_locus(root, path,
 											   input_target,
@@ -935,6 +998,179 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 }
 
 /*
+ * Create Paths for Multiple DISTINCT-qualified aggregates.
+ *
+ * The goal is that using a single execution path to handle all DQAs, so
+ * before removing duplication a SplitTuple node is created. This node handles
+ * each input tuple to n output tuples(n is DQA expr number). Each output tuple
+ * only contains an AggExprId, one DQA expr and all GROUP by expr. For example,
+ * SELECT DQA(a), DQA(b) FROM foo GROUP BY c;
+ * After the tuple split, two tuples are generated:
+ * -------------------
+ * | 1 | a | n/a | c |
+ * -------------------
+ * -------------------
+ * | 2 | n/a | b | c |
+ * -------------------
+ *
+ * In an aggregate executor, if the input tuple contains AggExprId, that means
+ * the tuple is split. Each value of AggExprId points to a bitmap set to
+ * represent args AttrNumber. In the Agg executor, each transfunc also keeps
+ * its own args bitmap set. The transfunc is invoked only if bitmapset matches
+ * with each other.
+ */
+static void
+add_multi_dqas_hash_agg_path(PlannerInfo *root,
+							 Path *path,
+							 cdb_agg_planning_context *ctx,
+							 RelOptInfo *output_rel,
+							 cdb_multi_dqas_info *info)
+{
+	CdbPathLocus distinct_locus;
+	bool		distinct_need_redistribute;
+	HashAggTableSizes hash_info;
+
+	if (!calcHashAggTableSizes(work_mem * 1024L,
+							   ctx->dNumGroups,
+							   path->pathtarget->width,
+							   false,	/* force */
+							   &hash_info))
+		return;
+
+	/*
+	 * If subpath is projection capable, we do not want to generate a
+	 * projection plan. The reason is that the projection plan does not
+	 * constrain a child tlist when it creates subplan. Thus, GROUP BY expr
+	 * may not be found in the scan targetlist.
+	 */
+	path = apply_projection_to_path(root, path->parent, path, info->input_proj_target);
+
+	/*
+	 * Finalize Aggregate
+	 *   -> Gather Motion
+	 *        -> Partial Aggregate
+	 *             -> HashAggregate, to remote duplicates
+	 *                  -> Redistribute Motion
+	 *                       -> TupleSplit (according to DISTINCT expr)
+	 *                            -> input
+	 */
+	path = (Path *) create_tup_split_path(root,
+										  output_rel,
+										  path,
+										  info->tup_split_target,
+										  root->parse->groupClause,
+										  info->agg_args_id_bms,
+										  info->numDisDQAs);
+
+	AggClauseCosts DedupCost = {};
+	get_agg_clause_costs(root, (Node *) info->tup_split_target->exprs,
+						 AGGSPLIT_SIMPLE,
+						 &DedupCost);
+
+	if (gp_enable_dqa_pruning)
+	{
+		/*
+		 * If we are grouping, we charge an additional cpu_operator_cost per
+		 * **grouping column** per input tuple for grouping comparisons.
+		 *
+		 * But in the tuple split case, other columns not for this DQA are
+		 * NULLs, the actual cost is way less than the number calculating based
+		 * on the length of grouping clause.
+		 *
+		 * So here we create a dummy grouping clause whose length is 1 (the
+		 * most common case of DQA), use it to calculate the cost, then set the
+		 * actual one back into the path.
+		 */
+		List *dummy_group_clause = list_make1(list_head(info->dqa_group_clause));
+
+		path = (Path *) create_agg_path(root,
+										output_rel,
+										path,
+										info->tup_split_target,
+										AGG_HASHED,
+										AGGSPLIT_SIMPLE,
+										true, /* streaming */
+										dummy_group_clause, /* only its length 1 is being used here */
+										NIL,
+										&DedupCost,
+										ctx->dNumGroups * getgpsegmentCount(),
+										&hash_info);
+
+		/* set the actual group clause back */
+		((AggPath *)path)->groupClause = info->dqa_group_clause;
+	}
+
+	distinct_locus = cdb_choose_grouping_locus(root, path,
+											   info->tup_split_target,
+											   info->dqa_group_clause, NIL, NIL,
+											   &distinct_need_redistribute);
+
+	if (distinct_need_redistribute)
+		path = cdbpath_create_motion_path(root, path, NIL, false,
+										  distinct_locus);
+
+	AggStrategy split = AGG_PLAIN;
+	unsigned long DEDUPLICATED_FLAG = 0;
+	PathTarget *partial_target = info->partial_target;
+
+	if (root->parse->groupClause)
+	{
+		path = (Path *) create_agg_path(root,
+										output_rel,
+										path,
+										info->tup_split_target,
+										AGG_HASHED,
+										AGGSPLIT_SIMPLE,
+										false, /* streaming */
+										info->dqa_group_clause,
+										NIL,
+										&DedupCost,
+										ctx->dNumGroups * getgpsegmentCount(),
+										&hash_info);
+
+		split = AGG_HASHED;
+		DEDUPLICATED_FLAG = AGGSPLITOP_DEDUPLICATED;
+		partial_target = strip_aggdistinct(info->partial_target);
+	}
+
+	path = (Path *) create_agg_path(root,
+									output_rel,
+									path,
+									partial_target,
+									split,
+									AGGSPLIT_INITIAL_SERIAL | DEDUPLICATED_FLAG,
+									false, /* streaming */
+									root->parse->groupClause,
+									NIL,
+									ctx->agg_partial_costs,
+									ctx->dNumGroups * getgpsegmentCount(),
+									&hash_info);
+
+	CdbPathLocus singleQE_locus;
+	CdbPathLocus_MakeSingleQE(&singleQE_locus, getgpsegmentCount());
+	path = cdbpath_create_motion_path(root,
+									  path,
+									  NIL,
+									  false,
+									  singleQE_locus);
+
+	path = (Path *) create_agg_path(root,
+									output_rel,
+									path,
+									info->final_target,
+									split,
+									AGGSPLIT_FINAL_DESERIAL | DEDUPLICATED_FLAG,
+									false, /* streaming */
+									root->parse->groupClause,
+									(List *) root->parse->havingQual,
+									ctx->agg_final_costs,
+									ctx->dNumGroups,
+									&hash_info);
+
+	add_path(output_rel, path);
+}
+
+/*
  * Figure out the desired data distribution to perform the grouping.
  *
  * In case of a simple GROUP BY, we prefer to distribute the data according to
@@ -1069,4 +1305,303 @@ cdb_choose_grouping_locus(PlannerInfo *root, Path *path,
 
 	*need_redistribute_p = need_redistribute;
 	return locus;
+}
+
+static DQAType
+recognize_dqa_type(cdb_agg_planning_context *ctx)
+{
+	ListCell    *lc, *lcc;
+	List        *dqaArgs = NIL;
+	ctx->type = INVALID_DQA;
+
+	foreach (lc, ctx->agg_costs->distinctAggrefs)
+	{
+		Aggref *aggref = (Aggref *) lfirst(lc);
+		SortGroupClause *arg_sortcl;
+
+		/* I can not give a case for a DQA have order by yet. */
+		if (aggref->aggorder != NIL)
+			return ctx->type;
+
+		foreach (lcc, aggref->aggdistinct)
+		{
+			arg_sortcl = (SortGroupClause *) lfirst(lcc);
+			if (!arg_sortcl->hashable)
+			{
+				/*
+				 * XXX: I'm not sure if the hashable flag is always set correctly
+				 * for DISTINCT args. DISTINCT aggs are never implemented with hashing
+				 * in PostgreSQL.
+				 */
+				return ctx->type;
+			}
+		}
+
+		/* get the first dqa arguments */
+		if (dqaArgs == NIL)
+		{
+			dqaArgs = aggref->args;
+			ctx->type = SINGLE_DQA;
+		}
+		/* if there is another dqa with different args, it's MULTI_DQAS */
+		else if (!equal(dqaArgs, aggref->args))
+		{
+			ctx->type = MULTI_DQAS;
+			break;
+		}
+	}
+
+	if (ctx->type != INVALID_DQA)
+	{
+		/* Check that there are no non-DISTINCT aggregates mixed in. */
+		List *varnos = pull_var_clause((Node *) ctx->target->exprs,
+									   PVC_INCLUDE_AGGREGATES |
+									   PVC_INCLUDE_WINDOWFUNCS |
+									   PVC_INCLUDE_PLACEHOLDERS);
+		foreach (lc, varnos)
+		{
+			Node	   *node = lfirst(lc);
+
+			if (IsA(node, Aggref))
+			{
+				Aggref	   *aggref = (Aggref *) node;
+
+				if (!aggref->aggdistinct)
+				{
+					/* mixing DISTINCT and non-DISTINCT aggs */
+					if (ctx->type == SINGLE_DQA)
+						ctx->type = SINGLE_DQA_WITHAGG;
+					else
+						ctx->type = MULTI_DQAS_WITHAGG;
+
+					return ctx->type;
+				}
+			}
+		}
+	}
+
+	return ctx->type;
+}
+
+/*
+ * fetch_multi_dqas_info
+ *
+ * 1. fetch all dqas path required information as single dqa's function.
+ *
+ * 2. append an AggExprId into Pathtarget to indicate which DQA expr is
+ * in the output tuple after TupleSplit.
+ */
+static void
+fetch_multi_dqas_info(PlannerInfo *root,
+					  Path *path,
+					  cdb_agg_planning_context *ctx,
+					  cdb_multi_dqas_info *info)
+{
+	int id;
+	int bms_no = 0;
+	ListCell    *lc;
+	Index		maxRef = 0;
+	PathTarget *proj_target = copy_pathtarget(path->pathtarget);
+
+	if (proj_target->sortgrouprefs)
+	{
+		for (int idx = 0; idx < list_length(proj_target->exprs); idx++)
+		{
+			if (proj_target->sortgrouprefs[idx] > maxRef)
+				maxRef = proj_target->sortgrouprefs[idx];
+		}
+	}
+	else
+		proj_target->sortgrouprefs = (Index *) palloc0(list_length(proj_target->exprs) * sizeof(Index));
+
+	info->agg_args_id_bms = palloc0(sizeof(Bitmapset *) * list_length(ctx->agg_costs->distinctAggrefs));
+
+	/*
+	 * assign numDisDQAs and agg_args_id_bms
+	 *
+	 * find all DQAs with different args, count the number, store their args bitmapsets
+	 */
+	foreach (lc, ctx->agg_costs->distinctAggrefs)
+	{
+		Aggref	        *aggref = (Aggref *) lfirst(lc);
+		SortGroupClause *arg_sortcl;
+		TargetEntry     *arg_tle;
+		ListCell        *lc2;
+		Bitmapset       *bms = NULL;
+
+		foreach (lc2, aggref->aggdistinct)
+		{
+			arg_sortcl = (SortGroupClause *) lfirst(lc2);
+			arg_tle = get_sortgroupclause_tle(arg_sortcl, aggref->args);
+			ListCell    *lc3;
+			int         dqa_idx = 0;
+
+			foreach (lc3, proj_target->exprs)
+			{
+				Expr    *expr = lfirst(lc3);
+
+				if (equal(arg_tle->expr, expr))
+					break;
+
+				dqa_idx++;
+			}
+
+			/*
+			 * DQA expr is not in PathTarget
+			 *
+			 * SELECT DQA(a) from foo;
+			 */
+			if (dqa_idx == list_length(proj_target->exprs))
+			{
+				add_column_to_pathtarget(proj_target, arg_tle->expr, ++maxRef);
+
+				SortGroupClause *sortcl;
+
+				sortcl = copyObject(arg_sortcl);
+				sortcl->tleSortGroupRef = maxRef;
+				sortcl->hashable = true;	/* we verified earlier that it's hashable */
+
+				info->dqa_group_clause = lappend(info->dqa_group_clause, sortcl);
+
+				bms = bms_add_member(bms, maxRef);
+			}
+			else if (proj_target->sortgrouprefs[dqa_idx] == 0)
+			{
+				/*
+				 * DQA expr in PathTarget but no reference
+				 *
+				 * SELECT DQA(a) FROM foo;
+				 */
+				proj_target->sortgrouprefs[dqa_idx] = ++maxRef;
+
+				SortGroupClause *sortcl;
+
+				sortcl = copyObject(arg_sortcl);
+				sortcl->tleSortGroupRef = maxRef;
+				sortcl->hashable = true;	/* we verified earlier that it's hashable */
+
+				info->dqa_group_clause = lappend(info->dqa_group_clause, sortcl);
+
+				bms = bms_add_member(bms, maxRef);
+			}
+			else
+			{
+				/*
+				 * DQA expr in PathTarget and referenced by GROUP BY clause
+				 *
+				 * SELECT DQA(a) FROM foo GROUP BY a;
+				 */
+				Index exprRef = proj_target->sortgrouprefs[dqa_idx];
+				bms = bms_add_member(bms, exprRef);
+			}
+		}
+
+		/* DQA(a, b) and DQA(b, a) can share one split tuple  */
+		for (id = 0; id < bms_no; id++)
+		{
+			if (bms_equal(bms, info->agg_args_id_bms[id]))
+				break;
+		}
+
+		/* skip if same args pattern has stored */
+		if (id == bms_no)
+			info->agg_args_id_bms[bms_no++] = bms;
+	}
+	info->numDisDQAs = bms_no;
+
+	info->input_proj_target = proj_target;
+	info->tup_split_target = copy_pathtarget(proj_target);
+	{
+		AggExprId *a_expr_id = makeNode(AggExprId);
+		add_column_to_pathtarget(info->tup_split_target, (Expr *)a_expr_id, ++maxRef);
+
+		Oid eqop;
+		bool hashable;
+		SortGroupClause *sortcl;
+		get_sort_group_operators(INT4OID, false, true, false, NULL, &eqop, NULL, &hashable);
+
+		sortcl = makeNode(SortGroupClause);
+		sortcl->tleSortGroupRef = maxRef;
+		sortcl->hashable = hashable;
+		sortcl->eqop = eqop;
+		info->dqa_group_clause = lcons(sortcl, info->dqa_group_clause);
+	}
+
+	info->dqa_group_clause = list_concat(info->dqa_group_clause,
+										 list_copy(root->parse->groupClause));
+
+	info->partial_target= ctx->partial_grouping_target;
+	info->final_target = ctx->target;
+}
+
+/*
+ * fetch_single_dqa_info
+ *
+ * fetch single dqa path required information and store in cdb_multi_dqas_info
+ *
+ * info->input_target contains subpath target expr + all DISTINCT expr
+ *
+ * info->dqa_group_clause contains DISTINCT expr + GROUP BY expr
+ */
+static void
+fetch_single_dqa_info(PlannerInfo *root,
+					  Path *path,
+					  cdb_agg_planning_context *ctx,
+					  cdb_multi_dqas_info *info)
+{
+	Index		maxRef;
+
+	/* Prepare a modifiable copy of the input path target */
+	info->input_proj_target = copy_pathtarget(path->pathtarget);
+	maxRef = 0;
+	List *exprLst = info->input_proj_target->exprs;
+	if (info->input_proj_target->sortgrouprefs)
+	{
+		for (int idx = 0; idx < list_length(exprLst); idx++)
+		{
+			if (info->input_proj_target->sortgrouprefs[idx] > maxRef)
+				maxRef = info->input_proj_target->sortgrouprefs[idx];
+		}
+	}
+	else
+		info->input_proj_target->sortgrouprefs = (Index *) palloc0(list_length(exprLst) * sizeof(Index));
+
+	Aggref	   *aggref = list_nth(ctx->agg_costs->distinctAggrefs, 0);
+	SortGroupClause *arg_sortcl;
+	SortGroupClause *sortcl = NULL;
+	TargetEntry *arg_tle;
+	int			idx = 0;
+	ListCell   *lc;
+	ListCell   *lcc;
+
+	foreach (lc, aggref->aggdistinct)
+	{
+		arg_sortcl = (SortGroupClause *) lfirst(lc);
+		arg_tle = get_sortgroupref_tle(arg_sortcl->tleSortGroupRef, aggref->args);
+
+		/* Now find this expression in the sub-path's target list */
+		idx = 0;
+		foreach(lcc, info->input_proj_target->exprs)
+		{
+			Expr		*expr = lfirst(lcc);
+
+			if (equal(expr, arg_tle->expr))
+				break;
+			idx++;
+		}
+
+		if (idx == list_length(info->input_proj_target->exprs))
+			add_column_to_pathtarget(info->input_proj_target, arg_tle->expr, ++maxRef);
+		else if (info->input_proj_target->sortgrouprefs[idx] == 0)
+			info->input_proj_target->sortgrouprefs[idx] = ++maxRef;
+
+		sortcl = copyObject(arg_sortcl);
+		sortcl->tleSortGroupRef = info->input_proj_target->sortgrouprefs[idx];
+		sortcl->hashable = true;	/* we verified earlier that it's hashable */
+
+		info->dqa_group_clause = lappend(info->dqa_group_clause, sortcl);
+	}
+
+	info->dqa_group_clause = list_concat(list_copy(root->parse->groupClause),
+										 info->dqa_group_clause);
 }

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1391,6 +1391,7 @@ motion_sanity_walker(Node *node, sanity_result_t *result)
 		case T_FunctionScan:
 		case T_ValuesScan:
 		case T_Agg:
+		case T_TupleSplit:
 		case T_Unique:
 		case T_Hash:
 		case T_SetOp:

--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -639,6 +639,23 @@ plan_tree_mutator(Node *node,
 			}
 			break;
 
+		case T_TupleSplit:
+			{
+				TupleSplit  *tup_split = (TupleSplit *) node;
+				TupleSplit  *new_tup_split;
+
+				FLATCOPY(new_tup_split, tup_split, TupleSplit);
+				PLANMUTATE(new_tup_split, tup_split);
+				COPYARRAY(new_tup_split, tup_split, numCols, grpColIdx);
+
+				new_tup_split->dqa_args_id_bms = palloc0(sizeof(Bitmapset *) * tup_split->numDisDQAs);
+				for (int i = 0; i < tup_split->numDisDQAs; i++)
+					new_tup_split->dqa_args_id_bms[i] = bms_copy(tup_split->dqa_args_id_bms[i]);
+
+				return (Node *) new_tup_split;
+			}
+			break;
+
 		case T_TableFunctionScan:
 			{
 				TableFunctionScan *tabfunc = (TableFunctionScan *) node;

--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -460,6 +460,7 @@ DirectDispatchUpdateContentIdsFromPlan(PlannerInfo *root, Plan *plan)
 		case T_Material:
 		case T_Sort:
 		case T_Agg:
+		case T_TupleSplit:
 		case T_Unique:
 		case T_Gather:
 		case T_Hash:

--- a/src/backend/executor/Makefile
+++ b/src/backend/executor/Makefile
@@ -26,7 +26,7 @@ OBJS = execAmi.o execCurrent.o execGrouping.o execIndexing.o execJunk.o \
        nodeNestloop.o nodeFunctionscan.o nodeRecursiveunion.o nodeResult.o \
        nodeSamplescan.o nodeSeqscan.o nodeSetOp.o nodeSort.o nodeUnique.o \
        nodeValuesscan.o nodeCtescan.o nodeWorktablescan.o \
-       nodeSubplan.o nodeSubqueryscan.o nodeTidscan.o \
+       nodeSubplan.o nodeSubqueryscan.o nodeTidscan.o nodeTupleSplit.o \
        nodeForeignscan.o nodeWindowAgg.o tstoreReceiver.o tqueue.o spi.o
 
 OBJS += nodeExternalscan.o \

--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -49,6 +49,7 @@
 #include "executor/nodeSubplan.h"
 #include "executor/nodeSubqueryscan.h"
 #include "executor/nodeTidscan.h"
+#include "executor/nodeTupleSplit.h"
 #include "executor/nodeUnique.h"
 #include "executor/nodeValuesscan.h"
 #include "executor/nodeWindowAgg.h"
@@ -281,6 +282,10 @@ ExecReScan(PlanState *node)
 
 		case T_AggState:
 			ExecReScanAgg((AggState *) node);
+			break;
+
+		case T_TupleSplit:
+			ExecReScanTupleSplit((TupleSplitState *) node);
 			break;
 
 		case T_WindowAggState:
@@ -760,6 +765,10 @@ ExecSquelchNode(PlanState *node)
 
 		case T_AggState:
 			ExecSquelchAgg((AggState*) node);
+			break;
+
+		case T_TupleSplitState:
+			ExecSquelchTupleSplit((TupleSplitState*) node);
 			break;
 
 		case T_WindowAggState:

--- a/src/backend/executor/nodeTupleSplit.c
+++ b/src/backend/executor/nodeTupleSplit.c
@@ -1,0 +1,211 @@
+/*-------------------------------------------------------------------------
+ * nodeTupleSplit.c
+ *	  Implementation of nodeTupleSplit.
+ *
+ * Portions Copyright (c) 2019-Present Pivotal Software, Inc.
+ *
+ * IDENTIFICATION
+ *	    src/backend/executor/nodeTupleSplit.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "executor/executor.h"
+#include "executor/nodeTupleSplit.h"
+#include "optimizer/tlist.h"
+
+/* -----------------
+ * ExecInitTupleSplit
+ *
+ *	Creates the run-time information for the tuple split node produced by the
+ *	planner and initializes its outer subtree
+ * -----------------
+ */
+TupleSplitState *ExecInitTupleSplit(TupleSplit *node, EState *estate, int eflags)
+{
+	TupleSplitState     *tup_spl_state;
+	Plan                *outerPlan;
+
+	/* check for unsupported flags */
+	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
+
+	tup_spl_state = makeNode(TupleSplitState);
+	tup_spl_state->ss.ps.plan = (Plan *) node;
+	tup_spl_state->ss.ps.state = estate;
+
+	ExecAssignExprContext(estate, &tup_spl_state->ss.ps);
+
+	/*
+	 * tuple table initialization
+	 */
+	tup_spl_state->ss.ss_ScanTupleSlot = ExecInitExtraTupleSlot(estate);
+	ExecInitResultTupleSlot(estate, &tup_spl_state->ss.ps);
+
+	/*
+	 * initialize child expressions
+	 */
+	tup_spl_state->ss.ps.targetlist = (List *)
+		ExecInitExpr((Expr *) node->plan.targetlist,
+					 (PlanState *) tup_spl_state);
+
+	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
+	{
+		tup_spl_state->ss.ps.cdbexplainbuf = makeStringInfo();
+		tup_spl_state->ss.ps.cdbexplainfun = NULL;
+	}
+
+	/*
+	 * initialize child nodes
+	 */
+	outerPlan = outerPlan(node);
+	outerPlanState(tup_spl_state) = ExecInitNode(outerPlan, estate, eflags);
+
+	/*
+	 * initialize source tuple type.
+	 */
+	ExecAssignScanTypeFromOuterPlan(&tup_spl_state->ss);
+
+	ExecAssignResultTypeFromTL(&tup_spl_state->ss.ps);
+	ExecAssignProjectionInfo(&tup_spl_state->ss.ps, NULL);
+
+	/*
+	 * initialize group by bitmap set
+	 */
+	for (int keyno = 0; keyno < node->numCols; keyno++)
+	{
+		tup_spl_state->grpbySet = bms_add_member(tup_spl_state->grpbySet, node->grpColIdx[keyno]);
+	}
+
+	/*
+	 * initialize input tuple isnull buffer
+	 */
+	tup_spl_state->isnull_orig = (bool *) palloc0(sizeof(bool) * list_length(outerPlan(node)->targetlist));
+
+	/* create bitmap set for each dqa expr to store its input tuple attribute number */
+	AttrNumber maxAttrNum = 0;
+	tup_spl_state->dqa_args_attr_num = palloc0(sizeof(Bitmapset *) * node->numDisDQAs);
+	for (int i = 0; i < node->numDisDQAs; i++)
+	{
+		int j = -1;
+		while ((j = bms_next_member(node->dqa_args_id_bms[i], j)) >= 0)
+		{
+			TargetEntry *te = get_sortgroupref_tle((Index)j, node->plan.lefttree->targetlist);
+			tup_spl_state->dqa_args_attr_num[i] = bms_add_member(tup_spl_state->dqa_args_attr_num[i], te->resno);
+
+			if (maxAttrNum < te->resno)
+				maxAttrNum = te->resno;
+		}
+	}
+
+	tup_spl_state->maxAttrNum = maxAttrNum;
+	/*
+	 * add all DQA expr AttrNum into a bitmapset
+	 */
+	for (int i = 0; i < node->numDisDQAs; i++)
+		tup_spl_state->all_dist_attr_num = bms_add_members(tup_spl_state->all_dist_attr_num, tup_spl_state->dqa_args_attr_num[i]);
+
+	return tup_spl_state;
+}
+
+/*
+ * ExecTupleSplit -
+ *
+ *      ExecTupleSplit receives tuples from its outer subplan. Every
+ *      input tuple will generate n output tuples (n is the number of
+ *      the DQAs exprs). Each output tuple only contain one DQA expr and
+ *      all GROUP BY exprs.
+ */
+struct TupleTableSlot *ExecTupleSplit(TupleSplitState *node)
+{
+	TupleTableSlot  *result;
+	ExprContext     *econtext;
+	TupleSplit      *plan;
+	ExprDoneCond     isDone;
+
+	econtext = node->ss.ps.ps_ExprContext;
+	plan = (TupleSplit *)node->ss.ps.plan;
+
+	/* if all DQAs of the last slot were processed, get a new slot */
+	if (node->currentExprId == 0)
+	{
+		node->outerslot = ExecProcNode(outerPlanState(node));
+
+		if (TupIsNull(node->outerslot))
+			return NULL;
+
+		slot_getsomeattrs(node->outerslot, node->maxAttrNum);
+
+		/* store original tupleslot isnull array */
+		memcpy(node->isnull_orig, slot_get_isnull(node->outerslot),
+			   node->outerslot->PRIVATE_tts_nvalid * sizeof(bool));
+	}
+
+	/* reset the isnull array to the original state */
+	bool *isnull = slot_get_isnull(node->outerslot);
+	memcpy(isnull, node->isnull_orig, node->outerslot->PRIVATE_tts_nvalid);
+
+	for (AttrNumber attno = 1; attno <= node->outerslot->PRIVATE_tts_nvalid; attno++)
+	{
+		/* If the column is in the group by, keep it */
+		if (bms_is_member(attno, node->grpbySet))
+			continue;
+
+		/* If the column is relevant to the current dqa, keep it */
+		if (bms_is_member(attno, node->dqa_args_attr_num[node->currentExprId]))
+			continue;
+
+		/* If the column does not belong to any DQA but the projection needs it, keep it */
+		if (!bms_is_member(attno, node->all_dist_attr_num))
+			continue;
+
+		/* otherwise, null this column out */
+		isnull[attno - 1] = true;
+	}
+
+	/* project the tuple */
+	econtext->ecxt_outertuple = node->outerslot;
+	result = ExecProject(node->ss.ps.ps_ProjInfo, &isDone);
+
+	/* the next DQA to process */
+	node->currentExprId = (node->currentExprId + 1) % plan->numDisDQAs;
+	ResetExprContext(econtext);
+
+	return result;
+}
+
+void ExecEndTupleSplit(TupleSplitState *node)
+{
+	PlanState   *outerPlan;
+
+	bms_free(node->grpbySet);
+	pfree(node->isnull_orig);
+
+	/*
+	 * We don't actually free any ExprContexts here (see comment in
+	 * ExecFreeExprContext), just unlink the output one from the plan node
+	 * suffices.
+	 */
+	ExecFreeExprContext(&node->ss.ps);
+
+	/* clean up tuple table */
+	ExecClearTuple(node->ss.ss_ScanTupleSlot);
+
+	outerPlan = outerPlanState(node);
+	ExecEndNode(outerPlan);
+
+	EndPlanStateGpmonPkt(&node->ss.ps);
+}
+
+void ExecReScanTupleSplit(TupleSplitState *node)
+{
+	node->currentExprId = 0;
+
+	if (node->ss.ps.lefttree->chgParam == NULL)
+		ExecReScan(node->ss.ps.lefttree);
+}
+
+void ExecSquelchTupleSplit(TupleSplitState *node)
+{
+	ExecSquelchNode(outerPlanState(node));
+}

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1172,6 +1172,29 @@ _copyAgg(const Agg *from)
 	COPY_NODE_FIELD(chain);
 	COPY_SCALAR_FIELD(streaming);
 
+	COPY_SCALAR_FIELD(agg_expr_id);
+	return newnode;
+}
+
+/*
+ * _copyTupleSplit
+ */
+static TupleSplit *
+_copyTupleSplit(const TupleSplit *from)
+{
+	TupleSplit  *newnode = makeNode(TupleSplit);
+
+	CopyPlanFields((const Plan *) from, (Plan *) newnode);
+	COPY_SCALAR_FIELD(numCols);
+	if (from->numCols > 0)
+	{
+		COPY_POINTER_FIELD(grpColIdx, from->numCols * sizeof(AttrNumber));
+	}
+
+	COPY_SCALAR_FIELD(numDisDQAs);
+	for (int i = 0; i < from->numDisDQAs; i ++)
+		COPY_BITMAPSET_FIELD(dqa_args_id_bms[i]);
+
 	return newnode;
 }
 
@@ -5455,6 +5478,11 @@ _copyForeignKeyCacheInfo(const ForeignKeyCacheInfo *from)
 	return newnode;
 }
 
+static AggExprId*
+_copyAggExprId(const AggExprId *from)
+{
+	return makeNode(AggExprId);
+}
 
 /*
  * copyObject
@@ -5603,6 +5631,9 @@ copyObject(const void *from)
 			break;
 		case T_Agg:
 			retval = _copyAgg(from);
+			break;
+		case T_TupleSplit:
+			retval = _copyTupleSplit(from);
 			break;
 		case T_WindowAgg:
 			retval = _copyWindowAgg(from);
@@ -6463,6 +6494,10 @@ copyObject(const void *from)
 			 */
 		case T_ForeignKeyCacheInfo:
 			retval = _copyForeignKeyCacheInfo(from);
+			break;
+
+		case T_AggExprId:
+			retval = _copyAggExprId(from);
 			break;
 
 		default:

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -3749,6 +3749,9 @@ equal(const void *a, const void *b)
 		case T_RoleSpec:
 			retval = _equalRoleSpec(a, b);
 			break;
+		case T_AggExprId:
+			retval = true;
+			break;
 
 		default:
 			elog(ERROR, "unrecognized node type: %d",

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -284,6 +284,9 @@ exprType(const Node *expr)
 		case T_PartListNullTestExpr:
 			type = BOOLOID;
 			break;
+		case T_AggExprId:
+			type = INT4OID;
+			break;
 
 		default:
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(expr));
@@ -972,6 +975,9 @@ exprCollation(const Node *expr)
 			 * ORCA currently does not support collation,
 			 * so return invalid oid for ORCA only expressions
 			 */
+			coll = InvalidOid;
+			break;
+		case T_AggExprId:
 			coll = InvalidOid;
 			break;
 		default:
@@ -1945,6 +1951,7 @@ expression_tree_walker(Node *node,
 		case T_PartBoundOpenExpr:
 		case T_PartListRuleExpr:
 		case T_PartListNullTestExpr:
+		case T_AggExprId:
 			/* primitive node types with no expression subnodes */
 			break;
 		case T_WithCheckOption:
@@ -3237,6 +3244,14 @@ expression_tree_mutator(Node *node,
 				MUTATE(newnode->args, tsc->args, List *);
 				MUTATE(newnode->repeatable, tsc->repeatable, Expr *);
 				return (Node *) newnode;
+			}
+			break;
+		case T_AggExprId:
+			{
+				AggExprId *exprId = (AggExprId *)node;
+				AggExprId *new_exprId;
+				FLATCOPY(new_exprId, exprId, AggExprId);
+				return (Node *)new_exprId;
 			}
 			break;
 		default:

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -390,6 +390,21 @@ _outMergeJoin(StringInfo str, MergeJoin *node)
 }
 
 static void
+_outTupleSplit(StringInfo str, TupleSplit *node)
+{
+	WRITE_NODE_TYPE("TupleSplit");
+
+	_outPlanInfo(str, (Plan *) node);
+
+	WRITE_INT_FIELD(numCols);
+	WRITE_INT_ARRAY(grpColIdx, node->numCols, AttrNumber);
+	WRITE_INT_FIELD(numDisDQAs);
+
+	for (int i = 0; i < node->numDisDQAs ; i ++)
+		WRITE_BITMAPSET_FIELD(dqa_args_id_bms[i]);
+}
+
+static void
 _outAgg(StringInfo str, Agg *node)
 {
 	WRITE_NODE_TYPE("AGG");
@@ -407,6 +422,8 @@ _outAgg(StringInfo str, Agg *node)
 	WRITE_NODE_FIELD(groupingSets);
 	WRITE_NODE_FIELD(chain);
 	WRITE_BOOL_FIELD(streaming);
+
+	WRITE_UINT_FIELD(agg_expr_id);
 }
 
 static void
@@ -1246,6 +1263,11 @@ _outCreateAmStmt(StringInfo str, const CreateAmStmt *node)
 	WRITE_NODE_FIELD(handler_name);
 	WRITE_INT_FIELD(amtype);
 }
+static void
+_outAggExprId(StringInfo str, const AggExprId *node)
+{
+	WRITE_NODE_TYPE("AGGEXPRID");
+}
 
 /*
  * _outNode -
@@ -1389,6 +1411,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_Agg:
 				_outAgg(str, obj);
+				break;
+			case T_TupleSplit:
+				_outTupleSplit(str, obj);
 				break;
 			case T_WindowAgg:
 				_outWindowAgg(str, obj);
@@ -2139,6 +2164,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_CreateAmStmt:
 				_outCreateAmStmt(str, obj);
+				break;
+			case T_AggExprId:
+				_outAggExprId(str, obj);
 				break;
 
 			default:

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -989,6 +989,29 @@ _outAgg(StringInfo str, const Agg *node)
 	WRITE_NODE_FIELD(groupingSets);
 	WRITE_NODE_FIELD(chain);
 	WRITE_BOOL_FIELD(streaming);
+
+	WRITE_UINT_FIELD(agg_expr_id);
+}
+#endif /* COMPILING_BINARY_FUNCS */
+
+#ifndef COMPILING_BINARY_FUNCS
+static void
+_outTupleSplit(StringInfo str, const TupleSplit *node)
+{
+	int         i;
+
+	WRITE_NODE_TYPE("TupleSplit");
+
+	_outPlanInfo(str, (const Plan *) node);
+
+	WRITE_INT_FIELD(numCols);
+	appendStringInfoString(str, " :grpColIdx");
+	for (i = 0; i < node->numCols; i++)
+		appendStringInfo(str, " %d", node->grpColIdx[i]);
+
+	WRITE_INT_FIELD(numDisDQAs);
+	for (i = 0; i < node->numDisDQAs; i++)
+		WRITE_BITMAPSET_FIELD(dqa_args_id_bms[i]);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
@@ -5352,6 +5375,9 @@ outNode(StringInfo str, const void *obj)
 				break;
 			case T_Agg:
 				_outAgg(str, obj);
+				break;
+			case T_TupleSplit:
+				_outTupleSplit(str, obj);
 				break;
 			case T_WindowAgg:
 				_outWindowAgg(str, obj);

--- a/src/backend/nodes/print.c
+++ b/src/backend/nodes/print.c
@@ -550,6 +550,8 @@ plannode_type(Plan *p)
 			return "SORT";
 		case T_Agg:
 			return "AGG";
+		case T_TupleSplit:
+			return "TupleSplit";
 		case T_WindowAgg:
 			return "WINDOWAGG";
 		case T_TableFunctionScan:

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2086,6 +2086,13 @@ _readLockingClause(void)
 	READ_DONE();
 }
 
+static AggExprId *
+_readAggExprId(void)
+{
+	READ_LOCALS(AggExprId);
+	READ_DONE();
+}
+
 static Node *
 _readValue(NodeTag nt)
 {
@@ -2336,6 +2343,9 @@ readNodeBinary(void)
 				break;
 			case T_Agg:
 				return_value = _readAgg();
+				break;
+			case T_TupleSplit:
+				return_value = _readTupleSplit();
 				break;
 			case T_WindowAgg:
 				return_value = _readWindowAgg();
@@ -3066,7 +3076,9 @@ readNodeBinary(void)
 			case T_LockingClause:
 				return_value = _readLockingClause();
 				break;
-
+			case T_AggExprId:
+				return_value = _readAggExprId();
+				break;
 			default:
 				return_value = NULL; /* keep the compiler silent */
 				elog(ERROR, "could not deserialize unrecognized node type: %d",

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3088,6 +3088,25 @@ _readAgg(void)
 	READ_NODE_FIELD(groupingSets);
 	READ_NODE_FIELD(chain);
 	READ_BOOL_FIELD(streaming);
+	READ_UINT_FIELD(agg_expr_id);
+
+	READ_DONE();
+}
+
+static TupleSplit *
+_readTupleSplit(void)
+{
+	READ_LOCALS(TupleSplit);
+
+	ReadCommonPlan(&local_node->plan);
+
+	READ_INT_FIELD(numCols);
+	READ_ATTRNUMBER_ARRAY(grpColIdx, local_node->numCols);
+	READ_INT_FIELD(numDisDQAs);
+
+	local_node->dqa_args_id_bms = palloc0(sizeof(Bitmapset *) * local_node->numDisDQAs);
+	for (int i = 0; i < local_node->numDisDQAs; i++)
+		local_node->dqa_args_id_bms[i] = _readBitmapset();
 
 	READ_DONE();
 }
@@ -4233,6 +4252,8 @@ parseNodeString(void)
 		return_value = _readSort();
 	else if (MATCH("AGG", 3))
 		return_value = _readAgg();
+	else if (MATCH("TupleSplit", 10))
+		return_value = _readTupleSplit();
 	else if (MATCH("WINDOWAGG", 9))
 		return_value = _readWindowAgg();
 	else if (MATCH("UNIQUE", 6))

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2117,6 +2117,29 @@ cost_agg(Path *path, PlannerInfo *root,
 }
 
 /*
+ * cost_tup_split
+ *		Determines and returns the cost of performing an TupleSplit plan node,
+ *		including the cost of its input.
+ */
+void cost_tup_split(Path *path, PlannerInfo *root,
+					int numDQAs,
+					Cost input_startup_cost, Cost input_total_cost,
+					double input_tuples)
+{
+	double		output_tuples;
+	Cost		startup_cost;
+	Cost		total_cost;
+
+	output_tuples = numDQAs * input_tuples;
+	startup_cost = input_total_cost;
+	total_cost = startup_cost + cpu_operator_cost * input_tuples;
+
+	path->rows = output_tuples;
+	path->startup_cost = startup_cost;
+	path->total_cost = total_cost;
+}
+
+/*
  * cost_windowagg
  *		Determines and returns the cost of performing a WindowAgg plan node,
  *		including the cost of its input.

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1011,6 +1011,9 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 				set_upper_references(root, plan, rtoffset);
 			}
 			break;
+		case T_TupleSplit:
+			set_upper_references(root, plan, rtoffset);
+			break;
 		case T_WindowAgg:
 			{
 				WindowAgg  *wplan = (WindowAgg *) plan;

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -3134,6 +3134,7 @@ finalize_plan(PlannerInfo *root, Plan *plan, Bitmapset *valid_params,
 		case T_SetOp:
 		case T_Repeat:
 		case T_SplitUpdate:
+		case T_TupleSplit:
 			break;
 
 		default:

--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -373,6 +373,12 @@ plan_tree_walker(Node *node,
 			/* Other fields are simple items and lists of simple items. */
 			break;
 
+		case T_TupleSplit:
+			if (walk_plan_node_fields((Plan *) node, walker, context))
+				return true;
+			/* Other fields are simple items and lists of simple items. */
+			break;
+
 		case T_WindowAgg:
 			if (walk_plan_node_fields((Plan *) node, walker, context))
 				return true;

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -8450,6 +8450,12 @@ get_rule_expr(Node *node, deparse_context *context,
 			}
 			break;
 
+		case T_AggExprId:
+			{
+				appendStringInfo(buf, "AggExprId");
+			}
+			break;
+
 		default:
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(node));
 			break;

--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -206,6 +206,8 @@ typedef struct AggStatePerTransData
 	 */
 	FunctionCallInfoData combinefn_fcinfo;
 
+	/* for MultiDQA split tuple check */
+	int     agg_expr_id;
 }	AggStatePerTransData;
 
 /*

--- a/src/include/executor/nodeTupleSplit.h
+++ b/src/include/executor/nodeTupleSplit.h
@@ -1,0 +1,27 @@
+/*-------------------------------------------------------------------------
+ * nodeTupleSplit.h
+ *	  prototypes for nodeTupleSplit.
+ *
+ * Portions Copyright (c) 2019-Present Pivotal Software, Inc.
+ *
+ * src/include/executor/nodeTupleSplit.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef GPDB_NODETUPLESPLIT_H
+#define GPDB_NODETUPLESPLIT_H
+
+#include "fmgr.h"
+#include "executor/tuptable.h"
+#include "nodes/execnodes.h"
+#include "nodes/primnodes.h"
+#include "utils/tuplesort.h"
+
+extern TupleSplitState *ExecInitTupleSplit(TupleSplit *node, EState *estate, int eflags);
+extern struct TupleTableSlot *ExecTupleSplit(TupleSplitState *node);
+extern void ExecEndTupleSplit(TupleSplitState *node);
+extern void ExecReScanTupleSplit(TupleSplitState *node);
+
+extern void ExecSquelchTupleSplit(TupleSplitState *node);
+#endif /* NODETUPLESPLIT_H */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2640,6 +2640,12 @@ typedef enum HashAggStatus
 	HASHAGG_END_OF_PASSES
 } HashAggStatus;
 
+typedef struct SplitAggInfo
+{
+	int             idx;
+	TupleTableSlot  *outerslot;
+} SplitAggInfo;
+
 typedef struct AggState
 {
 	ScanState	ss;				/* its first field is NodeTag */
@@ -2705,7 +2711,34 @@ typedef struct AggState
 	 * which an Agg's target list usually has.
 	 */
 	bool		ps_TupFromTlist;
+
+	/* if input tuple has an AggExprId, save the Attribute Number */
+	Index       AggExprId_AttrNum;
 } AggState;
+
+typedef struct TupleSplitState
+{
+	ScanState	    ss;				/* its first field is NodeTag */
+
+	bool		    *isnull_orig;
+	Bitmapset       *grpbySet;
+
+	TupleTableSlot  *outerslot;
+	Index           currentExprId;
+
+	AttrNumber	maxAttrNum;
+	Bitmapset       **dqa_args_attr_num;
+	Bitmapset       *all_dist_attr_num;
+
+	Index            largest_attno_in_dqas;
+} TupleSplitState;
+
+typedef struct AggExprIdState
+{
+	ExprState	xprstate;
+
+	PlanState   *parent;
+} AggExprIdState;
 
 /* ----------------
  *	WindowAggState information

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -93,6 +93,7 @@ typedef enum NodeTag
 	T_Material,
 	T_Sort,
 	T_Agg,
+	T_TupleSplit,
 	T_WindowAgg,
 	T_Unique,
 	T_Gather,
@@ -159,6 +160,7 @@ typedef enum NodeTag
 	T_MaterialState,
 	T_SortState,
 	T_AggState,
+	T_TupleSplitState,
 	T_WindowAggState,
 	T_UniqueState,
 	T_GatherState,
@@ -238,6 +240,7 @@ typedef enum NodeTag
 	T_Flow,
 	T_GroupId,
 	T_GroupingSetId,
+	T_AggExprId,
 	T_DistributedBy,
 	T_DMLActionExpr,
 	T_PartSelectedExpr,
@@ -291,6 +294,7 @@ typedef enum NodeTag
 	T_PartBoundOpenExprState,
 	T_PartListRuleExprState,
 	T_PartListNullTestExprState,
+	T_AggExprIdState,
 
 	/*
 	 * TAGS FOR PLANNER NODES (relation.h)
@@ -332,6 +336,7 @@ typedef enum NodeTag
 	T_GroupingSetsPath,
 	T_MinMaxAggPath,
 	T_WindowAggPath,
+	T_TupleSplitPath,
 	T_SetOpPath,
 	T_RecursiveUnionPath,
 	T_LockRowsPath,

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1168,7 +1168,28 @@ typedef struct Agg
 
 	/* Stream entries when out of memory instead of spilling to disk */
 	bool		streaming;
+
+	/* if input tuple has an AggExprId, save the tlist index */
+	Index       agg_expr_id;
 } Agg;
+
+/* ---------------
+ *		tuple split node
+ *
+ * A TupleSplit node implements tuple split in multiple DQAs MPP query.
+ *
+ * ---------------
+ */
+typedef struct TupleSplit
+{
+	Plan		plan;
+
+	int			numCols;		    /* number of grouping columns */
+	AttrNumber *grpColIdx;		    /* their indexes in the target list */
+
+	int         numDisDQAs;         /* the number of different dqa exprs */
+	Bitmapset **dqa_args_id_bms;    /* each DQA's arg indexes bitmapset */
+} TupleSplit;
 
 /* ----------------
  *		window aggregate node

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -376,6 +376,16 @@ typedef struct GroupingSetId
 } GroupingSetId;
 
 /*
+ * AggExprId
+ *
+ *    A hint for aggregation which agg expr is this split tuple for.
+ */
+typedef struct AggExprId
+{
+	Expr        xpr;
+} AggExprId;
+
+/*
  * GroupingFunc
  *
  * A GroupingFunc is a GROUPING(...) expression, which behaves in many ways

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -1715,6 +1715,23 @@ typedef struct AggPath
 } AggPath;
 
 /*
+ * TupleSplitPath represents tuple split by DQAs expr
+ *
+ * In gpdb, we need to split one input tuple to n output tuples for MultiDQA
+ * MPP execution. Each output tuple only contains one DQA expr and all GROUP BY
+ * exprs.
+ */
+typedef struct TupleSplitPath
+{
+	Path		path;
+	Path	   *subpath;		/* path representing input source */
+	List	   *groupClause;	/* a list of SortGroupClause's */
+
+	int         numDisDQAs;     /* the number of different DQAs */
+	Bitmapset **agg_args_id_bms;  /* the bitmapsets which store the dqa arg indexes */
+} TupleSplitPath;
+
+/*
  * GroupingSetsPath represents a GROUPING SETS aggregation
  *
  * Currently we only support this in sorted not hashed form, so the input

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -145,7 +145,10 @@ extern void cost_agg(Path *path, PlannerInfo *root,
 		 double input_tuples,
 		 struct HashAggTableSizes *hash_info,
 		 bool hash_streaming);
-
+extern void cost_tup_split(Path *path, PlannerInfo *root,
+						   int numDQAs,
+						   Cost input_startup_cost, Cost input_total_cost,
+						   double input_tuples);
 extern void cost_windowagg(Path *path, PlannerInfo *root,
 			   List *windowFuncs, int numPartCols, int numOrderCols,
 			   Cost input_startup_cost, Cost input_total_cost,

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -213,6 +213,23 @@ extern AggPath *create_agg_path(PlannerInfo *root,
 				const AggClauseCosts *aggcosts,
 				double numGroups,
 				struct HashAggTableSizes *hash_info);
+
+extern TupleSplitPath *create_tup_split_path(PlannerInfo *root,
+											 RelOptInfo *rel,
+											 Path *subpath,
+											 PathTarget *target,
+											 List *groupClause,
+											 Bitmapset **bitmapset,
+											 int numDisDQAs);
+
+extern AggPath *create_shadow_eliminate_path(PlannerInfo *root,
+											 RelOptInfo *rel,
+											 Path *subpath,
+											 PathTarget *target,
+											 double numGroups,
+											 int mapSz,
+											 int *shadow_mapping);
+
 extern GroupingSetsPath *create_groupingsets_path(PlannerInfo *root,
 						 RelOptInfo *rel,
 						 Path *subpath,

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -178,6 +178,10 @@ extern Agg *make_agg(List *tlist, List *qual,
 		 List *groupingSets, List *chain,
 		 double dNumGroups, Plan *lefttree);
 extern Limit *make_limit(Plan *lefttree, Node *limitOffset, Node *limitCount);
+extern TupleSplit *make_tup_split(List *tlist,
+								  int numDQAs, Bitmapset **dqas_ref_bms,
+								  int numGroupCols, AttrNumber *grpColIdx,
+								  Plan *lefttree);
 
 /*
  * prototypes for plan/initsplan.c

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -108,6 +108,21 @@ select ten, ten, count(distinct two), count(distinct four) from tenk1 group by 1
    7 |   7 |     1 |     2
 (10 rows)
 
+select case when ten < 5 then ten else ten * 2 end, count(distinct two) from tenk1 group by 1;
+ case | count 
+------+-------
+    2 |     1
+    3 |     1
+    4 |     1
+   16 |     1
+   18 |     1
+    0 |     1
+    1 |     1
+   12 |     1
+   10 |     1
+   14 |     1
+(10 rows)
+
 --MPP-20151: distinct is transformed to a group-by
 select distinct two from tenk1 order by two;
  two 

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -25,7 +25,7 @@ select count(distinct d) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct d) from dqa_t1;
-                   QUERY PLAN                   
+                   QUERY PLAN
 ------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -52,7 +52,7 @@ select count(distinct d) from dqa_t1 group by i;
 (12 rows)
 
 explain (costs off) select count(distinct d) from dqa_t1 group by i;
-                         QUERY PLAN                         
+                         QUERY PLAN
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
@@ -83,7 +83,7 @@ select count(distinct d), sum(distinct d) from dqa_t1 group by i;
 (12 rows)
 
 explain (costs off) select count(distinct d), sum(distinct d) from dqa_t1 group by i;
-                         QUERY PLAN                         
+                         QUERY PLAN
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
@@ -103,34 +103,42 @@ select count(distinct d), count(distinct dt) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1;
-                   QUERY PLAN                   
-------------------------------------------------
- Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on dqa_t1
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: d, dt, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, d, dt
+                           ->  TupleSplit
+                                 Split by Col: (d), (dt)
+                                 ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(4 rows)
+(11 rows)
 
--- start_ignore
--- GPDB_96_MERGE_FIXME: this used to get a smarter multi-dqa agg plan
--- end_ignore
 select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
  count | count | count 
 -------+-------+-------
     23 |    10 |    34
 (1 row)
 
--- start_ignore
--- GPDB_96_MERGE_FIXME: this used to get a smarter multi-dqa agg plan
--- end_ignore
 explain (costs off) select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
-                   QUERY PLAN                   
-------------------------------------------------
- Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on dqa_t1
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: d, c, dt, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, d, c, dt
+                           ->  TupleSplit
+                                 Split by Col: (d), (c), (dt)
+                                 ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(4 rows)
+(11 rows)
 
 select count(distinct d), count(distinct dt) from dqa_t1 group by c;
  count | count 
@@ -147,22 +155,26 @@ select count(distinct d), count(distinct dt) from dqa_t1 group by c;
     10 |    10
 (10 rows)
 
--- start_ignore
--- GPDB_96_MERGE_FIXME: this used to get a smarter multi-dqa agg plan
--- end_ignore
 explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 group by c;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: c
-         ->  Sort
-               Sort Key: c
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: c
-                     ->  Seq Scan on dqa_t1
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: c
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: c
+               ->  HashAggregate
+                     Group Key: (AggExprId), d, dt, c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: c, d, dt, (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, d, dt, c
+                                 ->  TupleSplit
+                                       Split by Col: (d), (dt)
+                                       Group Key: c
+                                       ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(9 rows)
+(16 rows)
 
 select count(distinct d), count(distinct dt) from dqa_t1 group by d;
  count | count 
@@ -192,20 +204,26 @@ select count(distinct d), count(distinct dt) from dqa_t1 group by d;
      1 |     5
 (23 rows)
 
--- start_ignore
--- GPDB_96_MERGE_FIXME: this used to get a smarter multi-dqa agg plan
--- end_ignore
 explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 group by d;
-                QUERY PLAN                
-------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: d
-         ->  Sort
-               Sort Key: d
-               ->  Seq Scan on dqa_t1
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d
+               ->  HashAggregate
+                     Group Key: (AggExprId), dt, d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, dt, (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, dt, d
+                                 ->  TupleSplit
+                                       Split by Col: (d), (dt)
+                                       Group Key: d
+                                       ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(7 rows)
+(16 rows)
 
 select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d;
  count 
@@ -289,7 +307,7 @@ select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d gr
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d group by dqa_t2.dt;
-                         QUERY PLAN                         
+                         QUERY PLAN
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
@@ -314,7 +332,7 @@ select count(distinct c) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct c) from dqa_t1;
-                               QUERY PLAN                               
+                               QUERY PLAN
 ------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -369,7 +387,7 @@ select count(distinct c) from dqa_t1 group by dt;
 (34 rows)
 
 explain (costs off) select count(distinct c) from dqa_t1 group by dt;
-                            QUERY PLAN                            
+                            QUERY PLAN
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
@@ -413,7 +431,7 @@ select count(distinct c) from dqa_t1 group by d;
 (23 rows)
 
 explain (costs off) select count(distinct c) from dqa_t1 group by d;
-                QUERY PLAN                
+                QUERY PLAN
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
@@ -440,7 +458,7 @@ select count(distinct i), sum(distinct i) from dqa_t1 group by c;
 (10 rows)
 
 explain (costs off) select count(distinct i), sum(distinct i) from dqa_t1 group by c;
-                            QUERY PLAN                            
+                            QUERY PLAN
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
@@ -461,17 +479,21 @@ select count(distinct c), count(distinct dt) from dqa_t1;
     10 |    34
 (1 row)
 
--- start_ignore
--- GPDB_96_MERGE_FIXME: this used to get a smarter multi-dqa agg plan
--- end_ignore
 explain (costs off) select count(distinct c), count(distinct dt) from dqa_t1;
-                   QUERY PLAN                   
-------------------------------------------------
- Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on dqa_t1
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c, dt, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, c, dt
+                           ->  TupleSplit
+                                 Split by Col: (c), (dt)
+                                 ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(4 rows)
+(11 rows)
 
 select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
  count | count | i  
@@ -490,22 +512,26 @@ select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
      5 |     8 |  4
 (12 rows)
 
--- start_ignore
--- GPDB_96_MERGE_FIXME: this used to get a smarter multi-dqa agg plan
--- end_ignore
 explain (costs off) select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: i
-         ->  Sort
-               Sort Key: i
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: i
-                     ->  Seq Scan on dqa_t1
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: i
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: i
+               ->  HashAggregate
+                     Group Key: (AggExprId), c, dt, i
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: i, c, dt, (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, c, dt, i
+                                 ->  TupleSplit
+                                       Split by Col: (c), (dt)
+                                       Group Key: i
+                                       ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(9 rows)
+(16 rows)
 
 select count(distinct i), count(distinct c), d from dqa_t1 group by d;
  count | count | d  
@@ -535,20 +561,26 @@ select count(distinct i), count(distinct c), d from dqa_t1 group by d;
      5 |     5 |  4
 (23 rows)
 
--- start_ignore
--- GPDB_96_MERGE_FIXME: this used to get a smarter multi-dqa agg plan
--- end_ignore
 explain (costs off) select count(distinct i), count(distinct c), d from dqa_t1 group by d;
-                QUERY PLAN                
-------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: d
-         ->  Sort
-               Sort Key: d
-               ->  Seq Scan on dqa_t1
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d
+               ->  HashAggregate
+                     Group Key: (AggExprId), i, c, d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, i, c, (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, i, c, d
+                                 ->  TupleSplit
+                                       Split by Col: (i), (c)
+                                       Group Key: d
+                                       ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(7 rows)
+(16 rows)
 
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
  count 
@@ -557,7 +589,7 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
 (1 row)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
-                                      QUERY PLAN                                       
+                                      QUERY PLAN
 ---------------------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -639,7 +671,7 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c g
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
-                                        QUERY PLAN                                        
+                                        QUERY PLAN
 ------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
@@ -661,6 +693,639 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                                              ->  Seq Scan on dqa_t2
  Optimizer: Postgres query optimizer
 (19 rows)
+
+-- multidqa with groupby and order by
+select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
+ sum | count | count | i  | c 
+-----+-------+-------+----+---
+  14 |     1 |     1 |  0 | 0
+  15 |     1 |     1 |  0 | 2
+  16 |     1 |     1 |  0 | 4
+  17 |     1 |     1 |  0 | 6
+   2 |     1 |     1 |  0 | 8
+  16 |     1 |     1 |  1 | 1
+  17 |     1 |     1 |  1 | 3
+  18 |     1 |     1 |  1 | 5
+  19 |     1 |     1 |  1 | 7
+   3 |     1 |     1 |  1 | 9
+   4 |     1 |     1 |  2 | 0
+  18 |     1 |     1 |  2 | 2
+  19 |     1 |     1 |  2 | 4
+  20 |     1 |     1 |  2 | 6
+  21 |     1 |     1 |  2 | 8
+   5 |     1 |     1 |  3 | 1
+  20 |     1 |     1 |  3 | 3
+  21 |     1 |     1 |  3 | 5
+  22 |     1 |     1 |  3 | 7
+  23 |     1 |     1 |  3 | 9
+  17 |     1 |     1 |  4 | 0
+   6 |     1 |     1 |  4 | 2
+  22 |     1 |     1 |  4 | 4
+  23 |     1 |     1 |  4 | 6
+  24 |     1 |     1 |  4 | 8
+  18 |     1 |     1 |  5 | 1
+   7 |     1 |     1 |  5 | 3
+  24 |     1 |     1 |  5 | 5
+  25 |     1 |     1 |  5 | 7
+  26 |     1 |     1 |  5 | 9
+  28 |     1 |     1 |  6 | 0
+  19 |     1 |     1 |  6 | 2
+   8 |     1 |     1 |  6 | 4
+  26 |     1 |     1 |  6 | 6
+  27 |     1 |     1 |  6 | 8
+  30 |     1 |     1 |  7 | 1
+  20 |     1 |     1 |  7 | 3
+   9 |     1 |     1 |  7 | 5
+  28 |     1 |     1 |  7 | 7
+  29 |     1 |     1 |  7 | 9
+  31 |     1 |     1 |  8 | 0
+   9 |     1 |     1 |  8 | 2
+  21 |     1 |     1 |  8 | 4
+  10 |     1 |     1 |  8 | 6
+  30 |     1 |     1 |  8 | 8
+  33 |     1 |     1 |  9 | 1
+  11 |     1 |     1 |  9 | 3
+  22 |     1 |     1 |  9 | 5
+  11 |     1 |     1 |  9 | 7
+   9 |     1 |     1 |  9 | 9
+  11 |     1 |     1 | 10 | 0
+  35 |     1 |     1 | 10 | 2
+  13 |     1 |     1 | 10 | 4
+   0 |     1 |     1 | 10 | 6
+  12 |     1 |     1 | 10 | 8
+  13 |     1 |     1 | 11 | 1
+  14 |     1 |     1 | 11 | 3
+  15 |     1 |     1 | 11 | 5
+   1 |     1 |     1 | 11 | 7
+  13 |     1 |     1 | 11 | 9
+(60 rows)
+
+explain (costs off) select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, c
+   ->  Finalize HashAggregate
+         Group Key: i, c
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Partial HashAggregate
+                     Group Key: i, c
+                     ->  HashAggregate
+                           Group Key: (AggExprId), d, i, c
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: i, c, d, (AggExprId)
+                                 ->  Streaming HashAggregate
+                                       Group Key: AggExprId, d, i, c
+                                       ->  TupleSplit
+                                             Split by Col: (d), (i), (c)
+                                             Group Key: i, c
+                                             ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+-- multi args singledqa
+-- FIXME: orca result is incorrect. recorde in issue #9374
+select corr(distinct d, i) from dqa_t1;
+        corr        
+--------------------
+ 0.0824013341460019
+(1 row)
+
+explain (costs off) select corr(distinct d, i) from dqa_t1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  HashAggregate
+                     Group Key: ((d)::double precision), ((i)::double precision)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: ((d)::double precision), ((i)::double precision)
+                           ->  Streaming HashAggregate
+                                 Group Key: (d)::double precision, (i)::double precision
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- multi args singledqa with group by
+select corr(distinct d, i) from dqa_t1 group by d;
+ corr 
+------
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+(23 rows)
+
+explain (costs off) select corr(distinct d, i) from dqa_t1 group by d;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: d
+         ->  HashAggregate
+               Group Key: d, (d)::double precision, (i)::double precision
+               ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select corr(distinct d, i) from dqa_t1 group by c;
+        corr        
+--------------------
+  0.136706026184786
+  0.136706026184786
+  0.326224104260335
+ -0.118104768408327
+ 0.0700865292449608
+ 0.0700865292449608
+ -0.175826369278399
+ -0.175826369278399
+  0.420377774079621
+ 0.0579678449086239
+(10 rows)
+
+explain (costs off) select corr(distinct d, i) from dqa_t1 group by c;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: c
+         ->  HashAggregate
+               Group Key: c, ((d)::double precision), ((i)::double precision)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c
+                     ->  Streaming HashAggregate
+                           Group Key: c, (d)::double precision, (i)::double precision
+                           ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- multi args multidqa
+select count(distinct c), corr(distinct d, i) from dqa_t1;
+ count |        corr        
+-------+--------------------
+    10 | 0.0824013341460019
+(1 row)
+
+explain (costs off) select count(distinct c), corr(distinct d, i) from dqa_t1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c, ((d)::double precision), ((i)::double precision), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, c, ((d)::double precision), ((i)::double precision)
+                           ->  TupleSplit
+                                 Split by Col: (c), ((d)::double precision,(i)::double precision)
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(distinct d), corr(distinct d, i) from dqa_t1;
+ count |        corr        
+-------+--------------------
+    23 | 0.0824013341460019
+(1 row)
+
+explain (costs off) select count(distinct d), corr(distinct d, i) from dqa_t1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: d, ((d)::double precision), ((i)::double precision), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, d, ((d)::double precision), ((i)::double precision)
+                           ->  TupleSplit
+                                 Split by Col: (d), ((d)::double precision,(i)::double precision)
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+ count | count |        corr        
+-------+-------+--------------------
+    23 |    12 | 0.0824013341460019
+(1 row)
+
+explain (costs off) select count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: d, i, ((d)::double precision), ((i)::double precision), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, d, i, ((d)::double precision), ((i)::double precision)
+                           ->  TupleSplit
+                                 Split by Col: (d), (i), ((d)::double precision,(i)::double precision)
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(distinct c), count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+ count | count | count |        corr        
+-------+-------+-------+--------------------
+    10 |    23 |    12 | 0.0824013341460019
+(1 row)
+
+explain (costs off) select count(distinct c), count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c, d, i, ((d)::double precision), ((i)::double precision), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, c, d, i, ((d)::double precision), ((i)::double precision)
+                           ->  TupleSplit
+                                 Split by Col: (c), (d), (i), ((d)::double precision,(i)::double precision)
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- multi args multidqa with group by
+select count(distinct c), corr(distinct d, i), d from dqa_t1 group by d;
+ count | corr | d  
+-------+------+----
+     5 |      |  0
+     5 |      |  1
+     5 |      |  2
+     5 |      |  3
+     5 |      |  4
+     5 |      |  5
+     5 |      |  6
+     5 |      |  7
+     4 |      |  8
+     4 |      |  9
+     4 |      | 10
+     4 |      | 11
+     4 |      | 12
+     4 |      | 13
+     4 |      | 14
+     4 |      | 15
+     4 |      | 16
+     4 |      | 17
+     4 |      | 18
+     4 |      | 19
+     4 |      | 20
+     4 |      | 21
+     4 |      | 22
+(23 rows)
+
+explain (costs off) select count(distinct c), corr(distinct d, i), d from dqa_t1 group by d;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d
+               ->  HashAggregate
+                     Group Key: (AggExprId), c, ((d)::double precision), ((i)::double precision), d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, c, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, c, ((d)::double precision), ((i)::double precision), d
+                                 ->  TupleSplit
+                                       Split by Col: (c), ((d)::double precision,(i)::double precision)
+                                       Group Key: d
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct c), corr(distinct d, i), d, i from dqa_t1 group by d,i;
+ count | corr | d  | i  
+-------+------+----+----
+     1 |      |  0 |  0
+     1 |      |  0 |  8
+     1 |      |  0 |  9
+     1 |      |  0 | 10
+     1 |      |  0 | 11
+     1 |      |  1 |  0
+     1 |      |  1 |  1
+     1 |      |  1 |  9
+     1 |      |  1 | 10
+     1 |      |  1 | 11
+     1 |      |  2 |  0
+     1 |      |  2 |  1
+     1 |      |  2 |  2
+     1 |      |  2 | 10
+     1 |      |  2 | 11
+     1 |      |  3 |  0
+     1 |      |  3 |  1
+     1 |      |  3 |  2
+     1 |      |  3 |  3
+     1 |      |  3 | 11
+     1 |      |  4 |  0
+     1 |      |  4 |  1
+     1 |      |  4 |  2
+     1 |      |  4 |  3
+     1 |      |  4 |  4
+     1 |      |  5 |  1
+     1 |      |  5 |  2
+     1 |      |  5 |  3
+     1 |      |  5 |  4
+     1 |      |  5 |  5
+     1 |      |  6 |  2
+     1 |      |  6 |  3
+     1 |      |  6 |  4
+     1 |      |  6 |  5
+     1 |      |  6 |  6
+     1 |      |  7 |  3
+     1 |      |  7 |  4
+     1 |      |  7 |  5
+     1 |      |  7 |  6
+     1 |      |  7 |  7
+     1 |      |  8 |  5
+     1 |      |  8 |  6
+     1 |      |  8 |  7
+     1 |      |  8 |  8
+     1 |      |  9 |  6
+     1 |      |  9 |  7
+     1 |      |  9 |  8
+     1 |      |  9 |  9
+     1 |      | 10 |  7
+     1 |      | 10 |  8
+     1 |      | 10 |  9
+     1 |      | 10 | 10
+     1 |      | 11 |  8
+     1 |      | 11 |  9
+     1 |      | 11 | 10
+     1 |      | 11 | 11
+     1 |      | 12 |  0
+     1 |      | 12 |  9
+     1 |      | 12 | 10
+     1 |      | 12 | 11
+     1 |      | 13 |  0
+     1 |      | 13 |  1
+     1 |      | 13 | 10
+     1 |      | 13 | 11
+     1 |      | 14 |  0
+     1 |      | 14 |  1
+     1 |      | 14 |  2
+     1 |      | 14 | 11
+     1 |      | 15 |  0
+     1 |      | 15 |  1
+     1 |      | 15 |  2
+     1 |      | 15 |  3
+     1 |      | 16 |  1
+     1 |      | 16 |  2
+     1 |      | 16 |  3
+     1 |      | 16 |  4
+     1 |      | 17 |  2
+     1 |      | 17 |  3
+     1 |      | 17 |  4
+     1 |      | 17 |  5
+     1 |      | 18 |  3
+     1 |      | 18 |  4
+     1 |      | 18 |  5
+     1 |      | 18 |  6
+     1 |      | 19 |  4
+     1 |      | 19 |  5
+     1 |      | 19 |  6
+     1 |      | 19 |  7
+     1 |      | 20 |  5
+     1 |      | 20 |  6
+     1 |      | 20 |  7
+     1 |      | 20 |  8
+     1 |      | 21 |  6
+     1 |      | 21 |  7
+     1 |      | 21 |  8
+     1 |      | 21 |  9
+     1 |      | 22 |  7
+     1 |      | 22 |  8
+     1 |      | 22 |  9
+     1 |      | 22 | 10
+(100 rows)
+
+explain (costs off) select count(distinct c), corr(distinct d, i), d, i from dqa_t1 group by d,i;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d, i
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d, i
+               ->  HashAggregate
+                     Group Key: (AggExprId), c, ((d)::double precision), ((i)::double precision), d, i
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, i, c, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, c, ((d)::double precision), ((i)::double precision), d, i
+                                 ->  TupleSplit
+                                       Split by Col: (c), ((d)::double precision,(i)::double precision)
+                                       Group Key: d, i
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct c), corr(distinct d, i), dt from dqa_t1 group by dt;
+ count |        corr        |     dt     
+-------+--------------------+------------
+     3 |   0.59603956067927 | 06-25-2009
+     3 | 0.0750939261482638 | 06-20-2009
+     3 | 0.0750939261482638 | 07-11-2009
+     3 | 0.0750939261482638 | 06-18-2009
+     3 | 0.0750939261482638 | 06-14-2009
+     3 |  0.755928946018455 | 06-10-2009
+     3 | 0.0750939261482638 | 06-28-2009
+     3 | 0.0750939261482638 | 06-17-2009
+     3 | 0.0750939261482638 | 06-16-2009
+     3 |   0.59603956067927 | 06-24-2009
+     3 | 0.0750939261482638 | 06-29-2009
+     3 | 0.0750939261482638 | 07-09-2009
+     3 | 0.0750939261482638 | 06-21-2009
+     3 | 0.0750939261482638 | 06-26-2009
+     3 | -0.709570905570559 | 06-13-2009
+     3 | -0.709570905570559 | 06-23-2009
+     3 |   0.59603956067927 | 06-11-2009
+     3 | 0.0750939261482638 | 07-10-2009
+     3 | 0.0750939261482638 | 07-01-2009
+     3 | -0.709570905570559 | 06-12-2009
+     3 |   0.59603956067927 | 07-04-2009
+     3 | 0.0750939261482638 | 06-15-2009
+     3 | 0.0750939261482638 | 06-30-2009
+     3 |   0.59603956067927 | 07-05-2009
+     2 |                 -1 | 07-12-2009
+     3 | 0.0750939261482638 | 07-02-2009
+     3 | 0.0750939261482638 | 06-27-2009
+     3 |                 -1 | 07-03-2009
+     3 | -0.709570905570559 | 07-06-2009
+     2 |                 -1 | 07-13-2009
+     3 | -0.709570905570559 | 07-07-2009
+     3 | 0.0750939261482638 | 07-08-2009
+     3 | 0.0750939261482638 | 06-19-2009
+     3 | -0.709570905570559 | 06-22-2009
+(34 rows)
+
+explain (costs off) select count(distinct c), corr(distinct d, i), dt from dqa_t1 group by dt;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: dt
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: dt
+               ->  HashAggregate
+                     Group Key: (AggExprId), c, ((d)::double precision), ((i)::double precision), dt
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: dt, c, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, c, ((d)::double precision), ((i)::double precision), dt
+                                 ->  TupleSplit
+                                       Split by Col: (c), ((d)::double precision,(i)::double precision)
+                                       Group Key: dt
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct d), corr(distinct d, i), i from dqa_t1 group by i;
+ count | corr | i  
+-------+------+----
+     9 |      |  0
+     9 |      |  1
+     9 |      |  2
+     9 |      |  3
+     8 |      |  4
+     8 |      |  5
+     8 |      |  6
+     8 |      |  7
+     8 |      |  8
+     8 |      |  9
+     8 |      | 10
+     8 |      | 11
+(12 rows)
+
+explain (costs off) select count(distinct d), corr(distinct d, i), i from dqa_t1 group by i;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: i
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: i
+               ->  HashAggregate
+                     Group Key: (AggExprId), d, ((d)::double precision), ((i)::double precision), i
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: i, d, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, d, ((d)::double precision), ((i)::double precision), i
+                                 ->  TupleSplit
+                                       Split by Col: (d), ((d)::double precision,(i)::double precision)
+                                       Group Key: i
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct d), corr(distinct d, i), d from dqa_t1 group by d;
+ count | corr | d  
+-------+------+----
+     1 |      |  0
+     1 |      |  1
+     1 |      |  2
+     1 |      |  3
+     1 |      |  4
+     1 |      |  5
+     1 |      |  6
+     1 |      |  7
+     1 |      |  8
+     1 |      |  9
+     1 |      | 10
+     1 |      | 11
+     1 |      | 12
+     1 |      | 13
+     1 |      | 14
+     1 |      | 15
+     1 |      | 16
+     1 |      | 17
+     1 |      | 18
+     1 |      | 19
+     1 |      | 20
+     1 |      | 21
+     1 |      | 22
+(23 rows)
+
+explain (costs off) select count(distinct d), corr(distinct d, i), d from dqa_t1 group by d;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d
+               ->  HashAggregate
+                     Group Key: (AggExprId), ((d)::double precision), ((i)::double precision), d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, ((d)::double precision), ((i)::double precision), d
+                                 ->  TupleSplit
+                                       Split by Col: (d), ((d)::double precision,(i)::double precision)
+                                       Group Key: d
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct d), corr(distinct d, i), c from dqa_t1 group by c;
+ count |        corr        | c 
+-------+--------------------+---
+    10 |  0.136706026184786 | 0
+    10 |  0.136706026184786 | 1
+    10 |  0.326224104260335 | 2
+    10 | -0.118104768408327 | 3
+    10 | 0.0700865292449608 | 4
+    10 | 0.0700865292449608 | 5
+    10 | -0.175826369278399 | 6
+    10 | -0.175826369278399 | 7
+    10 |  0.420377774079621 | 8
+    10 | 0.0579678449086239 | 9
+(10 rows)
+
+explain (costs off) select count(distinct d), corr(distinct d, i), c from dqa_t1 group by c;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: c
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: c
+               ->  HashAggregate
+                     Group Key: (AggExprId), d, ((d)::double precision), ((i)::double precision), c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: c, d, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, d, ((d)::double precision), ((i)::double precision), c
+                                 ->  TupleSplit
+                                       Split by Col: (d), ((d)::double precision,(i)::double precision)
+                                       Group Key: c
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
 
 -- MPP-19037
 drop table if exists fact_route_aggregation;
@@ -1248,7 +1913,7 @@ select count(distinct d) from dqa_t1 group by i;
 (12 rows)
 
 explain (costs off) select count(distinct d) from dqa_t1 group by i;
-                   QUERY PLAN                   
+                   QUERY PLAN
 ------------------------------------------------
  Finalize GroupAggregate
    Group Key: i
@@ -1302,3 +1967,21 @@ SELECT distinct C.z, count(distinct FS.x), count(distinct FS.y) FROM (SELECT i A
 (0 rows)
 
 drop table foo_mdqa;
+-- non-strict agg test
+-- Like COUNT(col), but also counts NULLs
+create or replace function countall_trans(c int, newval int) returns int as $$
+  SELECT $1 + 1;
+$$ language sql;
+create aggregate countall(sfunc = countall_trans, basetype = int, stype = int, initcond = 0, combinefunc = int4pl);
+-- Test table
+create table nonullstab (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into nonullstab select 1, 1 from generate_series(1, 100);
+-- This returns wrong result. countall(distinct a) should return 1.
+select countall(distinct a), count(distinct b) from nonullstab;
+ countall | count 
+----------+-------
+        1 |     1
+(1 row)
+

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -107,13 +107,20 @@ select count(distinct d), count(distinct dt) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1;
-                   QUERY PLAN                   
-------------------------------------------------
- Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on dqa_t1
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: d, dt, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, d, dt
+                           ->  TupleSplit
+                                 Split by Col: (d), (dt)
+                                 ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(4 rows)
+(11 rows)
 
 select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
  count | count | count 
@@ -122,13 +129,20 @@ select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
-                   QUERY PLAN                   
-------------------------------------------------
- Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on dqa_t1
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: d, c, dt, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, d, c, dt
+                           ->  TupleSplit
+                                 Split by Col: (d), (c), (dt)
+                                 ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(4 rows)
+(11 rows)
 
 select count(distinct d), count(distinct dt) from dqa_t1 group by c;
  count | count 
@@ -146,18 +160,25 @@ select count(distinct d), count(distinct dt) from dqa_t1 group by c;
 (10 rows)
 
 explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 group by c;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: c
-         ->  Sort
-               Sort Key: c
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: c
-                     ->  Seq Scan on dqa_t1
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: c
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: c
+               ->  HashAggregate
+                     Group Key: (AggExprId), d, dt, c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: c, d, dt, (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, d, dt, c
+                                 ->  TupleSplit
+                                       Split by Col: (d), (dt)
+                                       Group Key: c
+                                       ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(9 rows)
+(16 rows)
 
 select count(distinct d), count(distinct dt) from dqa_t1 group by d;
  count | count 
@@ -188,16 +209,25 @@ select count(distinct d), count(distinct dt) from dqa_t1 group by d;
 (23 rows)
 
 explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 group by d;
-                QUERY PLAN                
-------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: d
-         ->  Sort
-               Sort Key: d
-               ->  Seq Scan on dqa_t1
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d
+               ->  HashAggregate
+                     Group Key: (AggExprId), dt, d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, dt, (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, dt, d
+                                 ->  TupleSplit
+                                       Split by Col: (d), (dt)
+                                       Group Key: d
+                                       ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(7 rows)
+(16 rows)
 
 select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d;
  count 
@@ -446,13 +476,20 @@ select count(distinct c), count(distinct dt) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct c), count(distinct dt) from dqa_t1;
-                   QUERY PLAN                   
-------------------------------------------------
- Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on dqa_t1
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c, dt, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, c, dt
+                           ->  TupleSplit
+                                 Split by Col: (c), (dt)
+                                 ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(4 rows)
+(11 rows)
 
 select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
  count | count | i  
@@ -472,18 +509,25 @@ select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
 (12 rows)
 
 explain (costs off) select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: i
-         ->  Sort
-               Sort Key: i
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: i
-                     ->  Seq Scan on dqa_t1
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: i
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: i
+               ->  HashAggregate
+                     Group Key: (AggExprId), c, dt, i
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: i, c, dt, (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, c, dt, i
+                                 ->  TupleSplit
+                                       Split by Col: (c), (dt)
+                                       Group Key: i
+                                       ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(9 rows)
+(16 rows)
 
 select count(distinct i), count(distinct c), d from dqa_t1 group by d;
  count | count | d  
@@ -514,16 +558,25 @@ select count(distinct i), count(distinct c), d from dqa_t1 group by d;
 (23 rows)
 
 explain (costs off) select count(distinct i), count(distinct c), d from dqa_t1 group by d;
-                QUERY PLAN                
-------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: d
-         ->  Sort
-               Sort Key: d
-               ->  Seq Scan on dqa_t1
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d
+               ->  HashAggregate
+                     Group Key: (AggExprId), i, c, d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, i, c, (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, i, c, d
+                                 ->  TupleSplit
+                                       Split by Col: (i), (c)
+                                       Group Key: d
+                                       ->  Seq Scan on dqa_t1
  Optimizer: Postgres query optimizer
-(7 rows)
+(16 rows)
 
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
  count 
@@ -633,6 +686,633 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                                        ->  Seq Scan on dqa_t2
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (17 rows)
+
+-- multidqa with groupby and order by
+select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
+ sum | count | count | i  | c 
+-----+-------+-------+----+---
+  14 |     1 |     1 |  0 | 0
+  15 |     1 |     1 |  0 | 2
+  16 |     1 |     1 |  0 | 4
+  17 |     1 |     1 |  0 | 6
+   2 |     1 |     1 |  0 | 8
+  16 |     1 |     1 |  1 | 1
+  17 |     1 |     1 |  1 | 3
+  18 |     1 |     1 |  1 | 5
+  19 |     1 |     1 |  1 | 7
+   3 |     1 |     1 |  1 | 9
+   4 |     1 |     1 |  2 | 0
+  18 |     1 |     1 |  2 | 2
+  19 |     1 |     1 |  2 | 4
+  20 |     1 |     1 |  2 | 6
+  21 |     1 |     1 |  2 | 8
+   5 |     1 |     1 |  3 | 1
+  20 |     1 |     1 |  3 | 3
+  21 |     1 |     1 |  3 | 5
+  22 |     1 |     1 |  3 | 7
+  23 |     1 |     1 |  3 | 9
+  17 |     1 |     1 |  4 | 0
+   6 |     1 |     1 |  4 | 2
+  22 |     1 |     1 |  4 | 4
+  23 |     1 |     1 |  4 | 6
+  24 |     1 |     1 |  4 | 8
+  18 |     1 |     1 |  5 | 1
+   7 |     1 |     1 |  5 | 3
+  24 |     1 |     1 |  5 | 5
+  25 |     1 |     1 |  5 | 7
+  26 |     1 |     1 |  5 | 9
+  28 |     1 |     1 |  6 | 0
+  19 |     1 |     1 |  6 | 2
+   8 |     1 |     1 |  6 | 4
+  26 |     1 |     1 |  6 | 6
+  27 |     1 |     1 |  6 | 8
+  30 |     1 |     1 |  7 | 1
+  20 |     1 |     1 |  7 | 3
+   9 |     1 |     1 |  7 | 5
+  28 |     1 |     1 |  7 | 7
+  29 |     1 |     1 |  7 | 9
+  31 |     1 |     1 |  8 | 0
+   9 |     1 |     1 |  8 | 2
+  21 |     1 |     1 |  8 | 4
+  10 |     1 |     1 |  8 | 6
+  30 |     1 |     1 |  8 | 8
+  33 |     1 |     1 |  9 | 1
+  11 |     1 |     1 |  9 | 3
+  22 |     1 |     1 |  9 | 5
+  11 |     1 |     1 |  9 | 7
+   9 |     1 |     1 |  9 | 9
+  11 |     1 |     1 | 10 | 0
+  35 |     1 |     1 | 10 | 2
+  13 |     1 |     1 | 10 | 4
+   0 |     1 |     1 | 10 | 6
+  12 |     1 |     1 | 10 | 8
+  13 |     1 |     1 | 11 | 1
+  14 |     1 |     1 | 11 | 3
+  15 |     1 |     1 | 11 | 5
+   1 |     1 |     1 | 11 | 7
+  13 |     1 |     1 | 11 | 9
+(60 rows)
+
+explain (costs off) select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, c
+   ->  Finalize HashAggregate
+         Group Key: i, c
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Partial HashAggregate
+                     Group Key: i, c
+                     ->  HashAggregate
+                           Group Key: (AggExprId), d, i, c
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: i, c, d, (AggExprId)
+                                 ->  Streaming HashAggregate
+                                       Group Key: AggExprId, d, i, c
+                                       ->  TupleSplit
+                                             Split by Col: (d), (i), (c)
+                                             Group Key: i, c
+                                             ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+-- multi args singledqa
+-- FIXME: orca result is incorrect. recorde in issue #9374
+select corr(distinct d, i) from dqa_t1;
+ corr 
+------
+     
+(1 row)
+
+explain (costs off) select corr(distinct d, i) from dqa_t1;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: ((d)::double precision)
+                     ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.88.0
+(7 rows)
+
+-- multi args singledqa with group by
+select corr(distinct d, i) from dqa_t1 group by d;
+ corr 
+------
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+(23 rows)
+
+explain (costs off) select corr(distinct d, i) from dqa_t1 group by d;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: d
+         ->  Sort
+               Sort Key: d
+               ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.88.0
+(7 rows)
+
+select corr(distinct d, i) from dqa_t1 group by c;
+        corr        
+--------------------
+  0.136706026184786
+  0.136706026184786
+  0.326224104260335
+ -0.118104768408327
+ 0.0700865292449608
+ 0.0700865292449608
+ -0.175826369278399
+ -0.175826369278399
+  0.420377774079621
+ 0.0579678449086239
+(10 rows)
+
+explain (costs off) select corr(distinct d, i) from dqa_t1 group by c;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: c
+         ->  Sort
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c
+                     ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.88.0
+(9 rows)
+
+-- multi args multidqa
+select count(distinct c), corr(distinct d, i) from dqa_t1;
+ count |        corr        
+-------+--------------------
+    10 | 0.0824013341460019
+(1 row)
+
+explain (costs off) select count(distinct c), corr(distinct d, i) from dqa_t1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c, ((d)::double precision), ((i)::double precision), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, c, ((d)::double precision), ((i)::double precision)
+                           ->  TupleSplit
+                                 Split by Col: (c), ((d)::double precision,(i)::double precision)
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(distinct d), corr(distinct d, i) from dqa_t1;
+ count |        corr        
+-------+--------------------
+    23 | 0.0824013341460019
+(1 row)
+
+explain (costs off) select count(distinct d), corr(distinct d, i) from dqa_t1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: d, ((d)::double precision), ((i)::double precision), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, d, ((d)::double precision), ((i)::double precision)
+                           ->  TupleSplit
+                                 Split by Col: (d), ((d)::double precision,(i)::double precision)
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+ count | count |        corr        
+-------+-------+--------------------
+    23 |    12 | 0.0824013341460019
+(1 row)
+
+explain (costs off) select count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: d, i, ((d)::double precision), ((i)::double precision), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, d, i, ((d)::double precision), ((i)::double precision)
+                           ->  TupleSplit
+                                 Split by Col: (d), (i), ((d)::double precision,(i)::double precision)
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(distinct c), count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+ count | count | count |        corr        
+-------+-------+-------+--------------------
+    10 |    23 |    12 | 0.0824013341460019
+(1 row)
+
+explain (costs off) select count(distinct c), count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c, d, i, ((d)::double precision), ((i)::double precision), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Group Key: AggExprId, c, d, i, ((d)::double precision), ((i)::double precision)
+                           ->  TupleSplit
+                                 Split by Col: (c), (d), (i), ((d)::double precision,(i)::double precision)
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- multi args multidqa with group by
+select count(distinct c), corr(distinct d, i), d from dqa_t1 group by d;
+ count | corr | d  
+-------+------+----
+     5 |      |  0
+     5 |      |  1
+     5 |      |  2
+     5 |      |  3
+     5 |      |  4
+     5 |      |  5
+     5 |      |  6
+     5 |      |  7
+     4 |      |  8
+     4 |      |  9
+     4 |      | 10
+     4 |      | 11
+     4 |      | 12
+     4 |      | 13
+     4 |      | 14
+     4 |      | 15
+     4 |      | 16
+     4 |      | 17
+     4 |      | 18
+     4 |      | 19
+     4 |      | 20
+     4 |      | 21
+     4 |      | 22
+(23 rows)
+
+explain (costs off) select count(distinct c), corr(distinct d, i), d from dqa_t1 group by d;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d
+               ->  HashAggregate
+                     Group Key: (AggExprId), c, ((d)::double precision), ((i)::double precision), d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, c, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, c, ((d)::double precision), ((i)::double precision), d
+                                 ->  TupleSplit
+                                       Split by Col: (c), ((d)::double precision,(i)::double precision)
+                                       Group Key: d
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct c), corr(distinct d, i), d, i from dqa_t1 group by d,i;
+ count | corr | d  | i  
+-------+------+----+----
+     1 |      |  0 |  0
+     1 |      |  0 |  8
+     1 |      |  0 |  9
+     1 |      |  0 | 10
+     1 |      |  0 | 11
+     1 |      |  1 |  0
+     1 |      |  1 |  1
+     1 |      |  1 |  9
+     1 |      |  1 | 10
+     1 |      |  1 | 11
+     1 |      |  2 |  0
+     1 |      |  2 |  1
+     1 |      |  2 |  2
+     1 |      |  2 | 10
+     1 |      |  2 | 11
+     1 |      |  3 |  0
+     1 |      |  3 |  1
+     1 |      |  3 |  2
+     1 |      |  3 |  3
+     1 |      |  3 | 11
+     1 |      |  4 |  0
+     1 |      |  4 |  1
+     1 |      |  4 |  2
+     1 |      |  4 |  3
+     1 |      |  4 |  4
+     1 |      |  5 |  1
+     1 |      |  5 |  2
+     1 |      |  5 |  3
+     1 |      |  5 |  4
+     1 |      |  5 |  5
+     1 |      |  6 |  2
+     1 |      |  6 |  3
+     1 |      |  6 |  4
+     1 |      |  6 |  5
+     1 |      |  6 |  6
+     1 |      |  7 |  3
+     1 |      |  7 |  4
+     1 |      |  7 |  5
+     1 |      |  7 |  6
+     1 |      |  7 |  7
+     1 |      |  8 |  5
+     1 |      |  8 |  6
+     1 |      |  8 |  7
+     1 |      |  8 |  8
+     1 |      |  9 |  6
+     1 |      |  9 |  7
+     1 |      |  9 |  8
+     1 |      |  9 |  9
+     1 |      | 10 |  7
+     1 |      | 10 |  8
+     1 |      | 10 |  9
+     1 |      | 10 | 10
+     1 |      | 11 |  8
+     1 |      | 11 |  9
+     1 |      | 11 | 10
+     1 |      | 11 | 11
+     1 |      | 12 |  0
+     1 |      | 12 |  9
+     1 |      | 12 | 10
+     1 |      | 12 | 11
+     1 |      | 13 |  0
+     1 |      | 13 |  1
+     1 |      | 13 | 10
+     1 |      | 13 | 11
+     1 |      | 14 |  0
+     1 |      | 14 |  1
+     1 |      | 14 |  2
+     1 |      | 14 | 11
+     1 |      | 15 |  0
+     1 |      | 15 |  1
+     1 |      | 15 |  2
+     1 |      | 15 |  3
+     1 |      | 16 |  1
+     1 |      | 16 |  2
+     1 |      | 16 |  3
+     1 |      | 16 |  4
+     1 |      | 17 |  2
+     1 |      | 17 |  3
+     1 |      | 17 |  4
+     1 |      | 17 |  5
+     1 |      | 18 |  3
+     1 |      | 18 |  4
+     1 |      | 18 |  5
+     1 |      | 18 |  6
+     1 |      | 19 |  4
+     1 |      | 19 |  5
+     1 |      | 19 |  6
+     1 |      | 19 |  7
+     1 |      | 20 |  5
+     1 |      | 20 |  6
+     1 |      | 20 |  7
+     1 |      | 20 |  8
+     1 |      | 21 |  6
+     1 |      | 21 |  7
+     1 |      | 21 |  8
+     1 |      | 21 |  9
+     1 |      | 22 |  7
+     1 |      | 22 |  8
+     1 |      | 22 |  9
+     1 |      | 22 | 10
+(100 rows)
+
+explain (costs off) select count(distinct c), corr(distinct d, i), d, i from dqa_t1 group by d,i;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d, i
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d, i
+               ->  HashAggregate
+                     Group Key: (AggExprId), c, ((d)::double precision), ((i)::double precision), d, i
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, i, c, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, c, ((d)::double precision), ((i)::double precision), d, i
+                                 ->  TupleSplit
+                                       Split by Col: (c), ((d)::double precision,(i)::double precision)
+                                       Group Key: d, i
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct c), corr(distinct d, i), dt from dqa_t1 group by dt;
+ count |        corr        |     dt     
+-------+--------------------+------------
+     3 |   0.59603956067927 | 06-25-2009
+     3 | 0.0750939261482638 | 06-20-2009
+     3 | 0.0750939261482638 | 07-11-2009
+     3 | 0.0750939261482638 | 06-18-2009
+     3 | 0.0750939261482638 | 06-14-2009
+     3 |  0.755928946018455 | 06-10-2009
+     3 | 0.0750939261482638 | 06-28-2009
+     3 | 0.0750939261482638 | 06-17-2009
+     3 | 0.0750939261482638 | 06-16-2009
+     3 |   0.59603956067927 | 06-24-2009
+     3 | 0.0750939261482638 | 06-29-2009
+     3 | 0.0750939261482638 | 07-09-2009
+     3 | 0.0750939261482638 | 06-21-2009
+     3 | 0.0750939261482638 | 06-26-2009
+     3 | -0.709570905570559 | 06-13-2009
+     3 | -0.709570905570559 | 06-23-2009
+     3 |   0.59603956067927 | 06-11-2009
+     3 | 0.0750939261482638 | 07-10-2009
+     3 | 0.0750939261482638 | 07-01-2009
+     3 | -0.709570905570559 | 06-12-2009
+     3 |   0.59603956067927 | 07-04-2009
+     3 | 0.0750939261482638 | 06-15-2009
+     3 | 0.0750939261482638 | 06-30-2009
+     3 |   0.59603956067927 | 07-05-2009
+     2 |                 -1 | 07-12-2009
+     3 | 0.0750939261482638 | 07-02-2009
+     3 | 0.0750939261482638 | 06-27-2009
+     3 |                 -1 | 07-03-2009
+     3 | -0.709570905570559 | 07-06-2009
+     2 |                 -1 | 07-13-2009
+     3 | -0.709570905570559 | 07-07-2009
+     3 | 0.0750939261482638 | 07-08-2009
+     3 | 0.0750939261482638 | 06-19-2009
+     3 | -0.709570905570559 | 06-22-2009
+(34 rows)
+
+explain (costs off) select count(distinct c), corr(distinct d, i), dt from dqa_t1 group by dt;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: dt
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: dt
+               ->  HashAggregate
+                     Group Key: (AggExprId), c, ((d)::double precision), ((i)::double precision), dt
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: dt, c, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, c, ((d)::double precision), ((i)::double precision), dt
+                                 ->  TupleSplit
+                                       Split by Col: (c), ((d)::double precision,(i)::double precision)
+                                       Group Key: dt
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct d), corr(distinct d, i), i from dqa_t1 group by i;
+ count | corr | i  
+-------+------+----
+     9 |      |  0
+     9 |      |  1
+     9 |      |  2
+     9 |      |  3
+     8 |      |  4
+     8 |      |  5
+     8 |      |  6
+     8 |      |  7
+     8 |      |  8
+     8 |      |  9
+     8 |      | 10
+     8 |      | 11
+(12 rows)
+
+explain (costs off) select count(distinct d), corr(distinct d, i), i from dqa_t1 group by i;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: i
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: i
+               ->  HashAggregate
+                     Group Key: (AggExprId), d, ((d)::double precision), ((i)::double precision), i
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: i, d, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, d, ((d)::double precision), ((i)::double precision), i
+                                 ->  TupleSplit
+                                       Split by Col: (d), ((d)::double precision,(i)::double precision)
+                                       Group Key: i
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct d), corr(distinct d, i), d from dqa_t1 group by d;
+ count | corr | d  
+-------+------+----
+     1 |      |  0
+     1 |      |  1
+     1 |      |  2
+     1 |      |  3
+     1 |      |  4
+     1 |      |  5
+     1 |      |  6
+     1 |      |  7
+     1 |      |  8
+     1 |      |  9
+     1 |      | 10
+     1 |      | 11
+     1 |      | 12
+     1 |      | 13
+     1 |      | 14
+     1 |      | 15
+     1 |      | 16
+     1 |      | 17
+     1 |      | 18
+     1 |      | 19
+     1 |      | 20
+     1 |      | 21
+     1 |      | 22
+(23 rows)
+
+explain (costs off) select count(distinct d), corr(distinct d, i), d from dqa_t1 group by d;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: d
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: d
+               ->  HashAggregate
+                     Group Key: (AggExprId), ((d)::double precision), ((i)::double precision), d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, ((d)::double precision), ((i)::double precision), d
+                                 ->  TupleSplit
+                                       Split by Col: (d), ((d)::double precision,(i)::double precision)
+                                       Group Key: d
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select count(distinct d), corr(distinct d, i), c from dqa_t1 group by c;
+ count |        corr        | c 
+-------+--------------------+---
+    10 |  0.136706026184786 | 0
+    10 |  0.136706026184786 | 1
+    10 |  0.326224104260335 | 2
+    10 | -0.118104768408327 | 3
+    10 | 0.0700865292449608 | 4
+    10 | 0.0700865292449608 | 5
+    10 | -0.175826369278399 | 6
+    10 | -0.175826369278399 | 7
+    10 |  0.420377774079621 | 8
+    10 | 0.0579678449086239 | 9
+(10 rows)
+
+explain (costs off) select count(distinct d), corr(distinct d, i), c from dqa_t1 group by c;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: c
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: c
+               ->  HashAggregate
+                     Group Key: (AggExprId), d, ((d)::double precision), ((i)::double precision), c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: c, d, ((d)::double precision), ((i)::double precision), (AggExprId)
+                           ->  Streaming HashAggregate
+                                 Group Key: AggExprId, d, ((d)::double precision), ((i)::double precision), c
+                                 ->  TupleSplit
+                                       Split by Col: (d), ((d)::double precision,(i)::double precision)
+                                       Group Key: c
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(16 rows)
 
 -- MPP-19037
 drop table if exists fact_route_aggregation;
@@ -1275,3 +1955,21 @@ SELECT distinct C.z, count(distinct FS.x), count(distinct FS.y) FROM (SELECT i A
 (0 rows)
 
 drop table foo_mdqa;
+-- non-strict agg test
+-- Like COUNT(col), but also counts NULLs
+create or replace function countall_trans(c int, newval int) returns int as $$
+  SELECT $1 + 1;
+$$ language sql;
+create aggregate countall(sfunc = countall_trans, basetype = int, stype = int, initcond = 0, combinefunc = int4pl);
+-- Test table
+create table nonullstab (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into nonullstab select 1, 1 from generate_series(1, 100);
+-- This returns wrong result. countall(distinct a) should return 1.
+select countall(distinct a), count(distinct b) from nonullstab;
+ countall | count 
+----------+-------
+        1 |     1
+(1 row)
+

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -5494,13 +5494,13 @@ select * from
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-ERROR:  could not devise a query plan for the given query (pathnode.c:465)
+ERROR:  could not devise a query plan for the given query (pathnode.c:468)
 select * from
   int8_tbl a left join lateral
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-ERROR:  could not devise a query plan for the given query (pathnode.c:465)
+ERROR:  could not devise a query plan for the given query (pathnode.c:468)
 -- case requiring nested PlaceHolderVars
 explain (verbose, costs off)
 select * from

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -5607,13 +5607,13 @@ select * from
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-ERROR:  could not devise a query plan for the given query (pathnode.c:465)
+ERROR:  could not devise a query plan for the given query (pathnode.c:468)
 select * from
   int8_tbl a left join lateral
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-ERROR:  could not devise a query plan for the given query (pathnode.c:465)
+ERROR:  could not devise a query plan for the given query (pathnode.c:468)
 -- case requiring nested PlaceHolderVars
 explain (verbose, costs off)
 select * from

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -35,6 +35,8 @@ SELECT * FROM mpp2687v;
 select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from tenk1 group by 1;
 select ten, ten, count(distinct two), count(distinct four) from tenk1 group by 1,2;
 
+select case when ten < 5 then ten else ten * 2 end, count(distinct two) from tenk1 group by 1;
+
 --MPP-20151: distinct is transformed to a group-by
 select distinct two from tenk1 order by two;
 select distinct two, four from tenk1 order by two, four;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -63,6 +63,53 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
 
+-- multidqa with groupby and order by
+select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
+explain (costs off) select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
+
+-- multi args singledqa
+-- FIXME: orca result is incorrect. recorde in issue #9374
+select corr(distinct d, i) from dqa_t1;
+explain (costs off) select corr(distinct d, i) from dqa_t1;
+
+-- multi args singledqa with group by
+select corr(distinct d, i) from dqa_t1 group by d;
+explain (costs off) select corr(distinct d, i) from dqa_t1 group by d;
+
+select corr(distinct d, i) from dqa_t1 group by c;
+explain (costs off) select corr(distinct d, i) from dqa_t1 group by c;
+
+-- multi args multidqa
+select count(distinct c), corr(distinct d, i) from dqa_t1;
+explain (costs off) select count(distinct c), corr(distinct d, i) from dqa_t1;
+
+select count(distinct d), corr(distinct d, i) from dqa_t1;
+explain (costs off) select count(distinct d), corr(distinct d, i) from dqa_t1;
+
+select count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+explain (costs off) select count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+
+select count(distinct c), count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+explain (costs off) select count(distinct c), count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
+
+-- multi args multidqa with group by
+select count(distinct c), corr(distinct d, i), d from dqa_t1 group by d;
+explain (costs off) select count(distinct c), corr(distinct d, i), d from dqa_t1 group by d;
+
+select count(distinct c), corr(distinct d, i), d, i from dqa_t1 group by d,i;
+explain (costs off) select count(distinct c), corr(distinct d, i), d, i from dqa_t1 group by d,i;
+
+select count(distinct c), corr(distinct d, i), dt from dqa_t1 group by dt;
+explain (costs off) select count(distinct c), corr(distinct d, i), dt from dqa_t1 group by dt;
+
+select count(distinct d), corr(distinct d, i), i from dqa_t1 group by i;
+explain (costs off) select count(distinct d), corr(distinct d, i), i from dqa_t1 group by i;
+
+select count(distinct d), corr(distinct d, i), d from dqa_t1 group by d;
+explain (costs off) select count(distinct d), corr(distinct d, i), d from dqa_t1 group by d;
+
+select count(distinct d), corr(distinct d, i), c from dqa_t1 group by c;
+explain (costs off) select count(distinct d), corr(distinct d, i), c from dqa_t1 group by c;
 
 -- MPP-19037
 drop table if exists fact_route_aggregation;
@@ -238,3 +285,18 @@ SELECT distinct C.z, count(distinct FS.x), count(distinct FS.y) FROM (SELECT i A
 
 
 drop table foo_mdqa;
+
+-- non-strict agg test
+
+-- Like COUNT(col), but also counts NULLs
+create or replace function countall_trans(c int, newval int) returns int as $$
+  SELECT $1 + 1;
+$$ language sql;
+create aggregate countall(sfunc = countall_trans, basetype = int, stype = int, initcond = 0, combinefunc = int4pl);
+
+-- Test table
+create table nonullstab (a int, b int);
+insert into nonullstab select 1, 1 from generate_series(1, 100);
+
+-- This returns wrong result. countall(distinct a) should return 1.
+select countall(distinct a), count(distinct b) from nonullstab;


### PR DESCRIPTION
This PR bring Multi-DQA MPP execution to master again after 9.6 merged but a new strategy introduced. A new aggregate, `AGG_TUP_SPLIT`, divides each input tuple to `n` output tuples (`n` is the number of DQA exprs).  Each output tuple only contains one DQA expr and all GROUP BY expr, so that we can remove multiple DQA in one path. After previous work, a normal two-stage aggregate without distinct attaches on top. 

For this method, it is a limitation that GROUP BY clause can not be the same as DQA expr. The two-stage aggregate will get the wrong result since  GROUP BY keeps its expr in every tuple. To deal with this corner case, I declare a new expr named ShadowExpr. It just simply copy its major expr's value and cheat executor.
```
SELECT count(distinct a), count(distinct b) FROM foo GROUP BY a;
```
this query will translate as
```
SELECT count(distinct a), count(distinct b) FROM foo GROUP BY a';
(a' is the Shadow Expr for a, and all (a')'s value == a value)
```

 
Co-authored-by: Adam Li <ali@pivotal.io>
Inspired by: Heikki Linnakangas <heikki.linnakangas@iki.fi>
## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
