### PR TITLE
6X: Fix error code overwrite in cdbdisp_dumpDispatchResult.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -474,9 +474,8 @@ cdbdisp_dumpDispatchResult(CdbDispatchResult *dispatchResult)
 		dispatchResult->error_message->len > 0)
 	{
 		if (errstart(ERROR, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN))
-			errdata = errfinish_and_return(errcode(ERRCODE_INTERNAL_ERROR),
-										   (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-											errmsg("%s", dispatchResult->error_message->data)));
+			errdata = errfinish_and_return(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+											errmsg("%s", dispatchResult->error_message->data));
 		else
 			pg_unreachable();
 

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -234,7 +234,7 @@ server started
  
 (1 row)
 12<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=25361: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=25361: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -7,8 +7,8 @@ create extension if not exists gp_inject_fault;
 CREATE
 
 -- start_matchsubs
--- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
+-- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/
+-- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
 -- end_matchsubs
 
 -- to make test deterministic and fast
@@ -141,7 +141,7 @@ END
 -- session 2: in transaction, gxid is dispatched to writer gang, cann't
 --            update cdb_component_dbs, following query should fail
 2:END;
-ERROR:  Error on receive from seg1 127.0.0.1:7003 pid=2406: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg1 127.0.0.1:7003 pid=2406: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -152,7 +152,7 @@ DETAIL:
 ----+----
 (0 rows)
 3:END;
-ERROR:  Error on receive from seg1 127.0.0.1:7003 pid=2417: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg1 127.0.0.1:7003 pid=2417: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -160,7 +160,7 @@ DETAIL:
 --            cdb_component_dbs, following query should fail and session
 --            is reset
 4:select * from tmp4;
-ERROR:  Error on receive from seg1 slice1 127.0.0.1:7003 pid=2432: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg1 slice1 127.0.0.1:7003 pid=2432: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -171,7 +171,7 @@ LINE 1: select * from tmp4;
 -- session 5: has a subtransaction, cann't update cdb_component_dbs,
 --            following query should fail
 5:select * from tmp51;
-ERROR:  Error on receive from seg1 slice1 127.0.0.1:7003 pid=2441: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg1 slice1 127.0.0.1:7003 pid=2441: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
@@ -88,7 +88,7 @@ SET
  t                         
 (1 row)
 1<:  <... completed>
-ERROR:  FTS detected connection lost during dispatch to seg0 127.0.0.1:7002 pid=5106: (cdbdispatchresult.c:476)
+ERROR:  FTS detected connection lost during dispatch to seg0 127.0.0.1:7002 pid=5106:
 
 1:SELECT gp_inject_fault('start_prepare', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_inject_fault 

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -2,8 +2,8 @@
 --
 -- # create a match/subs expression
 --
--- m/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/gm
+-- m/ERROR:.*server closed the connection unexpectedly/
+-- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
 -- end_matchsubs
 include: helpers/server_helpers.sql;
 CREATE
@@ -121,12 +121,12 @@ END
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21988)
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29474: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29474: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29462: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29462: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -627,7 +627,7 @@ server started
  
 (1 row)
 4<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29553: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29553: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -2,8 +2,8 @@
 --
 -- # create a match/subs expression
 --
--- m/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/gm
+-- m/ERROR:.*server closed the connection unexpectedly/
+-- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
 -- end_matchsubs
 3:CREATE extension if NOT EXISTS gp_inject_fault;
 CREATE
@@ -102,12 +102,12 @@ UPDATE 10
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21369)
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24819: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24819: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24830: server closed the connection unexpectedly (cdbdispatchresult.c:476)
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24830: server closed the connection unexpectedly
 DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/sql/fts_errors.sql
+++ b/src/test/isolation2/sql/fts_errors.sql
@@ -6,8 +6,8 @@
 create extension if not exists gp_inject_fault;
 
 -- start_matchsubs
--- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/
+-- m/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/
+-- s/^ERROR:  Error on receive from .*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
 -- end_matchsubs
 
 -- to make test deterministic and fast

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -2,8 +2,8 @@
 --
 -- # create a match/subs expression
 --
--- m/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/gm
+-- m/ERROR:.*server closed the connection unexpectedly/
+-- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
 -- end_matchsubs
 include: helpers/server_helpers.sql;
 

--- a/src/test/isolation2/sql/uao_crash_compaction_row.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_row.sql
@@ -2,8 +2,8 @@
 --
 -- # create a match/subs expression
 --
--- m/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/
--- s/ERROR:.*server closed the connection unexpectedly (cdbdispatchresult.c:\d+)/ERROR: server closed the connection unexpectedly (cdbdispatchresult.c:XXX)/gm
+-- m/ERROR:.*server closed the connection unexpectedly/
+-- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
 -- end_matchsubs
 3:CREATE extension if NOT EXISTS gp_inject_fault;
 3:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;


### PR DESCRIPTION
The error code should not set twice with different codes in `errfinish_and_return`.
Since the order of function's parameters is dependent on the compiler.
If the final error code is ERRCODE_INTERNAL_ERROR, file name and line number print out.
```
ERROR:  Error on receive from SEG IP:PORT pid=PID: *** (cdbdispatchresult.c:487)
```

It's strange to print out the file name and line number here.
So, remove ERRCODE_INTERNAL_ERROR, and only keep ERRCODE_GP_INTERCONNECTION_ERROR,
which is also the error code before commit: 143bb7c.

Reviewed-by: Paul Guo <paulguo@gmail.com>
(cherry picked from commit 55d6415bb3d0ada27c85eb138807fd2f5322367b)