### PR TITLE
 Remove Motion codepath to detoast HeapTuples, convert to MemTuple instead. (5X_STABLE)

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -431,15 +431,11 @@ CandidateForSerializeDirect(int16 targetRoute, struct directTransportBuffer *b)
 int
 SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTransportBuffer *b, TupleChunkList tcList, int16 targetRoute)
 {
-	int			i;
 	int			natts;
 	int			dataSize = TUPLE_CHUNK_HEADER_SIZE;
-	MemoryContext oldCtxt;
 	TupleDesc	tupdesc;
 	TupleChunkListItem tcItem = NULL;
-	GenericTuple gtuple = ExecFetchSlotGenericTuple(slot);
 
-	AssertArg(gtuple != NULL);
 	AssertArg(pSerInfo != NULL);
 	AssertArg(b != NULL);
 
@@ -461,14 +457,24 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 	tcList->serialized_data_length = 0;
 	tcList->max_chunk_length = Gp_max_tuple_chunk_size;
 
-	if (is_memtuple(gtuple)) /* memtuple case */
+	if (slot->PRIVATE_tts_heaptuple == NULL ||
+		(slot->PRIVATE_tts_heaptuple->t_data->t_infomask & HEAP_HASEXTERNAL) != 0)
 	{
-		MemTuple	tuple = (MemTuple) gtuple;
+		/*
+		 * Virtual or MemTuple slot, or a HeapTuple with toasted datums.
+		 * Send it as a MemTuple.
+		 */
+		MemTuple	tuple;
 		int			tupleSize;
 		int			paddedSize;
-		bool need_toast = memtuple_get_hasext(tuple);
 
-		if (need_toast)
+		if (slot->PRIVATE_tts_memtuple &&
+			!memtuple_get_hasext(slot->PRIVATE_tts_memtuple))
+		{
+			/* we can use the existing MemTuple as it is. */
+			tuple = slot->PRIVATE_tts_memtuple;
+		}
+		else
 		{
 			MemoryContext oldContext;
 			oldContext = MemoryContextSwitchTo(s_tupSerMemCtxt);
@@ -518,17 +524,25 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 
 		MemoryContextReset(s_tupSerMemCtxt);
 	}
-	else /* heaptuple case */
+	else
 	{
-		HeapTuple	tuple = (HeapTuple) gtuple;
+		/* HeapTuple that doesn't require detoasting */
+		HeapTuple	tuple = slot->PRIVATE_tts_heaptuple;
 		TupSerHeader tsh;
-
-		unsigned int	datalen;
-		unsigned int	nullslen;
+		unsigned int datalen;
+		unsigned int nullslen;
 
 		HeapTupleHeader t_data = tuple->t_data;
 
-		unsigned char *pos;
+		datalen = tuple->t_len - t_data->t_hoff;
+		if (HeapTupleHasNulls(tuple))
+			nullslen = BITMAPLEN(HeapTupleHeaderGetNatts(t_data));
+		else
+			nullslen = 0;
+
+		tsh.tuplen = sizeof(TupSerHeader) + TYPEALIGN(TUPLE_CHUNK_ALIGN, nullslen) + datalen;
+		tsh.natts = HeapTupleHeaderGetNatts(t_data);
+		tsh.infomask = t_data->t_infomask;
 
 		if (CandidateForSerializeDirect(targetRoute, b))
 		{
@@ -536,20 +550,10 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 			 * Here we first try to in-line serialize the tuple directly into
 			 * buffer.
 			 */
-			datalen = tuple->t_len - t_data->t_hoff;
-			if (HeapTupleHasNulls(tuple))
-				nullslen = BITMAPLEN(HeapTupleHeaderGetNatts(t_data));
-			else
-				nullslen = 0;
-
-			tsh.tuplen = sizeof(TupSerHeader) + TYPEALIGN(TUPLE_CHUNK_ALIGN, nullslen) + TYPEALIGN(TUPLE_CHUNK_ALIGN, datalen);
-			tsh.natts = HeapTupleHeaderGetNatts(t_data);
-			tsh.infomask = t_data->t_infomask;
-
-
-			if (dataSize + tsh.tuplen <= b->prilen &&
-				(tsh.infomask & HEAP_HASEXTERNAL) == 0)
+			if (dataSize + tsh.tuplen <= b->prilen)
 			{
+				unsigned char *pos;
+
 				pos = b->pri + TUPLE_CHUNK_HEADER_SIZE;
 
 				memcpy(pos, (char *) &tsh, sizeof(TupSerHeader));
@@ -572,7 +576,6 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 
 				SetChunkType(b->pri, TC_WHOLE);
 				SetChunkDataSize(b->pri, dataSize - TUPLE_CHUNK_HEADER_SIZE);
-
 				return dataSize;
 			}
 		}
@@ -588,119 +591,16 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 
 		AssertState(s_tupSerMemCtxt != NULL);
 
-		datalen = tuple->t_len - t_data->t_hoff;
-		if (HeapTupleHasNulls(tuple))
-			nullslen = BITMAPLEN(HeapTupleHeaderGetNatts(t_data));
-		else
-			nullslen = 0;
+		addByteStringToChunkList(tcList, (char *) &tsh, sizeof(TupSerHeader), &pSerInfo->chunkCache);
 
-		tsh.tuplen = sizeof(TupSerHeader) + TYPEALIGN(TUPLE_CHUNK_ALIGN,nullslen) + datalen;
-		tsh.natts = HeapTupleHeaderGetNatts(t_data);
-		tsh.infomask = t_data->t_infomask;
-
-		addByteStringToChunkList(tcList, (char *)&tsh, sizeof(TupSerHeader), &pSerInfo->chunkCache);
-		/* If we don't have any attributes which have been toasted, we
-		 * can be very very simple: just send the raw data. */
-		if ((tsh.infomask & HEAP_HASEXTERNAL) == 0)
+		if (nullslen)
 		{
-			if (nullslen)
-			{
-				addByteStringToChunkList(tcList, (char *)t_data->t_bits, nullslen, &pSerInfo->chunkCache);
-				addPadding(tcList,&pSerInfo->chunkCache,nullslen);
-			}
-
-			addByteStringToChunkList(tcList, (char *)t_data + t_data->t_hoff, datalen, &pSerInfo->chunkCache);
-			addPadding(tcList,&pSerInfo->chunkCache,datalen);
+			addByteStringToChunkList(tcList, (char *) t_data->t_bits, nullslen, &pSerInfo->chunkCache);
+			addPadding(tcList, &pSerInfo->chunkCache, nullslen);
 		}
-		else
-		{
-			/* We have to be more careful when we have tuples that
-			 * have been toasted. Ideally we'd like to send the
-			 * untoasted attributes in as "raw" a format as possible
-			 * but that makes rebuilding the tuple harder .
-			 */
-			oldCtxt = MemoryContextSwitchTo(s_tupSerMemCtxt);
 
-			/* deconstruct the tuple (faster than a heap_getattr loop) */
-			heap_deform_tuple(tuple, tupdesc, pSerInfo->values, pSerInfo->nulls);
-
-			MemoryContextSwitchTo(oldCtxt);
-
-			/* Send the nulls character-array. */
-			addByteStringToChunkList(tcList, pSerInfo->nulls, natts, &pSerInfo->chunkCache);
-			addPadding(tcList,&pSerInfo->chunkCache,natts);
-
-			/*
-			 * send the attributes of this tuple: NOTE anything which allocates
-			 * temporary space (e.g. could result in a PG_DETOAST_DATUM) should be
-			 * executed with the memory context set to s_tupSerMemCtxt
-			 */
-			for (i = 0; i < natts; ++i)
-			{
-				SerAttrInfo *attrInfo = pSerInfo->myinfo + i;
-				Datum		origattr = pSerInfo->values[i],
-					attr;
-
-				/* skip null attributes (already taken care of above) */
-				if (pSerInfo->nulls[i])
-					continue;
-
-				if (attrInfo->typlen == -1)
-				{
-					int32		sz;
-					char	   *data;
-
-					/*
-					 * If we have a toasted datum, forcibly detoast it here to avoid
-					 * memory leakage: we want to force the detoast allocation(s) to
-					 * happen in our reset-able serialization context.
-					 */
-					oldCtxt = MemoryContextSwitchTo(s_tupSerMemCtxt);
-					attr = PointerGetDatum(PG_DETOAST_DATUM_PACKED(origattr));
-					MemoryContextSwitchTo(oldCtxt);
-
-					sz = VARSIZE_ANY_EXHDR(attr);
-					data = VARDATA_ANY(attr);
-
-					/* Send length first, then data */
-					addInt32ToChunkList(tcList, sz, &pSerInfo->chunkCache);
-					addByteStringToChunkList(tcList, data, sz, &pSerInfo->chunkCache);
-					addPadding(tcList, &pSerInfo->chunkCache, sz);
-				}
-				else if (attrInfo->typlen == -2)
-				{
-					int32		sz;
-					char	   *data;
-
-					/* CString, we would send the string with the terminating '\0' */
-					data = DatumGetCString(origattr);
-					sz = strlen(data) + 1;
-
-					/* Send length first, then data */
-					addInt32ToChunkList(tcList, sz, &pSerInfo->chunkCache);
-					addByteStringToChunkList(tcList, data, sz, &pSerInfo->chunkCache);
-					addPadding(tcList, &pSerInfo->chunkCache, sz);
-				}
-				else if (attrInfo->typbyval)
-				{
-					/*
-					 * We send a full-width Datum for all pass-by-value types, regardless of
-					 * the actual size.
-					 */
-					addByteStringToChunkList(tcList, (char *) &origattr, sizeof(Datum), &pSerInfo->chunkCache);
-					addPadding(tcList, &pSerInfo->chunkCache, sizeof(Datum));
-				}
-				else
-				{
-					addByteStringToChunkList(tcList, DatumGetPointer(origattr), attrInfo->typlen, &pSerInfo->chunkCache);
-					addPadding(tcList, &pSerInfo->chunkCache, attrInfo->typlen);
-
-					attr = origattr;
-				}
-			}
-
-			MemoryContextReset(s_tupSerMemCtxt);
-		}
+		addByteStringToChunkList(tcList, (char *) t_data + t_data->t_hoff, datalen, &pSerInfo->chunkCache);
+		addPadding(tcList, &pSerInfo->chunkCache, datalen);
 	}
 
 	/*
@@ -735,121 +635,8 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 }
 
 /*
- * Deserialize a HeapTuple's data from a byte-array.
- *
- * This code is based on the binary input handling functions in copy.c.
+ * Reassemble and deserialize a list of tuple chunks, into a tuple.
  */
-HeapTuple
-DeserializeTuple(SerTupInfo * pSerInfo, StringInfo serialTup)
-{
-	MemoryContext oldCtxt;
-	TupleDesc	tupdesc;
-	HeapTuple	htup;
-	int			natts;
-	SerAttrInfo *attrInfo;
-	int			i;
-
-	AssertArg(pSerInfo != NULL);
-	AssertArg(serialTup != NULL);
-
-	tupdesc = pSerInfo->tupdesc;
-	natts = tupdesc->natts;
-
-	/*
-	 * Flip to our tuple-serialization memory-context, to speed up memory
-	 * reclamation operations.
-	 */
-	AssertState(s_tupSerMemCtxt != NULL);
-	oldCtxt = MemoryContextSwitchTo(s_tupSerMemCtxt);
-
-	/* Receive nulls character-array. */
-	pq_copymsgbytes(serialTup, pSerInfo->nulls, natts);
-	skipPadding(serialTup);
-
-	/* Deserialize the non-NULL attributes of this tuple */
-	for (i = 0; i < natts; ++i)
-	{
-		attrInfo = pSerInfo->myinfo + i;
-
-		if (pSerInfo->nulls[i])	/* NULL field. */
-		{
-			pSerInfo->values[i] = (Datum) 0;
-			continue;
-		}
-
-		if (attrInfo->typlen == -1)
-		{
-			int32		sz;
-			struct varlena *p;
-
-			/* Read length first */
-			pq_copymsgbytes(serialTup, (char *) &sz, sizeof(int32));
-			if (sz < 0)
-				elog(ERROR, "invalid length received for a varlen Datum");
-
-			p = palloc(sz + VARHDRSZ);
-
-			pq_copymsgbytes(serialTup, VARDATA(p), sz);
-			SET_VARSIZE(p, sz + VARHDRSZ);
-
-			pSerInfo->values[i] = PointerGetDatum(p);
-		}
-		else if (attrInfo->typlen == -2)
-		{
-			int32		sz;
-			char	   *p;
-
-			/* CString, with terminating '\0' included */
-
-			/* Read length first */
-			pq_copymsgbytes(serialTup, (char *) &sz, sizeof(int32));
-			if (sz < 0)
-				elog(ERROR, "invalid length received for a CString");
-
-			p = palloc(sz + VARHDRSZ);
-
-			/* Then data */
-			pq_copymsgbytes(serialTup, p, sz);
-
-			pSerInfo->values[i] = CStringGetDatum(p);
-		}
-		else if (attrInfo->typbyval)
-		{
-			/* Read a whole Datum */
-
-			pq_copymsgbytes(serialTup, (char *) &(pSerInfo->values[i]), sizeof(Datum));
-		}
-		else
-		{
-			/* fixed width, pass-by-ref */
-			char	   *p = palloc(attrInfo->typlen);
-
-			pq_copymsgbytes(serialTup, p, attrInfo->typlen);
-
-			pSerInfo->values[i] = PointerGetDatum(p);
-		}
-	}
-
-	/*
-	 * Construct the tuple from the Datums and nulls values.  NOTE:  Switch
-	 * out of our temporary context before we form the tuple!
-	 */
-	MemoryContextSwitchTo(oldCtxt);
-
-	htup = heap_form_tuple(tupdesc, pSerInfo->values, pSerInfo->nulls);
-
-	MemoryContextReset(s_tupSerMemCtxt);
-
-	/* Trouble if it didn't eat the whole buffer */
-	if (serialTup->cursor != serialTup->len)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
-				 errmsg("incorrect binary data format")));
-
-	/* All done.  Return the result. */
-	return htup;
-}
-
 GenericTuple
 CvtChunksToTup(TupleChunkList tcList, SerTupInfo *pSerInfo, TupleRemapper *remapper)
 {
@@ -1000,19 +787,9 @@ CvtChunksToTup(TupleChunkList tcList, SerTupInfo *pSerInfo, TupleRemapper *remap
 			pos += sizeof(TupSerHeader);
 
 			/*
-			 * if the tuple had toasted elements we have to deserialize the
-			 * old slow way.
+			 * Tuples with toasted elements should've been converted to MemTuples.
 			 */
-			if ((tshp->infomask & HEAP_HASEXTERNAL) != 0)
-			{
-				serData.cursor += sizeof(TupSerHeader);
-
-				tup = (GenericTuple) DeserializeTuple(pSerInfo, &serData);
-
-				/* Free up memory we used. */
-				pfree(serData.data);
-				return tup;
-			}
+			Assert((tshp->infomask & HEAP_HASEXTERNAL) == 0);
 
 			/* reconstruct lengths of null bitmap and data part */
 			if (tshp->infomask & HEAP_HASNULL)

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -303,11 +303,6 @@ addByteStringToChunkList(TupleChunkList tcList, char *data, int datalen, TupleCh
 			break;
 
 		tcItem = getChunkFromCache(chunkCache);
-		if (tcItem == NULL)
-		{
-			ereport(FATAL, (errcode(ERRCODE_OUT_OF_MEMORY),
-							errmsg("Could not allocate space for new chunk. %d of %d bytes in %d chunks", tcList->serialized_data_length, datalen, tcList->num_chunks)));
-		}
 		tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 		SetChunkType(tcItem->chunk_data, TC_PARTIAL_MID);
 		appendChunkToTCList(tcList, tcItem);
@@ -352,11 +347,6 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 	tcList->max_chunk_length = Gp_max_tuple_chunk_size;
 
 	tcItem = getChunkFromCache(&pSerInfo->chunkCache);
-	if (tcItem == NULL)
-	{
-		ereport(FATAL, (errcode(ERRCODE_OUT_OF_MEMORY),
-						errmsg("Could not allocate space for first chunk item in new chunk list.")));
-	}
 
 	/* assume that we'll take a single chunk */
 	SetChunkType(tcItem->chunk_data, TC_WHOLE);
@@ -517,11 +507,6 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 		 * out-of-line serialization.
 		 */
 		tcItem = getChunkFromCache(&pSerInfo->chunkCache);
-		if (tcItem == NULL)
-		{
-			ereport(FATAL, (errcode(ERRCODE_OUT_OF_MEMORY),
-							errmsg("Could not allocate space for first chunk item in new chunk list.")));
-		}
 		SetChunkType(tcItem->chunk_data, TC_WHOLE);
 		tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 		appendChunkToTCList(tcList, tcItem);
@@ -597,12 +582,6 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 		 * out-of-line serialization.
 		 */
 		tcItem = getChunkFromCache(&pSerInfo->chunkCache);
-		if (tcItem == NULL)
-		{
-			ereport(FATAL,
-					(errcode(ERRCODE_OUT_OF_MEMORY),
-					 errmsg("could not allocate space for first chunk item in new chunk list")));
-		}
 		SetChunkType(tcItem->chunk_data, TC_WHOLE);
 		tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 		appendChunkToTCList(tcList, tcItem);

--- a/src/include/cdb/tupser.h
+++ b/src/include/cdb/tupser.h
@@ -82,14 +82,11 @@ extern void SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 										   TupleChunkList tcList,
 										   MotionConn *conn);
 
-/* Convert a HeapTuple into chunks directly in a set of transport buffers */
+/* Convert a tuple into chunks directly in a set of transport buffers */
 extern int SerializeTuple(TupleTableSlot *tuple, SerTupInfo *pSerInfo, struct directTransportBuffer *b, TupleChunkList tcList, int16 targetRoute);
 
-/* Deserialize a HeapTuple's data from a byte-array. */
-extern HeapTuple DeserializeTuple(SerTupInfo * pSerInfo, StringInfo serialTup);
-
 /* Convert a sequence of chunks containing serialized tuple data into a
- * HeapTuple.
+ * HeapTuple or MemTuple.
  */
 extern GenericTuple CvtChunksToTup(TupleChunkList tclist, SerTupInfo * pSerInfo, TupleRemapper *remapper);
 

--- a/src/test/regress/expected/motion_gp.out
+++ b/src/test/regress/expected/motion_gp.out
@@ -1,0 +1,124 @@
+CREATE TABLE motiondata (
+  id int,
+  plain text,     -- inline, uncompressed
+  main text,      --inline, compressible
+  external text,  -- external, uncompressed
+  extended text); -- external, compressible
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE motiondata ALTER COLUMN plain SET STORAGE plain;
+ALTER TABLE motiondata ALTER COLUMN main SET STORAGE main;
+ALTER TABLE motiondata ALTER COLUMN external SET STORAGE external;
+ALTER TABLE motiondata ALTER COLUMN extended SET STORAGE extended;
+-- a simple small tuple.
+INSERT INTO motiondata (id, plain, main, external, extended) VALUES (1, 'foo', 'bar', 'baz', 'foobar');
+-- Large datum, inline uncompressed
+INSERT INTO motiondata (id, plain) VALUES (2, repeat('1234567890', 1000));
+-- Large datum, inline compressed
+INSERT INTO motiondata (id, main)  VALUES (3, repeat('1234567890', 1000));
+-- Large datum, inline compressed, but doesn't fit in a short varlen even
+-- after compression
+INSERT INTO motiondata (id, main)  VALUES (4, repeat('1234567890', 2000));
+-- Large datum, external uncompressed
+INSERT INTO motiondata (id, external) VALUES (5, repeat('1234567890', 1000));
+-- Large datum, external, compressed
+INSERT INTO motiondata (id, extended) VALUES (6, repeat('1234567890', 100000));
+-- Check that the sizes are as expected. The exact sizes are not important,
+-- but should be in the right ballpark.
+SELECT id,
+       pg_column_size(plain) AS plain_sz,
+       pg_column_size(main) AS main_sz,
+       pg_column_size(external) AS external_sz,
+       pg_column_size(extended) AS extended_sz
+FROM motiondata;
+ id | plain_sz | main_sz | external_sz | extended_sz 
+----+----------+---------+-------------+-------------
+  1 |        7 |       4 |           4 |           7
+  2 |    10004 |         |             |            
+  3 |          |     135 |             |            
+  4 |          |     251 |             |            
+  5 |          |         |       10000 |            
+  6 |          |         |             |       11463
+(6 rows)
+
+CREATE TABLE motiondata_ao WITH (appendonly=true) AS SELECT * from motiondata;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- A helper function for printing an abbreviated version of a long datum. Otherwise, the output
+-- of selecting the large datums become unwieldly.
+create or replace function abbreviate(t text) returns text as $$
+begin
+  if length(t) <= 15 then
+    return length(t) || ': ' || t;
+  else
+    return length(t) || ': ' || substring(t from 1 for 5) || '...' || substring(t from length(t)-4 for 5);
+  end if;
+end;
+$$ language plpgsql;
+-- Runs query 'sql', and prints an abbreviated result set.
+--
+-- Note: It's important that we run the query as it is, and abbreviate the
+-- resulting values afterwards. If we put the abbreviate() function calls into
+-- the query itself, then they will be evaluated in the QEs, and the original
+-- large datums are not sent through the Motion at all. Since we're trying to
+-- test the Motion tuple serialization code, that would defeat the purpose.
+create or replace function abbreviate_result(sql text) returns setof motiondata
+as $$
+declare
+  rec motiondata%rowtype;
+begin
+  for rec in EXECUTE sql
+  loop
+     rec.plain = abbreviate(rec.plain);
+     rec.main = abbreviate(rec.main);
+     rec.external = abbreviate(rec.external);
+     rec.extended = abbreviate(rec.extended);
+     RETURN NEXT rec ;
+  end loop;
+end;
+$$ language plpgsql;
+-- This exercises the codepath where the HeapTuple is sent over the wire as is, if it
+-- doesn't contain toasted datums.
+select * from abbreviate_result($$
+  select id, plain, main, external, extended from motiondata
+$$) order by id;
+ id |        plain         |         main         |       external       |        extended        
+----+----------------------+----------------------+----------------------+------------------------
+  1 | 3: foo               | 3: bar               | 3: baz               | 6: foobar
+  2 | 10000: 12345...67890 |                      |                      | 
+  3 |                      | 10000: 12345...67890 |                      | 
+  4 |                      | 20000: 12345...67890 |                      | 
+  5 |                      |                      | 10000: 12345...67890 | 
+  6 |                      |                      |                      | 1000000: 12345...67890
+(6 rows)
+
+-- Because of the 'id + 0' expression, the Seq Scan node has to project,
+-- and passes a virtual slot to the Motion.
+select * from abbreviate_result($$
+  select id + 0 as id, plain, main, external, extended from motiondata
+$$) order by id;
+ id |        plain         |         main         |       external       |        extended        
+----+----------------------+----------------------+----------------------+------------------------
+  1 | 3: foo               | 3: bar               | 3: baz               | 6: foobar
+  2 | 10000: 12345...67890 |                      |                      | 
+  3 |                      | 10000: 12345...67890 |                      | 
+  4 |                      | 20000: 12345...67890 |                      | 
+  5 |                      |                      | 10000: 12345...67890 | 
+  6 |                      |                      |                      | 1000000: 12345...67890
+(6 rows)
+
+-- Here, the Motion gets an already-built MemTuple from the Seq Scan, because it's
+-- an AO table.
+select * from abbreviate_result($$
+  select id, plain, main, external, extended from motiondata_ao
+$$) order by id;
+ id |        plain         |         main         |       external       |        extended        
+----+----------------------+----------------------+----------------------+------------------------
+  1 | 3: foo               | 3: bar               | 3: baz               | 6: foobar
+  2 | 10000: 12345...67890 |                      |                      | 
+  3 |                      | 10000: 12345...67890 |                      | 
+  4 |                      | 20000: 12345...67890 |                      | 
+  5 |                      |                      | 10000: 12345...67890 | 
+  6 |                      |                      |                      | 1000000: 12345...67890
+(6 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -20,7 +20,7 @@ test: gp_metadata variadic_parameters default_parameters function_extensions spi
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table gp_create_view resource_queue_with_rule
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions
 test: bitmap_index gp_dump_query_oids analyze gp_owner_permission incremental_analyze gang_reuse
-test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules
+test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules motion_gp
 # dispatch should always run seperately from other cases.
 test: dispatch
 

--- a/src/test/regress/sql/motion_gp.sql
+++ b/src/test/regress/sql/motion_gp.sql
@@ -1,0 +1,94 @@
+CREATE TABLE motiondata (
+  id int,
+  plain text,     -- inline, uncompressed
+  main text,      --inline, compressible
+  external text,  -- external, uncompressed
+  extended text); -- external, compressible
+
+ALTER TABLE motiondata ALTER COLUMN plain SET STORAGE plain;
+ALTER TABLE motiondata ALTER COLUMN main SET STORAGE main;
+ALTER TABLE motiondata ALTER COLUMN external SET STORAGE external;
+ALTER TABLE motiondata ALTER COLUMN extended SET STORAGE extended;
+
+-- a simple small tuple.
+INSERT INTO motiondata (id, plain, main, external, extended) VALUES (1, 'foo', 'bar', 'baz', 'foobar');
+
+-- Large datum, inline uncompressed
+INSERT INTO motiondata (id, plain) VALUES (2, repeat('1234567890', 1000));
+
+-- Large datum, inline compressed
+INSERT INTO motiondata (id, main)  VALUES (3, repeat('1234567890', 1000));
+
+-- Large datum, inline compressed, but doesn't fit in a short varlen even
+-- after compression
+INSERT INTO motiondata (id, main)  VALUES (4, repeat('1234567890', 2000));
+
+-- Large datum, external uncompressed
+INSERT INTO motiondata (id, external) VALUES (5, repeat('1234567890', 1000));
+
+-- Large datum, external, compressed
+INSERT INTO motiondata (id, extended) VALUES (6, repeat('1234567890', 100000));
+
+-- Check that the sizes are as expected. The exact sizes are not important,
+-- but should be in the right ballpark.
+SELECT id,
+       pg_column_size(plain) AS plain_sz,
+       pg_column_size(main) AS main_sz,
+       pg_column_size(external) AS external_sz,
+       pg_column_size(extended) AS extended_sz
+FROM motiondata;
+
+CREATE TABLE motiondata_ao WITH (appendonly=true) AS SELECT * from motiondata;
+
+-- A helper function for printing an abbreviated version of a long datum. Otherwise, the output
+-- of selecting the large datums become unwieldly.
+create or replace function abbreviate(t text) returns text as $$
+begin
+  if length(t) <= 15 then
+    return length(t) || ': ' || t;
+  else
+    return length(t) || ': ' || substring(t from 1 for 5) || '...' || substring(t from length(t)-4 for 5);
+  end if;
+end;
+$$ language plpgsql;
+
+-- Runs query 'sql', and prints an abbreviated result set.
+--
+-- Note: It's important that we run the query as it is, and abbreviate the
+-- resulting values afterwards. If we put the abbreviate() function calls into
+-- the query itself, then they will be evaluated in the QEs, and the original
+-- large datums are not sent through the Motion at all. Since we're trying to
+-- test the Motion tuple serialization code, that would defeat the purpose.
+create or replace function abbreviate_result(sql text) returns setof motiondata
+as $$
+declare
+  rec motiondata%rowtype;
+begin
+  for rec in EXECUTE sql
+  loop
+     rec.plain = abbreviate(rec.plain);
+     rec.main = abbreviate(rec.main);
+     rec.external = abbreviate(rec.external);
+     rec.extended = abbreviate(rec.extended);
+     RETURN NEXT rec ;
+  end loop;
+end;
+$$ language plpgsql;
+
+-- This exercises the codepath where the HeapTuple is sent over the wire as is, if it
+-- doesn't contain toasted datums.
+select * from abbreviate_result($$
+  select id, plain, main, external, extended from motiondata
+$$) order by id;
+
+-- Because of the 'id + 0' expression, the Seq Scan node has to project,
+-- and passes a virtual slot to the Motion.
+select * from abbreviate_result($$
+  select id + 0 as id, plain, main, external, extended from motiondata
+$$) order by id;
+
+-- Here, the Motion gets an already-built MemTuple from the Seq Scan, because it's
+-- an AO table.
+select * from abbreviate_result($$
+  select id, plain, main, external, extended from motiondata_ao
+$$) order by id;


### PR DESCRIPTION
Backpatch of #9268 to 5X_STABLE. No differences, opening PR to run the concourse pipeline on it.