### PR TITLE
Enable autovacuum on catalog tables

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -149,7 +149,7 @@ pylint:
 $(MOCK_BIN):
 	@echo "--- mock for platform $(UBUNTU_PLATFORM)"
 	@if [ "$(UBUNTU_PLATFORM)" = "Ubuntu" ]; then\
-       pip install mock;\
+       pip3 install mock;\
      else\
        mkdir -p $(PYTHONSRC_INSTALL_SITE) && \
 	   cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(MOCK_DIR).tar.gz && \

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1280,7 +1280,7 @@ def checkTableMissingEntry(cat):
 
     # Skip catalogs without primary key
     if len(pkey) == 0:
-        logger.warn("[WARN] Skipped missing/extra entry check for %s" % catname)
+        logger.warning("[WARN] Skipped missing/extra entry check for %s" % catname)
         return
 
     castedPkey = cat.getPrimaryKey()
@@ -1526,7 +1526,7 @@ def checkTableInconsistentEntry(cat):
 
     # Skip catalogs without primary key
     if pkey == []:
-        logger.warn("[WARN] Skipped cross consistency check for %s" %
+        logger.warning("[WARN] Skipped cross consistency check for %s" %
                     catname)
         return
 
@@ -1680,7 +1680,7 @@ def checkTableDuplicateEntry(cat):
 
     # Skip catalogs without primary key
     if pkey == []:
-        logger.warn("[WARN] Skipped duplicate check for %s" %
+        logger.warning("[WARN] Skipped duplicate check for %s" %
                     catname)
         return
 
@@ -2079,7 +2079,7 @@ def runAllChecks():
         print_repair_issues(repair_dir_path)
 
     if GV.retcode >= ERROR_NOREPAIR:
-        logger.warn('[WARN]: unable to generate repairs for some issues')
+        logger.warning('[WARN]: unable to generate repairs for some issues')
     logger.info("Check complete")
 
 

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -296,13 +296,13 @@ class GPCatalog():
         # -------------
         
         # pg_class:
-        #   - relfilenode should generally be consistent, but may not be (jira?)
+        #   - relfilenode is not consistent across nodes
         #   - relpages/reltuples/relfrozenxid/relminmxid are all vacumm/analyze related
-        #   - relhasindex/relhaspkey are only cleared when vacuum completes
+        #   - relhasindex/relhasrules/relhastriggers are only cleared when vacuum completes
         #   - relowner has its own checks:
         #       => may want to separate out "owner" columns like acl and oid
         self._tables['pg_class']._setKnownDifferences(
-            "relfilenode relpages reltuples relhasindex relhaspkey relowner relfrozenxid relminmxid relallvisible")
+            "relowner relfilenode relpages reltuples relallvisible relhasindex relhasrules relhastriggers relfrozenxid relminmxid")
 
         # pg_type: typowner has its own checks:
         #       => may want to separate out "owner" columns like acl and oid

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1783,10 +1783,11 @@ vac_update_datfrozenxid(void)
 
 		heap_inplace_update(relation, tuple);
 		heap_freetuple(tuple);
-
+#ifdef FAULT_INJECTOR
 		FaultInjector_InjectFaultIfSet(
 			"vacuum_update_dat_frozen_xid", DDLNotSpecified,
 			NameStr(cached_dbform->datname), "");
+#endif
 	}
 
 	ReleaseSysCache(cached_tuple);

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2457,7 +2457,12 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 		vacuum_rel(aovisimap_relid, NULL, params, true);
 	params->options = orig_option;
 
