### PR TITLE
Remove Motion codepath to detoast HeapTuples, convert to MemTuple instead.

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -271,15 +271,6 @@ addByteStringToChunkList(TupleChunkList tcList, char *data, int datalen, TupleCh
 			break;
 
 		tcItem = getChunkFromCache(chunkCache);
-		if (tcItem == NULL)
-		{
-			ereport(FATAL,
-					(errcode(ERRCODE_OUT_OF_MEMORY),
-					 errmsg("could not allocate space for new chunk"),
-					 errdetail("%d of %d bytes in %d chunks",
-							   tcList->serialized_data_length, datalen,
-							   tcList->num_chunks)));
-		}
 		tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 		SetChunkType(tcItem->chunk_data, TC_PARTIAL_MID);
 		appendChunkToTCList(tcList, tcItem);
@@ -324,12 +315,6 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 	tcList->max_chunk_length = Gp_max_tuple_chunk_size;
 
 	tcItem = getChunkFromCache(&pSerInfo->chunkCache);
-	if (tcItem == NULL)
-	{
-		ereport(FATAL,
-				(errcode(ERRCODE_OUT_OF_MEMORY),
-				 errmsg("could not allocate space for first chunk item in new chunk list")));
-	}
 
 	/* assume that we'll take a single chunk */
 	SetChunkType(tcItem->chunk_data, TC_WHOLE);
@@ -490,12 +475,6 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 		 * out-of-line serialization.
 		 */
 		tcItem = getChunkFromCache(&pSerInfo->chunkCache);
-		if (tcItem == NULL)
-		{
-			ereport(FATAL,
-					(errcode(ERRCODE_OUT_OF_MEMORY),
-					 errmsg("could not allocate space for first chunk item in new chunk list")));
-		}
 		SetChunkType(tcItem->chunk_data, TC_WHOLE);
 		tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 		appendChunkToTCList(tcList, tcItem);
@@ -571,12 +550,6 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 		 * out-of-line serialization.
 		 */
 		tcItem = getChunkFromCache(&pSerInfo->chunkCache);
-		if (tcItem == NULL)
-		{
-			ereport(FATAL,
-					(errcode(ERRCODE_OUT_OF_MEMORY),
-					 errmsg("could not allocate space for first chunk item in new chunk list")));
-		}
 		SetChunkType(tcItem->chunk_data, TC_WHOLE);
 		tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 		appendChunkToTCList(tcList, tcItem);

--- a/src/include/cdb/tupser.h
+++ b/src/include/cdb/tupser.h
@@ -81,14 +81,11 @@ extern void SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 										   TupleChunkList tcList,
 										   MotionConn *conn);
 
-/* Convert a HeapTuple into chunks directly in a set of transport buffers */
+/* Convert a tuple into chunks directly in a set of transport buffers */
 extern int SerializeTuple(TupleTableSlot *tuple, SerTupInfo *pSerInfo, struct directTransportBuffer *b, TupleChunkList tcList, int16 targetRoute);
 
-/* Deserialize a HeapTuple's data from a byte-array. */
-extern HeapTuple DeserializeTuple(SerTupInfo * pSerInfo, StringInfo serialTup);
-
 /* Convert a sequence of chunks containing serialized tuple data into a
- * HeapTuple.
+ * HeapTuple or MemTuple.
  */
 extern GenericTuple CvtChunksToTup(TupleChunkList tclist, SerTupInfo * pSerInfo, TupleRemapper *remapper);
 

