### PR TITLE
Revert create pathkey in `convert_subquery_pathkeys` and push down gather motion

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1030,27 +1030,6 @@ convert_subquery_pathkeys(PlannerInfo *root, RelOptInfo *rel,
 																 tle);
 
 					/* See if we have a matching EC for that */
-					/*
-					 * In GPDB, we pass create_it = 'true', because even if the
-					 * sub-pathkey doesn't seem interesting to the parent, we
-					 * want to preserve the ordering if the result is gathered
-					 * to a single node later on. This case comes up, if you
-					 * e.g. create a view with an ORDER BY:
-					 *
-					 * CREATE VIEW v AS SELECT * FROM sourcetable ORDER BY vn;
-					 *
-					 * and query it:
-					 *
-					 * SELECT row_number() OVER(), vn FROM v_sourcetable;
-					 *
-					 * Although it's not required by the SQL standard, we try
-					 * to preserve the PostgreSQL behaviour, and honor the
-					 * ORDER BY. The parent query doesn't have an equivalence
-					 * class for the path key (vn), but if we don't pass it
-					 * up to the parent, it will not preserve the order when
-					 * it adds the Gather Motion to pull together the rows,
-					 * underneath the WindowAgg.
-					 */
 					outer_ec = get_eclass_for_sort_expr(root,
 														outer_expr,
 														NULL,
@@ -1059,7 +1038,7 @@ convert_subquery_pathkeys(PlannerInfo *root, RelOptInfo *rel,
 														sub_expr_coll,
 														0,
 														rel->relids,
-														true); /* create_it */
+														false); /* create_it */
 
 					/*
 					 * If we don't find a matching EC, this sub-pathkey isn't

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2729,6 +2729,7 @@ create_subqueryscan_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 	pathnode->path.rescannable = false;
 	pathnode->path.sameslice_relids = NULL;
 
+	pathnode->required_outer = bms_copy(required_outer);
 	cost_subqueryscan(pathnode, root, rel, pathnode->path.param_info);
 
 	return pathnode;

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -1358,6 +1358,9 @@ typedef struct SubqueryScanPath
 {
 	Path		path;
 	Path	   *subpath;		/* path representing subquery execution */
