### PR TITLE
icw: fix deadlock between gporca and DML_over_joins

### DIFF
--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -1698,11 +1698,14 @@ create table tab3 (a int, b int) distributed by (b);
 insert into tab1 values (1, 1);
 insert into tab2 values (1, 1);
 insert into tab3 values (1, 1);
+-- we must not write the WHERE condition as `relname='tab2'`, it matches tables
+-- in all the schemas, which will cause problems in other tests; we should use
+-- the `::regclass` way as it only matches the table in current search_path.
 set allow_system_table_mods=true;
-update pg_class set relpages = 10000 where relname='tab2';
-update pg_class set reltuples = 100000000 where relname='tab2';
-update pg_class set relpages = 100000000 where relname='tab3';
-update pg_class set reltuples = 100000 where relname='tab3';
+update pg_class set relpages = 10000 where oid='tab2'::regclass;
+update pg_class set reltuples = 100000000 where oid='tab2'::regclass;
+update pg_class set relpages = 100000000 where oid='tab3'::regclass;
+update pg_class set reltuples = 100000 where oid='tab3'::regclass;
 -- Planner: there is redistribute motion above tab1, however, we can also
 -- remove the explicit redistribute motion here because the final join
 -- co-locate with the result relation tab1.

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -1700,11 +1700,14 @@ create table tab3 (a int, b int) distributed by (b);
 insert into tab1 values (1, 1);
 insert into tab2 values (1, 1);
 insert into tab3 values (1, 1);
+-- we must not write the WHERE condition as `relname='tab2'`, it matches tables
+-- in all the schemas, which will cause problems in other tests; we should use
+-- the `::regclass` way as it only matches the table in current search_path.
 set allow_system_table_mods=true;
-update pg_class set relpages = 10000 where relname='tab2';
-update pg_class set reltuples = 100000000 where relname='tab2';
-update pg_class set relpages = 100000000 where relname='tab3';
-update pg_class set reltuples = 100000 where relname='tab3';
+update pg_class set relpages = 10000 where oid='tab2'::regclass;
+update pg_class set reltuples = 100000000 where oid='tab2'::regclass;
+update pg_class set relpages = 100000000 where oid='tab3'::regclass;
+update pg_class set reltuples = 100000 where oid='tab3'::regclass;
 -- Planner: there is redistribute motion above tab1, however, we can also
 -- remove the explicit redistribute motion here because the final join
 -- co-locate with the result relation tab1.

--- a/src/test/regress/sql/DML_over_joins.sql
+++ b/src/test/regress/sql/DML_over_joins.sql
@@ -1293,11 +1293,14 @@ insert into tab1 values (1, 1);
 insert into tab2 values (1, 1);
 insert into tab3 values (1, 1);
 
+-- we must not write the WHERE condition as `relname='tab2'`, it matches tables
+-- in all the schemas, which will cause problems in other tests; we should use
+-- the `::regclass` way as it only matches the table in current search_path.
 set allow_system_table_mods=true;
-update pg_class set relpages = 10000 where relname='tab2';
-update pg_class set reltuples = 100000000 where relname='tab2';
-update pg_class set relpages = 100000000 where relname='tab3';
-update pg_class set reltuples = 100000 where relname='tab3';
+update pg_class set relpages = 10000 where oid='tab2'::regclass;
+update pg_class set reltuples = 100000000 where oid='tab2'::regclass;
+update pg_class set relpages = 100000000 where oid='tab3'::regclass;
+update pg_class set reltuples = 100000 where oid='tab3'::regclass;
 
 -- Planner: there is redistribute motion above tab1, however, we can also
 -- remove the explicit redistribute motion here because the final join


### PR DESCRIPTION
The tests `gporca` and `DML_over_joins` both create a table with the
name `tab2` in their own schemas, there is no conflict.  However in
`DML_over_joins` it will update `pg_class` like below:

    update pg_class set relpages = 10000 where relname='tab2';

This will update the `tab2` rows of both tests, so there is a chance to
cause a deadlock on master when the `gporca` test drops its schema and
tables.

Fixed by letting `DML_over_joins` only update the `tab2` row of its own
schema.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
