### PR TITLE
docs: add missing space between gpexpand and -i option

### DIFF
--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -129,8 +129,7 @@
                     id="image_rcs_t1m_2r"/>
                 </entry>
                 <entry>Initialize new segments into the array and create an expansion schema
-                    (<codeph>gpexpand</codeph><codeph>-i</codeph>
-                  <varname>input_file</varname>). </entry>
+                    (<codeph>gpexpand -i <varname>input_file</varname></codeph>).</entry>
               </row>
               <row>
                 <entry namest="c1" nameend="c2"><p><b>Online Expansion and Table


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
