### PR TITLE
Consider different cdbhash value in EC.

### DIFF
--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -83,7 +83,7 @@ static const Oid cdbhash_type_compatibility_table[COMPAT_TABLE_LENGTH] =
 	BITOID, VARBITOID,
 	InvalidOid,
 
-	/* object identidier types */
+	/* object identifier types */
 	OIDOID, REGPROCOID, REGPROCEDUREOID, REGOPEROID,
 	REGOPERATOROID, REGCLASSOID, REGTYPEOID, ANYENUMOID,
 	InvalidOid
@@ -875,7 +875,7 @@ bool isGreenplumDbOprRedistributable(Oid oprid)
 /*
  * isGreenplumDbPathkeyDistCompatible
  *
- * Return true if there exists one const type and one non-const
+ * Return true if there exists one const type and one non-Const
  * type in an EC of pathkey have the compatible hash value.
  * 
  * This is used check whether we could redistribute single rel in
@@ -892,8 +892,8 @@ isGreenplumDbPathkeyDistCompatible(PathKey *pathkey)
 
 	ec = pathkey->pk_eclass;
 	/*
-	 * Values of diffrent type(float4, float8) could be in the same EC.
-	 * But they may have different hash value to do Motion.
+	 * Values of different types(float4, float8) could be in the same EC.
+	 * But they may have different hash values to do Motion.
 	 * In GPDB5 cdbhash treat some types, e.g. all integers, have the same
 	 * hash values. But other types, e.g. float4 and float8, have different
 	 * hash values. See cdbhash_type_compatibility_table for details.
@@ -904,8 +904,8 @@ isGreenplumDbPathkeyDistCompatible(PathKey *pathkey)
 		EquivalenceMember *em = (EquivalenceMember *) lfirst(j);
 		
 		/* 
-		 * the first loop only check non-const items in EC
-		 * non-const items must have the same data type.
+		 * the first loop only check non-Const items in EC
+		 * non-Const items must have the compatible data type.
 		 */
 		if (em->em_is_const)
 			continue;
@@ -918,7 +918,7 @@ isGreenplumDbPathkeyDistCompatible(PathKey *pathkey)
 			return false;
 	}
 	
-	/* no non-const items in EC */
+	/* no non-Const items in EC */
 	if(non_const_ec_type == InvalidOid)
 		return false;
 

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -60,8 +60,34 @@
 /* Fast mod using a bit mask, assuming that y is a power of 2 */
 #define FASTMOD(x,y)		((x) & ((y)-1))
 
-#define IS_INTEGER_TYPE(type)                             \
-    (type == INT2OID || type == INT4OID || type == INT8OID)
+/* 
+ * arrays of types that have compatible cdbhash functions. InvalidOid is used to terminate each array
+ * this array is based on function hashDatum.
+ */
+#define COMPAT_TABLE_LENGTH 24
+static const Oid cdbhash_type_compatibility_table[COMPAT_TABLE_LENGTH] = 
+{
+	/* integer types */
+	INT2OID, INT4OID, INT8OID,
+	InvalidOid,
+
+	/* text types */
+	BPCHAROID, TEXTOID, VARCHAROID, BYTEAOID,
+	InvalidOid,
+
+	/* network types */
+	INETOID, CIDROID,
+	InvalidOid,
+  
+	/* bit string */
+	BITOID, VARBITOID,
+	InvalidOid,
+
+	/* object identidier types */
+	OIDOID, REGPROCOID, REGPROCEDUREOID, REGOPEROID,
+	REGOPERATOROID, REGCLASSOID, REGTYPEOID, ANYENUMOID,
+	InvalidOid
+};
 
 /* local function declarations */
 static uint32 fnv1_32_buf(void *buf, size_t len, uint32 hashval);
@@ -846,6 +872,16 @@ bool isGreenplumDbOprRedistributable(Oid oprid)
 	}
 }
 
