### PR TITLE
Print warning message in checkNetworkTimeout.

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1259,6 +1259,7 @@ SetupTCPInterconnect(EState *estate)
 
 	interconnect_context->teardownActive = false;
 	interconnect_context->activated = false;
+	interconnect_context->networkTimeoutIsLogged = false;
 	interconnect_context->incompleteConns = NIL;
 	interconnect_context->sliceTable = copyObject(sliceTable);
 	interconnect_context->sliceId = sliceTable->localSlice;

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -505,6 +505,9 @@ typedef struct ChunkTransportState
 	bool		activated;
 
 	bool		aggressiveRetry;
+	
+	/* whether we've logged when network timeout happens */
+	bool		networkTimeoutIsLogged;
 
 	bool		teardownActive;
 	List		*incompleteConns;


### PR DESCRIPTION
Packets will be dropped repeatly on some specific ports.
We need a way to quickly identify this issue.
But when network is bad, packets will also be dropped.
In past checkNetworkTimeout will error out when a packet
failed to receive ACK more than one hour(see GUC
gp_interconnect_transmit_timeout), which is too strict.

This commit introduces a warning message to report this
possible problem, and DBA could examine the port in further.

It's just adding a warning message, so no additional tests are added.