### PR TITLE
Remove nobarrier, allocsize mount options from docs

### DIFF
--- a/gpdb-doc/dita/best_practices/sysconfig.xml
+++ b/gpdb-doc/dita/best_practices/sysconfig.xml
@@ -35,9 +35,11 @@
 
     <section id="file_system">
       <title>File System</title>
-      <p>XFS is the file system used for Greenplum Database data directories. XFS should be mounted
-        with the following mount options:
-        <codeblock>rw,nodev,noatime,inode64</codeblock></p>
+      <p>XFS is the file system used for Greenplum Database data directories. On RHEL/CentOS
+        systems, mount XFS volumes with the following mount options:
+        <codeblock>rw,nodev,noatime,nobarrier,inode64</codeblock></p>
+      <p>The <codeph>nobarrier</codeph> option is not supported on Ubuntu systems. Use only the
+        options:<codeblock>rw,nodev,noatime,inode64</codeblock></p>
     </section>
     <section id="port_config"><p>See the <xref href="../install_guide/prep_os.html#topic3"
           format="dita" scope="peer">recommended OS parameter settings</xref> in the <cite>Greenplum

--- a/gpdb-doc/dita/best_practices/sysconfig.xml
+++ b/gpdb-doc/dita/best_practices/sysconfig.xml
@@ -37,7 +37,7 @@
       <title>File System</title>
       <p>XFS is the file system used for Greenplum Database data directories. XFS should be mounted
         with the following mount options:
-        <codeblock>rw,nodev,noatime,nobarrier,inode64</codeblock></p>
+        <codeblock>rw,nodev,noatime,inode64</codeblock></p>
     </section>
     <section id="port_config"><p>See the <xref href="../install_guide/prep_os.html#topic3"
           format="dita" scope="peer">recommended OS parameter settings</xref> in the <cite>Greenplum

--- a/gpdb-doc/dita/install_guide/prep_os.xml
+++ b/gpdb-doc/dita/install_guide/prep_os.xml
@@ -290,12 +290,12 @@ vm.dirty_ratio = 10</codeblock></p>
       <title>XFS Mount Options</title>
       <p>XFS is the preferred data storage file system on Linux platforms. Use the
             <codeph>mount</codeph> command with the following recommended XFS mount
-          options:<codeblock>rw,nodev,noatime,nobarrier,inode64</codeblock></p>
+          options:<codeblock>rw,nodev,noatime,inode64</codeblock></p>
       <p>See the <codeph>mount</codeph> manual page (<codeph>man mount</codeph> opens the man page)
           for more information about using this command.</p>
       <p>The XFS options can also be set in the <codeph>/etc/fstab</codeph> file. This example entry
         from an <codeph>fstab</codeph> file specifies the XFS options.</p>
-      <codeblock>/dev/data /data xfs nodev,noatime,nobarrier,inode64 0 0</codeblock>
+      <codeblock>/dev/data /data xfs nodev,noatime,inode64 0 0</codeblock>
     </section>
     <section id="disk_io_settings">
       <title>Disk I/O Settings</title>

--- a/gpdb-doc/dita/install_guide/prep_os.xml
+++ b/gpdb-doc/dita/install_guide/prep_os.xml
@@ -289,13 +289,15 @@ vm.dirty_ratio = 10</codeblock></p>
     <section id="xfs_mount">
       <title>XFS Mount Options</title>
       <p>XFS is the preferred data storage file system on Linux platforms. Use the
-            <codeph>mount</codeph> command with the following recommended XFS mount
+            <codeph>mount</codeph> command with the following recommended XFS mount options for RHEL
+          and CentOS systems:<codeblock>rw,nodev,noatime,nobarrier,inode64</codeblock></p>
+      <p>The <codeph>nobarrier</codeph> option is not supported on Ubuntu systems. Use only the
           options:<codeblock>rw,nodev,noatime,inode64</codeblock></p>
-      <p>See the <codeph>mount</codeph> manual page (<codeph>man mount</codeph> opens the man page)
-          for more information about using this command.</p>
+        <p>See the <codeph>mount</codeph> manual page (<codeph>man mount</codeph> opens the man
+          page) for more information about using this command.</p>
       <p>The XFS options can also be set in the <codeph>/etc/fstab</codeph> file. This example entry
         from an <codeph>fstab</codeph> file specifies the XFS options.</p>
-      <codeblock>/dev/data /data xfs nodev,noatime,inode64 0 0</codeblock>
+      <codeblock>/dev/data /data xfs nodev,noatime,nobarrier,inode64 0 0</codeblock>
     </section>
     <section id="disk_io_settings">
       <title>Disk I/O Settings</title>

--- a/gpdb-doc/markdown/cloud/gpdb-cloud-tech-rec.html.md.erb
+++ b/gpdb-doc/markdown/cloud/gpdb-cloud-tech-rec.html.md.erb
@@ -22,7 +22,7 @@ The disk settings for cloud deployments are the same as on-premise with a few mo
 
 -  Mount options:
    ```
-   rw,noatime,nodev,inode64,allocsize=16m
+   rw,noatime,nodev,inode64
    ```
 -  Use mq-deadline instead of the deadline scheduler for the R5 series instance type in AWS
 -  For clusters requiring software RAID, use level 0 and chunk size of 256

--- a/gpdb-doc/markdown/cloud/gpdb-cloud-tech-rec.html.md.erb
+++ b/gpdb-doc/markdown/cloud/gpdb-cloud-tech-rec.html.md.erb
@@ -22,8 +22,9 @@ The disk settings for cloud deployments are the same as on-premise with a few mo
 
 -  Mount options:
    ```
-   rw,noatime,nodev,inode64
+   rw,noatime,nobarrier,nodev,inode64
    ```
+    <br/>**Note:** The `nobarrier` option is not supported on Ubuntu nodes.
 -  Use mq-deadline instead of the deadline scheduler for the R5 series instance type in AWS
 -  For clusters requiring software RAID, use level 0 and chunk size of 256
 -  Use a swap disk per VM (32GB size works well)

--- a/gpdb-doc/markdown/cloud/gpdb-cloud-tech-rec.html.md.erb
+++ b/gpdb-doc/markdown/cloud/gpdb-cloud-tech-rec.html.md.erb
@@ -22,7 +22,7 @@ The disk settings for cloud deployments are the same as on-premise with a few mo
 
 -  Mount options:
    ```
-   rw,noatime,nobarrier,nodev,inode64,allocsize=16m
+   rw,noatime,nodev,inode64,allocsize=16m
    ```
 -  Use mq-deadline instead of the deadline scheduler for the R5 series instance type in AWS
 -  For clusters requiring software RAID, use level 0 and chunk size of 256


### PR DESCRIPTION
Removing `nobarrier` as its not supported in Ubuntu, and is no longer recommended in RHEL/CentOS. Also removing one remaining stray reference to `allocsize` (removed from docs in earlier commit).

Change will be backported to 6X_STABLE, 5X_STABLE.