### PR TITLE
Forbid DROP PARTITION with no partition name or value.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16276,8 +16276,7 @@ wack_pid_relname(AlterPartitionId 		 *pid,
 				 PartitionNode  		**ppNode,
 				 Relation 				  rel,
 				 PgPartRule 			**ppar_prule,
-				 char 					**plrelname,
-				 char 					 *lRelNameBuf)
+				 char 					**plrelname)
 {
 	AlterPartitionId 	*locPid = pid;	/* local pid if IDRule */
 
@@ -16295,7 +16294,7 @@ wack_pid_relname(AlterPartitionId 		 *pid,
 
 		par_prule = *ppar_prule;
 
-		*plrelname = par_prule->relname;
+		*plrelname = pstrdup(par_prule->relname);
 
 		if (par_prule && par_prule->topRule && par_prule->topRule->children)
 			*ppNode = par_prule->topRule->children;
@@ -16310,10 +16309,8 @@ wack_pid_relname(AlterPartitionId 		 *pid,
 	{
 		*ppNode = RelationBuildPartitionDesc(rel, false);
 
-		snprintf(lRelNameBuf, (NAMEDATALEN*2),
-					 "relation \"%s\"",
+		*plrelname = psprintf("relation \"%s\"",
 					 RelationGetRelationName(rel));
-		*plrelname = lRelNameBuf;
 	}
 
 	return locPid;
@@ -16331,7 +16328,6 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 	char			 	 namBuf[NAMEDATALEN];
 	AlterPartitionId 	*locPid 	= NULL;	/* local pid if IDRule */
 	PgPartRule* 		 par_prule 	= NULL;	/* prule for parent if IDRule */
-	char 		 		 lRelNameBuf[(NAMEDATALEN*2)];
 	char 				*lrelname   = NULL;
 	bool				 is_split = false;
 	bool				 bSetTemplate = (att == AT_PartSetTemplate);
@@ -16353,8 +16349,7 @@ ATPExecPartAdd(AlteredTableInfo *tab,
 							 &pNode,
 							 rel,
 							 &par_prule,
-							 &lrelname,
-							 lRelNameBuf);
+							 &lrelname);
 
 	if (!pNode)
 		ereport(ERROR,
@@ -16699,7 +16694,6 @@ ATPExecPartDrop(Relation rel,
 	bool 				 bCheckMaybe = !(ds->missing_ok);
 	AlterPartitionId 	*locPid 	 = pid;  /* local pid if IDRule */
 	PgPartRule* 		 par_prule 	 = NULL; /* prule for parent if IDRule */
-	char 		 		 lRelNameBuf[(NAMEDATALEN*2)];
 	char 				*lrelname	= NULL;
 	bool 				 bForceDrop	= false;
 
@@ -16728,8 +16722,7 @@ ATPExecPartDrop(Relation rel,
 							 &pNode,
 							 rel,
 							 &par_prule,
-							 &lrelname,
-							 lRelNameBuf);
+							 &lrelname);
 
 	if (AT_AP_IDNone == locPid->idtype)
 	{
@@ -17315,7 +17308,6 @@ ATPExecPartRename(Relation rel,
 	PartitionNode  		*pNode     = NULL;
 	AlterPartitionId 	*locPid    = pid;	/* local pid if IDRule */
 	PgPartRule* 		 par_prule = NULL;	/* prule for parent if IDRule */
-	char 		 		 lRelNameBuf[(NAMEDATALEN*2)];
 	char 				*lrelname=NULL;
 
 	if (Gp_role != GP_ROLE_DISPATCH)
@@ -17326,8 +17318,7 @@ ATPExecPartRename(Relation rel,
 							 &pNode,
 							 rel,
 							 &par_prule,
-							 &lrelname,
-							 lRelNameBuf);
+							 &lrelname);
 
 	prule = get_part_rule(rel, pid, true, true, NULL, false);
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16714,9 +16714,7 @@ ATPExecPartDrop(Relation rel,
 		bForceDrop = true;
 	}
 
-	/* missing partition id only ok for range partitions -- just get
-	 * first one */
-
+	/* resolve the target partition */
 	locPid =
 			wack_pid_relname(pid,
 							 &pNode,
@@ -16726,22 +16724,15 @@ ATPExecPartDrop(Relation rel,
 
 	if (AT_AP_IDNone == locPid->idtype)
 	{
-		if (pNode && pNode->part && (pNode->part->parkind != 'r'))
-		{
-			if (strlen(lrelname))
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("missing name or value for DROP for %s",
-								lrelname)));
-			else
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("missing name or value for DROP")));
-		}
-
-		/* if a range partition, and not specified, just get the first one */
-		locPid->idtype = AT_AP_IDRank;
-		locPid->partiddef = (Node *)makeInteger(1);
+		if (strlen(lrelname))
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("missing name or value for DROP for %s",
+							lrelname)));
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("missing name or value for DROP")));
 	}
 
 	prule = get_part_rule(rel, pid, bCheckMaybe, true, NULL, false);

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -624,7 +624,7 @@ NOTICE:  CREATE TABLE will create partition "mpp3263_1_prt_aa_2" for table "mpp3
 alter table mpp3263 add column AAA int;
 alter table mpp3263 add column BBB int;
 alter table mpp3263 drop column BBB;
