### PR TITLE
Set the default value of wal_keep_segments to 5

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2120,7 +2120,7 @@ static struct config_int ConfigureNamesInt[] =
 			NULL
 		},
 		&wal_keep_segments,
-		0, 0, INT_MAX,
+		5, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -78,6 +78,9 @@ $$ language plpgsql;
 -- start_ignore
 -- let the mirror be marked as 'down' quickly
 \! gpconfig -c gp_fts_mark_mirror_down_grace_period -v 2
+-- since setting wal_keep_segments to 0 is not safe for master/standby,
+-- we are not going to set wal_keep_segments to 0 now, to avoid flaky tests
+\! gpconfig -c wal_keep_segments -v 1
 \! gpstop -u
 -- end_ignore
 -- stop a mirror
@@ -153,5 +156,6 @@ select wait_for_mirror_sync(0::smallint);
 select role, preferred_role, content, mode, status from gp_segment_configuration;
 -- start_ignore
 \! gpconfig -c gp_fts_mark_mirror_down_grace_period -v 30
+\! gpconfig -r wal_keep_segments
 \! gpstop -u
 -- end_ignore


### PR DESCRIPTION
In this PR(https://github.com/greenplum-db/gpdb/pull/9248),
we set the default value of wal_keep_segments to 0, the same
as upstream, because we have replication slot to avoid removal
of WAL files required by the mirror. It seems to be fine.

But there is no replication slot for master/standby now. It's
unsafe to remove WAL files if the file was required by the standby.
So, for now, before the replication slot is added to master, let's
set the default value of wal_keep_segments to 5.

(cherry picked from commit 3ce78553e3b5de66c4a196eb727bcc4899c0ea8b)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
