### PR TITLE
Fixes misleading indentation

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -631,19 +631,19 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 	if (es->analyze)
 		ExplainPrintTriggers(es, queryDesc);
 
-    /*
-     * Display per-slice and whole-query statistics.
-     */
-    if (es->analyze)
-        cdbexplain_showExecStatsEnd(queryDesc->plannedstmt, queryDesc->showstatctx,
+	/*
+	 * Display per-slice and whole-query statistics.
+	 */
+	if (es->analyze)
+		cdbexplain_showExecStatsEnd(queryDesc->plannedstmt, queryDesc->showstatctx,
 									queryDesc->estate, es);
 
-    /*
+	/*
 	 * Show non-default GUC settings that might have affected the plan as well
 	 * as optimizer settings etc.
-     */
+	 */
 	ExplainOpenGroup("Settings", "Settings", true, es);
-	
+
 	if (queryDesc->plannedstmt->planGen == PLANGEN_PLANNER)
 		ExplainProperty("Optimizer", "Postgres query optimizer", false, es);
 #ifdef USE_ORCA

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -2327,16 +2327,16 @@ print_addrinfo_list(struct addrinfo *head)
 static void
 signal_register()
 {
-    /* when SIGTERM raised invoke process_term_signal */
-    signal_set(&gcb.signal_event,SIGTERM,process_term_signal,0);
+	/* when SIGTERM raised invoke process_term_signal */
+	signal_set(&gcb.signal_event, SIGTERM, process_term_signal, 0);
 
-    /* high priority so we accept as fast as possible */
-    if(event_priority_set(&gcb.signal_event, 0))
-        gwarning(NULL,"signal event priority set failed");
+	/* high priority so we accept as fast as possible */
+	if (event_priority_set(&gcb.signal_event, 0))
+		gwarning(NULL, "signal event priority set failed");
 
-    /* start watching this event */
-	if(signal_add(&gcb.signal_event, 0))
-        gfatal(NULL,"cannot set up event on signal register");
+	/* start watching this event */
+	if (signal_add(&gcb.signal_event, 0))
+		gfatal(NULL, "cannot set up event on signal register");
 
 }
 


### PR DESCRIPTION
This commit fixes the new Clang 10 warnings around misleading
indentation, in the same vein as commit b93a631f82607ebd.