### PR TITLE
Ensure correct initialization of DtxContextInfo

### DIFF
--- a/src/include/cdb/cdbdtxcontextinfo.h
+++ b/src/include/cdb/cdbdtxcontextinfo.h
@@ -15,7 +15,7 @@
 #define CDBDTXCONTEXTINFO_H
 #include "utils/tqual.h"
 
-#define DtxContextInfo_StaticInit {0,InvalidDistributedTransactionId,0,false,false,DistributedSnapshot_StaticInit,0,0}
+#define DtxContextInfo_StaticInit {0,0,false,false,DistributedSnapshot_StaticInit,0,0,InvalidDistributedTransactionId}
 
 typedef struct DtxContextInfo
 {
@@ -34,7 +34,7 @@ typedef struct DtxContextInfo
 	uint32							nestingLevel;
 
 	/* currentCommandId of QD, for debugging only */
-	CommandId				 		curcid;	
+	CommandId				 		curcid;
 } DtxContextInfo;
 
 extern DtxContextInfo QEDtxContextInfo;	


### PR DESCRIPTION
Commit 468bf68f18b7286b6621ac0300cb4e271833a7bc moved the curcid debug member to last to match changes to SharedSnapshotSlot. The move didn't account for DtxContextInfo_StaticInit however which kept the previous order. Fix by updating the static initializer to match the new order.