### PR TITLE
Fix binary swap test for pg_get_viewdef() fix

### DIFF
--- a/src/test/binary_swap/test_binary_swap.sh
+++ b/src/test/binary_swap/test_binary_swap.sh
@@ -25,6 +25,12 @@ clean_output()
     rm -f dump_current.sql dump_other.sql
 }
 
+## Run pre test to ignore expected failures
+run_pre_test()
+{
+    psql -f test_binary_swap_pre.sql postgres > /dev/null 2>&1
+}
+
 ## Run tests via pg_regress with given schedule name
 run_tests()
 {
@@ -134,6 +140,7 @@ clean_output
 
 ## Start/restart current Greenplum and do initial dump to compare against
 start_binary $GPHOME_CURRENT
+run_pre_test
 run_tests schedule1${VARIANT}
 
 ## Change the binary, dump, and then compare the two dumps generated

--- a/src/test/binary_swap/test_binary_swap_pre.sql
+++ b/src/test/binary_swap/test_binary_swap_pre.sql
@@ -1,0 +1,12 @@
+-- WARNING: This file is executed against the postgres database. If
+-- objects are to be manipulated in other databases, make sure to
+-- change to the correct database first.
+
+-- The pg_get_viewdef() function was fixed to properly show views
+-- defined with gp_dist_random() but it will diff in this binary swap
+-- test suite. Ignore by removing the view.
+\c regression;
+DROP VIEW IF EXISTS locktest_segments;
+
+\c isolation2test;
+DROP VIEW IF EXISTS locktest_segments;


### PR DESCRIPTION
After pg_get_viewdef() was fixed to handle views defined with
gp_dist_random(), the binary swap test started to fail because it had
one of those views being incorrectly dumped. This is an expected
failure and we'll need to remove the view before running the binary
swap test.

Expected failure diff:
```
<    FROM ONLY public.locktest_segments_dist
---
>    FROM gp_dist_random('public.locktest_segments_dist')
```

GPDB Reference:
https://github.com/greenplum-db/gpdb/commit/7af86a0bf2871a9e