### PR TITLE
Enable prove tests for pg_dump

### DIFF
--- a/src/bin/pg_dump/Makefile
+++ b/src/bin/pg_dump/Makefile
@@ -51,13 +51,11 @@ install: all installdirs
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(bindir)'
 
-# GPDB_96_MERGE_FIXME: these tests are currently not working on GPDB.
-# Fix and re-enable.
-#check:
-#	$(prove_check)
-#
-#installcheck:
-#	$(prove_installcheck)
+check:
+	$(prove_check)
+
+installcheck:
+	$(prove_installcheck)
 
 uninstall:
 	rm -f $(addprefix '$(DESTDIR)$(bindir)'/, pg_dump$(X) pg_restore$(X) pg_dumpall$(X))

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4341,12 +4341,32 @@ getNamespaces(Archive *fout, int *numNamespaces)
 						  "LEFT JOIN pg_init_privs pip "
 						  "ON (n.oid = pip.objoid "
 						  "AND pip.classoid = 'pg_namespace'::regclass "
-						  "AND pip.objsubid = 0) ",
+						  "AND pip.objsubid = 0",
 						  username_subquery,
 						  acl_subquery->data,
 						  racl_subquery->data,
 						  init_acl_subquery->data,
 						  init_racl_subquery->data);
+
+		/*
+		 * When we are doing a 'clean' run, we will be dropping and recreating
+		 * the 'public' schema (the only object which has that kind of
+		 * treatment in the backend and which has an entry in pg_init_privs)
+		 * and therefore we should not consider any initial privileges in
+		 * pg_init_privs in that case.
+		 *
+		 * See pg_backup_archiver.c:_printTocEntry() for the details on why
+		 * the public schema is special in this regard.
+		 *
+		 * Note that if the public schema is dropped and re-created, this is
+		 * essentially a no-op because the new public schema won't have an
+		 * entry in pg_init_privs anyway, as the entry will be removed when
+		 * the public schema is dropped.
+		 */
+		if (dopt->outputClean)
+			appendPQExpBuffer(query," AND pip.objoid <> 'public'::regnamespace");
+
+		appendPQExpBuffer(query,") ");
 
 		destroyPQExpBuffer(acl_subquery);
 		destroyPQExpBuffer(racl_subquery);

--- a/src/bin/pg_dump/t/002_pg_dump.pl
+++ b/src/bin/pg_dump/t/002_pg_dump.pl
@@ -2152,7 +2152,6 @@ my %tests = (
 		regexp => qr/^DROP /m,
 		like   => {},            # use more-specific options above
 		unlike => {
-			binary_upgrade           => 1,
 			column_inserts           => 1,
 			createdb                 => 1,
 			data_only                => 1,


### PR DESCRIPTION
These tests were added during the 9.6 merge cycle from upstream. During the
merge, some code from the tip of 9.6 was backported in an attempt to make the
tests pass, though it did not reach all the way.

Backporting upstream commit <609bba56fbd3> from the tip of 9.6 solves all but
one issue. In GPDB we deviate from upstream with regards to the treatment of the
public schema during binary dumps. This behaviour was introduced and explained
in the greenplum commit <5844158d1>. Remove the expectation from the DROP
statement to not be present in the tests.

Removes a FIXME.