### PR TITLE
6X: Fix invalid alloc size when invalidating caches

### DIFF
--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -248,6 +248,14 @@ AddInvalidationMessage(InvalidationChunk **listHdr,
 		/* Need another chunk; double size of last chunk */
 		int			chunksize = 2 * chunk->maxitems;
 
+		/*
+		 * Keep in mind: the max allowed alloc size is about 1GB, for
+		 * simplification we set the upper limit to half of that.
+		 */
+#define MAXCHUNKSIZE (MaxAllocSize / 2 / sizeof(SharedInvalidationMessage))
+		if (chunksize > MAXCHUNKSIZE)
+			chunksize >>= 1;
+
 		chunk = (InvalidationChunk *)
 			MemoryContextAlloc(CurTransactionContext,
 							   sizeof(InvalidationChunk) +


### PR DESCRIPTION
In AddInvalidationMessage() a new chunk always has double size of last
chunk, but once the size exceeds 1GB, the max allowed alloc size, an
error like "invalid memory alloc request size 1,342,177,300" will be
thrown.

Fixed by limiting the chunk size.

(cherry picked from commit a268b387530ba4007d97a9c72e402546f48ce9bc)
(cherry picked from commit 8fdf36d7eb3b48dd371f818506b32ca3c41be881)

This is the 6X version of https://github.com/greenplum-db/gpdb/pull/9113

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
