### PR TITLE
Don't set 'numsegments' on General, Entry or OuterQuery locus.

### DIFF
--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -95,11 +95,8 @@ makeGpPolicy(GpPolicyType ptype, int nattrs, int numsegments)
 	policy->numsegments = numsegments;
 	policy->nattrs = nattrs; 
 
-	Assert(numsegments > 0);
-	if (numsegments == GP_POLICY_INVALID_NUMSEGMENTS())
-	{
-		Assert(!"what's the proper value of numsegments?");
-	}
+	Assert(numsegments > 0 ||
+		   (ptype == POLICYTYPE_ENTRY && numsegments == -1));
 
 	return policy;
 }
@@ -312,8 +309,7 @@ GpPolicyFetch(Oid tbloid)
 
 			if (strcmp(on_clause, "MASTER_ONLY") == 0)
 			{
-				return makeGpPolicy(POLICYTYPE_ENTRY,
-									0, getgpsegmentCount());
+				return makeGpPolicy(POLICYTYPE_ENTRY, 0, -1);
 			}
 
 			return createRandomPartitionedPolicy(getgpsegmentCount());
@@ -413,8 +409,7 @@ GpPolicyFetch(Oid tbloid)
 	/* Interpret absence of a valid policy row as POLICYTYPE_ENTRY */
 	if (policy == NULL)
 	{
-		return makeGpPolicy(POLICYTYPE_ENTRY,
-							0, getgpsegmentCount());
+		return makeGpPolicy(POLICYTYPE_ENTRY, 0, -1);
 	}
 
 	return policy;