-alter table mpp3263 drop partition;
+alter table mpp3263 drop partition for (0);
 NOTICE:  dropped partition "aa_1" for relation "mpp3263"
 alter table mpp3263 add column CCC int;
 insert into mpp3263 (unique1) values (1111);
@@ -3757,7 +3757,7 @@ HINT:  You may be able to perform the operation on the partitioned table as a wh
 alter table fff_main_1_prt_1 add partition;
 ERROR:  can't alter "fff_main_1_prt_1"; it is part of a partitioned table
 HINT:  You may be able to perform the operation on the partitioned table as a whole.
-alter table fff_main_1_prt_1 drop partition;
+alter table fff_main_1_prt_1 drop partition for (0);
 ERROR:  can't alter "fff_main_1_prt_1"; it is part of a partitioned table
 HINT:  You may be able to perform the operation on the partitioned table as a whole.
 alter table fff_main_1_prt_1 add column c int;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -1810,19 +1810,13 @@ NOTICE:  dropped partition "jan01" for partition "girls" of relation "ataprank" 
 -- ok , skipping
 alter table ataprank alter partition girls drop partition if exists jan01;
 NOTICE:  partition "jan01" of partition "girls" of relation "ataprank" does not exist, skipping
--- ok until run out of partitions
-alter table ataprank alter partition girls drop partition ;
+-- ok
+alter table ataprank alter partition girls drop partition for ('2002-01-01');
 NOTICE:  dropped partition "jan02" for partition "girls" of relation "ataprank" and its children
-alter table ataprank alter partition girls drop partition ;
+alter table ataprank alter partition girls drop partition for ('2003-01-01');
 NOTICE:  dropped partition "jan03" for partition "girls" of relation "ataprank" and its children
-alter table ataprank alter partition girls drop partition ;
+alter table ataprank alter partition girls drop partition for ('2004-01-01');
 NOTICE:  dropped partition "jan04" for partition "girls" of relation "ataprank" and its children
-alter table ataprank alter partition girls drop partition ;
-ERROR:  cannot drop partition "jan05" of partition "girls" of relation "ataprank" -- only one remains
-HINT:  DROP the parent partition to remove the final partition
-alter table ataprank alter partition girls drop partition ;
-ERROR:  cannot drop partition "jan05" of partition "girls" of relation "ataprank" -- only one remains
-HINT:  DROP the parent partition to remove the final partition
 -- ok, skipping
 alter table ataprank alter partition girls drop partition if exists for (rank(5));
 NOTICE:  partition for specified rank of partition "girls" of relation "ataprank" does not exist, skipping

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -926,25 +926,23 @@ partition cc values ('2009-01-01')
 NOTICE:  CREATE TABLE will create partition "hhh_l1_1_prt_aa" for table "hhh_l1"
 NOTICE:  CREATE TABLE will create partition "hhh_l1_1_prt_bb" for table "hhh_l1"
 NOTICE:  CREATE TABLE will create partition "hhh_l1_1_prt_cc" for table "hhh_l1"
--- must have name or value for list partition
+-- must have name or value for partition
 alter table hhh_l1 drop partition;
 ERROR:  missing name or value for DROP for relation "hhh_l1"
 alter table hhh_l1 drop partition aa;
 alter table hhh_l1 drop partition for ('2008-01-01');
 NOTICE:  dropped partition "bb" for relation "hhh_l1"
