### PR TITLE
Pg upgrade multiple tablespaces in filespace

### DIFF
--- a/contrib/pg_upgrade/function.c
+++ b/contrib/pg_upgrade/function.c
@@ -103,6 +103,12 @@ install_support_functions_in_new_db(const char *db_name)
 							  "RETURNS VOID "
 							  "AS '$libdir/pg_upgrade_support' "
 							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(conn,
+	                          "CREATE OR REPLACE FUNCTION "
+	                          "binary_upgrade.set_next_preassigned_tablespace_oid(OID, TEXT) "
+	                          "RETURNS VOID "
+	                          "AS '$libdir/pg_upgrade_support' "
+	                          "LANGUAGE C STRICT;"));
 
 	PQfinish(conn);
 }

--- a/contrib/pg_upgrade/greenplum/info_gp.c
+++ b/contrib/pg_upgrade/greenplum/info_gp.c
@@ -37,13 +37,11 @@ system_tablespace(void)
 }
 
 static GetTablespacePathResponse
-found_in_file(char *tablespace_path, Oid tablespace_oid)
+found_in_file(char *tablespace_path)
 {
 	return make_response(
 		GetTablespacePathResponse_FOUND_USER_DEFINED_TABLESPACE,
-		psprintf("%s/%u",
-			tablespace_path,
-			tablespace_oid));
+		tablespace_path);
 }
 
 GetTablespacePathResponse
@@ -60,8 +58,7 @@ gp_get_tablespace_path(OldTablespaceFileContents *oldTablespaceFileContents, Oid
 		return system_tablespace();
 
 	return found_in_file(
-		OldTablespaceRecord_GetDirectoryPath(record),
-		tablespace_oid);
+		OldTablespaceRecord_GetDirectoryPath(record));
 }
 
 /*

--- a/contrib/pg_upgrade/greenplum/old_tablespace_file_contents.c
+++ b/contrib/pg_upgrade/greenplum/old_tablespace_file_contents.c
@@ -221,3 +221,9 @@ OldTablespaceRecord_GetIsUserDefinedTablespace(OldTablespaceRecord *record)
 {
 	return record->is_user_defined;
 }
+
+Oid
+OldTablespaceRecord_GetOid(OldTablespaceRecord *record)
+{
+	return record->tablespace_oid;
+}

--- a/contrib/pg_upgrade/greenplum/old_tablespace_file_contents.h
+++ b/contrib/pg_upgrade/greenplum/old_tablespace_file_contents.h
@@ -57,6 +57,9 @@ OldTablespaceRecord_GetTablespaceName(OldTablespaceRecord *record);
 char *
 OldTablespaceRecord_GetDirectoryPath(OldTablespaceRecord *record);
 
+Oid
+OldTablespaceRecord_GetOid(OldTablespaceRecord *record);
+
 bool
 OldTablespaceRecord_GetIsUserDefinedTablespace(OldTablespaceRecord *record);
 

--- a/contrib/pg_upgrade/test/integration/scripts/pg-upgrade-copy-from-master.c
+++ b/contrib/pg_upgrade/test/integration/scripts/pg-upgrade-copy-from-master.c
@@ -6,7 +6,7 @@
 
 #include "postgres_fe.h"
 #include "utilities/pg-upgrade-copy.h"
-#include "old_tablespace_file_parser_observer.h"
+#include "greenplum/old_tablespace_file_parser_observer.h"
 
 static void
 print_usage_header(char *message)

--- a/contrib/pg_upgrade/test/integration/utilities/pg-upgrade-copy.c
+++ b/contrib/pg_upgrade/test/integration/utilities/pg-upgrade-copy.c
@@ -93,10 +93,11 @@ backup_configuration_files(PgUpgradeCopyOptions *options)
 }
 
 static void
-update_symlinks_for_tablespaces_from(char *segment_path, char *new_tablespace_path)
+update_symlinks_for_tablespaces_from(char *segment_path, Oid tablespace_oid, char *new_tablespace_path)
 {
-	system(psprintf("find %s/pg_tblspc/* | xargs -I '{}' ln -sfn %s '{}'",
+	system(psprintf("find %s/pg_tblspc/%u | xargs -I '{}' ln -sfn %s '{}'",
 	                segment_path,
+	                tablespace_oid,
 	                new_tablespace_path));
 }
 
@@ -137,6 +138,7 @@ copy_tablespaces_from_the_master(PgUpgradeCopyOptions *copy_options)
 
 		update_symlinks_for_tablespaces_from(
 			copy_options->new_segment_path,
+			OldTablespaceRecord_GetOid(current_segment_record),
 			segment_tablespace_location_directory_with_gp_dbid);
 	}
 }

--- a/contrib/pg_upgrade/test/unit/info_gp_test.c
+++ b/contrib/pg_upgrade/test/unit/info_gp_test.c
@@ -108,7 +108,7 @@ test_it_returns_tablespace_path_when_tablespace_found_by_oid(void **state)
 	GetTablespacePathResponse response = gp_get_tablespace_path(make_fake_old_tablespace_file_contents(), tablespace_oid);
 
 	assert_int_equal(response.code, GetTablespacePathResponse_FOUND_USER_DEFINED_TABLESPACE);
-	assert_string_equal(response.tablespace_path, "some_path_to_tablespace/1234");
+	assert_string_equal(response.tablespace_path, "some_path_to_tablespace");
 }
 
 static void

--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -19,6 +19,7 @@
 #include "catalog/pg_class.h"
 #include "catalog/pg_enum.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_tablespace.h"
 #include "catalog/pg_type.h"
 #include "cdb/cdbvars.h"
 #include "commands/extension.h"
@@ -54,6 +55,7 @@ PG_FUNCTION_INFO_V1(create_empty_extension);
 PG_FUNCTION_INFO_V1(set_next_pg_namespace_oid);
 
 PG_FUNCTION_INFO_V1(set_preassigned_oids);
+PG_FUNCTION_INFO_V1(set_next_preassigned_tablespace_oid);
 
 Datum
 set_next_pg_type_oid(PG_FUNCTION_ARGS)
@@ -254,3 +256,19 @@ set_preassigned_oids(PG_FUNCTION_ARGS)
 
 	PG_RETURN_VOID();
 }
+
+Datum
+set_next_preassigned_tablespace_oid(PG_FUNCTION_ARGS)
+{
+	Oid			tsoid = PG_GETARG_OID(0);
+	char	   *objname = GET_STR(PG_GETARG_TEXT_P(1));
+
+	if (Gp_role == GP_ROLE_UTILITY)
+	{
+		AddPreassignedOidFromBinaryUpgrade(tsoid, TableSpaceRelationId, objname,
+		                                   InvalidOid, InvalidOid, InvalidOid);
+	}
+
+	PG_RETURN_VOID();
+}
+


### PR DESCRIPTION
Upgrade filespaces with multiple tablespaces

This solves a problem in upgrade where we'd try to create the GPDB tablespace directory layout multiple times for tablespaces belonging to the same filespace, which does not succeed. Create layout per tablespace oid directory, which are unique and avoids collision.

- dump tablespace with location including tablespace oid
- restore creates GPDB tablespace layout in the tablespace oid dir
- modify the old tablespace mapping file to include the tablespace oid
- modify test library to update symlinks to respective tablespace oids
- general test cleanup
- preserve tablespace oids during upgrade which helps copy from master