+	/*
+	 * Don't dispatch auto-vacuum. Each segment performs auto-vacuum as per
+	 * its own need.
+	 */
 	if (Gp_role == GP_ROLE_DISPATCH && !recursing &&
+		!IsAutoVacuumWorkerProcess() &&
 		(!is_appendoptimized || ao_vacuum_phase))
 	{
 		VacuumStatsContext stats_context;

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -1717,9 +1717,11 @@ AutoVacWorkerMain(int argc, char *argv[])
 		ereport(LOG,
 				(errmsg("autovacuum: processing database \"%s\"", dbname)));
 
+#ifdef FAULT_INJECTOR
 		FaultInjector_InjectFaultIfSet(
 			"auto_vac_worker_before_do_autovacuum", DDLNotSpecified,
 			dbname, "");
+#endif
 
 		if (PostAuthDelay)
 			pg_usleep(PostAuthDelay * 1000000L);

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -2143,7 +2143,10 @@ do_autovacuum(void)
 		bool		wraparound;
 
 		if (classForm->relkind != RELKIND_RELATION &&
-			classForm->relkind != RELKIND_MATVIEW)
+			classForm->relkind != RELKIND_MATVIEW &&
+			classForm->relkind != RELKIND_AOSEGMENTS &&
+			classForm->relkind != RELKIND_AOBLOCKDIR &&
+			classForm->relkind != RELKIND_AOVISIMAP)
 			continue;
 
 		relid = classForm->oid;
@@ -2818,7 +2821,11 @@ extract_autovac_opts(HeapTuple tup, TupleDesc pg_class_desc)
 
 	Assert(((Form_pg_class) GETSTRUCT(tup))->relkind == RELKIND_RELATION ||
 		   ((Form_pg_class) GETSTRUCT(tup))->relkind == RELKIND_MATVIEW ||
-		   ((Form_pg_class) GETSTRUCT(tup))->relkind == RELKIND_TOASTVALUE);
+		   ((Form_pg_class) GETSTRUCT(tup))->relkind == RELKIND_TOASTVALUE ||
+		   ((Form_pg_class) GETSTRUCT(tup))->relkind == RELKIND_AOSEGMENTS ||
+		   ((Form_pg_class) GETSTRUCT(tup))->relkind == RELKIND_AOBLOCKDIR ||
+		   ((Form_pg_class) GETSTRUCT(tup))->relkind ==  RELKIND_AOVISIMAP);
+
 
 	relopts = extractRelOptions(tup, pg_class_desc, NULL);
 	if (relopts == NULL)

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -15,6 +15,7 @@
 /appendonly.out
 /auth_constraint.out
 /autovacuum.out
+/autovacuum-segment.out
 /autovacuum-template0-segment.out
 /bb_memory_quota.out
 /bb_mpph.out

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -14,7 +14,7 @@
 /aocs.out
 /appendonly.out
 /auth_constraint.out
-/autovacuum-template0.out
+/autovacuum.out
 /autovacuum-template0-segment.out
 /bb_memory_quota.out
 /bb_mpph.out

--- a/src/test/regress/expected/rpt_joins.out
+++ b/src/test/regress/expected/rpt_joins.out
@@ -2135,6 +2135,8 @@ where f2 = 53;
 --
 create temp table t_5628 (c1 int, c2 int) distributed replicated;
 insert into t_5628 values (1,1), (2,2);
+set enable_indexscan to off;
+set enable_bitmapscan to off;
 explain (costs off) select max(c1) from pg_class left join t_5628 on true;
                          QUERY PLAN                         
 ------------------------------------------------------------

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -270,6 +270,7 @@ test: oid_wraparound
 test: fts_recovery_in_progress
 test: mirror_replay
 test: autovacuum
+test: autovacuum-segment
 test: autovacuum-template0-segment
 
 # gpexpand introduce the partial tables, check them if they can run correctly

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -269,7 +269,7 @@ test: oid_wraparound
 # hence it should be run in isolation.
 test: fts_recovery_in_progress
 test: mirror_replay
-test: autovacuum-template0
+test: autovacuum
 test: autovacuum-template0-segment
 
 # gpexpand introduce the partial tables, check them if they can run correctly