--- a/src/test/regress/expected/motion_gp.out
+++ b/src/test/regress/expected/motion_gp.out
@@ -1,0 +1,133 @@
+CREATE TABLE motiondata (
+  id int,
+  plain text,     -- inline, uncompressed
+  main text,      --inline, compressible
+  external text,  -- external, uncompressed
+  extended text); -- external, compressible
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE motiondata ALTER COLUMN plain SET STORAGE plain;
+ALTER TABLE motiondata ALTER COLUMN main SET STORAGE main;
+ALTER TABLE motiondata ALTER COLUMN external SET STORAGE external;
+ALTER TABLE motiondata ALTER COLUMN extended SET STORAGE extended;
+-- a simple small tuple.
+INSERT INTO motiondata (id, plain, main, external, extended) VALUES (1, 'foo', 'bar', 'baz', 'foobar');
+-- Large datum, inline uncompressed
+INSERT INTO motiondata (id, plain) VALUES (2, repeat('1234567890', 1000));
+-- Large datum, inline compressed
+INSERT INTO motiondata (id, main)  VALUES (3, repeat('1234567890', 1000));
+-- Large datum, inline compressed, but doesn't fit in a short varlen even
+-- after compression
+INSERT INTO motiondata (id, main)  VALUES (4, repeat('1234567890', 2000));
+-- Large datum, external uncompressed
+INSERT INTO motiondata (id, external) VALUES (5, repeat('1234567890', 1000));
+-- Large datum, external, compressed
+INSERT INTO motiondata (id, extended) VALUES (6, repeat('1234567890', 100000));
+-- Check that the sizes are as expected. The exact sizes are not important,
+-- but should be in the right ballpark.
+SELECT id,
+       pg_column_size(plain) AS plain_sz,
+       pg_column_size(main) AS main_sz,
+       pg_column_size(external) AS external_sz,
+       pg_column_size(extended) AS extended_sz
+FROM motiondata;
+ id | plain_sz | main_sz | external_sz | extended_sz 
+----+----------+---------+-------------+-------------
+  1 |        4 |       4 |           4 |           7
+  2 |    10004 |         |             |            
+  3 |          |     135 |             |            
+  4 |          |     251 |             |            
+  5 |          |         |       10000 |            
+  6 |          |         |             |       11463
+(6 rows)
+
+CREATE TABLE motiondata_ao WITH (appendonly=true) AS SELECT * from motiondata;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- A helper function for printing an abbreviated version of a long datum. Otherwise, the output
+-- of selecting the large datums become unwieldly.
+create or replace function abbreviate(t text) returns text as $$
+begin
+  if length(t) <= 15 then
+    return length(t) || ': ' || t;
+  else
+    return length(t) || ': ' || substring(t from 1 for 5) || '...' || substring(t from length(t)-4 for 5);
+  end if;
+end;
+$$ language plpgsql;
+-- Runs query 'sql', and prints an abbreviated result set.
+--
+-- Note: It's important that we run the query as it is, and abbreviate the
+-- resulting values afterwards. If we put the abbreviate() function calls into
+-- the query itself, then they will be evaluated in the QEs, and the original
+-- large datums are not sent through the Motion at all. Since we're trying to
+-- test the Motion tuple serialization code, that would defeat the purpose.
+create or replace function abbreviate_result(sql text) returns setof motiondata
+as $$
+declare
+  rec motiondata%rowtype;
+begin
+  for rec in EXECUTE sql
+  loop
+     rec.plain = abbreviate(rec.plain);
+     rec.main = abbreviate(rec.main);
+     rec.external = abbreviate(rec.external);
+     rec.extended = abbreviate(rec.extended);
+     RETURN NEXT rec ;
+  end loop;
+end;
+$$ language plpgsql;
+-- This exercises the codepath where the HeapTuple is sent over the wire as is, if it
+-- doesn't contain toasted datums.
+select * from abbreviate_result($$
+  select id, plain, main, external, extended from motiondata
+$$) order by id;
+ id |        plain         |         main         |       external       |        extended        
+----+----------------------+----------------------+----------------------+------------------------
+  1 | 3: foo               | 3: bar               | 3: baz               | 6: foobar
+  2 | 10000: 12345...67890 |                      |                      | 
+  3 |                      | 10000: 12345...67890 |                      | 
+  4 |                      | 20000: 12345...67890 |                      | 
+  5 |                      |                      | 10000: 12345...67890 | 
+  6 |                      |                      |                      | 1000000: 12345...67890
+(6 rows)
+
+-- Because of the 'id + 0' expression, the Seq Scan node has to project,
+-- and passes a virtual slot to the Motion.
+select * from abbreviate_result($$
+  select id + 0 as id, plain, main, external, extended from motiondata
+$$) order by id;
+ id |        plain         |         main         |       external       |        extended        
+----+----------------------+----------------------+----------------------+------------------------
+  1 | 3: foo               | 3: bar               | 3: baz               | 6: foobar
+  2 | 10000: 12345...67890 |                      |                      | 
+  3 |                      | 10000: 12345...67890 |                      | 
+  4 |                      | 20000: 12345...67890 |                      | 
+  5 |                      |                      | 10000: 12345...67890 | 
+  6 |                      |                      |                      | 1000000: 12345...67890
+(6 rows)
+
+-- Here, the Motion gets an already-built MemTuple from the Seq Scan, because it's
+-- an AO table.
+select * from abbreviate_result($$
+  select id, plain, main, external, extended from motiondata_ao
+$$) order by id;
+ id |        plain         |         main         |       external       |        extended        
+----+----------------------+----------------------+----------------------+------------------------
+  1 | 3: foo               | 3: bar               | 3: baz               | 6: foobar
+  2 | 10000: 12345...67890 |                      |                      | 
+  3 |                      | 10000: 12345...67890 |                      | 
+  4 |                      | 20000: 12345...67890 |                      | 
+  5 |                      |                      | 10000: 12345...67890 | 
+  6 |                      |                      |                      | 1000000: 12345...67890
+(6 rows)
+
+-- Test with a table with zero columns. Motion tuple serialization has a special
+-- codepath for zero-attribute tuples.
+CREATE TABLE motion_noatts ();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+INSERT INTO motion_noatts SELECT;
+SELECT * FROM motion_noatts;
+--
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -55,7 +55,7 @@ test: gp_connections
 # bitmap_index triggers recovery, run it seperately
 test: bitmap_index
 test: gp_dump_query_oids analyze gp_owner_permission incremental_analyze
