### PR TITLE
(6x backport) Subquery's locus should keep general

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -299,6 +299,15 @@ cdbpathlocus_from_subquery(struct PlannerInfo *root,
 				 */
 				if (flow->locustype == CdbLocusType_SegmentGeneral)
 					CdbPathLocus_MakeSegmentGeneral(&locus, numsegments);
+				else if (flow->locustype == CdbLocusType_General)
+				{
+					/*
+					 * If a subquery's locus is general, we should keep it
+					 * general here. And general locus's numsegments should
+					 * be the cluster size.
+					 */
+					CdbPathLocus_MakeGeneral(&locus, getgpsegmentCount());
+				}
 				else
 					CdbPathLocus_MakeSingleQE(&locus, numsegments);
 			}

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -80,7 +80,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 
 -- cte with function scans
 with cte as (select generate_series(1,10) g)  select * from  dd_singlecol_1 t1, cte where t1.a=cte.g and t1.a=1 limit 100;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | b | g 
 ---+---+---

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -4084,34 +4084,51 @@ select ss2.* from
   on i41.f1 = ss1.c1,
   lateral (select i41.*, i8.*, ss1.* from text_tbl limit 1) ss2
 where ss1.c2 = 0;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Nested Loop
    Output: (i41.f1), (i8.q1), (i8.q2), (i42.f1), (i43.f1), ((42))
-   ->  Hash Join
-         Output: i41.f1, i42.f1, i8.q1, i8.q2, i43.f1, 42
-         Hash Cond: (i41.f1 = i42.f1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         Output: i41.f1, i42.f1, i8.q1, i8.q2, i43.f1, (42)
          ->  Nested Loop
-               Output: i8.q1, i8.q2, i43.f1, i41.f1
+               Output: i41.f1, i42.f1, i8.q1, i8.q2, i43.f1, 42
                ->  Nested Loop
-                     Output: i8.q1, i8.q2, i43.f1
-                     ->  Seq Scan on public.int8_tbl i8
+                     Output: i41.f1, i42.f1, i8.q1, i8.q2
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Output: i41.f1, i42.f1
+                           Hash Key: 0
+                           ->  Hash Join
+                                 Output: i41.f1, i42.f1
+                                 Hash Cond: (i41.f1 = i42.f1)
+                                 ->  Seq Scan on public.int4_tbl i41
+                                       Output: i41.f1
+                                 ->  Hash
+                                       Output: i42.f1
+                                       ->  Seq Scan on public.int4_tbl i42
+                                             Output: i42.f1
+                     ->  Materialize
                            Output: i8.q1, i8.q2
-                           Filter: (i8.q1 = 0)
+                           ->  Seq Scan on public.int8_tbl i8
+                                 Output: i8.q1, i8.q2
+                                 Filter: (i8.q1 = 0)
+               ->  Materialize
+                     Output: i43.f1
                      ->  Seq Scan on public.int4_tbl i43
                            Output: i43.f1
                            Filter: (i43.f1 = 0)
-               ->  Seq Scan on public.int4_tbl i41
-                     Output: i41.f1
-         ->  Hash
-               Output: i42.f1
-               ->  Seq Scan on public.int4_tbl i42
-                     Output: i42.f1
-   ->  Limit
+   ->  Materialize
          Output: (i41.f1), (i8.q1), (i8.q2), (i42.f1), (i43.f1), ((42))
-         ->  Seq Scan on public.text_tbl
-               Output: i41.f1, i8.q1, i8.q2, i42.f1, i43.f1, (42)
-(25 rows)
+         ->  Limit
+               Output: (i41.f1), (i8.q1), (i8.q2), (i42.f1), (i43.f1), ((42))
+               ->  Gather Motion 3:1  (slice3; segments: 3)
+                     Output: (i41.f1), (i8.q1), (i8.q2), (i42.f1), (i43.f1), ((42))
+                     ->  Limit
+                           Output: (i41.f1), (i8.q1), (i8.q2), (i42.f1), (i43.f1), ((42))
+                           ->  Seq Scan on public.text_tbl
+                                 Output: i41.f1, i8.q1, i8.q2, i42.f1, i43.f1, (42)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(42 rows)
 
 --end_ignore
 select ss2.* from
@@ -4136,26 +4153,20 @@ select * from
   left join
     (tenk1 as a1 full join (select 1 as id) as yy on (a1.unique1 = yy.id))
   on (xx.id = coalesce(yy.id));
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)
-   ->  Hash Right Join
-         Hash Cond: (COALESCE((1)) = (1))
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: COALESCE((1))
-               ->  Hash Full Join
-                     Hash Cond: (a1.unique1 = (1))
-                     ->  Seq Scan on tenk1 a1
-                     ->  Hash
-                           ->  Redistribute Motion 1:3  (slice1; segments: 1)
-                                 Hash Key: (1)
-                                 ->  Result
+                      QUERY PLAN                      
+------------------------------------------------------
+ Hash Right Join
+   Hash Cond: (COALESCE((1)) = (1))
+   ->  Hash Full Join
+         Hash Cond: (a1.unique1 = (1))
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on tenk1 a1
          ->  Hash
