### PR TITLE
Avoid random warning message in test case.

### DIFF
--- a/src/test/regress/sql/icudp/gp_interconnect_min_retries_before_timeout.sql
+++ b/src/test/regress/sql/icudp/gp_interconnect_min_retries_before_timeout.sql
@@ -19,6 +19,11 @@ SELECT ROUND(foo.rval * foo.rval)::INT % 30 AS rval2, COUNT(*) AS count, SUM(len
   GROUP BY rval2
   ORDER BY rval2;
 
+-- start_ignore
+-- Set client_min_messages to error to avoid warning message printed by network jitter
+set client_min_messages='ERROR';
+-- end_ignore
+
 -- Set GUC value to its min value 
 SET gp_interconnect_min_retries_before_timeout = 1;
 SHOW gp_interconnect_min_retries_before_timeout;


### PR DESCRIPTION
change client_min_messages to error to avoid printing
warning in test case gp_interconnect_min_retries_before_timeout
when network jitter.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
