### PR TITLE
6X: Fix flaky test segspace.

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1238,7 +1238,7 @@ EndPrepare(GlobalTransaction gxact)
 	 * running in the procarray (twice!) and continue to hold locks.
 	 */
 	Assert(gxact->prepare_lsn != 0);
-	SyncRepWaitForLSN(gxact->prepare_lsn);
+	SyncRepWaitForLSN(gxact->prepare_lsn, false);
 
 	records.tail = records.head = NULL;
 } /* end EndPrepare */
@@ -2097,7 +2097,7 @@ RecordTransactionCommitPrepared(TransactionId xid,
 	 * Note that at this stage we have marked clog, but still show as running
 	 * in the procarray and continue to hold locks.
 	 */
-	SyncRepWaitForLSN(recptr);
+	SyncRepWaitForLSN(recptr, true);
 }
 
 /*
@@ -2193,7 +2193,7 @@ RecordTransactionAbortPrepared(TransactionId xid,
 	 * in the procarray and continue to hold locks.
 	 */
 	Assert(recptr != 0);
-	SyncRepWaitForLSN(recptr);
+	SyncRepWaitForLSN(recptr, false);
 }
 
 /*

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1660,7 +1660,7 @@ RecordTransactionCommit(void)
 	if (markXidCommitted || isDtxPrepared)
 	{
 		Assert(recptr != 0);
-		SyncRepWaitForLSN(recptr);
+		SyncRepWaitForLSN(recptr, true);
 	}
 
 	/* Compute latestXid while we have the child XIDs handy */

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -12282,7 +12282,7 @@ wait_to_avoid_large_repl_lag(void)
 		wal_bytes_written > (rep_lag_avoidance_threshold * 1024))
 	{
 		/* we use local cached copy of LogwrtResult here */
-		SyncRepWaitForLSN(LogwrtResult.Flush);
+		SyncRepWaitForLSN(LogwrtResult.Flush, false);
 		wal_bytes_written = 0;
 	}
 }
@@ -12298,7 +12298,7 @@ wait_for_mirror()
     tmpLogwrtResult = xlogctl->LogwrtResult;
     SpinLockRelease(&xlogctl->info_lck);
 
-    SyncRepWaitForLSN(tmpLogwrtResult.Flush);
+	SyncRepWaitForLSN(tmpLogwrtResult.Flush, false);
 }
 
 /*

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -96,7 +96,7 @@ static bool SyncRepQueueIsOrderedByLSN(int mode);
  * This backend then resets its state to SYNC_REP_NOT_WAITING.
  */
 void
-SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
+SyncRepWaitForLSN(XLogRecPtr XactCommitLSN, bool commit)
 {
 	char	   *new_status = NULL;
 	const char *old_status;
@@ -303,7 +303,7 @@ SyncRepWaitForLSN(XLogRecPtr XactCommitLSN)
 		 * failover. Then the syncrep will be turned off by the FTS to unblock
 		 * backends waiting here.
 		 */
-		if (QueryCancelPending)
+		if (QueryCancelPending && commit)
 		{
 			QueryCancelPending = false;
 			ereport(WARNING,

--- a/src/include/replication/syncrep.h
+++ b/src/include/replication/syncrep.h
@@ -35,7 +35,7 @@
 extern char *SyncRepStandbyNames;
 
 /* called by user backend */
-extern void SyncRepWaitForLSN(XLogRecPtr XactCommitLSN);
+extern void SyncRepWaitForLSN(XLogRecPtr XactCommitLSN, bool commit);
 
 /* called at backend exit */
 extern void SyncRepCleanupAtProcExit(void);


### PR DESCRIPTION
We recently start to control wal write burst by calling SyncRepWaitForLSN()
more frequently, then the changes cause the segspace test flaky.

In the segspace test case, there is an inject fault (exec_hashjoin_new_batch)
with interrupt event, this makes the test easier to have the cancel event
seen in SyncRepWaitForLSN() and then cause additional outputs sometimes.

Fixing this by disabling the current cancel handling code if it is not a commit
call of SyncRepWaitForLSN().

Here is the diff of the test failure.

 begin;
 insert into segspace_t1_created
 SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE t1.i1=t2.i2;
+DETAIL:  The transaction has already changed locally, it has to be replicated to standby.
 ERROR:  canceling MPP operation
+WARNING:  ignoring query cancel request for synchronous replication to ensure cluster consistency
 rollback;

Cherry-picked from 84642c4be38bee83876a06ff

Besides, add the commit parameter in SyncRepWaitForLSN() following the master
code. Checked the related upstream patch. Adding the new parameter in current
gpdb version should be fine.