### PR TITLE
Backport 6X: Support resource group runaway in global shared memory.

### DIFF
--- a/src/backend/utils/mmgr/redzone_handler.c
+++ b/src/backend/utils/mmgr/redzone_handler.c
@@ -211,7 +211,7 @@ RedZoneHandler_FlagTopConsumer()
 				maxGlobalShareMem = sessionGroupGSMem;
 				sessionGroupId = SessionGetResGroupId(curSessionState);
 
-				Assert(INVALID_OID != sessionGroupId);
+				Assert(InvalidOid != sessionGroupId);
 				resGroupId = sessionGroupId;
 			}
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -149,6 +149,7 @@ struct ResGroupProcData
 struct ResGroupSlotData
 {
 	Oid				groupId;
+	ResGroupData	*group;		/* pointer to the group */
 
 	int32			memQuota;	/* memory quota of current slot */
 	int32			memUsage;	/* total memory usage of procs belongs to this slot */
@@ -227,6 +228,12 @@ struct ResGroupControl
 	volatile int32	freeChunks;		/* memory chunks not allocated to any group,
 									will be used for the query which group share
 									memory is not enough*/
+	/* 
+	 * Safe memory threshold:
+	 * if remained global shared memory is less than this threshold,
+	 * then the resource group memory usage is in red zone.
+	 */
+	pg_atomic_uint32 safeChunksThreshold;
 
 	int32			chunkSizeInBits;
 	int 			segmentsOnMaster;
@@ -478,6 +485,7 @@ ResGroupControlInit(void)
     pResGroupControl->nGroups = MaxResourceGroups;
 	pResGroupControl->totalChunks = 0;
 	pResGroupControl->freeChunks = 0;
+	pg_atomic_init_u32(&pResGroupControl->safeChunksThreshold, 0);
 	pResGroupControl->chunkSizeInBits = BITS_IN_MB;
 
 	for (i = 0; i < MaxResourceGroups; i++)
@@ -561,6 +569,8 @@ InitResGroups(void)
 	/* These initialization must be done before createGroup() */
 	decideTotalChunks(&pResGroupControl->totalChunks, &pResGroupControl->chunkSizeInBits);
 	pResGroupControl->freeChunks = pResGroupControl->totalChunks;
+	pg_atomic_write_u32(&pResGroupControl->safeChunksThreshold,
+						pResGroupControl->totalChunks * (100 - runaway_detector_activation_percent) / 100);
 	if (pResGroupControl->totalChunks == 0)
 		ereport(PANIC,
 				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
@@ -681,7 +691,7 @@ InitResGroups(void)
 
 		ResGroupOps_SetCpuSet(DEFAULT_CPUSET_GROUP_ID, cpuset);
 	}
-	
+
 	pResGroupControl->loaded = true;
 	LOG_RESGROUP_DEBUG(LOG, "initialized %d resource groups", numGroups);
 
@@ -1449,6 +1459,7 @@ selfAttachResGroup(ResGroupData *group, ResGroupSlotData *slot)
 {
 	selfSetGroup(group);
 	selfSetSlot(slot);
+
 	groupIncMemUsage(group, slot, self->memUsage);
 	pg_atomic_add_fetch_u32((pg_atomic_uint32*) &slot->nProcs, 1);
 }
@@ -1475,6 +1486,7 @@ initSlot(ResGroupSlotData *slot, ResGroupData *group, int32 slotMemQuota)
 	Assert(!slotIsInUse(slot));
 	Assert(group->groupId != InvalidOid);
 
+	slot->group = group;
 	slot->groupId = group->groupId;
 	slot->caps = group->caps;
 	slot->memQuota = slotMemQuota;
@@ -1508,6 +1520,7 @@ slotpoolInit(void)
 	{
 		slot = &pResGroupControl->slots[i];
 
+		slot->group = NULL;
 		slot->groupId = InvalidOid;
 		slot->memQuota = -1;
 		slot->memUsage = 0;
@@ -1548,6 +1561,7 @@ slotpoolFreeSlot(ResGroupSlotData *slot)
 	Assert(slotIsInUse(slot));
 	Assert(slot->nProcs == 0);
 
+	slot->group = NULL;
 	slot->groupId = InvalidOid;
 	slot->memQuota = -1;
 	slot->memUsage = 0;
@@ -1923,6 +1937,12 @@ mempoolReserve(Oid groupId, int32 chunks)
 			break;
 	}
 
+	/* also update the safeChunksThreshold which is used in runaway detector */
+	if (reserved != 0)
+	{
+		pg_atomic_sub_fetch_u32(&pResGroupControl->safeChunksThreshold,
+								reserved * (100 - runaway_detector_activation_percent) / 100);
+	}
 	LOG_RESGROUP_DEBUG(LOG, "allocate %u out of %u chunks to group %d",
 					   reserved, oldFreeChunks, groupId);
 
@@ -1945,6 +1965,10 @@ mempoolRelease(Oid groupId, int32 chunks)
 	newFreeChunks = pg_atomic_add_fetch_u32((pg_atomic_uint32 *)
 											&pResGroupControl->freeChunks,
 											chunks);
+
+	/* also update the safeChunksThreshold which is used in runaway detector */
+	pg_atomic_add_fetch_u32(&pResGroupControl->safeChunksThreshold,
+							chunks * (100 - runaway_detector_activation_percent) / 100);
 
 	LOG_RESGROUP_DEBUG(LOG, "free %u to pool(%u) chunks from group %d",
 					   chunks, newFreeChunks - chunks, groupId);
@@ -2510,6 +2534,7 @@ AssignResGroupOnMaster(void)
 		pgstat_report_resgroup(0, bypassedGroup->groupId);
 
 		/* Initialize the fake slot */
+		bypassedSlot.group = groupInfo.group;
 		bypassedSlot.groupId = groupInfo.groupId;
 		bypassedSlot.memQuota = 0;
 		bypassedSlot.memUsage = 0;
@@ -2583,6 +2608,7 @@ UnassignResGroup(void)
 		groupDecMemUsage(bypassedGroup, &bypassedSlot, self->memUsage);
 
 		/* Reset the fake slot */
+		bypassedSlot.group = NULL;
 		bypassedSlot.groupId = InvalidOid;
 		bypassedGroup = NULL;
 
@@ -4212,4 +4238,121 @@ EnsureCpusetIsAvailable(int elevel)
 	}
 
 	return true;