--- if not specified, drop first range partition...
+-- same with range partitioning
+alter table hhh_r1 drop partition;
+ERROR:  missing name or value for DROP for relation "hhh_r1"
 alter table hhh_r1 drop partition for ('2007-04-01');
 NOTICE:  dropped partition "aa_4" for relation "hhh_r1"
-alter table hhh_r1 drop partition;
+alter table hhh_r1 drop partition for(rank(1));
 NOTICE:  dropped partition "aa_1" for relation "hhh_r1"
-alter table hhh_r1 drop partition;
-NOTICE:  dropped partition "aa_2" for relation "hhh_r1"
-alter table hhh_r1 drop partition;
-NOTICE:  dropped partition "aa_3" for relation "hhh_r1"
-alter table hhh_r1 drop partition;
-NOTICE:  dropped partition "aa_5" for relation "hhh_r1"
-alter table hhh_r1 drop partition;
-NOTICE:  dropped partition "aa_6" for relation "hhh_r1"
+alter table hhh_r1 drop partition aa_2;
+alter table hhh_r1 drop partition aa_3;
+alter table hhh_r1 drop partition aa_5;
+alter table hhh_r1 drop partition aa_6;
 -- more add partition tests
 -- start before first partition (fail because start equal end)
 alter table hhh_r1 add partition zaa start ('2007-07-01');

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -1814,19 +1814,13 @@ NOTICE:  dropped partition "jan01" for partition "girls" of relation "ataprank" 
 -- ok , skipping
 alter table ataprank alter partition girls drop partition if exists jan01;
 NOTICE:  partition "jan01" of partition "girls" of relation "ataprank" does not exist, skipping
--- ok until run out of partitions
-alter table ataprank alter partition girls drop partition ;
+-- ok
+alter table ataprank alter partition girls drop partition for ('2002-01-01');
 NOTICE:  dropped partition "jan02" for partition "girls" of relation "ataprank" and its children
-alter table ataprank alter partition girls drop partition ;
+alter table ataprank alter partition girls drop partition for ('2003-01-01');
 NOTICE:  dropped partition "jan03" for partition "girls" of relation "ataprank" and its children
-alter table ataprank alter partition girls drop partition ;
+alter table ataprank alter partition girls drop partition for ('2004-01-01');
 NOTICE:  dropped partition "jan04" for partition "girls" of relation "ataprank" and its children