--- a/src/test/regress/input/autovacuum-segment.source
+++ b/src/test/regress/input/autovacuum-segment.source
@@ -1,0 +1,48 @@
+-- Test to validate autovacuum is working fine on segments
+
+create or replace function test_consume_xids(int4) returns void
+as '@abs_srcdir@/regress.so', 'test_consume_xids'
+language C;
+
+-- start_ignore
+\! gpconfig -c debug_burn_xids -v on --skipvalidation
+-- Speed up test.
+\! gpconfig -c autovacuum_naptime -v 5
+\! gpstop -au
+-- end_ignore
+
+-- Autovacuum should take care of anti-XID wraparounds of catalog tables.
+-- Because of that, the age of pg_class should not go much above
+-- autovacuum_freeze_max_age (we assume the default of 200 million here).
+SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';
+
+-- Suspend the autovacuum worker from vacuuming before
+-- ShmemVariableCache->latestCompletedXid is expected to be updated
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- track that we've updated the row in pg_database for oldest database
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'regression', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+
+SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';
+
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- catalog table should be young
+SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';
+
+-- Reset GUCs.
+-- start_ignore
+\! gpconfig -r debug_burn_xids --skipvalidation
+\! gpconfig -r autovacuum_naptime
+\! gpstop -au
+-- end_ignore

--- a/src/test/regress/input/autovacuum-template0-segment.source
+++ b/src/test/regress/input/autovacuum-template0-segment.source
@@ -1,21 +1,17 @@
--- start_ignore
-create extension if not exists gp_inject_fault;
+-- Test to validate autovacuum takes care of anti-XID wraparounds of
+-- 'template0'. Because of that, the age of template0 should not go
+-- above autovacuum_freeze_max_age (we assume the default of 200
+-- million here)
 
 create or replace function test_consume_xids(int4) returns void
 as '@abs_srcdir@/regress.so', 'test_consume_xids'
 language C;
 
+-- start_ignore
 \! gpconfig -c debug_burn_xids -v on --skipvalidation
+\! gpconfig -c autovacuum_naptime -v 5
 \! gpstop -au
 -- end_ignore
-
--- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
--- of that, the age of template0 should not go much above
--- autovacuum_freeze_max_age (we assume the default of 200 million here).
-select age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
-
--- track that we've updated the row in pg_database for template0
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
 -- Suspend the autovacuum worker from vacuuming before
 -- ShmemVariableCache->latestCompletedXid is expected to be updated
@@ -25,8 +21,18 @@ select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_se
 select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
 select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
 
+select gp_segment_id, age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+
+-- start_ignore
+select gp_segment_id, datfrozenxid from gp_dist_random('pg_database') where datname='template0';
+-- end_ignore
+
 -- Wait until autovacuum is triggered
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- track that we've updated the row in pg_database for template0
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
 -- wait until autovacuum worker updates pg_database
@@ -34,14 +40,35 @@ SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) fr
 SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
 -- template0 should be young
-select age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+-- Sometimes one trigger of autovacuum doesn't bring down the age for
+-- template0, hence wait for few triggers to drop it
+DO $$
+DECLARE young BOOLEAN;
+BEGIN
+     FOR i in 1..300 loop
+	      SELECT age(datfrozenxid) < 200 * 1000000
+	      FROM gp_dist_random('pg_database') WHERE datname='template0' AND gp_segment_id = 0
+	      into young;
 
--- But autovacuum should not touch other databases. Hence, our database
--- should be well above the 200 million mark.
-select age(datfrozenxid) > 200 * 1000000 from gp_dist_random('pg_database') where datname=current_database() and gp_segment_id = 0;
+	      IF young THEN
+	         raise notice 'Template0 is young now';
+		 EXIT;
+	      END IF;
+	      PERFORM pg_sleep(0.2);
+     END LOOP;
+
+     IF not young THEN
+	raise notice 'Template0 is still old';
+     END IF;
+END$$;
 
 -- start_ignore
