### PR TITLE
5X: Harden analyze rootpartition to merge stats if relpages is incorrect

### DIFF
--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1140,7 +1140,7 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols)
 		int4 relpages = get_rel_relpages(partRelid);
 
 		// Partition is analyzed and we detect it is empty
-		if (relTuples == 0.0 && relpages == 1)
+		if (relTuples == 0.0 && relpages > 0)
 			continue;
 
 		all_parts_empty = false;

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1970,6 +1970,29 @@ SELECT relname, relpages, reltuples FROM pg_class WHERE relname LIKE 'incr_analy
  incr_analyze_test_1_prt_6 |        1 |         0
 (7 rows)
 
+-- Test merging of stats if an empty partition contains relpages > 0
+-- Do not collect samples while merging stats
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int) PARTITION BY RANGE (b) (START (0) END (6) EVERY (3));
+INSERT INTO foo SELECT i,i%3 FROM generate_series(1,10)i;
+ANALYZE foo_1_prt_1;
+ANALYZE foo_1_prt_2;
+SET allow_system_table_mods = 'DML';
+UPDATE pg_class set relpages=3 WHERE relname='foo_1_prt_2';
+RESET allow_system_table_mods;
+SET client_min_messages = 'log';
+analyze rootpartition foo;
+LOG:  Merging leaf partition stats to calculate root partition stats : column a
+LOG:  Merging leaf partition stats to calculate root partition stats : column b
+reset client_min_messages;
+-- ensure relpages is correctly set after analyzing
+analyze foo_1_prt_2;
+select reltuples, relpages from pg_class where relname ='foo_1_prt_2';
+ reltuples | relpages 
+-----------+----------
+         0 |        1
+(1 row)
+
 INSERT INTO t900c SELECT i%130, i%8, 'something'||i::text FROM generate_series(1,100)i;
 ANALYZE t900c;
 INSERT INTO foo_900_numeric_cols SELECT i,i FROM generate_series(1,100)i;

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -781,6 +781,22 @@ INSERT INTO incr_analyze_test SELECT s, md5(s::varchar), '2018-01-02' FROM gener
 ANALYZE incr_analyze_test_1_prt_2;
 SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'incr_analyze_test%' ORDER BY attname,tablename;
 SELECT relname, relpages, reltuples FROM pg_class WHERE relname LIKE 'incr_analyze_test%' ORDER BY relname;
+-- Test merging of stats if an empty partition contains relpages > 0
+-- Do not collect samples while merging stats
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int) PARTITION BY RANGE (b) (START (0) END (6) EVERY (3));
+INSERT INTO foo SELECT i,i%3 FROM generate_series(1,10)i;
+ANALYZE foo_1_prt_1;
+ANALYZE foo_1_prt_2;
+SET allow_system_table_mods = 'DML';
+UPDATE pg_class set relpages=3 WHERE relname='foo_1_prt_2';
+RESET allow_system_table_mods;
+SET client_min_messages = 'log';
+analyze rootpartition foo;
+reset client_min_messages;
+-- ensure relpages is correctly set after analyzing
+analyze foo_1_prt_2;
+select reltuples, relpages from pg_class where relname ='foo_1_prt_2';
 
 -- start_ignore
 DROP TABLE IF EXISTS t900c;


### PR DESCRIPTION
`analyze rootpartition` will merge statistics if all leaf partitions
have been analyzed. If a partition is empty (that is, the reltuples is
0), we previously considered it analyzed only if the relpages was also 1.

However, we have seen a state where the reltuples is 0 and relpages was
greater than 1 (one such case was resolved in 183947f8). This hardens analyze in
case we encounter such a scenario, as it can make `analyze rootpartition`
take significantly longer.
