### PR TITLE
Fixes misleading indentation

### DIFF
--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -230,7 +230,7 @@ AddDefaultRelationAttributeOptions(Relation rel, List *options)
 	if (!RelationIsAoCols(rel))
 		return;
 
- 	ce = form_default_storage_directive(options);
+	ce = form_default_storage_directive(options);
 	if (!ce)
 		ce = default_column_encoding_clause();
 

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2153,22 +2153,22 @@ BeginCopy(bool is_from,
 	 *
 	 * In COPY_EXECUTE mode, the dispatcher has already done the conversion.
 	 */
-  if (cstate->dispatch_mode != COPY_DISPATCH)
-  {
-	cstate->need_transcoding =
-		((cstate->file_encoding != GetDatabaseEncoding() ||
-		  pg_database_encoding_max_length() > 1));
-	/* See Multibyte encoding comment above */
-	cstate->encoding_embeds_ascii = PG_ENCODING_IS_CLIENT_ONLY(cstate->file_encoding);
-	setEncodingConversionProc(cstate, cstate->file_encoding, !is_from);
-  }
-  else
-  {
-	  cstate->need_transcoding = false;
-	  cstate->encoding_embeds_ascii = PG_ENCODING_IS_CLIENT_ONLY(cstate->file_encoding);
-  }
+	if (cstate->dispatch_mode != COPY_DISPATCH)
+	{
+		cstate->need_transcoding =
+			((cstate->file_encoding != GetDatabaseEncoding() ||
+			  pg_database_encoding_max_length() > 1));
+		/* See Multibyte encoding comment above */
+		cstate->encoding_embeds_ascii = PG_ENCODING_IS_CLIENT_ONLY(cstate->file_encoding);
+		setEncodingConversionProc(cstate, cstate->file_encoding, !is_from);
+	}
+	else
+	{
+		cstate->need_transcoding = false;
+		cstate->encoding_embeds_ascii = PG_ENCODING_IS_CLIENT_ONLY(cstate->file_encoding);
+	}
 
-	cstate->copy_dest = COPY_FILE;		/* default */
+	cstate->copy_dest = COPY_FILE;	/* default */
 
 	MemoryContextSwitchTo(oldcontext);
 

--- a/src/backend/executor/execScan.c
+++ b/src/backend/executor/execScan.c
@@ -315,7 +315,7 @@ tlist_matches_tupdesc(PlanState *ps, List *tlist, Index varno, TupleDesc tupdesc
 	 * If the plan context requires a particular hasoid setting, then that has
 	 * to match, too.
 	 */
- 	{
+	{
 		bool forceOids = ExecContextForcesOids(ps, &hasoid);
 
 		/* If Oid matters, and there are different requirement, then does not match */

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -592,7 +592,7 @@ init_execution_state(List *queryTree_list,
 						  fcache->readonly_func ? CURSOR_OPT_PARALLEL_OK : 0,
 											  NULL);
 
-	 		if (IsA(stmt, PlannedStmt))
+			if (IsA(stmt, PlannedStmt))
 				((PlannedStmt*)stmt)->metricsQueryType = FUNCTION_INNER_QUERY;
 
 			/*


### PR DESCRIPTION
Clang 10 has pretty sensitive (and correct) warnings around misleading
indentations, like the following:

```
functions.c:595:5: warning: misleading indentation; statement is not part of the previous 'else' [-Wmisleading-indentation]
                        if (IsA(stmt, PlannedStmt))
                        ^
functions.c:590:4: note: previous statement is here
                        else
                        ^
1 warning generated.
```

A lot of them has been with us since open sourcing Greenplum. A couple
of them were introduced recently enough. While I was at it, also format
the surrounding code in copy.c with pgindent.
