### PR TITLE
Fix `DELIMETER 'OFF'` validate error for external table.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1822,6 +1822,8 @@ BeginCopy(bool is_from,
 	CopyState	cstate;
 	int			num_phys_attrs;
 	MemoryContext oldcontext;
+	bool is_copy = true;
+	int num_columns = 0;
 
 	/* Allocate workspace and zero all fields */
 	cstate = (CopyStateData *) palloc0(sizeof(CopyStateData));
@@ -1840,10 +1842,20 @@ BeginCopy(bool is_from,
 
 	oldcontext = MemoryContextSwitchTo(cstate->copycontext);
 
+	/*
+	 * Since external scan calls BeginCopyFrom to init CopyStateData.
+	 * Current relation may be an external relation.
+	 */
+	if (RelationIsExternal(rel))
+	{
+		is_copy = false;
+		num_columns = rel->rd_att->natts;
+	}
+
 	/* Extract options from the statement node tree */
 	ProcessCopyOptions(cstate, is_from, options,
-					   0, /* pass correct value when COPY supports no delim */
-					   true);
+					   num_columns, /* pass correct value when COPY supports no delim */
+					   is_copy);
 
 
 	/* Process the source/target relation or query */

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1846,7 +1846,7 @@ BeginCopy(bool is_from,
 	 * Since external scan calls BeginCopyFrom to init CopyStateData.
 	 * Current relation may be an external relation.
 	 */
-	if (RelationIsExternal(rel))
+	if (rel != NULL && RelationIsExternal(rel))
 	{
 		is_copy = false;
 		num_columns = rel->rd_att->natts;

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -331,38 +331,45 @@ format 'csv' ( quote as '"' header);
 NOTICE:  HEADER means that each one of the data files has a header row
 -- "
 select count(*) from ext_whois;
+NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     23
 (1 row)
 
 create table v_w as select * from ext_whois;
+NOTICE:  HEADER means that each one of the data files has a header row
 -- sort distinct spill to disk/external sort
 select count(*) from (select * from v_w union select * from ext_whois) as foo;
+NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     23
 (1 row)
 
 select count(*) from (select * from v_w union all select * from ext_whois) as foo;
+NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     46
 (1 row)
 
 select count(*) from (select distinct * from ext_whois) as foo;
+NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     23
 (1 row)
 
 select count(*) from (select * from ext_whois order by 1 limit 300000 offset 30000) as foo;
+NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
      0
 (1 row)
 
 select count(*) from (select * from ext_whois order by 1 limit 300000 offset 10) as foo;
+NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     13
@@ -457,6 +464,7 @@ admin_postal_code,
 admin_country,
 rec_path,
 raw_record limit 10 offset 10;
+NOTICE:  HEADER means that each one of the data files has a header row
  source_lineno |   domain_name   
 ---------------+-----------------
            596 | 007dy.net
@@ -690,6 +698,7 @@ DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 -- get an error for missing gpfdist
 --
 select count(*) from ext_whois;
+NOTICE:  HEADER means that each one of the data files has a header row
 ERROR:  connection with gpfdist failed for gpfdist://@hostname@:7070/whois.csv. effective url: http://127.0.0.1:7070/whois.csv. error code = 61 (Connection refused)  (seg1 slice1 @hostname@:50001 pid=64820)
 drop external table ext_whois;
 drop external table exttab1_gpfdist_start;

--- a/src/bin/gpfdist/regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2.source
@@ -343,6 +343,7 @@ FORMAT 'csv'
 ;
 NOTICE:  HEADER means that each one of the data files has a header row
 SELECT count(*) FROM ext_lineitem;
+NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
    255
@@ -716,6 +717,7 @@ FORMAT 'csv'
 ;
 NOTICE:  HEADER means that each one of the data files has a header row
 SELECT count(*) FROM ext_lineitem;
+NOTICE:  HEADER means that each one of the data files has a header row
    255
 
 DROP EXTERNAL TABLE ext_lineitem;

--- a/src/test/isolation2/input/external_table.source
+++ b/src/test/isolation2/input/external_table.source
@@ -113,3 +113,14 @@ SELECT gp_inject_fault('interconnect_setup_palloc', 'reset', dbid)
 10: FETCH exttab_cur1;
 10: FETCH exttab_cur1;
 10: COMMIT;
+
+
+-- start_ignore
+DROP EXTERNAL WEB TABLE IF EXISTS ext_delim_off;
+-- end_ignore
+
+-- Create external table with delimiter off
+CREATE EXTERNAL WEB TABLE ext_delim_off ( junk text) execute 'echo hi' on master FORMAT 'text' (delimiter 'OFF' null E'\\N' escape E'\\');
+
+-- Query the ext_delim_off table
+SELECT * FROM ext_delim_off;

--- a/src/test/isolation2/output/external_table.source
+++ b/src/test/isolation2/output/external_table.source
@@ -187,3 +187,20 @@ DECLARE
 (0 rows)
 10: COMMIT;
 COMMIT
+
+
+GP_IGNORE:-- start_ignore
+GP_IGNORE:DROP EXTERNAL WEB TABLE IF EXISTS ext_delim_off;
+GP_IGNORE:DROP
+GP_IGNORE:-- end_ignore
+
+-- Create external table with delimiter off
+CREATE EXTERNAL WEB TABLE ext_delim_off ( junk text) execute 'echo hi' on master FORMAT 'text' (delimiter 'OFF' null E'\\N' escape E'\\');
+CREATE
+
+-- Query the ext_delim_off table
+SELECT * FROM ext_delim_off;
+ junk 
+------
+ hi   
+(1 row)


### PR DESCRIPTION
For below external table:
```
CREATE EXTERNAL WEB TABLE web_ext ( junk text) execute 'echo hi' ON MASTER
    FORMAT 'text' (delimiter 'OFF' null E'\\N' escape E'\\');
```
When querying the table, an unexpected error happens:
```
SELECT * FROM web_ext;
ERROR:  using no delimiter is only supported for external tables
```

Since external scan calls BeginCopyFrom to init CopyStateData.
When `ProcessCopyOptions` in `BeginCopy`, the relation may
be an external relation.
The fix checks whether the relation is an external relation and if yes,
set the correct parameters for `ProcessCopyOptions`.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
