### PR TITLE
Remove bogus change to "extension already exists" error message.

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -1640,7 +1640,7 @@ CreateExtension(CreateExtensionStmt *stmt)
 		else
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_OBJECT),
-					 errmsg("extension \"%s\" already exists. CreateExtension. ",
+					 errmsg("extension \"%s\" already exists",
 							stmt->extname)));
 	}
 

--- a/src/test/regress/expected/alter_extension.out
+++ b/src/test/regress/expected/alter_extension.out
@@ -1,6 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE AGGREGATE example_agg(int4) (
     SFUNC = int4larger,
     STYPE = int4
 );
 ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
 ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+-- Test creating an extension that already exists. Nothing too exciting about
+-- it, but let's keep up the test coverage.
+CREATE EXTENSION gp_inject_fault;
+ERROR:  extension "gp_inject_fault" already exists

--- a/src/test/regress/sql/alter_extension.sql
+++ b/src/test/regress/sql/alter_extension.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
 CREATE AGGREGATE example_agg(int4) (
     SFUNC = int4larger,
     STYPE = int4
@@ -5,3 +7,7 @@ CREATE AGGREGATE example_agg(int4) (
 
 ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
 ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+
+-- Test creating an extension that already exists. Nothing too exciting about
+-- it, but let's keep up the test coverage.
+CREATE EXTENSION gp_inject_fault;


### PR DESCRIPTION
The extra text was added as part of the 9.6 merge. It was a debugging aid
that was never supposed to reach the main repository. While we're at it,
add a test case for it.