### PR TITLE
Report errors for exclusion constraints correctly

### DIFF
--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -46,7 +46,7 @@ static int errdetails_index_policy(char *attname,
 								   Oid policy_indclass,
 								   Oid policy_eqop,
 								   Oid found_indclass,
-								   Oid exclop,
+								   Oid *exclop,
 								   index_check_policy_compatible_context *context);
 
 /*
@@ -848,7 +848,7 @@ index_check_policy_compatible(GpPolicy *policy,
 												 policy_opclass,
 												 policy_eqop,
 												 found_col_indclass,
-												 exclop ? exclop[j] : InvalidOid,
+												 exclop,
 												 error_context)));
 			return false;
 		}
@@ -896,7 +896,7 @@ errdetails_index_policy(char *attname,
 						Oid policy_opclass,
 						Oid policy_eqop,
 						Oid found_indclass,
-						Oid exclop,
+						Oid *exclop,
 						index_check_policy_compatible_context *context)
 {
 	errcode(ERRCODE_INVALID_TABLE_DEFINITION);


### PR DESCRIPTION
When adding unsupported constraints a suitable error message will be
constructed depending on it is an exclusion constraint or not.  There
was a bug that an out-of-array exclusion constraint operator was checked
for that purpose, so the runtime behavior is undetermined.

Fixed by checking the existence of the exclusion constraint operator
array instead of the operator itself.

Fixes https://github.com/greenplum-db/gpdb/issues/9312

Added WIP as we still need to update the ICW answers, but the fix itself should be ready for review.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
