### PR TITLE
(5x)Sanity check update/delete to prevent potential data corruption

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3015,7 +3015,7 @@ lnext:	;
 				tupleid = &tuple_ctid;
 
 				segno = ExecFindJunkAttribute(junkfilter, "gp_segment_id");
-				if (AttributeNumberIsValid(segno))
+				if (AttributeNumberIsValid(segno) && Gp_role != GP_ROLE_UTILITY)
 				{
 					  int32 segid;
 					  datum = ExecGetJunkAttribute(slot, segno, &isNull);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2996,11 +2996,13 @@ lnext:	;
 
 			/*
 			 * extract the 'ctid' junk attribute.
+			 * extract the 'gp_segment_id' and do tuple locality check.
 			 */
 			if (operation == CMD_UPDATE || operation == CMD_DELETE)
 			{
 				Datum		datum;
 				bool		isNull;
+				AttrNumber      segno;
 
 				datum = ExecGetJunkAttribute(slot, junkfilter->jf_junkAttNo,
 											 &isNull);
@@ -3011,6 +3013,26 @@ lnext:	;
 				tupleid = (ItemPointer) DatumGetPointer(datum);
 				tuple_ctid = *tupleid;	/* make sure we don't free the ctid!! */
 				tupleid = &tuple_ctid;
+
+				segno = ExecFindJunkAttribute(junkfilter, "gp_segment_id");
+				if (AttributeNumberIsValid(segno))
+				{
+					  int32 segid;
+					  datum = ExecGetJunkAttribute(slot, segno, &isNull);
+					  /* shouldn't ever get a null result... */
+					  if (isNull)
+					    elog(ERROR, "gp_segment_id is NULL");
+					  /*
+					   * Sanity check the distribution of the tuple to prevent
+					   * potential data corruption in case users manipulate data
+					   * incorrectly (e.g. insert data on incorrect segment through
+					   * utility mode) or there is bug in code, etc.
+					   */
+					  segid = DatumGetInt32(datum);
+					  if (segid >= MASTER_CONTENT_ID && segid != GpIdentity.segindex)
+					    elog(ERROR, "distribution key of the tuple doesn't belong to "
+						 "current segment (actually from seg%d)", segid);
+				}
 			}
 
 			/*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3029,7 +3029,7 @@ lnext:	;
 					   * utility mode) or there is bug in code, etc.
 					   */
 					  segid = DatumGetInt32(datum);
-					  if (segid >= MASTER_CONTENT_ID && segid != GpIdentity.segindex)
+					  if (segid != GpIdentity.segindex)
 					    elog(ERROR, "distribution key of the tuple doesn't belong to "
 						 "current segment (actually from seg%d)", segid);
 				}

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -17,6 +17,7 @@
 #include "miscadmin.h"
 
 #include "cdb/cdbpartition.h"
+#include "cdb/cdbvars.h"
 #include "commands/tablecmds.h"
 #include "executor/execDML.h"
 #include "executor/instrument.h"
@@ -119,6 +120,22 @@ ExecDML(DMLState *node)
 		ItemPointerData tuple_ctid = *tupleid;
 		tupleid = &tuple_ctid;
 
+		/*
+		 * Sanity check the distribution of the tuple to prevent potential
+		 * data corruption in case users manipulate data incorrectly (e.g.
+		 * insert data on incorrect segments through utility mode) or there is
+		 * bug in code, etc.
+		 */
+		if (AttributeNumberIsValid(node->segid_attno))
+		{
+			int32 segid = DatumGetInt32(slot_getattr(slot, node->segid_attno, &isnull));
+			Assert(!isnull);
+
+			if (segid != GpIdentity.segindex)
+				elog(ERROR, "distribution key of the tuple doesn't belong to "
+					 "current segment (actually from seg%d)", segid);
+		}
+
 		/* Correct tuple count by ignoring deletes when splitting tuples. */
 		ExecDelete(tupleid, node->cleanedUpSlot, NULL /* DestReceiver */, node->ps.state,
 				PLANGEN_OPTIMIZER /* Plan origin */, isUpdate);