--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -753,7 +753,7 @@ cdb_choose_grouping_locus(PlannerInfo *root, Path *path,
 	if (CdbPathLocus_IsBottleneck(path->locus))
 	{
 		need_redistribute = false;
-		CdbPathLocus_MakeNull(&locus, getgpsegmentCount());
+		CdbPathLocus_MakeNull(&locus);
 	}
 	else
 	{
@@ -854,7 +854,7 @@ cdb_choose_grouping_locus(PlannerInfo *root, Path *path,
 				CdbPathLocus_MakeSingleQE(&locus, getgpsegmentCount());
 		}
 		else
-			CdbPathLocus_MakeNull(&locus, getgpsegmentCount());
+			CdbPathLocus_MakeNull(&locus);
 	}
 
 	*need_redistribute_p = need_redistribute;

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -82,11 +82,6 @@ makeCdbHash(int numsegs, int natts, Oid *hashfuncs)
 
 	Assert(numsegs > 0);		/* verify number of segments is legal. */
 
-	if (numsegs == GP_POLICY_INVALID_NUMSEGMENTS())
-	{
-		Assert(!"what's the proper value of numsegments?");
-	}
-
 	/* Allocate a new CdbHash, with space for the datatype OIDs. */
 	h = palloc(sizeof(CdbHash));
 

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1262,10 +1262,6 @@ makeFlow(FlowType flotype, int numsegments)
 	Flow	   *flow = makeNode(Flow);
 
 	Assert(numsegments > 0);
-	if (numsegments == GP_POLICY_INVALID_NUMSEGMENTS())
-	{
-		Assert(!"what's the proper value of numsegments?");
-	}
 
 	flow->flotype = flotype;
 	flow->locustype = CdbLocusType_Null;

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -71,7 +71,6 @@ make_union_motion(Plan *lefttree, int numsegments)
 	Motion	   *motion;
 
 	Assert(numsegments > 0);
-	Assert(numsegments != GP_POLICY_INVALID_NUMSEGMENTS());
 
 	motion = make_motion(NULL, lefttree,
 						 0, NULL, NULL, NULL, NULL /* no ordering */);
@@ -92,7 +91,6 @@ make_sorted_union_motion(PlannerInfo *root, Plan *lefttree, int numSortCols,
 	Motion	   *motion;
 
 	Assert(numsegments > 0);
-	Assert(numsegments != GP_POLICY_INVALID_NUMSEGMENTS());
 
 	motion = make_motion(root, lefttree,
 						 numSortCols, sortColIdx, sortOperators, collations, nullsFirst);
@@ -116,7 +114,6 @@ make_hashed_motion(Plan *lefttree,
 	int			i;
 
 	Assert(numsegments > 0);
-	Assert(numsegments != GP_POLICY_INVALID_NUMSEGMENTS());
 	Assert(list_length(hashExprs) == list_length(hashOpfamilies));
 
 	/* Look up the right hash functions for the hash expressions */
@@ -146,7 +143,6 @@ make_broadcast_motion(Plan *lefttree, int numsegments)
 	Motion	   *motion;
 
 	Assert(numsegments > 0);
-	Assert(numsegments != GP_POLICY_INVALID_NUMSEGMENTS());
 
 	motion = make_motion(NULL, lefttree,
 						 0, NULL, NULL, NULL, NULL /* no ordering */);
@@ -166,7 +162,6 @@ make_explicit_motion(PlannerInfo *root, Plan *lefttree, AttrNumber segidColIdx, 
 	base.node = (Node *) root;
 
 	Assert(numsegments > 0);
-	Assert(numsegments != GP_POLICY_INVALID_NUMSEGMENTS());
 	Assert(segidColIdx > 0 && segidColIdx <= list_length(lefttree->targetlist));
 
 	motion = make_motion(NULL, lefttree,

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -313,27 +313,22 @@ make_motion_hash_all_targets(PlannerInfo *root, Path *subpath, List *tlist)
 void
 mark_append_locus(Path *path, GpSetOpType optype)
 {
-	/*
-	 * FIXME: for append we forcely collect data on all segments
-	 */
-	int			numsegments = getgpsegmentCount();
-
 	switch (optype)
 	{
 		case PSETOP_GENERAL:
-			CdbPathLocus_MakeGeneral(&path->locus, numsegments);
+			CdbPathLocus_MakeGeneral(&path->locus);
 			break;
 		case PSETOP_PARALLEL_PARTITIONED:
-			CdbPathLocus_MakeStrewn(&path->locus, numsegments);
+			CdbPathLocus_MakeStrewn(&path->locus, getgpsegmentCount());
 			break;
 		case PSETOP_SEQUENTIAL_QD:
 			CdbPathLocus_MakeEntry(&path->locus);
 			break;
 		case PSETOP_SEQUENTIAL_QE:
-			CdbPathLocus_MakeSingleQE(&path->locus, numsegments);
+			CdbPathLocus_MakeSingleQE(&path->locus, getgpsegmentCount());
 			break;
 		case PSETOP_SEQUENTIAL_OUTERQUERY:
-			CdbPathLocus_MakeOuterQuery(&path->locus, numsegments);
+			CdbPathLocus_MakeOuterQuery(&path->locus);
 			break;
 		case PSETOP_NONE:
 			break;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4931,7 +4931,7 @@ AdjustReplicatedTableCounts(EState *estate)
 	int i;
 	ResultRelInfo *resultRelInfo;
 	bool containReplicatedTable = false;
-	int			numsegments = getgpsegmentCount();
+	int			numsegments =  1;
 
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -568,6 +568,7 @@ CTranslatorRelcacheToDXL::RetrieveRel
 	}
 
 	if (NULL != rel->rd_cdbpolicy &&
+		POLICYTYPE_ENTRY != rel->rd_cdbpolicy->ptype &&
 		gpdb::GetGPSegmentCount() != rel->rd_cdbpolicy->numsegments)
 	{
 		// GPORCA does not support partially distributed tables yet

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -455,7 +455,7 @@ bring_to_outer_query(PlannerInfo *root, RelOptInfo *rel, List *outer_quals)
 			if (origpath->param_info)
 				continue;
 
-			CdbPathLocus_MakeOuterQuery(&outerquery_locus, origpath->locus.numsegments);
+			CdbPathLocus_MakeOuterQuery(&outerquery_locus);
 
 			path = cdbpath_create_motion_path(root,
 											  origpath,
@@ -1973,8 +1973,7 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 							make_tlist_from_pathtarget(subpath->pathtarget));
 
 		if (forceDistRand)
-			CdbPathLocus_MakeStrewn(&locus,
-									CdbPathLocus_NumSegments(subpath->locus));
+			CdbPathLocus_MakeStrewn(&locus, getgpsegmentCount());
 		else
 			locus = cdbpathlocus_from_subquery(root, rel, subpath);
 

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -5417,7 +5417,7 @@ int planner_segment_count(GpPolicy *policy)
 		return 1;
 	else if ( gp_segments_for_planner > 0 )
 		return gp_segments_for_planner;
-	else if (policy)
+	else if (policy && policy->ptype != POLICYTYPE_ENTRY)
 		return policy->numsegments;
 	else
 		return getgpsegmentCount();

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -8102,7 +8102,11 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 	Path	   *subpath = path->subpath;
 	int			numsegments;
 
-	numsegments = CdbPathLocus_NumSegments(path->path.locus);
+	if (CdbPathLocus_IsOuterQuery(path->path.locus) ||
+		CdbPathLocus_IsEntry(path->path.locus))
+		numsegments = 1;  /* dummy numsegments */
+	else
+		numsegments = CdbPathLocus_NumSegments(path->path.locus);
 
 	if (path->is_explicit_motion)
 	{

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1875,7 +1875,7 @@ grouping_planner(PlannerInfo *root, bool inheritance_update,
 	CdbPathLocus current_locus;
 	bool		must_gather;
 
-	CdbPathLocus_MakeNull(&current_locus, GP_POLICY_INVALID_NUMSEGMENTS());
+	CdbPathLocus_MakeNull(&current_locus);
 
 	/* Tweak caller-supplied tuple_fraction if have LIMIT/OFFSET */
 	if (parse->limitCount || parse->limitOffset)

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -29,6 +29,7 @@
 
 #include "catalog/gp_policy.h"
 #include "cdb/cdbpath.h"
+#include "cdb/cdbutil.h"
 #include "nodes/makefuncs.h"                /* makeVar() */
 #include "nodes/nodeFuncs.h"
 #include "optimizer/var.h"                  /* contain_vars_of_level_or_above */
@@ -163,8 +164,14 @@ build_simple_rel(PlannerInfo *root, int relid, RelOptKind reloptkind)
 			if (rte->forceDistRandom)
 			{
 				GpPolicy   *origpolicy = GpPolicyFetch(rte->relid);
+				int			numsegments;
 
-				rel->cdbpolicy = createRandomPartitionedPolicy(origpolicy->numsegments);
+				if (origpolicy->ptype != POLICYTYPE_ENTRY)
+					numsegments = origpolicy->numsegments;
+				else
+					numsegments = getgpsegmentCount();
+
+				rel->cdbpolicy = createRandomPartitionedPolicy(numsegments);
 
 				/* Scribble the tuple number of rel to reflect the real size */
 				rel->tuples = rel->tuples * planner_segment_count(rel->cdbpolicy);

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -62,12 +62,6 @@ typedef FormData_gp_policy *Form_gp_policy;
 #define SYM_POLICYTYPE_REPLICATED 'r'
 
 /*
- * A magic number, setting GpPolicy.numsegments to this value will cause a
- * failed assertion at runtime, which allows developers to debug with gdb.
- */
-#define GP_POLICY_INVALID_NUMSEGMENTS()		(-1)
-
-/*
  * Default set of segments, the value is controlled by the variable
  * gp_create_table_default_numsegments.
  */

--- a/src/include/cdb/cdbpathlocus.h
+++ b/src/include/cdb/cdbpathlocus.h
@@ -221,14 +221,14 @@ typedef struct CdbPathLocus
         _locus->distkey = NIL;                        \
     } while (0)
 
-#define CdbPathLocus_MakeNull(plocus, numsegments_)                   \
-            CdbPathLocus_MakeSimple((plocus), CdbLocusType_Null, (numsegments_))
+#define CdbPathLocus_MakeNull(plocus)                   \
+            CdbPathLocus_MakeSimple((plocus), CdbLocusType_Null, -1)
 #define CdbPathLocus_MakeEntry(plocus)                  \
-            CdbPathLocus_MakeSimple((plocus), CdbLocusType_Entry, getgpsegmentCount())
+            CdbPathLocus_MakeSimple((plocus), CdbLocusType_Entry, -1)
 #define CdbPathLocus_MakeSingleQE(plocus, numsegments_)               \
             CdbPathLocus_MakeSimple((plocus), CdbLocusType_SingleQE, (numsegments_))
-#define CdbPathLocus_MakeGeneral(plocus, numsegments_)                \
-            CdbPathLocus_MakeSimple((plocus), CdbLocusType_General, (numsegments_))
+#define CdbPathLocus_MakeGeneral(plocus)                \
+            CdbPathLocus_MakeSimple((plocus), CdbLocusType_General, -1)
 #define CdbPathLocus_MakeSegmentGeneral(plocus, numsegments_)                \
             CdbPathLocus_MakeSimple((plocus), CdbLocusType_SegmentGeneral, (numsegments_))
 #define CdbPathLocus_MakeReplicated(plocus, numsegments_)             \
@@ -252,9 +252,8 @@ typedef struct CdbPathLocus
 #define CdbPathLocus_MakeStrewn(plocus, numsegments_)                 \
             CdbPathLocus_MakeSimple((plocus), CdbLocusType_Strewn, (numsegments_))
 
-// GPDB_96_MERGE_FIXME numsegments doens't really make sense here
-#define CdbPathLocus_MakeOuterQuery(plocus, numsegments_)                 \
-	CdbPathLocus_MakeSimple((plocus), CdbLocusType_OuterQuery, (numsegments_))
+#define CdbPathLocus_MakeOuterQuery(plocus)                 \
+	CdbPathLocus_MakeSimple((plocus), CdbLocusType_OuterQuery, -1)
 
 /************************************************************************/
 


### PR DESCRIPTION
It's not clear what 'numsegments' means on a General, Entry or OuterQuery
locus. General means that the path is executable anywhere, and Entry means
it's executable in the dispatcher node, and neither of those really have
sensible concept of 'numsegments'. And OuterQuery means "whatever locus
the outer query has". So remove the 'numsegments' argument from their
constructors, set it to -1 instead. This requires adjusting a few
assertions that assumed that numsegments is set to something that looks
valid for those locus types.
