### PR TITLE
When serializing a tuple for Motion, don't decompress compressed datums.

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "access/htup.h"
+#include "access/tuptoaster.h"
 #include "catalog/pg_type.h"
 #include "cdb/cdbmotion.h"
 #include "cdb/cdbsrlz.h"
@@ -655,9 +656,17 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 					 * avoid memory leakage: we want to force the detoast
 					 * allocation(s) to happen in our reset-able serialization
 					 * context.
+					 *
+					 * Only detoast, don't decompress. It saves network bandwidth
+					 * to let the receiver decompress it. Furthermore, it's possible
+					 * that the receiver doesn't need to decompress it at all, which
+					 * can be a very big win.
 					 */
 					oldCtxt = MemoryContextSwitchTo(s_tupSerMemCtxt);
-					attr = PointerGetDatum(PG_DETOAST_DATUM_PACKED(origattr));
+					if (VARATT_IS_EXTERNAL(origattr))
+						attr = PointerGetDatum(heap_tuple_fetch_attr((struct varlena *) DatumGetPointer(origattr)));
+					else
+						attr = origattr;
 					MemoryContextSwitchTo(oldCtxt);
 
 					sz = VARSIZE_ANY_EXHDR(attr);


### PR DESCRIPTION
If a datum is toasted and compressed, only detoast it before serializing.
No need to decompress, the receiver can decompress it if needed. That's
a big win, if the receiver is just going to store the value back to disk,
and doesn't need to decompress it at all.

The corresponding codepath for MemTuples was already doing this, within
memtuple_form_to().

Addresses github issue https://github.com/greenplum-db/gpdb/issues/9253