-               ->  Redistribute Motion 1:3  (slice3; segments: 1)
-                     Hash Key: (1)
-                     ->  Result
+               ->  Result
+   ->  Hash
+         ->  Result
  Optimizer: Postgres query optimizer
-(17 rows)
+(11 rows)
 
 select * from
   (select 1 as id) as xx
@@ -5355,12 +5366,12 @@ select * from
     lateral (select q1, coalesce(ss1.x,q2) as y from int8_tbl d) ss2
   ) on c.q2 = ss2.q1,
   lateral (select ss2.y) ss3;
-                                                                                  QUERY PLAN                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop
+                                                                                     QUERY PLAN                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
    Output: c.q1, c.q2, a.q1, a.q2, b.q1, (COALESCE(b.q2, 42::bigint)), d.q1, (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)), ((COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)))
-   ->  Gather Motion 3:1  (slice4; segments: 3)
-         Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2))
+   ->  Nested Loop
+         Output: c.q1, c.q2, a.q1, a.q2, b.q1, (COALESCE(b.q2, 42::bigint)), d.q1, (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)), ((COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)))
          ->  Hash Right Join
                Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2))
                Hash Cond: (d.q1 = c.q2)
@@ -5389,10 +5400,10 @@ select * from
                            Hash Key: c.q2
                            ->  Seq Scan on public.int8_tbl c
                                  Output: c.q1, c.q2
-   ->  Materialize
-         Output: ((COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)))
-         ->  Result
-               Output: (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2))
+         ->  Materialize
+               Output: ((COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)))
+               ->  Result
+                     Output: (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2))
  Optimizer: Postgres query optimizer
  Settings: optimizer=off
 (38 rows)
@@ -5507,7 +5518,8 @@ select * from int8_tbl i8 left join lateral
                Output: f1, i8.q2
                One-Time Filter: false
  Optimizer: Postgres query optimizer
-(10 rows)
+ Settings: optimizer=off
+(11 rows)
 
 explain (verbose, costs off)
 select * from int8_tbl i8 left join lateral
@@ -5556,23 +5568,32 @@ select * from
   lateral (select f1 from int4_tbl
            where f1 = any (select unique1 from tenk1
                            where unique2 = v.x offset 0)) ss;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Nested Loop
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
    Output: "*VALUES*".column1, "*VALUES*".column2, int4_tbl.f1
-   ->  Values Scan on "*VALUES*"
-         Output: "*VALUES*".column1, "*VALUES*".column2
-   ->  Hash Semi Join
-         Output: int4_tbl.f1
-         Hash Cond: (int4_tbl.f1 = tenk1.unique1)
-         ->  Seq Scan on public.int4_tbl
+   ->  Nested Loop
+         Output: "*VALUES*".column1, "*VALUES*".column2, int4_tbl.f1
+         Join Filter: (SubPlan 1)
+         ->  Values Scan on "*VALUES*"
+               Output: "*VALUES*".column1, "*VALUES*".column2
+         ->  Materialize
                Output: int4_tbl.f1
-         ->  Hash
-               Output: tenk1.unique1
-               ->  Index Scan using tenk1_unique2 on public.tenk1
-                     Output: tenk1.unique1
-                     Index Cond: (tenk1.unique2 = "*VALUES*".column2)
-(14 rows)
+               ->  Seq Scan on public.int4_tbl
+                     Output: int4_tbl.f1
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Output: tenk1.unique1
+                 Filter: (tenk1.unique2 = "*VALUES*".column2)
+                 ->  Materialize
+                       Output: tenk1.unique1, tenk1.unique2
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             Output: tenk1.unique1, tenk1.unique2
+                             ->  Seq Scan on public.tenk1
+                                   Output: tenk1.unique1, tenk1.unique2
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(23 rows)
 
 select * from
   (values (0,9998), (1,1000)) v(id,x),

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -936,3 +936,33 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
  10
 (10 rows)
 
