### PR TITLE
Fix crash with JSON/YAML format EXPLAIN.

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -463,6 +463,170 @@ QUERY PLAN
 </explain>
 (1 row)
 -- explain_processing_on
+-- Test for github issue #9359
+--
+-- The plan contains an Agg and a Hash node on top of each other, neither of
+-- which have a plan->flow set. Explain should be able to dig the flow from
+-- the grandchild node then.
+CREATE TEMPORARY TABLE SUBSELECT_TBL (
+  f1 integer,
+  f2 integer,
+  f3 float
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (format json) SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE
+    f2 IN (SELECT f1 FROM SUBSELECT_TBL));
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 3,
+      "Receivers": 1,
+      "Slice": 2,
+      "Segments": 3,
+      "Gang Type": "primary reader",
+      "Startup Cost": 8994.54,
+      "Total Cost": 10427.66,
+      "Plan Rows": 35550,
+      "Plan Width": 4,
+      "Plans": [
+        {
+          "Node Type": "Hash Join",
+          "Parent Relationship": "Outer",
+          "Slice": 2,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Join Type": "Inner",
+          "Startup Cost": 8994.54,
+          "Total Cost": 10427.66,
+          "Plan Rows": 35550,
+          "Plan Width": 4,
+          "Hash Cond": "(subselect_tbl.f1 = subselect_tbl_1.f2)",
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Slice": 2,
+              "Segments": 3,
+              "Gang Type": "primary reader",
+              "Relation Name": "subselect_tbl",
+              "Alias": "subselect_tbl",
+              "Startup Cost": 0.00,
+              "Total Cost": 811.00,
+              "Plan Rows": 71100,
+              "Plan Width": 4
+            },
+            {
+              "Node Type": "Hash",
+              "Parent Relationship": "Inner",
+              "Slice": 2,
+              "Segments": 3,
+              "Gang Type": "primary reader",
+              "Startup Cost": 8982.04,
+              "Total Cost": 8982.04,
+              "Plan Rows": 1000,
+              "Plan Width": 8,
+              "Plans": [
+                {
+                  "Node Type": "Aggregate",
+                  "Strategy": "Hashed",
+                  "Parent Relationship": "Outer",
+                  "Slice": 2,
+                  "Segments": 3,
+                  "Gang Type": "primary reader",
+                  "Startup Cost": 8972.04,
+                  "Total Cost": 8982.04,
+                  "Plan Rows": 1000,
+                  "Plan Width": 8,
+                  "Group Key": ["subselect_tbl_1.f2"],
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Slice": 2,
+                      "Segments": 3,
+                      "Gang Type": "primary reader",
+                      "Join Type": "Semi",
+                      "Startup Cost": 1699.75,
+                      "Total Cost": 8883.16,
+                      "Plan Rows": 35550,
+                      "Plan Width": 8,
+                      "Hash Cond": "(subselect_tbl_1.f2 = subselect_tbl_2.f1)",
+                      "Plans": [
+                        {
+                          "Node Type": "Redistribute Motion",
+                          "Senders": 3,
+                          "Receivers": 3,
+                          "Parent Relationship": "Outer",
+                          "Slice": 1,
+                          "Segments": 3,
+                          "Gang Type": "primary reader",
+                          "Startup Cost": 0.00,
+                          "Total Cost": 2233.00,
+                          "Plan Rows": 71100,
+                          "Plan Width": 4,
+                          "Hash Key": "subselect_tbl_1.f2",
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Slice": 1,
+                              "Segments": 3,
+                              "Gang Type": "primary reader",
+                              "Relation Name": "subselect_tbl",
+                              "Alias": "subselect_tbl_1",
+                              "Startup Cost": 0.00,
+                              "Total Cost": 811.00,
+                              "Plan Rows": 71100,
+                              "Plan Width": 4
+                            }
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Slice": 2,
+                          "Segments": 3,
+                          "Gang Type": "primary reader",
+                          "Startup Cost": 811.00,
+                          "Total Cost": 811.00,
+                          "Plan Rows": 71100,
+                          "Plan Width": 4,
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Slice": 2,
+                              "Segments": 3,
+                              "Gang Type": "primary reader",
+                              "Relation Name": "subselect_tbl",
+                              "Alias": "subselect_tbl_2",
+                              "Startup Cost": 0.00,
+                              "Total Cost": 811.00,
+                              "Plan Rows": 71100,
+                              "Plan Width": 4
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Postgres query optimizer"
+    }
+  }
+]
+(1 row)
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -435,6 +435,197 @@ QUERY PLAN
 </explain>
 (1 row)
 -- explain_processing_on
+-- Test for github issue #9359
+--
+-- The plan contains an Agg and a Hash node on top of each other, neither of
+-- which have a plan->flow set. Explain should be able to dig the flow from
+-- the grandchild node then.
+CREATE TEMPORARY TABLE SUBSELECT_TBL (
+  f1 integer,
+  f2 integer,
+  f3 float
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (format json) SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE
+    f2 IN (SELECT f1 FROM SUBSELECT_TBL));
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Result",
+      "Slice": 0,
+      "Segments": 0,
+      "Gang Type": "unallocated",
+      "Startup Cost": 0.00,
+      "Total Cost": 1293.00,
+      "Plan Rows": 1,
+      "Plan Width": 12,
+      "Plans": [
+        {
+          "Node Type": "Gather Motion",
+          "Senders": 3,
+          "Receivers": 1,
+          "Parent Relationship": "Outer",
+          "Slice": 2,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Startup Cost": 0.00,
+          "Total Cost": 1293.00,
+          "Plan Rows": 1,
+          "Plan Width": 4,
+          "Plans": [
+            {
+              "Node Type": "Hash Join",
+              "Parent Relationship": "Outer",
+              "Slice": 2,
+              "Segments": 3,
+              "Gang Type": "primary reader",
+              "Join Type": "Semi",
+              "Startup Cost": 0.00,
+              "Total Cost": 1293.00,
+              "Plan Rows": 1,
+              "Plan Width": 4,
+              "Hash Cond": "(subselect_tbl.f1 = subselect_tbl_1.f2)",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Slice": 2,
+                  "Segments": 3,
+                  "Gang Type": "primary reader",
+                  "Relation Name": "subselect_tbl",
+                  "Alias": "subselect_tbl",
+                  "Startup Cost": 0.00,
+                  "Total Cost": 431.00,
+                  "Plan Rows": 1,
+                  "Plan Width": 4
+                },
+                {
+                  "Node Type": "Hash",
+                  "Parent Relationship": "Inner",
+                  "Slice": 2,
+                  "Segments": 3,
+                  "Gang Type": "primary reader",
+                  "Startup Cost": 862.00,
+                  "Total Cost": 862.00,
+                  "Plan Rows": 1,
+                  "Plan Width": 4,
+                  "Plans": [
+                    {
+                      "Node Type": "Hash Join",
+                      "Parent Relationship": "Outer",
+                      "Slice": 2,
+                      "Segments": 3,
+                      "Gang Type": "primary reader",
+                      "Join Type": "Inner",
+                      "Startup Cost": 0.00,
+                      "Total Cost": 862.00,
+                      "Plan Rows": 1,
+                      "Plan Width": 4,
+                      "Hash Cond": "(subselect_tbl_1.f2 = subselect_tbl_2.f1)",
+                      "Plans": [
+                        {
+                          "Node Type": "Redistribute Motion",
+                          "Senders": 3,
+                          "Receivers": 3,
+                          "Parent Relationship": "Outer",
+                          "Slice": 1,
+                          "Segments": 3,
+                          "Gang Type": "primary reader",
+                          "Startup Cost": 0.00,
+                          "Total Cost": 431.00,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Hash Key": "subselect_tbl_1.f2",
+                          "Plans": [
+                            {
+                              "Node Type": "Seq Scan",
+                              "Parent Relationship": "Outer",
+                              "Slice": 1,
+                              "Segments": 3,
+                              "Gang Type": "primary reader",
+                              "Relation Name": "subselect_tbl",
+                              "Alias": "subselect_tbl_1",
+                              "Startup Cost": 0.00,
+                              "Total Cost": 431.00,
+                              "Plan Rows": 1,
+                              "Plan Width": 4
+                            }
+                          ]
+                        },
+                        {
+                          "Node Type": "Hash",
+                          "Parent Relationship": "Inner",
+                          "Slice": 2,
+                          "Segments": 3,
+                          "Gang Type": "primary reader",
+                          "Startup Cost": 431.00,
+                          "Total Cost": 431.00,
+                          "Plan Rows": 1,
+                          "Plan Width": 4,
+                          "Plans": [
+                            {
+                              "Node Type": "Aggregate",
+                              "Strategy": "Sorted",
+                              "Parent Relationship": "Outer",
+                              "Slice": 2,
+                              "Segments": 3,
+                              "Gang Type": "primary reader",
+                              "Startup Cost": 0.00,
+                              "Total Cost": 431.00,
+                              "Plan Rows": 1,
+                              "Plan Width": 4,
+                              "Group Key": ["subselect_tbl_2.f1"],
+                              "Plans": [
+                                {
+                                  "Node Type": "Sort",
+                                  "Parent Relationship": "Outer",
+                                  "Slice": 2,
+                                  "Segments": 3,
+                                  "Gang Type": "primary reader",
+                                  "Startup Cost": 0.00,
+                                  "Total Cost": 431.00,
+                                  "Plan Rows": 1,
+                                  "Plan Width": 4,
+                                  "Sort Key": ["subselect_tbl_2.f1"],
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Seq Scan",
+                                      "Parent Relationship": "Outer",
+                                      "Slice": 2,
+                                      "Segments": 3,
+                                      "Gang Type": "primary reader",
+                                      "Relation Name": "subselect_tbl",
+                                      "Alias": "subselect_tbl_2",
+                                      "Startup Cost": 0.00,
+                                      "Total Cost": 431.00,
+                                      "Plan Rows": 1,
+                                      "Plan Width": 4
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Pivotal Optimizer (GPORCA) version 3.87.0"
+    }
+  }
+]
+(1 row)
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -96,6 +96,21 @@ EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
 EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);
 -- explain_processing_on
 
+
+-- Test for github issue #9359
+--
+-- The plan contains an Agg and a Hash node on top of each other, neither of
+-- which have a plan->flow set. Explain should be able to dig the flow from
+-- the grandchild node then.
+CREATE TEMPORARY TABLE SUBSELECT_TBL (
+  f1 integer,
+  f2 integer,
+  f3 float
+);
+explain (format json) SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE
+    f2 IN (SELECT f1 FROM SUBSELECT_TBL));
+
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;


### PR DESCRIPTION
The code in EXPLAIN that displays the gang information of a node was
correctly prepared to handle the case that a node was missing flow
information, by looking at the child plan's flow instead. However, it's
possible to have two such nodes on top of each other. We need to look at
the grandchild's flow in that case.

This only occurs with JSON/YAML format EXPLAIN, because in text format we
only print the gang information on Motion nodes.

Fixes https://github.com/greenplum-db/gpdb/issues/9359. Fix on 6X_STABLE
only; 5X_STABLE didn't have JSON/YAML format output, and this works on
master. I'm not entirely sure why this works on master, but I'm not going
to spend time figuring that out right now, because I'm just about to
refactor this so that it's not based on the Flow nodes at all
(https://github.com/greenplum-db/gpdb/pull/9093).