+}
+
+/*
+ * Check whether current resource group's memory usage is in RedZone.
+ */
+bool
+IsGroupInRedZone(void)
+{
+	uint32				remainGlobalSharedMem;
+	uint32				safeChunksThreshold;
+	ResGroupSlotData	*slot = self->slot;
+	ResGroupData		*group = self->group;
+
+	/*
+	 * IsGroupInRedZone is called frequently, we should put the
+	 * condition which returns with higher probability in front.
+	 * 
+	 * safe: global shared memory is not in redzone
+	 */
+	remainGlobalSharedMem = (uint32) pg_atomic_read_u32(&pResGroupControl->freeChunks);
+	safeChunksThreshold = (uint32) pg_atomic_read_u32(&pResGroupControl->safeChunksThreshold);
+	if (remainGlobalSharedMem >= safeChunksThreshold)
+		return false;
+
+	AssertImply(slot != NULL, group != NULL);
+	if (!slot)
+		return false;
+
+	/* safe: slot memory is not used up */
+	if (slot->memQuota > slot->memUsage)
+		return false;
+
+	/* safe: group shared memory is not in redzone */
+	if (group->memSharedGranted > group->memSharedUsage)
+		return false;
+
+	/* memory usage in this group is in RedZone */
+	return true;
+}
+
+
+
+/*
+ * Dump memory information for current resource group.
+ * This is the output of resource group runaway.
+ */
+void
+ResGroupGetMemoryRunawayInfo(StringInfo str)
+{
+	ResGroupSlotData	*slot = self->slot;
+	ResGroupData		*group = self->group;
+	uint32				remainGlobalSharedMem = 0;
+	uint32				safeChunksThreshold = 0;
+
+	if (group)
+	{
+		Assert(selfIsAssigned());
+
+		remainGlobalSharedMem = (uint32) pg_atomic_read_u32(&pResGroupControl->freeChunks);
+		safeChunksThreshold = (uint32) pg_atomic_read_u32(&pResGroupControl->safeChunksThreshold);
+
+		appendStringInfo(str,
+						 "current group id is %u, "
+						 "group memory usage %d MB, "
+						 "group shared memory quota is %d MB, "
+						 "slot memory quota is %d MB, "
+						 "global freechunks memory is %u MB, "
+						 "global safe memory threshold is %u MB",
+						 group->groupId,
+						 VmemTracker_ConvertVmemChunksToMB(group->memUsage),
+						 VmemTracker_ConvertVmemChunksToMB(group->memSharedGranted),
+						 VmemTracker_ConvertVmemChunksToMB(slot->memQuota),
+						 VmemTracker_ConvertVmemChunksToMB(remainGlobalSharedMem),
+						 VmemTracker_ConvertVmemChunksToMB(safeChunksThreshold));
+	}
+	else
+	{
+		Assert(!selfIsAssigned());
+
+		appendStringInfo(str,
+						 "Resource group memory information: "
+						 "memory usage in current proc is %d MB",
+						 VmemTracker_ConvertVmemChunksToMB(self->memUsage));
+	}
+}
+
+/*
+ * Return group id for a session
+ */
+Oid
+SessionGetResGroupId(SessionState *session)
+{
+	ResGroupSlotData	*sessionSlot = (ResGroupSlotData *)session->resGroupSlot;
+	if (sessionSlot)
+		return sessionSlot->groupId;
+	else
+		return InvalidOid;
+}
+
+/*
+ * Return group global share memory for a session
+ */
+int32
+SessionGetResGroupGlobalShareMemUsage(SessionState *session)
+{
+	ResGroupSlotData	*sessionSlot = (ResGroupSlotData *)session->resGroupSlot;
+	if (sessionSlot)
+	{
+		/* lock not needed here, we just need esimated result */
+		ResGroupData	*group = sessionSlot->group;
+		return group->memSharedUsage - group->memSharedGranted;
+	}
+	else
+	{
+		/* session doesnot have group slot */
+		return 0;
+	}
 }

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -18,6 +18,7 @@
 
 #include "cdb/memquota.h"
 #include "catalog/pg_resgroup.h"