+-- test if subquery locus is general, then
+-- we should keep it general
+set enable_hashjoin to on;
+set enable_mergejoin to off;
+set enable_nestloop to off;
+create table t_randomly_dist_table(c int) distributed randomly;
+-- the following plan should not contain redistributed motion (for planner)
+explain
+select * from (
+  select a from generate_series(1, 10)a
+  union all
+  select a from generate_series(1, 10)a
+) t_subquery_general
+join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=65.00..27369.76 rows=192600 width=8)
+   ->  Hash Join  (cost=65.00..27369.76 rows=64200 width=8)
+         Hash Cond: (t_randomly_dist_table.c = a.a)
+         ->  Seq Scan on t_randomly_dist_table  (cost=0.00..1063.00 rows=32100 width=4)
+         ->  Hash  (cost=40.00..40.00 rows=667 width=4)
+               ->  Append  (cost=0.00..20.00 rows=667 width=4)
+                     ->  Function Scan on generate_series a  (cost=0.00..10.00 rows=334 width=4)
+                     ->  Function Scan on generate_series a_1  (cost=0.00..10.00 rows=334 width=4)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -948,3 +948,37 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
  8
 (10 rows)
 
+-- test if subquery locus is general, then
+-- we should keep it general
+set enable_hashjoin to on;
+set enable_mergejoin to off;
+set enable_nestloop to off;
+create table t_randomly_dist_table(c int) distributed randomly;
+-- the following plan should not contain redistributed motion (for planner)
+explain
+select * from (
+  select a from generate_series(1, 10)a
+  union all
+  select a from generate_series(1, 10)a
+) t_subquery_general
+join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+   ->  Hash Join  (cost=0.00..431.15 rows=1 width=8)
+         Hash Cond: (generate_series.generate_series = t_randomly_dist_table.c)
+         ->  Append  (cost=0.00..0.03 rows=667 width=4)
+               ->  Result  (cost=0.00..0.01 rows=334 width=4)
+                     ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
+               ->  Result  (cost=0.00..0.01 rows=334 width=4)
+                     ->  Function Scan on generate_series generate_series_1  (cost=0.00..0.00 rows=334 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     Hash Key: t_randomly_dist_table.c
+                     ->  Seq Scan on t_randomly_dist_table  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0
+(13 rows)
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -5483,12 +5483,12 @@ select * from
     lateral (select q1, coalesce(ss1.x,q2) as y from int8_tbl d) ss2
   ) on c.q2 = ss2.q1,
   lateral (select ss2.y) ss3;
-                                                                                  QUERY PLAN                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop
+                                                                                     QUERY PLAN                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
    Output: c.q1, c.q2, a.q1, a.q2, b.q1, (COALESCE(b.q2, 42::bigint)), d.q1, (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)), ((COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)))
-   ->  Gather Motion 3:1  (slice4; segments: 3)
-         Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2))
+   ->  Nested Loop
+         Output: c.q1, c.q2, a.q1, a.q2, b.q1, (COALESCE(b.q2, 42::bigint)), d.q1, (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)), ((COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)))
          ->  Hash Right Join
                Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, (COALESCE(b.q2, 42::bigint)), (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2))
                Hash Cond: (d.q1 = c.q2)
@@ -5517,13 +5517,12 @@ select * from
                            Hash Key: c.q2
                            ->  Seq Scan on public.int8_tbl c
                                  Output: c.q1, c.q2
-   ->  Materialize
-         Output: ((COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)))
-         ->  Result
-               Output: (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2))
+         ->  Materialize
+               Output: ((COALESCE((COALESCE(b.q2, 42::bigint)), d.q2)))
+               ->  Result
+                     Output: (COALESCE((COALESCE(b.q2, 42::bigint)), d.q2))
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(38 rows)
+(37 rows)
 
 -- case that breaks the old ph_may_need optimization
 explain (verbose, costs off)