-test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules dispatch_encoding
+test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules dispatch_encoding motion_gp
 # dispatch should always run seperately from other cases.
 test: dispatch
 

--- a/src/test/regress/sql/motion_gp.sql
+++ b/src/test/regress/sql/motion_gp.sql
@@ -1,0 +1,100 @@
+CREATE TABLE motiondata (
+  id int,
+  plain text,     -- inline, uncompressed
+  main text,      --inline, compressible
+  external text,  -- external, uncompressed
+  extended text); -- external, compressible
+
+ALTER TABLE motiondata ALTER COLUMN plain SET STORAGE plain;
+ALTER TABLE motiondata ALTER COLUMN main SET STORAGE main;
+ALTER TABLE motiondata ALTER COLUMN external SET STORAGE external;
+ALTER TABLE motiondata ALTER COLUMN extended SET STORAGE extended;
+
+-- a simple small tuple.
+INSERT INTO motiondata (id, plain, main, external, extended) VALUES (1, 'foo', 'bar', 'baz', 'foobar');
+
+-- Large datum, inline uncompressed
+INSERT INTO motiondata (id, plain) VALUES (2, repeat('1234567890', 1000));
+
+-- Large datum, inline compressed
+INSERT INTO motiondata (id, main)  VALUES (3, repeat('1234567890', 1000));
+
+-- Large datum, inline compressed, but doesn't fit in a short varlen even
+-- after compression
+INSERT INTO motiondata (id, main)  VALUES (4, repeat('1234567890', 2000));
+
+-- Large datum, external uncompressed
+INSERT INTO motiondata (id, external) VALUES (5, repeat('1234567890', 1000));
+
+-- Large datum, external, compressed
+INSERT INTO motiondata (id, extended) VALUES (6, repeat('1234567890', 100000));
+
+-- Check that the sizes are as expected. The exact sizes are not important,
+-- but should be in the right ballpark.
+SELECT id,
+       pg_column_size(plain) AS plain_sz,
+       pg_column_size(main) AS main_sz,
+       pg_column_size(external) AS external_sz,
+       pg_column_size(extended) AS extended_sz
+FROM motiondata;
+
+CREATE TABLE motiondata_ao WITH (appendonly=true) AS SELECT * from motiondata;
+
+-- A helper function for printing an abbreviated version of a long datum. Otherwise, the output
+-- of selecting the large datums become unwieldly.
+create or replace function abbreviate(t text) returns text as $$
+begin
+  if length(t) <= 15 then
+    return length(t) || ': ' || t;
+  else
+    return length(t) || ': ' || substring(t from 1 for 5) || '...' || substring(t from length(t)-4 for 5);
+  end if;
+end;
+$$ language plpgsql;
+
+-- Runs query 'sql', and prints an abbreviated result set.
+--
+-- Note: It's important that we run the query as it is, and abbreviate the
+-- resulting values afterwards. If we put the abbreviate() function calls into
+-- the query itself, then they will be evaluated in the QEs, and the original
+-- large datums are not sent through the Motion at all. Since we're trying to
+-- test the Motion tuple serialization code, that would defeat the purpose.
+create or replace function abbreviate_result(sql text) returns setof motiondata
+as $$
+declare
+  rec motiondata%rowtype;
+begin
+  for rec in EXECUTE sql
+  loop
+     rec.plain = abbreviate(rec.plain);
+     rec.main = abbreviate(rec.main);
+     rec.external = abbreviate(rec.external);
+     rec.extended = abbreviate(rec.extended);
+     RETURN NEXT rec ;
+  end loop;
+end;
+$$ language plpgsql;
+
+-- This exercises the codepath where the HeapTuple is sent over the wire as is, if it
+-- doesn't contain toasted datums.
+select * from abbreviate_result($$
+  select id, plain, main, external, extended from motiondata
+$$) order by id;
+
+-- Because of the 'id + 0' expression, the Seq Scan node has to project,
+-- and passes a virtual slot to the Motion.
+select * from abbreviate_result($$
+  select id + 0 as id, plain, main, external, extended from motiondata
+$$) order by id;
+
+-- Here, the Motion gets an already-built MemTuple from the Seq Scan, because it's
+-- an AO table.
+select * from abbreviate_result($$
+  select id, plain, main, external, extended from motiondata_ao
+$$) order by id;
+
+-- Test with a table with zero columns. Motion tuple serialization has a special
+-- codepath for zero-attribute tuples.
+CREATE TABLE motion_noatts ();
+INSERT INTO motion_noatts SELECT;
+SELECT * FROM motion_noatts;


