### PR TITLE
    Support multiple init-file in pg_regress code.

### DIFF
--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -45,8 +45,3 @@ m/available \d+ MB/
 s/available \d+ MB//
 
 -- end_matchsubs
-
-
--- start_matchignore
-m/^ Optimizer: Pivotal Optimizer \(GPORCA\) version .*/
--- end_matchignore


### PR DESCRIPTION
    isolation2 Makefile uses multiple init-files but that does not work due to lack
    of the support.  (Note isolation2 test binary uses code in pg_regress and
    gpdiff.pl already supports multiple init-files).