### PR TITLE
Fix dynamic index scan use after free

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -368,6 +368,8 @@ FaultInjectorIdentifierEnumToString[] = {
 	_("create_gang_in_progress"),
 		/* inject fault during gang creation, before check for interrupts */
 	_("decrease_toast_max_chunk_size"),
+		/* inject fault inside dynamic index scan after context reset */
+	_("dynamic_index_scan_context_reset"),
 		/* inject fault when creating new TOAST tables, to modify the chunk size */
 	_("not recognized"),
 };
@@ -1079,6 +1081,7 @@ FaultInjector_NewHashEntry(
 
 			case DecreaseToastMaxChunkSize:
 			case ProcessStartupPacketFault:
+			case DynamicIndexScanContextReset:
 
 				break;
 			default:

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -250,6 +250,8 @@ typedef enum FaultInjectorIdentifier_e {
 
 	DecreaseToastMaxChunkSize,
 
+	DynamicIndexScanContextReset,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/isolation2/expected/dynamic_index_scan.out
+++ b/src/test/isolation2/expected/dynamic_index_scan.out
@@ -1,0 +1,48 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+-- Purpose of this test is to check that dynamic index scan works on a
+-- partitioned table with multiple multi-column indexes
+CREATE TABLE a_table_with_multi_column_index ( id character varying(64), data character varying(50), partition_key int ) DISTRIBUTED BY (partition_key) PARTITION BY RANGE(partition_key) (START(0) END(10) EVERY(1));
+CREATE
+CREATE INDEX a_multi_column_index ON a_table_with_multi_column_index USING btree (data, id);
+CREATE
+CREATE INDEX another_multi_column_index ON a_table_with_multi_column_index USING btree (data, partition_key);
+CREATE
+
+INSERT INTO a_table_with_multi_column_index SELECT i||'id', 'some data', i%10 FROM generate_series(1, 100)i;
+INSERT 100
+
+-- Following fault causes an extra allocation during dynamic index scan. The
+-- purpose of that is to prevent the allocator from hiding a stale pointer
+-- where it would reuse the stale address and populate it with valid data.
+SELECT gp_inject_fault('dynamic_index_scan_context_reset', 'skip', dbid) FROM pg_catalog.gp_segment_configuration WHERE role = 'p';
+gp_inject_fault
+---------------
+t              
+t              
+t              
+t              
+(4 rows)
+1&:SELECT gp_wait_until_triggered_fault('dynamic_index_scan_context_reset', 1, dbid) FROM pg_catalog.gp_segment_configuration WHERE role = 'p' AND content=2;  <waiting ...>
+
+SELECT count(b.id) FROM a_table_with_multi_column_index a, a_table_with_multi_column_index b WHERE a.id = b.id AND Upper(a.id) LIKE '%ID' AND a.data = 'some data';
+count
+-----
+100  
+(1 row)
+
+1<:  <... completed>
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
+
+SELECT gp_inject_fault('dynamic_index_scan_context_reset', 'reset', dbid) FROM pg_catalog.gp_segment_configuration WHERE role = 'p';
+gp_inject_fault
+---------------
+t              
+t              
+t              
+t              
+(4 rows)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -19,6 +19,7 @@ test: vacuum_full_recently_dead_tuple_due_to_distributed_snapshot
 test: resync_xlog_hints
 test: invalidated_toast_index
 test: dml_on_root_locks_all_parts
+test: dynamic_index_scan
 
 # Tests on Append-Optimized tables (row-oriented).
 test: uao/alter_while_vacuum_row

--- a/src/test/isolation2/sql/dynamic_index_scan.sql
+++ b/src/test/isolation2/sql/dynamic_index_scan.sql
@@ -1,0 +1,30 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- Purpose of this test is to check that dynamic index scan works on a
+-- partitioned table with multiple multi-column indexes
+CREATE TABLE a_table_with_multi_column_index (
+    id character varying(64),
+    data character varying(50),
+    partition_key int
+) DISTRIBUTED BY (partition_key) PARTITION BY RANGE(partition_key)
+(START(0) END(10) EVERY(1));
+CREATE INDEX a_multi_column_index ON a_table_with_multi_column_index USING btree (data, id);
+CREATE INDEX another_multi_column_index ON a_table_with_multi_column_index USING btree (data, partition_key);
+
+INSERT INTO a_table_with_multi_column_index SELECT i||'id', 'some data', i%10 FROM generate_series(1, 100)i;
+
+-- Following fault causes an extra allocation during dynamic index scan. The
+-- purpose of that is to prevent the allocator from hiding a stale pointer
+-- where it would reuse the stale address and populate it with valid data.
+SELECT gp_inject_fault('dynamic_index_scan_context_reset', 'skip', dbid) FROM pg_catalog.gp_segment_configuration WHERE role = 'p';
+1&:SELECT gp_wait_until_triggered_fault('dynamic_index_scan_context_reset', 1, dbid) FROM pg_catalog.gp_segment_configuration WHERE role = 'p' AND content=2;
+
+SELECT count(b.id)
+FROM a_table_with_multi_column_index a, a_table_with_multi_column_index b
+WHERE a.id = b.id
+AND Upper(a.id) LIKE '%ID'
+AND a.data = 'some data';
+
+1<:
+
+SELECT gp_inject_fault('dynamic_index_scan_context_reset', 'reset', dbid) FROM pg_catalog.gp_segment_configuration WHERE role = 'p';


### PR DESCRIPTION
Issue is that there are two pointers which reference the same target
list, however there is a chance that they become out of sync. One target
list exists on PlanState and the other on ProjectionInfo. When the
context is reset the target list is palloc'd again and assigned on
PlanState. Now the target list on ProjectionInfo is pointing to freed
memory, and so later references to it cause SIGSEGV.

One might expect to hit this with high frequency, however there is a
chance that the reset context and palloc pattern uses the same chunk and
recycles the old address. This happened frequently in our small test and
when it does the stale ProjectionInfo pointer, which had been pointing
to freed memory, is now coincidentally valid again.  Thus in order to
reliably reproduce the SIGSEGV issue we force the next palloc of
PlanState target list to use a different memory chunk by adding an
allocation of ALLOC_CHUNK_LIMIT*2+1 between context reset and palloc.