### PR TITLE
[6X Backport] In walreceiver, don't try to do ereport() in a signal handler.

### DIFF
--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -23,6 +23,7 @@
 #include "access/xlog.h"
 #include "miscadmin.h"
 #include "replication/walreceiver.h"
+#include "storage/proc.h"
 #include "utils/builtins.h"
 
 #ifdef HAVE_POLL_H
@@ -63,6 +64,7 @@ static void libpqrcv_disconnect(void);
 /* Prototypes for private functions */
 static bool libpq_select(int timeout_ms);
 static PGresult *libpqrcv_PQexec(const char *query);
+static PGresult *libpqrcv_PQgetResult(PGconn *streamConn);
 
 /*
  * Module load callback
@@ -233,7 +235,7 @@ libpqrcv_endstreaming(TimeLineID *next_tli)
 	 * called after receiving CopyDone from the backend - the walreceiver
 	 * never terminates replication on its own initiative.
 	 */
-	res = PQgetResult(streamConn);
+	res = libpqrcv_PQgetResult(streamConn);
 	if (PQresultStatus(res) == PGRES_TUPLES_OK)
 	{
 		/*
@@ -247,7 +249,7 @@ libpqrcv_endstreaming(TimeLineID *next_tli)
 		PQclear(res);
 
 		/* the result set should be followed by CommandComplete */
-		res = PQgetResult(streamConn);
+		res = libpqrcv_PQgetResult(streamConn);
 	}
 	else
 		*next_tli = 0;
@@ -259,7 +261,7 @@ libpqrcv_endstreaming(TimeLineID *next_tli)
 	PQclear(res);
 
 	/* Verify that there are no more results */
-	res = PQgetResult(streamConn);
+	res = libpqrcv_PQgetResult(streamConn);
 	if (res != NULL)
 		ereport(ERROR,
 				(errmsg("unexpected result after CommandComplete: %s",
@@ -383,12 +385,11 @@ libpq_select(int timeout_ms)
  * The function is modeled on PQexec() in libpq, but only implements
  * those parts that are in use in the walreceiver.
  *
- * Queries are always executed on the connection in streamConn.
+ * May return NULL, rather than an error result, on failure.
  */
 static PGresult *
 libpqrcv_PQexec(const char *query)
 {
-	PGresult   *result = NULL;
 	PGresult   *lastResult = NULL;
 
 	/*
@@ -398,47 +399,26 @@ libpqrcv_PQexec(const char *query)
 	 */
 
 	/*
-	 * Submit a query. Since we don't use non-blocking mode, this also can
-	 * block. But its risk is relatively small, so we ignore that for now.
+	 * Submit the query.  Since we don't use non-blocking mode, this could
+	 * theoretically block.  In practice, since we don't send very long query
+	 * strings, the risk seems negligible.
 	 */
 	if (!PQsendQuery(streamConn, query))
 		return NULL;
 
 	for (;;)
 	{
-		/*
-		 * Receive data until PQgetResult is ready to get the result without
-		 * blocking.
-		 */
-		while (PQisBusy(streamConn))
-		{
-			/*
-			 * We don't need to break down the sleep into smaller increments,
-			 * and check for interrupts after each nap, since we can just
-			 * elog(FATAL) within SIGTERM signal handler if the signal arrives
-			 * in the middle of establishment of replication connection.
-			 */
-			if (!libpq_select(-1))
-				continue;		/* interrupted */
-
-			/* Consume whatever data is available from the socket */
-			if (PQconsumeInput(streamConn) == 0)
-			{
-				/* trouble; drop whatever we had and return NULL */
-				PQclear(lastResult);
-				return NULL;
-			}
-		}
+		/* Wait for, and collect, the next PGresult. */
+		PGresult   *result;
+		result = libpqrcv_PQgetResult(streamConn);
+		if (result == NULL)
+			break;				/* query is complete, or failure */
 
 		/*
 		 * Emulate PQexec()'s behavior of returning the last result when there
 		 * are many.  Since walsender will never generate multiple results, we
 		 * skip the concatenation of error messages.
 		 */
-		result = PQgetResult(streamConn);
-		if (result == NULL)
-			break;				/* query is complete */
-
 		PQclear(lastResult);
 		lastResult = result;
 
@@ -450,6 +430,50 @@ libpqrcv_PQexec(const char *query)
 	}
 
 	return lastResult;
+}
+
+/*
+ * Perform the equivalent of PQgetResult(), but watch for interrupts.
+ */
+static PGresult *
+libpqrcv_PQgetResult(PGconn *streamConn)
+{
+	/*
+	 * Collect data until PQgetResult is ready to get the result without
+	 * blocking.
+	 */
+	while (PQisBusy(streamConn))
+	{
+		int			rc;
+
+		/*
+		 * We don't need to break down the sleep into smaller increments,
+		 * since we'll get interrupted by signals and can handle any
+		 * interrupts here.
+		 */
+		rc = WaitLatchOrSocket(&MyProc->procLatch,
+							   WL_POSTMASTER_DEATH | WL_SOCKET_READABLE |
+							   WL_LATCH_SET,
+							   PQsocket(streamConn),
+							   0);
+
+		/* Interrupted? */
+		if (rc & WL_LATCH_SET)
+		{
+			ResetLatch(&MyProc->procLatch);
+			ProcessWalRcvInterrupts();
+		}
+
+		/* Consume whatever data is available from the socket */
+		if (PQconsumeInput(streamConn) == 0)
+		{
+			/* trouble; return NULL */
+			return NULL;
+		}
+	}
+
+	/* Now we can collect and return the next PGresult */
+	return PQgetResult(streamConn);
 }
 
 /*
@@ -516,7 +540,7 @@ libpqrcv_receive(int timeout, char **buffer)
 	{
 		PGresult   *res;
 
-		res = PQgetResult(streamConn);
+		res = libpqrcv_PQgetResult(streamConn);
 		if (PQresultStatus(res) == PGRES_COMMAND_OK ||
 			PQresultStatus(res) == PGRES_COPY_IN)
 		{

--- a/src/include/replication/walreceiver.h
+++ b/src/include/replication/walreceiver.h
@@ -150,6 +150,7 @@ void		libpqwalreceiver_PG_init(void);
 
 /* prototypes for functions in walreceiver.c */
 extern void WalReceiverMain(void) __attribute__((noreturn));
+extern void ProcessWalRcvInterrupts(void);
 
 /* prototypes for functions in walreceiverfuncs.c */
 extern Size WalRcvShmemSize(void);

--- a/src/test/walrep/expected/walreceiver.out
+++ b/src/test/walrep/expected/walreceiver.out
@@ -1,8 +1,8 @@
 -- negative cases
 SELECT test_receive();
-ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:537)
+ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:561)
 SELECT test_send();
-ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:556)
+ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:580)
 SELECT test_disconnect();
  test_disconnect 
 -----------------


