### PR TITLE
5x: Fix add partition relops null pointer issue.

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -1425,10 +1425,17 @@ add_partition_rule(PartitionRule *rule)
 	values[Anum_pg_partition_rule_parlistvalues - 1] =
 			DirectFunctionCall1(textin,
 						CStringGetDatum(nodeToString(rule->parlistvalues)));
-	if (rule->parreloptions)
-		values[Anum_pg_partition_rule_parreloptions - 1] =
-				transformRelOptions((Datum) 0, rule->parreloptions, true, false);
-	else
+	/*
+	 * If rule->parreloptions is NIL, the function `transformRelOptions`
+	 * will return the first argument.
+	 */
+	values[Anum_pg_partition_rule_parreloptions - 1] =
+		transformRelOptions((Datum) 0, rule->parreloptions, true, false);
+	/*
+	 * There some cases that transformRelOptions in the above will return a NULL.
+	 * Add a check here.
+	 */
+	if (!values[Anum_pg_partition_rule_parreloptions - 1])
 		isnull[Anum_pg_partition_rule_parreloptions - 1] = true;
 
 	values[Anum_pg_partition_rule_partemplatespace -1] =

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -2542,6 +2542,44 @@ select * from s1 full outer join s2 on s1.d1 = s2.d2 and s1.p1 = s2.p2 where s1.
 drop table if exists s1;
 drop table if exists s2;
 -- end_ignore
+-- the following case is to test when we have a template
+-- we can correct add new subpartition with relation options.
+create table test_part_relops_tmpl (id int,  p1 text, p2 text, count int)
+distributed by (id)
+partition by list (p1)
+subpartition by list (p2)
+(
+  partition m1 values ('m1')
+  (subpartition l1 values ('l1'),
+   subpartition l2 values ('l2')),
+  partition m2 values ('m2')
+  (subpartition l1 values ('l1'),
+   subpartition l2 values ('l2'))
+);
+NOTICE:  CREATE TABLE will create partition "test_part_relops_tmpl_1_prt_m1" for table "test_part_relops_tmpl"
+NOTICE:  CREATE TABLE will create partition "test_part_relops_tmpl_1_prt_m1_2_prt_l1" for table "test_part_relops_tmpl_1_prt_m1"
+NOTICE:  CREATE TABLE will create partition "test_part_relops_tmpl_1_prt_m1_2_prt_l2" for table "test_part_relops_tmpl_1_prt_m1"
+NOTICE:  CREATE TABLE will create partition "test_part_relops_tmpl_1_prt_m2" for table "test_part_relops_tmpl"
+NOTICE:  CREATE TABLE will create partition "test_part_relops_tmpl_1_prt_m2_2_prt_l1" for table "test_part_relops_tmpl_1_prt_m2"
+NOTICE:  CREATE TABLE will create partition "test_part_relops_tmpl_1_prt_m2_2_prt_l2" for table "test_part_relops_tmpl_1_prt_m2"
+alter table test_part_relops_tmpl
+set subpartition template
+(
+   subpartition l1 values('l1')
+);
+NOTICE:  adding level 1 subpartition template specification for relation "test_part_relops_tmpl"
+NOTICE:  CREATE TABLE will create partition "test_part_relops_tmpl_1_prt_subpartition_template" for table "test_part_relops_tmpl"
+NOTICE:  CREATE TABLE will create partition "test_part_relops_tmpl_1_prt_subpartition_template_2_prt_l1" for table "test_part_relops_tmpl_1_prt_subpartition_template"
+-- previously, we do wrong in the function of `add_partition_rule`
+-- which invokes `transformRelOptions`, and transformRelOptions
+-- may return NULL in some cases. For example, the invokation of
+-- transformRelOptions in add_partition_rule set ignoreOids = true,
+-- so the following statement creates such senario by passing oids options,
+-- then transformRelOptions return NULL and we should correctly handle
+-- null pointers.
+alter table test_part_relops_tmpl alter partition for ('m1') add partition l3 values ('l3')
+with (oids=false);
+NOTICE:  CREATE TABLE will create partition "test_part_relops_tmpl_1_prt_m1_2_prt_l3" for table "test_part_relops_tmpl_1_prt_m1"
 create table mpp_2914A(id int,  buyDate date, kind char(1))
 DISTRIBUTED BY (id)
 partition by list (kind) 

--- a/src/test/regress/sql/partition1.sql
+++ b/src/test/regress/sql/partition1.sql
@@ -1510,6 +1510,36 @@ drop table if exists s1;
 drop table if exists s2;
 -- end_ignore
 
+-- the following case is to test when we have a template
+-- we can correct add new subpartition with relation options.
+create table test_part_relops_tmpl (id int,  p1 text, p2 text, count int)
+distributed by (id)
+partition by list (p1)
+subpartition by list (p2)
+(
+  partition m1 values ('m1')
+  (subpartition l1 values ('l1'),
+   subpartition l2 values ('l2')),
+  partition m2 values ('m2')
+  (subpartition l1 values ('l1'),
+   subpartition l2 values ('l2'))
+);
+
+alter table test_part_relops_tmpl
+set subpartition template
+(
+   subpartition l1 values('l1')
+);
+
+-- previously, we do wrong in the function of `add_partition_rule`
+-- which invokes `transformRelOptions`, and transformRelOptions
+-- may return NULL in some cases. For example, the invokation of
+-- transformRelOptions in add_partition_rule set ignoreOids = true,
+-- so the following statement creates such senario by passing oids options,
+-- then transformRelOptions return NULL and we should correctly handle
+-- null pointers.
+alter table test_part_relops_tmpl alter partition for ('m1') add partition l3 values ('l3')
+with (oids=false);
 
 create table mpp_2914A(id int,  buyDate date, kind char(1))
 DISTRIBUTED BY (id)


### PR DESCRIPTION
transformRelOptions may return a null pointer in some
cases, add the check in function `add_partition_rule`.

------------------------------

Cherry pick from master to 5X.

PR #9263 has been merged in master.

Will merge this PR when pipeline is OK.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
