### PR TITLE
Fix error scenarios of alter_db_set_tablespace test

### DIFF
--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -317,13 +317,20 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 -- Then the tablespace for the database remains to be the source tablespace in all segments and the master
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
--- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+-- Ensure for content 0, the mirror has removed the dboid dir under
+-- the target tablespace. We cannot wait for this fault for all
+-- mirrors and standby, as don't know till what stage other primaries
+-- has completed the command when error happens for content 0. If
+-- other primaries end up aborting before starting the directory copy,
+-- replay of abort record will not delete the directory.
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m' and content = 0;
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 (SELECT * FROM before_alter) EXCEPT (SELECT * FROM after_alter);
 
+-- Wait for all the mirrors to replay the xlog before checking destination directory
+SELECT force_mirrors_to_catch_up();
 -- And the dboid directory under the target tablespace directory is empty for all database instances.
 SELECT * FROM stat_db_objects('alter_db', 'adst_destination_tablespace');
 
@@ -383,13 +390,21 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 -- Then the tablespace for the database remains to be the source tablespace in all segments and the master
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 
--- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+-- Ensure for content 0, the mirror has removed the dboid dir under
+-- the target tablespace. We cannot wait for this fault for all
+-- mirrors and standby, as don't know till what stage other primaries
+-- has completed the command when error happens for content 0. If
+-- other primaries end up aborting before starting the directory copy,
+-- abort record will not delete the directory.
+
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m' and content = 0;
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
 (SELECT * FROM before_alter) EXCEPT (SELECT * FROM after_alter);
 
+-- Wait for all the mirrors to replay the xlog before checking destination directory
+SELECT force_mirrors_to_catch_up();
 -- And the dboid directory under the target tablespace directory is empty for all database instances.
 SELECT * FROM stat_db_objects('alter_db', 'adst_destination_tablespace');
 

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -425,15 +425,17 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
              2 | alter_db | adst_source_tablespace
 (4 rows)
 
--- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+-- Ensure for content 0, the mirror has removed the dboid dir under
+-- the target tablespace. We cannot wait for this fault for all
+-- mirrors and standby, as don't know till what stage other primaries
+-- has completed the command when error happens for content 0. If
+-- other primaries end up aborting before starting the directory copy,
+-- replay of abort record will not delete the directory.
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m' and content = 0;
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
- Success:
- Success:
- Success:
-(4 rows)
+(1 row)
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -442,6 +444,13 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
  dbid | relfilenode_dboid_relative_path | size 
 ------+---------------------------------+------
 (0 rows)
+
+-- Wait for all the mirrors to replay the xlog before checking destination directory
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
 
 -- And the dboid directory under the target tablespace directory is empty for all database instances.
 SELECT * FROM stat_db_objects('alter_db', 'adst_destination_tablespace');
@@ -553,15 +562,17 @@ SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
              2 | alter_db | adst_source_tablespace
 (4 rows)
 
--- Ensure that the mirrors including the standby master have removed the dboid dir under the target tablespace.
-SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+-- Ensure for content 0, the mirror has removed the dboid dir under
+-- the target tablespace. We cannot wait for this fault for all
+-- mirrors and standby, as don't know till what stage other primaries
+-- has completed the command when error happens for content 0. If
+-- other primaries end up aborting before starting the directory copy,
+-- abort record will not delete the directory.
+SELECT gp_wait_until_triggered_fault('after_drop_database_directories', 1, dbid) FROM gp_segment_configuration WHERE role='m' and content = 0;
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
- Success:
- Success:
- Success:
-(4 rows)
+(1 row)
 
 -- Then all the files of the database should remain in the dboid directory in the source tablespace directory for all database instances.
 CREATE TEMPORARY TABLE after_alter AS SELECT * FROM stat_db_objects('alter_db', 'adst_source_tablespace');
@@ -570,6 +581,13 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
  dbid | relfilenode_dboid_relative_path | size 
 ------+---------------------------------+------
 (0 rows)
+
+-- Wait for all the mirrors to replay the xlog before checking destination directory
+SELECT force_mirrors_to_catch_up();
+ force_mirrors_to_catch_up 
+---------------------------
+ 
+(1 row)
 
 -- And the dboid directory under the target tablespace directory is empty for all database instances.
 SELECT * FROM stat_db_objects('alter_db', 'adst_destination_tablespace');


### PR DESCRIPTION
alter_db_set_tablespace test has scenarios to inject error fault for
content 0. Then run ALTER DATABASE SET TABLESPACE command. Once error
is hit on content 0, the transaction is aborted. Based on when the
transaction gets aborted, its unpredictable what point the command has
reached for non-content 0 primaries. If non-content 0 primaries, have
reached the point of directory copy, then only abort record for them
will have database directory deletion record to be replayed on mirror,
else not. The test was waiting for directory deletion fault to be
triggered for all the content mirrors. This expectation is incorrect
and makes test flaky based on timing.

Hence, modifying the test for error scenarios to only wait for
directory deletion for content 0. Then wait for all the mirrors to
replay all the currently generated wal records, post which make sure
destination directory is empty. This should eliminate the flakiness
from the test.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