### PR DESCRIPTION
This is cherry-pick of upstream commit
a1a789eb5ac894b4ca4b7742f2dc2d9602116e46, slightly modified to work
with current GPDB code based of 9.4. Helps to fix the deadlocks seen
in CI for walreceiver.

-------------------
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Mon Apr 29 12:26:07 2019 -0400

    In walreceiver, don't try to do ereport() in a signal handler.

    This is quite unsafe, even for the case of ereport(FATAL) where we won't
    return control to the interrupted code, and despite this code's use of
    a flag to restrict the areas where we'd try to do it.  It's possible
    for example that we interrupt malloc or free while that's holding a lock
    that's meant to protect against cross-thread interference.  Then, any
    attempt to do malloc or free within ereport() will result in a deadlock,
    preventing the walreceiver process from exiting in response to SIGTERM.
    We hypothesize that this explains some hard-to-reproduce failures seen
    in the buildfarm.

    Hence, get rid of the immediate-exit code in WalRcvShutdownHandler,
    as well as the logic associated with WalRcvImmediateInterruptOK.
    Instead, we need to take care that potentially-blocking operations
    in the walreceiver's data transmission logic (libpqwalreceiver.c)
    will respond reasonably promptly to the process's latch becoming
    set and then call ProcessWalRcvInterrupts.  Much of the needed code
    for that was already present in libpqwalreceiver.c.  I refactored
    things a bit so that all the uses of PQgetResult use latch-aware
    waiting, but didn't need to do much more.

    These changes should be enough to ensure that libpqwalreceiver.c
    will respond promptly to SIGTERM whenever it's waiting to receive
    data.  In principle, it could block for a long time while waiting
    to send data too, and this patch does nothing to guard against that.
    I think that that hazard is mostly theoretical though: such blocking
    should occur only if we fill the kernel's data transmission buffers,
    and we don't generally send enough data to make that happen without
    waiting for input.  If we find out that the hazard isn't just
    theoretical, we could fix it by using PQsetnonblocking, but that
    would require more ticklish changes than I care to make now.

    This is a bug fix, but it seems like too big a change to push into
    the back branches without much more testing than there's time for
    right now.  Perhaps we'll back-patch once we have more confidence
    in the change.

    Patch by me; thanks to Thomas Munro for review.

    Discussion: https://postgr.es/m/20190416070119.GK2673@paquier.xyz

