### PR TITLE
6X: icw: fix flaky alter_db_set_tablespace

### DIFF
--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -624,14 +624,18 @@ SELECT force_mirrors_to_catch_up();
 -- Note: We can't use a temporary table as PANICS wipe them out
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
+-- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+-- Force scan to trigger the fault.
+SELECT gp_request_fts_probe_scan();
+-- Verify the failure should be triggered once.
+SELECT gp_wait_until_triggered_fault('fts_probe', 1, 1);
+
 -- And we track the removal of the dboid dir by all mirrors including the standby master, except the mirror of the primary about to panic.
 SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m' AND content!=0;
 
 -- And introduce a panic on a primary directly before the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
 SELECT gp_inject_fault('start_prepare', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
-
--- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
-SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the panic is triggered
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
@@ -689,14 +693,18 @@ SELECT force_mirrors_to_catch_up();
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 
+-- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+-- Force scan to trigger the fault.
+SELECT gp_request_fts_probe_scan();
+-- Verify the failure should be triggered once.
+SELECT gp_wait_until_triggered_fault('fts_probe', 1, 1);
+
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
 SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
 
 -- And introduce a panic on a primary directly after the primary writes the XLOG_XACT_PREPARE record during the dispatch of the PREPARE TRANSACTION command.
 SELECT gp_inject_fault('after_xlog_xact_prepare_flushed', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
-
--- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
-SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the panic is triggered
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -1065,6 +1065,27 @@ SELECT force_mirrors_to_catch_up();
 -- Note: We can't use a temporary table as PANICS wipe them out
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+-- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- Force scan to trigger the fault.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+-- Verify the failure should be triggered once.
+SELECT gp_wait_until_triggered_fault('fts_probe', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
 -- And we track the removal of the dboid dir by all mirrors including the standby master, except the mirror of the primary about to panic.
 SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m' AND content!=0;
  gp_inject_fault 
@@ -1078,13 +1099,6 @@ SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM 
 SELECT gp_inject_fault('start_prepare', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_inject_fault 
 -----------------
- Success:
-(1 row)
-
--- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
-SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
- gp_inject_fault_infinite 
---------------------------
  Success:
 (1 row)
 
@@ -1192,6 +1206,27 @@ SELECT force_mirrors_to_catch_up();
 -- And we record the filesystem state for the database in the source tablespace
 CREATE TABLE before_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+-- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- Force scan to trigger the fault.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+-- Verify the failure should be triggered once.
+SELECT gp_wait_until_triggered_fault('fts_probe', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
 -- And we track the removal of the dboid dir by all mirrors including the standby master.
 SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM gp_segment_configuration c WHERE role='m';
  gp_inject_fault 
@@ -1206,13 +1241,6 @@ SELECT gp_inject_fault('after_drop_database_directories', 'sleep', c.dbid) FROM 
 SELECT gp_inject_fault('after_xlog_xact_prepare_flushed', 'panic', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_inject_fault 
 -----------------
- Success:
-(1 row)
-
--- Skip fts probe such that we prevent the promotion of the mirror of the primary that we induce the panic on.
-SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
- gp_inject_fault_infinite 
---------------------------
  Success:
 (1 row)
 


### PR DESCRIPTION
The alter_db_set_tablespace test has been flaky for a long time, one
typical failure is like this:

    --- /regress/expected/alter_db_set_tablespace.out
    +++ /regress/results/alter_db_set_tablespace.out
    @@ -1204,21 +1213,348 @@
     NOTICE:  dboid dir for database alter_db does not exist on dbid = 2
     NOTICE:  dboid dir for database alter_db does not exist on dbid = 3
     NOTICE:  dboid dir for database alter_db does not exist on dbid = 4
    -NOTICE:  dboid dir for database alter_db does not exist on dbid = 5
     NOTICE:  dboid dir for database alter_db does not exist on dbid = 6
     NOTICE:  dboid dir for database alter_db does not exist on dbid = 7
     NOTICE:  dboid dir for database alter_db does not exist on dbid = 8

The test disables fts probing with fault injection, however it does not
wait for the fault to be triggered.  The other problem is that the fts
probing was disabled after the PANIC, that might not be in time.

So the problem was that we were having a scenario where we were
injecting the fault after the fts loop was beyond the fault point and
then when the subsequent PANIC was caused, fts was still active.

By manually triggering, and then by waiting to ensure that the fault is
hit at least once, we can guarantee that the scenario described above
doesn't happen.

Reviewed-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
Reviewed-by: Taylor Vesely <tvesely@pivotal.io>
Reviewed-by: Hubert Zhang <hzhang@pivotal.io>
(cherry picked from commit 54e3af6d270523761da1532903f503198cfcdeeb)

This is the 6X version of https://github.com/greenplum-db/gpdb/pull/9301

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
