### PR TITLE
Added the selection rate of the inner table non-empty bucket (#9147)

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2853,6 +2853,9 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 	double		hashjointuples;
 	double		virtualbuckets;
 	Selectivity innerbucketsize;
+	double		outerndistinct;
+	double		innerndistinct;
+	Selectivity outer_match_nonempty_frac;
 	ListCell   *hcl;
 
 	/* Mark the path with the correct row estimate */
@@ -2885,16 +2888,28 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 	 * because we avoid contaminating the cache with a value that's wrong for
 	 * non-unique-ified paths.
 	 */
+	outerndistinct = 1.0;
+
 	if (IsA(inner_path, UniquePath))
+	{
 		innerbucketsize = 1.0 / virtualbuckets;
+		innerndistinct = inner_path_rows;
+	}
 	else
 	{
 		innerbucketsize = 1.0;
+		innerndistinct = 1.0;
+
 		foreach(hcl, hashclauses)
 		{
 			RestrictInfo *restrictinfo = (RestrictInfo *) lfirst(hcl);
 			Expr *clause = restrictinfo->clause;
 			Selectivity thisbucketsize;
+			double thisinnerndistinct;
+			double thisouterndistinct;
+			VariableStatData vardatainner;
+			VariableStatData vardataouter;
+			bool isdefault;
 
 			Assert(IsA(restrictinfo, RestrictInfo));
 
@@ -2933,6 +2948,25 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 												 virtualbuckets);
 					restrictinfo->right_bucketsize = thisbucketsize;
 				}
+
+				examine_variable(root, get_rightop(clause), 0, &vardatainner);
+				thisinnerndistinct = get_variable_numdistinct(&vardatainner, &isdefault);
+				if (vardatainner.rel && vardatainner.rel->tuples > 0)
+				{
+					thisinnerndistinct *= vardatainner.rel->rows / vardatainner.rel->tuples;
+					thisinnerndistinct = clamp_row_est(thisinnerndistinct);
+				}
+				ReleaseVariableStats(vardatainner);
+
+				/* lefthand side is outer */
+				examine_variable(root, get_leftop(clause), 0, &vardataouter);
+				thisouterndistinct = get_variable_numdistinct(&vardataouter, &isdefault);
+				if (vardataouter.rel && vardataouter.rel->tuples > 0)
+				{
+					thisinnerndistinct *= vardataouter.rel->rows / vardataouter.rel->tuples;
+					thisinnerndistinct = clamp_row_est(thisinnerndistinct);
+				}
+				ReleaseVariableStats(vardataouter);
 			}
 			else
 			{
@@ -2949,10 +2983,33 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 												 virtualbuckets);
 					restrictinfo->left_bucketsize = thisbucketsize;
 				}
+
+				examine_variable(root, get_leftop(clause), 0, &vardatainner);
+				thisinnerndistinct = get_variable_numdistinct(&vardatainner, &isdefault);
+				if (vardatainner.rel && vardatainner.rel->tuples > 0)
+				{
+					thisinnerndistinct *= vardatainner.rel->rows / vardatainner.rel->tuples;
+					thisinnerndistinct = clamp_row_est(thisinnerndistinct);
+				}
+				ReleaseVariableStats(vardatainner);
+
+				/* righthand side is outers */
+				examine_variable(root, get_rightop(clause), 0, &vardataouter);
+				thisouterndistinct = get_variable_numdistinct(&vardataouter, &isdefault);
+				if (vardataouter.rel && vardataouter.rel->tuples > 0)
+				{
+					thisinnerndistinct *= vardataouter.rel->rows / vardataouter.rel->tuples;
+					thisinnerndistinct = clamp_row_est(thisinnerndistinct);
+				}
+				ReleaseVariableStats(vardataouter);
 			}
 
 			if (innerbucketsize > thisbucketsize)
 				innerbucketsize = thisbucketsize;
+			if (outerndistinct < thisouterndistinct)
+				outerndistinct = thisouterndistinct;
+			if (innerndistinct < thisinnerndistinct)
+				innerndistinct =  thisinnerndistinct;
 		}
 	}
 
@@ -2966,6 +3023,21 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 	qp_qual_cost.per_tuple -= hash_qual_cost.per_tuple;
 
 	/* CPU costs */