-\! gpconfig -c debug_burn_xids -v off --skipvalidation
+select gp_segment_id, datfrozenxid from gp_dist_random('pg_database') where datname='template0';
+-- end_ignore
+
+-- start_ignore
+\! gpconfig -r debug_burn_xids --skipvalidation
+\! gpconfig -r autovacuum_naptime
 \! gpstop -au
 -- end_ignore
 

--- a/src/test/regress/input/autovacuum.source
+++ b/src/test/regress/input/autovacuum.source
@@ -8,21 +8,23 @@ set debug_burn_xids=on;
 ALTER SYSTEM SET autovacuum_naptime = 5;
 select * from pg_reload_conf();
 
--- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
--- of that, the age of template0 should not go much above
+-- Autovacuum should take care of anti-XID wraparounds of catalog tables.
+-- Because of that, the age of pg_class should not go much above
 -- autovacuum_freeze_max_age (we assume the default of 200 million here).
-select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
-
--- track that we've updated the row in pg_database for template0
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, 1);
+SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
 
 -- Suspend the autovacuum worker from vacuuming before
 -- ShmemVariableCache->latestCompletedXid is expected to be updated
-SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'template0', '', 1, -1, 0, 1);
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, 1);
+
+-- track that we've updated the row in pg_database for oldest database
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'regression', '', 1, -1, 0, 1);
 
 select test_consume_xids(100 * 1000000);
 select test_consume_xids(100 * 1000000);
 select test_consume_xids(10 * 1000000);
+
+SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
 
 -- Wait until autovacuum is triggered
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, 1);
@@ -32,12 +34,8 @@ SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', 1);
 SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
 SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
 
--- template0 should be young
-select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
-
--- But autovacuum should not touch other databases. Hence, our database
--- should be well above the 200 million mark.
-select age(datfrozenxid) > 200 * 1000000 from pg_database where datname=current_database();
+-- catalog table should be young
+SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
 
 -- Reset GUCs.
 ALTER SYSTEM RESET autovacuum_naptime;

--- a/src/test/regress/output/autovacuum-segment.source
+++ b/src/test/regress/output/autovacuum-segment.source
@@ -1,0 +1,103 @@
+-- Test to validate autovacuum is working fine on segments
+create or replace function test_consume_xids(int4) returns void
+as '@abs_srcdir@/regress.so', 'test_consume_xids'
+language C;
+-- start_ignore
+\! gpconfig -c debug_burn_xids -v on --skipvalidation
+-- Speed up test.
+\! gpconfig -c autovacuum_naptime -v 5
+\! gpstop -au
+-- end_ignore
+-- Autovacuum should take care of anti-XID wraparounds of catalog tables.
+-- Because of that, the age of pg_class should not go much above
+-- autovacuum_freeze_max_age (we assume the default of 200 million here).
+SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';
+ gp_segment_id | ?column? 
+---------------+----------
+             2 | t
+             0 | t
+             1 | t
+(3 rows)
+
+-- Suspend the autovacuum worker from vacuuming before
+-- ShmemVariableCache->latestCompletedXid is expected to be updated
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- track that we've updated the row in pg_database for oldest database
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'regression', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+ 
+(1 row)
+
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+ 
+(1 row)
+
+select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+ 
+(1 row)
+
+SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';
+ gp_segment_id | ?column? 
+---------------+----------
+             1 | t
+             2 | t
+             0 | f
+(3 rows)
+
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- catalog table should be young
+SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';
+ gp_segment_id | ?column? 
+---------------+----------
+             1 | t
+             2 | t
+             0 | t
+(3 rows)
+
+-- Reset GUCs.
+-- start_ignore
+\! gpconfig -r debug_burn_xids --skipvalidation
+\! gpconfig -r autovacuum_naptime
+\! gpstop -au
+-- end_ignore

