### PR TITLE
Add case splitupdate for check-tuple-locality.

### DIFF
--- a/src/test/isolation2/expected/modify_table_data_corrupt.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt.out
@@ -163,6 +163,28 @@ UPDATE 2
 abort;
 ABORT
 
+-- test splitupdate.
+-- For orca, the plan contains a redistribute motion, so that
+-- this following statement will error out.
+-- For planner, the plan is using explicit redistribute motion,
+-- the to-delete tuple is set to send back where it is from, so
+-- it will not error out.
+explain (costs off) update tab1 set b = b + 1;
+ QUERY PLAN                                                    
+---------------------------------------------------------------
+ Update on tab1                                                
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3) 
+         ->  Split                                             
+               ->  Seq Scan on tab1                            
+ Optimizer: Postgres query optimizer                           
+(5 rows)
+begin;
+BEGIN
+update tab1 set b = b + 1;
+UPDATE 2
+abort;
+ABORT
+
 drop table tab1;
 DROP
 drop table tab2;

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -161,7 +161,31 @@ explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and 
 begin;
 BEGIN
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:737)  (seg1 127.0.1.1:7003 pid=57517) (nodeModifyTable.c:737)
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:737)  (seg1 127.0.1.1:7003 pid=47425) (nodeModifyTable.c:737)
+abort;
+ABORT
+
+-- test splitupdate.
+-- For orca, the plan contains a redistribute motion, so that
+-- this following statement will error out.
+-- For planner, the plan is using explicit redistribute motion,
+-- the to-delete tuple is set to send back where it is from, so
+-- it will not error out.
+explain (costs off) update tab1 set b = b + 1;
+ QUERY PLAN                                                 
+------------------------------------------------------------
+ Update on tab1                                             
+   ->  Result                                               
+         ->  Redistribute Motion 3:3  (slice1; segments: 3) 
+               Hash Key: tab1_1.b                           
+               ->  Split                                    
+                     ->  Seq Scan on tab1 tab1_1            
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0       
+(7 rows)
+begin;
+BEGIN
+update tab1 set b = b + 1;
+ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:737)  (seg1 127.0.1.1:7003 pid=47425) (nodeModifyTable.c:737)
 abort;
 ABORT
 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,5 +1,3 @@
-test: modify_table_data_corrupt
-
 test: setup
 
 test: lockmodes
@@ -42,6 +40,8 @@ test: gdd/dml_locks_only_targeted_table_in_query
 test: gdd/local-deadlock-03
 # gdd end
 test: gdd/end
+
+test: modify_table_data_corrupt
 
 # The following test injects a fault at a generic location
 # (StartTransaction).  The fault can be easily triggered by a

--- a/src/test/isolation2/sql/modify_table_data_corrupt.sql
+++ b/src/test/isolation2/sql/modify_table_data_corrupt.sql
@@ -59,6 +59,17 @@ begin;
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
 abort;
 
+-- test splitupdate.
+-- For orca, the plan contains a redistribute motion, so that
+-- this following statement will error out.
+-- For planner, the plan is using explicit redistribute motion,
+-- the to-delete tuple is set to send back where it is from, so
+-- it will not error out.
+explain (costs off) update tab1 set b = b + 1;
+begin;
+update tab1 set b = b + 1;
+abort;
+
 drop table tab1;
 drop table tab2;
 drop table tab3;


### PR DESCRIPTION
Commit d95f351a does not add splitupdate case.
This commit adds this kind of test cases.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
