### PR TITLE
Change lockmode for catalog pg_resgroup.

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -138,7 +138,7 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 	 * of CREATE and ALTER
 	 */
 	pg_resgroupcapability_rel = heap_open(ResGroupCapabilityRelationId, AccessExclusiveLock);
-	pg_resgroup_rel = heap_open(ResGroupRelationId, RowExclusiveLock);
+	pg_resgroup_rel = heap_open(ResGroupRelationId, AccessExclusiveLock);
 
 	/* Check if MaxResourceGroups limit is reached */
 	sscan = systable_beginscan(pg_resgroup_rel, ResGroupRsgnameIndexId, false,
@@ -282,7 +282,7 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 	 * Check the pg_resgroup relation to be certain the resource group already
 	 * exists.
 	 */
-	pg_resgroup_rel = heap_open(ResGroupRelationId, RowExclusiveLock);
+	pg_resgroup_rel = heap_open(ResGroupRelationId, AccessExclusiveLock);
 
 	ScanKeyInit(&scankey,
 				Anum_pg_resgroup_rsgname,

--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -245,7 +245,7 @@ pg_resgroup_get_status(PG_FUNCTION_ARGS)
 			 * block until creating/dropping finish to avoid inconsistent
 			 * resource group metadata
 			 */
-			pg_resgroup_rel = heap_open(ResGroupRelationId, ExclusiveLock);
+			pg_resgroup_rel = heap_open(ResGroupRelationId, AccessShareLock);
 
 			sscan = systable_beginscan(pg_resgroup_rel, InvalidOid, false,
 									   NULL, 0, NULL);


### PR DESCRIPTION
To read the catalog should only require AccessShareLock,
DDL(create|drop) should take AccessExclusiveLock, so they
conflict with each other.

-------------------------------------------------------------

Do not add extra test cases since the resgroup test suite has covered this.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