--- a/src/test/regress/output/autovacuum-template0-segment.source
+++ b/src/test/regress/output/autovacuum-template0-segment.source
@@ -1,36 +1,14 @@
--- start_ignore
-create extension if not exists gp_inject_fault;
+-- Test to validate autovacuum takes care of anti-XID wraparounds of
+-- 'template0'. Because of that, the age of template0 should not go
+-- above autovacuum_freeze_max_age (we assume the default of 200
+-- million here)
 create or replace function test_consume_xids(int4) returns void
 as '@abs_srcdir@/regress.so', 'test_consume_xids'
 language C;
+-- start_ignore
 \! gpconfig -c debug_burn_xids -v on --skipvalidation
-20201009:19:05:11:034329 gpconfig:gpdb6:zhanyi-[INFO]:-completed successfully with parameters '-c debug_burn_xids -v on --skipvalidation'
 \! gpstop -au
-20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Starting gpstop with args: -au
-20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Gathering information and validating the environment...
-20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Obtaining Greenplum Master catalog information
-20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Obtaining Segment details from master...
-20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.11.1+dev.22.gcf4e9dbf19 build dev'
-20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Signalling all postmaster processes to reload
 -- end_ignore
--- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
--- of that, the age of template0 should not go much above
--- autovacuum_freeze_max_age (we assume the default of 200 million here).
-select age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
- ?column? 
-----------
- t
- t
- t
-(3 rows)
-
--- track that we've updated the row in pg_database for template0
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
- gp_inject_fault 
------------------
- Success:
-(1 row)
-
 -- Suspend the autovacuum worker from vacuuming before
 -- ShmemVariableCache->latestCompletedXid is expected to be updated
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
@@ -57,10 +35,25 @@ select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_seg
  
 (1 row)
 
+select gp_segment_id, age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+ gp_segment_id | ?column? 
+---------------+----------
+             1 | t
+             2 | t
+             0 | f
+(3 rows)
+
 -- Wait until autovacuum is triggered
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
+ Success:
+(1 row)
+
+-- track that we've updated the row in pg_database for template0
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
@@ -84,30 +77,30 @@ SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_se
 (1 row)
 
 -- template0 should be young
-select age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
- ?column? 
-----------
- t
- t
- t
-(3 rows)
+-- Sometimes one trigger of autovacuum doesn't bring down the age for
+-- template0, hence wait for few triggers to drop it
+DO $$
+DECLARE young BOOLEAN;
+BEGIN
+     FOR i in 1..300 loop
+	      SELECT age(datfrozenxid) < 200 * 1000000
+	      FROM gp_dist_random('pg_database') WHERE datname='template0' AND gp_segment_id = 0
+	      into young;
 
--- But autovacuum should not touch other databases. Hence, our database
--- should be well above the 200 million mark.
-select age(datfrozenxid) > 200 * 1000000 from gp_dist_random('pg_database') where datname=current_database() and gp_segment_id = 0;
- ?column? 
-----------
- t
-(1 row)
+	      IF young THEN
+	         raise notice 'Template0 is young now';
+		 EXIT;
+	      END IF;
+	      PERFORM pg_sleep(0.2);
+     END LOOP;
 
+     IF not young THEN
+	raise notice 'Template0 is still old';
+     END IF;
+END$$;
+NOTICE:  Template0 is young now
 -- start_ignore
-\! gpconfig -c debug_burn_xids -v off --skipvalidation
-20201009:19:06:18:034710 gpconfig:gpdb6:zhanyi-[INFO]:-completed successfully with parameters '-c debug_burn_xids -v off --skipvalidation'
+\! gpconfig -r debug_burn_xids --skipvalidation
+\! gpconfig -r autovacuum_naptime
 \! gpstop -au
-20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Starting gpstop with args: -au
-20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Gathering information and validating the environment...
-20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Obtaining Greenplum Master catalog information
-20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Obtaining Segment details from master...
-20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.11.1+dev.22.gcf4e9dbf19 build dev'
-20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Signalling all postmaster processes to reload
 -- end_ignore

--- a/src/test/regress/output/autovacuum.source
+++ b/src/test/regress/output/autovacuum.source
@@ -10,25 +10,25 @@ select * from pg_reload_conf();
  t
 (1 row)
 
--- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
--- of that, the age of template0 should not go much above
+-- Autovacuum should take care of anti-XID wraparounds of catalog tables.
+-- Because of that, the age of pg_class should not go much above
 -- autovacuum_freeze_max_age (we assume the default of 200 million here).
-select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
+SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
  ?column? 
 ----------
  t
 (1 row)
 
--- track that we've updated the row in pg_database for template0
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, 1);
+-- Suspend the autovacuum worker from vacuuming before
+-- ShmemVariableCache->latestCompletedXid is expected to be updated
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
  Success:
 (1 row)
 
--- Suspend the autovacuum worker from vacuuming before
--- ShmemVariableCache->latestCompletedXid is expected to be updated
-SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'template0', '', 1, -1, 0, 1);
+-- track that we've updated the row in pg_database for oldest database
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'regression', '', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
  Success:
@@ -50,6 +50,12 @@ select test_consume_xids(10 * 1000000);
  test_consume_xids 
 -------------------
  
+(1 row)
+
+SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
+ ?column? 
+----------
+ f
 (1 row)
 
 -- Wait until autovacuum is triggered
@@ -78,16 +84,8 @@ SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
  Success:
 (1 row)
 
--- template0 should be young
-select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
- ?column? 
-----------
- t
-(1 row)
-
--- But autovacuum should not touch other databases. Hence, our database
--- should be well above the 200 million mark.
-select age(datfrozenxid) > 200 * 1000000 from pg_database where datname=current_database();
+-- catalog table should be young
+SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
  ?column? 
 ----------
  t

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -1948,7 +1948,7 @@ find_plan(char *ident, EPlan ** eplan, int *nplans)
 /*
  * test_consume_xids(int4), for rapidly consuming XIDs, to test wraparound.
  *
- * Used by the 'autovacuum-template0' test.
+ * Used by the 'autovacuum' test.
  */
 PG_FUNCTION_INFO_V1(test_consume_xids);
 Datum

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -14,8 +14,9 @@
 /aocs.sql
 /appendonly.sql
 /auth_constraint.sql
-/autovacuum-template0-segment.sql
 /autovacuum.sql
+/autovacuum-segment.sql
+/autovacuum-template0-segment.sql
 /bb_memory_quota.sql
 /bb_mpph.sql
 /collect_tabstat.sql

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -14,8 +14,8 @@
 /aocs.sql
 /appendonly.sql
 /auth_constraint.sql
-/autovacuum-template0.sql
 /autovacuum-template0-segment.sql
+/autovacuum.sql
 /bb_memory_quota.sql
 /bb_mpph.sql
 /collect_tabstat.sql

--- a/src/test/regress/sql/rpt_joins.sql
+++ b/src/test/regress/sql/rpt_joins.sql
@@ -447,6 +447,8 @@ where f2 = 53;
 --
 create temp table t_5628 (c1 int, c2 int) distributed replicated;
 insert into t_5628 values (1,1), (2,2);
+set enable_indexscan to off;
+set enable_bitmapscan to off;
 explain (costs off) select max(c1) from pg_class left join t_5628 on true;
 select max(c1) from pg_class left join t_5628 on true;
 


### PR DESCRIPTION
Allows emergency autovacuum on catalog tables across all databases.
Tables in information_schema are included as system tables in order to
maintain autovacuum behavior parity on template0 from commit 4e65571.
GUC "autovacuum" can still be set if desired, but remains disabled by
default.

I think it's probably debatable whether this is the right approach.  Given
that autovacuum operates on oldest database and in GPDB we do not
autovacuum all tables, it is possible that non-vacuumed user tables
keeps a database old enough that we do not autovacuum template0 as
frequently.

On my list of things to do:
1) Check old incidents relating to performance bottlenecks due to
autovacuum.
2) Investigate further into the GPDB_91_MERGE_FIXME regarding
vacuuming of temp tables from other backends