@@ -149,6 +166,24 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 
 	Plan *outerPlan  = outerPlan(node);
 	outerPlanState(dmlstate) = ExecInitNode(outerPlan, estate, eflags);
+
+	/*
+	 * ORCA Plan does not seem to set junk attribute for "gp_segment_id", else we
+	 * could call the simple code below.
+	 * resultRelInfo->ri_segid_attno = ExecFindJunkAttributeInTlist(outerPlanState(dmlstate)->plan->targetlist, "gp_segment_id");
+	 */
+	ListCell   *t;
+	dmlstate->segid_attno = InvalidAttrNumber;
+	foreach(t, outerPlanState(dmlstate)->plan->targetlist)
+	{
+		TargetEntry *tle = lfirst(t);
+
+		if (tle->resname && (strcmp(tle->resname, "gp_segment_id") == 0))
+		{
+			dmlstate->segid_attno = tle->resno;
+			break;
+		}
+	}
 
 	ExecAssignResultTypeFromTL(&dmlstate->ps);
 

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -126,7 +126,7 @@ ExecDML(DMLState *node)
 		 * insert data on incorrect segments through utility mode) or there is
 		 * bug in code, etc.
 		 */
-		if (AttributeNumberIsValid(node->segid_attno))
+		if (AttributeNumberIsValid(node->segid_attno) && Gp_role != GP_ROLE_UTILITY)
 		{
 			int32 segid = DatumGetInt32(slot_getattr(slot, node->segid_attno, &isnull));
 			Assert(!isnull);

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2578,6 +2578,7 @@ typedef struct DMLState
 	PlanState	ps;
 	JunkFilter *junkfilter;			/* filter that removes junk and dropped attributes */
 	TupleTableSlot *cleanedUpSlot;	/* holds 'final' tuple which matches the target relation schema */
+        AttrNumber	segid_attno;		/* attribute number of "gp_segment_id" */
 } DMLState;
 
 /*

--- a/src/test/isolation2/expected/modify_table_data_corrupt.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt.out
@@ -52,7 +52,11 @@ dbid|content
 2   |0      
 3   |1      
 4   |2      
-(4 rows)
+5   |0      
+6   |1      
+7   |2      
+8   |-1     
+(8 rows)
 -- 5x's islation2 framework use dbid to specify utility target
 -- 3 should be the seg1 for demo cluster with mirrors
 3U: insert into tab1 values (1, 1);

--- a/src/test/isolation2/expected/modify_table_data_corrupt.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt.out
@@ -1,0 +1,134 @@
+-- start_matchsubs
+-- m/nodeModifyTable.c:\d+/
+-- s/nodeModifyTable.c:\d+/nodeModifyTable.c:XXX/
+-- end_matchsubs
+
+-- start_ignore
+drop table tab1;
+ERROR:  table "tab1" does not exist
+drop table tab2;
+ERROR:  table "tab2" does not exist
+drop table tab3;
+ERROR:  table "tab3" does not exist
+-- end_ignore
+
+-- We do some check to verify the tuple to delete|update
+-- is from the segment it scans out. This case is to test
+-- such check.
+-- We build a plan that will add motion above result relation,
+-- however, does not contain explicit motion to send tuples back,
+-- and then login in segment using utility mode to insert some
+-- bad data.
+
+create table tab1(a int, b int) distributed by (b);
+CREATE
+create table tab2(a int, b int) distributed by (a);
+CREATE
+create table tab3 (a int, b int) distributed by (b);
+CREATE
+
+insert into tab1 values (1, 1);
+INSERT 1
+insert into tab2 values (1, 1);
+INSERT 1
+insert into tab3 values (1, 1);
+INSERT 1
+
+set allow_system_table_mods='dml';
+SET
+update pg_class set relpages = 10000 where relname='tab2';
+UPDATE 1
+update pg_class set reltuples = 100000000 where relname='tab2';
+UPDATE 1
+update pg_class set relpages = 100000000 where relname='tab3';
+UPDATE 1
+update pg_class set reltuples = 100000 where relname='tab3';
+UPDATE 1
+
+select dbid, content from gp_segment_configuration;
+dbid|content
+----+-------
+1   |-1     
+2   |0      
+3   |1      
+4   |2      
+5   |0      
+6   |1      
+7   |2      
+8   |-1     
+(8 rows)
+-- 5x's islation2 framework use dbid to specify utility target
+-- 3 should be the seg1 for demo cluster with mirrors
+3U: insert into tab1 values (1, 1);
+INSERT 1
+
+select gp_segment_id, * from tab1;
+gp_segment_id|a|b
+-------------+-+-
+0            |1|1
+1            |1|1
+(2 rows)
+
+-- planner does not error out because it will add explicit motion
+-- For orca, this will error out
+explain delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+QUERY PLAN                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------
+Delete (slice0; segments: 3)  (rows=9 width=10)                                                                            
+  ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1260003.37..101261253.84 rows=9 width=10)             
+        ->  Hash Join  (cost=1260003.37..101261253.84 rows=9 width=10)                                                     
+              Hash Cond: tab3.a = tab1.b                                                                                   
+              ->  Seq Scan on tab3  (cost=0.00..100001000.00 rows=33334 width=4)                                           
+              ->  Hash  (cost=1260002.37..1260002.37 rows=27 width=14)                                                     
+                    ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.04..1260002.37 rows=27 width=14)              
+                          ->  Hash Join  (cost=1.04..1260001.31 rows=9 width=14)                                           
+                                Hash Cond: tab2.a = tab1.a                                                                 
+                                ->  Seq Scan on tab2  (cost=0.00..1010000.00 rows=33333334 width=4)                        
+                                ->  Hash  (cost=1.03..1.03 rows=1 width=18)                                                
+                                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=18)
+                                            Hash Key: tab1.a                                                               
+                                            ->  Seq Scan on tab1  (cost=0.00..1.01 rows=1 width=18)                        
+Settings:  optimizer=off                                                                                                   
+Optimizer status: legacy query optimizer                                                                                   
+(16 rows)
+begin;
+BEGIN
+delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+DELETE 2
+abort;
+ABORT
+
+-- For orca, this will error out
+explain delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+QUERY PLAN                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------
+Delete (slice0; segments: 3)  (rows=9 width=10)                                                                            
+  ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1260003.37..101261253.84 rows=9 width=10)             
+        ->  Hash Join  (cost=1260003.37..101261253.84 rows=9 width=10)                                                     
+              Hash Cond: tab3.a = tab1.b                                                                                   
+              ->  Seq Scan on tab3  (cost=0.00..100001000.00 rows=33334 width=4)                                           
+              ->  Hash  (cost=1260002.37..1260002.37 rows=27 width=14)                                                     
+                    ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.04..1260002.37 rows=27 width=14)              
+                          ->  Hash Join  (cost=1.04..1260001.31 rows=9 width=14)                                           
+                                Hash Cond: tab2.a = tab1.a                                                                 
+                                ->  Seq Scan on tab2  (cost=0.00..1010000.00 rows=33333334 width=4)                        
+                                ->  Hash  (cost=1.03..1.03 rows=1 width=18)                                                
+                                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=18)
+                                            Hash Key: tab1.a                                                               
+                                            ->  Seq Scan on tab1  (cost=0.00..1.01 rows=1 width=18)                        
+Settings:  optimizer=off                                                                                                   
+Optimizer status: legacy query optimizer                                                                                   
+(16 rows)
+begin;
+BEGIN
+update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+UPDATE 2
+abort;
+ABORT
+
+drop table tab1;
+DROP
+drop table tab2;
+DROP
+drop table tab3;
+DROP

--- a/src/test/isolation2/expected/modify_table_data_corrupt.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt.out
@@ -52,11 +52,7 @@ dbid|content
 2   |0      
 3   |1      
 4   |2      
-5   |0      
-6   |1      
-7   |2      
-8   |-1     
-(8 rows)
+(4 rows)
 -- 5x's islation2 framework use dbid to specify utility target
 -- 3 should be the seg1 for demo cluster with mirrors
 3U: insert into tab1 values (1, 1);
@@ -99,12 +95,12 @@ abort;
 ABORT
 
 -- For orca, this will error out
-explain delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+explain update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
 QUERY PLAN                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------
-Delete (slice0; segments: 3)  (rows=9 width=10)                                                                            
-  ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1260003.37..101261253.84 rows=9 width=10)             
-        ->  Hash Join  (cost=1260003.37..101261253.84 rows=9 width=10)                                                     
+Update (slice0; segments: 3)  (rows=9 width=14)                                                                            
+  ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1260003.37..101261253.84 rows=9 width=14)             
+        ->  Hash Join  (cost=1260003.37..101261253.84 rows=9 width=14)                                                     
               Hash Cond: tab3.a = tab1.b                                                                                   
               ->  Seq Scan on tab3  (cost=0.00..100001000.00 rows=33334 width=4)                                           
               ->  Hash  (cost=1260002.37..1260002.37 rows=27 width=14)                                                     
@@ -126,9 +122,17 @@ UPDATE 2
 abort;
 ABORT
 
-drop table tab1;
-DROP
-drop table tab2;
-DROP
-drop table tab3;
-DROP
+-- Test splitupdate, 5x planner does not support splitupdate
+-- if orca enabled, the following split update will error out
+explain update tab1 set b = 999;
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+begin;
+BEGIN
+update tab1 set b = 999;
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+abort;
+ABORT
+
+-- drop table tab1;
+-- drop table tab2;
+-- drop table tab3;

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -1,0 +1,136 @@
+-- start_matchsubs
+-- m/nodeModifyTable.c:\d+/
+-- s/nodeModifyTable.c:\d+/nodeModifyTable.c:XXX/
+-- end_matchsubs
+
+-- start_ignore
+drop table tab1;
+ERROR:  table "tab1" does not exist
+drop table tab2;
+ERROR:  table "tab2" does not exist
+drop table tab3;
+ERROR:  table "tab3" does not exist
+-- end_ignore
+
+-- We do some check to verify the tuple to delete|update
+-- is from the segment it scans out. This case is to test
+-- such check.
+-- We build a plan that will add motion above result relation,
+-- however, does not contain explicit motion to send tuples back,
+-- and then login in segment using utility mode to insert some
+-- bad data.
+
+create table tab1(a int, b int) distributed by (b);
+CREATE
+create table tab2(a int, b int) distributed by (a);
+CREATE
+create table tab3 (a int, b int) distributed by (b);
+CREATE
+
+insert into tab1 values (1, 1);
+INSERT 1
+insert into tab2 values (1, 1);
+INSERT 1
+insert into tab3 values (1, 1);
+INSERT 1
+
+set allow_system_table_mods='dml';
+SET
+update pg_class set relpages = 10000 where relname='tab2';
+UPDATE 1
+update pg_class set reltuples = 100000000 where relname='tab2';
+UPDATE 1
+update pg_class set relpages = 100000000 where relname='tab3';
+UPDATE 1
+update pg_class set reltuples = 100000 where relname='tab3';
+UPDATE 1
+
+select dbid, content from gp_segment_configuration;
+dbid|content
+----+-------
+1   |-1     
+2   |0      
+3   |1      
+4   |2      
+5   |0      
+6   |1      
+7   |2      
+8   |-1     
+(8 rows)
+-- 5x's islation2 framework use dbid to specify utility target
+-- 3 should be the seg1 for demo cluster with mirrors
+3U: insert into tab1 values (1, 1);
+INSERT 1
+
+select gp_segment_id, * from tab1;
+gp_segment_id|a|b
+-------------+-+-
+0            |1|1
+1            |1|1
+(2 rows)
+
+-- planner does not error out because it will add explicit motion
+-- For orca, this will error out
+explain delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+QUERY PLAN                                                                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------
+Delete  (cost=0.00..8119.05 rows=1 width=1)                                                                                        
+  ->  Result  (cost=0.00..8119.02 rows=1 width=22)                                                                                 
+        ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..8119.02 rows=1 width=18)                                   
+              Hash Key: public.tab1.b                                                                                              
+              ->  Hash Join  (cost=0.00..8119.02 rows=1 width=18)                                                                  
+                    Hash Cond: tab3.a = public.tab1.b                                                                              
+                    ->  Table Scan on tab3  (cost=0.00..431.70 rows=33334 width=4)                                                 
+                    ->  Hash  (cost=7681.20..7681.20 rows=1 width=18)                                                              
+                          ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..7681.20 rows=1 width=18)                    
+                                ->  Hash Join  (cost=0.00..7681.20 rows=1 width=18)                                                
+                                      Hash Cond: tab2.a = public.tab1.a                                                            
+                                      ->  Table Scan on tab2  (cost=0.00..1127.67 rows=33333334 width=4)                           
+                                      ->  Hash  (cost=431.00..431.00 rows=1 width=18)                                              
+                                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=18)
+                                                  Hash Key: public.tab1.a                                                          
+                                                  ->  Table Scan on tab1  (cost=0.00..431.00 rows=1 width=18)                      
+Optimizer status: PQO version 3.86.0                                                                                               
+(17 rows)
+begin;
+BEGIN
+delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=54040) (cdbdisp.c:254)
+abort;
+ABORT
+
+-- For orca, this will error out
+explain delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+QUERY PLAN                                                                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------
+Delete  (cost=0.00..8119.05 rows=1 width=1)                                                                                        
+  ->  Result  (cost=0.00..8119.02 rows=1 width=22)                                                                                 
+        ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..8119.02 rows=1 width=18)                                   
+              Hash Key: public.tab1.b                                                                                              
+              ->  Hash Join  (cost=0.00..8119.02 rows=1 width=18)                                                                  
+                    Hash Cond: tab3.a = public.tab1.b                                                                              
+                    ->  Table Scan on tab3  (cost=0.00..431.70 rows=33334 width=4)                                                 
+                    ->  Hash  (cost=7681.20..7681.20 rows=1 width=18)                                                              
+                          ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..7681.20 rows=1 width=18)                    
+                                ->  Hash Join  (cost=0.00..7681.20 rows=1 width=18)                                                
+                                      Hash Cond: tab2.a = public.tab1.a                                                            
+                                      ->  Table Scan on tab2  (cost=0.00..1127.67 rows=33333334 width=4)                           
+                                      ->  Hash  (cost=431.00..431.00 rows=1 width=18)                                              
+                                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=18)
+                                                  Hash Key: public.tab1.a                                                          
+                                                  ->  Table Scan on tab1  (cost=0.00..431.00 rows=1 width=18)                      
+Optimizer status: PQO version 3.86.0                                                                                               
+(17 rows)
+begin;
+BEGIN
+update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=54040) (cdbdisp.c:254)
+abort;
+ABORT
+
+drop table tab1;
+DROP
+drop table tab2;
+DROP
+drop table tab3;
+DROP

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -52,11 +52,7 @@ dbid|content
 2   |0      
 3   |1      
 4   |2      
-5   |0      
-6   |1      
-7   |2      
-8   |-1     
-(8 rows)
+(4 rows)
 -- 5x's islation2 framework use dbid to specify utility target
 -- 3 should be the seg1 for demo cluster with mirrors
 3U: insert into tab1 values (1, 1);
@@ -95,42 +91,62 @@ Optimizer status: PQO version 3.86.0
 begin;
 BEGIN
 delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=54040) (cdbdisp.c:254)
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=100384) (cdbdisp.c:254)
 abort;
 ABORT
 
 -- For orca, this will error out
-explain delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-QUERY PLAN                                                                                                                         
------------------------------------------------------------------------------------------------------------------------------------
-Delete  (cost=0.00..8119.05 rows=1 width=1)                                                                                        
-  ->  Result  (cost=0.00..8119.02 rows=1 width=22)                                                                                 
-        ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..8119.02 rows=1 width=18)                                   
-              Hash Key: public.tab1.b                                                                                              
-              ->  Hash Join  (cost=0.00..8119.02 rows=1 width=18)                                                                  
-                    Hash Cond: tab3.a = public.tab1.b                                                                              
-                    ->  Table Scan on tab3  (cost=0.00..431.70 rows=33334 width=4)                                                 
-                    ->  Hash  (cost=7681.20..7681.20 rows=1 width=18)                                                              
-                          ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..7681.20 rows=1 width=18)                    
-                                ->  Hash Join  (cost=0.00..7681.20 rows=1 width=18)                                                
-                                      Hash Cond: tab2.a = public.tab1.a                                                            
-                                      ->  Table Scan on tab2  (cost=0.00..1127.67 rows=33333334 width=4)                           
-                                      ->  Hash  (cost=431.00..431.00 rows=1 width=18)                                              
-                                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=18)
-                                                  Hash Key: public.tab1.a                                                          
-                                                  ->  Table Scan on tab1  (cost=0.00..431.00 rows=1 width=18)                      
-Optimizer status: PQO version 3.86.0                                                                                               
-(17 rows)
+explain update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+QUERY PLAN                                                                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------
+Update  (cost=0.00..8119.09 rows=1 width=1)                                                                                                    
+  ->  Result  (cost=0.00..8119.02 rows=1 width=26)                                                                                             
+        ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..8119.02 rows=1 width=22)                                               
+              Hash Key: public.tab1.b                                                                                                          
+              ->  Split  (cost=0.00..8119.02 rows=1 width=22)                                                                                  
+                    ->  Result  (cost=0.00..8119.02 rows=1 width=22)                                                                           
+                          ->  Hash Join  (cost=0.00..8119.02 rows=1 width=18)                                                                  
+                                Hash Cond: tab3.a = public.tab1.b                                                                              
+                                ->  Table Scan on tab3  (cost=0.00..431.70 rows=33334 width=4)                                                 
+                                ->  Hash  (cost=7681.20..7681.20 rows=1 width=18)                                                              
+                                      ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..7681.20 rows=1 width=18)                    
+                                            ->  Hash Join  (cost=0.00..7681.20 rows=1 width=18)                                                
+                                                  Hash Cond: tab2.a = public.tab1.a                                                            
+                                                  ->  Table Scan on tab2  (cost=0.00..1127.67 rows=33333334 width=4)                           
+                                                  ->  Hash  (cost=431.00..431.00 rows=1 width=18)                                              
+                                                        ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=18)
+                                                              Hash Key: public.tab1.a                                                          
+                                                              ->  Table Scan on tab1  (cost=0.00..431.00 rows=1 width=18)                      
+Optimizer status: PQO version 3.86.0                                                                                                           
+(19 rows)
 begin;
 BEGIN
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=54040) (cdbdisp.c:254)
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=100384) (cdbdisp.c:254)
 abort;
 ABORT
 
-drop table tab1;
-DROP
-drop table tab2;
-DROP
-drop table tab3;
-DROP
+-- Test splitupdate, 5x planner does not support splitupdate
+-- if orca enabled, the following split update will error out
+explain update tab1 set b = 999;
+QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------
+Update  (cost=0.00..431.07 rows=1 width=1)                                                     
+  ->  Result  (cost=0.00..431.00 rows=1 width=26)                                              
+        ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=22)
+              Hash Key: public.tab1.b                                                          
+              ->  Split  (cost=0.00..431.00 rows=1 width=22)                                   
+                    ->  Result  (cost=0.00..431.00 rows=1 width=22)                            
+                          ->  Table Scan on tab1  (cost=0.00..431.00 rows=1 width=18)          
+Optimizer status: PQO version 3.86.0                                                           
+(8 rows)
+begin;
+BEGIN
+update tab1 set b = 999;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=100384) (cdbdisp.c:254)
+abort;
+ABORT
+
+-- drop table tab1;
+-- drop table tab2;
+-- drop table tab3;

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -52,7 +52,11 @@ dbid|content
 2   |0      
 3   |1      
 4   |2      
-(4 rows)
+5   |0      
+6   |1      
+7   |2      
+8   |-1     
+(8 rows)
 -- 5x's islation2 framework use dbid to specify utility target
 -- 3 should be the seg1 for demo cluster with mirrors
 3U: insert into tab1 values (1, 1);
@@ -61,8 +65,8 @@ INSERT 1
 select gp_segment_id, * from tab1;
 gp_segment_id|a|b
 -------------+-+-
-0            |1|1
 1            |1|1
+0            |1|1
 (2 rows)
 
 -- planner does not error out because it will add explicit motion
@@ -91,7 +95,7 @@ Optimizer status: PQO version 3.86.0
 begin;
 BEGIN
 delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=100384) (cdbdisp.c:254)
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=127638) (cdbdisp.c:254)
 abort;
 ABORT
 
@@ -122,7 +126,7 @@ Optimizer status: PQO version 3.86.0
 begin;
 BEGIN
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=100384) (cdbdisp.c:254)
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=127638) (cdbdisp.c:254)
 abort;
 ABORT
 
@@ -143,7 +147,7 @@ Optimizer status: PQO version 3.86.0
 begin;
 BEGIN
 update tab1 set b = 999;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=100384) (cdbdisp.c:254)
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=127638) (cdbdisp.c:254)
 abort;
 ABORT
 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,3 +1,4 @@
+test: modify_table_data_corrupt
 test: setup
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/sql/modify_table_data_corrupt.sql
+++ b/src/test/isolation2/sql/modify_table_data_corrupt.sql
@@ -1,0 +1,56 @@
+-- start_matchsubs
+-- m/nodeModifyTable.c:\d+/
+-- s/nodeModifyTable.c:\d+/nodeModifyTable.c:XXX/
+-- end_matchsubs
+
+-- start_ignore
+drop table tab1;
+drop table tab2;
+drop table tab3;
+-- end_ignore
+
+-- We do some check to verify the tuple to delete|update
+-- is from the segment it scans out. This case is to test
+-- such check.
+-- We build a plan that will add motion above result relation,
+-- however, does not contain explicit motion to send tuples back,
+-- and then login in segment using utility mode to insert some
+-- bad data.
+
+create table tab1(a int, b int) distributed by (b);
+create table tab2(a int, b int) distributed by (a);
+create table tab3 (a int, b int) distributed by (b);
+
+insert into tab1 values (1, 1);
+insert into tab2 values (1, 1);
+insert into tab3 values (1, 1);
+
+set allow_system_table_mods='dml';
+update pg_class set relpages = 10000 where relname='tab2';
+update pg_class set reltuples = 100000000 where relname='tab2';
+update pg_class set relpages = 100000000 where relname='tab3';
+update pg_class set reltuples = 100000 where relname='tab3';
+
+select dbid, content from gp_segment_configuration;
+-- 5x's islation2 framework use dbid to specify utility target
+-- 3 should be the seg1 for demo cluster with mirrors
+3U: insert into tab1 values (1, 1);
+
+select gp_segment_id, * from tab1;
+
+-- planner does not error out because it will add explicit motion
+-- For orca, this will error out
+explain delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+begin;
+delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+abort;
+
+-- For orca, this will error out
+explain delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+begin;
+update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+abort;
+
+drop table tab1;
+drop table tab2;
+drop table tab3;

--- a/src/test/isolation2/sql/modify_table_data_corrupt.sql
+++ b/src/test/isolation2/sql/modify_table_data_corrupt.sql
@@ -46,11 +46,18 @@ delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
 abort;
 
 -- For orca, this will error out
-explain delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
+explain update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
 begin;
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
 abort;
 
-drop table tab1;
-drop table tab2;
-drop table tab3;
+-- Test splitupdate, 5x planner does not support splitupdate
+-- if orca enabled, the following split update will error out
+explain update tab1 set b = 999;
+begin;
+update tab1 set b = 999;
+abort;
+
+-- drop table tab1;
+-- drop table tab2;
+-- drop table tab3;


### PR DESCRIPTION
Data being stored with bad distribution is not unusal in real product
environment. There could be issues if the ctid for update/delete is distributed
to another segment. This patch will double check this and error out.

-----------------------------------

On 5x, for planner, it is hard to build a test case because we have explicit motion.

6x version: https://github.com/greenplum-db/gpdb/pull/7304

related prs: 

for master: https://github.com/greenplum-db/gpdb/pull/9321 (merged)
for 6x: https://github.com/greenplum-db/gpdb/pull/9322 (merged)


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