+
+	/* In gpdb, we need to rebuild a SubqueryScanPath if MotionPath push down*/
+	Relids      required_outer;
 } SubqueryScanPath;
 
 /*

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1845,3 +1845,18 @@ order by 1,2;
  Execution time: 2.496 ms
 (23 rows)
 
+CREATE TABLE t1(c1 int, c2 int, c3 int);
+CREATE TABLE t2(c1 int, c2 int, c3 int);
+INSERT INTO t1 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+INSERT INTO t2 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+SET enable_hashagg = off;
+with tcte(c1, c2, c3) as (
+	SELECT c1, sum(c2) as c2, c3 FROM t1 WHERE c3 > 0 GROUP BY c1, c3
+	UNION ALL
+	SELECT c1, sum(c2) as c2, c3 FROM t2 WHERE c3 < 0 GROUP BY c1, c3
+)
+SELECT * FROM tcte WHERE c3 = 1;
+ c1 | c2 | c3 
+----+----+----
+(0 rows)
+

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1868,3 +1868,18 @@ order by 1,2;
  Execution time: 5.553 ms
 (25 rows)
 
+CREATE TABLE t1(c1 int, c2 int, c3 int);
+CREATE TABLE t2(c1 int, c2 int, c3 int);
+INSERT INTO t1 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+INSERT INTO t2 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+SET enable_hashagg = off;
+with tcte(c1, c2, c3) as (
+	SELECT c1, sum(c2) as c2, c3 FROM t1 WHERE c3 > 0 GROUP BY c1, c3
+	UNION ALL
+	SELECT c1, sum(c2) as c2, c3 FROM t2 WHERE c3 < 0 GROUP BY c1, c3
+)
+SELECT * FROM tcte WHERE c3 = 1;
+ c1 | c2 | c3 
+----+----+----
+(0 rows)
+

--- a/src/test/regress/expected/window.out
+++ b/src/test/regress/expected/window.out
@@ -1080,8 +1080,9 @@ SELECT * FROM
 WHERE depname = 'sales';
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Subquery Scan on emp
+ Subquery Scan on emp
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         Merge Key: empsalary.empno, empsalary.enroll_date
          ->  WindowAgg
                Order By: empsalary.empno
                ->  WindowAgg
@@ -1092,7 +1093,7 @@ WHERE depname = 'sales';
                            ->  Seq Scan on empsalary
                                  Filter: ((depname)::text = 'sales'::text)
  Optimizer: Postgres query optimizer
-(12 rows)
+(13 rows)
 
 -- Test Sort node reordering
 EXPLAIN (COSTS OFF)
@@ -1126,8 +1127,9 @@ SELECT * FROM
 WHERE depname = 'sales';
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Subquery Scan on emp
+ Subquery Scan on emp
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         Merge Key: (((empsalary.depname)::text || 'A'::text))
          ->  WindowAgg
                ->  WindowAgg
                      Partition By: (((empsalary.depname)::text || 'A'::text))
@@ -1136,7 +1138,7 @@ WHERE depname = 'sales';
                            ->  Seq Scan on empsalary
                                  Filter: ((depname)::text = 'sales'::text)
  Optimizer: Postgres query optimizer
-(10 rows)
+(11 rows)
 
 -- pushdown is unsafe because there's a PARTITION BY clause without depname:
 EXPLAIN (COSTS OFF)
@@ -1148,9 +1150,10 @@ SELECT * FROM
 WHERE depname = 'sales';
                                QUERY PLAN                               
 ------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Subquery Scan on emp
-         Filter: ((emp.depname)::text = 'sales'::text)
+ Subquery Scan on emp
+   Filter: ((emp.depname)::text = 'sales'::text)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: empsalary.enroll_date
          ->  WindowAgg
                Partition By: empsalary.enroll_date
                ->  Sort
@@ -1163,7 +1166,7 @@ WHERE depname = 'sales';
                                        Sort Key: empsalary.depname
                                        ->  Seq Scan on empsalary
  Optimizer: Postgres query optimizer
-(15 rows)
+(16 rows)
 
 -- pushdown is unsafe because the subquery contains window functions and the qual is volatile:
 EXPLAIN (COSTS OFF)
@@ -1175,9 +1178,10 @@ SELECT * FROM
 WHERE depname = 'sales' OR RANDOM() > 0.5;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Subquery Scan on emp
-         Filter: (((emp.depname)::text = 'sales'::text) OR (random() > '0.5'::double precision))
+ Subquery Scan on emp
+   Filter: (((emp.depname)::text = 'sales'::text) OR (random() > '0.5'::double precision))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: empsalary.depname
          ->  WindowAgg
                Partition By: empsalary.depname
                ->  Sort
@@ -1188,7 +1192,7 @@ WHERE depname = 'sales' OR RANDOM() > 0.5;
                                  Sort Key: (((empsalary.depname)::text || 'A'::text)), empsalary.depname
                                  ->  Seq Scan on empsalary
  Optimizer: Postgres query optimizer
-(13 rows)
+(14 rows)
 
 -- cleanup
 DROP TABLE empsalary;

--- a/src/test/regress/sql/qp_union_intersect.sql
+++ b/src/test/regress/sql/qp_union_intersect.sql
@@ -691,3 +691,16 @@ explain analyze select a, b, array_dims(array_agg(x)) from mergeappend_test r gr
 union all
 select null, null, array_dims(array_agg(x)) FROM mergeappend_test r
 order by 1,2;
+
+CREATE TABLE t1(c1 int, c2 int, c3 int);
+CREATE TABLE t2(c1 int, c2 int, c3 int);
+INSERT INTO t1 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+INSERT INTO t2 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+SET enable_hashagg = off;
+with tcte(c1, c2, c3) as (
+	SELECT c1, sum(c2) as c2, c3 FROM t1 WHERE c3 > 0 GROUP BY c1, c3
+	UNION ALL
+	SELECT c1, sum(c2) as c2, c3 FROM t2 WHERE c3 < 0 GROUP BY c1, c3
+)
+SELECT * FROM tcte WHERE c3 = 1;
+


### PR DESCRIPTION
In upstream, it does not create a new `pathkey` in `convert_subquery_pathkeys ` function. It also raises an issue in gpdb, so revert it.

After that, we need to handle a common case that a gather motion should keep data order however `subqueryscan` can not provide.

e.g. create a view with an ORDER BY:
 ``` CREATE VIEW v AS SELECT va, vn FROM sourcetable ORDER BY vn;```
 and query it:
```SELECT va FROM v_sourcetable;```

In the planer, a subqueryscan is created at the top of the view. In upstream, it is fine, even it does not have pathkey, the data is physically sorted well. But for us, we have a Gather Motion upon subqueryscan. The data is sorted on each segment, later Gather Motion has no indication how to merge tuple.

To deal with this problem, just push down the `gather motion` under a `subqueryscan`, if a `subqueryscan` does not have `pathkey` but its subpath has.

fix issue: #8987

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
