### PR TITLE
Change default value of wal_sender_timeout GUC

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2409,7 +2409,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_UNIT_MS | GUC_SUPERUSER_ONLY
 		},
 		&wal_sender_timeout,
-		60 * 1000, 0, INT_MAX,
+		300 * 1000, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
Based on reports from field for GPDB, 1 min of wal_sender_timeout GUC
is causing primary to terminate the replication connection too often
in heavy workload situations. This causes mirror to be marked down and
piles up WAL on primary. This is moslty seen in configurations where
fsync takes long time on mirrors. Hence, would be helpful to have
higher default value of this GUC to avoid unnecessary marking mirror
down situations. Only downside of this change would be when connection
between primary and mirror exist but for some reason mirror doesn't
respond, it will be detected little later compared to previous 1 min
timeout. But 1 min timeout is causing major downside and mirrors need
to be manually recovered after being marked down. Hence, its desirable
to not falsely break the connectiion due to timeout.

Increasing the timeout to 5 mins is just a educated guess as its hard
to come up with reasonable default, but bumping the value is desired
based on inputs.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
