### PR TITLE
InitBufferPool: remove memory scribbling

### DIFF
--- a/src/backend/storage/buffer/buf_init.c
+++ b/src/backend/storage/buffer/buf_init.c
@@ -98,7 +98,6 @@ ProtectMemoryPoolBuffers()
 void
 InitBufferPool(void)
 {
-    Size bufferBlocksTotalSize = mul_size((Size)NBuffers, (Size) BLCKSZ);
 	bool		foundBufs,
 				foundDescs,
 				foundIOLocks,
@@ -112,10 +111,7 @@ InitBufferPool(void)
 
 	BufferBlocks = (char *)
 		ShmemInitStruct("Buffer Blocks",
-						bufferBlocksTotalSize, &foundBufs);
-
-	/* GPDB: Init the buffer memory to something to help check for bugs */
-	memset(BufferBlocks,0xFE,bufferBlocksTotalSize);
+						NBuffers * (Size) BLCKSZ, &foundBufs);
 
 	/* Align lwlocks to cacheline boundary */
 	BufferIOLWLockArray = (LWLockMinimallyPadded *)


### PR DESCRIPTION
Per [discussion on gpdb-dev@](https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/3euvTnx51Bg/t1utLN6DAgAJ), remove the `0xFE` scribble. This bloats initdb runtime considerably and will stop being useful as soon as the cache fills with actual data.

We can also remove a diff against upstream.

-----------
- [ ] ~Add tests for the change~
- [ ] ~Document changes~
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck` ([done](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/dev:no-scribble))
- [ ] Review a PR in return to support the community
