### PR TITLE
Assorted Fixes Following PR #9085

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -5620,10 +5620,9 @@ retry:
 
 		resultRelInfo = targetid_get_partition(frame.relid, estate, true);
 		estate->es_result_relation_info = resultRelInfo;
+		slot = reconstructMatchingTupleSlot(baseSlot, resultRelInfo);
 
 		MemoryContextSwitchTo(oldcontext);
-
-		slot = reconstructMatchingTupleSlot(baseSlot, resultRelInfo);
 
 		/* since resultRelInfo has changed, refresh these values */
 		tupDesc = RelationGetDescr(resultRelInfo->ri_RelationDesc);

--- a/src/test/regress/expected/gpcopy_dispatch.out
+++ b/src/test/regress/expected/gpcopy_dispatch.out
@@ -45,14 +45,28 @@ INFO:  first field processed in the QE: 2
 CONTEXT:  COPY partdisttest, line 0
 DROP TABLE partdisttest;
 -- Hash distributed, with a dropped column
-CREATE TABLE partdisttest (a int, dropped int, b int, c int)
-  DISTRIBUTED BY (b)
-  PARTITION BY RANGE (a) (START (0) END (100) EVERY (50));
-ALTER TABLE partdisttest DROP COLUMN dropped;
+-- We used to have a bug where QD would pick the wrong partition and/or the
+-- wrong segment due to difference between the base table and a partition: the
+-- partitioing attribute(s) for the root table is column 3, but it is column 1
+-- in the leaf partition "neg". The QD would then mistakenly pick a partition
+-- for the NULL value, and error out that no such a partition exists.
+-- Note if the dropped columns are in a different position, a different (but
+-- really similar) symptom will appear: the QD will pick another partition,
+-- which potentially results in the wrong segment receiving the line / tuple.
+CREATE TABLE partdisttest (dropped1 int, dropped2 int, a int, b int, c int)
+  DISTRIBUTED BY (a)
+  PARTITION BY RANGE (b) (START (0) END (100) EVERY (50));
+ALTER TABLE partdisttest DROP COLUMN dropped1, DROP COLUMN dropped2;
 ALTER TABLE partdisttest ADD PARTITION neg start (-10) end (0);
 COPY partdisttest FROM stdin;
 INFO:  first field processed in the QE: 2
 CONTEXT:  COPY partdisttest, line 0
+SELECT tableoid::regclass, * FROM partdisttest;
+        tableoid        | a | b  | c 
+------------------------+---+----+---
+ partdisttest_1_prt_neg | 2 | -1 | 3
+(1 row)
+
 DROP TABLE partdisttest;
 -- Subpartitions
 CREATE TABLE partdisttest (a int, dropped int, b int, c int, d int)

--- a/src/test/regress/expected/gpcopy_dispatch.out
+++ b/src/test/regress/expected/gpcopy_dispatch.out
@@ -94,3 +94,33 @@ COPY partdisttest FROM stdin;
 INFO:  first field processed in the QE: 3
 CONTEXT:  COPY partdisttest, line 0
 DROP TABLE partdisttest;
+CREATE TABLE partdisttest (dropped bool, a smallint, b smallint)
+  DISTRIBUTED BY (a)
+  PARTITION BY RANGE(a)
+  (PARTITION segundo START(5));
+NOTICE:  CREATE TABLE will create partition "partdisttest_1_prt_segundo" for table "partdisttest"
+ALTER TABLE partdisttest DROP dropped;
+ALTER TABLE partdisttest ADD PARTITION primero START(0) END(5);
+NOTICE:  CREATE TABLE will create partition "partdisttest_1_prt_primero" for table "partdisttest"
+-- We used to have bug, when a partition has a different distribution
+-- column number than the base table, we'd lazily construct a tuple
+-- table slot for that partition, but in a (mistakenly) short-lived
+-- per query memory context. COPY FROM uses batch size of
+-- MAX_BUFFERED_TUPLES tuples, and after that it resets the per query
+-- context. As a result while processing second batch, segment used to
+-- crash. This test exposed the bug and now validates the fix.
+COPY (
+    SELECT 2,1
+    FROM (
+        SELECT generate_series(1, MAX_BUFFERED_TUPLES + 1)
+        FROM (VALUES (10000)) t(MAX_BUFFERED_TUPLES)
+        ) t
+    ) TO '/tmp/ten-thousand-and-one-lines.txt';
+COPY partdisttest FROM '/tmp/ten-thousand-and-one-lines.txt';
+INFO:  first field processed in the QE: 1
+SELECT tableoid::regclass, count(*) FROM partdisttest GROUP BY 1;
+          tableoid          | count 
+----------------------------+-------
+ partdisttest_1_prt_primero | 10001
+(1 row)
+


### PR DESCRIPTION
This patch set fixes two issues after committing #9085 :

1. COPY: Simplify partition distribution policy lookup. This manifests itself as inserting tuples onto the wrong segment, or more often "no partition for partitioning key"
1. Allocate tuple slot in the per query context

See either commit for details.

Resolves #9170 