### PR TITLE
Fix regex in spill test cases

### DIFF
--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -25,7 +25,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)
@@ -84,7 +84,7 @@ rv = plpy.execute(explain_query)
 result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
-    p = re.compile('.+\((seg[\d]+).+ ([\d+]) overflows;')
+    p = re.compile('.+\((seg\d+).+ (\d+) overflows;')
     m = p.match(cur_line)
     if m:
       overflows = int(m.group(2))

--- a/src/test/regress/expected/workfile/hashjoin_spill.out
+++ b/src/test/regress/expected/workfile/hashjoin_spill.out
@@ -23,7 +23,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)

--- a/src/test/regress/expected/workfile/materialize_spill.out
+++ b/src/test/regress/expected/workfile/materialize_spill.out
@@ -16,7 +16,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         result.append(workfile_created)

--- a/src/test/regress/expected/workfile/sisc_mat_sort.out
+++ b/src/test/regress/expected/workfile/sisc_mat_sort.out
@@ -17,7 +17,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)

--- a/src/test/regress/expected/workfile/sisc_sort_spill.out
+++ b/src/test/regress/expected/workfile/sisc_sort_spill.out
@@ -17,7 +17,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)

--- a/src/test/regress/expected/workfile/sort_spill.out
+++ b/src/test/regress/expected/workfile/sort_spill.out
@@ -17,7 +17,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -28,7 +28,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)
@@ -68,7 +68,7 @@ rv = plpy.execute(explain_query)
 result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
-    p = re.compile('.+\((seg[\d]+).+ ([\d+]) overflows;')
+    p = re.compile('.+\((seg\d+).+ (\d+) overflows;')
     m = p.match(cur_line)
     if m:
       overflows = int(m.group(2))

--- a/src/test/regress/sql/workfile/hashjoin_spill.sql
+++ b/src/test/regress/sql/workfile/hashjoin_spill.sql
@@ -26,7 +26,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)

--- a/src/test/regress/sql/workfile/materialize_spill.sql
+++ b/src/test/regress/sql/workfile/materialize_spill.sql
@@ -18,7 +18,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         result.append(workfile_created)

--- a/src/test/regress/sql/workfile/sisc_mat_sort.sql
+++ b/src/test/regress/sql/workfile/sisc_mat_sort.sql
@@ -19,7 +19,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)

--- a/src/test/regress/sql/workfile/sisc_sort_spill.sql
+++ b/src/test/regress/sql/workfile/sisc_sort_spill.sql
@@ -19,7 +19,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)

--- a/src/test/regress/sql/workfile/sort_spill.sql
+++ b/src/test/regress/sql/workfile/sort_spill.sql
@@ -19,7 +19,7 @@ result = []
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('.+\((segment [\d]+).+ Workfile: \(([\d+]) spilling\)')
+        p = re.compile('.+\((segment \d+).+ Workfile: \((\d+) spilling\)')
         m = p.match(cur_line)
         workfile_created = int(m.group(2))
         cur_row = int(workfile_created == nsegments)


### PR DESCRIPTION
[\d+] only match a single digit, which is not equal to \d+, the cases
obviously want match a number but not a digit.
