### PR TITLE
[5X] Should handle correctly for FileWrite() errors.

### DIFF
--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -170,21 +170,13 @@ static void BufferedAppendWrite(
 
 	while (writeLen > 0) 
 	{
-		int primaryError;
 		bool mirrorDataLossOccurred;
 		
 		MirroredAppendOnly_Append(
 							&bufferedAppend->mirroredOpen,
 							(char*)largeWriteMemory,
 							writeLen,
-							&primaryError,
 							&mirrorDataLossOccurred);
-		if (primaryError != 0)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("Could not write in table \"%s\" to segment file \"%s\": %m",
-					 		bufferedAppend->relationName,
-							bufferedAppend->filePathName)));
 	   
 		elogif(Debug_appendonly_print_append_block, LOG,
 				"Append-Only storage write: table \"%s\", segment file \"%s\", write position " INT64_FORMAT ", "

--- a/src/backend/cdb/cdbfilerepresyncworker.c
+++ b/src/backend/cdb/cdbfilerepresyncworker.c
@@ -460,14 +460,11 @@ FileRepPrimary_ResyncWrite(FileRepResyncHashEntry_s	*entry)
 											  &mirroredOpen,
 											  buffer,
 											  bufferLen,
-											  &primaryError,
 											  &mirrorDataLossOccurred);
 						
 						if (mirrorDataLossOccurred)
 							break;
 
-						Assert(primaryError == 0);	// No primary writes as resync worker.
-						
 						startOffset += bufferLen;
 						/* AO and CO Data Store writes 64k size by default */
 						bufferLen = (Size) Min(2*BLCKSZ, endOffset - startOffset);						

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -513,14 +513,7 @@ static void copy_append_only_segment_file(
 							  &mirroredDstOpen,
 							  buffer,
 							  bufferLen,
-							  &primaryError,
 							  &mirrorDataLossOccurred);
-		if (primaryError != 0)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not write file \"%s\": %s",
-							dstFileName,
-							strerror(primaryError))));
 		
 		readOffset += bufferLen;
 		

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -9562,14 +9562,7 @@ copy_append_only_data(
 							  &mirroredDstOpen,
 							  buffer,
 							  bufferLen,
-							  &primaryError,
 							  &mirrorDataLossOccurred);
-		if (primaryError != 0)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not write file \"%s\": %s",
-							dstFileName,
-							strerror(primaryError))));
 		
 		readOffset += bufferLen;
 		

--- a/src/include/cdb/cdbmirroredappendonly.h
+++ b/src/include/cdb/cdbmirroredappendonly.h
@@ -280,9 +280,6 @@ extern void MirroredAppendOnly_Append(
 
 	int32		appendDataLen,
 	
-				/* The byte length of the Append-Only data. */
-	int 		*primaryError,
-	
 	bool		*mirrorDataLossOccurred);
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This patch is related to two callers of MirroredAppendOnly_Append() (might call
FileWrite()). Previous comment and code seem to imply that FileWrite() could
not be called by the code paths finally so just two Assert are there. I did not
carefully check all call paths but probably we should still conservatively
check there in case there are existing bugs or regression especially
considering low level io function errors are dangerous and are hard to debug.
Though ideally we should check FileWrite() and handle immediately.
