### PR TITLE
5x backport: Subquery's locus should keep general.

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -393,6 +393,15 @@ cdbpathlocus_from_subquery(struct PlannerInfo  *root,
         case FLOW_SINGLETON:
             if (flow->segindex == -1)
                 CdbPathLocus_MakeEntry(&locus);
+	    else if (flow->locustype == CdbLocusType_General)
+	    {
+        	 /*
+	          * If a subquery's locus is general, we should keep it
+	          * general here. And general locus's numsegments should
+		  * be the cluster size.
+		  */
+  	         CdbPathLocus_MakeGeneral(&locus);
+	    }
             else
                 CdbPathLocus_MakeSingleQE(&locus);
             break;

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -85,8 +85,7 @@ INFO:  Dispatch command to SINGLE content
 
 -- cte with function scans
 with cte as (select generate_series(1,10) g)  select * from  dd_singlecol_1 t1, cte where t1.a=cte.g and t1.a=1 limit 100;
-INFO:  Dispatch command to ALL contents
-INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to SINGLE content
  a | b | g 
 ---+---+---
  1 | 1 | 1

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -762,3 +762,34 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
  7
 (10 rows)
 
+-- test if subquery locus is general, then
+-- we should keep it general
+set enable_hashjoin to on;
+set enable_mergejoin to off;
+set enable_nestloop to off;
+create table t_randomly_dist_table(c int) distributed randomly;
+-- the following plan should not contain redistributed motion (for planner)
+explain
+select * from (
+  select a from length('123')a
+  union all
+  select a from length('123')a
+) t_subquery_general
+join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.08..1304.99 rows=193 width=8)
+   ->  Hash Join  (cost=0.08..1304.99 rows=65 width=8)
+         Hash Cond: t_randomly_dist_table.c = a.a
+         ->  Seq Scan on t_randomly_dist_table  (cost=0.00..1062.00 rows=32067 width=4)
+         ->  Hash  (cost=0.06..0.06 rows=1 width=4)
+               ->  Append  (cost=0.00..0.04 rows=1 width=4)
+                     ->  Function Scan on a  (cost=0.00..0.01 rows=1 width=4)
+                     ->  Function Scan on a  (cost=0.00..0.01 rows=1 width=4)
+ Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -762,3 +762,45 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
  7
 (10 rows)
 
+-- test if subquery locus is general, then
+-- we should keep it general
+set enable_hashjoin to on;
+set enable_mergejoin to off;
+set enable_nestloop to off;
+create table t_randomly_dist_table(c int) distributed randomly;
+-- the following plan should not contain redistributed motion (for planner)
+explain
+select * from (
+  select a from length('123')a
+  union all
+  select a from length('123')a
+) t_subquery_general
+join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Hash Join  (cost=0.00..431.00 rows=1 width=8)
+         Hash Cond: a = c
+         ->  Append  (cost=0.00..0.00 rows=1 width=4)
+               ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                           Filter: a = 3
+                           ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+               ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                           Filter: a = 3
+                           ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     Hash Key: c
+                     ->  Table Scan on t_randomly_dist_table  (cost=0.00..431.00 rows=1 width=4)
+                           Filter: c = 3
+ Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=on
+ Optimizer status: PQO version 3.86.0
+(21 rows)
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -1949,3 +1949,36 @@ select * from x, yy;
 (4 rows)
 
 -- End of MPP-17848
+-- test subquery locus
+create table t_test_subquery_locus(a int) distributed randomly;
+explain
+with base(a) as (select * from t_test_subquery_locus where a < 10)
+select * from base where a > 20
+union all
+select port from gp_segment_configuration;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Append  (cost=0.00..1.04 rows=2 width=4)
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+         One-Time Filter: false
+   ->  Seq Scan on gp_segment_configuration  (cost=0.00..1.00 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+with base(a) as (select * from t_test_subquery_locus where a < 10)
+select * from base where a > 20
+union all
+select port from gp_segment_configuration;
+   a   
+-------
+ 15432
+ 25432
+ 25433
+ 25434
+ 25435
+ 25436
+ 25437
+ 16432
+(8 rows)
+

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -354,3 +354,22 @@ SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOI
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
 SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+
+-- test if subquery locus is general, then
+-- we should keep it general
+set enable_hashjoin to on;
+set enable_mergejoin to off;
+set enable_nestloop to off;
+create table t_randomly_dist_table(c int) distributed randomly;
+-- the following plan should not contain redistributed motion (for planner)
+explain
+select * from (
+  select a from length('123')a
+  union all
+  select a from length('123')a
+) t_subquery_general
+join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -340,3 +340,17 @@ with yy as (
 )
 select * from x, yy;
 -- End of MPP-17848
+
+-- test subquery locus
+create table t_test_subquery_locus(a int) distributed randomly;
+
+explain
+with base(a) as (select * from t_test_subquery_locus where a < 10)
+select * from base where a > 20
+union all
+select port from gp_segment_configuration;
+
+with base(a) as (select * from t_test_subquery_locus where a < 10)
+select * from base where a > 20
+union all
+select port from gp_segment_configuration;


### PR DESCRIPTION
If a subquery's locus is general, we should keep it general here.

-----------------------------------------------

This is backport from master commit(8acaf30) to 5x. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
