### PR TITLE
Fix flaky test failures due to oid conflict.

### DIFF
--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -48,7 +48,11 @@ test: modify_table_data_corrupt
 # concurrent test, so run the test by itself.
 test: deadlock_under_entry_db_singleton
 
-test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue misc
+#  this case creates table & index in utility mode, which may cause oid
+#  conflict when running in parallel with other cases.
+test: misc
+
+test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue
 test: vacuum_drop_phase_ao
 
 # below test(s) inject faults so each of them need to be in a separate group


### PR DESCRIPTION
    Saw the below similar test failure (e.g. in test starve_case) some times.  It
    seems that this is due to test misc. test misc was run in parallel with other
    tests (besides starve_case).  It creates table and index in utility mode and
    could easily introduce oid conflict. Moving the test out of the parallel
    running group to fix the failures.

     create table starve (c int);

     CREATE

     create table starve_helper (name varchar, sessionid int);

    -CREATE

    +DETAIL:  Key (oid)=(131128) already exists.

    +ERROR:  duplicate key value violates unique constraint "pg_type_oid_index"