### PR TITLE
Multi insert for CTAS (Create Table As).

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2979,7 +2979,6 @@ heap_multi_insert(Relation relation, HeapTuple *tuples, int ntuples,
 				  CommandId cid, int options, BulkInsertState bistate, TransactionId xid)
 {
 	bool        isFrozen = (xid == FrozenTransactionId);
-	HeapTuple  *heaptuples;
 	int			i;
 	int			ndone;
 	PGAlignedBlock scratch;
@@ -2988,6 +2987,10 @@ heap_multi_insert(Relation relation, HeapTuple *tuples, int ntuples,
 	Size		saveFreeSpace;
 	bool		need_tuple_data = RelationIsLogicallyLogged(relation);
 	bool		need_cids = RelationIsAccessibleInLogicalDecoding(relation);
+	/* Declare it as static to let this memory be not on stack. */
+	static HeapTuple	heaptuples[MAX_MULTI_INSERT_TUPLES];
+
+	Assert(ntuples <= MAX_MULTI_INSERT_TUPLES);
 
 	/* currently not needed (thus unsupported) for heap_multi_insert() */
 	AssertArg(!(options & HEAP_INSERT_NO_LOGICAL));
@@ -2997,7 +3000,6 @@ heap_multi_insert(Relation relation, HeapTuple *tuples, int ntuples,
 												   HEAP_DEFAULT_FILLFACTOR);
 
 	/* Toast and set header data in all the tuples */
-	heaptuples = palloc(ntuples * sizeof(HeapTuple));
 	for (i = 0; i < ntuples; i++)
 		heaptuples[i] = heap_prepare_insert(relation, tuples[i],
 											xid, cid, options, isFrozen);

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3610,7 +3610,6 @@ CopyFrom(CopyState cstate)
 	GpDistributionData	*distData = NULL; /* distribution data used to compute target seg */
 	uint64		processed = 0;
 	bool		useHeapMultiInsert;
-#define MAX_BUFFERED_TUPLES 1000
 	int			nTotalBufferedTuples = 0;
 	Size		totalBufferedTuplesSize = 0;
 	int			i;
@@ -4195,7 +4194,7 @@ CopyFrom(CopyState cstate)
 				resultRelInfoList = list_append_unique_ptr(resultRelInfoList, resultRelInfo);
 				if (resultRelInfo->bufferedTuples == NULL)
 				{
-					resultRelInfo->bufferedTuples = palloc(MAX_BUFFERED_TUPLES * sizeof(HeapTuple));
+					resultRelInfo->bufferedTuples = palloc(MAX_MULTI_INSERT_TUPLES * sizeof(HeapTuple));
 					resultRelInfo->nBufferedTuples = 0;
 					resultRelInfo->bufferedTuplesSize = 0;
 				}
@@ -4215,11 +4214,11 @@ CopyFrom(CopyState cstate)
 				 * the tuples are exceptionally wide.
 				 */
 				/*
-				 * GPDB_92_MERGE_FIXME: MAX_BUFFERED_TUPLES and 65535 might not be
+				 * GPDB_92_MERGE_FIXME: MAX_MULTI_INSERT_TUPLES and MAX_MULTI_INSERT_SIZE might not be
 				 * the best value for partition table
 				 */
-				if (nTotalBufferedTuples == MAX_BUFFERED_TUPLES ||
-					totalBufferedTuplesSize > 65535)
+				if (nTotalBufferedTuples == MAX_MULTI_INSERT_TUPLES ||
+					totalBufferedTuplesSize > MAX_MULTI_INSERT_SIZE)
 				{
 					cdbFlushInsertBatches(resultRelInfoList, cstate, estate, mycid, hi_options,
 										  slot, firstBufferedLineNo);

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -34,6 +34,9 @@
 
 typedef struct BulkInsertStateData *BulkInsertState;
 
+#define MAX_MULTI_INSERT_TUPLES	1000
+#define MAX_MULTI_INSERT_SIZE	65535
+
 /*
  * Possible lock modes for a tuple.
  */


### PR DESCRIPTION
This could improve the performance of CTAS usually especially when the target
table is with low width. This also could reduce wal size so that recovery on
mirror is much faster usually - that is being complained recently.

Will paste the test results later.