### PR TITLE
zstd: check for OOM when creating {C,D}Ctx

### DIFF
--- a/gpcontrib/zstd/zstd_compression.c
+++ b/gpcontrib/zstd/zstd_compression.c
@@ -70,6 +70,11 @@ zstd_constructor(PG_FUNCTION_ARGS)
 	state->ctx->cctx = ZSTD_createCCtx();
 	state->ctx->dctx = ZSTD_createDCtx();
 
+	if (!state->ctx->cctx)
+		elog(ERROR, "out of memory");
+	if (!state->ctx->dctx)
+		elog(ERROR, "out of memory");
+
 	PG_RETURN_POINTER(cs);
 }
 

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -988,6 +988,8 @@ BufFileStartCompression(BufFile *file)
 
 	file->zstd_context = zstd_alloc_context();
 	file->zstd_context->cctx = ZSTD_createCStream();
+	if (!file->zstd_context->cctx)
+		elog(ERROR, "out of memory");
 	ZSTD_initCStream(file->zstd_context->cctx, BUFFILE_ZSTD_COMPRESSION_LEVEL);
 
 	CurrentResourceOwner = oldowner;
@@ -1068,6 +1070,8 @@ BufFileEndCompression(BufFile *file)
 
 	/* Done writing. Initialize for reading */
 	file->zstd_context->dctx = ZSTD_createDStream();
+	if (!file->zstd_context->dctx)
+		elog(ERROR, "out of memory");
 	ZSTD_initDStream(file->zstd_context->dctx);
 
 	file->compressed_buffer.src = palloc(BLCKSZ);

--- a/src/include/storage/gp_compress.h
+++ b/src/include/storage/gp_compress.h
@@ -54,11 +54,14 @@ extern void gp_decompress(
  * To use:
  *
  * zstd_context *ctx = call zstd_alloc_context();
+ *
  * ctx->cctx = ZSTD_createCCtx();
+ * if (!ctx->cctx)
+ *     elog(ERROR, "out of memory");
  *
  * <use the context using normal ZSTD functions>
  *
- * zsd_free_context(ctx);
+ * zstd_free_context(ctx);
  *
  * If the transaction is aborted, the handle will be automatically closed,
  * when the resource owner is destroyed.


### PR DESCRIPTION
ZSTD creates CCtx and DCtx with malloc() by default, a NULL pointer will
be returned on OOM, the callers must check for NULL pointers.

Also fixed a typo in the comment.

Fixes: https://github.com/greenplum-db/gpdb/issues/9294

Reported-by: shellboy

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
