### PR TITLE
Ignore ORCA optimizer version in isolation2 tests

### DIFF
--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -45,3 +45,8 @@ m/available \d+ MB/
 s/available \d+ MB//
 
 -- end_matchsubs
+
+
+-- start_matchignore
+m/^ Optimizer: Pivotal Optimizer \(GPORCA\) version .*/
+-- end_matchignore


### PR DESCRIPTION
The modify_table_data_corrupt test failed due to difference in the ORCA version
string. So ignore it by adding the pattern in the isolation2 init_file.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