@@ -5588,8 +5587,7 @@ select c.*,a.*,ss1.q1,ss2.q1,ss3.* from
                      ->  Seq Scan on public.int4_tbl i
                            Output: i.f1
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(50 rows)
+(49 rows)
 
 -- check processing of postponed quals (bug #9041)
 explain (verbose, costs off)

--- a/src/test/regress/expected/qp_functions_in_subquery.out
+++ b/src/test/regress/expected/qp_functions_in_subquery.out
@@ -334,9 +334,9 @@ SELECT * FROM foo, (SELECT func1_read_int_sql_stb(5)) r order by 1,2,3;
 
 -- @description function_in_subqry_12.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(5)) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_13.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_int_vol(5)) r order by 1,2,3;
@@ -365,7 +365,7 @@ rollback;
 -- @description function_in_subqry_16.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(5)) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
@@ -3360,25 +3360,25 @@ PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_110.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_113.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_116.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_118.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_119.sql
 begin;
@@ -3389,50 +3389,50 @@ PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_120.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_121.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_stb(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_122.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_imm(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_123.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_124.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_stb(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_125.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_imm(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_126.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_127.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_stb(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_128.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=25190)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_129.sql
 begin;
@@ -3683,32 +3683,28 @@ rollback;
 -- @description function_in_subqry_withfunc2_150.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_153.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_156.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_158.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
@@ -3722,63 +3718,63 @@ rollback;
 -- @description function_in_subqry_withfunc2_160.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_161.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_stb(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_162.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_imm(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_163.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_164.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_stb(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_165.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_imm(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_166.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_167.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_stb(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_168.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=25190)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;

--- a/src/test/regress/expected/qp_functions_in_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_functions_in_subquery_optimizer.out
@@ -3368,25 +3368,25 @@ PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_110.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=24740)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_113.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=24740)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_116.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=24740)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_118.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=24740)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_119.sql
 begin;
@@ -3397,9 +3397,9 @@ PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_120.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=24740)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_121.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_nosql_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg1 slice1 172.17.0.6:25433 pid=118087)
@@ -3412,9 +3412,9 @@ CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_123.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=24740)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_124.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_sql_int_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg1 slice1 172.17.0.6:25433 pid=118087)
@@ -3427,9 +3427,9 @@ CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
 PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_126.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=24740)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_127.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_read_int_stb(5))) r order by 1,2,3;
 ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg1 slice1 172.17.0.6:25433 pid=118087)
@@ -3438,9 +3438,9 @@ PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT r
 -- @description function_in_subqry_withfunc2_128.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_stb(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
-CONTEXT:  PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
+ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:6002 pid=24740)
+CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
+PL/pgSQL function func1_read_setint_sql_stb(integer) line 5 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_129.sql
 begin;
@@ -3691,32 +3691,28 @@ rollback;
 -- @description function_in_subqry_withfunc2_150.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=24740)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_153.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=24740)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_156.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=24740)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_158.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  query plan with multiple segworker groups is not supported
-HINT:  likely caused by a function that reads or modifies data in a distributed table
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=24740)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
@@ -3730,7 +3726,7 @@ rollback;
 -- @description function_in_subqry_withfunc2_160.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=24740)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
@@ -3751,7 +3747,7 @@ rollback;
 -- @description function_in_subqry_withfunc2_163.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=24740)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
@@ -3772,7 +3768,7 @@ rollback;
 -- @description function_in_subqry_withfunc2_166.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=24740)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;
@@ -3786,7 +3782,7 @@ rollback;
 -- @description function_in_subqry_withfunc2_168.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  UPDATE is not allowed in a non-volatile function
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:6002 pid=24740)
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_stb(integer) line 5 at SQL statement
 rollback;

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -2022,20 +2022,21 @@ create function extractq2_2(t int8_tbl) returns table(ret1 int8) as $$
 $$ language sql immutable;
 explain (verbose, costs off)
 select x from int8_tbl, extractq2_2(int8_tbl) f(x);
