### PR TITLE
combine_cli_coverage: use gpMgmt/requirements-dev.txt for coverage

### DIFF
--- a/concourse/scripts/combine_cli_coverage.bash
+++ b/concourse/scripts/combine_cli_coverage.bash
@@ -27,7 +27,8 @@ read -r COMMIT_SHA < gpdb_src/.git/HEAD
 source ./gpdb_src/concourse/scripts/common.bash
 time install_gpdb
 
-pip install gsutil coverage
+pip install -r ./gpdb_src/gpMgmt/requirements-dev.txt
+pip install gsutil
 
 # Save the JSON_KEY to a file, for later use by gsutil.
 keyfile=secret-key.json


### PR DESCRIPTION
The combine_cli_coverage job was using pip to pull the latest version of
"coverage", which is 5.x.  However, the actual tests that generate the
coverage files use the gpMgmt/requirements-dev.txt, which pins the
version at 4.5.

This mismatch caused combine_cli_coverage job to fail.  Now we pin
its "coverage" version to 4.5 as well.

An additional change here could be to bump `coverage` to the latest version(`5.x`) in `requirements-dev.txt`, but that is not necessary to resolve this issue.

Co-authored-by Mark Sliva <msliva@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
