### PR TITLE
(5x) Sanity check update/delete to prevent potential data corruption

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -510,6 +510,12 @@ typedef struct EState
 
 	/* If query can insert/delete tuples, the command ID to mark them with */
 	CommandId	es_output_cid;
+	/*
+	 * Set when initplan, Update, Delete, or DML plans
+	 * the field gpsegid_attno is the index in the tupleslot which save
+	 * the gp_segment_id sys column.
+	 */
+	AttrNumber      gpsegid_attno;
 
 	/* Info about target table for insert/update/delete queries: */
 	ResultRelInfo *es_result_relations; /* array of ResultRelInfos */


### PR DESCRIPTION
Data being stored with bad distribution is not unusal in real product
environment. There could be issues if the ctid for update/delete is distributed
to another segment. This patch will double check this and error out.

------------------------

Similar pr for 6:  https://github.com/greenplum-db/gpdb/pull/7304 (merged already)

--------------------------

I do not add test cases because it is not easy to delete | update a ctid from other segments now.

pr 7304 has added some cases, but those cases now do not throw error now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