### PR DESCRIPTION
The Motion sender code has four different codepaths for serializing a tuple from the input slot:

1. Fetch MemTuple from slot, copy it out as it is.

2. Fetch MemTuple from slot, re-format it into a new MemTuple by fetching and inlining any toasted datums. Copy out the re-formatted MemTuple.

3. Fetch HeapTuple from slot, copy it out as it is.

4. Fetch HeapTuple from slot, copy out each attribute separately, fetching and inlining any toasted datums.

In addition to the above, there are "direct" versions of codepaths 1 and 3, used when the tuple fits in the caller-provided output buffer.

As discussed in https://github.com/greenplum-db/gpdb/issues/9253, the fourth codepath is very inefficient, if the input tuple contains datums that are compressed inline, but not toasted. We decompress such tuples before serializing, and in the worst case, might need to recompress them again in the receiver if it's written out to a table. I tried to fix that in commit 4c7f6cf7ec, but it was broken and was reverted in commit 774613a83c.

This is a new attempt at fixing the issue. This commit removes codepath 4. altogether, so that if the input tuple is a HeapTuple with any toasted attributes, it is first converted to a MemTuple and codepath 2 is used to serialize it. That way, we have less code to test, and materializing a MemTuple is roughly as fast as the old code to write out the attributes of a HeapTuple one by one, except that the MemTuple codepath avoids the decompression of already-compressed datums.

While we're at it, add some tests for the various codepaths through SerializeTuple().

To test the performance of the affected case, where the input tuple is a HeapTuple with toasted datums, I used this:

```
CREATE temporary TABLE foo (a text, b text, c text, d text, e text, f text,
  g text, h text, i text, j text, k text, l text, m text, n text, o text,
  p text, q text, r text, s text, t text, u text, v text, w text, x text,
  y text, z text, large text);
ALTER TABLE foo ALTER COLUMN large SET STORAGE external;
INSERT INTO foo
  SELECT 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
         'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
         repeat('1234567890', 1000)
  FROM generate_series(1, 10000);

-- verify that the data is uncompressed, should be about 110 MB.
SELECT pg_total_relation_size('foo');

\o /dev/null
\timing on
SELECT * FROM foo; -- repeat a few times
```
The last select took about 380 ms on my laptop, with or without this patch. So the new codepath where the input HeapTuple is converted to a MemTuple first, is about as fast as the old method. There might be small differences in the serialized size of the tuple, too, but I didn't explicitly measure that. If you have a toasted but not compressed datum, the input must be quite large, so small differences in the datum header sizes shouldn't matter much.

If the input HeapTuple contains any compressed datums, this avoids the recompression, so even if converting to a MemTuple was somewhat slower in that case, it should still be much better than before. I kept the HeapTuple codepath for the case that there are no toasted datums. I'm not sure it's significantly faster than converting to a MemTuple either; the caller has to slot_deform_tuple() the received tuple before it can do much with it, and that is slower with HeapTuples than MemTuples. But that codepath is straightforward enough that getting rid of it wouldn't save much code, and I don't feel like doing the performance testing to justify it right now.
