### PR TITLE
BACKPORT 6X: Print warning message in checkNetworkTimeout.

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1242,6 +1242,7 @@ SetupTCPInterconnect(EState *estate)
 
 	interconnect_context->teardownActive = false;
 	interconnect_context->activated = false;
+	interconnect_context->networkTimeoutIsLogged = false;
 	interconnect_context->incompleteConns = NIL;
 	interconnect_context->sliceTable = copyObject(sliceTable);
 	interconnect_context->sliceId = sliceTable->localSlice;

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3040,6 +3040,7 @@ SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable)
 	interconnect_context->size = CTS_INITIAL_SIZE;
 	interconnect_context->states = palloc0(CTS_INITIAL_SIZE * sizeof(ChunkTransportStateEntry));
 
+	interconnect_context->networkTimeoutIsLogged = false;
 	interconnect_context->teardownActive = false;
 	interconnect_context->activated = false;
 	interconnect_context->incompleteConns = NIL;
@@ -5039,7 +5040,7 @@ handleAckForDuplicatePkt(MotionConn *conn, icpkthdr *pkt)
  *		check network timeout case.
  */
 static inline void
-checkNetworkTimeout(ICBuffer *buf, uint64 now)
+checkNetworkTimeout(ICBuffer *buf, uint64 now, bool *networkTimeoutIsLogged)
 {
 	/*
 	 * Using only the time to first sent time to decide timeout is not enough,
@@ -5067,6 +5068,28 @@ checkNetworkTimeout(ICBuffer *buf, uint64 now)
 						   buf->pkt->seq, buf->conn->remoteHostAndPort,
 						   buf->pkt->dstPid, buf->pkt->dstContentId,
 						   buf->nRetry, Gp_interconnect_transmit_timeout)));
+	}
+
+	/*
+	 * Default value of Gp_interconnect_transmit_timeout is one hours.
+	 * It taks too long time to detect a network error and it is not user friendly.
+	 *
+	 * Packets would be dropped repeatly on some specific ports. We'd better have
+	 * a warning messgage for this case and give the DBA a chance to detect this error
+	 * earlier. Since packets would also be dropped when network is bad, we should not
+	 * error out here, but just give a warning message. Erroring our is still handled
+	 * by GUC Gp_interconnect_transmit_timeout as above. Note that warning message should
+	 * be printed for each statement only once.
+	 */
+	if ((buf->nRetry >= Gp_interconnect_min_retries_before_timeout) && !(*networkTimeoutIsLogged))
+	{
+		ereport(WARNING,
+				(errmsg("interconnect may encountered a network error, please check your network"),
+				 errdetail("Failed to send packet (seq %d) to %s (pid %d cid %d) after %d retries.",
+						   buf->pkt->seq, buf->conn->remoteHostAndPort,
+						   buf->pkt->dstPid, buf->pkt->dstContentId,
+						   buf->nRetry)));
+		*networkTimeoutIsLogged = true;
 	}
 }
 
@@ -5112,7 +5135,7 @@ checkExpiration(ChunkTransportState *transportStates,
 			curBuf->conn->stat_max_resent = Max(curBuf->conn->stat_max_resent,
 												curBuf->conn->stat_count_resent);
 
-			checkNetworkTimeout(curBuf, now);
+			checkNetworkTimeout(curBuf, now, &transportStates->networkTimeoutIsLogged);
 
 #ifdef AMS_VERBOSE_LOGGING
 			write_log("RESEND pkt with seq %d (retry %d, rtt " UINT64_FORMAT ") to route %d",
@@ -5284,7 +5307,7 @@ checkExpirationCapacityFC(ChunkTransportState *transportStates,
 		ic_control_info.lastPacketSendTime = now;
 
 		updateRetransmitStatistics(conn);
-		checkNetworkTimeout(buf, now);
+		checkNetworkTimeout(buf, now, &transportStates->networkTimeoutIsLogged);
 	}
 }
 

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -505,6 +505,9 @@ typedef struct ChunkTransportState
 	bool		activated;
 
 	bool		aggressiveRetry;
+	
+	/* whether we've logged when network timeout happens */
+	bool		networkTimeoutIsLogged;
 
 	bool		teardownActive;
 	List		*incompleteConns;

--- a/src/test/regress/sql/icudp/gp_interconnect_min_retries_before_timeout.sql
+++ b/src/test/regress/sql/icudp/gp_interconnect_min_retries_before_timeout.sql
@@ -19,6 +19,11 @@ SELECT ROUND(foo.rval * foo.rval)::INT % 30 AS rval2, COUNT(*) AS count, SUM(len
   GROUP BY rval2
   ORDER BY rval2;
 
+-- start_ignore
+-- Set client_min_messages to error to avoid warning message printed by network jitter
+set client_min_messages='ERROR';
+-- end_ignore
+
 -- Set GUC value to its min value 
 SET gp_interconnect_min_retries_before_timeout = 1;
 SHOW gp_interconnect_min_retries_before_timeout;


### PR DESCRIPTION
Packets will be dropped repeatly on some specific ports.
We need a way to quickly identify this issue.
But when network is bad, packets will also be dropped.
In past checkNetworkTimeout will error out when a packet
failed to receive ACK more than one hour(see GUC
gp_interconnect_transmit_timeout), which is too strict.

This commit introduces a warning message to report this
possible problem, and DBA could examine the port in further.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