-alter table ataprank alter partition girls drop partition ;
-ERROR:  cannot drop partition "jan05" of partition "girls" of relation "ataprank" -- only one remains
-HINT:  DROP the parent partition to remove the final partition
-alter table ataprank alter partition girls drop partition ;
-ERROR:  cannot drop partition "jan05" of partition "girls" of relation "ataprank" -- only one remains
-HINT:  DROP the parent partition to remove the final partition
 -- ok, skipping
 alter table ataprank alter partition girls drop partition if exists for (rank(5));
 NOTICE:  partition for specified rank of partition "girls" of relation "ataprank" does not exist, skipping

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -673,7 +673,7 @@ subpartition by range (unique2) subpartition template ( start (0) end (1000) eve
 insert into mpp3375a select * from mpp3375;
 
 alter table mpp3375a add default partition default_part;
-alter table mpp3375a drop partition;
+alter table mpp3375a drop partition for (0);
 alter table mpp3375a drop partition default_part;
 
 -- Check that a negative number can be used in START, without quotes.
@@ -759,18 +759,16 @@ CREATE TABLE mpp3261_part (
 ) partition by range (unique1)
 ( partition aa start (0) end (1000) every (100), default partition default_part );
 
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
--- Last partition, cannot be dropped, only default partition is left
-alter table mpp3261_part drop partition;
+alter table mpp3261_part drop partition for (0);
+alter table mpp3261_part drop partition for (100);
+alter table mpp3261_part drop partition for (200);
+alter table mpp3261_part drop partition for (300);
+alter table mpp3261_part drop partition for (400);
+alter table mpp3261_part drop partition for (500);
+alter table mpp3261_part drop partition for (600);
+alter table mpp3261_part drop partition for (700);
+alter table mpp3261_part drop partition for (800);
+alter table mpp3261_part drop partition for (900);
 
 -- Shouldn't take a long time to insert
 insert into mpp3261_part select * from mpp3261;
@@ -852,16 +850,16 @@ CREATE TABLE mpp3260 (
 
 -- Not Allowed to drop partition table directly
 drop table mpp3260_1_prt_aa_6;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
+alter table mpp3260 drop partition for (0);
+alter table mpp3260 drop partition for (100);
+alter table mpp3260 drop partition for (200);
+alter table mpp3260 drop partition for (300);
+alter table mpp3260 drop partition for (400);
+alter table mpp3260 drop partition for (500);
+alter table mpp3260 drop partition for (600);
+alter table mpp3260 drop partition for (700);
+alter table mpp3260 drop partition for (800);
+alter table mpp3260 drop partition for (900);
 drop table mpp3260_1_prt_default_part ;
 insert into mpp3260 (unique1) values (1);
 
@@ -887,17 +885,17 @@ subpartition by range (unique2) subpartition template ( start (0) end (1000) eve
 ( start (0) end (1000) every (100));
 -- Not Allowed to drop partition table directly
 drop table mpp3260a_1_prt_10;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
+alter table mpp3260a drop partition for (0);
+alter table mpp3260a drop partition for (100);
+alter table mpp3260a drop partition for (200);
+alter table mpp3260a drop partition for (300);
+alter table mpp3260a drop partition for (400);
+alter table mpp3260a drop partition for (500);
+alter table mpp3260a drop partition for (600);
+alter table mpp3260a drop partition for (700);
+alter table mpp3260a drop partition for (800);
 -- Last subpartition, cannot be dropped
-alter table mpp3260a drop partition;
+alter table mpp3260a drop partition for (900);
 drop table mpp3260a_1_prt_10;
 
 drop table mpp3260;

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -2345,7 +2345,7 @@ subpartition by range (unique2) subpartition template ( start (0) end (1000) eve
 ( start (0) end (1000) every (100));
 insert into mpp3375a select * from mpp3375;
 alter table mpp3375a add default partition default_part;
-alter table mpp3375a drop partition;
+alter table mpp3375a drop partition for (0);
 alter table mpp3375a drop partition default_part;
 -- Check that a negative number can be used in START, without quotes.
 CREATE TABLE mpp3241(a int, b int, c int)
@@ -2667,19 +2667,16 @@ CREATE TABLE mpp3261_part (
         string4         name
 ) partition by range (unique1)
 ( partition aa start (0) end (1000) every (100), default partition default_part );
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
-alter table mpp3261_part drop partition;
--- Last partition, cannot be dropped, only default partition is left
-alter table mpp3261_part drop partition;
-ERROR:  partition for rank 1 of relation "mpp3261_part" does not exist
+alter table mpp3261_part drop partition for (0);
+alter table mpp3261_part drop partition for (100);
+alter table mpp3261_part drop partition for (200);
+alter table mpp3261_part drop partition for (300);
+alter table mpp3261_part drop partition for (400);
+alter table mpp3261_part drop partition for (500);
+alter table mpp3261_part drop partition for (600);
+alter table mpp3261_part drop partition for (700);
+alter table mpp3261_part drop partition for (800);
+alter table mpp3261_part drop partition for (900);
 -- Shouldn't take a long time to insert
 insert into mpp3261_part select * from mpp3261;
 drop table mpp3261;
@@ -2803,16 +2800,16 @@ CREATE TABLE mpp3260 (
 drop table mpp3260_1_prt_aa_6;
 ERROR:  cannot drop partition "mpp3260_1_prt_aa_6" directly
 HINT:  Table "mpp3260_1_prt_aa_6" is a child partition of table "mpp3260".  To drop it, use ALTER TABLE "mpp3260" DROP PARTITION "aa_6"...
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
-alter table mpp3260 drop partition;
+alter table mpp3260 drop partition for (0);
+alter table mpp3260 drop partition for (100);
+alter table mpp3260 drop partition for (200);
+alter table mpp3260 drop partition for (300);
+alter table mpp3260 drop partition for (400);
+alter table mpp3260 drop partition for (500);
+alter table mpp3260 drop partition for (600);
+alter table mpp3260 drop partition for (700);
+alter table mpp3260 drop partition for (800);
+alter table mpp3260 drop partition for (900);
 drop table mpp3260_1_prt_default_part ;
 ERROR:  cannot drop partition "mpp3260_1_prt_default_part" directly
 HINT:  Table "mpp3260_1_prt_default_part" is a child partition of table "mpp3260".  To drop it, use ALTER TABLE "mpp3260" DROP PARTITION "default_part"...
@@ -2841,18 +2838,18 @@ subpartition by range (unique2) subpartition template ( start (0) end (1000) eve
 drop table mpp3260a_1_prt_10;
 ERROR:  cannot drop partition "mpp3260a_1_prt_10" directly
 HINT:  Table "mpp3260a_1_prt_10" is a child partition of table "mpp3260a".  To drop it, use ALTER TABLE "mpp3260a" DROP PARTITION FOR(RANK(10))...
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
-alter table mpp3260a drop partition;
+alter table mpp3260a drop partition for (0);
+alter table mpp3260a drop partition for (100);
+alter table mpp3260a drop partition for (200);
+alter table mpp3260a drop partition for (300);
+alter table mpp3260a drop partition for (400);
+alter table mpp3260a drop partition for (500);
+alter table mpp3260a drop partition for (600);
+alter table mpp3260a drop partition for (700);
+alter table mpp3260a drop partition for (800);
 -- Last subpartition, cannot be dropped
-alter table mpp3260a drop partition;
-ERROR:  cannot drop partition for rank 1 of relation "mpp3260a" -- only one remains
+alter table mpp3260a drop partition for (900);
+ERROR:  cannot drop partition for value (900) of relation "mpp3260a" -- only one remains
 HINT:  Use DROP TABLE "mpp3260a" to remove the table and the final partition
 drop table mpp3260a_1_prt_10;
 ERROR:  cannot drop partition "mpp3260a_1_prt_10" directly

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -270,7 +270,7 @@ alter table mpp3263 add column AAA int;
 alter table mpp3263 add column BBB int;
 alter table mpp3263 drop column BBB;
 
-alter table mpp3263 drop partition;
+alter table mpp3263 drop partition for (0);
 
 alter table mpp3263 add column CCC int;
 
@@ -1429,7 +1429,7 @@ alter table fff_main_1_prt_1 drop oids;
 alter table fff_main_1_prt_1 no inherit fff_main;
 alter table fff_main_1_prt_1 drop column rank;
 alter table fff_main_1_prt_1 add partition;
-alter table fff_main_1_prt_1 drop partition;
+alter table fff_main_1_prt_1 drop partition for (0);
 
 alter table fff_main_1_prt_1 add column c int;
 

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -910,12 +910,10 @@ for (rank(1)) ;
 -- ok , skipping
 alter table ataprank alter partition girls drop partition if exists jan01;
 
--- ok until run out of partitions
-alter table ataprank alter partition girls drop partition ;
-alter table ataprank alter partition girls drop partition ;
-alter table ataprank alter partition girls drop partition ;
-alter table ataprank alter partition girls drop partition ;
-alter table ataprank alter partition girls drop partition ;
+-- ok
+alter table ataprank alter partition girls drop partition for ('2002-01-01');
+alter table ataprank alter partition girls drop partition for ('2003-01-01');
+alter table ataprank alter partition girls drop partition for ('2004-01-01');
 
 -- ok, skipping
 alter table ataprank alter partition girls drop partition if exists for (rank(5));

--- a/src/test/regress/sql/partition1.sql
+++ b/src/test/regress/sql/partition1.sql
@@ -625,18 +625,19 @@ partition bb values ('2008-01-01'),
 partition cc values ('2009-01-01')
 );
 
--- must have name or value for list partition
+-- must have name or value for partition
 alter table hhh_l1 drop partition;
 alter table hhh_l1 drop partition aa;
 alter table hhh_l1 drop partition for ('2008-01-01');
 
--- if not specified, drop first range partition...
+-- same with range partitioning
+alter table hhh_r1 drop partition;
 alter table hhh_r1 drop partition for ('2007-04-01');
-alter table hhh_r1 drop partition;
-alter table hhh_r1 drop partition;
-alter table hhh_r1 drop partition;
-alter table hhh_r1 drop partition;
-alter table hhh_r1 drop partition;
+alter table hhh_r1 drop partition for(rank(1));
+alter table hhh_r1 drop partition aa_2;
+alter table hhh_r1 drop partition aa_3;
+alter table hhh_r1 drop partition aa_5;
+alter table hhh_r1 drop partition aa_6;
 
 -- more add partition tests
 


### PR DESCRIPTION
Previously, this was allowed:

    postgres=# ALTER TABLE parttab DROP PARTITION;
    ALTER TABLE

It dropped the first partition, by rank. In other words, it was a
shorthand for:
    
    ALTER TABLE parttab DROP PARTITION FOR (RANK (1));

We don't need such a shorthand. It's too much of a footgun; if a user
wants to drop partition, he should name it properly.