+
+	/*
+	 * If virtualbuckets is much larger than innerndistinct, and
+	 * outerndistinct is much larger than innerndistinct. Then most
+	 * tuples of the outer table will match the empty bucket. So when
+	 * we calculate the cost of traversing the bucket, we need to ignore
+	 * the tuple matching empty bucket.
+	 */
+	outer_match_nonempty_frac = 1.0;
+	if (virtualbuckets > innerndistinct * 2 && outerndistinct > innerndistinct * 2)
+	{
+		outer_match_nonempty_frac = (1 -
+									 ((outerndistinct - innerndistinct)/outerndistinct)*
+									 ((virtualbuckets - innerndistinct)/virtualbuckets));
+	}
 
 	if (path->jpath.jointype == JOIN_SEMI || path->jpath.jointype == JOIN_ANTI)
 	{
@@ -2987,7 +3059,7 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 		inner_scan_frac = 2.0 / (semifactors->match_count + 1.0);
 
 		startup_cost += hash_qual_cost.startup;
-		run_cost += hash_qual_cost.per_tuple * outer_matched_rows *
+		run_cost += hash_qual_cost.per_tuple * outer_matched_rows * outer_match_nonempty_frac *
 			clamp_row_est(inner_path_rows * innerbucketsize * inner_scan_frac) * 0.5;
 
 		/*
@@ -3027,6 +3099,7 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 		 */
 		startup_cost += hash_qual_cost.startup;
 		run_cost += hash_qual_cost.per_tuple * outer_path_rows *
+			outer_match_nonempty_frac *
 			clamp_row_est(inner_path_rows * innerbucketsize) * 0.5;
 
 		/*

--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -380,22 +380,25 @@ ANALYZE test_join_card1;
 ANALYZE test_join_card2;
 ANALYZE test_join_card3;
 EXPLAIN SELECT * FROM test_join_card1 t1, test_join_card2 t2, test_join_card3 t3 WHERE t1.b = t2.b and t3.b = t2.b;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=717.00..1479.01 rows=2910 width=22)
-   ->  Hash Join  (cost=717.00..1479.01 rows=970 width=22)
-         Hash Cond: t2.b::text = t1.b::text
-         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=240.00..907.44 rows=5820 width=12)
-               ->  Hash Join  (cost=240.00..674.64 rows=1940 width=12)
-                     Hash Cond: t2.b::text = t3.b::text
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..308.95 rows=5999 width=4)
-                           ->  Seq Scan on test_join_card2 t2  (cost=0.00..68.99 rows=2000 width=4)
-                     ->  Hash  (cost=115.00..115.00 rows=3334 width=8)
-                           ->  Seq Scan on test_join_card3 t3  (cost=0.00..115.00 rows=3334 width=8)
-         ->  Hash  (cost=227.00..227.00 rows=6667 width=10)
-               ->  Seq Scan on test_join_card1 t1  (cost=0.00..227.00 rows=6667 width=10)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=1081.62..1521.42 rows=2910 width=22)
+   ->  Hash Join  (cost=1081.62..1463.22 rows=970 width=22)
+         Hash Cond: ((t3.b)::text = (t1.b)::text)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..315.00 rows=3334 width=8)
+               Hash Key: t3.b
+               ->  Seq Scan on test_join_card3 t3  (cost=0.00..115.00 rows=3334 width=8)
+         ->  Hash  (cost=1008.87..1008.87 rows=1940 width=14)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=533.91..1008.87 rows=1940 width=14)
+                     Hash Key: t1.b
+                     ->  Hash Join  (cost=533.91..892.47 rows=1940 width=14)
+                           Hash Cond: ((t1.b)::text = (t2.b)::text)
+                           ->  Seq Scan on test_join_card1 t1  (cost=0.00..227.00 rows=6667 width=10)
+                           ->  Hash  (cost=308.95..308.95 rows=5999 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..308.95 rows=5999 width=4)
+                                       ->  Seq Scan on test_join_card2 t2  (cost=0.00..68.99 rows=2000 width=4)
  Optimizer: Postgres query optimizer
-(13 rows)
+(16 rows)
 
 -- start_ignore
 DROP TABLE IF EXISTS test_join_card1;

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -1121,34 +1121,48 @@ explain select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' ord
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=43.50..43.73 rows=93 width=62)
    Merge Key: pt1_1_prt_junk_data.dist
-   ->  Sort  (cost=43.50..43.73 rows=31 width=62)
+   ->  Sort  (cost=41.79..42.02 rows=31 width=62)
          Sort Key: pt1_1_prt_junk_data.dist
-         ->  Hash Join  (cost=20.43..40.47 rows=31 width=62)
-               Hash Cond: pt_1_prt_junk_data.ptid = pt1_1_prt_junk_data.ptid
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.86 rows=4 width=31)
-                     ->  Append  (cost=0.00..18.68 rows=2 width=31)
-                           ->  Seq Scan on pt_1_prt_junk_data  (cost=0.00..3.11 rows=1 width=31)
-                                 Filter: pt1 = 'hello0'::text
-                           ->  Seq Scan on pt_1_prt_2  (cost=0.00..3.11 rows=1 width=31)
-                                 Filter: pt1 = 'hello0'::text
-                           ->  Seq Scan on pt_1_prt_3  (cost=0.00..3.11 rows=1 width=31)
-                                 Filter: pt1 = 'hello0'::text
-                           ->  Seq Scan on pt_1_prt_4  (cost=0.00..3.11 rows=1 width=31)
-                                 Filter: pt1 = 'hello0'::text
-                           ->  Seq Scan on pt_1_prt_5  (cost=0.00..3.11 rows=1 width=31)
-                                 Filter: pt1 = 'hello0'::text
-                           ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.11 rows=1 width=31)
-                                 Filter: pt1 = 'hello0'::text
-               ->  Hash  (cost=19.08..19.08 rows=36 width=31)
-                     ->  Append  (cost=0.00..19.08 rows=36 width=31)
+         ->  Hash Join  (cost=19.14..38.76 rows=31 width=62)
+               Hash Cond: (pt1_1_prt_junk_data.ptid = pt_1_prt_junk_data.ptid)
+               ->  Append  (cost=0.00..18.08 rows=36 width=31)
+                     ->  Result  (cost=0.00..3.63 rows=21 width=31)
+                           One-Time Filter: PartSelected
                            ->  Seq Scan on pt1_1_prt_junk_data  (cost=0.00..3.63 rows=21 width=31)
-                           ->  Seq Scan on pt1_1_prt_2  (cost=0.00..3.09 rows=3 width=31)
+                     ->  Result  (cost=0.00..2.09 rows=3 width=31)
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on pt1_1_prt_2  (cost=0.00..2.09 rows=3 width=31)
+                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                           One-Time Filter: PartSelected
                            ->  Seq Scan on pt1_1_prt_3  (cost=0.00..3.09 rows=3 width=31)
+                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                           One-Time Filter: PartSelected
                            ->  Seq Scan on pt1_1_prt_4  (cost=0.00..3.09 rows=3 width=31)
+                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                           One-Time Filter: PartSelected
                            ->  Seq Scan on pt1_1_prt_5  (cost=0.00..3.09 rows=3 width=31)
+                     ->  Result  (cost=0.00..3.09 rows=3 width=31)
+                           One-Time Filter: PartSelected
                            ->  Seq Scan on pt1_1_prt_6  (cost=0.00..3.09 rows=3 width=31)
+               ->  Hash  (cost=18.91..18.91 rows=6 width=31)
+                     ->  Partition Selector for pt1 (dynamic scan id: 2)  (cost=0.00..18.91 rows=6 width=31)
+                           Filter: pt_1_prt_junk_data.ptid
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.91 rows=6 width=31)
+                                 ->  Append  (cost=0.00..18.68 rows=2 width=31)
+                                       ->  Seq Scan on pt_1_prt_junk_data  (cost=0.00..3.11 rows=1 width=31)
+                                             Filter: (pt1 = 'hello0'::text)
+                                       ->  Seq Scan on pt_1_prt_2  (cost=0.00..3.11 rows=1 width=31)
+                                             Filter: (pt1 = 'hello0'::text)
+                                       ->  Seq Scan on pt_1_prt_3  (cost=0.00..3.11 rows=1 width=31)
+                                             Filter: (pt1 = 'hello0'::text)
+                                       ->  Seq Scan on pt_1_prt_4  (cost=0.00..3.11 rows=1 width=31)
+                                             Filter: (pt1 = 'hello0'::text)
+                                       ->  Seq Scan on pt_1_prt_5  (cost=0.00..3.11 rows=1 width=31)
+                                             Filter: (pt1 = 'hello0'::text)
+                                       ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.11 rows=1 width=31)
+                                             Filter: (pt1 = 'hello0'::text)
  Optimizer: Postgres query optimizer
-(29 rows)
+(43 rows)
 
 select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt1.dist;
  dist |  pt1   |  pt2  |    pt3    | ptid | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -1165,37 +1179,51 @@ select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt
 (9 rows)
 
 explain select count(*) from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0';
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Aggregate  (cost=40.76..40.77 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=40.70..40.74 rows=1 width=8)
-         ->  Aggregate  (cost=40.70..40.71 rows=1 width=8)
-               ->  Hash Join  (cost=20.43..40.47 rows=31 width=0)
-                     Hash Cond: pt_1_prt_junk_data.ptid = pt1_1_prt_junk_data.ptid
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.86 rows=4 width=4)
-                           ->  Append  (cost=0.00..18.68 rows=2 width=4)
-                                 ->  Seq Scan on pt_1_prt_junk_data  (cost=0.00..3.11 rows=1 width=4)
-                                       Filter: pt1 = 'hello0'::text
-                                 ->  Seq Scan on pt_1_prt_2  (cost=0.00..3.11 rows=1 width=4)
-                                       Filter: pt1 = 'hello0'::text
-                                 ->  Seq Scan on pt_1_prt_3  (cost=0.00..3.11 rows=1 width=4)
-                                       Filter: pt1 = 'hello0'::text
-                                 ->  Seq Scan on pt_1_prt_4  (cost=0.00..3.11 rows=1 width=4)
-                                       Filter: pt1 = 'hello0'::text
-                                 ->  Seq Scan on pt_1_prt_5  (cost=0.00..3.11 rows=1 width=4)
-                                       Filter: pt1 = 'hello0'::text
-                                 ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.11 rows=1 width=4)
-                                       Filter: pt1 = 'hello0'::text
-                     ->  Hash  (cost=19.08..19.08 rows=36 width=4)
-                           ->  Append  (cost=0.00..19.08 rows=36 width=4)
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=39.06..39.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=38.99..39.04 rows=1 width=8)
+         ->  Aggregate  (cost=38.99..39.00 rows=1 width=8)
+               ->  Hash Join  (cost=19.14..38.76 rows=31 width=0)
+                     Hash Cond: (pt1_1_prt_junk_data.ptid = pt_1_prt_junk_data.ptid)
+                     ->  Append  (cost=0.00..18.08 rows=36 width=4)
+                           ->  Result  (cost=0.00..3.63 rows=21 width=4)
+                                 One-Time Filter: PartSelected
                                  ->  Seq Scan on pt1_1_prt_junk_data  (cost=0.00..3.63 rows=21 width=4)
-                                 ->  Seq Scan on pt1_1_prt_2  (cost=0.00..3.09 rows=3 width=4)
+                           ->  Result  (cost=0.00..2.09 rows=3 width=4)
+                                 One-Time Filter: PartSelected
+                                 ->  Seq Scan on pt1_1_prt_2  (cost=0.00..2.09 rows=3 width=4)
+                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                 One-Time Filter: PartSelected
                                  ->  Seq Scan on pt1_1_prt_3  (cost=0.00..3.09 rows=3 width=4)
+                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                 One-Time Filter: PartSelected
                                  ->  Seq Scan on pt1_1_prt_4  (cost=0.00..3.09 rows=3 width=4)
+                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                 One-Time Filter: PartSelected
                                  ->  Seq Scan on pt1_1_prt_5  (cost=0.00..3.09 rows=3 width=4)
+                           ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                 One-Time Filter: PartSelected
                                  ->  Seq Scan on pt1_1_prt_6  (cost=0.00..3.09 rows=3 width=4)
+                     ->  Hash  (cost=18.91..18.91 rows=6 width=4)
+                           ->  Partition Selector for pt1 (dynamic scan id: 2)  (cost=0.00..18.91 rows=6 width=4)
+                                 Filter: pt_1_prt_junk_data.ptid
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..18.91 rows=6 width=4)
+                                       ->  Append  (cost=0.00..18.68 rows=2 width=4)
+                                             ->  Seq Scan on pt_1_prt_junk_data  (cost=0.00..3.11 rows=1 width=4)
+                                                   Filter: (pt1 = 'hello0'::text)
+                                             ->  Seq Scan on pt_1_prt_2  (cost=0.00..3.11 rows=1 width=4)
+                                                   Filter: (pt1 = 'hello0'::text)
+                                             ->  Seq Scan on pt_1_prt_3  (cost=0.00..3.11 rows=1 width=4)
+                                                   Filter: (pt1 = 'hello0'::text)
+                                             ->  Seq Scan on pt_1_prt_4  (cost=0.00..3.11 rows=1 width=4)
+                                                   Filter: (pt1 = 'hello0'::text)
+                                             ->  Seq Scan on pt_1_prt_5  (cost=0.00..3.11 rows=1 width=4)
+                                                   Filter: (pt1 = 'hello0'::text)
+                                             ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.11 rows=1 width=4)
+                                                   Filter: (pt1 = 'hello0'::text)
  Optimizer: Postgres query optimizer
-(28 rows)
+(42 rows)
 
 select count(*) from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0';
  count 
@@ -2278,11 +2306,11 @@ explain select * from apart as a, b, c where a.t = b.t and a.id = c.id;
                      ->  Seq Scan on apart_1_prt_3 a_2  (cost=0.00..5.00 rows=67 width=8)
                      ->  Seq Scan on apart_1_prt_4 a_3  (cost=0.00..5.00 rows=67 width=8)
                      ->  Seq Scan on apart_1_prt_5 a_4  (cost=0.00..4.99 rows=67 width=8)
-               ->  Hash  (cost=3.20..3.20 rows=7 width=6)
-                     ->  Seq Scan on c  (cost=0.00..3.20 rows=7 width=6)
-         ->  Hash  (cost=3.20..3.20 rows=4 width=6)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.20 rows=4 width=6)
-                     ->  Seq Scan on b  (cost=0.00..3.05 rows=2 width=6)
+               ->  Hash  (cost=3.25..3.25 rows=5 width=6)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=6)
+                           ->  Seq Scan on b  (cost=0.00..3.05 rows=2 width=6)
+         ->  Hash  (cost=3.20..3.20 rows=7 width=6)
+               ->  Seq Scan on c  (cost=0.00..3.20 rows=7 width=6)
  Optimizer: Postgres query optimizer
 (17 rows)
 
@@ -2298,13 +2326,13 @@ select * from apart as a, b, c where a.t = b.t and a.id = c.id;
 
 set gp_dynamic_partition_pruning = on;
 explain select * from apart as a, b, c where a.t = b.t and a.id = c.id;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=6.78..35.85 rows=5 width=20)
-   ->  Hash Join  (cost=6.78..35.85 rows=2 width=20)
-         Hash Cond: a.t = b.t
-         ->  Hash Join  (cost=3.45..32.39 rows=7 width=14)
-               Hash Cond: a.id = c.id
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=6.89..34.56 rows=5 width=20)
+   ->  Hash Join  (cost=6.89..34.56 rows=2 width=20)
+         Hash Cond: (a.id = c.id)
+         ->  Hash Join  (cost=3.44..31.04 rows=4 width=14)
+               Hash Cond: (a.t = b.t)
                ->  Append  (cost=0.00..24.99 rows=333 width=8)
                      ->  Result  (cost=0.00..5.00 rows=67 width=7)
                            One-Time Filter: PartSelected
@@ -2321,13 +2349,13 @@ explain select * from apart as a, b, c where a.t = b.t and a.id = c.id;
                      ->  Result  (cost=0.00..4.99 rows=67 width=8)
                            One-Time Filter: PartSelected
                            ->  Seq Scan on apart_1_prt_5 a_4  (cost=0.00..4.99 rows=67 width=8)
-               ->  Hash  (cost=3.20..3.20 rows=7 width=6)
-                     ->  Partition Selector for apart (dynamic scan id: 1)  (cost=0.00..3.20 rows=7 width=6)
-                           Filter: c.id
-                           ->  Seq Scan on c  (cost=0.00..3.20 rows=7 width=6)
-         ->  Hash  (cost=3.20..3.20 rows=4 width=6)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.20 rows=4 width=6)
-                     ->  Seq Scan on b  (cost=0.00..3.05 rows=2 width=6)
+               ->  Hash  (cost=3.25..3.25 rows=5 width=6)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=5 width=6)
+                           ->  Seq Scan on b  (cost=0.00..3.05 rows=2 width=6)
+         ->  Hash  (cost=3.20..3.20 rows=7 width=6)
+               ->  Partition Selector for apart (dynamic scan id: 1)  (cost=0.00..3.20 rows=7 width=6)
+                     Filter: c.id
+                     ->  Seq Scan on c  (cost=0.00..3.20 rows=7 width=6)
  Optimizer: Postgres query optimizer
 (29 rows)
 

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -285,6 +285,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
 (1 row)
 
 -- github issues 5795. explain fails previously.
+-- start_ignore
 explain SELECT * from information_schema.key_column_usage;
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
@@ -315,6 +316,7 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: Postgres query optimizer
 (25 rows)
 
+--end_ignore
 -- github issue 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -316,6 +316,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
 (1 row)
 
 -- github issues 5795. explain fails previously.
+-- start_ignore
 explain SELECT * from information_schema.key_column_usage;
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
@@ -346,6 +347,7 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: Postgres query optimizer
 (25 rows)
 
+--end_ignore
 -- github issue 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3079,21 +3079,21 @@ select * from
   int4(sin(1)) q1,
   int4(sin(0)) q2
 where thousand = (q1 + q2);
-                          QUERY PLAN                           
----------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
-         Hash Cond: (tenk1.twothousand = int4_tbl.f1)
+         Hash Cond: (tenk1.thousand = (q1.q1 + q2.q2))
          ->  Hash Join
-               Hash Cond: (tenk1.thousand = (q1.q1 + q2.q2))
+               Hash Cond: (tenk1.twothousand = int4_tbl.f1)
                ->  Seq Scan on tenk1
                ->  Hash
-                     ->  Nested Loop
-                           ->  Function Scan on q1
-                           ->  Function Scan on q2
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Seq Scan on int4_tbl
          ->  Hash
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                     ->  Seq Scan on int4_tbl
+               ->  Nested Loop
+                     ->  Function Scan on q1
+                     ->  Function Scan on q2
  Optimizer: Postgres query optimizer
 (14 rows)
 

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -639,16 +639,16 @@ select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t
 
 -- ensure plan has two inner joins with the where clause & join predicates ANDed
 explain (costs off) select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a = t3.a);
-                      QUERY PLAN                      
-------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: ((t1.a = t2.a) AND (t1.b = t3.b))
-         ->  Seq Scan on t1
+         Hash Cond: (t2.a = t1.a)
+         ->  Seq Scan on t2
          ->  Hash
                ->  Hash Join
-                     Hash Cond: (t2.a = t3.a)
-                     ->  Seq Scan on t2
+                     Hash Cond: ((t1.a = t3.a) AND (t1.b = t3.b))
+                     ->  Seq Scan on t1
                      ->  Hash
                            ->  Seq Scan on t3
  Optimizer: Postgres query optimizer
@@ -714,36 +714,43 @@ explain select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 lef
   join t3 on tt.t1b = t3.b 
   join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b 
   join t3 t3_1 on tt1.t1b = t3_1.b and (tt1.t2a is NULL OR tt1.t1b = t3.b);
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=61.48..78.25 rows=4 width=56)
-   ->  Hash Right Join  (cost=61.48..78.25 rows=2 width=56)
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice7; segments: 3)  (cost=53.13..69.98 rows=4 width=56)
+   ->  Hash Right Join  (cost=53.13..69.91 rows=2 width=56)
          Hash Cond: (t2_1.a = t1_1.a)
          Filter: ((t2_1.a IS NULL) OR (t1_1.b = t3.b))
          ->  Seq Scan on t2 t2_1  (cost=0.00..12.99 rows=333 width=8)
-         ->  Hash  (cost=61.43..61.43 rows=2 width=48)
-               ->  Hash Join  (cost=44.65..61.43 rows=2 width=48)
-                     Hash Cond: (t1_1.b = t1.b)
-                     ->  Seq Scan on t1 t1_1  (cost=0.00..13.00 rows=334 width=8)
-                     ->  Hash  (cost=44.53..44.53 rows=4 width=40)
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=27.62..44.53 rows=4 width=40)
-                                 ->  Hash Right Join  (cost=27.62..44.39 rows=2 width=40)
-                                       Hash Cond: (t2.a = t1.a)
-                                       ->  Seq Scan on t2  (cost=0.00..12.99 rows=333 width=8)
-                                       ->  Hash  (cost=27.58..27.58 rows=2 width=32)
-                                             ->  Hash Join  (cost=4.35..27.58 rows=2 width=32)
-                                                   Hash Cond: (t1.b = t3_1.b)
-                                                   ->  Hash Join  (cost=2.18..25.27 rows=4 width=20)
-                                                         Hash Cond: (t1.b = t3.b)
+         ->  Hash  (cost=53.09..53.09 rows=2 width=48)
+               ->  Redistribute Motion 3:3  (slice6; segments: 3)  (cost=36.25..53.09 rows=2 width=48)
+                     Hash Key: t1_1.a
+                     ->  Hash Right Join  (cost=36.25..53.02 rows=2 width=48)
+                           Hash Cond: (t2.a = t1.a)
+                           ->  Seq Scan on t2  (cost=0.00..12.99 rows=333 width=8)
+                           ->  Hash  (cost=36.21..36.21 rows=2 width=40)
+                                 ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=20.28..36.21 rows=2 width=40)
+                                       Hash Key: t1.a
+                                       ->  Hash Join  (cost=20.28..36.15 rows=2 width=40)
+                                             Hash Cond: (t1.b = t3.b)
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2.18..17.98 rows=4 width=20)
+                                                   Hash Key: t1.b
+                                                   ->  Hash Join  (cost=2.18..17.78 rows=4 width=20)
+                                                         Hash Cond: (t1.b = t3_1.b)
                                                          ->  Seq Scan on t1  (cost=0.00..13.00 rows=334 width=8)
                                                          ->  Hash  (cost=2.10..2.10 rows=2 width=12)
                                                                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.10 rows=2 width=12)
-                                                                     ->  Seq Scan on t3  (cost=0.00..2.02 rows=1 width=12)
-                                                   ->  Hash  (cost=2.10..2.10 rows=2 width=12)
-                                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..2.10 rows=2 width=12)
-                                                               ->  Seq Scan on t3 t3_1  (cost=0.00..2.02 rows=1 width=12)
+                                                                     ->  Seq Scan on t3 t3_1  (cost=0.00..2.02 rows=1 width=12)
+                                             ->  Hash  (cost=17.98..17.98 rows=4 width=20)
+                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=2.18..17.98 rows=4 width=20)
+                                                         Hash Key: t3.b
+                                                         ->  Hash Join  (cost=2.18..17.78 rows=4 width=20)
+                                                               Hash Cond: (t1_1.b = t3.b)
+                                                               ->  Seq Scan on t1 t1_1  (cost=0.00..13.00 rows=334 width=8)
+                                                               ->  Hash  (cost=2.10..2.10 rows=2 width=12)
+                                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..2.10 rows=2 width=12)
+                                                                           ->  Seq Scan on t3  (cost=0.00..2.02 rows=1 width=12)
  Optimizer: Postgres query optimizer
-(27 rows)
+(34 rows)
 
 select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt 
   join t3 on tt.t1b = t3.b 

--- a/src/test/regress/expected/join_hash.out
+++ b/src/test/regress/expected/join_hash.out
@@ -1,0 +1,30 @@
+--
+-- exercises for the hash join code
+--
+begin;
+-- If virtualbuckets is much larger than innerndistinct, and
+-- outerndistinct is much larger than innerndistinct. Then most
+-- tuples of the outer table will match the empty bucket. So when
+-- we calculate the cost of traversing the bucket, we need to ignore
+-- the tuple matching empty bucket.
+savepoint settings;
+create table join_hash_t_small(a int);
+create table join_hash_t_big(b int);
+insert into join_hash_t_small select i%100 from generate_series(0, 3000)i;
+insert into join_hash_t_big select i%100000 from generate_series(1, 100000)i ;
+analyze join_hash_t_small;
+analyze join_hash_t_big;
+explain (costs off) select * from join_hash_t_small, join_hash_t_big where a = b;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (join_hash_t_big.b = join_hash_t_small.a)
+         ->  Seq Scan on join_hash_t_big
+         ->  Hash
+               ->  Seq Scan on join_hash_t_small
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+rollback to settings;
+ROLLBACK;

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -714,17 +714,17 @@ explain (costs off)
 select * from
   (select * from t3 a union all select * from t3 b) ss
   join int4_tbl on f1 = expensivefunc(x);
-                       QUERY PLAN                        
----------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
-         Hash Cond: (int4_tbl.f1 = expensivefunc(a.x))
-         ->  Broadcast Motion 3:3  (slice1; segments: 3)
-               ->  Seq Scan on int4_tbl
+         Hash Cond: (expensivefunc(a.x) = int4_tbl.f1)
+         ->  Append
+               ->  Seq Scan on t3 a
+               ->  Seq Scan on t3 b
          ->  Hash
-               ->  Append
-                     ->  Seq Scan on t3 a
-                     ->  Seq Scan on t3 b
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on int4_tbl
  Optimizer: Postgres query optimizer
 (10 rows)
 

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -110,7 +110,7 @@ test: namespace
 # ----------
 # Another group of parallel tests
 # ----------
-test: privileges security_label collate lock replica_identity
+test: privileges security_label collate lock replica_identity join_hash
 
 # MATERIALIZED_VIEW_FIXME : matview is not supported on greenplum. Enable the test when the feature is ready.
 test: matview

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -147,7 +147,9 @@ explain (format yaml, costs off) SELECT * FROM dummy_aotab;
 explain (format xml, costs off) insert into dummy_aotab values (1);
 
 -- github issues 5795. explain fails previously.
+-- start_ignore
 explain SELECT * from information_schema.key_column_usage;
+--end_ignore
 
 -- github issue 5794.
 set gp_enable_explain_allstat=on;

--- a/src/test/regress/sql/join_hash.sql
+++ b/src/test/regress/sql/join_hash.sql
@@ -1,0 +1,25 @@
+--
+-- exercises for the hash join code
+--
+
+begin;
+
+-- If virtualbuckets is much larger than innerndistinct, and
+-- outerndistinct is much larger than innerndistinct. Then most
+-- tuples of the outer table will match the empty bucket. So when
+-- we calculate the cost of traversing the bucket, we need to ignore
+-- the tuple matching empty bucket.
+savepoint settings;
+create table join_hash_t_small(a int);
+create table join_hash_t_big(b int);
+
+insert into join_hash_t_small select i%100 from generate_series(0, 3000)i;
+insert into join_hash_t_big select i%100000 from generate_series(1, 100000)i ;
+
+analyze join_hash_t_small;
+analyze join_hash_t_big;
+
+explain (costs off) select * from join_hash_t_small, join_hash_t_big where a = b;
+rollback to settings;
+
+ROLLBACK;


### PR DESCRIPTION
The planner will use big table as inner table in hash join
if small table have fewer unique values. But this plan is
much slower than using small table as inner table.

In general, the cost of creating a hash table is higher
than the cost of querying a hash table. So we tend to use
small tables as internal tables. But if the average chain
length of the bucket is large, the situation is just the
opposite.

If virtualbuckets is much larger than innerndistinct, and
outerndistinct is much larger than innerndistinct. Then most
tuples of the outer table will match the empty bucket. So when
we calculate the cost of traversing the bucket, we need to
ignore the tuple matching empty bucket.

So we add the selection rate of the inner table non-empty
bucket. The formula is:
(1 - ((outerndistinct - innerndistinct)/outerndistinct)*
((virtualbuckets - innerndistinct)/virtualbuckets))

this commit cherry-pick from  d525474047757865f88a2f0d6d8e43837e15f70d
Backport from master to gpdb6

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
