### PR TITLE
Replace ExecFetchSlotHeapTuple()+heap_copytuple() with ExecCopySlotHe…

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4190,7 +4190,6 @@ CopyFrom(CopyState cstate)
 				HeapTuple	tuple;
 				if (resultRelInfo->nBufferedTuples == 0)
 					firstBufferedLineNo = cstate->cur_lineno;
-				tuple = ExecFetchSlotHeapTuple(slot);
 
 				resultRelInfoList = list_append_unique_ptr(resultRelInfoList, resultRelInfo);
 				if (resultRelInfo->bufferedTuples == NULL)
@@ -4202,7 +4201,8 @@ CopyFrom(CopyState cstate)
 
 				MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 				/* Add this tuple to the tuple buffer */
-				resultRelInfo->bufferedTuples[resultRelInfo->nBufferedTuples++] = heap_copytuple(tuple);
+				tuple = ExecCopySlotHeapTuple(slot);
+				resultRelInfo->bufferedTuples[resultRelInfo->nBufferedTuples++] = tuple;
 				resultRelInfo->bufferedTuplesSize += tuple->t_len;
 				nTotalBufferedTuples++;
 				totalBufferedTuplesSize += tuple->t_len;


### PR DESCRIPTION
…apTuple() in CopyFrom()

This saves a memory copy of tuple length for each tuple handling. I did not see
big improvement with 'copy from' perf testing with this change ( 1%+ avg.
running time reduction of 20 runs with table lenth 1k+) but it is still
helpful.