### PR TITLE
Fix a mistake to elogif messages

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -254,7 +254,7 @@ checkIfFailedDueToRecoveryInProgress(fts_segment_info *ftsInfo)
 				   (uint32) (tmpptr >> 32),
 				   (uint32) tmpptr,
 				   ftsInfo->primary_cdbinfo->config->segindex,
-				   ftsInfo->mirror_cdbinfo->config->dbid,
+				   ftsInfo->primary_cdbinfo->config->dbid,
 				   ftsInfo->mirror_cdbinfo->config->dbid);
 		}
 	}


### PR DESCRIPTION
One field needs the primary dbid, but the code
passes the mirror's dbid.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
