### PR TITLE
Make plan_node_id assignments in ORCA 0-based

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -325,7 +325,11 @@ COptTasks::ConvertToPlanStmtFromDXL
 	GPOS_ASSERT(NULL != md_accessor);
 	GPOS_ASSERT(NULL != dxlnode);
 
-	CIdGenerator plan_id_generator(1 /* ulStartId */);
+	/*
+	 * Since GPDB 7 (commit 0ae9004), plan node IDs start from 0 in GPDB.
+	 * GPDB 6 and lower had plan node IDs starting from 0.
+	 */
+	CIdGenerator plan_id_generator(0 /* ulStartId */);
 	CIdGenerator motion_id_generator(1 /* ulStartId */);
 	CIdGenerator param_id_generator(0 /* ulStartId */);
 


### PR DESCRIPTION
This is a follow-up to 0ae90045c7, which made plan_node_id assignments
in the server 0-based. The commit also changed gpperfom's explicit
dependencies on 1-based plan_node_ids to 0-base. This led to the
following gpperfmon behave test failing in CI for when ORCA is
enabled.

```
Then wait until the results from boolean sql "SELECT rows_out =
count(distinct content) from queries_history, gp_segment_configuration
where query_text like 'select gp_segment_id, count(*)%' and db =
'gptest' and content != -1 group by rows_out" is "true"
```

This commit fixes this failure by ensuring plan_node_ids start at 0,
with the root plan node getting an id 0.

Co-authored-by: Hao Wang <haowang@pivotal.io>
Co-authored-by: Jesse Zhang <jzhang@pivotal.io>