+/*
+ * isGreenplumDbPathkeyDistCompatible
+ *
+ * Return true if there exists one const type and one non-const
+ * type in an EC of pathkey have the compatible hash value.
+ * 
+ * This is used check whether we could redistribute single rel in
+ * join. See comments in cdbpath_match_preds_to_partkey_tail() for
+ * details.
+ */
 bool
 isGreenplumDbPathkeyDistCompatible(PathKey *pathkey)
 {
@@ -858,8 +894,9 @@ isGreenplumDbPathkeyDistCompatible(PathKey *pathkey)
 	/*
 	 * Values of diffrent type(float4, float8) could be in the same EC.
 	 * But they may have different hash value to do Motion.
-	 * In GPDB5 cdbhash treat all integers have the same hash values
-	 * But other type, e.g. float4 and float8 have different hash values.
+	 * In GPDB5 cdbhash treat some types, e.g. all integers, have the same
+	 * hash values. But other types, e.g. float4 and float8, have different
+	 * hash values. See cdbhash_type_compatibility_table for details.
 	 * This function checks whether items in an EC have the same cdbhash value.
 	 */
 	foreach(j, ec->ec_members)
@@ -875,7 +912,7 @@ isGreenplumDbPathkeyDistCompatible(PathKey *pathkey)
 
 		if (non_const_ec_type == InvalidOid)
 			non_const_ec_type = em->em_datatype;
-		else if (non_const_ec_type == em->em_datatype || (IS_INTEGER_TYPE(em->em_datatype) && IS_INTEGER_TYPE(non_const_ec_type)))
+		else if (cdbhash_type_compatible(em->em_datatype, non_const_ec_type))
 			continue;
 		else
 			return false;
@@ -896,7 +933,7 @@ isGreenplumDbPathkeyDistCompatible(PathKey *pathkey)
 		if (!em->em_is_const)
 			continue;
 
-		if (non_const_ec_type == em->em_datatype || (IS_INTEGER_TYPE(em->em_datatype) && IS_INTEGER_TYPE(non_const_ec_type)))
+		if (cdbhash_type_compatible(em->em_datatype, non_const_ec_type))
 			return true;
 	}
 
@@ -1008,4 +1045,34 @@ static int
 ispowof2(int numsegs)
 {
 	return !(numsegs & (numsegs - 1));
+}
+
+/*
+ * check whether two types are cdbhash compatible.
+ */
+bool
+cdbhash_type_compatible(Oid ltypid, Oid rtypid)
+{
+	int i;
+	int ltypeGroup = -1;
+	int rtypeGroup = -1;
+	int groupNo = 0;
+
+	if (ltypid == rtypid)
+		return true;
+
+	for (i = 0; i < COMPAT_TABLE_LENGTH; i++)
+	{
+		if (cdbhash_type_compatibility_table[i] == ltypid)
+			ltypeGroup = groupNo;
+		if (cdbhash_type_compatibility_table[i] == rtypid)
+			rtypeGroup = groupNo;
+		if (cdbhash_type_compatibility_table[i] == InvalidOid)
+			groupNo++;
+	}
+
+	if (ltypeGroup == -1 || rtypeGroup == -1)
+		return false;
+
+	return (ltypeGroup == rtypeGroup) ? true : false;
 }

