### PR TITLE
Fix flaky test segspace.

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -314,7 +314,7 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 		 * failover. Then the syncrep will be turned off by the FTS to unblock
 		 * backends waiting here.
 		 */
-		if (QueryCancelPending)
+		if (QueryCancelPending && commit)
 		{
 			QueryCancelPending = false;
 			ereport(WARNING,


### PR DESCRIPTION
We recently start to control wal write burst by calling SyncRepWaitForLSN()
more frequently, then the changes cause the segspace test flaky.

In the segspace test case, there is an inject fault (exec_hashjoin_new_batch)
with interrupt event, this makes the test easier to have the cancel event
seen in SyncRepWaitForLSN() and then cause additional outputs sometimes.

Fixing this by disabling the current cancel handling code if it is not a commit
call of SyncRepWaitForLSN().

Here is the diff of the test failure.

 begin;
 insert into segspace_t1_created
 SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE t1.i1=t2.i2;
+DETAIL:  The transaction has already changed locally, it has to be replicated to standby.
 ERROR:  canceling MPP operation
+WARNING:  ignoring query cancel request for synchronous replication to ensure cluster consistency
 rollback;