+#include "utils/session_state.h"
 
 /*
  * The max number of resource groups.
@@ -215,6 +216,10 @@ extern void CpusetDifference(char *cpuset1, const char *cpuset2, int len);
 extern bool CpusetIsEmpty(const char *cpuset);
 extern void SetCpusetEmpty(char *cpuset, int cpusetSize);
 extern bool EnsureCpusetIsAvailable(int elevel);
+extern bool IsGroupInRedZone(void);
+extern void ResGroupGetMemoryRunawayInfo(StringInfo str);
+extern Oid SessionGetResGroupId(SessionState *session);
+extern int32 SessionGetResGroupGlobalShareMemUsage(SessionState *session);
 
 #define LOG_RESGROUP_DEBUG(...) \
 	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);

--- a/src/test/isolation2/init_file_resgroup
+++ b/src/test/isolation2/init_file_resgroup
@@ -1,5 +1,6 @@
 -- start_matchignore
 m/^CONTEXT:  SQL function ".+" statement \d+$/
+m/^ERROR:  Canceling query because of high VMEM .+/
 -- end_matchignore
 
 -- start_matchsubs

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -47,6 +47,7 @@ $$;
 ! gpconfig -c gp_resource_manager -v group;
 ! gpconfig -c gp_resource_group_cpu_limit -v 0.9;
 ! gpconfig -c max_connections -v 250 -m 25;
+! gpconfig -c runaway_detector_activation_percent -v 100;
 ! gpstop -rai;
 -- end_ignore
 

--- a/src/test/isolation2/input/resgroup/resgroup_memory_runaway.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_runaway.source
@@ -1,0 +1,139 @@
+-- start_ignore
+DROP ROLE IF EXISTS role1_memory_test;
+DROP RESOURCE GROUP rg1_memory_test;
+DROP RESOURCE GROUP rg2_memory_test;
+-- end_ignore
+
+CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS
+'@abs_builddir@/../regress/regress@DLSUFFIX@', 'resGroupPalloc'
+LANGUAGE C READS SQL DATA;
+
+CREATE OR REPLACE FUNCTION hold_memory_by_percent(float) RETURNS int AS $$
+	SELECT * FROM resGroupPalloc($1)
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE VIEW rg_mem_status AS
+	SELECT groupname, memory_limit, memory_shared_quota
+	FROM gp_toolkit.gp_resgroup_config
+	WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test'
+	ORDER BY groupid;
+
+CREATE OR REPLACE VIEW memory_result AS SELECT rsgname, memory_usage from gp_toolkit.gp_resgroup_status;
+
+-- start_ignore
+! gpconfig -c runaway_detector_activation_percent -v 50;
+! gpstop -ari;
+-- end_ignore
+
+-- after the restart we need a new connection to run the queries
+--	1) single allocation
+--	Group Share Quota = 0
+--	Global Share Quota > 0
+--	Slot Quota > 0
+--	-----------------------
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2 * 2 => 20%
+--	rg1's single slot quota: 20% / 2 => 10%
+--	rg1's shared quota: 20% - 20% => %0
+--	system free chunks: 100% - 10% - 30% - 20% => 40%
+--  global area safe threshold: 40% / 2 = 20%
+1: CREATE RESOURCE GROUP rg1_memory_test
+    WITH (concurrency=2, cpu_rate_limit=10,
+          memory_limit=20, memory_shared_quota=0);
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+1: SELECT hold_memory_by_percent(1.0);
+1: SELECT hold_memory_by_percent(0.3);
+1: SELECT hold_memory_by_percent(0.3);
+1q:
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+2: SET ROLE TO role1_memory_test;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2q:
+
+0: DROP ROLE role1_memory_test;
+0: DROP RESOURCE GROUP rg1_memory_test;
+0q:
+
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2  => 10%
+--	rg1's single slot quota: 10% / 2 => 5%
+--	rg1's shared quota: %20 - %10 => %10
+--	system free chunks: 100% - 10% - 30% - 20% => 40%
+--  safe threshold: 40% / 2 = 20%
+1: CREATE RESOURCE GROUP rg1_memory_test
+    WITH (concurrency=2, cpu_rate_limit=10,
+          memory_limit=20, memory_shared_quota=50);
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+1: SELECT hold_memory_by_percent(1.0);
+1: SELECT hold_memory_by_percent(0.3);
+1: SELECT hold_memory_by_percent(0.3);
+1: SELECT hold_memory_by_percent(0.3);
+1q:
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+2: SET ROLE TO role1_memory_test;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2q:
+
+0: DROP ROLE role1_memory_test;
+0: DROP RESOURCE GROUP rg1_memory_test;
+0q:
+
+
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2  => 10%
+--	rg1's single slot quota: 10% / 2 => 5%
+--	rg1's shared quota: %20 - %10 => %10
+--	rg2's expected: 100% * 20% => 20%
+--	system free chunks: 100% - 10% - 30% - 20% - 20%=> 20%
+--  safe threshold: 20% / 2 = 10%
+1: CREATE RESOURCE GROUP rg1_memory_test
+    WITH (concurrency=2, cpu_rate_limit=10,
+          memory_limit=20, memory_shared_quota=50);
+1: CREATE RESOURCE GROUP rg2_memory_test
+    WITH (concurrency=2, cpu_rate_limit=10,
+          memory_limit=20, memory_shared_quota=0);
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+1: SELECT hold_memory_by_percent(1.0);
+1: SELECT hold_memory_by_percent(0.15);
+1: SELECT hold_memory_by_percent(0.15);
+1q:
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+2: SET ROLE TO role1_memory_test;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
+2q:
+
+0: DROP ROLE role1_memory_test;
+0: DROP RESOURCE GROUP rg1_memory_test;
+0: DROP RESOURCE GROUP rg2_memory_test;
+0q:
+
+
+-- start_ignore
+! gpconfig -c runaway_detector_activation_percent -v 100;
+! gpstop -ari;
+-- end_ignore

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -18,6 +18,7 @@ test: resgroup/resgroup_bypass_memory_limit
 test: resgroup/resgroup_alter_concurrency
 test: resgroup/resgroup_memory_statistic
 test: resgroup/resgroup_memory_limit
+test: resgroup/resgroup_memory_runaway
 test: resgroup/resgroup_alter_memory
 test: resgroup/resgroup_cpu_rate_limit
 test: resgroup/resgroup_alter_memory_spill_ratio

--- a/src/test/isolation2/output/resgroup/resgroup_memory_runaway.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_runaway.source
@@ -1,0 +1,259 @@
+-- start_ignore
+DROP ROLE IF EXISTS role1_memory_test;
+DROP
+DROP RESOURCE GROUP rg1_memory_test;
+ERROR:  resource group "rg1_memory_test" does not exist
+DROP RESOURCE GROUP rg2_memory_test;
+ERROR:  resource group "rg2_memory_test" does not exist
+-- end_ignore
+
+CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS '@abs_builddir@/../regress/regress@DLSUFFIX@', 'resGroupPalloc' LANGUAGE C READS SQL DATA;
+CREATE
+
+CREATE OR REPLACE FUNCTION hold_memory_by_percent(float) RETURNS int AS $$ SELECT * FROM resGroupPalloc($1) $$ LANGUAGE sql;
+CREATE
+
+CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test' ORDER BY groupid;
+CREATE
+
+CREATE OR REPLACE VIEW memory_result AS SELECT rsgname, memory_usage from gp_toolkit.gp_resgroup_status;
+CREATE
+
+-- start_ignore
+! gpconfig -c runaway_detector_activation_percent -v 50;
+20191213:05:03:47:014263 gpconfig:hubert-gp-centos:huanzhang-[INFO]:-completed successfully with parameters '-c runaway_detector_activation_percent -v 50'
+
+! gpstop -ari;
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Starting gpstop with args: -ari
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Gathering information and validating the environment...
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Obtaining Greenplum Master catalog information
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Obtaining Segment details from master...
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5211.gf5c0dd1 build dev'
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Master segment instance directory=/home/huanzhang/workspace/gpdb7/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Attempting forceful termination of any leftover master process
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Terminating processes for segment /home/huanzhang/workspace/gpdb7/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Stopping master standby host hubert-gp-centos mode=immediate
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Successfully shutdown standby process on hubert-gp-centos
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-0.00% of jobs completed
+20191213:05:03:49:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-100.00% of jobs completed
+20191213:05:03:49:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20191213:05:03:49:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-0.00% of jobs completed
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-100.00% of jobs completed
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-----------------------------------------------------
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-   Segments stopped successfully      = 6
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-   Segments with errors during stop   = 0
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-----------------------------------------------------
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Database successfully shutdown with no errors reported
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover gpmmon process
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-No leftover gpmmon process found
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover gpsmon processes
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover shared memory
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Restarting System...
+
+-- end_ignore
+
+-- after the restart we need a new connection to run the queries
+--	1) single allocation
+--	Group Share Quota = 0
+--	Global Share Quota > 0
+--	Slot Quota > 0
+--	-----------------------
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2 * 2 => 20%
+--	rg1's single slot quota: 20% / 2 => 10%
+--	rg1's shared quota: 20% - 20% => %0
+--	system free chunks: 100% - 10% - 30% - 20% => 40%
+--  global area safe threshold: 40% / 2 = 20%
+1: CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0);
+CREATE
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+CREATE
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+SET
+1: SELECT hold_memory_by_percent(1.0);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ERROR:  Canceling query because of high VMEM usage. current group id is 806868, group memory usage 218 MB, group shared memory quota is 0 MB, slot memory quota is 68 MB, global freechunks memory is 124 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+1q: ... <quitting>
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+2: SET ROLE TO role1_memory_test;
+SET
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ERROR:  Canceling query because of high VMEM usage. current group id is 806868, group memory usage 218 MB, group shared memory quota is 0 MB, slot memory quota is 68 MB, global freechunks memory is 124 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:7002 pid=10883) (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+2q: ... <quitting>
+
+0: DROP ROLE role1_memory_test;
+DROP
+0: DROP RESOURCE GROUP rg1_memory_test;
+DROP
+0q: ... <quitting>
+
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2  => 10%
+--	rg1's single slot quota: 10% / 2 => 5%
+--	rg1's shared quota: %20 - %10 => %10
+--	system free chunks: 100% - 10% - 30% - 20% => 40%
+--  safe threshold: 40% / 2 = 20%
+1: CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=20, memory_shared_quota=50);
+CREATE
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+CREATE
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+SET
+1: SELECT hold_memory_by_percent(1.0);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ERROR:  Canceling query because of high VMEM usage. current group id is 806877, group memory usage 259 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 117 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+1q: ... <quitting>
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+2: SET ROLE TO role1_memory_test;
+SET
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ERROR:  Canceling query because of high VMEM usage. current group id is 806877, group memory usage 259 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 117 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:7002 pid=10918) (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+2q: ... <quitting>
+
+0: DROP ROLE role1_memory_test;
+DROP
+0: DROP RESOURCE GROUP rg1_memory_test;
+DROP
+0q: ... <quitting>
+
+
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2  => 10%
+--	rg1's single slot quota: 10% / 2 => 5%
+--	rg1's shared quota: %20 - %10 => %10
+--	rg2's expected: 100% * 20% => 20%
+--	system free chunks: 100% - 10% - 30% - 20% - 20%=> 20%
+--  safe threshold: 20% / 2 = 10%
+1: CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=20, memory_shared_quota=50);
+CREATE
+1: CREATE RESOURCE GROUP rg2_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0);
+CREATE
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+CREATE
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+SET
+1: SELECT hold_memory_by_percent(1.0);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.15);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.15);
+ERROR:  Canceling query because of high VMEM usage. current group id is 806886, group memory usage 178 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 62 MB, global safe memory threshold is 69 MB (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+1q: ... <quitting>
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+2: SET ROLE TO role1_memory_test;
+SET
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
+ERROR:  Canceling query because of high VMEM usage. current group id is 806886, group memory usage 178 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 62 MB, global safe memory threshold is 69 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:7002 pid=10952) (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+2q: ... <quitting>
+
+0: DROP ROLE role1_memory_test;
+DROP
+0: DROP RESOURCE GROUP rg1_memory_test;
+DROP
+0: DROP RESOURCE GROUP rg2_memory_test;
+DROP
+0q: ... <quitting>
+
+


### PR DESCRIPTION

    Support resource group runaway in global shared memory.

    In resource queue, gpdb has runaway mechanism which kills the top memory
    consumer query when the memory usage of the segment is in red zone.
    We support similar mechanism in resource group mode as well.
    Resource group has three level memory management:
    1. slot level.
    2. group shared level.
    3. global shared level.
    Query will fetch memory from lower level firstly, if lower level is used
    up, then go to uppper level.
    We set runaway on global shared level, which means if a query in a resource
    group used up all the level1 and level2 memory and begin to consume level3
    memory. If global shared memory usage reaches a red zone(e.g. 80% usage),
    then we select a top consumer query to kill.

    Note that if global shared memory is not set, runaway will not take effect.

    Reviewed-by: Ning Yu <nyu@pivotal.io>
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
