### PR TITLE
Make dtm_recovery_on_standby test stable

### DIFF
--- a/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
@@ -121,8 +121,8 @@ select reinitialize_standby();
 -- end_ignore
 
 -- Sync state between master and standby must be restored at the end.
-select application_name, state, sync_state from pg_stat_replication;
- application_name | state     | sync_state 
-------------------+-----------+------------
- gp_walreceiver   | streaming | sync       
+select application_name, state from pg_stat_replication;
+ application_name | state     
+------------------+-----------
+ gp_walreceiver   | streaming 
 (1 row)

--- a/src/test/isolation2/sql/segwalrep/dtm_recovery_on_standby.sql
+++ b/src/test/isolation2/sql/segwalrep/dtm_recovery_on_standby.sql
@@ -96,4 +96,4 @@ select reinitialize_standby();
 -- end_ignore
 
 -- Sync state between master and standby must be restored at the end.
-select application_name, state, sync_state from pg_stat_replication;
+select application_name, state from pg_stat_replication;


### PR DESCRIPTION
This test fails sometimes with below diff

```
-- Sync state between master and standby must be restored at the end.
 select application_name, state, sync_state from pg_stat_replication;
  application_name | state     | sync_state
 ------------------+-----------+------------
- gp_walreceiver   | streaming | sync
+ gp_walreceiver   | streaming | async
 (1 row)
```

The reason being, if this query is excuted in window between when
standby is created and changes state to streaming but yet to set flush
to valid location based on reply from standby.
pg_stat_get_wal_senders() reports sync_state as "async", if flush
location is invalid pointer. Hence, we get the above diff sometimes in
test based on timing.

To fix the same, removing the sync_state field from above query for
this test. As in GPDB we always create standby as sync only, secondly
"state" is giving us what we wish to check here, which is if standby
is up and running or not. Checking for sync_state is unnecessary and
hence avoid the same and make test stable. If we have to keep the
sync_state, would have to add unnecessary retry logic for this query.

Ideally, the code in `pg_stat_get_wal_senders()` should be modified as 
well. It masking out the sync_state this way is not right. It should only do 
this if state = "backup", but that's separate discussion which needs to 
happen upstream.