--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -444,8 +444,8 @@ cdbpullup_findPathKeyExprInTargetList(PathKey *item, List *targetlist)
 	}
 
 	/*
-	 * If there is no non const candidate, then it's OK to return
-	 * the constant regardless of the target list.
+	 * It's OK to return a constant member, as long as it's
+	 * compatible with all the non-Const members.
 	 */
 	foreach(lc, eclass->ec_members)
 	{

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -100,6 +100,9 @@ extern bool isGreenplumDbOprRedistributable(Oid oprid);
  */
 extern bool isGreenplumDbPathkeyDistCompatible(PathKey *pathkey);
 
+/* check whether two types are cdbhash compatible. */
+extern bool cdbhash_type_compatible(Oid ltypid, Oid rtypeid);
+
 /*
  * Return true if the Oid is an array type.  This can be used prior
  *   to hashing the datum because array typeoids are expected to

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -15,6 +15,8 @@
 #ifndef CDBHASH_H
 #define CDBHASH_H
 
+#include "nodes/relation.h"
+
 /*
  * hashing algorithms.
  */
@@ -92,6 +94,11 @@ extern bool isGreenplumDbHashable(Oid typid);
  * Return true if the operator Oid is hashable internally in Greenplum Database.
  */
 extern bool isGreenplumDbOprRedistributable(Oid oprid);
+
+/*
+ * Return true if pathkey's distribeted locations are compatible in Greenplum Database.
+ */
+extern bool isGreenplumDbPathkeyDistCompatible(PathKey *pathkey);
 
 /*
  * Return true if the Oid is an array type.  This can be used prior

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3228,7 +3228,13 @@ DROP TABLE member;
 DROP TABLE member_group;
 DROP TABLE member_subgroup;
 DROP TABLE region;
--- test the query have equivalence class with const members
+--
+-- Test the query have equivalence class with const members.
+-- Mix timestamp and timestamptz in a join. We cannot use a Redistribute
+-- Motion, because the cross-datatype = operator between them doesn't belong
+-- to any hash operator class. We cannot hash rows in a way that matches would
+-- land on the same segment in that case.
+--
 CREATE TABLE gp_timestamp1 (a int, b timestamp) DISTRIBUTED BY (a, b);
 CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
 INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3228,3 +3228,130 @@ DROP TABLE member;
 DROP TABLE member_group;
 DROP TABLE member_subgroup;
 DROP TABLE region;
+-- test the query have equivalence class with const members
+CREATE TABLE gp_timestamp1 (a int, b timestamp) DISTRIBUTED BY (a, b);
+CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+ANALYZE gp_timestamp1;
+ANALYZE gp_timestamp2;
+SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' order by a;
+ a  |            b             
+----+--------------------------
+  1 | Wed Nov 09 00:00:00 2016
+  2 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  4 | Wed Nov 09 00:00:00 2016
+  5 | Wed Nov 09 00:00:00 2016
+  6 | Wed Nov 09 00:00:00 2016
+  7 | Wed Nov 09 00:00:00 2016
+  8 | Wed Nov 09 00:00:00 2016
+  9 | Wed Nov 09 00:00:00 2016
+ 10 | Wed Nov 09 00:00:00 2016
+ 11 | Wed Nov 09 00:00:00 2016
+ 12 | Wed Nov 09 00:00:00 2016
+(13 rows)
+
+SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamp '2016/11/09' order by a;
+ a  |            b             
+----+--------------------------
+  1 | Wed Nov 09 00:00:00 2016
+  2 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  4 | Wed Nov 09 00:00:00 2016
+  5 | Wed Nov 09 00:00:00 2016
+  6 | Wed Nov 09 00:00:00 2016
+  7 | Wed Nov 09 00:00:00 2016
+  8 | Wed Nov 09 00:00:00 2016
+  9 | Wed Nov 09 00:00:00 2016
+ 10 | Wed Nov 09 00:00:00 2016
+ 11 | Wed Nov 09 00:00:00 2016
+ 12 | Wed Nov 09 00:00:00 2016
+(13 rows)
+
+SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' AND b = timestamp '2016/11/09' order by a;
+ a  |            b             
+----+--------------------------
+  1 | Wed Nov 09 00:00:00 2016
+  2 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  4 | Wed Nov 09 00:00:00 2016
+  5 | Wed Nov 09 00:00:00 2016
+  6 | Wed Nov 09 00:00:00 2016
+  7 | Wed Nov 09 00:00:00 2016
+  8 | Wed Nov 09 00:00:00 2016
+  9 | Wed Nov 09 00:00:00 2016
+ 10 | Wed Nov 09 00:00:00 2016
+ 11 | Wed Nov 09 00:00:00 2016
+ 12 | Wed Nov 09 00:00:00 2016
+(13 rows)
+
+CREATE TABLE gp_f1 (a int, b float4) DISTRIBUTED BY (a, b);
+CREATE TABLE gp_f2 (c int, d float4) DISTRIBUTED BY (c, d);
+INSERT INTO gp_f1 SELECT i, i FROM generate_series(1, 12) i;
+INSERT INTO gp_f1 SELECT i, 3 FROM generate_series(1, 12) i;
+INSERT INTO gp_f2 SELECT i, i FROM generate_series(1, 12) i;
+ANALYZE gp_f1;
+ANALYZE gp_f2;
+SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 order by a;
+ a  | b 
+----+---
+  1 | 3
+  2 | 3
+  3 | 3
+  3 | 3
+  4 | 3
+  5 | 3
+  6 | 3
+  7 | 3
+  8 | 3
+  9 | 3
+ 10 | 3
+ 11 | 3
+ 12 | 3
+(13 rows)
+
+SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float4 order by a;
+ a  | b 
+----+---
+  1 | 3
+  2 | 3
+  3 | 3
+  3 | 3
+  4 | 3
+  5 | 3
+  6 | 3
+  7 | 3
+  8 | 3
+  9 | 3
+ 10 | 3
+ 11 | 3
+ 12 | 3
+(13 rows)
+
+SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 AND b = 3.0::float4 order by a;
+ a  | b 
+----+---
+  1 | 3
+  2 | 3
+  3 | 3
+  3 | 3
+  4 | 3
+  5 | 3
+  6 | 3
+  7 | 3
+  8 | 3
+  9 | 3
+ 10 | 3
+ 11 | 3
+ 12 | 3
+(13 rows)
+
+DROP TABLE gp_timestamp1;
+DROP TABLE gp_timestamp2;
+DROP TABLE gp_f1;
+DROP TABLE gp_f2;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3242,6 +3242,7 @@ INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(
 INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
 ANALYZE gp_timestamp1;
 ANALYZE gp_timestamp2;
+-- col b is type of timestamp, but const is type of timestamptz. Their hash values are not compatible
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' order by a;
  a  |            b             
 ----+--------------------------
@@ -3260,6 +3261,7 @@ SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '
  12 | Wed Nov 09 00:00:00 2016
 (13 rows)
 
+-- col b is type of timestamp, so is const. Their hash values are compatible
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamp '2016/11/09' order by a;
  a  |            b             
 ----+--------------------------
@@ -3278,6 +3280,9 @@ SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamp '20
  12 | Wed Nov 09 00:00:00 2016
 (13 rows)
 
+-- Another variation: There are two constants in the same equivalence class. One's
+-- datatype is compatible with the distribution key, the other's is not. We can
+-- redistribute based on the compatible constant.
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' AND b = timestamp '2016/11/09' order by a;
  a  |            b             
 ----+--------------------------
@@ -3296,6 +3301,15 @@ SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '
  12 | Wed Nov 09 00:00:00 2016
 (13 rows)
 
+-- Similar case. Here, the =(float8, float4) cross-type operator would not be
+-- hashable in 5X, since they use different hash functions. Check function
+-- cdbhash() for details.
+-- Note that in 6X and above, float8 and float4 have the same hash values when
+-- they are equal by default (except legacy cdbhash opclass). Check catalog
+-- pg_amop for detailed compatibility. The legacy cdbhash opclass refers to
+-- cdbhash in 5X. For example, legacy cdbhash opclass includes cdbhash_integer_ops,
+-- cdbhash_float4_ops and cdbhash_float8_ops, which means all integer are compatible,
+-- but float4 and float8 are not compatible.
 CREATE TABLE gp_f1 (a int, b float4) DISTRIBUTED BY (a, b);
 CREATE TABLE gp_f2 (c int, d float4) DISTRIBUTED BY (c, d);
 INSERT INTO gp_f1 SELECT i, i FROM generate_series(1, 12) i;
@@ -3303,6 +3317,7 @@ INSERT INTO gp_f1 SELECT i, 3 FROM generate_series(1, 12) i;
 INSERT INTO gp_f2 SELECT i, i FROM generate_series(1, 12) i;
 ANALYZE gp_f1;
 ANALYZE gp_f2;
+-- col b is type of float4, but const is type of float8. Their hash values are not compatible
 SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 order by a;
  a  | b 
 ----+---
@@ -3321,6 +3336,7 @@ SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 order by a;
  12 | 3
 (13 rows)
 
+-- col b is type of float4, so is const. Their hash values are compatible
 SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float4 order by a;
  a  | b 
 ----+---
@@ -3339,6 +3355,9 @@ SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float4 order by a;
  12 | 3
 (13 rows)
 
+-- Another variation: There are two constants in the same equivalence class. One's
+-- datatype is compatible with the distribution key, the other's is not. We can
+-- redistribute based on the compatible constant.
 SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 AND b = 3.0::float4 order by a;
  a  | b 
 ----+---

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3243,6 +3243,7 @@ INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(
 INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
 ANALYZE gp_timestamp1;
 ANALYZE gp_timestamp2;
+-- col b is type of timestamp, but const is type of timestamptz. Their hash values are not compatible
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' order by a;
  a  |            b             
 ----+--------------------------
@@ -3261,6 +3262,7 @@ SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '
  12 | Wed Nov 09 00:00:00 2016
 (13 rows)
 
+-- col b is type of timestamp, so is const. Their hash values are compatible
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamp '2016/11/09' order by a;
  a  |            b             
 ----+--------------------------
@@ -3279,6 +3281,9 @@ SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamp '20
  12 | Wed Nov 09 00:00:00 2016
 (13 rows)
 
+-- Another variation: There are two constants in the same equivalence class. One's
+-- datatype is compatible with the distribution key, the other's is not. We can
+-- redistribute based on the compatible constant.
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' AND b = timestamp '2016/11/09' order by a;
  a  |            b             
 ----+--------------------------
@@ -3297,6 +3302,15 @@ SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '
  12 | Wed Nov 09 00:00:00 2016
 (13 rows)
 
+-- Similar case. Here, the =(float8, float4) cross-type operator would not be
+-- hashable in 5X, since they use different hash functions. Check function
+-- cdbhash() for details.
+-- Note that in 6X and above, float8 and float4 have the same hash values when
+-- they are equal by default (except legacy cdbhash opclass). Check catalog
+-- pg_amop for detailed compatibility. The legacy cdbhash opclass refers to
+-- cdbhash in 5X. For example, legacy cdbhash opclass includes cdbhash_integer_ops,
+-- cdbhash_float4_ops and cdbhash_float8_ops, which means all integer are compatible,
+-- but float4 and float8 are not compatible.
 CREATE TABLE gp_f1 (a int, b float4) DISTRIBUTED BY (a, b);
 CREATE TABLE gp_f2 (c int, d float4) DISTRIBUTED BY (c, d);
 INSERT INTO gp_f1 SELECT i, i FROM generate_series(1, 12) i;
@@ -3304,6 +3318,7 @@ INSERT INTO gp_f1 SELECT i, 3 FROM generate_series(1, 12) i;
 INSERT INTO gp_f2 SELECT i, i FROM generate_series(1, 12) i;
 ANALYZE gp_f1;
 ANALYZE gp_f2;
+-- col b is type of float4, but const is type of float8. Their hash values are not compatible
 SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 order by a;
  a  | b 
 ----+---
@@ -3322,6 +3337,7 @@ SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 order by a;
  12 | 3
 (13 rows)
 
+-- col b is type of float4, so is const. Their hash values are compatible
 SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float4 order by a;
  a  | b 
 ----+---
@@ -3340,6 +3356,9 @@ SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float4 order by a;
  12 | 3
 (13 rows)
 
+-- Another variation: There are two constants in the same equivalence class. One's
+-- datatype is compatible with the distribution key, the other's is not. We can
+-- redistribute based on the compatible constant.
 SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 AND b = 3.0::float4 order by a;
  a  | b 
 ----+---

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3229,7 +3229,13 @@ DROP TABLE member;
 DROP TABLE member_group;
 DROP TABLE member_subgroup;
 DROP TABLE region;
--- test the query have equivalence class with const members
+--
+-- Test the query have equivalence class with const members.
+-- Mix timestamp and timestamptz in a join. We cannot use a Redistribute
+-- Motion, because the cross-datatype = operator between them doesn't belong
+-- to any hash operator class. We cannot hash rows in a way that matches would
+-- land on the same segment in that case.
+--
 CREATE TABLE gp_timestamp1 (a int, b timestamp) DISTRIBUTED BY (a, b);
 CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
 INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3229,3 +3229,130 @@ DROP TABLE member;
 DROP TABLE member_group;
 DROP TABLE member_subgroup;
 DROP TABLE region;
+-- test the query have equivalence class with const members
+CREATE TABLE gp_timestamp1 (a int, b timestamp) DISTRIBUTED BY (a, b);
+CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(1, 12) i;
+INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
+ANALYZE gp_timestamp1;
+ANALYZE gp_timestamp2;
+SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' order by a;
+ a  |            b             
+----+--------------------------
+  1 | Wed Nov 09 00:00:00 2016
+  2 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  4 | Wed Nov 09 00:00:00 2016
+  5 | Wed Nov 09 00:00:00 2016
+  6 | Wed Nov 09 00:00:00 2016
+  7 | Wed Nov 09 00:00:00 2016
+  8 | Wed Nov 09 00:00:00 2016
+  9 | Wed Nov 09 00:00:00 2016
+ 10 | Wed Nov 09 00:00:00 2016
+ 11 | Wed Nov 09 00:00:00 2016
+ 12 | Wed Nov 09 00:00:00 2016
+(13 rows)
+
+SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamp '2016/11/09' order by a;
+ a  |            b             
+----+--------------------------
+  1 | Wed Nov 09 00:00:00 2016
+  2 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  4 | Wed Nov 09 00:00:00 2016
+  5 | Wed Nov 09 00:00:00 2016
+  6 | Wed Nov 09 00:00:00 2016
+  7 | Wed Nov 09 00:00:00 2016
+  8 | Wed Nov 09 00:00:00 2016
+  9 | Wed Nov 09 00:00:00 2016
+ 10 | Wed Nov 09 00:00:00 2016
+ 11 | Wed Nov 09 00:00:00 2016
+ 12 | Wed Nov 09 00:00:00 2016
+(13 rows)
+
+SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' AND b = timestamp '2016/11/09' order by a;
+ a  |            b             
+----+--------------------------
+  1 | Wed Nov 09 00:00:00 2016
+  2 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  3 | Wed Nov 09 00:00:00 2016
+  4 | Wed Nov 09 00:00:00 2016
+  5 | Wed Nov 09 00:00:00 2016
+  6 | Wed Nov 09 00:00:00 2016
+  7 | Wed Nov 09 00:00:00 2016
+  8 | Wed Nov 09 00:00:00 2016
+  9 | Wed Nov 09 00:00:00 2016
+ 10 | Wed Nov 09 00:00:00 2016
+ 11 | Wed Nov 09 00:00:00 2016
+ 12 | Wed Nov 09 00:00:00 2016
+(13 rows)
+
+CREATE TABLE gp_f1 (a int, b float4) DISTRIBUTED BY (a, b);
+CREATE TABLE gp_f2 (c int, d float4) DISTRIBUTED BY (c, d);
+INSERT INTO gp_f1 SELECT i, i FROM generate_series(1, 12) i;
+INSERT INTO gp_f1 SELECT i, 3 FROM generate_series(1, 12) i;
+INSERT INTO gp_f2 SELECT i, i FROM generate_series(1, 12) i;
+ANALYZE gp_f1;
+ANALYZE gp_f2;
+SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 order by a;
+ a  | b 
+----+---
+  1 | 3
+  2 | 3
+  3 | 3
+  3 | 3
+  4 | 3
+  5 | 3
+  6 | 3
+  7 | 3
+  8 | 3
+  9 | 3
+ 10 | 3
+ 11 | 3
+ 12 | 3
+(13 rows)
+
+SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float4 order by a;
+ a  | b 
+----+---
+  1 | 3
+  2 | 3
+  3 | 3
+  3 | 3
+  4 | 3
+  5 | 3
+  6 | 3
+  7 | 3
+  8 | 3
+  9 | 3
+ 10 | 3
+ 11 | 3
+ 12 | 3
+(13 rows)
+
+SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 AND b = 3.0::float4 order by a;
+ a  | b 
+----+---
+  1 | 3
+  2 | 3
+  3 | 3
+  3 | 3
+  4 | 3
+  5 | 3
+  6 | 3
+  7 | 3
+  8 | 3
+  9 | 3
+ 10 | 3
+ 11 | 3
+ 12 | 3
+(13 rows)
+
+DROP TABLE gp_timestamp1;
+DROP TABLE gp_timestamp2;
+DROP TABLE gp_f1;
+DROP TABLE gp_f2;

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -247,7 +247,13 @@ DROP TABLE member_group;
 DROP TABLE member_subgroup;
 DROP TABLE region;
 
--- test the query have equivalence class with const members
+--
+-- Test the query have equivalence class with const members.
+-- Mix timestamp and timestamptz in a join. We cannot use a Redistribute
+-- Motion, because the cross-datatype = operator between them doesn't belong
+-- to any hash operator class. We cannot hash rows in a way that matches would
+-- land on the same segment in that case.
+--
 CREATE TABLE gp_timestamp1 (a int, b timestamp) DISTRIBUTED BY (a, b);
 CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
 

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -257,7 +257,6 @@ DROP TABLE region;
 CREATE TABLE gp_timestamp1 (a int, b timestamp) DISTRIBUTED BY (a, b);
 CREATE TABLE gp_timestamp2 (c int, d timestamp) DISTRIBUTED BY (c, d);
 
-
 INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
 INSERT INTO gp_timestamp1 SELECT i, timestamp '2016/11/09' FROM generate_series(1, 12) i;
 INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day' FROM generate_series(1, 12) i;
@@ -265,13 +264,26 @@ INSERT INTO gp_timestamp2 SELECT i, timestamp '2016/11/06' + i * interval '1 day
 ANALYZE gp_timestamp1;
 ANALYZE gp_timestamp2;
 
+-- col b is type of timestamp, but const is type of timestamptz. Their hash values are not compatible
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' order by a;
+-- col b is type of timestamp, so is const. Their hash values are compatible
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamp '2016/11/09' order by a;
+-- Another variation: There are two constants in the same equivalence class. One's
+-- datatype is compatible with the distribution key, the other's is not. We can
+-- redistribute based on the compatible constant.
 SELECT a, b FROM gp_timestamp1 JOIN gp_timestamp2 ON a = c AND b = timestamptz '2016/11/09' AND b = timestamp '2016/11/09' order by a;
 
+-- Similar case. Here, the =(float8, float4) cross-type operator would not be
+-- hashable in 5X, since they use different hash functions. Check function
+-- cdbhash() for details.
+-- Note that in 6X and above, float8 and float4 have the same hash values when
+-- they are equal by default (except legacy cdbhash opclass). Check catalog
+-- pg_amop for detailed compatibility. The legacy cdbhash opclass refers to
+-- cdbhash in 5X. For example, legacy cdbhash opclass includes cdbhash_integer_ops,
+-- cdbhash_float4_ops and cdbhash_float8_ops, which means all integer are compatible,
+-- but float4 and float8 are not compatible.
 CREATE TABLE gp_f1 (a int, b float4) DISTRIBUTED BY (a, b);
 CREATE TABLE gp_f2 (c int, d float4) DISTRIBUTED BY (c, d);
-
 
 INSERT INTO gp_f1 SELECT i, i FROM generate_series(1, 12) i;
 INSERT INTO gp_f1 SELECT i, 3 FROM generate_series(1, 12) i;
@@ -280,8 +292,13 @@ INSERT INTO gp_f2 SELECT i, i FROM generate_series(1, 12) i;
 ANALYZE gp_f1;
 ANALYZE gp_f2;
 
+-- col b is type of float4, but const is type of float8. Their hash values are not compatible
 SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 order by a;
+-- col b is type of float4, so is const. Their hash values are compatible
 SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float4 order by a;
+-- Another variation: There are two constants in the same equivalence class. One's
+-- datatype is compatible with the distribution key, the other's is not. We can
+-- redistribute based on the compatible constant.
 SELECT a, b FROM gp_f1 JOIN gp_f2 ON a = c AND b = 3.0::float8 AND b = 3.0::float4 order by a;
 
 DROP TABLE gp_timestamp1;


### PR DESCRIPTION
Continue fix for issue 8918 on GPDB5

In GPDB5, items in an EC may have different cdbhash values,
which means their distributed keys may be different as well.
For example, in T.D = <constant expr>, if T.D is float4,
while <constant expr> is float8. Even if they are both 1.0,
we could not consider they could be distributed on the same segment after motion.
So CdbPathkeyDistCompatible() is added to fix this issue.


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
