### PR TITLE
DTX recovery process keeps failing if primary is waiting commit/abort…

### DIFF
--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -60,3 +60,4 @@ RelfilenodeGenLock					50
 WorkFileManagerLock					51
 DistributedLogTruncateLock			52
 TwophaseCommitLock				53
+TwophaseRecoveryLock			54

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -470,7 +470,7 @@ standard_ProcessUtility(Node *parsetree,
 						}
 						PreventTransactionChain(isTopLevel, "COMMIT PREPARED");
 						PreventCommandDuringRecovery("COMMIT PREPARED");
-						FinishPreparedTransaction(stmt->gid, /* isCommit */ true, /* raiseErrorIfNotFound */ true);
+						FinishPreparedTransaction(stmt->gid, /* isCommit */ true, false, /* raiseErrorIfNotFound */ true);
 						break;
 
 					case TRANS_STMT_ROLLBACK_PREPARED:
@@ -481,7 +481,7 @@ standard_ProcessUtility(Node *parsetree,
 						}
 						PreventTransactionChain(isTopLevel, "ROLLBACK PREPARED");
 						PreventCommandDuringRecovery("ROLLBACK PREPARED");
-						FinishPreparedTransaction(stmt->gid, /* isCommit */ false, /* raiseErrorIfNotFound */ true);
+						FinishPreparedTransaction(stmt->gid, /* isCommit */ false, false, /* raiseErrorIfNotFound */ true);
 						break;
 
 					case TRANS_STMT_ROLLBACK:

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -89,6 +89,6 @@ extern void RemoveTwoPhaseFile(TransactionId xid, bool giveWarning);
 
 extern void CheckPointTwoPhase(XLogRecPtr redo_horizon);
 
-extern bool FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFound);
+extern bool FinishPreparedTransaction(const char *gid, bool isCommit, bool isRecovery, bool raiseErrorIfNotFound);
 
 #endif   /* TWOPHASE_H */

--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -1,0 +1,73 @@
+-- Test this scenario:
+-- mirror has latency replaying the WAL from the primary, the master is reset
+-- from PANIC, master will start the DTX recovery process to recover the
+-- in-progress two-phase transactions. When DTX recovery process performing
+-- 'RECOVERY COMMIT PREPARED' on a transaction that is currently waiting for
+-- sync replication, it should wait rather than error out.
+
+1: create table t_wait_lsn(a int);
+CREATE
+
+-- suspend segment 0 before performing 'COMMIT PREPARED'
+2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2&: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';  <waiting ...>
+1&: insert into t_wait_lsn select generate_series(1,10);  <waiting ...>
+2<:  <... completed>
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- let walreceiver on mirror 0 skip WAL flush
+2: select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- resume 'COMMIT PREPARED', session 1 will hang on 'SyncRepWaitForLSN'
+2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- trigger master reset
+3: select gp_inject_fault('before_read_command', 'panic', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3: select 1;
+PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- resume walreceiver on mirror 0
+-1U: select gp_inject_fault_infinite('walrecv_skip_flush', 'reset', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-1Uq: ... <quitting>
+
+4: select count(*) from t_wait_lsn;
+ count 
+-------
+ 10    
+(1 row)
+4: drop table t_wait_lsn;
+DROP
+4q: ... <quitting>
+Traceback (most recent call last):
+  File "./sql_isolation_testcase.py", line 696, in <module>
+    executor.process_isolation_file(sys.stdin, sys.stdout)
+  File "./sql_isolation_testcase.py", line 488, in process_isolation_file
+    process.stop()
+  File "./sql_isolation_testcase.py", line 130, in stop
+    raise Exception("Should not finish test case while waiting for results")
+Exception: Should not finish test case while waiting for results

--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -4,6 +4,8 @@
 -- in-progress two-phase transactions. When DTX recovery process performing
 -- 'RECOVERY COMMIT PREPARED' on a transaction that is currently waiting for
 -- sync replication, it should wait rather than error out.
+1: create or replace function wait_until_standby_in_state(targetstate text) returns void as $$ declare replstate text; /* in func */ begin loop select state into replstate from pg_stat_replication; /* in func */ exit when replstate = targetstate; /* in func */ perform pg_sleep(0.1); /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
 
 1: create table t_wait_lsn(a int);
 CREATE
@@ -35,6 +37,12 @@ CREATE
  Success:                 
 (1 row)
 
+0U: select count(*) from pg_prepared_xacts;
+ count 
+-------
+ 1     
+(1 row)
+
 -- trigger master reset
 3: select gp_inject_fault('before_read_command', 'panic', 1);
  gp_inject_fault 
@@ -46,6 +54,13 @@ PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
+
+-- wait for master finish crash recovery
+-1U: select wait_until_standby_in_state('streaming');
+ wait_until_standby_in_state 
+-----------------------------
+                             
+(1 row)
 
 -- resume walreceiver on mirror 0
 -1U: select gp_inject_fault_infinite('walrecv_skip_flush', 'reset', dbid) from gp_segment_configuration where content=0 and role='m';

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -187,6 +187,7 @@ test: segwalrep/twophase_tolerance_with_mirror_promotion
 test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby
+test: segwalrep/dtx_recovery_wait_lsn
 test: pg_basebackup
 test: pg_basebackup_with_tablespaces
 test: fts_manual_probe

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -1,0 +1,31 @@
+-- Test this scenario:
+-- mirror has latency replaying the WAL from the primary, the master is reset
+-- from PANIC, master will start the DTX recovery process to recover the
+-- in-progress two-phase transactions. When DTX recovery process performing
+-- 'RECOVERY COMMIT PREPARED' on a transaction that is currently waiting for
+-- sync replication, it should wait rather than error out.
+
+1: create table t_wait_lsn(a int);
+
+-- suspend segment 0 before performing 'COMMIT PREPARED'
+2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', dbid) from gp_segment_configuration where content=0 and role='p';
+2&: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';
+1&: insert into t_wait_lsn select generate_series(1,10);
+2<:
+
+-- let walreceiver on mirror 0 skip WAL flush
+2: select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segment_configuration where content=0 and role='m';
+-- resume 'COMMIT PREPARED', session 1 will hang on 'SyncRepWaitForLSN'
+2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+
+-- trigger master reset
+3: select gp_inject_fault('before_read_command', 'panic', 1);
+3: select 1;
+
+-- resume walreceiver on mirror 0
+-1U: select gp_inject_fault_infinite('walrecv_skip_flush', 'reset', dbid) from gp_segment_configuration where content=0 and role='m';
+-1Uq:
+
+4: select count(*) from t_wait_lsn;
+4: drop table t_wait_lsn;
+4q:


### PR DESCRIPTION
… prepared

When mirror has latency replaying the WAL from the primary and the master is
reset from PANIC, master will start the DTX recovery process to recover the
in-progress two-phase transactions. While DTX recovery process performing
'RECOVERY COMMIT PREPARED' on a transaction that is currently waiting for sync
replication, it should wait rather than error out.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