-                   QUERY PLAN                   
-------------------------------------------------
- Nested Loop
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ((int8_tbl.*).q2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ((int8_tbl.*).q2)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ((int8_tbl.*).q2)
-         ->  Result
-               Output: (int8_tbl.*).q2
+         ->  Materialize
+               Output: ((int8_tbl.*).q2)
+               ->  Result
+                     Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer
-(11 rows)
+ Settings: optimizer=off
+(12 rows)
 
 select x from int8_tbl, extractq2_2(int8_tbl) f(x);
          x         
@@ -2054,23 +2055,24 @@ create function extractq2_append(t int8_tbl) returns table(ret1 int8) as $$
 $$ language sql immutable;
 explain (verbose, costs off)
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
-                   QUERY PLAN                   
-------------------------------------------------
- Nested Loop
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ((int8_tbl.*).q2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ((int8_tbl.*).q2)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ((int8_tbl.*).q2)
-         ->  Append
-               ->  Result
-                     Output: (int8_tbl.*).q2
-               ->  Result
-                     Output: (int8_tbl.*).q2
+         ->  Materialize
+               Output: ((int8_tbl.*).q2)
+               ->  Append
+                     ->  Result
+                           Output: (int8_tbl.*).q2
+                     ->  Result
+                           Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer
-(14 rows)
+ Settings: optimizer=off
+(15 rows)
 
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
          x         
@@ -2091,23 +2093,24 @@ create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$
   select (select extractq2(t))                                                  
 $$ language sql immutable;                                                      
 explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
-                   QUERY PLAN                    
--------------------------------------------------
- Nested Loop
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ($1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ($1)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ($1)
-         ->  Result
-               Output: $1
-               InitPlan 1 (returns $1)  (slice2)
-                 ->  Result
-                       Output: ($0).q2
+         ->  Materialize
+               Output: ($1)
+               ->  Result
+                     Output: $1
+                     InitPlan 1 (returns $1)  (slice2)
+                       ->  Result
+                             Output: ($0).q2
  Optimizer: Postgres query optimizer
-(14 rows)
+ Settings: optimizer=off
+(15 rows)
 
 select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
          x         

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -2024,18 +2024,18 @@ create function extractq2_2(t int8_tbl) returns table(ret1 int8) as $$
 $$ language sql immutable;
 explain (verbose, costs off)
 select x from int8_tbl, extractq2_2(int8_tbl) f(x);
-                   QUERY PLAN                   
-------------------------------------------------
- Nested Loop
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ((int8_tbl.*).q2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ((int8_tbl.*).q2)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ((int8_tbl.*).q2)
-         ->  Result
-               Output: (int8_tbl.*).q2
+         ->  Materialize
+               Output: ((int8_tbl.*).q2)
+               ->  Result
+                     Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -2056,21 +2056,21 @@ create function extractq2_append(t int8_tbl) returns table(ret1 int8) as $$
 $$ language sql immutable;
 explain (verbose, costs off)
 select x from int8_tbl, extractq2_append(int8_tbl) f(x);
-                   QUERY PLAN                   
-------------------------------------------------
- Nested Loop
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ((int8_tbl.*).q2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ((int8_tbl.*).q2)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ((int8_tbl.*).q2)
-         ->  Append
-               ->  Result
-                     Output: (int8_tbl.*).q2
-               ->  Result
-                     Output: (int8_tbl.*).q2
+         ->  Materialize
+               Output: ((int8_tbl.*).q2)
+               ->  Append
+                     ->  Result
+                           Output: (int8_tbl.*).q2
+                     ->  Result
+                           Output: (int8_tbl.*).q2
  Optimizer: Postgres query optimizer
 (14 rows)
 
@@ -2093,21 +2093,21 @@ create function extractq2_wapper(t int8_tbl) returns table(ret1 int8) as $$
   select (select extractq2(t))                                                  
 $$ language sql immutable;                                                      
 explain (verbose, costs off) select x from int8_tbl, extractq2_wapper(int8_tbl) f(x);
-                   QUERY PLAN                    
--------------------------------------------------
- Nested Loop
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: ($1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: int8_tbl.*
+   ->  Nested Loop
+         Output: ($1)
          ->  Seq Scan on public.int8_tbl
                Output: int8_tbl.*
-   ->  Materialize
-         Output: ($1)
-         ->  Result
-               Output: $1
-               InitPlan 1 (returns $1)  (slice2)
-                 ->  Result
-                       Output: ($0).q2
+         ->  Materialize
+               Output: ($1)
+               ->  Result
+                     Output: $1
+                     InitPlan 1 (returns $1)  (slice2)
+                       ->  Result
+                             Output: ($0).q2
  Optimizer: Postgres query optimizer
 (14 rows)
 


### PR DESCRIPTION
If a subquery's locus is general, we should keep it general here.
And general locus's numsegments should be the cluster size.

--------------------------------------

This is cherry-picked from master commit (8acaf307d0a) to 6X.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
